### PR TITLE
[19.09] remove inherited #center overflow

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -134,7 +134,6 @@ body {
 #right {
     @extend .position-absolute;
     @extend .h-100;
-    @extend .overflow-hidden;
 }
 #left {
     @extend .unified-panel;
@@ -154,7 +153,6 @@ body {
     }
 }
 #center {
-    @extend .overflow-hidden;
     left: $panel-width;
     right: $panel-width;
     .center-container {


### PR DESCRIPTION
this broke libraries, and generally shouldn't be used
with such scope I believe

It is unclear what is purpose of these rules + there are other like this in the `base.scss`.

fixes https://github.com/galaxyproject/galaxy/issues/8781
supersedes https://github.com/galaxyproject/galaxy/pull/8783