### PR TITLE
Data Libraries scrollbar fix

### DIFF
--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -107,6 +107,8 @@ var LibraryDatasetView = Backbone.View.extend({
         $(".tooltip").remove();
         var template = this.templateDataset();
         this.$el.html(template({ item: this.model }));
+        // hack to force scrollbars to be shown
+        this.el.style.setProperty('overflow', 'auto', 'important');
         $(".peek").html(this.model.get("peek"));
         $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
         this._mountNametags("initialize");

--- a/client/galaxy/scripts/mvc/library/library-folder-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folder-view.js
@@ -80,8 +80,8 @@ var FolderView = Backbone.View.extend({
             });
 
         $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
-        //hack to show scrollbars
-        $("#center").css("overflow", "auto");
+        // hack to force scrollbars to be shown
+        this.el.style.setProperty('overflow', 'auto', 'important');
     },
 
     _serializeRoles: function(role_list) {

--- a/client/galaxy/scripts/mvc/library/library-folderlist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-folderlist-view.js
@@ -138,7 +138,8 @@ var FolderListView = Backbone.View.extend({
             this.paginate();
         }
         $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
-        $("#center").css("overflow", "auto");
+        // hack to force scrollbars to be shown
+        this.el.style.setProperty('overflow', 'auto', 'important');
     },
 
     paginate: function(options) {

--- a/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
+++ b/client/galaxy/scripts/mvc/library/library-foldertoolbar-view.js
@@ -102,6 +102,8 @@ var FolderToolbarView = Backbone.View.extend({
             }
         }
         this.$el.html(toolbar_template(template_defaults));
+        // hack to force scrollbars to be shown
+        this.el.style.setProperty('overflow', 'auto', 'important');
     },
 
     /**

--- a/client/galaxy/scripts/mvc/library/library-library-view.js
+++ b/client/galaxy/scripts/mvc/library/library-library-view.js
@@ -87,8 +87,8 @@ var LibraryView = Backbone.View.extend({
             });
 
         $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
-        //hack to show scrollbars
-        $("#center").css("overflow", "auto");
+        // hack to force scrollbars to be shown
+        this.el.style.setProperty('overflow', 'auto', 'important');
     },
 
     _serializeRoles: function(role_list) {

--- a/client/galaxy/scripts/mvc/library/library-librarytoolbar-view.js
+++ b/client/galaxy/scripts/mvc/library/library-librarytoolbar-view.js
@@ -50,6 +50,8 @@ var LibraryToolbarView = Backbone.View.extend({
                 "without_restricted"
             );
         }
+        // hack to force scrollbars to be shown
+        this.el.style.setProperty('overflow', 'auto', 'important');
     },
 
     /**


### PR DESCRIPTION
Fixes the bug we've discovered during the Galaxy training, specifically, not working scrolling at the data libraries page.

Tested in Google Chrome v77.0.3865.90 and in Firefox 69.0.