### PR TITLE
Remove references to "self = this" and other "this" keyword aliasing

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
         "no-console": "off",
         "no-unused-vars": ["error", { args: "none" }],
         "prefer-const": "error",
+        "consistent-this": "error",
         // I'd love to turn on camelcase, but it's a big shift with tons of current errors.
         // camelcase: [
         //     "error",

--- a/client/galaxy/scripts/components/Select2.js
+++ b/client/galaxy/scripts/components/Select2.js
@@ -6,15 +6,14 @@ export default {
     props: ["options", "value", "placeholder"],
     template: `<select><slot></slot></select>`,
     mounted: function() {
-        const vm = this;
         $(this.$el)
             // init select2
             .select2({ data: this.options, placeholder: this.placeholder, allowClear: this.placeholder })
             .val(this.value)
             .trigger("change")
             // emit event on change.
-            .on("change", function(event) {
-                vm.$emit("input", event.val);
+            .on("change", event => {
+                this.$emit("input", event.val);
             });
     },
     watch: {

--- a/client/galaxy/scripts/components/SidePanel.vue
+++ b/client/galaxy/scripts/components/SidePanel.vue
@@ -40,17 +40,16 @@ export default {
     },
     methods: {
         dragHandler(e) {
-            const self = this;
             const draggingLeft = this.side === "left";
 
             const initialX = e.pageX;
             const initialWidth = this.width;
 
-            function move(e) {
+            const move = e => {
                 const delta = e.pageX - initialX;
                 let newWidth = draggingLeft ? initialWidth + delta : initialWidth - delta;
                 newWidth = Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, newWidth));
-                self.resize(newWidth);
+                this.resize(newWidth);
             }
 
             function moved() {

--- a/client/galaxy/scripts/components/User/CloudAuth/model/BaseModel.js
+++ b/client/galaxy/scripts/components/User/CloudAuth/model/BaseModel.js
@@ -57,14 +57,13 @@ export class BaseModel {
     // Setting a property name as transient for a class means its
     // state will be caclulated without regard to that propety
     static setTransient(...fieldNames) {
-        const klass = this; // this will be a class
-        if (!transients.has(klass)) {
-            transients.set(klass, new Set());
+        if (!transients.has(this)) {
+            transients.set(this, new Set());
         }
 
-        const fields = transients.get(klass);
+        const fields = transients.get(this);
         fieldNames.forEach(fieldName => fields.add(fieldName));
-        transients.set(klass, fields);
+        transients.set(this, fields);
     }
 
     /* Validation */

--- a/client/galaxy/scripts/layout/masthead.js
+++ b/client/galaxy/scripts/layout/masthead.js
@@ -10,7 +10,6 @@ const View = Backbone.View.extend({
     initialize: function(options) {
         const Galaxy = getGalaxyInstance();
 
-        const self = this;
         this.options = options;
         this.setElement(this._template());
         this.$navbarBrandLink = this.$(".navbar-brand");
@@ -23,13 +22,13 @@ const View = Backbone.View.extend({
         this.collection = new Menu.Collection();
         this.collection
             .on("add", model => {
-                self.$navbarTabs.append(new Menu.Tab({ model: model }).render().$el);
+                this.$navbarTabs.append(new Menu.Tab({ model: model }).render().$el);
             })
             .on("reset", () => {
-                self.$navbarTabs.empty();
+                this.$navbarTabs.empty();
             })
             .on("dispatch", callback => {
-                self.collection.each(m => {
+                this.collection.each(m => {
                     callback(m);
                 });
             })
@@ -68,7 +67,7 @@ const View = Backbone.View.extend({
             })
             .on("beforeunload", () => {
                 let text = "";
-                self.collection.each(model => {
+                this.collection.each(model => {
                     const q = model.get("onbeforeunload") && model.get("onbeforeunload")();
                     if (q) {
                         text += `${q} `;

--- a/client/galaxy/scripts/layout/modal.js
+++ b/client/galaxy/scripts/layout/modal.js
@@ -83,13 +83,12 @@ $.extend(Modal.prototype, {
         }
     },
     hide: function() {
-        const modal = this;
-        modal.$dialog.fadeOut(() => {
-            modal.$overlay.hide();
-            modal.$backdrop.removeClass("in");
-            modal.$body.children().remove();
+        this.$dialog.fadeOut(() => {
+            this.$overlay.hide();
+            this.$backdrop.removeClass("in");
+            this.$body.children().remove();
             // Clear min-width to allow for modal to take size of new body.
-            modal.$body.css("min-width", undefined);
+            this.$body.css("min-width", undefined);
         });
     }
 });

--- a/client/galaxy/scripts/layout/page.js
+++ b/client/galaxy/scripts/layout/page.js
@@ -15,7 +15,6 @@ const View = Backbone.View.extend({
     _panelids: ["left", "right"],
 
     initialize: function(options) {
-        const self = this;
         this.config = _.defaults(options.config || {}, {
             message_box_visible: false,
             message_box_content: "",
@@ -29,7 +28,7 @@ const View = Backbone.View.extend({
         // attach global objects, build mastheads
         const Galaxy = getGalaxyInstance();
         Galaxy.modal = this.modal = new Modal.View();
-        Galaxy.router = this.router = options.Router && new options.Router(self, options);
+        Galaxy.router = this.router = options.Router && new options.Router(this, options);
         Galaxy.data = this.data = new Data(this);
         this.masthead = new Masthead.View(this.config);
         this.center = new Panel.CenterPanel();
@@ -44,9 +43,9 @@ const View = Backbone.View.extend({
                 view.allow_title_display = true;
             }
             if (view.active_tab) {
-                self.masthead.highlight(view.active_tab);
+                this.masthead.highlight(view.active_tab);
             }
-            self.center.display(view);
+            this.center.display(view);
         };
 
         // build page template
@@ -75,10 +74,10 @@ const View = Backbone.View.extend({
                 const panel_class_name = panel_id.charAt(0).toUpperCase() + panel_id.slice(1);
                 const panel_class = options[panel_class_name];
                 if (panel_class) {
-                    const panel_instance = new panel_class(self, options);
-                    const panel_el = self.$(`#${panel_id}`);
-                    self[panel_instance.toString()] = panel_instance;
-                    self.panels[panel_id] = new Panel.SidePanel({
+                    const panel_instance = new panel_class(this, options);
+                    const panel_el = this.$(`#${panel_id}`);
+                    this[panel_instance.toString()] = panel_instance;
+                    this.panels[panel_id] = new Panel.SidePanel({
                         id: panel_id,
                         el: panel_el,
                         view: panel_instance
@@ -153,14 +152,13 @@ const View = Backbone.View.extend({
 
     /** Render panels */
     renderPanels: function() {
-        const self = this;
         _.each(this._panelids, panel_id => {
-            const panel = self.panels[panel_id];
+            const panel = this.panels[panel_id];
             if (panel) {
                 panel.render();
             } else {
-                self.$center.css(panel_id, 0);
-                self.$(`#${panel_id}`).hide();
+                this.$center.css(panel_id, 0);
+                this.$(`#${panel_id}`).hide();
             }
         });
         return this;

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -24,19 +24,17 @@ const SidePanel = Backbone.View.extend({
     },
 
     render: function() {
-        const self = this;
         const panel = this.view;
         const components = this.view.model.attributes || {};
 
         if (this.id === "left" && this.view && this.view.isVueWrapper) {
             const node = document.createElement("div");
             this.$el.replaceWith(node);
-
             this.view.mountVueComponent(node);
         } else {
             this.$el.html(this._templatePanel(this.id));
             _.each(components.buttons, button => {
-                self.$(".panel-header-buttons").append(button.$el);
+                this.$(".panel-header-buttons").append(button.$el);
             });
             this.$el.addClass(components.cls);
             this.$(".panel-header-text").html(_.escape(components.title));
@@ -84,19 +82,18 @@ const SidePanel = Backbone.View.extend({
     },
 
     _mousedownDragHandler: function(ev) {
-        const self = this;
         const draggingLeft = this.id === "left";
         // Save the mouse position and width of the element (panel) when the
         // drag interaction is first started
         const initialX = ev.pageX;
-        const initialWidth = self.$el.width();
+        const initialWidth = this.$el.width();
 
-        function move(e) {
+        const move = e => {
             const delta = e.pageX - initialX;
             let newWidth = draggingLeft ? initialWidth + delta : initialWidth - delta;
             // Limit range
             newWidth = Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, newWidth));
-            self.resize(newWidth);
+            this.resize(newWidth);
         }
 
         // This is a page wide overlay that assists in capturing the move and
@@ -163,7 +160,7 @@ const SidePanel = Backbone.View.extend({
     // ..............................................................
     //TODO: only used in message.mako?
     /**   */
-    handle_minwidth_hint: function(hint) {
+    handle_minwidth_hint: hint => {
         const space = this.$center().width() - (this.hidden ? this.saved_size : 0);
         if (space < hint) {
             if (!this.hidden) {
@@ -176,18 +173,18 @@ const SidePanel = Backbone.View.extend({
                 this.hiddenByTool = false;
             }
         }
-        return self;
+        return this;
     },
 
     /**   */
-    force_panel: function(op) {
+    force_panel: op => {
         if (op == "show") {
             return this.show();
         }
         if (op == "hide") {
             return this.hide();
         }
-        return self;
+        return this;
     },
 
     toString: function() {

--- a/client/galaxy/scripts/layout/panel.js
+++ b/client/galaxy/scripts/layout/panel.js
@@ -160,7 +160,7 @@ const SidePanel = Backbone.View.extend({
     // ..............................................................
     //TODO: only used in message.mako?
     /**   */
-    handle_minwidth_hint: hint => {
+    handle_minwidth_hint: function(hint) {
         const space = this.$center().width() - (this.hidden ? this.saved_size : 0);
         if (space < hint) {
             if (!this.hidden) {
@@ -177,7 +177,7 @@ const SidePanel = Backbone.View.extend({
     },
 
     /**   */
-    force_panel: op => {
+    force_panel: function(op) {
         if (op == "show") {
             return this.show();
         }

--- a/client/galaxy/scripts/layout/scratchbook.js
+++ b/client/galaxy/scripts/layout/scratchbook.js
@@ -72,7 +72,6 @@ export default Backbone.View.extend({
 
     /** Add a dataset to the frames */
     addDataset: function(dataset_id) {
-        const self = this;
         let current_dataset = null;
         const Galaxy = getGalaxyInstance();
         if (Galaxy && Galaxy.currHistoryPanel) {
@@ -83,13 +82,13 @@ export default Backbone.View.extend({
             };
             Galaxy.currHistoryPanel.collection.each(model => {
                 if (!model.get("deleted") && model.get("visible")) {
-                    self.history_cache[history_id].dataset_ids.push(model.get("id"));
+                    this.history_cache[history_id].dataset_ids.push(model.get("id"));
                 }
             });
         }
         const _findDataset = (dataset, offset) => {
             if (dataset) {
-                const history_details = self.history_cache[dataset.get("history_id")];
+                const history_details = this.history_cache[dataset.get("history_id")];
                 if (history_details && history_details.dataset_ids) {
                     const dataset_list = history_details.dataset_ids;
                     const pos = dataset_list.indexOf(dataset.get("id"));
@@ -102,7 +101,7 @@ export default Backbone.View.extend({
         const _loadDatasetOffset = (dataset, offset, frame) => {
             const new_dataset_id = _findDataset(dataset, offset);
             if (new_dataset_id) {
-                self._loadDataset(new_dataset_id, (new_dataset, config) => {
+                this._loadDataset(new_dataset_id, (new_dataset, config) => {
                     current_dataset = new_dataset;
                     frame.model.set(config);
                 });
@@ -112,7 +111,7 @@ export default Backbone.View.extend({
         };
         this._loadDataset(dataset_id, (dataset, config) => {
             current_dataset = dataset;
-            self.add(
+            this.add(
                 _.extend(
                     {
                         menu: [
@@ -145,7 +144,6 @@ export default Backbone.View.extend({
     },
 
     _loadDataset: function(dataset_id, callback) {
-        const self = this;
         const dataset = new Dataset({ id: dataset_id });
         $.when(dataset.fetch()).then(() => {
             const is_tabular = _.find(
@@ -153,7 +151,7 @@ export default Backbone.View.extend({
                 data_type => dataset.get("data_type").indexOf(data_type) !== -1
             );
             let title = dataset.get("name");
-            const history_details = self.history_cache[dataset.get("history_id")];
+            const history_details = this.history_cache[dataset.get("history_id")];
             if (history_details) {
                 title = `${history_details.name}: ${title}`;
             }
@@ -180,7 +178,6 @@ export default Backbone.View.extend({
 
     /** Add a trackster visualization to the frames. */
     addTrackster: function(viz_id) {
-        const self = this;
         const viz = new visualization.Visualization({ id: viz_id });
         $.when(viz.fetch()).then(() => {
             const ui = new TracksterUI(getAppRoot());
@@ -219,7 +216,7 @@ export default Backbone.View.extend({
                     );
                 }
             };
-            self.add(frame_config);
+            this.add(frame_config);
         });
     },
 

--- a/client/galaxy/scripts/legacy/grid/grid-model.js
+++ b/client/galaxy/scripts/legacy/grid/grid-model.js
@@ -100,8 +100,7 @@ export default Backbone.Model.extend({
         }
 
         // Add filter arguments to data, placing "f-" in front of all arguments.
-        var self = this;
-        _.each(_.pairs(self.attributes.filters), k => {
+        _.each(_.pairs(this.attributes.filters), k => {
             url_data[`f-${k[0]}`] = k[1];
         });
         return url_data;

--- a/client/galaxy/scripts/legacy/grid/grid-view.js
+++ b/client/galaxy/scripts/legacy/grid/grid-view.js
@@ -26,7 +26,6 @@ export default Backbone.View.extend({
         this.dict_format = grid_config.dict_format;
         this.title = grid_config.title;
         this.title_id = grid_config.title_id;
-        var self = this;
 
         // why is this a global?
         // Answer: autocom_tagging passes this function from python and
@@ -40,7 +39,7 @@ export default Backbone.View.extend({
                 $("#standard-search").slideToggle("fast");
                 $("#advanced-search").slideToggle("fast");
             }
-            self.add_filter_condition("tags", tag);
+            this.add_filter_condition("tags", tag);
         };
 
         // set element
@@ -53,10 +52,10 @@ export default Backbone.View.extend({
                 });
                 $.ajax({
                     url: `${grid_config.url_base}?${$.param(url_data)}`,
-                    success: function(response) {
+                    success: response => {
                         response.embedded = grid_config.embedded;
                         response.filters = grid_config.filters || {};
-                        self.init_grid(response);
+                        this.init_grid(response);
                     }
                 });
             } else {
@@ -116,10 +115,9 @@ export default Backbone.View.extend({
         // update message
         if (options.message) {
             this.$el.find("#grid-message").html(Templates.message(options));
-            var self = this;
             if (options.use_hide_message) {
                 setTimeout(() => {
-                    self.$el.find("#grid-message").html("");
+                    this.$el.find("#grid-message").html("");
                 }, 5000);
             }
         }
@@ -136,13 +134,12 @@ export default Backbone.View.extend({
     // Initialize grid controls
     init_grid_controls: function() {
         // link
-        var self = this;
 
         // Initialize grid operation button.
-        this.$el.find(".operation-button").each(function() {
-            $(this).off();
-            $(this).click(function() {
-                self.submit_operation(this);
+        this.$el.find(".operation-button").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
+                this.submit_operation(e.currentTarget);
                 return false;
             });
         });
@@ -160,38 +157,38 @@ export default Backbone.View.extend({
         });
 
         // Initialize sort links.
-        this.$el.find(".sort-link").each(function() {
-            $(this).off();
-            $(this).click(function() {
-                self.set_sort_condition($(this).attr("sort_key"));
+        this.$el.find(".sort-link").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
+                this.set_sort_condition($(e.currentTarget).attr("sort_key"));
                 return false;
             });
         });
 
         // Initialize text filters.
-        this.$el.find(".text-filter-form").each(function() {
-            $(this).off();
-            $(this).submit(function() {
-                var column_key = $(this).attr("column_key");
+        this.$el.find(".text-filter-form").each((index, element) => {
+            $(element).off();
+            $(element).submit(e => {
+                var column_key = $(e.currentTarget).attr("column_key");
                 var text_input_obj = $(`#input-${column_key}-filter`);
                 var text_input = text_input_obj.val();
                 text_input_obj.val("");
-                self.add_filter_condition(column_key, text_input);
+                this.add_filter_condition(column_key, text_input);
                 return false;
             });
         });
 
         // Initialize categorical filters.
-        this.$el.find(".text-filter-val > a").each(function() {
-            $(this).off();
-            $(this).click(function() {
+        this.$el.find(".text-filter-val > a").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
                 // Remove visible element.
-                $(this)
+                $(e.currentTarget)
                     .parent()
                     .remove();
 
                 // Remove filter condition.
-                self.remove_filter_condition($(this).attr("filter_key"), $(this).attr("filter_val"));
+                this.remove_filter_condition($(this).attr("filter_key"), $(this).attr("filter_val"));
 
                 // Return
                 return false;
@@ -199,20 +196,20 @@ export default Backbone.View.extend({
         });
 
         // Initialize categorical filters.
-        this.$el.find(".categorical-filter > a").each(function() {
-            $(this).off();
-            $(this).click(function() {
-                self.set_categorical_filter($(this).attr("filter_key"), $(this).attr("filter_val"));
+        this.$el.find(".categorical-filter > a").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
+                this.set_categorical_filter($(e.currentTarget).attr("filter_key"), $(e.currentTarget).attr("filter_val"));
                 return false;
             });
         });
 
         // Initialize standard, advanced search toggles.
-        this.$el.find(".advanced-search-toggle").each(function() {
-            $(this).off();
-            $(this).click(() => {
-                self.$el.find("#standard-search").slideToggle("fast");
-                self.$el.find("#advanced-search").slideToggle("fast");
+        this.$el.find(".advanced-search-toggle").each((index, element) => {
+            $(element).off();
+            $(element).click(() => {
+                this.$el.find("#standard-search").slideToggle("fast");
+                this.$el.find("#advanced-search").slideToggle("fast");
                 return false;
             });
         });
@@ -220,7 +217,7 @@ export default Backbone.View.extend({
         // Add event to check all box
         this.$el.find("#check_all").off();
         this.$el.find("#check_all").on("click", () => {
-            self.check_all_items();
+            this.check_all_items();
         });
     },
 
@@ -245,14 +242,13 @@ export default Backbone.View.extend({
 
         // get options
         var options = this.grid.attributes;
-        var self = this;
 
         //
         // add page click events
         //
-        this.$el.find(".page-link > a").each(function() {
-            $(this).click(function() {
-                self.set_page($(this).attr("page_num"));
+        this.$el.find(".page-link > a").each((index, element) => {
+            $(element).click(e => {
+                this.set_page($(e.currentTarget).attr("page_num"));
                 return false;
             });
         });
@@ -260,11 +256,11 @@ export default Backbone.View.extend({
         //
         // add inbound/outbound events
         //
-        this.$el.find(".use-target").each(function() {
-            $(this).click(function() {
-                self.execute({
-                    href: $(this).attr("href"),
-                    target: $(this).attr("target")
+        this.$el.find(".use-target").each((index, element) => {
+            $(element).click(e => {
+                this.execute({
+                    href: $(e.currentTarget).attr("href"),
+                    target: $(e.currentTarget).attr("target")
                 });
                 return false;
             });
@@ -278,17 +274,16 @@ export default Backbone.View.extend({
 
         // add operation popup menus
         _.each(options.items, (item, index) => {
-            var button = self.$(`#grid-${item.encode_id}-popup`).off();
+            var button = this.$(`#grid-${item.encode_id}-popup`).off();
             var popup = new PopupMenu(button);
             _.each(options.operations, operation => {
-                self._add_operation(popup, operation, item);
+                this._add_operation(popup, operation, item);
             });
         });
     },
 
     /** Add an operation to the items menu */
     _add_operation: function(popup, operation, item) {
-        var self = this;
         var settings = item.operation_config[operation.label];
         if (settings.allowed && operation.allow_popup) {
             popup.addItem({
@@ -296,13 +291,13 @@ export default Backbone.View.extend({
                 href: settings.url_args,
                 target: settings.target,
                 confirmation_text: operation.confirm,
-                func: function(e) {
+                func: e => {
                     e.preventDefault();
                     var label = $(e.target).html();
                     if (operation.onclick) {
                         operation.onclick(item.encode_id);
                     } else {
-                        self.execute(this.findItemByHtml(label));
+                        this.execute(this.findItemByHtml(label));
                     }
                 }
             });
@@ -321,13 +316,13 @@ export default Backbone.View.extend({
 
         // Add button that displays filter and provides a button to delete it.
         var t = $(Templates.filter_element(name, value));
-        var self = this;
-        t.click(function() {
+
+        t.click(e => {
             // Remove visible element.
-            $(this).remove();
+            $(e.currentTarget).remove();
 
             // Remove filter condition.
-            self.remove_filter_condition(name, value);
+            this.remove_filter_condition(name, value);
         });
 
         // append to container
@@ -384,27 +379,27 @@ export default Backbone.View.extend({
         var category_filter = this.grid.get("categorical_filters")[name];
 
         var cur_value = this.grid.get("filters")[name];
-        var self = this;
-        this.$el.find(`.${name}-filter`).each(function() {
-            var text = $.trim($(this).text());
+
+        this.$el.find(`.${name}-filter`).each((index, element) => {
+            var text = $.trim($(element).text());
             var filter = category_filter[text];
             var filter_value = filter[name];
             if (filter_value == new_value) {
                 // Remove filter link since grid will be using this filter. It is assumed that
                 // this element has a single child, a hyperlink/anchor with text.
-                $(this).empty();
-                $(this).addClass("current-filter");
-                $(this).append(text);
+                $(element).empty();
+                $(element).addClass("current-filter");
+                $(element).append(text);
             } else if (filter_value == cur_value) {
                 // Add hyperlink for this filter since grid will no longer be using this filter. It is assumed that
                 // this element has a single child, a hyperlink/anchor.
-                $(this).empty();
+                $(element).empty();
                 var t = $(`<a href="javascript:void(0)" role="button">${text}</a>`);
                 t.click(() => {
-                    self.set_categorical_filter(name, filter_value);
+                    this.set_categorical_filter(name, filter_value);
                 });
-                $(this).removeClass("current-filter");
-                $(this).append(t);
+                $(element).removeClass("current-filter");
+                $(element).append(t);
             }
         });
 
@@ -417,35 +412,34 @@ export default Backbone.View.extend({
     // Set page to view.
     set_page: function(new_page) {
         // Update page hyperlink to reflect new page.
-        var self = this;
-        this.$el.find(".page-link").each(function() {
-            var id = $(this).attr("id");
+        this.$el.find(".page-link").each((index, element) => {
+            var id = $(element).attr("id");
 
             var // Id has form 'page-link-<page_num>
                 page_num = parseInt(id.split("-")[2], 10);
 
-            var cur_page = self.grid.get("cur_page");
+            var cur_page = this.grid.get("cur_page");
             var text;
             if (page_num === new_page) {
                 // Remove link to page since grid will be on this page. It is assumed that
                 // this element has a single child, a hyperlink/anchor with text.
-                text = $(this)
+                text = $(element)
                     .children()
                     .text();
-                $(this).empty();
-                $(this).addClass("inactive-link");
-                $(this).text(text);
+                $(element).empty();
+                $(element).addClass("inactive-link");
+                $(element).text(text);
             } else if (page_num === cur_page) {
                 // Add hyperlink to this page since grid will no longer be on this page. It is assumed that
                 // this element has a single child, a hyperlink/anchor.
-                text = $(this).text();
-                $(this).empty();
-                $(this).removeClass("inactive-link");
+                text = $(element).text();
+                $(element).empty();
+                $(element).removeClass("inactive-link");
                 var t = $(`<a href="javascript:void(0)" role="button">${text}</a>`);
                 t.click(() => {
-                    self.set_page(page_num);
+                    this.set_page(page_num);
                 });
-                $(this).append(t);
+                $(element).append(t);
             }
         });
 
@@ -649,22 +643,21 @@ export default Backbone.View.extend({
 
         // Show overlay to indicate loading and prevent user actions.
         this.$el.find(".loading-elt-overlay").show();
-        var self = this;
         $.ajax({
             type: method,
-            url: self.grid.get("url_base"),
-            data: self.grid.get_url_data(),
+            url: this.grid.get("url_base"),
+            data: this.grid.get_url_data(),
             error: function() {
                 alert("Grid refresh failed");
             },
-            success: function(response_text) {
+            success: response_text => {
                 // backup
-                var embedded = self.grid.get("embedded");
-                var insert = self.grid.get("insert");
-                var advanced_search = self.$el.find("#advanced-search").is(":visible");
+                var embedded = this.grid.get("embedded");
+                var insert = this.grid.get("insert");
+                var advanced_search = this.$el.find("#advanced-search").is(":visible");
 
                 // request new configuration
-                var json = self.dict_format ? response_text : $.parseJSON(response_text);
+                var json = this.dict_format ? response_text : $.parseJSON(response_text);
 
                 // update
                 json.embedded = embedded;
@@ -672,14 +665,14 @@ export default Backbone.View.extend({
                 json.advanced_search = advanced_search;
 
                 // Initialize new grid config
-                self.init_grid(json);
+                this.init_grid(json);
 
                 // Hide loading overlay.
-                self.$el.find(".loading-elt-overlay").hide();
+                this.$el.find(".loading-elt-overlay").hide();
             },
-            complete: function() {
+            complete: () => {
                 // Clear grid of transient request attributes.
-                self.grid.set({
+                this.grid.set({
                     operation: undefined,
                     item_ids: undefined
                 });

--- a/client/galaxy/scripts/mvc/annotation.js
+++ b/client/galaxy/scripts/mvc/annotation.js
@@ -28,16 +28,15 @@ var AnnotationEditor = Backbone.View.extend(baseMVC.LoggableMixin)
 
         /** Build the DOM elements, call select to on the created input, and set up behaviors */
         render: function() {
-            var view = this;
             this.$el.html(this._template());
 
             //TODO: handle empties better
             this.$annotation().make_text_editable({
                 use_textarea: true,
-                on_finish: function(newAnnotation) {
-                    view.$annotation().text(newAnnotation);
-                    view.model.save({ annotation: newAnnotation }, { silent: true }).fail(() => {
-                        view.$annotation().text(view.model.previous("annotation"));
+                on_finish: newAnnotation => {
+                    this.$annotation().text(newAnnotation);
+                    this.model.save({ annotation: newAnnotation }, { silent: true }).fail(() => {
+                        this.$annotation().text(this.model.previous("annotation"));
                     });
                 }
             });

--- a/client/galaxy/scripts/mvc/base-mvc.js
+++ b/client/galaxy/scripts/mvc/base-mvc.js
@@ -234,8 +234,7 @@ var SearchableModelMixin = {
      *      returning a list of keys of attributes that contain searchFor
      */
     search: function(searchFor) {
-        var model = this;
-        return _.filter(this.searchAttributes, key => model.searchAttribute(key, searchFor));
+        return _.filter(this.searchAttributes, key => this.searchAttribute(key, searchFor));
     },
 
     /** alias of search, but returns a boolean; accepts attribute specifiers where
@@ -266,12 +265,11 @@ var SearchableModelMixin = {
      *      To include whitespace in terms: wrap the term in double quotations (name="blah bler").
      */
     matchesAll: function(terms) {
-        var model = this;
         // break the terms up by whitespace and filter out the empty strings
         terms = terms.match(/(".*"|\w*=".*"|\S*)/g).filter(s => !!s);
         return _.all(terms, term => {
             term = term.replace(/"/g, "");
-            return model.matches(term);
+            return this.matches(term);
         });
     }
 };
@@ -312,9 +310,8 @@ var HiddenUntilActivatedViewMixin = /** @lends hiddenUntilActivatedMixin# */ {
         this.hidden = this.isHidden();
 
         if ($activator) {
-            var mixin = this;
             $activator.on("click", ev => {
-                mixin.toggle(mixin.HUAVOptions.showSpeed);
+                this.toggle(mixin.HUAVOptions.showSpeed);
             });
         }
     },

--- a/client/galaxy/scripts/mvc/base/controlled-fetch-collection.js
+++ b/client/galaxy/scripts/mvc/base/controlled-fetch-collection.js
@@ -215,14 +215,13 @@ var PaginatedCollection = ControlledFetchCollection.extend({
 
     /** fetch the next page of data */
     fetchPage: function(pageNum, options) {
-        var self = this;
-        pageNum = self.constrainPageNum(pageNum);
-        self.currentPage = pageNum;
-        options = _.defaults(options || {}, self.getPageLimitOffset(pageNum));
+        pageNum = this.constrainPageNum(pageNum);
+        this.currentPage = pageNum;
+        options = _.defaults(options || {}, this.getPageLimitOffset(pageNum));
 
-        self.trigger("fetching-more");
-        return self.fetch(options).always(() => {
-            self.trigger("fetching-more-done");
+        this.trigger("fetching-more");
+        return this.fetch(options).always(() => {
+            this.trigger("fetching-more-done");
         });
     },
 
@@ -333,12 +332,11 @@ var InfinitelyScrollingCollection = ControlledFetchCollection.extend({
         // whitelist options to prevent allowing limit/offset/filters
         // (use vanilla fetch instead)
         options = options || {};
-        var self = this;
         options = _.pick(options, "silent");
         options.filters = {};
-        return self.fetch(options).done(() => {
-            self.allFetched = true;
-            self.trigger("all-fetched", self);
+        return this.fetch(options).done(() => {
+            this.allFetched = true;
+            this.trigger("all-fetched", this);
         });
     }
 });

--- a/client/galaxy/scripts/mvc/base/controlled-fetch-collection.js
+++ b/client/galaxy/scripts/mvc/base/controlled-fetch-collection.js
@@ -152,23 +152,22 @@ var ControlledFetchCollection = Backbone.Collection.extend({
      */
     setOrder: function(order, options) {
         options = options || {};
-        var collection = this;
-        var comparator = collection.comparators[order];
+        var comparator = this.comparators[order];
         if (_.isUndefined(comparator)) {
             throw new Error(`unknown order: ${order}`);
         }
         // if( _.isUndefined( comparator ) ){ return; }
-        if (comparator === collection.comparator) {
+        if (comparator === this.comparator) {
             return;
         }
 
-        collection.order = order;
-        collection.comparator = comparator;
+        this.order = order;
+        this.comparator = comparator;
 
         if (!options.silent) {
-            collection.trigger("changed-order", options);
+            this.trigger("changed-order", options);
         }
-        return collection;
+        return this;
     }
 });
 
@@ -289,10 +288,9 @@ var InfinitelyScrollingCollection = ControlledFetchCollection.extend({
 
         Galaxy.debug("ControlledFetchCollection.fetchMore:", options);
         options = _.clone(options || {});
-        var collection = this;
 
         Galaxy.debug("fetchMore, options.reset:", options.reset);
-        if (!options.reset && collection.allFetched) {
+        if (!options.reset && this.allFetched) {
             return jQuery.when();
         }
 
@@ -301,27 +299,27 @@ var InfinitelyScrollingCollection = ControlledFetchCollection.extend({
         if (options.reset) {
             options.offset = 0;
         } else if (options.offset === undefined) {
-            options.offset = collection.lastFetched;
+            options.offset = this.lastFetched;
         }
-        var limit = (options.limit = options.limit || collection.limitPerFetch || null);
+        var limit = (options.limit = options.limit || this.limitPerFetch || null);
         Galaxy.debug("fetchMore, limit:", limit, "offset:", options.offset);
 
-        collection.trigger("fetching-more");
+        this.trigger("fetching-more");
         return (
-            collection
+            this
                 .fetch(options)
                 .always(() => {
-                    collection.trigger("fetching-more-done");
+                    this.trigger("fetching-more-done");
                 })
                 // maintain allFetched flag and trigger if all were fetched this time
-                .done(function _postFetchMore(fetchedData) {
+                .done(fetchedData => {
                     var numFetched = _.isArray(fetchedData) ? fetchedData.length : 0;
-                    collection.lastFetched += numFetched;
-                    Galaxy.debug("fetchMore, lastFetched:", collection.lastFetched);
+                    this.lastFetched += numFetched;
+                    Galaxy.debug("fetchMore, lastFetched:", this.lastFetched);
                     // anything less than a full page means we got all there is to get
                     if (!limit || numFetched < limit) {
-                        collection.allFetched = true;
-                        collection.trigger("all-fetched", this);
+                        this.allFetched = true;
+                        this.trigger("all-fetched", this);
                     }
                 })
         );

--- a/client/galaxy/scripts/mvc/collection/base-creator.js
+++ b/client/galaxy/scripts/mvc/collection/base-creator.js
@@ -101,12 +101,11 @@ var CollectionCreatorMixin = {
 
     /** render the footer, completion controls, and cancel controls */
     _renderFooter: function(speed, callback) {
-        var self = this;
         var $footer = this.$(".footer")
             .empty()
             .html(this.templates.footer());
         _.each(this.footerSettings, (property, selector) => {
-            self.$(selector).prop("checked", self[property]);
+            this.$(selector).prop("checked", this[property]);
         });
         if (typeof this.oncancel === "function") {
             this.$(".cancel-create.btn").show();

--- a/client/galaxy/scripts/mvc/collection/collection-li-edit.js
+++ b/client/galaxy/scripts/mvc/collection/collection-li-edit.js
@@ -64,9 +64,8 @@ var DatasetDCEListItemEdit = DATASET_LI_EDIT.DatasetListItemEdit.extend(
          *  Note: fetch with no 'change' event triggering to prevent automatic rendering.
          */
         _fetchModelDetails: function() {
-            var view = this;
-            if (view.model.inReadyState() && !view.model.hasDetails()) {
-                return view.model.fetch({ silent: true });
+            if (this.model.inReadyState() && !this.model.hasDetails()) {
+                return this.model.fetch({ silent: true });
             }
             return $.when();
         },

--- a/client/galaxy/scripts/mvc/collection/collection-li.js
+++ b/client/galaxy/scripts/mvc/collection/collection-li.js
@@ -204,9 +204,8 @@ var DatasetDCEListItemView = DatasetListItemView.extend(
          *  Note: fetch with no 'change' event triggering to prevent automatic rendering.
          */
         _fetchModelDetails: function() {
-            var view = this;
-            if (view.model.inReadyState() && !view.model.hasDetails()) {
-                return view.model.fetch({ silent: true });
+            if (this.model.inReadyState() && !this.model.hasDetails()) {
+                return this.model.fetch({ silent: true });
             }
             return $.when();
         },

--- a/client/galaxy/scripts/mvc/collection/collection-view-edit.js
+++ b/client/galaxy/scripts/mvc/collection/collection-view-edit.js
@@ -57,7 +57,6 @@ var CollectionViewEdit = _super.extend(
             this.tagsEditorShown = true;
 
             //TODO: extract
-            var panel = this;
 
             var nameSelector = "> .controls .name";
             $where
@@ -65,15 +64,15 @@ var CollectionViewEdit = _super.extend(
                 .attr("title", _l("Click to rename collection"))
                 .tooltip({ placement: "bottom" })
                 .make_text_editable({
-                    on_finish: function(newName) {
-                        var previousName = panel.model.get("name");
+                    on_finish: newName => {
+                        var previousName = this.model.get("name");
                         if (newName && newName !== previousName) {
-                            panel.$el.find(nameSelector).text(newName);
-                            panel.model.save({ name: newName }).fail(() => {
-                                panel.$el.find(nameSelector).text(panel.model.previous("name"));
+                            this.$el.find(nameSelector).text(newName);
+                            this.model.save({ name: newName }).fail(() => {
+                                this.$el.find(nameSelector).text(this.model.previous("name"));
                             });
                         } else {
-                            panel.$el.find(nameSelector).text(previousName);
+                            this.$el.find(nameSelector).text(previousName);
                         }
                     }
                 });

--- a/client/galaxy/scripts/mvc/collection/collection-view.js
+++ b/client/galaxy/scripts/mvc/collection/collection-view.js
@@ -51,14 +51,13 @@ var CollectionView = _super.extend(
 
         _queueNewRender: function($newRender, speed) {
             speed = speed === undefined ? this.fxSpeed : speed;
-            var panel = this;
             this.handleWarning($newRender);
-            panel.log("_queueNewRender:", $newRender, speed);
+            this.log("_queueNewRender:", $newRender, speed);
             // TODO: jquery@1.12 doesn't change display when the elem has display: flex
             // this causes display: block for those elems after the use of show/hide animations
             // animations are removed from this view for now until fixed
-            panel._swapNewRender($newRender);
-            panel.trigger("rendered", panel);
+            this._swapNewRender($newRender);
+            this.trigger("rendered", this);
         },
 
         handleWarning: function($newRender) {
@@ -105,11 +104,10 @@ var CollectionView = _super.extend(
         // ------------------------------------------------------------------------ collection sub-views
         /** In this override, add/remove expanded/collapsed model ids to/from web storage */
         _setUpItemViewListeners: function(view) {
-            var panel = this;
-            _super.prototype._setUpItemViewListeners.call(panel, view);
+            _super.prototype._setUpItemViewListeners.call(this, view);
 
             // use pub-sub to: handle drilldown expansion and collapse
-            panel.listenTo(view, {
+            this.listenTo(view, {
                 "expanded:drilldown": function(v, drilldown) {
                     this._expandDrilldownPanel(drilldown);
                 },

--- a/client/galaxy/scripts/mvc/collection/list-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/list-collection-creator.js
@@ -84,7 +84,7 @@ var DatasetCollectionElementView = Backbone.View.extend(BASE_MVC.LoggableMixin).
         var parentWidth = this.$el.parent().width();
         this.$el.animate({ "margin-right": parentWidth }, "fast", () => {
             this.trigger("discard", {
-                source: view
+                source: this
             });
             this.destroy();
         });

--- a/client/galaxy/scripts/mvc/collection/pair-collection-creator.js
+++ b/client/galaxy/scripts/mvc/collection/pair-collection-creator.js
@@ -86,20 +86,19 @@ var PairCollectionCreator = _super.extend({
     _renderList: function(speed, callback) {
         //this.debug( '-- _renderList' );
         //precondition: there are two valid elements in workingElements
-        var creator = this;
 
         var $tmp = $("<div/>");
-        var $list = creator.$list();
+        var $list = this.$list();
 
         // lose the original views, create the new, append all at once, then call their renders
         _.each(this.elementViews, view => {
             view.destroy();
-            creator.removeElementView(view);
+            this.removeElementView(view);
         });
-        $tmp.append(creator._createForwardElementView().$el);
-        $tmp.append(creator._createReverseElementView().$el);
+        $tmp.append(this._createForwardElementView().$el);
+        $tmp.append(this._createReverseElementView().$el);
         $list.empty().append($tmp.children());
-        _.invoke(creator.elementViews, "render");
+        _.invoke(this.elementViews, "render");
     },
 
     /** create the forward element view */

--- a/client/galaxy/scripts/mvc/dataset/data.js
+++ b/client/galaxy/scripts/mvc/dataset/data.js
@@ -98,20 +98,18 @@ export var TabularDataset = Dataset.extend({
         }
 
         // Get next chunk.
-        var self = this;
-
         var next_chunk = $.Deferred();
         $.getJSON(this.attributes.chunk_url, {
-            offset: self.attributes.offset
+            offset: this.attributes.offset
         }).success(chunk => {
             var rval;
             if (chunk.ck_data !== "") {
                 // Found chunk.
                 rval = chunk;
-                self.attributes.offset = chunk.offset;
+                this.attributes.offset = chunk.offset;
             } else {
                 // At EOF.
-                self.attributes.at_eof = true;
+                this.attributes.at_eof = true;
                 rval = null;
             }
             next_chunk.resolve(rval);
@@ -153,17 +151,16 @@ var TabularDatasetChunkedView = Backbone.View.extend({
     },
 
     attempt_to_fetch: function(func) {
-        var self = this;
         if (!this.loading_chunk && this.scrolled_to_bottom()) {
             this.loading_chunk = true;
             this.loading_indicator.show();
-            $.when(self.model.get_next_chunk()).then(result => {
+            $.when(this.model.get_next_chunk()).then(result => {
                 if (result) {
-                    self._renderChunk(result);
-                    self.loading_chunk = false;
+                    this._renderChunk(result);
+                    this.loading_chunk = false;
                 }
-                self.loading_indicator.hide();
-                self.expand_to_container();
+                this.loading_indicator.hide();
+                this.expand_to_container();
             });
         }
     },
@@ -191,16 +188,14 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         }
 
         // Render first chunk.
-        var self = this;
-
         var first_chunk = this.model.get("first_data_chunk");
         if (first_chunk) {
             // First chunk is bootstrapped, so render now.
             this._renderChunk(first_chunk);
         } else {
             // No bootstrapping, so get first chunk and then render.
-            $.when(self.model.get_next_chunk()).then(result => {
-                self._renderChunk(result);
+            $.when(this.model.get_next_chunk()).then(result => {
+                this._renderChunk(result);
             });
         }
 
@@ -208,7 +203,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
 
         // Set up chunk loading when scrolling using the scrolling element.
         this.scroll_elt.scroll(() => {
-            self.attempt_to_fetch();
+            this.attempt_to_fetch();
         });
     },
 
@@ -517,7 +512,6 @@ var TabularButtonTracksterView = Backbone.View.extend({
 
     // show button
     show: function(e) {
-        var self = this;
 
         // is numeric
         function is_numeric(n) {
@@ -569,9 +563,9 @@ var TabularButtonTracksterView = Backbone.View.extend({
             });
             $("#btn_viz").off("click");
             $("#btn_viz").click(() => {
-                self.frame.add({
+                this.frame.add({
                     title: _l("Trackster"),
-                    url: `${self.url_viz}/trackster?${$.param(btn_viz_pars)}`
+                    url: `${this.url_viz}/trackster?${$.param(btn_viz_pars)}`
                 });
             });
 

--- a/client/galaxy/scripts/mvc/dataset/dataset-choice.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-choice.js
@@ -272,13 +272,12 @@ var DatasetChoice = Backbone.View.extend(BASE_MVC.LoggableMixin).extend({
     //TODO:?? why not just pass in view?
     /** return a plain JSON object with both the view and dataset attributes */
     toJSON: function() {
-        var chooser = this;
         return {
-            label: chooser.label,
-            datasets: chooser.datasetJSON,
+            label: this.label,
+            datasets: this.datasetJSON,
             selected: _.compact(
-                _.map(chooser.selected, id =>
-                    _.findWhere(chooser.datasetJSON, {
+                _.map(this.selected, id =>
+                    _.findWhere(this.datasetJSON, {
                         id: id
                     })
                 )
@@ -300,20 +299,19 @@ var DatasetChoice = Backbone.View.extend(BASE_MVC.LoggableMixin).extend({
      *  @fires 'error' if the modal has no selectable datasets based on this.where - passed this and other args
      */
     chooseWithModal: function() {
-        var chooser = this;
 
         return this._createModal()
             .done(json => {
                 if (json) {
-                    chooser.selected = _.pluck(json, "id");
-                    chooser.trigger("selected", chooser, json);
-                    chooser.render();
+                    this.selected = _.pluck(json, "id");
+                    this.trigger("selected", this, json);
+                    this.render();
                 } else {
-                    chooser.trigger("cancelled", chooser);
+                    this.trigger("cancelled", this);
                 }
             })
             .fail(function() {
-                chooser.trigger("error", chooser, arguments);
+                this.trigger("error", this, arguments);
             });
     },
 

--- a/client/galaxy/scripts/mvc/dataset/dataset-edit-attributes.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-edit-attributes.js
@@ -31,22 +31,21 @@ var View = Backbone.View.extend({
 
     /** fetch data for the selected dataset and build forms */
     render: function() {
-        var self = this;
         $.ajax({
-            url: `${getAppRoot()}dataset/get_edit?dataset_id=${self.model.get("dataset_id")}`,
-            success: function(response) {
-                !self.initial_message && self.message.update(response);
-                self.initial_message = true;
-                _.each(self.forms, (form, key) => {
+            url: `${getAppRoot()}dataset/get_edit?dataset_id=${this.model.get("dataset_id")}`,
+            success: response => {
+                !this.initial_message && this.message.update(response);
+                this.initial_message = true;
+                _.each(this.forms, (form, key) => {
                     form.model.set("inputs", response[`${key}_inputs`]);
                     form.model.set("hide_operations", response[`${key}_disable`]);
                     form.render();
                 });
-                self.$el.show();
+                this.$el.show();
             },
-            error: function(response) {
+            error: response => {
                 var err_msg = response.responseJSON && response.responseJSON.err_msg;
-                self.message.update({
+                this.message.update({
                     status: "danger",
                     message: err_msg || "Error occurred while loading the dataset."
                 });
@@ -56,7 +55,6 @@ var View = Backbone.View.extend({
 
     /** submit data to backend to update attributes */
     _submit: function(operation, form) {
-        var self = this;
         var data = form.data.create();
         data.dataset_id = this.model.get("dataset_id");
         data.operation = operation;
@@ -64,14 +62,14 @@ var View = Backbone.View.extend({
             type: "PUT",
             url: `${getAppRoot()}dataset/set_edit`,
             data: data,
-            success: function(response) {
-                self.message.update(response);
-                self.render();
-                self._reloadHistory();
+            success: response => {
+                this.message.update(response);
+                this.render();
+                this._reloadHistory();
             },
-            error: function(response) {
+            error: response => {
                 var err_msg = response.responseJSON && response.responseJSON.err_msg;
-                self.message.update({
+                this.message.update({
                     status: "danger",
                     message: err_msg || "Error occurred while editing the dataset attributes."
                 });
@@ -121,7 +119,6 @@ var View = Backbone.View.extend({
 
     /** edit main attributes form */
     _getAttribute: function() {
-        var self = this;
         var form = new Form({
             title: _l("Edit attributes"),
             operations: {
@@ -129,8 +126,8 @@ var View = Backbone.View.extend({
                     tooltip: _l("Save attributes of the dataset."),
                     icon: "fa-floppy-o",
                     title: _l("Save"),
-                    onclick: function() {
-                        self._submit("attributes", form);
+                    onclick: () => {
+                        this._submit("attributes", form);
                     }
                 }),
                 submit_autodetect: new Ui.Button({
@@ -138,8 +135,8 @@ var View = Backbone.View.extend({
                         "This will inspect the dataset and attempt to correct the values of fields if they are not accurate.",
                     icon: "fa-undo",
                     title: "Auto-detect",
-                    onclick: function() {
-                        self._submit("autodetect", form);
+                    onclick: () => {
+                        this._submit("autodetect", form);
                     }
                 })
             }
@@ -149,7 +146,6 @@ var View = Backbone.View.extend({
 
     /** datatype conversion form */
     _getConversion: function() {
-        var self = this;
         var form = new Form({
             title: _l("Convert to new format"),
             operations: {
@@ -157,8 +153,8 @@ var View = Backbone.View.extend({
                     tooltip: _l("Convert the datatype to a new format."),
                     title: _l("Convert datatype"),
                     icon: "fa-exchange",
-                    onclick: function() {
-                        self._submit("conversion", form);
+                    onclick: () => {
+                        this._submit("conversion", form);
                     }
                 })
             }
@@ -168,7 +164,6 @@ var View = Backbone.View.extend({
 
     /** change datatype form */
     _getDatatype: function() {
-        var self = this;
         var form = new Form({
             title: _l("Change datatype"),
             operations: {
@@ -176,16 +171,16 @@ var View = Backbone.View.extend({
                     tooltip: _l("Change the datatype to a new type."),
                     title: _l("Change datatype"),
                     icon: "fa-exchange",
-                    onclick: function() {
-                        self._submit("datatype", form);
+                    onclick: () => {
+                        this._submit("datatype", form);
                     }
                 }),
                 submit_datatype_detect: new Ui.Button({
                     tooltip: _l("Detect the datatype and change it."),
                     title: _l("Detect datatype"),
                     icon: "fa-undo",
-                    onclick: function() {
-                        self._submit("datatype_detect", form);
+                    onclick: () => {
+                        this._submit("datatype_detect", form);
                     }
                 })
             }
@@ -195,7 +190,6 @@ var View = Backbone.View.extend({
 
     /** dataset permissions form */
     _getPermission: function() {
-        var self = this;
         var form = new Form({
             title: _l("Manage dataset permissions"),
             operations: {
@@ -203,8 +197,8 @@ var View = Backbone.View.extend({
                     tooltip: _l("Save permissions."),
                     title: _l("Save permissions"),
                     icon: "fa-floppy-o ",
-                    onclick: function() {
-                        self._submit("permission", form);
+                    onclick: () => {
+                        this._submit("permission", form);
                     }
                 })
             }

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -343,7 +343,6 @@ var DatasetListItemEdit = _super.extend(
             if (!this.hasUser) {
                 return;
             }
-            var view = this;
             this.annotationEditor = new ANNOTATIONS.AnnotationEditor({
                 model: this.model,
                 el: $where.find(".annotation-display"),
@@ -351,11 +350,11 @@ var DatasetListItemEdit = _super.extend(
                     this.render();
                 },
                 // persist state on the hda view (and not the editor) since these are currently re-created each time
-                onshow: function() {
-                    view.annotationEditorShown = true;
+                onshow: () => {
+                    this.annotationEditorShown = true;
                 },
-                onhide: function() {
-                    view.annotationEditorShown = false;
+                onhide: () => {
+                    this.annotationEditorShown = false;
                 },
                 $activator: faIconButton({
                     title: _l("Edit dataset annotation"),

--- a/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li-edit.js
@@ -48,7 +48,6 @@ var DatasetListItemEdit = _super.extend(
 
         /** Render icon-button to edit the attributes (format, permissions, etc.) this dataset. */
         _renderEditButton: function() {
-            var self = this;
             // don't show edit while uploading, in-accessible
             // DO show if in error (ala previous history panel)
             if (this.model.get("state") === STATES.DISCARDED || !this.model.get("accessible")) {
@@ -62,12 +61,12 @@ var DatasetListItemEdit = _super.extend(
                 href: `${getAppRoot()}datasets/edit?dataset_id=${this.model.attributes.id}`,
                 faIcon: "fa-pencil",
                 classes: "edit-btn",
-                onclick: function(ev) {
+                onclick: e => {
                     const Galaxy = getGalaxyInstance();
                     if (Galaxy.router) {
-                        ev.preventDefault();
+                        e.preventDefault();
                         Galaxy.router.push("datasets/edit", {
-                            dataset_id: self.model.attributes.id
+                            dataset_id: this.model.attributes.id
                         });
                     }
                 }
@@ -97,16 +96,15 @@ var DatasetListItemEdit = _super.extend(
                 return null;
             }
 
-            var self = this;
             var deletedAlready = this.model.isDeletedOrPurged();
             return faIconButton({
                 title: !deletedAlready ? _l("Delete") : _l("Dataset is already deleted"),
                 disabled: deletedAlready,
                 faIcon: "fa-times",
                 classes: "delete-btn",
-                onclick: function() {
-                    self.$el.find(".icon-btn.delete-btn").tooltip("dispose");
-                    self.model["delete"]();
+                onclick: () => {
+                    this.$el.find(".icon-btn.delete-btn").tooltip("dispose");
+                    this.model["delete"]();
                 }
             });
         },
@@ -139,7 +137,6 @@ var DatasetListItemEdit = _super.extend(
         _renderToolHelpButton: function() {
             var datasetID = this.model.attributes.dataset_id;
             var jobID = this.model.attributes.creating_job;
-            var self = this;
 
             var parseToolBuild = data => {
                 var helpString = `<div id="thdiv-${datasetID}" class="toolhelp">`;
@@ -150,7 +147,7 @@ var DatasetListItemEdit = _super.extend(
                     helpString += "<strong>Tool help is unavailable for this dataset.</strong><hr/>";
                 }
                 helpString += "</div>";
-                self.$el.find(".details").append($.parseHTML(helpString));
+                this.$el.find(".details").append($.parseHTML(helpString));
             };
             var parseToolID = data => {
                 $.ajax({
@@ -174,9 +171,9 @@ var DatasetListItemEdit = _super.extend(
                 classes: "icon-btn",
                 href: "#",
                 faIcon: "fa-question",
-                onclick: function() {
-                    if (self.$el.find(".toolhelp").length > 0) {
-                        self.$el.find(".toolhelp").toggle();
+                onclick: () => {
+                    if (this.$el.find(".toolhelp").length > 0) {
+                        this.$el.find(".toolhelp").toggle();
                     } else {
                         $.ajax({
                             url: `${getAppRoot()}api/jobs/${jobID}`
@@ -219,18 +216,17 @@ var DatasetListItemEdit = _super.extend(
 
         /** Render icon-button to report an error on this dataset to the galaxy admin. */
         _renderErrButton: function() {
-            var self = this;
             return faIconButton({
                 title: _l("View or report this error"),
                 href: `${getAppRoot()}datasets/error?dataset_id=${this.model.attributes.id}`,
                 classes: "report-error-btn",
                 faIcon: "fa-bug",
-                onclick: function(ev) {
+                onclick: e => {
                     const Galaxy = getGalaxyInstance();
                     if (Galaxy.router) {
-                        ev.preventDefault();
+                        e.preventDefault();
                         Galaxy.router.push("datasets/error", {
-                            dataset_id: self.model.attributes.id
+                            dataset_id: this.model.attributes.id
                         });
                     }
                 }

--- a/client/galaxy/scripts/mvc/dataset/dataset-li.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li.js
@@ -96,9 +96,8 @@ export var DatasetListItemView = _super.extend(
          *  Note: fetch with no 'change' event triggering to prevent automatic rendering.
          */
         _fetchModelDetails: function() {
-            var view = this;
-            if (view.model.inReadyState() && !view.model.hasDetails()) {
-                return view.model.fetch({ silent: true });
+            if (this.model.inReadyState() && !this.model.hasDetails()) {
+                return this.model.fetch({ silent: true });
             }
             return $.when();
         },
@@ -109,12 +108,11 @@ export var DatasetListItemView = _super.extend(
          *  @param {Function} callback      an optional function called when removal is done (scoped to this view)
          */
         remove: function(speed, callback) {
-            var view = this;
             speed = speed || this.fxSpeed;
             this.$el.fadeOut(speed, () => {
-                Backbone.View.prototype.remove.call(view);
+                Backbone.View.prototype.remove.call(this);
                 if (callback) {
-                    callback.call(view);
+                    callback.call(this);
                 }
             });
         },
@@ -228,12 +226,11 @@ export var DatasetListItemView = _super.extend(
 
         /** Render messages to be displayed only when the details are shown */
         _renderDetailMessages: function() {
-            var view = this;
             var $warnings = $('<div class="detail-messages"></div>');
-            var json = view.model.toJSON();
+            var json = this.model.toJSON();
             //TODO:! unordered (map)
             _.each(view.templates.detailMessages, templateFn => {
-                $warnings.append($(templateFn(json, view)));
+                $warnings.append($(templateFn(json, this)));
             });
             return $warnings;
         },

--- a/client/galaxy/scripts/mvc/dataset/dataset-li.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-li.js
@@ -60,32 +60,31 @@ export var DatasetListItemView = _super.extend(
         /** event listeners */
         _setUpListeners: function() {
             _super.prototype._setUpListeners.call(this);
-            var self = this;
 
             // re-rendering on any model changes
-            return self.listenTo(self.model, {
-                change: function(model) {
+            return this.listenTo(this.model, {
+                change: model => {
                     // if the model moved into the ready state and is expanded without details, fetch those details now
                     if (
-                        self.model.changedAttributes().state &&
-                        self.model.inReadyState() &&
-                        self.expanded &&
-                        !self.model.hasDetails()
+                        this.model.changedAttributes().state &&
+                        this.model.inReadyState() &&
+                        this.expanded &&
+                        !this.model.hasDetails()
                     ) {
                         // normally, will render automatically (due to fetch -> change),
                         // but! setting_metadata sometimes doesn't cause any other changes besides state
                         // so, not rendering causes it to seem frozen in setting_metadata state
-                        self.model.fetch({ silent: true }).done(() => {
-                            self.render();
+                        this.model.fetch({ silent: true }).done(() => {
+                            this.render();
                         });
                     } else {
-                        if (_.has(self.model.changed, "tags") && _.keys(self.model.changed).length === 2) {
+                        if (_.has(this.model.changed, "tags") && _.keys(this.model.changed).length === 2) {
                             // If only the tags and update time have changed,
                             // rerender specifically the titlebar region.
                             // Otherwise default to the full render.
-                            self._mountVueNametags();
+                            this._mountVueNametags();
                         } else {
-                            self.render();
+                            this.render();
                         }
                     }
                 }
@@ -179,12 +178,11 @@ export var DatasetListItemView = _super.extend(
                 displayBtnData.href = this.model.urls.display;
 
                 // add frame manager option onclick event
-                var self = this;
                 displayBtnData.onclick = ev => {
                     const Galaxy = getGalaxyInstance();
                     if (Galaxy.frame && Galaxy.frame.active) {
                         // Add dataset to frames.
-                        Galaxy.frame.addDataset(self.model.get("id"));
+                        Galaxy.frame.addDataset(this.model.get("id"));
                         ev.preventDefault();
                     }
                 };

--- a/client/galaxy/scripts/mvc/dataset/dataset-model.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-model.js
@@ -147,9 +147,8 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
 
             // ........................................................................ ajax
             fetch: function(options) {
-                var dataset = this;
                 return Backbone.Model.prototype.fetch.call(this, options).always(() => {
-                    dataset._generateUrls();
+                    this._generateUrls();
                 });
             },
 
@@ -199,11 +198,10 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
 
                 //TODO: ideally this would be a DELETE call to the api
                 //  using purge async for now
-                var hda = this;
 
                 var xhr = jQuery.ajax(options);
                 xhr.done((message, status, responseObj) => {
-                    hda.set({ deleted: true, purged: true });
+                    this.set({ deleted: true, purged: true });
                 });
                 xhr.fail((xhr, status, message) => {
                     // Exception messages are hidden within error page including:  '...not allowed in this Galaxy instance.'
@@ -217,7 +215,7 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
                         error = messageBuriedInUnfortunatelyFormattedError;
                     }
                     xhr.responseText = error;
-                    hda.trigger("error", hda, xhr, options, _l(error), {
+                    this.trigger("error", this, xhr, options, _l(error), {
                         error: error
                     });
                 });

--- a/client/galaxy/scripts/mvc/form/form-data.js
+++ b/client/galaxy/scripts/mvc/form/form-data.js
@@ -12,10 +12,9 @@ export var Manager = Backbone.Model.extend({
     /** Creates a checksum. */
     checksum: function() {
         var sum = "";
-        var self = this;
-        this.app.section.$el.find(".section-row").each(function() {
-            var id = $(this).attr("id");
-            var field = self.app.field_list[id];
+        this.app.section.$el.find(".section-row").each((index, element) => {
+            var id = $(element).attr("id");
+            var field = this.app.field_list[id];
             if (field) {
                 sum += `${id}:${JSON.stringify(field.value && field.value())}:${field.collapsed}:${field.connected};`;
             }
@@ -25,7 +24,6 @@ export var Manager = Backbone.Model.extend({
 
     /** Convert dom into a dictionary of flat id/value pairs used e.g. on job submission. */
     create: function() {
-        var self = this;
 
         // get raw dictionary from dom
         var dict = {};
@@ -34,15 +32,15 @@ export var Manager = Backbone.Model.extend({
         // add to result dictionary, label elements
         var result_dict = {};
         this.flat_dict = {};
-        function add(flat_id, input_id, input_value) {
-            self.flat_dict[flat_id] = input_id;
+        const add = (flat_id, input_id, input_value) => {
+            this.flat_dict[flat_id] = input_id;
             result_dict[flat_id] = input_value;
-            if (self.app.element_list[input_id]) {
-                self.app.element_list[input_id].$el.attr("tour_id", flat_id);
+            if (this.app.element_list[input_id]) {
+                this.app.element_list[input_id].$el.attr("tour_id", flat_id);
             }
         }
         // converter between raw dictionary and job dictionary
-        function convert(identifier, head) {
+        const convert = (identifier, head) => {
             for (var index in head) {
                 var node = head[index];
                 if (node.input) {
@@ -74,7 +72,7 @@ export var Manager = Backbone.Model.extend({
                             }
                             break;
                         case "conditional":
-                            var value = self.app.field_list[input.id].value();
+                            var value = this.app.field_list[input.id].value();
                             add(`${flat_id}|${input.test_param.name}`, input.id, value);
                             var selectedCase = matchCase(input, value);
                             if (selectedCase != -1) {
@@ -85,7 +83,7 @@ export var Manager = Backbone.Model.extend({
                             convert((!input.flat && flat_id) || "", node);
                             break;
                         default:
-                            var field = self.app.field_list[input.id];
+                            var field = this.app.field_list[input.id];
                             if (field && field.value) {
                                 value = field.value();
                                 if (input.ignore === undefined || input.ignore != value) {
@@ -126,10 +124,9 @@ export var Manager = Backbone.Model.extend({
     /** Matches a new tool model to the current input elements e.g. used to update dynamic options
      */
     matchModel: function(model, callback) {
-        var self = this;
         visitInputs(model.inputs, (input, name) => {
-            if (self.flat_dict[name]) {
-                callback(input, self.flat_dict[name]);
+            if (this.flat_dict[name]) {
+                callback(input, this.flat_dict[name]);
             }
         });
     },
@@ -138,10 +135,9 @@ export var Manager = Backbone.Model.extend({
      */
     matchResponse: function(response) {
         var result = {};
-        var self = this;
-        function search(id, head) {
+        const search = (id, head) => {
             if (typeof head === "string") {
-                var input_id = self.flat_dict[id];
+                var input_id = this.flat_dict[id];
                 if (input_id) {
                     result[input_id] = head;
                 }
@@ -166,17 +162,15 @@ export var Manager = Backbone.Model.extend({
     /** Map dom tree to dictionary tree with input elements.
      */
     _iterate: function(parent, dict) {
-        var self = this;
         var children = $(parent).children();
-        children.each(function() {
-            var child = this;
+        children.each((index, child) => {
             var id = $(child).attr("id");
             if ($(child).hasClass("section-row")) {
-                var input = self.app.input_list[id];
+                var input = this.app.input_list[id];
                 dict[id] = (input && { input: input }) || {};
-                self._iterate(child, dict[id]);
+                this._iterate(child, dict[id]);
             } else {
-                self._iterate(child, dict);
+                this._iterate(child, dict);
             }
         });
     }

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -51,24 +51,23 @@ export default Backbone.View.extend({
         this.render();
 
         // add click handler
-        var self = this;
         this.$collapsible_icon.on("click", () => {
-            self.field.collapsed = !self.field.collapsed;
-            self.field.connected = false;
+            this.field.collapsed = !this.field.collapsed;
+            this.field.connected = false;
             app.trigger && app.trigger("change");
-            self.render();
+            this.render();
         });
         this.$connected_icon.on("click", () => {
-            self.field.connected = !self.field.connected;
-            self.field.collapsed = self.field.connected;
+            this.field.connected = !this.field.connected;
+            this.field.collapsed = this.field.connected;
             app.trigger && app.trigger("change");
-            self.render();
+            this.render();
         });
 
         // hide error on value change
         if (this.field.model && !this.model.get("always_refresh")) {
             this.listenTo(this.field.model, "change:value", () => {
-                self.reset();
+                this.reset();
             });
         }
 

--- a/client/galaxy/scripts/mvc/form/form-section.js
+++ b/client/galaxy/scripts/mvc/form/form-section.js
@@ -20,10 +20,9 @@ var View = Backbone.View.extend({
 
     /** Render section view */
     render: function() {
-        var self = this;
         this.$el.empty();
         _.each(this.inputs, input => {
-            self.add(input);
+            this.add(input);
         });
     },
 
@@ -49,7 +48,6 @@ var View = Backbone.View.extend({
 
     /** Add a conditional block */
     _addConditional: function(input_def) {
-        var self = this;
         input_def.test_param.id = input_def.id;
         input_def.test_param.textable = false;
         this.app.model.get("sustain_conditionals") && (input_def.test_param.disabled = true);
@@ -64,10 +62,10 @@ var View = Backbone.View.extend({
                 this._append(sub_section.$el.addClass("ui-portlet-section pl-2"), `${input_def.id}-section-${i}`);
             }
             field.model.set("onchange", value => {
-                var selectedCase = self.app.data.matchCase(input_def, value);
+                var selectedCase = this.app.data.matchCase(input_def, value);
                 for (var i in input_def.cases) {
                     var case_def = input_def.cases[i];
-                    var section_row = self.$(`#${input_def.id}-section-${i}`);
+                    var section_row = this.$(`#${input_def.id}-section-${i}`);
                     var nonhidden = false;
                     for (var j in case_def.inputs) {
                         if (!case_def.inputs[j].hidden) {
@@ -81,7 +79,7 @@ var View = Backbone.View.extend({
                         section_row.hide();
                     }
                 }
-                self.app.trigger("change");
+                this.app.trigger("change");
             });
             // trigger refresh on conditional input field after all input elements have been created
             field.trigger("change");
@@ -90,7 +88,6 @@ var View = Backbone.View.extend({
 
     /** Add a repeat block */
     _addRepeat: function(input_def) {
-        var self = this;
         var block_index = 0;
 
         // create repeat block element
@@ -98,24 +95,25 @@ var View = Backbone.View.extend({
             title: input_def.title || "Repeat",
             min: input_def.min,
             max: input_def.max,
-            onnew: function() {
-                create(input_def.inputs);
-                self.app.trigger("change");
-            }
         });
 
         // helper function to create new repeat blocks
-        function create(inputs) {
+        const create = inputs => {
             var sub_section_id = `${input_def.id}-section-${block_index++}`;
-            var sub_section = new View(self.app, { inputs: inputs });
+            var sub_section = new View(this.app, { inputs: inputs });
             repeat.add({
                 id: sub_section_id,
                 $el: sub_section.$el,
-                ondel: function() {
+                ondel: () => {
                     repeat.del(sub_section_id);
-                    self.app.trigger("change");
+                    this.app.trigger("change");
                 }
             });
+        }
+
+        repeat.onnew = () => {
+            create(input_def.inputs);
+            this.app.trigger("change");
         }
 
         //
@@ -161,12 +159,11 @@ var View = Backbone.View.extend({
 
     /** Add a single input field element */
     _addRow: function(input_def) {
-        var self = this;
         var id = input_def.id;
         input_def.onchange =
             input_def.onchange ||
             (() => {
-                self.app.trigger("change", id);
+                this.app.trigger("change", id);
             });
         var field = this.parameters.create(input_def);
         this.app.field_list[id] = field;

--- a/client/galaxy/scripts/mvc/form/form-view.js
+++ b/client/galaxy/scripts/mvc/form/form-view.js
@@ -27,9 +27,8 @@ export default Backbone.View.extend({
 
     /** Update available options */
     update: function(new_model) {
-        var self = this;
         this.data.matchModel(new_model, (node, input_id) => {
-            var field = self.field_list[input_id];
+            var field = this.field_list[input_id];
             if (field.update) {
                 field.update(node);
                 field.trigger("change");
@@ -89,7 +88,6 @@ export default Backbone.View.extend({
 
     /** Render tool form */
     render: function() {
-        var self = this;
         this.off("change");
         this.off("reset");
         // contains the dom field elements as created by the parameter factory i.e. form-parameters
@@ -108,17 +106,17 @@ export default Backbone.View.extend({
         // add listener which triggers on checksum change, and reset the form input wrappers
         var current_check = this.data.checksum();
         this.on("change", input_id => {
-            var input = self.input_list[input_id];
-            if (!input || input.refresh_on_change || self.model.get("always_refresh")) {
-                var new_check = self.data.checksum();
+            var input = this.input_list[input_id];
+            if (!input || input.refresh_on_change || this.model.get("always_refresh")) {
+                var new_check = this.data.checksum();
                 if (new_check != current_check) {
                     current_check = new_check;
-                    self.model.get("onchange")();
+                    this.model.get("onchange")();
                 }
             }
         });
         this.on("reset", () => {
-            _.each(self.element_list, input_element => {
+            _.each(this.element_list, input_element => {
                 input_element.reset();
             });
         });

--- a/client/galaxy/scripts/mvc/form/form-wrapper.js
+++ b/client/galaxy/scripts/mvc/form/form-wrapper.js
@@ -18,13 +18,12 @@ var View = Backbone.View.extend({
     },
 
     render: function() {
-        var self = this;
         $.ajax({
             url: getAppRoot() + this.url,
             type: "GET"
         })
             .done(response => {
-                var options = $.extend({}, self.model.attributes, response);
+                var options = $.extend({}, this.model.attributes, response);
                 var form = new Form({
                     title: options.title,
                     title_id: options.title_id,
@@ -40,18 +39,18 @@ var View = Backbone.View.extend({
                             title: options.submit_title || "Save",
                             icon: options.submit_icon || "fa-save",
                             cls: "btn btn-primary",
-                            onclick: function() {
-                                self._submit(form);
+                            onclick: () => {
+                                this._submit(form);
                             }
                         })
                     }
                 });
-                self.$el.empty().append(form.$el);
+                this.$el.empty().append(form.$el);
             })
             .fail(response => {
-                self.$el.empty().append(
+                this.$el.empty().append(
                     new Ui.Message({
-                        message: `Failed to load resource ${self.url}.`,
+                        message: `Failed to load resource ${this.url}.`,
                         status: "danger",
                         persistent: true
                     }).$el
@@ -60,9 +59,8 @@ var View = Backbone.View.extend({
     },
 
     _submit: function(form) {
-        var self = this;
         $.ajax({
-            url: getAppRoot() + self.url,
+            url: getAppRoot() + this.url,
             data: JSON.stringify(form.data.create()),
             type: "PUT",
             contentType: "application/json"
@@ -78,17 +76,17 @@ var View = Backbone.View.extend({
                         persistent: false
                     };
                 }
-                if (self.redirect) {
-                    window.location = `${getAppRoot() + self.redirect}?${$.param(params)}`;
+                if (this.redirect) {
+                    window.location = `${getAppRoot() + this.redirect}?${$.param(params)}`;
                 } else {
                     form.data.matchModel(response, (input, input_id) => {
                         form.field_list[input_id].value(input.value);
                     });
-                    self._showMessage(form, response.message);
+                    this._showMessage(form, response.message);
                 }
             })
             .fail(response => {
-                self._showMessage(form, {
+                this._showMessage(form, {
                     message: response.responseJSON.err_msg,
                     status: "danger",
                     persistent: false

--- a/client/galaxy/scripts/mvc/grid/grid-model.js
+++ b/client/galaxy/scripts/mvc/grid/grid-model.js
@@ -96,8 +96,7 @@ export default Backbone.Model.extend({
         }
 
         // Add filter arguments to data, placing "f-" in front of all arguments.
-        var self = this;
-        _.each(_.pairs(self.attributes.filters), k => {
+        _.each(_.pairs(this.attributes.filters), k => {
             url_data[`f-${k[0]}`] = k[1];
         });
         return url_data;

--- a/client/galaxy/scripts/mvc/grid/grid-shared.js
+++ b/client/galaxy/scripts/mvc/grid/grid-shared.js
@@ -9,7 +9,6 @@ import LoadingIndicator from "ui/loading-indicator";
 
 var View = Backbone.View.extend({
     initialize: function(options) {
-        var self = this;
         const Galaxy = getGalaxyInstance();
         LoadingIndicator.markViewAsLoading(this);
         this.model = new Backbone.Model(options);
@@ -20,9 +19,9 @@ var View = Backbone.View.extend({
         }
         $.ajax({
             url: `${getAppRoot() + this.item}/${this.model.get("action_id")}?${$.param(Galaxy.params)}`,
-            success: function(response) {
-                self.model.set(response);
-                self.render();
+            success: response => {
+                this.model.set(response);
+                this.render();
             }
         });
     },
@@ -34,7 +33,6 @@ var View = Backbone.View.extend({
     },
 
     _templateShared: function() {
-        var self = this;
         var $tmpl = $(`<div><br/><h2>${this.model.get("plural")} shared with you by others</h2></div>`);
         var options = this.model.attributes;
         if (options.shared_by_others && options.shared_by_others.length > 0) {
@@ -47,7 +45,7 @@ var View = Backbone.View.extend({
                     "</table>"
             );
             _.each(options.shared_by_others, (it, index) => {
-                var display_url = `${getAppRoot() + self.item}/display_by_username_and_slug?username=${
+                var display_url = `${getAppRoot() + this.item}/display_by_username_and_slug?username=${
                     it.username
                 }&slug=${it.slug}`;
                 $table.append(

--- a/client/galaxy/scripts/mvc/grid/grid-view.js
+++ b/client/galaxy/scripts/mvc/grid/grid-view.js
@@ -25,7 +25,6 @@ export default Backbone.View.extend({
         this.grid = new GridModel();
         this.title = grid_config.title;
         this.active_tab = grid_config.active_tab;
-        var self = this;
 
         // Subscribe to changes in the store, currently just storing
         // tag changes from the tagging components, but that will change
@@ -35,11 +34,11 @@ export default Backbone.View.extend({
             state => state.gridSearch.searchTags,
             newTags => {
                 const tagArray = Array.from(newTags);
-                self.grid.add_filter("tags", tagArray, false);
-                self.openAdvancedSearch();
-                self.render_filter_button("tags", tagArray);
-                self.go_page_one();
-                self.execute();
+                this.grid.add_filter("tags", tagArray, false);
+                this.openAdvancedSearch();
+                this.render_filter_button("tags", tagArray);
+                this.go_page_one();
+                this.execute();
             }
         );
 
@@ -51,10 +50,10 @@ export default Backbone.View.extend({
             });
             $.ajax({
                 url: `${grid_config.url_base}?${$.param(url_data)}`,
-                success: function(response) {
+                success: response => {
                     response.embedded = grid_config.embedded;
                     response.filters = grid_config.filters || {};
-                    self.init_grid(response);
+                    this.init_grid(response);
                 }
             });
         } else {
@@ -124,10 +123,9 @@ export default Backbone.View.extend({
         // update message
         if (options.message) {
             this.$el.find("#grid-message").html(Templates.message(options));
-            var self = this;
             if (options.use_hide_message) {
                 window.setTimeout(() => {
-                    self.$el.find("#grid-message").html("");
+                    this.$el.find("#grid-message").html("");
                 }, 5000);
             }
         }
@@ -143,14 +141,12 @@ export default Backbone.View.extend({
 
     // Initialize grid controls
     init_grid_controls: function() {
-        // link
-        var self = this;
 
         // Initialize grid operation button.
-        this.$el.find(".operation-button").each(function() {
-            $(this).off();
-            $(this).click(function() {
-                self.submit_operation(this);
+        this.$el.find(".operation-button").each((index, element) => {
+            $(element).off();
+            $(element).click(() => {
+                this.submit_operation(this);
                 return false;
             });
         });
@@ -168,10 +164,10 @@ export default Backbone.View.extend({
         });
 
         // Initialize sort links.
-        this.$el.find(".sort-link").each(function() {
-            $(this).off();
-            $(this).click(function() {
-                self.set_sort_condition($(this).attr("sort_key"));
+        this.$el.find(".sort-link").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
+                this.set_sort_condition($(e.currentTarget).attr("sort_key"));
                 return false;
             });
         });
@@ -179,27 +175,27 @@ export default Backbone.View.extend({
         // Initialize text filters.
         this.$el.find(".text-filter-form").each(function() {
             $(this).off();
-            $(this).submit(function() {
-                var column_key = $(this).attr("column_key");
+            $(this).submit(e => {
+                var column_key = $(e.currentTarget).attr("column_key");
                 var text_input_obj = $(`#input-${column_key}-filter`);
                 var text_input = text_input_obj.val();
                 text_input_obj.val("");
-                self.add_filter_condition(column_key, text_input);
+                this.add_filter_condition(column_key, text_input);
                 return false;
             });
         });
 
         // Initialize categorical filters.
-        this.$el.find(".text-filter-val > a").each(function() {
-            $(this).off();
-            $(this).click(function() {
+        this.$el.find(".text-filter-val > a").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
                 // Remove visible element.
-                $(this)
+                $(element)
                     .parent()
                     .remove();
 
                 // Remove filter condition.
-                self.remove_filter_condition($(this).attr("filter_key"), $(this).attr("filter_val"));
+                this.remove_filter_condition($(e.currentTarget).attr("filter_key"), $(e.currentTarget).attr("filter_val"));
 
                 // Return
                 return false;
@@ -207,20 +203,20 @@ export default Backbone.View.extend({
         });
 
         // Initialize categorical filters.
-        this.$el.find(".categorical-filter > a").each(function() {
-            $(this).off();
-            $(this).click(function() {
-                self.set_categorical_filter($(this).attr("filter_key"), $(this).attr("filter_val"));
+        this.$el.find(".categorical-filter > a").each((index, element) => {
+            $(element).off();
+            $(element).click(e => {
+                this.set_categorical_filter($(e.currentTarget).attr("filter_key"), $(e.currentTarget).attr("filter_val"));
                 return false;
             });
         });
 
         // Initialize standard, advanced search toggles.
-        this.$el.find(".advanced-search-toggle").each(function() {
-            $(this).off();
-            $(this).click(() => {
-                self.$el.find("#standard-search").slideToggle("fast");
-                self.$el.find("#advanced-search").slideToggle("fast");
+        this.$el.find(".advanced-search-toggle").each((index, element) => {
+            $(element).off();
+            $(element).click(() => {
+                this.$el.find("#standard-search").slideToggle("fast");
+                this.$el.find("#advanced-search").slideToggle("fast");
                 return false;
             });
         });
@@ -228,7 +224,7 @@ export default Backbone.View.extend({
         // Add event to check all box
         this.$el.find("#check_all").off();
         this.$el.find("#check_all").on("click", () => {
-            self.check_all_items();
+            this.check_all_items();
         });
     },
 
@@ -253,14 +249,13 @@ export default Backbone.View.extend({
 
         // get options
         var options = this.grid.attributes;
-        var self = this;
 
         //
         // add page click events
         //
-        this.$el.find(".page-link-grid > a").each(function() {
-            $(this).click(function() {
-                self.set_page($(this).attr("page_num"));
+        this.$el.find(".page-link-grid > a").each((index, element) => {
+            $(element).click(function() {
+                this.set_page($(element).attr("page_num"));
                 return false;
             });
         });
@@ -268,11 +263,11 @@ export default Backbone.View.extend({
         //
         // add inbound/outbound events
         //
-        this.$el.find(".use-target").each(function() {
-            $(this).click(function() {
-                self.execute({
-                    href: $(this).attr("href"),
-                    target: $(this).attr("target")
+        this.$el.find(".use-target").each((index, element) => {
+            $(element).click(e => {
+                this.execute({
+                    href: $(e.currentTarget).attr("href"),
+                    target: $(e.currentTarget).attr("target")
                 });
                 return false;
             });
@@ -286,17 +281,16 @@ export default Backbone.View.extend({
 
         // add operation popup menus
         _.each(options.items, (item, index) => {
-            var button = self.$(`#grid-${item.encode_id}-popup`).off();
+            var button = this.$(`#grid-${item.encode_id}-popup`).off();
             var popup = new PopupMenu(button);
             _.each(options.operations, operation => {
-                self.add_operation(popup, operation, item);
+                this.add_operation(popup, operation, item);
             });
         });
     },
 
     /** Add an operation to the items menu */
     add_operation: function(popup, operation, item) {
-        var self = this;
         var settings = item.operation_config[operation.label];
         if (settings.allowed && operation.allow_popup) {
             popup.addItem({
@@ -304,13 +298,13 @@ export default Backbone.View.extend({
                 href: settings.url_args,
                 target: settings.target,
                 confirmation_text: operation.confirm,
-                func: function(e) {
+                func: e => {
                     e.preventDefault();
                     var label = $(e.target).html();
                     if (operation.onclick) {
                         operation.onclick(item.encode_id);
                     } else {
-                        self.execute(this.findItemByHtml(label));
+                        this.execute(this.findItemByHtml(label));
                     }
                 }
             });
@@ -337,13 +331,12 @@ export default Backbone.View.extend({
     render_filter_button: function(name, value) {
         // Add button that displays filter and provides a button to delete it.
         var t = $(Templates.filter_element(name, value));
-        var self = this;
-        t.click(function() {
+        t.click( e => {
             // Remove visible element.
-            $(this).remove();
+            $(e.currentTarget).remove();
 
             // Remove filter condition.
-            self.remove_filter_condition(name, value);
+            this.remove_filter_condition(name, value);
         });
 
         // append to container
@@ -401,27 +394,26 @@ export default Backbone.View.extend({
         var category_filter = this.grid.get("categorical_filters")[name];
 
         var cur_value = this.grid.get("filters")[name];
-        var self = this;
-        this.$el.find(`.${name}-filter`).each(function() {
-            var text = $.trim($(this).text());
+        this.$el.find(`.${name}-filter`).each((index, element) => {
+            var text = $.trim($(element).text());
             var filter = category_filter[text];
             var filter_value = filter[name];
             if (filter_value == new_value) {
                 // Remove filter link since grid will be using this filter. It is assumed that
                 // this element has a single child, a hyperlink/anchor with text.
-                $(this).empty();
-                $(this).addClass("current-filter");
-                $(this).append(text);
+                $(element).empty();
+                $(element).addClass("current-filter");
+                $(element).append(text);
             } else if (filter_value == cur_value) {
                 // Add hyperlink for this filter since grid will no longer be using this filter. It is assumed that
                 // this element has a single child, a hyperlink/anchor.
-                $(this).empty();
+                $(element).empty();
                 var t = $(`<a href="javascript:void(0)" role="button">${text}</a>`);
                 t.click(() => {
-                    self.set_categorical_filter(name, filter_value);
+                    this.set_categorical_filter(name, filter_value);
                 });
-                $(this).removeClass("current-filter");
-                $(this).append(t);
+                $(e.currentTarget).removeClass("current-filter");
+                $(e.currentTarget).append(t);
             }
         });
 
@@ -434,35 +426,34 @@ export default Backbone.View.extend({
     // Set page to view.
     set_page: function(new_page) {
         // Update page hyperlink to reflect new page.
-        var self = this;
-        this.$el.find(".page-link").each(function() {
-            var id = $(this).attr("id");
+        this.$el.find(".page-link").each((index, element) => {
+            var id = $(element).attr("id");
 
             var // Id has form 'page-link-<page_num>
                 page_num = parseInt(id.split("-")[2], 10);
 
-            var cur_page = self.grid.get("cur_page");
+            var cur_page = this.grid.get("cur_page");
             var text;
             if (page_num === new_page) {
                 // Remove link to page since grid will be on this page. It is assumed that
                 // this element has a single child, a hyperlink/anchor with text.
-                text = $(this)
+                text = $(element)
                     .children()
                     .text();
-                $(this).empty();
-                $(this).addClass("inactive-link");
-                $(this).text(text);
+                $(element).empty();
+                $(element).addClass("inactive-link");
+                $(element).text(text);
             } else if (page_num === cur_page) {
                 // Add hyperlink to this page since grid will no longer be on this page. It is assumed that
                 // this element has a single child, a hyperlink/anchor.
-                text = $(this).text();
-                $(this).empty();
-                $(this).removeClass("inactive-link");
+                text = $(element).text();
+                $(element).empty();
+                $(element).removeClass("inactive-link");
                 var t = $(`<a href="javascript:void(0)" role="button">${text}</a>`);
                 t.click(() => {
-                    self.set_page(page_num);
+                    this.set_page(page_num);
                 });
-                $(this).append(t);
+                $(element).append(t);
             }
         });
 
@@ -655,19 +646,18 @@ export default Backbone.View.extend({
 
         // Show overlay to indicate loading and prevent user actions.
         this.$el.find(".loading-elt-overlay").show();
-        var self = this;
         $.ajax({
             type: method,
-            url: self.grid.get("url_base"),
-            data: self.grid.get_url_data(),
+            url: this.grid.get("url_base"),
+            data: this.grid.get_url_data(),
             error: function() {
                 alert("Grid refresh failed");
             },
-            success: function(response_text) {
+            success: response_text => {
                 // backup
-                var embedded = self.grid.get("embedded");
-                var insert = self.grid.get("insert");
-                var advanced_search = self.$el.find("#advanced-search").is(":visible");
+                var embedded = this.grid.get("embedded");
+                var insert = this.grid.get("insert");
+                var advanced_search = this.$el.find("#advanced-search").is(":visible");
 
                 // request new configuration
                 var json = response_text;
@@ -678,14 +668,14 @@ export default Backbone.View.extend({
                 json.advanced_search = advanced_search;
 
                 // Initialize new grid config
-                self.init_grid(json);
+                this.init_grid(json);
 
                 // Hide loading overlay.
-                self.$el.find(".loading-elt-overlay").hide();
+                this.$el.find(".loading-elt-overlay").hide();
             },
-            complete: function() {
+            complete: () => {
                 // Clear grid of transient request attributes.
-                self.grid.set({
+                this.grid.set({
                     operation: undefined,
                     item_ids: undefined
                 });

--- a/client/galaxy/scripts/mvc/history/history-model.js
+++ b/client/galaxy/scripts/mvc/history/history-model.js
@@ -266,17 +266,16 @@ export var History = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
             /** fetch this histories data (using options) then it's contents (using contentsOptions) */
             fetchWithContents: function(options, contentsOptions) {
                 options = options || {};
-                var self = this;
 
                 // console.log( this + '.fetchWithContents' );
                 // TODO: push down to a base class
                 options.view = "dev-detailed";
 
                 // fetch history then use history data to fetch (paginated) contents
-                return this.fetch(options).then(function getContents(history) {
-                    self.contents.history = self;
-                    self.contents.setHistoryId(history.id);
-                    return self.fetchContents(contentsOptions);
+                return this.fetch(options).then(history => {
+                    this.contents.history = this;
+                    this.contents.setHistoryId(history.id);
+                    return this.fetchContents(contentsOptions);
                 });
             },
 

--- a/client/galaxy/scripts/mvc/history/history-view-annotated.js
+++ b/client/galaxy/scripts/mvc/history/history-view-annotated.js
@@ -53,7 +53,7 @@ var AnnotatedHistoryView = _super.extend(
                 ])
                 .appendTo($controls);
 
-            return self.views;
+            return this.views;
         },
 
         // ------------------------------------------------------------------------ sub-views

--- a/client/galaxy/scripts/mvc/history/history-view-edit-current.js
+++ b/client/galaxy/scripts/mvc/history/history-view-edit-current.js
@@ -450,15 +450,14 @@ var CurrentHistoryView = _super.extend(
         //TODO: remove to batch
         /** unhide any hidden datasets */
         unhideHidden: function() {
-            var self = this;
             if (window.confirm(_l("Really unhide all hidden datasets?"))) {
                 // get all hidden, regardless of deleted/purged
-                return self.model.contents
+                return this.model.contents
                     ._filterAndUpdate({ visible: false, deleted: "", purged: "" }, { visible: true })
                     .done(() => {
                         // TODO: would be better to render these as they're unhidden instead of all at once
-                        if (!self.model.contents.includeHidden) {
-                            self.renderItems();
+                        if (!this.model.contents.includeHidden) {
+                            this.renderItems();
                         }
                     });
             }
@@ -467,9 +466,8 @@ var CurrentHistoryView = _super.extend(
 
         /** delete any hidden datasets */
         deleteHidden: function() {
-            var self = this;
             if (window.confirm(_l("Really delete all hidden datasets?"))) {
-                return self.model.contents._filterAndUpdate(
+                return this.model.contents._filterAndUpdate(
                     // get all hidden, regardless of deleted/purged
                     { visible: false, deleted: "", purged: "" },
                     // both delete *and* unhide them

--- a/client/galaxy/scripts/mvc/library/library-folder-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folder-view.js
@@ -68,10 +68,9 @@ var FolderView = Backbone.View.extend({
         var template = this.templateFolderPermissions();
         this.$el.html(template({ folder: this.model, is_admin: is_admin }));
 
-        var self = this;
-        $.get(`${getAppRoot()}api/folders/${self.id}/permissions?scope=current`)
+        $.get(`${getAppRoot()}api/folders/${this.id}/permissions?scope=current`)
             .done(fetched_permissions => {
-                self.prepareSelectBoxes({
+                this.prepareSelectBoxes({
                     fetched_permissions: fetched_permissions
                 });
             })
@@ -95,32 +94,31 @@ var FolderView = Backbone.View.extend({
     prepareSelectBoxes: function(options) {
         this.options = _.extend(this.options, options);
         var fetched_permissions = this.options.fetched_permissions;
-        var self = this;
 
         var selected_add_item_roles = this._serializeRoles(fetched_permissions.add_library_item_role_list);
         var selected_manage_folder_roles = this._serializeRoles(fetched_permissions.manage_folder_role_list);
         var selected_modify_folder_roles = this._serializeRoles(fetched_permissions.modify_folder_role_list);
 
-        self.addSelectObject = new mod_select.View(
+        this.addSelectObject = new mod_select.View(
             this._createSelectOptions(this, "add_perm", selected_add_item_roles, false)
         );
-        self.manageSelectObject = new mod_select.View(
+        this.manageSelectObject = new mod_select.View(
             this._createSelectOptions(this, "manage_perm", selected_manage_folder_roles, false)
         );
-        self.modifySelectObject = new mod_select.View(
+        this.modifySelectObject = new mod_select.View(
             this._createSelectOptions(this, "modify_perm", selected_modify_folder_roles, false)
         );
     },
 
-    _createSelectOptions: function(self, id, init_data) {
+    _createSelectOptions: function(context, id, init_data) {
         var select_options = {
             minimumInputLength: 0,
             css: id,
             multiple: true,
             placeholder: "Click to select a role",
-            container: self.$el.find(`#${id}`),
+            container: context.$el.find(`#${id}`),
             ajax: {
-                url: `${getAppRoot()}api/folders/${self.id}/permissions?scope=available`,
+                url: `${getAppRoot()}api/folders/${context.id}/permissions?scope=available`,
                 dataType: "json",
                 quietMillis: 100,
                 data: function(term, page) {
@@ -180,17 +178,16 @@ var FolderView = Backbone.View.extend({
      * Save the permissions for roles entered in the select boxes.
      */
     savePermissions: function(event) {
-        var self = this;
         var add_ids = this._extractIds(this.addSelectObject.$el.select2("data"));
         var manage_ids = this._extractIds(this.manageSelectObject.$el.select2("data"));
         var modify_ids = this._extractIds(this.modifySelectObject.$el.select2("data"));
-        $.post(`${getAppRoot()}api/folders/${self.id}/permissions?action=set_permissions`, {
+        $.post(`${getAppRoot()}api/folders/${this.id}/permissions?action=set_permissions`, {
             "add_ids[]": add_ids,
             "manage_ids[]": manage_ids,
             "modify_ids[]": modify_ids
         })
             .done(fetched_permissions => {
-                self.showPermissions({
+                this.showPermissions({
                     fetched_permissions: fetched_permissions
                 });
                 Toast.success("Permissions saved.");

--- a/client/galaxy/scripts/mvc/library/library-folderlist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderlist-view.js
@@ -62,7 +62,6 @@ var FolderListView = Backbone.View.extend({
 
     fetchFolder: function(options = {}) {
         this.options.include_deleted = options.include_deleted;
-        var self = this;
 
         this.folderContainer = new mod_library_model.FolderContainer({
             id: this.options.id
@@ -73,11 +72,11 @@ var FolderListView = Backbone.View.extend({
             this.folderContainer.url = `${this.folderContainer.url}?include_deleted=true`;
         }
         this.folderContainer.fetch({
-            success: function(folder_container) {
-                self.folder_container = folder_container;
-                self.render();
+            success: folder_container => {
+                this.folder_container = folder_container;
+                this.render();
             },
-            error: function(model, response) {
+            error: (model, response) => {
                 const Galaxy = getGalaxyInstance();
                 if (typeof response.responseJSON !== "undefined") {
                     Toast.error(`${response.responseJSON.err_msg} Click this to go back.`, "", {
@@ -123,7 +122,7 @@ var FolderListView = Backbone.View.extend({
 
         // when dataset_id is present render its details too
         if (this.options.dataset_id) {
-            var row = _.findWhere(self.rowViews, {
+            var row = _.findWhere(this.rowViews, {
                 id: this.options.dataset_id
             });
             if (row) {
@@ -212,9 +211,8 @@ var FolderListView = Backbone.View.extend({
      * function for each. Also binds the hover behavior.
      */
     renderAll: function() {
-        var self = this;
         _.each(this.collection.models.reverse(), model => {
-            self.renderOne(model);
+            this.renderOne(model);
         });
         this.postRender();
     },
@@ -298,16 +296,15 @@ var FolderListView = Backbone.View.extend({
      */
     selectAll: function(event) {
         var selected = event.target.checked;
-        var self = this;
         // Iterate each checkbox
-        $(":checkbox", "#folder_list_body").each(function() {
-            this.checked = selected;
-            var $row = $(this).closest("tr");
+        $(":checkbox", "#folder_list_body").each((index, element) => {
+            element.checked = selected;
+            var $row = $(element).closest("tr");
             // Change color of selected/unselected
             if (selected) {
-                self.makeDarkRow($row);
+                this.makeDarkRow($row);
             } else {
-                self.makeWhiteRow($row);
+                this.makeWhiteRow($row);
             }
         });
     },

--- a/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
+++ b/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
@@ -796,16 +796,15 @@ var FolderToolbarView = Backbone.View.extend({
      */
     selectAll: function(event) {
         var selected = event.target.checked;
-        var self = this;
         // Iterate each checkbox
-        $(":checkbox", "#dataset_list tbody").each(function() {
+        $(":checkbox", "#dataset_list tbody").each((index, element) => {
             this.checked = selected;
-            var $row = $(this).closest("tr");
+            var $row = $(element).closest("tr");
             // Change color of selected/unselected
             if (selected) {
-                self.makeDarkRow($row);
+                this.makeDarkRow($row);
             } else {
-                self.makeWhiteRow($row);
+                this.makeWhiteRow($row);
             }
         });
     },

--- a/client/galaxy/scripts/mvc/library/library-library-view.js
+++ b/client/galaxy/scripts/mvc/library/library-library-view.js
@@ -75,10 +75,9 @@ var LibraryView = Backbone.View.extend({
         var template = this.templateLibraryPermissions();
         this.$el.html(template({ library: this.model, is_admin: is_admin }));
 
-        var self = this;
-        $.get(`${getAppRoot()}api/libraries/${self.id}/permissions?scope=current`)
+        $.get(`${getAppRoot()}api/libraries/${this.id}/permissions?scope=current`)
             .done(fetched_permissions => {
-                self.prepareSelectBoxes({
+                this.prepareSelectBoxes({
                     fetched_permissions: fetched_permissions
                 });
             })
@@ -102,38 +101,37 @@ var LibraryView = Backbone.View.extend({
     prepareSelectBoxes: function(options) {
         this.options = _.extend(this.options, options);
         var fetched_permissions = this.options.fetched_permissions;
-        var self = this;
 
         var selected_access_library_roles = this._serializeRoles(fetched_permissions.access_library_role_list);
         var selected_add_item_roles = this._serializeRoles(fetched_permissions.add_library_item_role_list);
         var selected_manage_library_roles = this._serializeRoles(fetched_permissions.manage_library_role_list);
         var selected_modify_library_roles = this._serializeRoles(fetched_permissions.modify_library_role_list);
 
-        self.accessSelectObject = new mod_select.View(
+        this.accessSelectObject = new mod_select.View(
             this._createSelectOptions(this, "access_perm", selected_access_library_roles, true)
         );
-        self.addSelectObject = new mod_select.View(
+        this.addSelectObject = new mod_select.View(
             this._createSelectOptions(this, "add_perm", selected_add_item_roles, false)
         );
-        self.manageSelectObject = new mod_select.View(
+        this.manageSelectObject = new mod_select.View(
             this._createSelectOptions(this, "manage_perm", selected_manage_library_roles, false)
         );
-        self.modifySelectObject = new mod_select.View(
+        this.modifySelectObject = new mod_select.View(
             this._createSelectOptions(this, "modify_perm", selected_modify_library_roles, false)
         );
     },
 
-    _createSelectOptions: function(self, id, init_data, is_library_access) {
+    _createSelectOptions: function(context, id, init_data, is_library_access) {
         is_library_access = is_library_access === true ? is_library_access : false;
         var select_options = {
             minimumInputLength: 0,
             css: id,
             multiple: true,
             placeholder: "Click to select a role",
-            container: self.$el.find(`#${id}`),
+            container: context.$el.find(`#${id}`),
             ajax: {
                 url: `${getAppRoot()}api/libraries/${
-                    self.id
+                    context.id
                 }/permissions?scope=available&is_library_access=${is_library_access}`,
                 dataType: "json",
                 quietMillis: 100,
@@ -181,11 +179,10 @@ var LibraryView = Backbone.View.extend({
     },
 
     makeDatasetPrivate: function() {
-        var self = this;
-        $.post(`${getAppRoot()}api/libraries/datasets/${self.id}/permissions?action=make_private`)
+        $.post(`${getAppRoot()}api/libraries/datasets/${this.id}/permissions?action=make_private`)
             .done(fetched_permissions => {
-                self.model.set({ is_unrestricted: false });
-                self.showPermissions({
+                this.model.set({ is_unrestricted: false });
+                this.showPermissions({
                     fetched_permissions: fetched_permissions
                 });
                 Toast.success("The dataset is now private to you.");
@@ -196,11 +193,10 @@ var LibraryView = Backbone.View.extend({
     },
 
     removeDatasetRestrictions: function() {
-        var self = this;
-        $.post(`${getAppRoot()}api/libraries/datasets/${self.id}/permissions?action=remove_restrictions`)
+        $.post(`${getAppRoot()}api/libraries/datasets/${this.id}/permissions?action=remove_restrictions`)
             .done(fetched_permissions => {
-                self.model.set({ is_unrestricted: true });
-                self.showPermissions({
+                this.model.set({ is_unrestricted: true });
+                this.showPermissions({
                     fetched_permissions: fetched_permissions
                 });
                 Toast.success("Access to this dataset is now unrestricted.");
@@ -218,14 +214,13 @@ var LibraryView = Backbone.View.extend({
         return ids_list;
     },
     savePermissions: function(event) {
-        var self = this;
 
         var access_ids = this._extractIds(this.accessSelectObject.$el.select2("data"));
         var add_ids = this._extractIds(this.addSelectObject.$el.select2("data"));
         var manage_ids = this._extractIds(this.manageSelectObject.$el.select2("data"));
         var modify_ids = this._extractIds(this.modifySelectObject.$el.select2("data"));
 
-        $.post(`${getAppRoot()}api/libraries/${self.id}/permissions?action=set_permissions`, {
+        $.post(`${getAppRoot()}api/libraries/${this.id}/permissions?action=set_permissions`, {
             "access_ids[]": access_ids,
             "add_ids[]": add_ids,
             "manage_ids[]": manage_ids,
@@ -233,7 +228,7 @@ var LibraryView = Backbone.View.extend({
         })
             .done(fetched_permissions => {
                 //fetch dataset again
-                self.showPermissions({
+                this.showPermissions({
                     fetched_permissions: fetched_permissions
                 });
                 Toast.success("Permissions saved.");

--- a/client/galaxy/scripts/mvc/list/list-view.js
+++ b/client/galaxy/scripts/mvc/list/list-view.js
@@ -420,12 +420,11 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
         },
 
         _destroyItemViews: function(view) {
-            var self = this;
-            self.views.forEach(v => {
-                self.stopListening(v);
+            this.views.forEach(v => {
+                this.stopListening(v);
             });
-            self.views = [];
-            return self;
+            this.views = [];
+            return this;
         },
 
         /** free any sub-views the list has */
@@ -487,10 +486,9 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
 
         /** Attach views in this.views to the model based on $whereTo */
         _attachItems: function($whereTo) {
-            var self = this;
             // console.log( '_attachItems:', $whereTo, this.$list( $whereTo ) );
             //ASSUMES: $list has been emptied
-            this.$list($whereTo).append(this.views.map(view => self._renderItemView$el(view)));
+            this.$list($whereTo).append(this.views.map(view => this._renderItemView$el(view)));
             return this;
         },
 

--- a/client/galaxy/scripts/mvc/tool/tools.js
+++ b/client/galaxy/scripts/mvc/tool/tools.js
@@ -204,9 +204,8 @@ var Tool = Backbone.Model.extend({
      * Set many input values at once.
      */
     set_input_values: function(inputs_dict) {
-        var self = this;
         _.each(_.keys(inputs_dict), input_name => {
-            self.set_input_value(input_name, inputs_dict[input_name]);
+            this.set_input_value(input_name, inputs_dict[input_name]);
         });
     },
 
@@ -387,17 +386,16 @@ var ToolSearch = Backbone.Model.extend({
             // Start a new ajax-request in X ms
             $("#search-clear-btn").hide();
             $("#search-spinner").show();
-            var self = this;
             this.timer = setTimeout(() => {
                 // log the search to analytics if present
                 if (typeof ga !== "undefined") {
                     ga("send", "pageview", `${getAppRoot()}?q=${q}`);
                 }
                 $.get(
-                    self.urlRoot,
+                    this.urlRoot,
                     { q: q },
                     data => {
-                        self.set("results", data);
+                        this.set("results", data);
                         $("#search-spinner").hide();
                         $("#search-clear-btn").show();
                     },
@@ -430,7 +428,6 @@ var ToolPanel = Backbone.Model.extend({
      */
     parse: function(response) {
         // Recursive function to parse tool panel elements.
-        var self = this;
 
         var // Helper to recursively parse tool panel.
             parse_elt = elt_dict => {
@@ -438,7 +435,7 @@ var ToolPanel = Backbone.Model.extend({
                 // There are many types of tools; for now, anything that ends in 'Tool'
                 // and is not a ExpressionTool is treated as a generic tool.
                 if (type.indexOf("Tool") === type.length - 4) {
-                    const tool = self.attributes.tools.get(elt_dict.id);
+                    const tool = this.attributes.tools.get(elt_dict.id);
                     if (type === "ExpressionTool") {
                         tool.hide();
                     }

--- a/client/galaxy/scripts/mvc/tours.js
+++ b/client/galaxy/scripts/mvc/tours.js
@@ -118,12 +118,11 @@ var Tours = Backbone.Collection.extend({
 export var ToursView = Backbone.View.extend({
     title: _l("Tours"),
     initialize: function() {
-        var self = this;
         this.setElement("<div/>");
         this.model = new Tours();
         this.model.fetch({
-            success: function() {
-                self.render();
+            success: () => {
+                this.render();
             },
             error: function() {
                 // Do something.

--- a/client/galaxy/scripts/mvc/ui/icon-button.js
+++ b/client/galaxy/scripts/mvc/ui/icon-button.js
@@ -120,7 +120,6 @@ var IconButtonMenuView = Backbone.View.extend({
 
     render: function() {
         // initialize icon buttons
-        var self = this;
         this.collection.each(button => {
             // create and add icon button to menu
             var elt = $("<a/>")
@@ -128,7 +127,7 @@ var IconButtonMenuView = Backbone.View.extend({
                 .attr("title", button.attributes.title)
                 .addClass("icon-button menu-button")
                 .addClass(button.attributes.icon_class)
-                .appendTo(self.$el)
+                .appendTo(this.$el)
                 .click(button.attributes.on_click);
 
             // configure tooltip

--- a/client/galaxy/scripts/mvc/ui/ui-color-picker.js
+++ b/client/galaxy/scripts/mvc/ui/ui-color-picker.js
@@ -31,17 +31,16 @@ export default Backbone.View.extend({
         this.visible = false;
         this.value(this.options.value);
         this.$boxes = this.$(".ui-color-picker-box");
-        var self = this;
-        this.$boxes.on("click", function() {
-            self.value($(this).css("background-color"));
-            self.$header.trigger("click");
+        this.$boxes.on("click", () => {
+            this.value($(this).css("background-color"));
+            this.$header.trigger("click");
         });
         this.$header.on("click", () => {
-            self.visible = !self.visible;
-            if (self.visible) {
-                self.$view.fadeIn("fast");
+            this.visible = !this.visible;
+            if (this.visible) {
+                this.$view.fadeIn("fast");
             } else {
-                self.$view.fadeOut("fast");
+                this.$view.fadeOut("fast");
             }
         });
     },

--- a/client/galaxy/scripts/mvc/ui/ui-drilldown.js
+++ b/client/galaxy/scripts/mvc/ui/ui-drilldown.js
@@ -19,12 +19,11 @@ var View = Options.BaseIcons.extend({
     _setValue: function(new_value) {
         Options.BaseIcons.prototype._setValue.call(this, new_value);
         if (new_value !== undefined && new_value !== null && this.header_index) {
-            var self = this;
             var values = $.isArray(new_value) ? new_value : [new_value];
             _.each(values, v => {
-                var list = self.header_index[v];
+                var list = this.header_index[v];
                 _.each(list, element => {
-                    self._setState(element, true);
+                    this._setState(element, true);
                 });
             });
         }
@@ -46,25 +45,24 @@ var View = Options.BaseIcons.extend({
 
     /** Template to create options tree */
     _templateOptions: function() {
-        var self = this;
         this.header_index = {};
 
         // attach event handler
-        function attach($el, header_id) {
+        const attach = ($el, header_id) => {
             var $button = $el.find(`.button-${header_id}`);
             $button.on("click", () => {
-                self._setState(header_id, !$button.data("is_expanded"));
+                this._setState(header_id, !$button.data("is_expanded"));
             });
         }
 
         // recursive function which iterates through options
-        function iterate($tmpl, options, header) {
+        const iterate = ($tmpl, options, header) => {
             header = header || [];
             for (var i in options) {
                 var level = options[i];
                 var has_options = level.options && level.options.length > 0;
                 var new_header = header.slice(0);
-                self.header_index[level.value] = new_header.slice(0);
+                this.header_index[level.value] = new_header.slice(0);
                 var $group = $("<div/>");
                 if (has_options) {
                     var header_id = Utils.uid();
@@ -78,7 +76,7 @@ var View = Options.BaseIcons.extend({
                         $("<div/>")
                             .append($button)
                             .append(
-                                self._templateOption({
+                                this._templateOption({
                                     label: level.name,
                                     value: level.value
                                 })
@@ -90,7 +88,7 @@ var View = Options.BaseIcons.extend({
                     attach($group, header_id);
                 } else {
                     $group.append(
-                        self._templateOption({
+                        this._templateOption({
                             label: level.name,
                             value: level.value
                         })

--- a/client/galaxy/scripts/mvc/ui/ui-frames.js
+++ b/client/galaxy/scripts/mvc/ui/ui-frames.js
@@ -38,7 +38,6 @@ var FrameView = Backbone.View.extend({
     },
 
     render: function() {
-        var self = this;
         var options = this.model.attributes;
         this.$title.html(_.escape(options.title) || "");
         this.$header.find(".f-icon-left").remove();
@@ -51,14 +50,14 @@ var FrameView = Backbone.View.extend({
             } else {
                 $option
                     .on("click", () => {
-                        option.onclick(self);
+                        option.onclick(this);
                     })
                     .tooltip({
                         title: option.tooltip || "",
                         placement: "bottom"
                     });
             }
-            self.$header.append($option);
+            this.$header.append($option);
         });
         if (options.url) {
             this.$content.html(
@@ -69,9 +68,9 @@ var FrameView = Backbone.View.extend({
             );
         } else if (options.content) {
             if (_.isFunction(options.content)) {
-                options.content(self.$content);
+                options.content(this.$content);
             } else {
-                self.$content.html(options.content);
+                this.$content.html(options.content);
             }
         }
     }
@@ -106,7 +105,6 @@ var View = Backbone.View.extend({
     event: {}, // dictionary keeping track of current event
 
     initialize: function(options) {
-        var self = this;
         this.options = _.defaults(options || {}, this.defaultOptions);
         this.visible = this.options.visible;
         this.top = this.top_max = this.options.top_min;
@@ -135,8 +133,8 @@ var View = Backbone.View.extend({
         }
         this._panelRefresh();
         $(window).resize(() => {
-            if (self.visible) {
-                self._panelRefresh();
+            if (this.visible) {
+                this._panelRefresh();
             }
         });
     },
@@ -209,15 +207,14 @@ var View = Backbone.View.extend({
 
     /** Remove a frame */
     del: function(frame) {
-        var self = this;
         var $frame = frame.$el;
         $frame.fadeOut("fast", () => {
             $frame.remove();
-            delete self.frame_list[frame.id];
-            self.frame_counter--;
-            self._panelRefresh(true);
-            self._panelAnimationComplete();
-            self.trigger("remove");
+            delete this.frame_list[frame.id];
+            this.frame_counter--;
+            this._panelRefresh(true);
+            this._panelAnimationComplete();
+            this.trigger("remove");
         });
     },
 
@@ -508,11 +505,10 @@ var View = Backbone.View.extend({
 
     /** Complete panel animation / frames not moving */
     _panelAnimationComplete: function() {
-        var self = this;
         $(".frame")
             .promise()
             .done(() => {
-                self._panelScroll(0, true);
+                this._panelScroll(0, true);
             });
     },
 
@@ -552,7 +548,6 @@ var View = Backbone.View.extend({
 
     /** Insert frame at given location */
     _frameInsert: function(frame, new_loc, animate) {
-        var self = this;
         var place_list = [];
         if (frame) {
             frame.grid_location = null;
@@ -566,12 +561,12 @@ var View = Backbone.View.extend({
         });
         place_list.sort((a, b) => (a[1] < b[1] ? -1 : a[1] > b[1] ? 1 : 0));
         _.each(place_list, place => {
-            self._framePlace(place[0], animate);
+            this._framePlace(place[0], animate);
         });
         this.top_max = 0;
         _.each(this.frame_list, f => {
             if (f.grid_location !== null) {
-                self.top_max = Math.max(self.top_max, f.grid_location.top + f.grid_location.height);
+                this.top_max = Math.max(this.top_max, f.grid_location.top + f.grid_location.height);
             }
         });
         this.top_max = $(window).height() - this.top_max * this.options.cell - 2 * this.options.margin;
@@ -615,9 +610,8 @@ var View = Backbone.View.extend({
         frame.screen_location.top = p.top;
         if (animate) {
             this._frameFocus(frame, true);
-            var self = this;
             frame.$el.animate({ top: p.top, left: p.left }, "fast", () => {
-                self._frameFocus(frame, false);
+                this._frameFocus(frame, false);
             });
         } else {
             frame.$el.css({ top: p.top, left: p.left });

--- a/client/galaxy/scripts/mvc/ui/ui-list.js
+++ b/client/galaxy/scripts/mvc/ui/ui-list.js
@@ -78,7 +78,6 @@ var View = Backbone.View.extend({
 
     /** Add row */
     add: function(options) {
-        var self = this;
         if (this.$(`[id="${options.id}"]`).length === 0) {
             if (!Utils.isEmpty(options.id)) {
                 var $el = $(
@@ -89,7 +88,7 @@ var View = Backbone.View.extend({
                 );
                 $el.find("button").on("click", () => {
                     $el.remove();
-                    self._refresh();
+                    this._refresh();
                 });
                 this.selections.append($el);
                 this._refresh();

--- a/client/galaxy/scripts/mvc/ui/ui-misc.js
+++ b/client/galaxy/scripts/mvc/ui/ui-misc.js
@@ -43,9 +43,8 @@ export var Message = Backbone.View.extend({
             this.$el[this.model.get("fade") ? "fadeIn" : "show"]();
             this.timeout && window.clearTimeout(this.timeout);
             if (!this.model.get("persistent")) {
-                var self = this;
                 this.timeout = window.setTimeout(() => {
-                    self.model.set("message", "");
+                    this.model.set("message", "");
                 }, 3000);
             }
         } else {
@@ -93,7 +92,6 @@ export var Input = Backbone.View.extend({
         return this.model.get("value");
     },
     render: function() {
-        var self = this;
         this.$el
             .removeClass()
             .addClass(`ui-${this.tagName}`)
@@ -107,11 +105,11 @@ export var Input = Backbone.View.extend({
         var datalist = this.model.get("datalist");
         if ($.isArray(datalist) && datalist.length > 0) {
             this.$el.autocomplete({
-                source: function(request, response) {
-                    response(self.model.get("datalist"));
+                source: (request, response) => {
+                    response(this.model.get("datalist"));
                 },
-                change: function() {
-                    self._onchange();
+                change: () => {
+                    this._onchange();
                 }
             });
         }
@@ -119,7 +117,7 @@ export var Input = Backbone.View.extend({
             this.$el.val(this.model.get("value"));
         }
         _.each(["readonly", "disabled"], attr_name => {
-            self.model.get(attr_name) ? self.$el.attr(attr_name, true) : self.$el.removeAttr(attr_name);
+            this.model.get(attr_name) ? this.$el.attr(attr_name, true) : this.$el.removeAttr(attr_name);
         });
         this.$el[this.model.get("visible") ? "show" : "hide"]();
         return this;
@@ -204,7 +202,6 @@ export var TextSelect = Backbone.View.extend({
 /** Creates a upload element input field */
 export var Upload = Backbone.View.extend({
     initialize: function(options) {
-        var self = this;
         this.model = (options && options.model) || new Backbone.Model(options);
         this.setElement(
             $("<div/>")
@@ -223,7 +220,7 @@ export var Upload = Backbone.View.extend({
         );
         this.listenTo(this.model, "change", this.render, this);
         this.$file.on("change", e => {
-            self._readFile(e);
+            this._readFile(e);
         });
         this.render();
     },
@@ -239,12 +236,11 @@ export var Upload = Backbone.View.extend({
         return this;
     },
     _readFile: function(e) {
-        var self = this;
         var file = e.target.files && e.target.files[0];
         if (file) {
             var reader = new FileReader();
-            reader.onload = function() {
-                self.model.set({ wait: false, value: this.result });
+            reader.onload = () => {
+                this.model.set({ wait: false, value: this.result });
             };
             this.model.set({ wait: true, value: null });
             reader.readAsText(file);

--- a/client/galaxy/scripts/mvc/ui/ui-modal.js
+++ b/client/galaxy/scripts/mvc/ui/ui-modal.js
@@ -75,7 +75,6 @@ export var View = Backbone.View.extend({
      * Render modal
      */
     render: function() {
-        var self = this;
         this.$el.html(this._template());
 
         // link elements
@@ -115,8 +114,8 @@ export var View = Backbone.View.extend({
                     .attr("id", `button-${counter++}`)
                     .text(name)
                     .click(callback);
-                self.$buttons.append($button).append("&nbsp;");
-                self.buttonList[name] = $button;
+                this.$buttons.append($button).append("&nbsp;");
+                this.buttonList[name] = $button;
             });
         } else {
             this.$footer.hide();

--- a/client/galaxy/scripts/mvc/ui/ui-options.js
+++ b/client/galaxy/scripts/mvc/ui/ui-options.js
@@ -7,7 +7,6 @@ import Buttons from "mvc/ui/ui-buttons";
 
 var Base = Backbone.View.extend({
     initialize: function(options) {
-        var self = this;
         this.model =
             (options && options.model) ||
             new Backbone.Model({
@@ -26,13 +25,12 @@ var Base = Backbone.View.extend({
         this.listenTo(this.model, "change:data", this._changeData, this);
         this.listenTo(this.model, "change:visible", this._changeVisible, this);
         this.on("change", () => {
-            self.model.get("onchange")(self.value());
+            this.model.get("onchange")(this.value());
         });
         this.render();
     },
 
     render: function() {
-        var self = this;
         this.$el
             .empty()
             .removeClass()
@@ -46,10 +44,10 @@ var Base = Backbone.View.extend({
         this.all_button = null;
         if (this.model.get("multiple")) {
             this.all_button = new Buttons.ButtonCheck({
-                onclick: function() {
-                    self.$("input").prop("checked", self.all_button.value() !== 0);
-                    self.value(self._getValue());
-                    self.trigger("change");
+                onclick: () => {
+                    this.$("input").prop("checked", this.all_button.value() !== 0);
+                    this.value(this._getValue());
+                    this.trigger("change");
                 }
             });
             this.$menu.append(this.all_button.$el);
@@ -69,14 +67,13 @@ var Base = Backbone.View.extend({
     },
 
     _changeData: function() {
-        var self = this;
         this.$options.empty();
         if (this._templateOptions) {
             this.$options.append(this._templateOptions(this.model.get("data")));
         } else {
             _.each(this.model.get("data"), option => {
-                self.$options.append(
-                    $(self._templateOption(option))
+                this.$options.append(
+                    $(this._templateOption(option))
                         .addClass("ui-option")
                         .tooltip({
                             title: option.tooltip || "",
@@ -86,8 +83,8 @@ var Base = Backbone.View.extend({
             });
         }
         this.$("input").on("change", () => {
-            self.value(self._getValue());
-            self.trigger("change");
+            this.value(this._getValue());
+            this.trigger("change");
         });
         this._changeValue();
         this._changeWait();
@@ -168,13 +165,12 @@ var Base = Backbone.View.extend({
 
     /** Set value to dom */
     _setValue: function(new_value) {
-        var self = this;
         if (new_value !== undefined) {
             this.$("input").prop("checked", false);
             if (new_value !== null) {
                 var values = $.isArray(new_value) ? new_value : [new_value];
                 _.each(values, v => {
-                    self.$(`input[value="${v}"]`)
+                    this.$(`input[value="${v}"]`)
                         .first()
                         .prop("checked", true);
                 });

--- a/client/galaxy/scripts/mvc/ui/ui-popover.js
+++ b/client/galaxy/scripts/mvc/ui/ui-popover.js
@@ -32,12 +32,11 @@ export default Backbone.View.extend({
         $(this.$target).popover("show");
 
         // add event to hide if click is outside of popup and not on container
-        var self = this;
         const $popover = $(this.$target.data("bs.popover").tip);
         $popover.find(".popover-header > i").on("click", () => this.hide());
         $("body").on(`mousedown.${this.uid}`, e => {
             if (!$($popover).is(e.target) && $($popover).has(e.target).length === 0) {
-                self.hide();
+                this.hide();
             }
         });
     },

--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -6,7 +6,6 @@ import Ui from "mvc/ui/ui-misc";
 export var View = Backbone.View.extend({
     visible: false,
     initialize: function(options) {
-        var self = this;
         this.model =
             (options && options.model) ||
             new Backbone.Model({
@@ -44,15 +43,14 @@ export var View = Backbone.View.extend({
             icon: "fa-eye",
             tooltip: "Collapse/Expand",
             cls: "ui-button-icon-plain",
-            onclick: function() {
-                self[self.collapsed ? "expand" : "collapse"]();
+            onclick: () => {
+                this[this.collapsed ? "expand" : "collapse"]();
             }
         });
         this.render();
     },
 
     render: function() {
-        var self = this;
         var options = this.model.attributes;
         this.$el
             .removeClass()
@@ -79,7 +77,7 @@ export var View = Backbone.View.extend({
         this.$title_text[options.collapsible ? "addClass" : "removeClass"]("no-highlight collapsible").off();
         if (options.collapsible) {
             this.$title_text.on("click", () => {
-                self[self.collapsed ? "expand" : "collapse"]();
+                this[this.collapsed ? "expand" : "collapse"]();
             });
             options.collapsed ? this.collapse() : this.expand();
         }
@@ -98,7 +96,7 @@ export var View = Backbone.View.extend({
             this.$buttons.empty().show();
             $.each(this.model.get("buttons"), (name, item) => {
                 item.$el.prop("id", name);
-                self.$buttons.append(item.$el);
+                this.$buttons.append(item.$el);
             });
         } else {
             this.$buttons.hide();
@@ -112,7 +110,7 @@ export var View = Backbone.View.extend({
         if (options.operations) {
             $.each(options.operations, (name, item) => {
                 item.$el.prop("id", name);
-                self.$operations.append(item.$el);
+                this.$operations.append(item.$el);
             });
         }
         return this;

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -125,7 +125,6 @@ const Configurations = {
 /** View for hda and hdca content selector ui elements */
 const View = Backbone.View.extend({
     initialize: function(options) {
-        const self = this;
         this.model =
             (options && options.model) ||
             new Backbone.Model({
@@ -161,13 +160,13 @@ const View = Backbone.View.extend({
         const element = this.$el.get(0);
         element.addEventListener("dragenter", e => {
             this.lastenter = e.target;
-            self.$el.addClass("ui-dragover");
+            this.$el.addClass("ui-dragover");
         });
         element.addEventListener("dragover", e => {
             e.preventDefault();
         });
         element.addEventListener("dragleave", e => {
-            this.lastenter === e.target && self.$el.removeClass("ui-dragover");
+            this.lastenter === e.target && this.$el.removeClass("ui-dragover");
         });
         element.addEventListener("drop", e => {
             e.preventDefault();
@@ -197,7 +196,7 @@ const View = Backbone.View.extend({
 
         // add change event
         this.on("change", () => {
-            options.onchange && options.onchange(self.value());
+            options.onchange && options.onchange(this.value());
         });
     },
 
@@ -258,12 +257,11 @@ const View = Backbone.View.extend({
 
     /** Change of current select field */
     _changeCurrent: function() {
-        const self = this;
         _.each(this.fields, (field, i) => {
-            const cnf = self.config[i];
-            if (self.model.get("current") == i) {
+            const cnf = this.config[i];
+            if (this.model.get("current") == i) {
                 field.$el.show();
-                _.each(self.$batch, ($batchfield, batchmode) => {
+                _.each(this.$batch, ($batchfield, batchmode) => {
                     if (cnf.batch == batchmode) {
                         $batchfield.show();
                     } else {
@@ -271,11 +269,11 @@ const View = Backbone.View.extend({
                     }
                 });
                 if (cnf.src == "hda") {
-                    self.button_dialog.show();
+                    this.button_dialog.show();
                 } else {
-                    self.button_dialog.hide();
+                    this.button_dialog.hide();
                 }
-                self.button_type.value(i);
+                this.button_type.value(i);
             } else {
                 field.$el.hide();
             }
@@ -289,7 +287,6 @@ const View = Backbone.View.extend({
 
     /** Change of type */
     _changeType: function() {
-        const self = this;
         const galaxy = getGalaxyInstance();
 
         // identify selector type identifier i.e. [ flavor ]_[ type ]_[ multiple ]
@@ -305,7 +302,7 @@ const View = Backbone.View.extend({
         }
 
         // prepare extension component of error message
-        const data = self.model.get("data");
+        const data = this.model.get("data");
         const extensions = Utils.textify(this.model.get("extensions"));
         const src_labels = this.model.get("src_labels");
 
@@ -313,21 +310,21 @@ const View = Backbone.View.extend({
         this.fields = [];
         this.button_data = [];
         _.each(this.config, (c, i) => {
-            self.button_data.push({
+            this.button_data.push({
                 value: i,
                 icon: c.icon,
                 tooltip: c.tooltip
             });
-            self.fields.push(
+            this.fields.push(
                 new Select.View({
-                    optional: self.model.get("optional"),
+                    optional: this.model.get("optional"),
                     multiple: c.multiple,
                     searchable:
-                        !c.multiple || (data && data[c.src] && data[c.src].length > self.model.get("pagelimit")),
+                        !c.multiple || (data && data[c.src] && data[c.src].length > this.model.get("pagelimit")),
                     individual: true,
                     error_text: `No ${extensions ? `${extensions} ` : ""}${src_labels[c.src] || "content"} available.`,
-                    onchange: function() {
-                        self.trigger("change");
+                    onchange: () => {
+                        this.trigger("change");
                     }
                 })
             );
@@ -336,9 +333,9 @@ const View = Backbone.View.extend({
             value: this.model.get("current"),
             data: this.button_data,
             cls: "pr-lg-2",
-            onchange: function(value) {
-                self.model.set("current", value);
-                self.trigger("change");
+            onchange: value => {
+                this.model.set("current", value);
+                this.trigger("change");
             }
         });
 
@@ -383,16 +380,14 @@ const View = Backbone.View.extend({
 
     /** Change of wait flag */
     _changeWait: function() {
-        const self = this;
         _.each(this.fields, field => {
-            field[self.model.get("wait") ? "wait" : "unwait"]();
+            field[this.model.get("wait") ? "wait" : "unwait"]();
         });
     },
 
     /** Change of available options */
     _changeData: function() {
         const options = this.model.get("data");
-        const self = this;
         const select_options = {};
         _.each(options, (items, src) => {
             select_options[src] = [];
@@ -405,11 +400,11 @@ const View = Backbone.View.extend({
                     origin: item.origin,
                     tags: item.tags
                 });
-                self.cache[`${item.id}_${src}`] = item;
+                this.cache[`${item.id}_${src}`] = item;
             });
         });
         _.each(this.config, (c, i) => {
-            select_options[c.src] && self.fields[i].add(select_options[c.src], (a, b) => b.hid - a.hid);
+            select_options[c.src] && this.fields[i].add(select_options[c.src], (a, b) => b.hid - a.hid);
         });
     },
 
@@ -468,7 +463,6 @@ const View = Backbone.View.extend({
 
     /** Add values from drag/drop */
     _handleDropValues: function(drop_data, drop_partial = true) {
-        const self = this;
         const data = this.model.get("data");
         const current = this.model.get("current");
         const config = this.config[current];
@@ -478,7 +472,7 @@ const View = Backbone.View.extend({
             if (values.length > 0) {
                 let data_changed = false;
                 _.each(values, v => {
-                    self._patchValue(v);
+                    this._patchValue(v);
                     const new_id = v.id;
                     const new_src = (v.src = this._getSource(v));
                     const new_value = { id: new_id, src: new_src };
@@ -524,10 +518,9 @@ const View = Backbone.View.extend({
 
     /** Highlight drag result */
     _handleDropStatus: function(status) {
-        const self = this;
         this.$el.removeClass("ui-dragover").addClass(`ui-dragover-${status}`);
         setTimeout(() => {
-            self.$el.removeClass(`ui-dragover-${status}`);
+            this.$el.removeClass(`ui-dragover-${status}`);
         }, this.model.get("statustimer"));
     },
 

--- a/client/galaxy/scripts/mvc/ui/ui-select-ftp.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-ftp.js
@@ -9,16 +9,14 @@ import List from "mvc/ui/ui-list";
 var View = Backbone.View.extend({
     // initialize
     initialize: function(options) {
-        // link this
-        var self = this;
 
         // create ui-list view to keep track of selected ftp files
         this.ftpfile_list = new List.View({
             name: "file",
             optional: options.optional,
             multiple: options.multiple,
-            onchange: function() {
-                options.onchange && options.onchange(self.value());
+            onchange: () => {
+                options.onchange && options.onchange(this.value());
             }
         });
 
@@ -28,7 +26,7 @@ var View = Backbone.View.extend({
         // initial fetch of ftps
         Utils.get({
             url: `${getAppRoot()}api/remote_files`,
-            success: function(response) {
+            success: response => {
                 var data = [];
                 for (var i in response) {
                     data.push({
@@ -36,7 +34,7 @@ var View = Backbone.View.extend({
                         label: response[i]["path"]
                     });
                 }
-                self.ftpfile_list.update(data);
+                this.ftpfile_list.update(data);
             }
         });
     },

--- a/client/galaxy/scripts/mvc/ui/ui-select-genomespace.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-genomespace.js
@@ -8,8 +8,6 @@ import GenomespaceBrowser from "mvc/tool/tool-genomespace";
 var View = Backbone.View.extend({
     // initialize
     initialize: function(options) {
-        // link this
-        var self = this;
         this.options = options;
 
         // create insert new list element button
@@ -18,8 +16,8 @@ var View = Backbone.View.extend({
             icon: "fa fa-sign-in",
             cls: "btn btn-secondary float-left",
             tooltip: _l("Browse GenomeSpace"),
-            onclick: function() {
-                self.browseGenomeSpace(options);
+            onclick: () => {
+                this.browseGenomeSpace(options);
             }
         });
 
@@ -34,10 +32,9 @@ var View = Backbone.View.extend({
 
     /** Browse GenomeSpace */
     browseGenomeSpace: function(options) {
-        var self = this;
         GenomespaceBrowser.openFileBrowser({
-            successCallback: function(data) {
-                self.value(data.destination);
+            successCallback: data => {
+                this.value(data.destination);
             }
         });
     },

--- a/client/galaxy/scripts/mvc/ui/ui-select-library.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-library.js
@@ -12,10 +12,9 @@ var Libraries = Backbone.Collection.extend({
 // collection of dataset
 var LibraryDatasets = Backbone.Collection.extend({
     initialize: function() {
-        var self = this;
         this.config = new Backbone.Model({ library_id: null });
         this.config.on("change", () => {
-            self.fetch({ reset: true });
+            this.fetch({ reset: true });
         });
     },
     url: function() {
@@ -27,9 +26,6 @@ var LibraryDatasets = Backbone.Collection.extend({
 var View = Backbone.View.extend({
     // initialize
     initialize: function(options) {
-        // link this
-        var self = this;
-
         // collections
         this.libraries = new Libraries();
         this.datasets = new LibraryDatasets();
@@ -40,8 +36,8 @@ var View = Backbone.View.extend({
         // select field for the library
         // TODO: Remove this once the library API supports searching for library datasets
         this.library_select = new Ui.Select.View({
-            onchange: function(value) {
-                self.datasets.config.set("library_id", value);
+            onchange: value => {
+                this.datasets.config.set("library_id", value);
             }
         });
 
@@ -50,29 +46,29 @@ var View = Backbone.View.extend({
             name: "dataset",
             optional: options.optional,
             multiple: options.multiple,
-            onchange: function() {
-                self.trigger("change");
+            onchange: () => {
+                this.trigger("change");
             }
         });
 
         // add reset handler for fetched libraries
         this.libraries.on("reset", () => {
             var data = [];
-            self.libraries.each(model => {
+            this.libraries.each(model => {
                 data.push({
                     value: model.id,
                     label: model.get("name")
                 });
             });
-            self.library_select.update({ data: data });
+            this.library_select.update({ data: data });
         });
 
         // add reset handler for fetched library datasets
         this.datasets.on("reset", () => {
             var data = [];
-            var library_current = self.library_select.text();
+            var library_current = this.library_select.text();
             if (library_current !== null) {
-                self.datasets.each(model => {
+                this.datasets.each(model => {
                     if (model.get("type") === "file") {
                         data.push({
                             value: model.id,
@@ -81,13 +77,13 @@ var View = Backbone.View.extend({
                     }
                 });
             }
-            self.dataset_list.update({ data: data });
+            this.dataset_list.update({ data: data });
         });
 
         // add change event. fires on trigger
         this.on("change", () => {
             if (options.onchange) {
-                options.onchange(self.value());
+                options.onchange(this.value());
             }
         });
 
@@ -99,10 +95,10 @@ var View = Backbone.View.extend({
         // initial fetch of libraries
         this.libraries.fetch({
             reset: true,
-            success: function() {
-                self.library_select.trigger("change");
-                if (self.options.value !== undefined) {
-                    self.value(self.options.value);
+            success: () => {
+                this.library_select.trigger("change");
+                if (this.options.value !== undefined) {
+                    this.value(this.options.value);
                 }
             }
         });

--- a/client/galaxy/scripts/mvc/ui/ui-select.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select.js
@@ -51,10 +51,9 @@ var View = Backbone.View.extend({
             }
 
             // add change event
-            var self = this;
             if (this.options.onchange) {
                 this.$el.on("change", () => {
-                    self.options.onchange(self.value());
+                    this.options.onchange(this.value());
                 });
             }
         }

--- a/client/galaxy/scripts/mvc/ui/ui-tabs.js
+++ b/client/galaxy/scripts/mvc/ui/ui-tabs.js
@@ -97,7 +97,6 @@ export var View = Backbone.View.extend({
 
     /** Adds a new tab */
     _add: function(tab_model) {
-        var self = this;
         var options = tab_model.attributes;
         this.$content.append(
             $("<div/>")
@@ -111,11 +110,11 @@ export var View = Backbone.View.extend({
                 .tooltip({
                     title: options.tooltip || "",
                     placement: "bottom",
-                    container: self.$el
+                    container: this.$el
                 })
                 .on("click", e => {
                     e.preventDefault();
-                    self.show(options.id);
+                    this.show(options.id);
                 })
         );
         if (this.size() == 1) {

--- a/client/galaxy/scripts/mvc/upload/collection/collection-row.js
+++ b/client/galaxy/scripts/mvc/upload/collection/collection-row.js
@@ -17,7 +17,6 @@ export default Backbone.View.extend({
     },
 
     initialize: function(app, options) {
-        var self = this;
         this.app = app;
         this.model = options.model;
         this.setElement(this._template(options.model));
@@ -46,12 +45,12 @@ export default Backbone.View.extend({
 
         // handle click event
         this.$symbol.on("click", () => {
-            self._removeRow();
+            this._removeRow();
         });
 
         // handle text editing event
         this.$text_content.on("change input", e => {
-            self.model.set({
+            this.model.set({
                 url_paste: $(e.target).val(),
                 file_size: $(e.target).val().length
             });
@@ -59,22 +58,22 @@ export default Backbone.View.extend({
 
         // model events
         this.listenTo(this.model, "change:percentage", () => {
-            self._refreshPercentage();
+            this._refreshPercentage();
         });
         this.listenTo(this.model, "change:status", () => {
-            self._refreshStatus();
+            this._refreshStatus();
         });
         this.listenTo(this.model, "change:info", () => {
-            self._refreshInfo();
+            this._refreshInfo();
         });
         this.listenTo(this.model, "change:file_size", () => {
-            self._refreshFileSize();
+            this._refreshFileSize();
         });
         this.listenTo(this.model, "remove", () => {
-            self.remove();
+            this.remove();
         });
         this.app.collection.on("reset", () => {
-            self.remove();
+            this.remove();
         });
     },
 

--- a/client/galaxy/scripts/mvc/upload/collection/collection-view.js
+++ b/client/galaxy/scripts/mvc/upload/collection/collection-view.js
@@ -33,7 +33,6 @@ export default Backbone.View.extend({
     },
 
     initialize: function(app) {
-        var self = this;
         this.app = app;
         this.options = app.options;
         this.list_extensions = app.list_extensions;
@@ -46,60 +45,60 @@ export default Backbone.View.extend({
         this.btnLocal = new Ui.Button({
             id: "btn-local",
             title: _l("Choose local files"),
-            onclick: function() {
-                self.uploadbox.select();
+            onclick: () => {
+                this.uploadbox.select();
             },
             icon: "fa fa-laptop"
         });
         this.btnFtp = new Ui.Button({
             id: "btn-ftp",
             title: _l("Choose FTP files"),
-            onclick: function() {
-                self._eventFtp();
+            onclick: () => {
+                this._eventFtp();
             },
             icon: "fa fa-folder-open-o"
         });
         this.btnCreate = new Ui.Button({
             id: "btn-new",
             title: "Paste/Fetch data",
-            onclick: function() {
-                self._eventCreate();
+            onclick: () => {
+                this._eventCreate();
             },
             icon: "fa fa-edit"
         });
         this.btnStart = new Ui.Button({
             id: "btn-start",
             title: _l("Start"),
-            onclick: function() {
-                self._eventStart();
+            onclick: () => {
+                this._eventStart();
             }
         });
         this.btnBuild = new Ui.Button({
             id: "btn-build",
             title: _l("Build"),
-            onclick: function() {
-                self._eventBuild();
+            onclick: () => {
+                this._eventBuild();
             }
         });
         this.btnStop = new Ui.Button({
             id: "btn-stop",
             title: _l("Pause"),
-            onclick: function() {
-                self._eventStop();
+            onclick: () => {
+                this._eventStop();
             }
         });
         this.btnReset = new Ui.Button({
             id: "btn-reset",
             title: _l("Reset"),
-            onclick: function() {
-                self._eventReset();
+            onclick: () => {
+                this._eventReset();
             }
         });
         this.btnClose = new Ui.Button({
             id: "btn-close",
             title: _l("Close"),
-            onclick: function() {
-                self.app.modal.hide();
+            onclick: () => {
+                this.app.modal.hide();
             }
         });
         _.each(
@@ -114,36 +113,36 @@ export default Backbone.View.extend({
                 this.btnClose
             ],
             button => {
-                self.$(".upload-buttons").prepend(button.$el);
+                this.$(".upload-buttons").prepend(button.$el);
             }
         );
 
         // file upload
         this.uploadbox = this.$(".upload-box").uploadbox({
             url: this.app.options.upload_path,
-            announce: function(index, file) {
-                self._eventAnnounce(index, file);
+            announce: (index, file) => {
+                this._eventAnnounce(index, file);
             },
-            initialize: function(index) {
-                return self.app.toData([self.collection.get(index)], self.history_id);
+            initialize: index => {
+                return this.app.toData([this.collection.get(index)], this.history_id);
             },
-            progress: function(index, percentage) {
-                self._eventProgress(index, percentage);
+            progress: (index, percentage) => {
+                this._eventProgress(index, percentage);
             },
-            success: function(index, message) {
-                self._eventSuccess(index, message);
+            success: (index, message) => {
+                this._eventSuccess(index, message);
             },
-            error: function(index, message) {
-                self._eventError(index, message);
+            error: (index, message) => {
+                this._eventError(index, message);
             },
-            complete: function() {
-                self._eventComplete();
+            complete: () => {
+                this._eventComplete();
             },
-            ondragover: function() {
-                self.$(".upload-box").addClass("highlight");
+            ondragover: () => {
+                this.$(".upload-box").addClass("highlight");
             },
-            ondragleave: function() {
-                self.$(".upload-box").removeClass("highlight");
+            ondragleave: () => {
+                this.$(".upload-box").removeClass("highlight");
             }
         });
 
@@ -158,8 +157,8 @@ export default Backbone.View.extend({
             container: this.$(".upload-footer-extension"),
             data: _.filter(this.list_extensions, ext => !ext.composite_files),
             value: this.options.default_extension,
-            onchange: function(extension) {
-                self.updateExtension(extension);
+            onchange: extension => {
+                this.updateExtension(extension);
             }
         });
 
@@ -172,8 +171,8 @@ export default Backbone.View.extend({
                 { id: "list:paired", text: "List of Pairs" }
             ],
             value: "list",
-            onchange: function(collectionType) {
-                self.updateCollectionType(collectionType);
+            onchange: collectionType => {
+                this.updateCollectionType(collectionType);
             }
         });
 
@@ -182,9 +181,9 @@ export default Backbone.View.extend({
             .on("click", e => {
                 new UploadExtension({
                     $el: $(e.target),
-                    title: self.select_extension.text(),
-                    extension: self.select_extension.value(),
-                    list: self.list_extensions,
+                    title: this.select_extension.text(),
+                    extension: this.select_extension.value(),
+                    list: this.list_extensions,
                     placement: "top"
                 });
             })
@@ -198,14 +197,14 @@ export default Backbone.View.extend({
             container: this.$(".upload-footer-genome"),
             data: this.list_genomes,
             value: this.options.default_genome,
-            onchange: function(genome) {
-                self.updateGenome(genome);
+            onchange: genome => {
+                this.updateGenome(genome);
             }
         });
 
         // events
         this.collection.on("remove", model => {
-            self._eventRemove(model);
+            this._eventRemove(model);
         });
         this._updateScreen();
     },
@@ -312,13 +311,12 @@ export default Backbone.View.extend({
 
     /** Show/hide ftp popup */
     _eventFtp: function() {
-        var self = this;
         this.ftp.show(
             new UploadFtp({
                 collection: this.collection,
                 ftp_upload_site: this.ftp_upload_site,
-                onadd: function(ftp_file) {
-                    return self.uploadbox.add([
+                onadd: ftp_file => {
+                    return this.uploadbox.add([
                         {
                             mode: "ftp",
                             name: ftp_file.path,
@@ -327,8 +325,8 @@ export default Backbone.View.extend({
                         }
                     ]);
                 },
-                onremove: function(model_index) {
-                    self.collection.remove(model_index);
+                onremove: model_index => {
+                    this.collection.remove(model_index);
                 }
             }).$el
         );
@@ -344,13 +342,12 @@ export default Backbone.View.extend({
         if (this.counter.announce == 0 || this.counter.running > 0) {
             return;
         }
-        var self = this;
         this.upload_size = 0;
         this.upload_completed = 0;
         this.collection.each(model => {
             if (model.get("status") == "init") {
                 model.set("status", "queued");
-                self.upload_size += model.get("file_size");
+                this.upload_size += model.get("file_size");
             }
         });
         this.ui_button.model.set({ percentage: 0, status: "success" });
@@ -384,11 +381,10 @@ export default Backbone.View.extend({
 
     /** Update extension for all models */
     updateExtension: function(extension, defaults_only) {
-        var self = this;
         this.collection.each(model => {
             if (
                 model.get("status") == "init" &&
-                (model.get("extension") == self.options.default_extension || !defaults_only)
+                (model.get("extension") == this.options.default_extension || !defaults_only)
             ) {
                 model.set("extension", extension);
             }
@@ -402,11 +398,10 @@ export default Backbone.View.extend({
 
     /** Update genome for all models */
     updateGenome: function(genome, defaults_only) {
-        var self = this;
         this.collection.each(model => {
             if (
                 model.get("status") == "init" &&
-                (model.get("genome") == self.options.default_genome || !defaults_only)
+                (model.get("genome") == this.options.default_genome || !defaults_only)
             ) {
                 model.set("genome", genome);
             }

--- a/client/galaxy/scripts/mvc/upload/composite/composite-row.js
+++ b/client/galaxy/scripts/mvc/upload/composite/composite-row.js
@@ -20,7 +20,6 @@ export default Backbone.View.extend({
     },
 
     initialize: function(app, options) {
-        var self = this;
         this.app = app;
         this.model = options.model;
         this.setElement(this._template());
@@ -39,21 +38,21 @@ export default Backbone.View.extend({
 
         // build upload functions
         this.uploadinput = this.$el.uploadinput({
-            ondragover: function() {
-                self.model.get("enabled") && self.$el.addClass("alert-success");
+            ondragover: () => {
+                this.model.get("enabled") && this.$el.addClass("alert-success");
             },
-            ondragleave: function() {
-                self.$el.removeClass("alert-success");
+            ondragleave: () => {
+                this.$el.removeClass("alert-success");
             },
-            onchange: function(files) {
-                if (self.model.get("status") != "running" && files && files.length > 0) {
-                    self.model.reset({
+            onchange: files => {
+                if (this.model.get("status") != "running" && files && files.length > 0) {
+                    this.model.reset({
                         file_data: files[0],
                         file_name: files[0].name,
                         file_size: files[0].size,
                         file_mode: files[0].mode || "local"
                     });
-                    self._refreshReady();
+                    this._refreshReady();
                 }
             }
         });
@@ -68,24 +67,24 @@ export default Backbone.View.extend({
         this.button_menu.addMenu({
             icon: "fa-laptop",
             title: _l("Choose local file"),
-            onclick: function() {
-                self.uploadinput.dialog();
+            onclick: () => {
+                this.uploadinput.dialog();
             }
         });
         if (this.app.ftp_upload_site) {
             this.button_menu.addMenu({
                 icon: "fa-folder-open-o",
                 title: _l("Choose FTP file"),
-                onclick: function() {
-                    self._showFtp();
+                onclick: () => {
+                    this._showFtp();
                 }
             });
         }
         this.button_menu.addMenu({
             icon: "fa-edit",
             title: "Paste/Fetch data",
-            onclick: function() {
-                self.model.reset({
+            onclick: () => {
+                this.model.reset({
                     file_mode: "new",
                     file_name: "New File"
                 });
@@ -108,17 +107,17 @@ export default Backbone.View.extend({
 
         // handle text editing event
         this.$text_content.on("change input", e => {
-            self.model.set({
+            this.model.set({
                 url_paste: $(e.target).val(),
                 file_size: $(e.target).val().length
             });
-            self._refreshReady();
+            this._refreshReady();
         });
 
         // handle settings popover
         this.$settings
             .on("click", e => {
-                self._showSettings();
+                this._showSettings();
             })
             .on("mousedown", e => {
                 e.preventDefault();
@@ -126,28 +125,28 @@ export default Backbone.View.extend({
 
         // model events
         this.listenTo(this.model, "change:percentage", () => {
-            self._refreshPercentage();
+            this._refreshPercentage();
         });
         this.listenTo(this.model, "change:status", () => {
-            self._refreshStatus();
+            this._refreshStatus();
         });
         this.listenTo(this.model, "change:info", () => {
-            self._refreshInfo();
+            this._refreshInfo();
         });
         this.listenTo(this.model, "change:file_name", () => {
-            self._refreshFileName();
+            this._refreshFileName();
         });
         this.listenTo(this.model, "change:file_mode", () => {
-            self._refreshMode();
+            this._refreshMode();
         });
         this.listenTo(this.model, "change:file_size", () => {
-            self._refreshFileSize();
+            this._refreshFileSize();
         });
         this.listenTo(this.model, "remove", () => {
-            self.remove();
+            this.remove();
         });
         this.app.collection.on("reset", () => {
-            self.remove();
+            this.remove();
         });
     },
 
@@ -258,20 +257,19 @@ export default Backbone.View.extend({
 
     /** Show/hide ftp popup */
     _showFtp: function() {
-        var self = this;
         this.ftp.show(
             new UploadFtp({
                 ftp_upload_site: this.app.ftp_upload_site,
-                onchange: function(ftp_file) {
-                    self.ftp.hide();
-                    if (self.model.get("status") != "running" && ftp_file) {
-                        self.model.reset({
+                onchange: ftp_file => {
+                    this.ftp.hide();
+                    if (this.model.get("status") != "running" && ftp_file) {
+                        this.model.reset({
                             file_mode: "ftp",
                             file_name: ftp_file.path,
                             file_size: ftp_file.size,
                             file_path: ftp_file.path
                         });
-                        self._refreshReady();
+                        this._refreshReady();
                     }
                 }
             }).$el

--- a/client/galaxy/scripts/mvc/upload/composite/composite-view.js
+++ b/client/galaxy/scripts/mvc/upload/composite/composite-view.js
@@ -14,7 +14,6 @@ import Ui from "mvc/ui/ui-misc";
 export default Backbone.View.extend({
     collection: new UploadModel.Collection(),
     initialize: function(app) {
-        var self = this;
         this.app = app;
         this.options = app.options;
         this.list_extensions = app.list_extensions;
@@ -26,26 +25,26 @@ export default Backbone.View.extend({
         this.btnReset = new Ui.Button({
             id: "btn-reset",
             title: _l("Reset"),
-            onclick: function() {
-                self._eventReset();
+            onclick: () => {
+                this._eventReset();
             }
         });
         this.btnStart = new Ui.Button({
             title: _l("Start"),
-            onclick: function() {
-                self._eventStart();
+            onclick: () => {
+                this._eventStart();
             }
         });
         this.btnClose = new Ui.Button({
             title: _l("Close"),
-            onclick: function() {
-                self.app.modal.hide();
+            onclick: () => {
+                this.app.modal.hide();
             }
         });
 
         // append buttons to dom
         _.each([this.btnReset, this.btnStart, this.btnClose], button => {
-            self.$(".upload-buttons").prepend(button.$el);
+            this.$(".upload-buttons").prepend(button.$el);
         });
 
         // select extension
@@ -53,15 +52,15 @@ export default Backbone.View.extend({
             css: "upload-footer-selection",
             container: this.$(".upload-footer-extension"),
             data: _.filter(this.list_extensions, ext => ext.composite_files),
-            onchange: function(extension) {
-                self.collection.reset();
-                var details = _.findWhere(self.list_extensions, {
+            onchange: extension => {
+                this.collection.reset();
+                var details = _.findWhere(this.list_extensions, {
                     id: extension
                 });
                 if (details && details.composite_files) {
                     _.each(details.composite_files, item => {
-                        self.collection.add({
-                            id: self.collection.size(),
+                        this.collection.add({
+                            id: this.collection.size(),
                             file_desc: item.description || item.name,
                             optional: item.optional
                         });
@@ -75,9 +74,9 @@ export default Backbone.View.extend({
             .on("click", e => {
                 new UploadExtension({
                     $el: $(e.target),
-                    title: self.select_extension.text(),
-                    extension: self.select_extension.value(),
-                    list: self.list_extensions,
+                    title: this.select_extension.text(),
+                    extension: this.select_extension.value(),
+                    list: this.list_extensions,
                     placement: "top"
                 });
             })
@@ -95,10 +94,10 @@ export default Backbone.View.extend({
 
         // listener for collection triggers on change in composite datatype and extension selection
         this.listenTo(this.collection, "add", model => {
-            self._eventAnnounce(model);
+            this._eventAnnounce(model);
         });
         this.listenTo(this.collection, "change add", () => {
-            self.render();
+            this.render();
         });
         this.select_extension.options.onchange(this.select_extension.value());
         this.render();
@@ -141,24 +140,23 @@ export default Backbone.View.extend({
 
     /** Start upload process */
     _eventStart: function() {
-        var self = this;
         this.collection.each(model => {
             model.set({
-                genome: self.select_genome.value(),
-                extension: self.select_extension.value()
+                genome: this.select_genome.value(),
+                extension: this.select_extension.value()
             });
         });
         $.uploadpost({
             url: this.app.options.upload_path,
             data: this.app.toData(this.collection.filter()),
-            success: function(message) {
-                self._eventSuccess(message);
+            success: message => {
+                this._eventSuccess(message);
             },
-            error: function(message) {
-                self._eventError(message);
+            error: message => {
+                this._eventError(message);
             },
-            progress: function(percentage) {
-                self._eventProgress(percentage);
+            progress: percentage => {
+                this._eventProgress(percentage);
             }
         });
     },

--- a/client/galaxy/scripts/mvc/upload/default/default-row.js
+++ b/client/galaxy/scripts/mvc/upload/default/default-row.js
@@ -20,7 +20,6 @@ export default Backbone.View.extend({
     },
 
     initialize: function(app, options) {
-        var self = this;
         this.app = app;
         this.list_extensions = app.list_extensions;
         this.model = options.model;
@@ -51,11 +50,11 @@ export default Backbone.View.extend({
         // create select genomes
         this.select_genome = new Select.View({
             css: "upload-genome",
-            data: self.app.list_genomes,
+            data: this.app.list_genomes,
             container: this.$(".upload-genome"),
             value: default_genome,
-            onchange: function(genome) {
-                self.model.set("genome", genome);
+            onchange: genome => {
+                this.model.set("genome", genome);
             }
         });
 
@@ -65,8 +64,8 @@ export default Backbone.View.extend({
             data: _.filter(this.list_extensions, ext => !ext.composite_files),
             container: this.$(".upload-extension"),
             value: default_extension,
-            onchange: function(extension) {
-                self.model.set("extension", extension);
+            onchange: extension => {
+                this.model.set("extension", extension);
             }
         });
 
@@ -78,7 +77,7 @@ export default Backbone.View.extend({
 
         // handle click event
         this.$symbol.on("click", () => {
-            self._removeRow();
+            this._removeRow();
         });
 
         // handle extension info popover
@@ -103,7 +102,7 @@ export default Backbone.View.extend({
         // handle settings popover
         this.$settings
             .on("click", e => {
-                self._showSettings();
+                this._showSettings();
             })
             .on("mousedown", e => {
                 e.preventDefault();
@@ -111,7 +110,7 @@ export default Backbone.View.extend({
 
         // handle text editing event
         this.$text_content.on("change input", e => {
-            self.model.set({
+            this.model.set({
                 url_paste: $(e.target).val(),
                 file_size: $(e.target).val().length
             });
@@ -119,27 +118,27 @@ export default Backbone.View.extend({
 
         // handle text editing event
         this.$title.on("change input", e => {
-            self.model.set({ file_name: $(e.target).val() });
+            this.model.set({ file_name: $(e.target).val() });
         });
 
         // model events
         this.listenTo(this.model, "change:percentage", () => {
-            self._refreshPercentage();
+            this._refreshPercentage();
         });
         this.listenTo(this.model, "change:status", () => {
-            self._refreshStatus();
+            this._refreshStatus();
         });
         this.listenTo(this.model, "change:info", () => {
-            self._refreshInfo();
+            this._refreshInfo();
         });
         this.listenTo(this.model, "change:genome", () => {
-            self._refreshGenome();
+            this._refreshGenome();
         });
         this.listenTo(this.model, "change:extension", () => {
-            self._refreshExtension();
+            this._refreshExtension();
         });
         this.listenTo(this.model, "change:file_size", () => {
-            self._refreshFileSize();
+            this._refreshFileSize();
         });
     },
 

--- a/client/galaxy/scripts/mvc/upload/default/default-view.js
+++ b/client/galaxy/scripts/mvc/upload/default/default-view.js
@@ -33,7 +33,6 @@ export default Backbone.View.extend({
     },
 
     initialize: function(app) {
-        var self = this;
         this.app = app;
         this.options = app.options;
         this.list_extensions = app.list_extensions;
@@ -50,91 +49,91 @@ export default Backbone.View.extend({
         this.btnLocal = new Ui.Button({
             id: "btn-local",
             title: _l("Choose local file"),
-            onclick: function() {
-                self.uploadbox.select();
+            onclick: () => {
+                this.uploadbox.select();
             },
             icon: "fa fa-laptop"
         });
         this.btnFtp = new Ui.Button({
             id: "btn-ftp",
             title: _l("Choose FTP file"),
-            onclick: function() {
-                self._eventFtp();
+            onclick: () => {
+                this._eventFtp();
             },
             icon: "fa fa-folder-open-o"
         });
         this.btnCreate = new Ui.Button({
             id: "btn-new",
             title: "Paste/Fetch data",
-            onclick: function() {
-                self._eventCreate();
+            onclick: () => {
+                this._eventCreate();
             },
             icon: "fa fa-edit"
         });
         this.btnStart = new Ui.Button({
             id: "btn-start",
             title: _l("Start"),
-            onclick: function() {
-                self._eventStart();
+            onclick: () => {
+                this._eventStart();
             }
         });
         this.btnStop = new Ui.Button({
             id: "btn-stop",
             title: _l("Pause"),
-            onclick: function() {
-                self._eventStop();
+            onclick: () => {
+                this._eventStop();
             }
         });
         this.btnReset = new Ui.Button({
             id: "btn-reset",
             title: _l("Reset"),
-            onclick: function() {
-                self._eventReset();
+            onclick: () => {
+                this._eventReset();
             }
         });
         this.btnClose = new Ui.Button({
             id: "btn-close",
             title: _l("Close"),
-            onclick: function() {
-                self.app.modal.hide();
+            onclick: () => {
+                this.app.modal.hide();
             }
         });
         _.each(
             [this.btnLocal, this.btnFtp, this.btnCreate, this.btnStop, this.btnReset, this.btnStart, this.btnClose],
             button => {
-                self.$(".upload-buttons").prepend(button.$el);
+                this.$(".upload-buttons").prepend(button.$el);
             }
         );
 
         // file upload
         this.uploadbox = this.$uploadbox.uploadbox({
             url: this.app.options.upload_path,
-            announce: function(index, file) {
-                self._eventAnnounce(index, file);
+            announce: (index, file) => {
+                this._eventAnnounce(index, file);
             },
-            initialize: function(index) {
-                return self.app.toData([self.collection.get(index)], self.history_id);
+            initialize: index => {
+                return this.app.toData([this.collection.get(index)], this.history_id);
             },
-            progress: function(index, percentage) {
-                self._eventProgress(index, percentage);
+            progress: (index, percentage) => {
+                this._eventProgress(index, percentage);
             },
-            success: function(index, message) {
-                self._eventSuccess(index, message);
+            success: (index, message) => {
+                this._eventSuccess(index, message);
             },
-            error: function(index, message) {
-                self._eventError(index, message);
+            error: (index, message) => {
+                this._eventError(index, message);
             },
-            warning: function(index, message) {
-                self._eventWarning(index, message);
+            warning: (index, message) => {
+                this._eventWarning(index, message);
             },
-            complete: function() {
-                self._eventComplete();
+            complete: () => {
+                this._eventComplete();
             },
-            ondragover: function() {
-                self.$uploadbox.addClass("highlight");
+            ondragover: () => {
+                this.$uploadbox.addClass("highlight");
             },
-            ondragleave: function() {
-                self.$uploadbox.removeClass("highlight");
+            ondragleave: () => {
+                this.$uploadbox.removeClass("highlight");
             }
         });
 
@@ -150,8 +149,8 @@ export default Backbone.View.extend({
             container: this.$(".upload-footer-extension"),
             data: _.filter(this.list_extensions, ext => !ext.composite_files),
             value: this.options.default_extension,
-            onchange: function(extension) {
-                self._changeExtension(extension);
+            onchange: extension => {
+                this._changeExtension(extension);
             }
         });
 
@@ -160,9 +159,9 @@ export default Backbone.View.extend({
             .on("click", e => {
                 new UploadExtension({
                     $el: $(e.target),
-                    title: self.select_extension.text(),
-                    extension: self.select_extension.value(),
-                    list: self.list_extensions,
+                    title: this.select_extension.text(),
+                    extension: this.select_extension.value(),
+                    list: this.list_extensions,
                     placement: "top"
                 });
             })
@@ -176,8 +175,8 @@ export default Backbone.View.extend({
             container: this.$(".upload-footer-genome"),
             data: this.list_genomes,
             value: this.options.default_genome,
-            onchange: function(genome) {
-                self._changeGenome(genome);
+            onchange: genome => {
+                this._changeGenome(genome);
             }
         });
 
@@ -185,9 +184,9 @@ export default Backbone.View.extend({
         this.loader = new LazyLimited({
             $container: this.$uploadbox,
             collection: this.collection,
-            new_content: function(model) {
-                var upload_row = new UploadRow(self, { model: model });
-                self.$uploadtable.find("> tbody:first").append(upload_row.$el);
+            new_content: model => {
+                var upload_row = new UploadRow(this, { model: model });
+                this.$uploadtable.find("> tbody:first").append(upload_row.$el);
                 upload_row.render();
                 return upload_row;
             }
@@ -195,7 +194,7 @@ export default Backbone.View.extend({
 
         // events
         this.collection.on("remove", model => {
-            self._eventRemove(model);
+            this._eventRemove(model);
         });
         this.render();
     },
@@ -322,13 +321,12 @@ export default Backbone.View.extend({
 
     /** Show/hide ftp popup */
     _eventFtp: function() {
-        var self = this;
         this.ftp.show(
             new UploadFtp({
                 collection: this.collection,
                 ftp_upload_site: this.ftp_upload_site,
-                onadd: function(ftp_file) {
-                    return self.uploadbox.add([
+                onadd: ftp_file => {
+                    return this.uploadbox.add([
                         {
                             mode: "ftp",
                             name: ftp_file.path,
@@ -337,8 +335,8 @@ export default Backbone.View.extend({
                         }
                     ]);
                 },
-                onremove: function(model_index) {
-                    self.collection.remove(model_index);
+                onremove: model_index => {
+                    this.collection.remove(model_index);
                 }
             }).$el
         );
@@ -353,13 +351,12 @@ export default Backbone.View.extend({
     _eventStart: function() {
         if (this.counter.announce !== 0 && this.counter.running === 0) {
             // prepare upload process
-            var self = this;
             this.upload_size = 0;
             this.upload_completed = 0;
             this.collection.each(model => {
                 if (model.get("status") == "init") {
                     model.set("status", "queued");
-                    self.upload_size += model.get("file_size");
+                    this.upload_size += model.get("file_size");
                 }
             });
             this.ui_button.model.set({
@@ -406,11 +403,10 @@ export default Backbone.View.extend({
 
     /** Update extension for all models */
     _changeExtension: function(extension, defaults_only) {
-        var self = this;
         this.collection.each(model => {
             if (
                 model.get("status") == "init" &&
-                (model.get("extension") == self.options.default_extension || !defaults_only)
+                (model.get("extension") == this.options.default_extension || !defaults_only)
             ) {
                 model.set("extension", extension);
             }
@@ -419,11 +415,10 @@ export default Backbone.View.extend({
 
     /** Update genome for all models */
     _changeGenome: function(genome, defaults_only) {
-        var self = this;
         this.collection.each(model => {
             if (
                 model.get("status") == "init" &&
-                (model.get("genome") == self.options.default_genome || !defaults_only)
+                (model.get("genome") == this.options.default_genome || !defaults_only)
             ) {
                 model.set("genome", genome);
             }
@@ -432,11 +427,10 @@ export default Backbone.View.extend({
 
     /** Package and upload ftp files in a single request */
     _uploadFtp: function() {
-        var self = this;
         var list = [];
         this.collection.each(model => {
             if (model.get("status") == "queued" && model.get("file_mode") == "ftp") {
-                self.uploadbox.remove(model.id);
+                this.uploadbox.remove(model.id);
                 list.push(model);
             }
         });
@@ -444,14 +438,14 @@ export default Backbone.View.extend({
             $.uploadpost({
                 data: this.app.toData(list),
                 url: this.app.options.upload_path,
-                success: function(message) {
+                success: message => {
                     _.each(list, model => {
-                        self._eventSuccess(model.id);
+                        this._eventSuccess(model.id);
                     });
                 },
-                error: function(message) {
+                error: message => {
                     _.each(list, model => {
-                        self._eventError(model.id, message);
+                        this._eventError(model.id, message);
                     });
                 }
             });

--- a/client/galaxy/scripts/mvc/upload/upload-button.js
+++ b/client/galaxy/scripts/mvc/upload/upload-button.js
@@ -5,7 +5,6 @@ import _l from "utils/localization";
 
 var View = Backbone.View.extend({
     initialize: function(options) {
-        var self = this;
         this.model =
             (options && options.model) ||
             new Backbone.Model({
@@ -20,7 +19,7 @@ var View = Backbone.View.extend({
         this.$progress = this.$(".progress-bar");
         this.listenTo(this.model, "change", this.render, this);
         this.render();
-        $(window).on("beforeunload", () => self.model.get("onunload")());
+        $(window).on("beforeunload", () => this.model.get("onunload")());
     },
 
     render: function() {

--- a/client/galaxy/scripts/mvc/upload/upload-ftp.js
+++ b/client/galaxy/scripts/mvc/upload/upload-ftp.js
@@ -43,33 +43,31 @@ export default Backbone.View.extend({
     },
 
     render: function() {
-        var self = this;
         this.$wait.show();
         this.$content.hide();
         this.$warning.hide();
         this.$help.hide();
         UploadUtils.getRemoteFiles(
-            function(ftp_files) {
-                self.model.set("ftp_files", ftp_files);
-                self._index();
-                self._renderTable();
+            (ftp_files) => {
+                this.model.set("ftp_files", ftp_files);
+                this._index();
+                this._renderTable();
             },
-            function() {
-                self._renderTable();
+            () => {
+                this._renderTable();
             }
         );
     },
 
     /** Fill table with ftp entries */
     _renderTable: function() {
-        var self = this;
         var ftp_files = this.model.get("ftp_files");
         this.rows = [];
         if (ftp_files && ftp_files.length > 0) {
             this.$body.empty();
             var size = 0;
             _.each(ftp_files, ftp_file => {
-                self.rows.push(self._renderRow(ftp_file));
+                this.rows.push(this._renderRow(ftp_file));
                 size += ftp_file.size;
             });
             this.$number.html(`${ftp_files.length} files`);
@@ -80,7 +78,7 @@ export default Backbone.View.extend({
                     .addClass(this.model.get("class_add"))
                     .off()
                     .on("click", () => {
-                        self._all();
+                        this._all();
                     });
                 this._refresh();
             }
@@ -94,7 +92,6 @@ export default Backbone.View.extend({
 
     /** Add row */
     _renderRow: function(ftp_file) {
-        var self = this;
         var options = this.model.attributes;
         var $it = $(this._templateRow(ftp_file));
         var $icon = $it.find(".icon");
@@ -103,8 +100,8 @@ export default Backbone.View.extend({
             var model_index = this.ftp_index[ftp_file.path];
             $icon.addClass(model_index === undefined ? options.class_add : options.class_remove);
             $it.on("click", () => {
-                self._switch($icon, ftp_file);
-                self._refresh();
+                this._switch($icon, ftp_file);
+                this._refresh();
             });
         } else {
             $it.on("click", () => {
@@ -116,12 +113,11 @@ export default Backbone.View.extend({
 
     /** Create ftp index */
     _index: function() {
-        var self = this;
         this.ftp_index = {};
         this.collection &&
             this.collection.each(model => {
                 if (model.get("file_mode") == "ftp") {
-                    self.ftp_index[model.get("file_path")] = model.id;
+                    this.ftp_index[model.get("file_path")] = model.id;
                 }
             });
     },

--- a/client/galaxy/scripts/mvc/upload/upload-settings.js
+++ b/client/galaxy/scripts/mvc/upload/upload-settings.js
@@ -34,19 +34,18 @@ export default Backbone.View.extend({
     },
 
     render: function() {
-        var self = this;
         this.$table.empty();
         _.each(this.options.parameters, parameter => {
             var $checkbox = $("<div/>")
                 .addClass(`upload-${parameter.id} fa`)
-                .addClass((self.model.get(parameter.id) && self.options.class_check) || self.options.class_uncheck);
+                .addClass((this.model.get(parameter.id) && this.options.class_check) || this.options.class_uncheck);
             const $row = $("<tr/>")
                 .append($("<td/>").append($checkbox))
                 .append($("<td/>").append(parameter.title))
                 .on("click", () => {
-                    self.model.get("enabled") && self.model.set(parameter.id, !self.model.get(parameter.id));
+                    this.model.get("enabled") && this.model.set(parameter.id, !this.model.get(parameter.id));
                 });
-            self.$table.append($row);
+            this.$table.append($row);
         });
         this.$cover[(this.model.get("enabled") && "hide") || "show"]();
     }

--- a/client/galaxy/scripts/mvc/upload/upload-view.js
+++ b/client/galaxy/scripts/mvc/upload/upload-view.js
@@ -66,10 +66,9 @@ export default Backbone.View.extend({
     /** Show/hide upload dialog */
     show: function() {
         const Galaxy = getGalaxyInstance();
-        var self = this;
         if (!Galaxy.currHistoryPanel || !Galaxy.currHistoryPanel.model) {
             window.setTimeout(() => {
-                self.show();
+                this.show();
             }, 500);
             return;
         }

--- a/client/galaxy/scripts/mvc/user/user-custom-builds.js
+++ b/client/galaxy/scripts/mvc/user/user-custom-builds.js
@@ -20,7 +20,6 @@ var Collection = Backbone.Collection.extend({
 var View = Backbone.View.extend({
     initialize: function(options) {
         const Galaxy = getGalaxyInstance();
-        var self = this;
         this.active_tab = "user";
         var history_id = Galaxy.currHistoryPanel && Galaxy.currHistoryPanel.model.id;
         this.model = new Backbone.Model();
@@ -30,8 +29,8 @@ var View = Backbone.View.extend({
         this.message = new Ui.Message({});
         this.installed_builds = new Ui.Select.View({
             optional: true,
-            onchange: function() {
-                self.installed_builds.value(null);
+            onchange: () => {
+                this.installed_builds.value(null);
             },
             empty_text: "List of available builds:",
             error_text: "No system installed builds available."
@@ -73,10 +72,10 @@ var View = Backbone.View.extend({
                 )
         );
         this.listenTo(this.collection, "add remove reset", () => {
-            self._renderTable();
+            this._renderTable();
         });
         this.listenTo(this.model, "change", () => {
-            self._renderForm();
+            this._renderForm();
         });
         this.collection.fetch();
         this.model.fetch();
@@ -88,14 +87,13 @@ var View = Backbone.View.extend({
     },
 
     _renderTable: function() {
-        var self = this;
         this.table.delAll();
         this.collection.sort();
         this.collection.each(model => {
-            self.table.add(model.get("name"));
-            self.table.add(model.id);
-            self.table.add(model.get("count") !== undefined ? model.get("count") : "Processing...");
-            self.table.add(
+            this.table.add(model.get("name"));
+            this.table.add(model.id);
+            this.table.add(model.get("count") !== undefined ? model.get("count") : "Processing...");
+            this.table.add(
                 new Ui.Button({
                     icon: "fa-trash-o",
                     cls: "ui-button-icon-plain",
@@ -105,12 +103,11 @@ var View = Backbone.View.extend({
                     }
                 }).$el
             );
-            self.table.append(model.id);
+            this.table.append(model.id);
         });
     },
 
     _renderForm: function() {
-        var self = this;
         var initial_type = "fasta";
         var form = new Form({
             inputs: [
@@ -193,32 +190,32 @@ var View = Backbone.View.extend({
                     tooltip: _l("Create new Build"),
                     title: _l("Save"),
                     cls: "btn btn-primary",
-                    onclick: function() {
+                    onclick: () => {
                         var data = form.data.create();
                         if (!data.id || !data.name) {
-                            self.message.update({
+                            this.message.update({
                                 message: "All inputs are required.",
                                 status: "danger"
                             });
                         } else {
-                            self.collection.create(data, {
+                            this.collection.create(data, {
                                 wait: true,
-                                success: function(response) {
+                                success: response => {
                                     if (response.get("message")) {
-                                        self.message.update({
+                                        this.message.update({
                                             message: response.get("message"),
                                             status: "warning"
                                         });
                                     } else {
-                                        self.message.update({
+                                        this.message.update({
                                             message: "Successfully added a new custom build.",
                                             status: "success"
                                         });
                                     }
                                 },
-                                error: function(response, err) {
+                                error: (response, err) => {
                                     var message = err && err.responseJSON && err.responseJSON.err_msg;
-                                    self.message.update({
+                                    this.message.update({
                                         message: message || "Failed to create custom build.",
                                         status: "danger"
                                     });
@@ -228,11 +225,11 @@ var View = Backbone.View.extend({
                     }
                 })
             },
-            onchange: function() {
+            onchange: () => {
                 var input_id = form.data.match("len|type");
                 if (input_id) {
                     var input_field = form.field_list[input_id];
-                    self._renderHelp(input_field.value());
+                    this._renderHelp(input_field.value());
                 }
             }
         });

--- a/client/galaxy/scripts/mvc/visualization/chart/components/model.js
+++ b/client/galaxy/scripts/mvc/visualization/chart/components/model.js
@@ -55,7 +55,6 @@ export default Backbone.Model.extend({
 
     /** Pack and save nested chart model */
     save: function(options) {
-        var self = this;
         options = options || {};
         this.chart_dict = this.serialize();
         var viz = new Visualization({
@@ -68,9 +67,9 @@ export default Backbone.Model.extend({
             }
         });
         viz.save()
-            .then(function(response) {
+            .then(response => {
                 if (response && response.id) {
-                    self.visualization_id = response.id;
+                    this.visualization_id = response.id;
                     if (options.success) {
                         options.success();
                     }

--- a/client/galaxy/scripts/mvc/visualization/chart/views/groups.js
+++ b/client/galaxy/scripts/mvc/visualization/chart/views/groups.js
@@ -11,29 +11,27 @@ import FormData from "mvc/form/form-data";
 
 var GroupView = Backbone.View.extend({
     initialize: function(app, options) {
-        var self = this;
         this.deferred = app.deferred;
         this.chart = app.chart;
         this.group = options.group;
         this.setElement($("<div/>"));
-        this.listenTo(this.chart, "change:dataset_id", function() {
-            self.render();
+        this.listenTo(this.chart, "change:dataset_id", () => {
+            this.render();
         });
         this.render();
     },
     render: function() {
-        var self = this;
         var inputs = Utils.clone(this.chart.plugin.groups) || [];
         var dataset_id = this.chart.get("dataset_id");
         if (dataset_id) {
             this.chart.state("wait", "Loading metadata...");
-            this.deferred.execute(function(process) {
+            this.deferred.execute(process => {
                 Utils.get({
                     url: getAppRoot() + "api/datasets/" + dataset_id,
                     cache: true,
-                    success: function(dataset) {
+                    success: dataset => {
                         var data_columns = {};
-                        FormData.visitInputs(inputs, function(input, prefixed) {
+                        FormData.visitInputs(inputs, (input, prefixed) => {
                             if (input.type == "data_column") {
                                 data_columns[prefixed] = Utils.clone(input);
                                 var columns = [];
@@ -54,7 +52,7 @@ var GroupView = Backbone.View.extend({
                                 }
                                 input.data = columns;
                             }
-                            var model_value = self.group.get(prefixed);
+                            var model_value = this.group.get(prefixed);
                             if (model_value !== undefined && !input.hidden) {
                                 input.value = model_value;
                             }
@@ -65,19 +63,19 @@ var GroupView = Backbone.View.extend({
                             hidden: true,
                             value: data_columns
                         });
-                        self.chart.state("ok", "Metadata initialized...");
-                        self.form = new Form({
+                        this.chart.state("ok", "Metadata initialized...");
+                        this.form = new Form({
                             inputs: inputs,
-                            onchange: function() {
-                                self.group.set(self.form.data.create());
-                                self.chart.set("modified", true);
-                                self.chart.trigger("redraw");
+                            onchange: () => {
+                                this.group.set(this.form.data.create());
+                                this.chart.set("modified", true);
+                                this.chart.trigger("redraw");
                             }
                         });
-                        self.group.set(self.form.data.create());
-                        self.$el.empty().append(self.form.$el);
+                        this.group.set(this.form.data.create());
+                        this.$el.empty().append(this.form.$el);
                         process.resolve();
-                        self.chart.trigger("redraw");
+                        this.chart.trigger("redraw");
                     }
                 });
             });
@@ -87,31 +85,30 @@ var GroupView = Backbone.View.extend({
 
 export default Backbone.View.extend({
     initialize: function(app) {
-        var self = this;
         this.app = app;
         this.chart = app.chart;
         this.repeat = new Repeat.View({
             title: "Data series",
             title_new: "Data series",
             min: 1,
-            onnew: function() {
-                self.chart.groups.add({ id: Utils.uid() });
+            onnew: () => {
+                this.chart.groups.add({ id: Utils.uid() });
             }
         });
         this.setElement($("<div/>").append(this.repeat.$el));
-        this.listenTo(this.chart.groups, "remove", function(group) {
-            self.repeat.del(group.id);
-            self.chart.trigger("redraw");
+        this.listenTo(this.chart.groups, "remove", group => {
+            this.repeat.del(group.id);
+            this.chart.trigger("redraw");
         });
-        this.listenTo(this.chart.groups, "reset", function() {
-            self.repeat.delAll();
+        this.listenTo(this.chart.groups, "reset", () => {
+            this.repeat.delAll();
         });
-        this.listenTo(this.chart.groups, "add", function(group) {
-            self.repeat.add({
+        this.listenTo(this.chart.groups, "add", group => {
+            this.repeat.add({
                 id: group.id,
-                $el: new GroupView(self.app, { group: group }).$el,
-                ondel: function() {
-                    self.chart.groups.remove(group);
+                $el: new GroupView(this.app, { group: group }).$el,
+                ondel: () => {
+                    this.chart.groups.remove(group);
                 }
             });
         });

--- a/client/galaxy/scripts/mvc/visualization/chart/views/settings.js
+++ b/client/galaxy/scripts/mvc/visualization/chart/views/settings.js
@@ -7,15 +7,13 @@ import FormData from "mvc/form/form-data";
 
 export default Backbone.View.extend({
     initialize: function(app, options) {
-        var self = this;
         this.chart = app.chart;
         this.setElement("<div/>");
-        this.listenTo(this.chart, "load", function() {
-            self.render();
+        this.listenTo(this.chart, "load", () => {
+            this.render();
         });
     },
     render: function() {
-        var self = this;
         var inputs = Utils.clone(this.chart.plugin.settings) || [];
         var panel_option = this.chart.plugin.specs.use_panels;
         if (panel_option == "optional") {
@@ -30,17 +28,17 @@ export default Backbone.View.extend({
         }
         this.$el.empty();
         if (_.size(inputs) > 0) {
-            FormData.visitInputs(inputs, function(input, name) {
-                var model_value = self.chart.settings.get(name);
+            FormData.visitInputs(inputs, (input, name) => {
+                var model_value = this.chart.settings.get(name);
                 if (model_value !== undefined && !input.hidden) {
                     input.value = model_value;
                 }
             });
             this.form = new Form({
                 inputs: inputs,
-                onchange: function() {
-                    self.chart.settings.set(self.form.data.create());
-                    self.chart.trigger("redraw");
+                onchange: () => {
+                    this.chart.settings.set(this.form.data.create());
+                    this.chart.trigger("redraw");
                 }
             });
             this.chart.settings.set(this.form.data.create());

--- a/client/galaxy/scripts/mvc/visualization/chart/views/viewer.js
+++ b/client/galaxy/scripts/mvc/visualization/chart/views/viewer.js
@@ -8,7 +8,6 @@ import Utils from "utils/utils";
 
 export default Backbone.View.extend({
     initialize: function(app, options) {
-        var self = this;
         this.app = app;
         this.chart = this.app.chart;
         this.options = options;
@@ -27,25 +26,25 @@ export default Backbone.View.extend({
         this.$text = this.$(".text");
         this._fullscreen(this.$el, 20);
         this._createContainer("div");
-        this.chart.on("redraw", function(confirmed) {
-            if (!self.chart.get("modified") || !self.chart.plugin.specs.confirm || confirmed) {
-                self.app.deferred.execute(function(process) {
+        this.chart.on("redraw", confirmed => {
+            if (!this.chart.get("modified") || !this.chart.plugin.specs.confirm || confirmed) {
+                this.app.deferred.execute(process => {
                     console.debug("viewer:redraw() - Redrawing...");
-                    self._draw(process, self.chart);
+                    this._draw(process, this.chart);
                 });
             } else {
-                self.chart.state("info", "Please confirm the settings before rendering the results.");
+                this.chart.state("info", "Please confirm the settings before rendering the results.");
             }
         });
-        this.chart.on("set:state", function() {
-            var $container = self.$(".charts-viewer-container");
-            var $info = self.$info;
-            var $icon = self.$icon;
-            var $text = self.$text;
+        this.chart.on("set:state", () => {
+            var $container = this.$(".charts-viewer-container");
+            var $info = this.$info;
+            var $icon = this.$icon;
+            var $text = this.$text;
             $icon.removeClass();
             $info.show();
-            $text.html(self.chart.get("state_info"));
-            var state = self.chart.get("state");
+            $text.html(this.chart.get("state_info"));
+            var state = this.chart.get("state");
             switch (state) {
                 case "ok":
                     $info.hide();

--- a/client/galaxy/scripts/mvc/workflow/workflow-canvas.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-canvas.js
@@ -143,21 +143,20 @@ class CanvasManager {
     }
 
     init_drag() {
-        var self = this;
         var move = (x, y) => {
-            x = Math.min(x, self.cv.width() / 2);
-            x = Math.max(x, -self.cc.width() + self.cv.width() / 2);
-            y = Math.min(y, self.cv.height() / 2);
-            y = Math.max(y, -self.cc.height() + self.cv.height() / 2);
-            self.cc.css({
+            x = Math.min(x, this.cv.width() / 2);
+            x = Math.max(x, -this.cc.width() + this.cv.width() / 2);
+            y = Math.min(y, this.cv.height() / 2);
+            y = Math.max(y, -this.cc.height() + this.cv.height() / 2);
+            this.cc.css({
                 left: x,
                 top: y
             });
-            self.cv.css({
+            this.cv.css({
                 "background-position-x": x,
                 "background-position-y": y
             });
-            self.update_viewport_overlay();
+            this.update_viewport_overlay();
         };
         // Dragging within canvas background
         this.cc.each(function() {
@@ -169,9 +168,9 @@ class CanvasManager {
             .bind("click", function() {
                 document.activeElement.blur();
             })
-            .bind("dragstart", function() {
-                var o = $(this).offset();
-                var p = self.cc.position();
+            .bind("dragstart", e => {
+                var o = $(e.currentTarget).offset();
+                var p = this.cc.position();
                 y_adjust = p.top - o.top;
                 x_adjust = p.left - o.left;
             })
@@ -179,50 +178,50 @@ class CanvasManager {
                 move((d.offsetX + x_adjust) / this.canvasZoom, (d.offsetY + y_adjust) / this.canvasZoom);
             })
             .bind("dragend", () => {
-                self.app.workflow.fit_canvas_to_nodes();
-                self.draw_overview();
+                this.app.workflow.fit_canvas_to_nodes();
+                this.draw_overview();
             });
         this.overview.click(e => {
-            if (self.overview.hasClass("blockaclick")) {
-                self.overview.removeClass("blockaclick");
+            if (this.overview.hasClass("blockaclick")) {
+                this.overview.removeClass("blockaclick");
             } else {
-                var in_w = self.cc.width();
-                var in_h = self.cc.height();
-                var o_w = self.oc.width();
-                var o_h = self.oc.height();
-                var new_x_offset = e.pageX - self.oc.offset().left - self.ov.width() / 2;
-                var new_y_offset = e.pageY - self.oc.offset().top - self.ov.height() / 2;
+                var in_w = this.cc.width();
+                var in_h = this.cc.height();
+                var o_w = this.oc.width();
+                var o_h = this.oc.height();
+                var new_x_offset = e.pageX - this.oc.offset().left - this.ov.width() / 2;
+                var new_y_offset = e.pageY - this.oc.offset().top - this.ov.height() / 2;
                 move(-((new_x_offset / o_w) * in_w), -((new_y_offset / o_h) * in_h));
-                self.app.workflow.fit_canvas_to_nodes();
-                self.draw_overview();
+                this.app.workflow.fit_canvas_to_nodes();
+                this.draw_overview();
             }
         });
         // Dragging for overview pane
         this.ov
             .bind("drag", (e, d) => {
-                var in_w = self.cc.width();
-                var in_h = self.cc.height();
-                var o_w = self.oc.width();
-                var o_h = self.oc.height();
-                var new_x_offset = d.offsetX - self.overview.offset().left;
-                var new_y_offset = d.offsetY - self.overview.offset().top;
+                var in_w = this.cc.width();
+                var in_h = this.cc.height();
+                var o_w = this.oc.width();
+                var o_h = this.oc.height();
+                var new_x_offset = d.offsetX - this.overview.offset().left;
+                var new_y_offset = d.offsetY - this.overview.offset().top;
                 move(-((new_x_offset / o_w) * in_w), -((new_y_offset / o_h) * in_h));
             })
             .bind("dragend", () => {
-                self.overview.addClass("blockaclick");
-                self.app.workflow.fit_canvas_to_nodes();
-                self.draw_overview();
+                this.overview.addClass("blockaclick");
+                this.app.workflow.fit_canvas_to_nodes();
+                this.draw_overview();
             });
         // Dragging for overview border (resize)
-        $(".workflow-overview").bind("drag", function(e, d) {
-            var op = $(this).offsetParent();
+        $(".workflow-overview").bind("drag", (e, d) => {
+            var op = $(e.currentTarget).offsetParent();
             var opo = op.offset();
             var new_size = Math.max(op.width() - (d.offsetX - opo.left), op.height() - (d.offsetY - opo.top));
-            $(this).css({
+            $(e.currentTarget).css({
                 width: new_size,
                 height: new_size
             });
-            self.draw_overview();
+            this.draw_overview();
         });
         /*  Disable dragging for child element of the panel so that resizing can
                 only be done by dragging the borders */

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -10,11 +10,10 @@ import ToolFormBase from "mvc/tool/tool-form-base";
 /** Default form wrapper for non-tool modules in the workflow editor. */
 var Default = Backbone.View.extend({
     initialize: function(options) {
-        var self = this;
         var node = options.node;
         this.form = new Form(
             Utils.merge(options, {
-                onchange: function() {
+                onchange: () => {
                     Utils.request({
                         type: "POST",
                         url: `${getAppRoot()}api/workflows/build_module`,
@@ -22,7 +21,7 @@ var Default = Backbone.View.extend({
                             id: node.id,
                             type: node.type,
                             content_id: node.content_id,
-                            inputs: self.form.data.create()
+                            inputs: this.form.data.create()
                         },
                         success: function(data) {
                             node.update_field_data(data);
@@ -39,7 +38,6 @@ var Default = Backbone.View.extend({
 /** Tool form wrapper for the workflow editor. */
 var Tool = Backbone.View.extend({
     initialize: function(options) {
-        var self = this;
         var node = options.node;
         this.form = new ToolFormBase(
             Utils.merge(options, {
@@ -48,14 +46,14 @@ var Tool = Backbone.View.extend({
                 narrow: true,
                 initial_errors: true,
                 cls: "ui-portlet-section",
-                initialmodel: function(process, form) {
-                    self._customize(form);
+                initialmodel: (process, form) => {
+                    this._customize(form);
                     process.resolve();
                 },
                 buildmodel: function(process, form) {
                     form.model.get("postchange")(process, form);
                 },
-                postchange: function(process, form) {
+                postchange: (process, form) => {
                     const Galaxy = getGalaxyInstance();
                     var options = form.model.attributes;
                     var current_state = {
@@ -69,9 +67,9 @@ var Tool = Backbone.View.extend({
                         type: "POST",
                         url: `${getAppRoot()}api/workflows/build_module`,
                         data: current_state,
-                        success: function(data) {
+                        success: data => {
                             form.model.set(data.config_form);
-                            self._customize(form);
+                            this._customize(form);
                             form.update(data.config_form);
                             form.errors(data.config_form);
                             // This hasn't modified the workflow, just returned

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -160,26 +160,26 @@ function add_node_icon($to_el, nodeType) {
 // create form view
 export default Backbone.View.extend({
     initialize: function(options) {
-        var self = (window.workflow_globals.app = this);
+        window.workflow_globals.app = this;
         this.options = options;
         this.urls = (options && options.urls) || {};
-        var workflow_index = self.urls.workflow_index;
+        var workflow_index = this.urls.workflow_index;
         var save_current_workflow = (eventObj, success_callback) => {
             show_message("Saving workflow", "progress");
-            self.workflow.check_changes_in_active_form();
-            if (!self.workflow.has_changes) {
+            this.workflow.check_changes_in_active_form();
+            if (!this.workflow.has_changes) {
                 hide_modal();
                 if (success_callback) {
                     success_callback();
                 }
                 return;
             }
-            self.workflow.rectify_workflow_outputs();
+            this.workflow.rectify_workflow_outputs();
             Utils.request({
-                url: `${getAppRoot()}api/workflows/${self.options.id}`,
+                url: `${getAppRoot()}api/workflows/${this.options.id}`,
                 type: "PUT",
-                data: { workflow: self.workflow.to_simple() },
-                success: function(data) {
+                data: { workflow: this.workflow.to_simple() },
+                success: data => {
                     var body = $("<div/>").text(data.message);
                     if (data.errors) {
                         body.addClass("warningmark");
@@ -193,12 +193,12 @@ export default Backbone.View.extend({
                     } else {
                         body.addClass("donemark");
                     }
-                    self.workflow.name = data.name;
-                    self.workflow.has_changes = false;
-                    self.workflow.stored = true;
-                    self.workflow.workflow_version = data.version;
-                    self.showWorkflowParameters();
-                    self.build_version_select();
+                    this.workflow.name = data.name;
+                    this.workflow.has_changes = false;
+                    this.workflow.stored = true;
+                    this.workflow.workflow_version = data.version;
+                    this.showWorkflowParameters();
+                    this.build_version_select();
                     if (data.errors) {
                         show_modal("Saving workflow", body, {
                             Ok: hide_modal
@@ -228,32 +228,32 @@ export default Backbone.View.extend({
                 $(this).focus();
                 $(this).select();
             })
-            .keyup(function(e) {
+            .keyup(e => {
                 // If ESC is pressed clear the search field
                 if (e.keyCode == 27) {
-                    this.value = "";
+                    e.currentTarget.value = "";
                 }
                 // Remove italics.
-                $(this).css("font-style", "normal");
+                $(e.currentTarget).css("font-style", "normal");
                 // Don't update if same value as last time
-                if (this.value.length < 3) {
+                if (e.currentTarget.value.length < 3) {
                     reset_tool_search(false);
-                } else if (this.value != this.lastValue) {
+                } else if (e.currentTarget.value != e.currentTarget.lastValue) {
                     // Add class to denote that searching is active.
-                    $(this).addClass("search_active");
+                    $(e.currentTarget).addClass("search_active");
                     // input.addClass(config.loadingClass);
                     // Add '*' to facilitate partial matching.
-                    var q = this.value;
+                    var q = e.currentTarget.value;
                     // Stop previous ajax-request
-                    if (this.timer) {
-                        window.clearTimeout(this.timer);
+                    if (e.currentTarget.timer) {
+                        window.clearTimeout(e.currentTarget.timer);
                     }
                     // Start a new ajax-request in X ms
                     $("#search-spinner").show();
                     $("#search-clear-btn").hide();
                     this.timer = window.setTimeout(() => {
                         $.get(
-                            self.urls.tool_search,
+                            this.urls.tool_search,
                             { q: q },
                             data => {
                                 // input.removeClass(config.loadingClass);
@@ -344,11 +344,11 @@ export default Backbone.View.extend({
         this.ext_to_type = this.datatypes_mapping.ext_to_class_name;
         this.type_to_type = this.datatypes_mapping.class_to_classes;
 
-        this.get_workflow_versions = function() {
+        this.get_workflow_versions = () => {
             const _workflow_version_dropdown = {};
             const workflow_versions = JSON.parse(
                 $.ajax({
-                    url: `${getAppRoot()}api/workflows/${self.options.id}/versions`,
+                    url: `${getAppRoot()}api/workflows/${this.options.id}/versions`,
                     async: false
                 }).responseText
             );
@@ -357,7 +357,7 @@ export default Backbone.View.extend({
                 const current_wf = workflow_versions[i];
                 let version_text = `Version ${current_wf.version}, ${current_wf.steps} steps`;
                 let selected = false;
-                if (i == self.workflow.workflow_version) {
+                if (i == this.workflow.workflow_version) {
                     version_text = `${version_text} (active)`;
                     selected = true;
                 }
@@ -380,34 +380,34 @@ export default Backbone.View.extend({
                         .selected(v.selected)
                 );
             });
-            $("#workflow-version-switch").on("change", function() {
+            $("#workflow-version-switch").on("change", e => {
                 $("#workflow-version-switch").unbind("change");
-                if (this.value != self.workflow.workflow_version) {
-                    if (self.workflow && self.workflow.has_changes) {
+                if (e.currentTarget.value != this.workflow.workflow_version) {
+                    if (this.workflow && this.workflow.has_changes) {
                         const r = window.confirm(
                             "There are unsaved changes to your workflow which will be lost. Continue ?"
                         );
                         if (r == false) {
                             // We rebuild the version select list, to reset the selected version
-                            self.build_version_select();
+                            this.build_version_select();
                             return;
                         }
                     }
-                    self.load_workflow(self.options.id, this.value);
+                    this.load_workflow(this.options.id, this.value);
                 }
             });
         };
 
         this.load_workflow = function load_workflow(id, version) {
             this._workflowLoadAjax(id, version, {
-                success: function(data) {
-                    self.reset();
-                    self.workflow.from_simple(data, true);
-                    self.workflow.has_changes = false;
-                    self.workflow.fit_canvas_to_nodes();
-                    self.scroll_to_nodes();
-                    self.canvas_manager.draw_overview();
-                    self.build_version_select();
+                success: data => {
+                    this.reset();
+                    this.workflow.from_simple(data, true);
+                    this.workflow.has_changes = false;
+                    this.workflow.fit_canvas_to_nodes();
+                    this.scroll_to_nodes();
+                    this.canvas_manager.draw_overview();
+                    this.build_version_select();
 
                     // Determine if any parameters were 'upgraded' and provide message
                     var upgrade_message = "";
@@ -421,7 +421,7 @@ export default Backbone.View.extend({
                         });
                         if (details) {
                             upgrade_message += `<li>Step ${parseInt(step_id, 10) + 1}: ${
-                                self.workflow.nodes[step_id].name
+                                this.workflow.nodes[step_id].name
                             }<ul>${details}</ul></li>`;
                         }
                     });
@@ -434,7 +434,7 @@ export default Backbone.View.extend({
                     } else {
                         hide_modal();
                     }
-                    self.showWorkflowParameters();
+                    this.showWorkflowParameters();
                 },
                 error: function(response) {
                     show_modal("Loading workflow failed.", response.err_msg, {
@@ -451,10 +451,10 @@ export default Backbone.View.extend({
         };
 
         // Load workflow definition
-        this.load_workflow(self.options.id, self.options.version);
+        this.load_workflow(this.options.id, this.options.version);
         if (make_popupmenu) {
             $("#workflow-run-button").click(
-                () => (window.location = `${getAppRoot()}workflows/run?id=${self.options.id}`)
+                () => (window.location = `${getAppRoot()}workflows/run?id=${this.options.id}`)
             );
             $("#workflow-save-button").click(() => save_current_workflow());
             $("#workflow-report-button").click(() => edit_report());
@@ -462,12 +462,12 @@ export default Backbone.View.extend({
             $("#workflow-canvas-button").click(() => edit_canvas());
             make_popupmenu($("#workflow-options-button"), {
                 "Save As": workflow_save_as,
-                "Edit Attributes": function() {
-                    self.workflow.clear_active_node();
+                "Edit Attributes": () => {
+                    this.workflow.clear_active_node();
                 },
                 "Auto Re-layout": layout_editor,
                 Download: {
-                    url: `${getAppRoot()}api/workflows/${self.options.id}/download?format=json-download`,
+                    url: `${getAppRoot()}api/workflows/${this.options.id}/download?format=json-download`,
                     action: function() {}
                 }
             });
@@ -480,20 +480,20 @@ export default Backbone.View.extend({
                     '<br><label style="display:inline-block; width: 100%;">Annotation: </label><input type="text" id="wf_annotation" style="width: 80%;" /></form>'
             );
             show_modal("Save As a New Workflow", body, {
-                OK: function() {
+                OK: () => {
                     var rename_name =
                         $("#workflow_rename").val().length > 0
                             ? $("#workflow_rename").val()
-                            : `SavedAs_${self.workflow.name}`;
+                            : `SavedAs_${this.workflow.name}`;
                     var rename_annotation = $("#wf_annotation").val().length > 0 ? $("#wf_annotation").val() : "";
                     $.ajax({
-                        url: self.urls.workflow_save_as,
+                        url: this.urls.workflow_save_as,
                         type: "POST",
                         data: {
                             workflow_name: rename_name,
                             workflow_annotation: rename_annotation,
-                            workflow_data: function() {
-                                return JSON.stringify(self.workflow.to_simple());
+                            workflow_data: () => {
+                                return JSON.stringify(this.workflow.to_simple());
                             }
                         }
                     })
@@ -512,10 +512,10 @@ export default Backbone.View.extend({
         }
 
         function layout_editor() {
-            self.workflow.layout();
-            self.workflow.fit_canvas_to_nodes();
-            self.scroll_to_nodes();
-            self.canvas_manager.draw_overview();
+            this.workflow.layout();
+            this.workflow.fit_canvas_to_nodes();
+            this.scroll_to_nodes();
+            this.canvas_manager.draw_overview();
         }
 
         function edit_report() {
@@ -554,7 +554,7 @@ export default Backbone.View.extend({
 
         // Unload handler
         window.onbeforeunload = () => {
-            if (self.workflow && self.workflow.has_changes) {
+            if (this.workflow && this.workflow.has_changes) {
                 return "There are unsaved changes to your workflow which will be lost.";
             }
         };
@@ -584,7 +584,7 @@ export default Backbone.View.extend({
         });
 
         // Rename async.
-        async_save_text("workflow-name", "workflow-name", self.urls.rename_async, "new_name");
+        async_save_text("workflow-name", "workflow-name", this.urls.rename_async, "new_name");
 
         // Tag async. Simply have the workflow edit element generate a click on the tag element to activate tagging.
         $("#workflow-tag").click(() => {
@@ -595,7 +595,7 @@ export default Backbone.View.extend({
         async_save_text(
             "workflow-annotation",
             "workflow-annotation",
-            self.urls.annotate_async,
+            this.urls.annotate_async,
             "new_annotation",
             25,
             true,
@@ -604,7 +604,6 @@ export default Backbone.View.extend({
     },
 
     _buildToolPanelWorkflows: function() {
-        var self = this;
         var $section = $(
             '<div class="toolSectionWrapper">' +
                 '<div class="toolSectionTitle">' +
@@ -616,15 +615,15 @@ export default Backbone.View.extend({
                 "</div>"
         );
         _.each(this.options.workflows, workflow => {
-            if (workflow.id !== self.options.id) {
+            if (workflow.id !== this.options.id) {
                 var copy = new Ui.Button({
                     icon: "fa fa-copy",
                     cls: "ui-button-icon-plain",
                     tooltip: _l("Copy and insert individual steps"),
-                    onclick: function() {
+                    onclick: () => {
                         const Galaxy = getGalaxyInstance();
                         if (workflow.step_count < 2) {
-                            self.copy_into_workflow(workflow.id, workflow.name);
+                            this.copy_into_workflow(workflow.id, workflow.name);
                         } else {
                             // don't ruin the workflow by adding 50 steps unprompted.
                             Galaxy.modal.show({
@@ -634,9 +633,9 @@ export default Backbone.View.extend({
                                     Cancel: function() {
                                         Galaxy.modal.hide();
                                     },
-                                    Copy: function() {
+                                    Copy: () => {
                                         Galaxy.modal.hide();
-                                        self.copy_into_workflow(workflow.id, workflow.name);
+                                        this.copy_into_workflow(workflow.id, workflow.name);
                                     }
                                 }
                             });
@@ -648,7 +647,7 @@ export default Backbone.View.extend({
                     .attr("role", "button")
                     .html(workflow.name)
                     .on("click", () => {
-                        self.add_node_for_subworkflow(workflow.latest_id, workflow.name);
+                        this.add_node_for_subworkflow(workflow.latest_id, workflow.name);
                     });
                 $section.find(".toolSectionBg").append(
                     $("<div/>")
@@ -663,14 +662,13 @@ export default Backbone.View.extend({
 
     copy_into_workflow: function(workflowId) {
         // Load workflow definition
-        var self = this;
         this._workflowLoadAjax(workflowId, null, {
-            success: function(data) {
-                self.workflow.from_simple(data, false);
+            success: data => {
+                this.workflow.from_simple(data, false);
                 // Determine if any parameters were 'upgraded' and provide message
                 var upgrade_message = "";
                 $.each(data.upgrade_messages, (k, v) => {
-                    upgrade_message += `<li>Step ${parseInt(k, 10) + 1}: ${self.workflow.nodes[k].name}<ul>`;
+                    upgrade_message += `<li>Step ${parseInt(k, 10) + 1}: ${this.workflow.nodes[k].name}<ul>`;
                     $.each(v, (i, vv) => {
                         upgrade_message += `<li>${vv}</li>`;
                     });
@@ -730,12 +728,11 @@ export default Backbone.View.extend({
     },
 
     _moduleInitAjax: function(node, request_data) {
-        var self = this;
         Utils.request({
             type: "POST",
             url: `${getAppRoot()}api/workflows/build_module`,
             data: request_data,
-            success: function(data) {
+            success: data => {
                 const Galaxy = getGalaxyInstance();
                 node.init_field_data(data);
                 node.update_field_data(data);
@@ -749,7 +746,7 @@ export default Backbone.View.extend({
                     var callout = $(node.element).find(`.callout.${ot.name.replace(/(?=[()])/g, "\\")}`);
                     callout.find("img").attr("src", `${Galaxy.root}static/images/fugue/asterisk-small.png`);
                 });
-                self.workflow.activate_node(node);
+                this.workflow.activate_node(node);
             }
         });
     },
@@ -878,7 +875,6 @@ export default Backbone.View.extend({
     },
 
     prebuildNode: function(type, title_text, content_id) {
-        var self = this;
         var $f = $(`<div class='toolForm toolFormInCanvas' tabindex = '0' aria-label='Node ${title_text}'/>`);
         var $title = $(`<div class='toolFormTitle unselectable'><span class='nodeTitle'>${title_text}</div></div>`);
         add_node_icon($title.find(".nodeTitle"), type);
@@ -935,27 +931,27 @@ export default Backbone.View.extend({
         width += buttons.width() + 10;
         $f.css("width", width);
         $f.bind("dragstart", () => {
-            self.workflow.activate_node(node);
+            this.workflow.activate_node(node);
         })
-            .bind("dragend", function() {
-                self.workflow.node_changed(this);
-                self.workflow.fit_canvas_to_nodes();
-                self.canvas_manager.draw_overview();
+            .bind("dragend", e => {
+                this.workflow.node_changed(e.currentTarget);
+                this.workflow.fit_canvas_to_nodes();
+                this.canvas_manager.draw_overview();
             })
             .bind("dragclickonly", () => {
-                self.workflow.activate_node(node);
+                this.workflow.activate_node(node);
             })
-            .bind("drag", function(e, d) {
+            .bind("drag", (e, d) => {
                 // Move
-                var po = $(this)
+                var po = $(e.currentTarget)
                     .offsetParent()
                     .offset();
                 // Find relative offset and scale by zoom
-                var x = (d.offsetX - po.left) / self.canvas_manager.canvasZoom;
-                var y = (d.offsetY - po.top) / self.canvas_manager.canvasZoom;
-                $(this).css({ left: x, top: y });
+                var x = (d.offsetX - po.left) / this.canvas_manager.canvasZoom;
+                var y = (d.offsetY - po.top) / this.canvas_manager.canvasZoom;
+                $(e.currentTarget).css({ left: x, top: y });
                 // Redraw
-                $(this)
+                $(e.currentTarget)
                     .find(".terminal")
                     .each(function() {
                         this.terminal.redraw();

--- a/client/galaxy/scripts/qunit/tests/metrics_logger_tests.js
+++ b/client/galaxy/scripts/qunit/tests/metrics_logger_tests.js
@@ -8,15 +8,14 @@ import metrics from "utils/metrics-logger";
 import testApp from "qunit/test-app";
 
 var MockConsole = function() {
-    var self = this;
-    self.lastMessage = null;
-    ["log", "debug", "info", "warn", "error"].forEach(function(fnName) {
-        self[fnName] = function() {
+    this.lastMessage = null;
+    ["log", "debug", "info", "warn", "error"].forEach(fnName => {
+        this[fnName] = () => {
             var args = Array.prototype.slice.call(arguments, 0);
-            self.lastMessage = { level: fnName, args: args };
+            this.lastMessage = { level: fnName, args: args };
         };
     });
-    return self;
+    return this;
 };
 
 (window.bootstrapped = {}).user = {

--- a/client/galaxy/scripts/qunit/tests/modal_tests.js
+++ b/client/galaxy/scripts/qunit/tests/modal_tests.js
@@ -7,14 +7,13 @@ QUnit.module("Modal dialog test", {
     beforeEach: function() {
         $.fx.off = true;
         testApp.create();
-        var self = this;
         this.app = new GalaxyModal.View({
             title: "Test title",
             body: "Test body",
             buttons: {
                 Ok: function() {},
-                Cancel: function() {
-                    self.app.hide();
+                Cancel: () => {
+                    this.app.hide();
                 }
             }
         });

--- a/client/galaxy/scripts/qunit/tests/ui_tests.js
+++ b/client/galaxy/scripts/qunit/tests/ui_tests.js
@@ -21,12 +21,11 @@ QUnit.module("Ui test", {
 
 QUnit.test("tabs", function(assert) {
     assert.ok($.fn);
-    var self = this;
     var tabs = new Tabs.View({});
     var collection = tabs.collection;
     collection.add({ id: "id_a", title: "title_a", icon: "icon_a", $el: "el_a" });
-    var _test = function() {
-        self.clock.tick(window.WAIT_FADE);
+    var _test = () => {
+        this.clock.tick(window.WAIT_FADE);
         collection.each(function(model, index) {
             var $tab_element = tabs.$("#tab-" + model.id + " .nav-link");
             var $tab_content = tabs.$("#" + model.id);
@@ -50,10 +49,10 @@ QUnit.test("tabs", function(assert) {
     _test();
     tabs.model.set("visible", false);
     tabs.collection.reset();
-    self.clock.tick(window.WAIT_FADE);
+    this.clock.tick(window.WAIT_FADE);
     assert.ok(tabs.$el.css("display", "none"), "Everything hidden.");
     tabs.model.set("visible", true);
-    self.clock.tick(window.WAIT_FADE);
+    this.clock.tick(window.WAIT_FADE);
     assert.ok(tabs.$el.css("display", "block"), "Everything shown.");
     collection.add({ id: "id_c", title: "title_c", icon: "icon_c", $el: "el_c" });
     tabs.model.set("current", "id_c");

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -159,35 +159,31 @@ QUnit.test("input type can accept any datatype", function(assert) {
 });
 
 QUnit.test("cannot accept when already connected", function(assert) {
-    var self = this;
     // If other is subtype but already connected, cannot accept
-    this.with_test_connector(function() {
-        assert.ok(!self.test_accept());
+    this.with_test_connector(() => {
+        assert.ok(!this.test_accept());
     });
 });
 
 QUnit.test("can accept already connected inputs if input is multiple", function(assert) {
-    var self = this;
     this.multiple();
-    this.with_test_connector(function() {
-        assert.ok(self.test_accept());
+    this.with_test_connector(() => {
+        assert.ok(this.test_accept());
     });
 });
 
 QUnit.test("cannot accept already connected inputs if input is multiple but datatypes don't match", function(assert) {
     var other = { node: {}, datatypes: ["binary"] }; // binary is not txt
 
-    var self = this;
     this.multiple();
-    this.with_test_connector(function() {
-        assert.ok(!self.test_accept(other));
+    this.with_test_connector(() => {
+        assert.ok(!this.test_accept(other));
     });
 });
 
 QUnit.test("can accept list collection for multiple input parameters if datatypes match", function(assert) {
-    var self = this;
     this.multiple();
-    assert.ok(self.test_accept());
+    assert.ok(this.test_accept());
 });
 
 QUnit.test("can accept list collection for empty multiple inputs", function(assert) {
@@ -198,9 +194,8 @@ QUnit.test("can accept list collection for empty multiple inputs", function(asse
             return new Terminals.CollectionTypeDescription("list");
         }
     };
-    var self = this;
     this.multiple();
-    assert.ok(self.test_accept(other));
+    assert.ok(this.test_accept(other));
 });
 
 QUnit.test("cannot accept list collection for multiple input if collection already connected", function(assert) {
@@ -211,10 +206,9 @@ QUnit.test("cannot accept list collection for multiple input if collection alrea
             return new Terminals.CollectionTypeDescription("list");
         }
     };
-    var self = this;
     this.multiple();
     this.with_test_connector(function() {
-        assert.ok(!self.test_accept(other));
+        assert.ok(!this.test_accept(other));
     });
 });
 
@@ -290,8 +284,7 @@ QUnit.module("Input collection terminal model test", {
 });
 
 QUnit.test("Collection output can connect to same collection input type", function(assert) {
-    var self = this;
-    var inputTerminal = self.input_terminal;
+    var inputTerminal = this.input_terminal;
     assert.ok(inputTerminal);
     var outputTerminal = new Terminals.OutputCollectionTerminal({
         datatypes: "txt",
@@ -305,8 +298,7 @@ QUnit.test("Collection output can connect to same collection input type", functi
 });
 
 QUnit.test("Collection output cannot connect to different collection input type", function(assert) {
-    var self = this;
-    var inputTerminal = self.input_terminal;
+    var inputTerminal = this.input_terminal;
     var outputTerminal = new Terminals.OutputCollectionTerminal({
         datatypes: "txt",
         collection_type: "paired"
@@ -913,10 +905,9 @@ QUnit.module("terminal mapping logic", {
         return new Node(create_app(), { element: nodeEl });
     },
     _addExistingOutput: function(terminal, output, connected) {
-        var self = this;
         var node = terminal.node;
         if (connected) {
-            var inputTerminal = self.newInputTerminal();
+            var inputTerminal = this.newInputTerminal();
             new Connector(inputTerminal, output);
         }
         this._addTerminalTo(output, node.output_terminals);
@@ -938,10 +929,9 @@ QUnit.module("terminal mapping logic", {
         return this._addExistingOutput(terminal, connectedOutput, true);
     },
     addConnectedInput: function(terminal) {
-        var self = this;
         var connectedInput = this.newInputTerminal();
         var node = terminal.node;
-        var outputTerminal = self.newOutputTerminal();
+        var outputTerminal = this.newOutputTerminal();
         new Connector(connectedInput, outputTerminal);
         this._addTerminalTo(connectedInput, node.input_terminals);
         return connectedInput;

--- a/client/galaxy/scripts/ui/loading-indicator.js
+++ b/client/galaxy/scripts/ui/loading-indicator.js
@@ -4,7 +4,6 @@ import jQuery from "jquery";
 var $ = jQuery;
 //TODO: too specific to history panel
 function LoadingIndicator($where, options) {
-    var self = this;
     // defaults
     options = jQuery.extend(
         {
@@ -61,7 +60,7 @@ function LoadingIndicator($where, options) {
         return $indicator;
     }
 
-    self.show = (msg, speed, callback) => {
+    this.show = (msg, speed, callback) => {
         msg = msg || "loading...";
         speed = speed || "fast";
         // remove previous
@@ -70,21 +69,21 @@ function LoadingIndicator($where, options) {
             .find(".loading-indicator")
             .remove();
         // since position is fixed - we insert as sibling
-        self.$indicator = render().insertBefore($where);
-        self.message(msg);
-        self.$indicator.fadeIn(speed, callback);
-        return self;
+        this.$indicator = render().insertBefore($where);
+        this.message(msg);
+        this.$indicator.fadeIn(speed, callback);
+        return this;
     };
 
-    self.message = msg => {
-        self.$indicator.find("i").text(msg);
+    this.message = msg => {
+        this.$indicator.find("i").text(msg);
     };
 
-    self.hide = (speed, callback) => {
+    this.hide = (speed, callback) => {
         speed = speed || "fast";
-        if (self.$indicator && self.$indicator.length) {
-            self.$indicator.fadeOut(speed, () => {
-                self.$indicator.remove();
+        if (this.$indicator && this.$indicator.length) {
+            this.$indicator.fadeOut(speed, () => {
+                this.$indicator.remove();
                 if (callback) {
                     callback();
                 }
@@ -94,9 +93,9 @@ function LoadingIndicator($where, options) {
                 callback();
             }
         }
-        return self;
+        return this;
     };
-    return self;
+    return this;
 }
 
 const markViewAsLoading = function(view) {

--- a/client/galaxy/scripts/utils/config.js
+++ b/client/galaxy/scripts/utils/config.js
@@ -363,7 +363,6 @@ var ConfigSettingCollectionView = Backbone.View.extend({
      */
     render_in_modal: function(title) {
         // Set up handlers for cancel, ok button and for handling esc key.
-        var self = this;
         const Galaxy = getGalaxyInstance();
 
         var cancel_fn = () => {
@@ -374,7 +373,7 @@ var ConfigSettingCollectionView = Backbone.View.extend({
         var ok_fn = () => {
             Galaxy.modal.hide();
             $(window).unbind("keypress.check_enter_esc");
-            self.update_from_form();
+            this.update_from_form();
         };
 
         var check_enter_esc = e => {
@@ -408,14 +407,13 @@ var ConfigSettingCollectionView = Backbone.View.extend({
      * Update settings with new values entered via form.
      */
     update_from_form: function() {
-        var self = this;
         this.collection.each((setting, index) => {
             if (!setting.get("hidden")) {
                 // Set value from view.
                 var id = `param_${index}`;
-                var value = self.$el.find(`#${id}`).val();
+                var value = this.$el.find(`#${id}`).val();
                 if (setting.get("type") === "bool") {
-                    value = self.$el.find(`#${id}`).is(":checked");
+                    value = this.$el.find(`#${id}`).is(":checked");
                 }
                 setting.set_value(value);
             }

--- a/client/galaxy/scripts/utils/deferred.js
+++ b/client/galaxy/scripts/utils/deferred.js
@@ -16,7 +16,6 @@ export default Backbone.Model.extend({
      *  If the callback does not take any arguments, the deferred is resolved instantly.
      */
     execute: function(callback) {
-        var self = this;
         var id = Utils.uid();
         var has_deferred = callback.length > 0;
         const Galaxy = getGalaxyInstance();
@@ -26,20 +25,20 @@ export default Backbone.Model.extend({
 
         // deferred process
         var process = $.Deferred();
-        process.promise().always(function() {
-            delete self.active[id];
+        process.promise().always(() => {
+            delete this.active[id];
             has_deferred &&
                 Galaxy.emit.debug(
                     "deferred::execute()",
-                    `${this.state()
+                    `${process.state()
                         .charAt(0)
-                        .toUpperCase() + this.state().slice(1)} ${id}`
+                        .toUpperCase() + process.state().slice(1)} ${id}`
                 );
         });
 
         // deferred queue
         $.when(this.last).always(() => {
-            if (self.active[id]) {
+            if (this.active[id]) {
                 has_deferred && Galaxy.emit.debug("deferred::execute()", `Running ${id}`);
                 callback(process);
                 !has_deferred && process.resolve();

--- a/client/galaxy/scripts/utils/graph.js
+++ b/client/galaxy/scripts/utils/graph.js
@@ -42,14 +42,13 @@ function iterate(obj, propsOrFn) {
 /** A graph edge containing the name/id of both source and target and optional data
  */
 function Edge(source, target, data) {
-    var self = this;
-    self.source = source !== undefined ? source : null;
-    self.target = target !== undefined ? target : null;
-    self.data = data || null;
+    this.source = source !== undefined ? source : null;
+    this.target = target !== undefined ? target : null;
+    this.data = data || null;
     //if( typeof data === 'object' ){
     //    extend( self, data );
     //}
-    return self;
+    return this;
 }
 /** String representation */
 Edge.prototype.toString = function() {
@@ -75,12 +74,11 @@ Edge.prototype.toJSON = function() {
  *      A vertex contains a list of Edges (whose sources are this vertex) and maintains the degree.
  */
 function Vertex(name, data) {
-    var self = this;
-    self.name = name !== undefined ? name : "(unnamed)";
-    self.data = data || null;
-    self.edges = {};
-    self.degree = 0;
-    return self;
+    this.name = name !== undefined ? name : "(unnamed)";
+    this.data = data || null;
+    this.edges = {};
+    this.degree = 0;
+    return this;
 }
 
 /** String representation */
@@ -109,10 +107,9 @@ Vertex.prototype.toJSON = function() {
  *      and an optional dictionary containing the 3 vertex/edge processing fns listed below.
  */
 var GraphSearch = function(graph, processFns) {
-    var self = this;
-    self.graph = graph;
+    this.graph = graph;
 
-    self.processFns = processFns || {
+    this.processFns = processFns || {
         vertexEarly: function(vertex, search) {
             //console.debug( 'processing vertex:', vertex.name, vertex );
         },
@@ -124,22 +121,21 @@ var GraphSearch = function(graph, processFns) {
         }
     };
 
-    self._cache = {};
-    return self;
+    this._cache = {};
+    return this;
 };
 
 /** Search interface where start is the vertex (or the name/id of the vertex) to begin the search at
  *      This public interface caches searches and returns the cached version if it's already been done.
  */
 GraphSearch.prototype.search = function _search(start) {
-    var self = this;
-    if (start in self._cache) {
-        return self._cache[start];
+    if (start in this._cache) {
+        return this._cache[start];
     }
     if (!(start instanceof Vertex)) {
-        start = self.graph.vertices[start];
+        start = this.graph.vertices[start];
     }
-    return (self._cache[start.name] = self._search(start));
+    return (this._cache[start.name] = this._search(start));
 };
 
 /** Actual search (private) function (abstract here) */
@@ -159,10 +155,9 @@ GraphSearch.prototype.searchTree = function _searchTree(start) {
 
 /** Helper fn that returns a graph (a search tree) based on the search object passed in (does not actually search) */
 GraphSearch.prototype._searchTree = function __searchTree(search) {
-    var self = this;
     return new Graph(true, {
         edges: search.edges,
-        vertices: Object.keys(search.discovered).map(key => self.graph.vertices[key].toJSON())
+        vertices: Object.keys(search.discovered).map(key => this.graph.vertices[key].toJSON())
     });
 };
 
@@ -170,9 +165,8 @@ GraphSearch.prototype._searchTree = function __searchTree(search) {
 /** Breadth first search algo.
  */
 var BreadthFirstSearch = function(graph, processFns) {
-    var self = this;
     GraphSearch.call(this, graph, processFns);
-    return self;
+    return this;
 };
 BreadthFirstSearch.prototype = new GraphSearch();
 BreadthFirstSearch.prototype.constructor = BreadthFirstSearch;
@@ -225,9 +219,8 @@ BreadthFirstSearch.prototype._search = function __search(start, search) {
 /** Depth first search algorithm.
  */
 var DepthFirstSearch = function(graph, processFns) {
-    var self = this;
     GraphSearch.call(this, graph, processFns);
-    return self;
+    return this;
 };
 DepthFirstSearch.prototype = new GraphSearch();
 DepthFirstSearch.prototype.constructor = DepthFirstSearch;
@@ -298,13 +291,12 @@ window.Graph = Graph;
 /** Set up options and instance variables */
 Graph.prototype.init = function(options) {
     options = options || {};
-    var self = this;
 
-    self.allowReflexiveEdges = options.allowReflexiveEdges || false;
+    this.allowReflexiveEdges = options.allowReflexiveEdges || false;
 
-    self.vertices = {};
-    self.numEdges = 0;
-    return self;
+    this.vertices = {};
+    this.numEdges = 0;
+    return this;
 };
 
 /** Read data from the plain object data - both in d3 form (nodes and links) or vertices and edges */
@@ -312,14 +304,13 @@ Graph.prototype.read = function(data) {
     if (!data) {
         return this;
     }
-    var self = this;
     if (Object.prototype.hasOwnProperty.call(data, "nodes")) {
-        return self.readNodesAndLinks(data);
+        return this.readNodesAndLinks(data);
     }
     if (Object.prototype.hasOwnProperty.call(data, "vertices")) {
-        return self.readVerticesAndEdges(data);
+        return this.readVerticesAndEdges(data);
     }
-    return self;
+    return this;
 };
 
 //TODO: the next two could be combined
@@ -330,20 +321,18 @@ Graph.prototype.readNodesAndLinks = function(data) {
     }
     //console.debug( 'readNodesAndLinks:', data );
     //console.debug( 'data:\n' + JSON.stringify( data, null, '  ' ) );
-    var self = this;
     data.nodes.forEach(node => {
-        self.createVertex(node.name, node.data);
+        this.createVertex(node.name, node.data);
     });
     //console.debug( JSON.stringify( self.vertices, null, '  ' ) );
 
     (data.links || []).forEach((edge, i) => {
         var sourceName = data.nodes[edge.source].name;
         var targetName = data.nodes[edge.target].name;
-        self.createEdge(sourceName, targetName, self.directed);
+        this.createEdge(sourceName, targetName, this.directed);
     });
-    //self.print();
     //console.debug( JSON.stringify( self.toNodesAndLinks(), null, '  ' ) );
-    return self;
+    return this;
 };
 
 /** Create the graph using a list of nodes and a list of edges (where source and target are names of nodes) */
@@ -353,18 +342,16 @@ Graph.prototype.readVerticesAndEdges = function(data) {
     }
     //console.debug( 'readVerticesAndEdges:', data );
     //console.debug( 'data:\n' + JSON.stringify( data, null, '  ' ) );
-    var self = this;
     data.vertices.forEach(node => {
-        self.createVertex(node.name, node.data);
+        this.createVertex(node.name, node.data);
     });
-    //console.debug( JSON.stringify( self.vertices, null, '  ' ) );
+    //console.debug( JSON.stringify( this.vertices, null, '  ' ) );
 
     (data.edges || []).forEach((edge, i) => {
-        self.createEdge(edge.source, edge.target, self.directed);
+        this.createEdge(edge.source, edge.target, this.directed);
     });
-    //self.print();
-    //console.debug( JSON.stringify( self.toNodesAndLinks(), null, '  ' ) );
-    return self;
+    //console.debug( JSON.stringify( this.toNodesAndLinks(), null, '  ' ) );
+    return this;
 };
 
 /** Return the vertex with name, creating it if necessary */
@@ -394,20 +381,17 @@ Graph.prototype.createEdge = function(sourceName, targetName, directed, data) {
         return null;
     }
 
-    //TODO: prob. move to vertex
-    var self = this;
-
     var edge = new Edge(sourceName, targetName, data);
     sourceVertex.edges[targetName] = edge;
     sourceVertex.degree += 1;
-    self.numEdges += 1;
+    this.numEdges += 1;
 
     //TODO:! don't like having duplicate edges for non-directed graphs
     // mirror edges (reversing source and target) in non-directed graphs
     //  but only if not reflexive
     if (!isReflexive && !directed) {
         // flip directed to prevent recursion loop
-        self.createEdge(targetName, sourceName, true);
+        this.createEdge(targetName, sourceName, true);
     }
 
     return edge;
@@ -425,38 +409,34 @@ Graph.prototype.eachVertex = function(propsOrFn) {
 
 /** Return a list of the vertices adjacent to vertex */
 Graph.prototype.adjacent = function(vertex) {
-    var self = this;
-    return iterate(vertex.edges, edge => self.vertices[edge.target]);
+    return iterate(vertex.edges, edge => this.vertices[edge.target]);
 };
 
 /** Call fn on each vertex adjacent to vertex */
 Graph.prototype.eachAdjacent = function(vertex, fn) {
-    var self = this;
     return iterate(vertex.edges, edge => {
-        var adj = self.vertices[edge.target];
+        var adj = this.vertices[edge.target];
         return fn.call(vertex, adj, edge);
     });
 };
 
 /** Print the graph to the console (debugging) */
 Graph.prototype.print = function() {
-    var self = this;
-    console.log(`Graph has ${Object.keys(self.vertices).length} vertices`);
-    self.eachVertex(vertex => {
+    console.log(`Graph has ${Object.keys(this.vertices).length} vertices`);
+    this.eachVertex(vertex => {
         console.log(vertex.toString());
         vertex.eachEdge(edge => {
             console.log(`\t ${edge}`);
         });
     });
-    return self;
+    return this;
 };
 
 /** Return a DOT format string of this graph */
 Graph.prototype.toDOT = function() {
-    var self = this;
     var strings = [];
     strings.push("graph bler {");
-    self.edges(edge => {
+    this.edges(edge => {
         strings.push(`\t${edge.from} -- ${edge.to};`);
     });
     strings.push("}");
@@ -465,14 +445,13 @@ Graph.prototype.toDOT = function() {
 
 /** Return vertices and edges of this graph in d3 node/link format */
 Graph.prototype.toNodesAndLinks = function() {
-    var self = this;
     var indeces = {};
     return {
-        nodes: self.eachVertex((vertex, key, i) => {
+        nodes: this.eachVertex((vertex, key, i) => {
             indeces[vertex.name] = i;
             return vertex.toJSON();
         }),
-        links: self.edges(edge => {
+        links: this.edges(edge => {
             var json = edge.toJSON();
             json.source = indeces[edge.source];
             json.target = indeces[edge.target];
@@ -483,10 +462,9 @@ Graph.prototype.toNodesAndLinks = function() {
 
 /** Return vertices and edges of this graph where edges use the name/id as source and target */
 Graph.prototype.toVerticesAndEdges = function() {
-    var self = this;
     return {
-        vertices: self.eachVertex((vertex, key) => vertex.toJSON()),
-        edges: self.edges(edge => edge.toJSON())
+        vertices: this.eachVertex((vertex, key) => vertex.toJSON()),
+        edges: this.edges(edge => edge.toJSON())
     };
 };
 
@@ -526,7 +504,6 @@ Graph.prototype.depthFirstSearchTree = function(start, processFns) {
 Graph.prototype.weakComponents = function() {
     //TODO: alternately, instead of returning graph-like objects:
     //  - could simply decorate the vertices (vertex.component = componentIndex), or clone the graph and do that
-    var self = this;
 
     var searchGraph = this;
     var undiscovered;
@@ -540,11 +517,11 @@ Graph.prototype.weakComponents = function() {
         undiscovered = undiscovered.filter(name => !(name in search.discovered));
 
         return {
-            vertices: Object.keys(search.discovered).map(vertexName => self.vertices[vertexName].toJSON()),
+            vertices: Object.keys(search.discovered).map(vertexName => this.vertices[vertexName].toJSON()),
             edges: search.edges.map(edge => {
                 // restore any reversed edges
-                var hasBeenReversed = self.vertices[edge.target].edges[edge.source] !== undefined;
-                if (self.directed && hasBeenReversed) {
+                var hasBeenReversed = this.vertices[edge.target].edges[edge.source] !== undefined;
+                if (this.directed && hasBeenReversed) {
                     var swap = edge.source;
                     edge.source = edge.target;
                     edge.target = swap;
@@ -554,9 +531,9 @@ Graph.prototype.weakComponents = function() {
         };
     }
 
-    if (self.directed) {
+    if (this.directed) {
         // if directed - convert to undirected for search
-        searchGraph = new Graph(false, self.toNodesAndLinks());
+        searchGraph = new Graph(false, this.toNodesAndLinks());
     }
     undiscovered = Object.keys(searchGraph.vertices);
     //console.debug( '(initial) undiscovered:', undiscovered );

--- a/client/galaxy/scripts/viz/bbi-data-manager.js
+++ b/client/galaxy/scripts/viz/bbi-data-manager.js
@@ -18,7 +18,6 @@ var BBIDataManager = visualization.GenomeDataManager.extend({
 
         var url = `${getAppRoot()}datasets/${this.get("dataset").id}/display`;
 
-        var self = this;
         $.when(bigwig.makeBwg(url)).then((bb, err) => {
             $.when(bb.readWigData(region.get("chrom"), region.get("start"), region.get("end"))).then(data => {
                 // Transform data into "bigwig" format for LinePainter. "bigwig" format is an array of 2-element arrays
@@ -53,7 +52,7 @@ var BBIDataManager = visualization.GenomeDataManager.extend({
                     dataset_type: "bigwig"
                 };
 
-                self.set_data(region, entry);
+                this.set_data(region, entry);
                 deferred.resolve(entry);
             });
         });

--- a/client/galaxy/scripts/viz/sweepster.js
+++ b/client/galaxy/scripts/viz/sweepster.js
@@ -40,7 +40,6 @@ var ToolParameterTree = Backbone.Model.extend({
 
     initialize: function(options) {
         // Set up tool parameters to work with tree.
-        var self = this;
         this.get("tool")
             .get("inputs")
             .each(input => {
@@ -49,33 +48,33 @@ var ToolParameterTree = Backbone.Model.extend({
                     "change:min change:max change:num_samples",
                     input => {
                         if (input.get("in_ptree")) {
-                            self.set_tree_data();
+                            this.set_tree_data();
                         }
                     },
-                    self
+                    this
                 );
                 input.on(
                     "change:in_ptree",
                     input => {
                         if (input.get("in_ptree")) {
-                            self.add_param(input);
+                            this.add_param(input);
                         } else {
-                            self.remove_param(input);
+                            this.remove_param(input);
                         }
-                        self.set_tree_data();
+                        this.set_tree_data();
                     },
-                    self
+                    this
                 );
             });
 
         // If there is a config, use it.
         if (options.config) {
             _.each(options.config, input_config => {
-                var input = self
+                var input = this
                     .get("tool")
                     .get("inputs")
                     .find(input => input.get("name") === input_config.name);
-                self.add_param(input);
+                this.add_param(input);
                 input.set(input_config);
             });
         }
@@ -182,7 +181,6 @@ var ToolParameterTree = Backbone.Model.extend({
         }
 
         // Walk subtree starting at clicked node to get full list of settings.
-        var self = this;
 
         var get_settings = (node, settings) => {
             // Add setting for this node. Root node does not have a param,
@@ -194,7 +192,7 @@ var ToolParameterTree = Backbone.Model.extend({
             if (!node.children) {
                 // At leaf node, so return settings.
                 return new ToolInputsSettings({
-                    inputs: self.get("tool").get("inputs"),
+                    inputs: this.get("tool").get("inputs"),
                     values: settings
                 });
             } else {
@@ -407,14 +405,13 @@ var SweepsterTrackView = Backbone.View.extend({
         settings.get("inputs").each(input => {
             settings_div.append(`${input.get("label")}: ${values[input.get("name")]}<br/>`);
         });
-        var self = this;
 
         $("<button/>")
             .appendTo(settings_div)
             .text("Run on complete dataset")
             .click(() => {
                 settings_div.toggle();
-                self.trigger("run_on_dataset", settings);
+                this.trigger("run_on_dataset", settings);
             });
 
         var icon_menu = mod_icon_btn.create_icon_buttons_menu([
@@ -428,8 +425,8 @@ var SweepsterTrackView = Backbone.View.extend({
             {
                 title: _l("Remove"),
                 icon_class: "cross-circle",
-                on_click: function() {
-                    self.$el.remove();
+                on_click: () => {
+                    this.$el.remove();
                     $(".tooltip").remove();
                     // TODO: remove track from viz collection.
                 }
@@ -439,7 +436,7 @@ var SweepsterTrackView = Backbone.View.extend({
 
         // Render tile placeholders.
         this.model.get("regions").each(() => {
-            self.$el.append(
+            this.$el.append(
                 $("<td/>")
                     .addClass("tile")
                     .html($("<img/>").attr("src", `${getAppRoot()}images/loading_large_white_bg.gif`))
@@ -455,7 +452,6 @@ var SweepsterTrackView = Backbone.View.extend({
      * Draw tiles for regions.
      */
     draw_tiles: function() {
-        var self = this;
         var track = this.model.get("track");
         var regions = this.model.get("regions");
         var tile_containers = this.$el.find("td.tile");
@@ -469,12 +465,12 @@ var SweepsterTrackView = Backbone.View.extend({
         $.when(track.data_manager.data_is_ready()).then(data_ok => {
             // Draw tile for each region.
             regions.each((region, index) => {
-                var resolution = region.length() / self.TILE_LEN;
+                var resolution = region.length() / this.TILE_LEN;
                 var w_scale = 1 / resolution;
-                var mode = self.model.get("mode");
+                var mode = this.model.get("mode");
                 $.when(track.data_manager.get_data(region, mode, resolution, {})).then(tile_data => {
-                    var canvas = self.canvas_manager.new_canvas();
-                    canvas.width = self.TILE_LEN;
+                    var canvas = this.canvas_manager.new_canvas();
+                    canvas.width = this.TILE_LEN;
                     canvas.height = track.get_canvas_height(tile_data, mode, w_scale, canvas.width);
                     track.draw_tile(tile_data, canvas.getContext("2d"), mode, region, w_scale);
                     $(tile_containers[index])
@@ -532,31 +528,30 @@ var ToolInputValOrSweepView = Backbone.View.extend({
         sweep_inputs_row.insertAfter(single_input_row);
 
         // Add buttons for adding/removing parameter.
-        var self = this;
 
         var menu = mod_icon_btn.create_icon_buttons_menu(
             [
                 {
                     title: _l("Add parameter to tree"),
                     icon_class: "plus-button",
-                    on_click: function() {
+                    on_click: () => {
                         input.set("in_ptree", true);
                         single_input_row.hide();
                         sweep_inputs_row.show();
-                        $(this).hide();
-                        self.$el.find(".icon-button.toggle").show();
+                        $(e.currentTarget).hide();
+                        this.$el.find(".icon-button.toggle").show();
                     }
                 },
                 {
                     title: _l("Remove parameter from tree"),
                     icon_class: "toggle",
-                    on_click: function() {
+                    on_click: () => {
                         // Remove parameter from tree params where name matches clicked paramter.
                         input.set("in_ptree", false);
                         sweep_inputs_row.hide();
                         single_input_row.show();
-                        $(this).hide();
-                        self.$el.find(".icon-button.plus-button").show();
+                        $(e.currentTarget).hide();
+                        this.$el.find(".icon-button.plus-button").show();
                     }
                 }
             ],
@@ -568,9 +563,9 @@ var ToolInputValOrSweepView = Backbone.View.extend({
         // Show/hide input rows and icons depending on whether parameter is in the tree.
         if (input.get("in_ptree")) {
             single_input_row.hide();
-            self.$el.find(".icon-button.plus-button").hide();
+            this.$el.find(".icon-button.plus-button").hide();
         } else {
-            self.$el.find(".icon-button.toggle").hide();
+            this.$el.find(".icon-button.toggle").hide();
             sweep_inputs_row.hide();
         }
 
@@ -599,9 +594,7 @@ var ToolParameterTreeDesignView = Backbone.View.extend({
         this.$el.append(tool_form_view.$el);
 
         // Set up views for each tool input.
-        var self = this;
-
-        var inputs = self.model.get("tool").get("inputs");
+        var inputs = this.model.get("tool").get("inputs");
         this.$el
             .find(".form-row")
             .not(".form-actions")
@@ -638,8 +631,6 @@ var ToolParameterTreeView = Backbone.View.extend({
         this.width = 100 * (2 + tree_params.length);
         this.height = 15 * this.model.get_num_leaves();
 
-        var self = this;
-
         // Layout tree.
         var cluster = d3.layout.cluster().size([this.height, this.width - 160]);
 
@@ -653,7 +644,7 @@ var ToolParameterTreeView = Backbone.View.extend({
         _.each(tree_params, (param, index) => {
             var x = param_depths[index + 1];
             var center_left = $("#center").position().left;
-            self.$el.append(
+            this.$el.append(
                 $("<div>")
                     .addClass("label")
                     .text(param.get("label"))
@@ -687,7 +678,7 @@ var ToolParameterTreeView = Backbone.View.extend({
             .attr("class", "node")
             .attr("transform", d => `translate(${d.y},${d.x})`)
             .on("mouseover", a_node => {
-                var connected_node_ids = _.pluck(self.model.get_connected_nodes(a_node), "id");
+                var connected_node_ids = _.pluck(this.model.get_connected_nodes(a_node), "id");
                 // TODO: probably can use enter() to do this more easily.
                 node.filter(d => _.find(connected_node_ids, id => id === d.id) !== undefined).style("fill", "#f00");
             })
@@ -729,9 +720,8 @@ export var SweepsterVisualizationView = Backbone.View.extend({
         this.model.get("parameter_tree").on("change:tree_data", this.handle_node_clicks, this);
 
         // Each track must have a view so it has a canvas manager.
-        var self = this;
         this.model.get("tracks").each(track => {
-            track.get("track").view = self;
+            track.get("track").view = this;
         });
 
         // Set block, reverse strand block colors; these colors will be used for all tracks.
@@ -797,9 +787,8 @@ export var SweepsterVisualizationView = Backbone.View.extend({
         $("#left").append(tree_design_view.$el);
 
         // Render track collection container/view in right panel.
-        var self = this;
 
-        var regions = self.model.get("regions");
+        var regions = this.model.get("regions");
         var tr = $("<tr/>").appendTo(this.track_collection_container);
 
         regions.each(region => {
@@ -812,8 +801,8 @@ export var SweepsterVisualizationView = Backbone.View.extend({
         var tracks_div = $("<div>").addClass("tiles");
         $("#right").append(tracks_div.append(this.track_collection_container));
 
-        self.model.get("tracks").each(track => {
-            self.add_track(track);
+        this.model.get("tracks").each(track => {
+            this.add_track(track);
         });
 
         // -- Render help and tool parameter tree in center panel. --
@@ -889,8 +878,8 @@ export var SweepsterVisualizationView = Backbone.View.extend({
         var mode_mapping = {};
         _.each(modes, mode => {
             mode_mapping[mode] = () => {
-                self.model.set("default_mode", mode);
-                self.model.get("tracks").each(track => {
+                this.model.set("default_mode", mode);
+                this.model.get("tracks").each(track => {
                     track.set("mode", mode);
                 });
             };
@@ -930,31 +919,30 @@ export var SweepsterVisualizationView = Backbone.View.extend({
      * Add track to model and view.
      */
     add_track: function(pm_track) {
-        var self = this;
         var param_tree = this.model.get("parameter_tree");
 
         // Add track to model.
-        self.model.add_track(pm_track);
+        this.model.add_track(pm_track);
 
         var track_view = new SweepsterTrackView({
             model: pm_track,
-            canvas_manager: self.canvas_manager
+            canvas_manager: this.canvas_manager
         });
-        track_view.on("run_on_dataset", self.run_tool_on_dataset, self);
-        self.track_collection_container.append(track_view.$el);
+        track_view.on("run_on_dataset", this.run_tool_on_dataset, this);
+        this.track_collection_container.append(track_view.$el);
         track_view.$el.hover(
             () => {
                 var settings_leaf = param_tree.get_leaf(pm_track.get("settings").get("values"));
                 var connected_node_ids = _.pluck(param_tree.get_connected_nodes(settings_leaf), "id");
 
                 // TODO: can do faster with enter?
-                d3.select(self.tool_param_tree_view.$el[0])
+                d3.select(this.tool_param_tree_view.$el[0])
                     .selectAll("g.node")
                     .filter(d => _.find(connected_node_ids, id => id === d.id) !== undefined)
                     .style("fill", "#f00");
             },
             () => {
-                d3.select(self.tool_param_tree_view.$el[0])
+                d3.select(this.tool_param_tree_view.$el[0])
                     .selectAll("g.node")
                     .style("fill", "#000");
             }
@@ -968,7 +956,6 @@ export var SweepsterVisualizationView = Backbone.View.extend({
      */
     handle_node_clicks: function() {
         // When node clicked in tree, run tool and add tracks to model.
-        var self = this;
 
         var param_tree = this.model.get("parameter_tree");
         var regions = this.model.get("regions");
@@ -977,9 +964,9 @@ export var SweepsterVisualizationView = Backbone.View.extend({
 
         node.on("click", (d, i) => {
             // Get all settings corresponding to node.
-            var tool = self.model.get("tool");
+            var tool = this.model.get("tool");
 
-            var dataset = self.model.get("dataset");
+            var dataset = this.model.get("dataset");
             var all_settings = param_tree.get_node_settings(d);
             var run_jobs_deferred = $.Deferred();
 
@@ -987,7 +974,7 @@ export var SweepsterVisualizationView = Backbone.View.extend({
             if (all_settings.length >= 10) {
                 show_modal(
                     "Whoa there cowboy!",
-                    `You clicked on a node to try ${self.model.get("tool").get("name")} with ${
+                    `You clicked on a node to try ${this.model.get("tool").get("name")} with ${
                         all_settings.length
                     } different combinations of settings. You can only run 10 jobs at a time.`,
                     {
@@ -1012,9 +999,9 @@ export var SweepsterVisualizationView = Backbone.View.extend({
                     var pm_track = new SweepsterTrack({
                         settings: settings,
                         regions: regions,
-                        mode: self.model.get("default_mode")
+                        mode: this.model.get("default_mode")
                     });
-                    self.add_track(pm_track);
+                    this.add_track(pm_track);
                     return pm_track;
                 });
 
@@ -1036,10 +1023,10 @@ export var SweepsterVisualizationView = Backbone.View.extend({
                             // the tool parameters and parameter tree.
                             track_config.tool = null;
 
-                            track_config.prefs = self.config.to_key_value_dict();
+                            track_config.prefs = this.config.to_key_value_dict();
 
                             // Create and add track for output dataset.
-                            var track_obj = tracks.object_from_template(track_config, self, null);
+                            var track_obj = tracks.object_from_template(track_config, this, null);
                             track_obj.init_for_tool_data();
 
                             pm_track.set("track", track_obj);

--- a/client/galaxy/scripts/viz/trackster/filters.js
+++ b/client/galaxy/scripts/viz/trackster/filters.js
@@ -308,10 +308,9 @@ _.extend(NumberFilter.prototype, {
         this.high = values[1];
 
         // Set timeout to update if filter low, high are stable.
-        var self = this;
         setTimeout(() => {
-            if (values[0] === self.low && values[1] === self.high) {
-                self.manager.track.request_draw({
+            if (values[0] === this.low && values[1] === this.high) {
+                this.manager.track.request_draw({
                     force: true,
                     clear_after: true
                 });

--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -1570,9 +1570,8 @@ extend(TracksterView.prototype, DrawableCollection.prototype, {
 
         // When drawable config changes, mark view as changed. This
         // captures most (all?) state change that needs to be saved.
-        var self = this;
         drawable.config.on("change", () => {
-            self.changed();
+            this.changed();
         });
     },
 
@@ -1871,7 +1870,6 @@ var TracksterToolView = Backbone.View.extend({
      * Render tool UI.
      */
     render: function() {
-        var self = this;
         var tool = this.model;
         var parent_div = this.$el.addClass("dynamic-tool").hide();
 
@@ -1918,10 +1916,10 @@ var TracksterToolView = Backbone.View.extend({
             .appendTo(run_tool_row);
         run_on_region_button.click(() => {
             // Run tool to create new track.
-            self.run_on_region();
+            this.run_on_region();
         });
         run_on_dataset_button.click(() => {
-            self.run_on_dataset();
+            this.run_on_dataset();
         });
 
         if (tool.is_visible()) {
@@ -3542,32 +3540,31 @@ extend(TiledTrack.prototype, Drawable.prototype, Track.prototype, {
         /*
         this.normal_postdraw_actions = this.postdraw_actions;
         this.postdraw_actions = function(tiles, width, w_scale, clear_after) {
-            var self = this;
 
             // Do normal postdraw init.
-            self.normal_postdraw_actions(tiles, width, w_scale, clear_after);
+            this.normal_postdraw_actions(tiles, width, w_scale, clear_after);
 
             // Tool-execution specific post-draw init:
 
             // Reset dataset check, wait time.
-            self.dataset_check_type = 'converted_datasets_state';
-            self.data_query_wait = DEFAULT_DATA_QUERY_WAIT;
+            this.dataset_check_type = 'converted_datasets_state';
+            this.data_query_wait = DEFAULT_DATA_QUERY_WAIT;
 
             // Reset data URL when dataset indexing has completed/when not pending.
             var ss_deferred = new util.ServerStateDeferred({
-                url: self.dataset_state_url,
-                url_params: {dataset_id : self.dataset.id, hda_ldda: self.dataset.get('hda_ldda')},
-                interval: self.data_query_wait,
+                url: this.dataset_state_url,
+                url_params: {dataset_id : this.dataset.id, hda_ldda: this.dataset.get('hda_ldda')},
+                interval: this.data_query_wait,
                 // Set up deferred to check dataset state until it is not pending.
                 success_fn: function(result) { return result !== "pending"; }
             });
-            $.when(ss_deferred.go()).then(function() {
+            $.when(ss_deferred.go()).then(() => {
                 // Dataset is indexed, so use converted data.
-                self.data_manager.set('data_type', 'data');
+                this.data_manager.set('data_type', 'data');
             });
 
             // Reset post-draw actions function.
-            self.postdraw_actions = self.normal_postdraw_actions;
+            this.postdraw_actions = this.normal_postdraw_actions;
         };
         */
     }
@@ -3982,11 +3979,10 @@ var LineTrack = function(view, container, obj_dict) {
 
     // If server has byte-range support, use BBI data manager to read directly from the BBI file.
     // FIXME: there should be a flag to wait for this check to complete before loading the track.
-    var self = this;
     $.when(supportsByteRanges(`${getAppRoot()}datasets/${this.dataset.id}/display`)).then(supportsByteRanges => {
         if (supportsByteRanges) {
-            self.data_manager = new bbi.BBIDataManager({
-                dataset: self.dataset
+            this.data_manager = new bbi.BBIDataManager({
+                dataset: this.dataset
             });
         }
     });

--- a/client/galaxy/scripts/viz/trackster/util.js
+++ b/client/galaxy/scripts/viz/trackster/util.js
@@ -36,10 +36,9 @@ var ServerStateDeferred = Backbone.Model.extend({
      */
     go: function() {
         var deferred = $.Deferred();
-        var self = this;
-        var ajax_settings = self.get("ajax_settings");
-        var success_fn = self.get("success_fn");
-        var interval = self.get("interval");
+        var ajax_settings = this.get("ajax_settings");
+        var success_fn = this.get("success_fn");
+        var interval = this.get("interval");
 
         var _go = () => {
             $.ajax(ajax_settings).success(result => {

--- a/client/galaxy/scripts/viz/visualization.js
+++ b/client/galaxy/scripts/viz/visualization.js
@@ -19,12 +19,11 @@ var CustomToJSON = {
      * Returns JSON representation of object using to_json_keys and to_json_mappers.
      */
     toJSON: function() {
-        var self = this;
         var json = {};
-        _.each(self.constructor.to_json_keys, k => {
-            var val = self.get(k);
-            if (k in self.constructor.to_json_mappers) {
-                val = self.constructor.to_json_mappers[k](val, self);
+        _.each(this.constructor.to_json_keys, k => {
+            var val = this.get(k);
+            if (k in this.constructor.to_json_mappers) {
+                val = this.constructor.to_json_mappers[k](val, this);
             }
             json[k] = val;
         });
@@ -299,9 +298,8 @@ var GenomeDataManager = Cache.extend({
         }
 
         // Put data into manager.
-        var self = this;
         _.each(entries, entry => {
-            self.set_data(entry.region, entry);
+            this.set_data(entry.region, entry);
         });
     },
 
@@ -604,13 +602,11 @@ var GenomeDataManager = Cache.extend({
     get_genome_wide_data: function(genome) {
         // -- Get all data. --
 
-        var self = this;
-
         var all_data_available = true;
 
         var //  Map chromosome info into genome data.
             gw_data = _.map(genome.get("chroms_info").chrom_info, chrom_info => {
-                var chrom_data = self.get_elt(
+                var chrom_data = this.get_elt(
                     new GenomeRegion({
                         chrom: chrom_info.chrom,
                         start: 0,
@@ -635,7 +631,7 @@ var GenomeDataManager = Cache.extend({
 
         var deferred = $.Deferred();
         $.getJSON(this.get("dataset").url(), { data_type: "genome_data" }, genome_wide_data => {
-            self.add_data(genome_wide_data.data);
+            this.add_data(genome_wide_data.data);
             deferred.resolve(genome_wide_data.data);
         });
 
@@ -993,14 +989,14 @@ var BackboneTrack = Backbone.Model.extend(CustomToJSON).extend(
         // This definition matches that produced by to_dict() methods in tracks.js
         to_json_keys: ["track_type", "dataset", "prefs", "mode", "filters", "tool_state"],
         to_json_mappers: {
-            prefs: function(p, self) {
+            prefs: function(p, context) {
                 if (_.size(p) === 0) {
                     p = {
-                        name: self
+                        name: context
                             .get("config")
                             .get("name")
                             .get("value"),
-                        color: self
+                        color: context
                             .get("config")
                             .get("color")
                             .get("value")
@@ -1088,14 +1084,14 @@ var GenomeVisualization = Visualization.extend(CustomToJSON).extend(
         to_json_keys: ["view", "viewport", "bookmarks"],
 
         to_json_mappers: {
-            view: function(dummy, self) {
+            view: function(dummy, context) {
                 return {
                     obj_type: "View",
                     prefs: {
-                        name: self.get("title"),
+                        name: context.get("title"),
                         content_visible: true
                     },
-                    drawables: self.get("drawables")
+                    drawables: context.get("drawables")
                 };
             }
         }

--- a/client/galaxy/scripts/viz/visualization.js
+++ b/client/galaxy/scripts/viz/visualization.js
@@ -389,12 +389,10 @@ var GenomeDataManager = Cache.extend({
         }
 
         // Do request.
-        var manager = this;
-
         var entry = $.getJSON(dataset.url(), params, result => {
             // Add region to the result.
             result.region = region;
-            manager.set_data(region, result);
+            this.set_data(region, result);
         });
 
         this.set_data(region, entry);
@@ -521,7 +519,6 @@ var GenomeDataManager = Cache.extend({
         // Get additional data, append to current data, and set new data. Use a custom deferred object
         // to signal when new data is available.
         //
-        var data_manager = this;
 
         var new_data_request = this.load_data(query_region, mode, resolution, extra_params);
 
@@ -541,7 +538,7 @@ var GenomeDataManager = Cache.extend({
                     result.message = result.message.replace(/[0-9]+/, result.data.length);
                 }
             }
-            data_manager.set_data(region, result);
+            this.set_data(region, result);
             new_data_available.resolve(result);
         });
         return new_data_available;

--- a/client/galaxy/scripts/viz/viz_views.js
+++ b/client/galaxy/scripts/viz/viz_views.js
@@ -40,13 +40,12 @@ var TrackHeaderView = Backbone.View.extend({
     },
 
     render_action_icons: function() {
-        var self = this;
         this.icons_div = $("<div/>")
             .addClass("track-icons")
             .hide()
             .appendTo(this.$el);
         _.each(this.model.action_icons_def, icon_dict => {
-            self.add_action_icon(
+            this.add_action_icon(
                 icon_dict.name,
                 icon_dict.title,
                 icon_dict.css_class,
@@ -64,14 +63,13 @@ var TrackHeaderView = Backbone.View.extend({
      * Add an action icon to this object. Appends icon unless prepend flag is specified.
      */
     add_action_icon: function(name, title, css_class, on_click_fn, prepend, hide) {
-        var self = this;
         this.action_icons[name] = $("<a/>")
             .attr("title", title)
             .addClass("icon-button")
             .addClass(css_class)
             .tooltip()
             .click(() => {
-                on_click_fn(self.model);
+                on_click_fn(this.model);
             })
             .appendTo(this.icons_div);
         if (hide) {


### PR DESCRIPTION
This pull request is ready for review but is not ready to be merged until it receives more reviews and testing. I am still currently testing, but I would also appreciate some QA from others.

This pull request adds a linting rule for the “this” keyword to prevent aliasing the “this” keyword. 
The preferred method of binding the this keyword to an inner function is by using an arrow function which is es6 compliant.
The old method of doing this involved using ```self = this``` and then taking advantage of a javascript closure. This method is now outdated  and can be confusing at times especially when functions use both the self and this keyword. It can be difficult to tell what the context actually is. This PR adds some much needed consitency
