### PR TITLE
data_manager_conf.xml.sample is missing

### DIFF
--- a/config/data_manager_conf.xml.sample
+++ b/config/data_manager_conf.xml.sample
@@ -1,0 +1,1 @@
+../lib/galaxy/config/sample/data_manager_conf.xml.sample

--- a/lib/galaxy/config/sample/data_manager_conf.xml.sample
+++ b/lib/galaxy/config/sample/data_manager_conf.xml.sample
@@ -1,0 +1,3 @@
+<?xml version="1.0"?>
+<data_managers>
+</data_managers>


### PR DESCRIPTION
Maybe it is on purpose but since the 19.09 the data_manager_conf.xml.sample is missing in the config directory although still referred in the [galaxy.yml](https://github.com/galaxyproject/galaxy/blob/release_19.09/lib/galaxy/config/sample/galaxy.yml.sample#L1542-L1544)
