### PR TITLE
[19.09] improve tool panel searching

### DIFF
--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -1,6 +1,8 @@
 """
 Module for building and searching the index of tools
-installed within this Galaxy.
+installed within this Galaxy. Before changing index-building
+or searching related parts it is deeply recommended to read
+through the library docs at https://whoosh.readthedocs.io.
 """
 import logging
 import re
@@ -35,9 +37,6 @@ class ToolBoxSearch(object):
     """
 
     def __init__(self, toolbox, index_help=True):
-        """
-        Create a searcher for `toolbox`.
-        """
         self.schema = Schema(id=STORED,
                              stub=KEYWORD,
                              name=TEXT(analyzer=analysis.SimpleAnalyzer()),
@@ -91,7 +90,7 @@ class ToolBoxSearch(object):
             "help": to_unicode("")
         }
         if tool.name.find('-') != -1:
-            # Hyphens are wildcards in Whoosh causing bad things
+            # Replace hyphens, since they are wildcards in Whoosh causing false positives
             add_doc_kwds['name'] = (' ').join([token.text for token in self.rex(to_unicode(tool.name))])
         else:
             add_doc_kwds['name'] = to_unicode(tool.name)
@@ -122,7 +121,7 @@ class ToolBoxSearch(object):
         Perform search on the in-memory index. Weight in the given boosts.
         """
         # Change field boosts for searcher
-        searcher = self.index.searcher(
+        self.searcher = self.index.searcher(
             weighting=BM25F(
                 field_B={'name_B': float(tool_name_boost),
                          'section_B': float(tool_section_boost),
@@ -132,42 +131,56 @@ class ToolBoxSearch(object):
                          'help_B': float(tool_help_boost)}
             )
         )
-        # Set query to search name, description, section, help, and labels.
+        # Use OrGroup to change the default operation for joining multiple terms to logical OR.
+        # This means e.g. for search 'bowtie of king arthur' a document that only has 'bowtie' will be a match.
+        # https://whoosh.readthedocs.io/en/latest/api/qparser.html#whoosh.qparser.MultifieldPlugin
+        # However this changes scoring i.e. searching 'bowtie of king arthur' a document with 'arthur arthur arthur'
+        # would have a higher score than a document with 'bowtie arthur' which is usually unexpected for a user.
+        # Hence we introduce a bonus on multi-hits using the 'factory()' method using a scaling factor between 0-1.
+        # https://whoosh.readthedocs.io/en/latest/parsing.html#searching-for-any-terms-instead-of-all-terms-by-default
         og = OrGroup.factory(0.9)
-        parser = MultifieldParser(['name', 'description', 'section', 'help', 'labels', 'stub'], schema=self.schema, group=og)
+        self.parser = MultifieldParser(['name', 'description', 'section', 'help', 'labels', 'stub'], schema=self.schema, group=og)
         cleaned_query = q.lower()
-        # Hyphens are wildcards in Whoosh causing bad things
+        # Replace hyphens, since they are wildcards in Whoosh causing false positives
         if cleaned_query.find('-') != -1:
             cleaned_query = (' ').join([token.text for token in self.rex(to_unicode(cleaned_query))])
-        # Perform tool search with ngrams if set to true in the config file
         if tool_enable_ngram_search is True:
-            hits_with_score = {}
-            token_analyzer = StandardAnalyzer() | analysis.NgramFilter(minsize=int(tool_ngram_minsize), maxsize=int(tool_ngram_maxsize))
-            ngrams = [token.text for token in token_analyzer(cleaned_query)]
-            for query in ngrams:
-                # Get the tool list with respective scores for each qgram
-                curr_hits = searcher.search(parser.parse('*' + query + '*'), limit=float(tool_search_limit))
-                for i, curr_hit in enumerate(curr_hits):
-                    is_present = False
-                    for prev_hit in hits_with_score:
-                        # Check if the tool appears again for the next qgram search
-                        if curr_hit['id'] == prev_hit:
-                            is_present = True
-                            # Add the current score with the previous one if the
-                            # tool appears again for the next qgram
-                            hits_with_score[prev_hit] = curr_hits.score(i) + hits_with_score[prev_hit]
-                    # Add the tool if not present to the collection with its score
-                    if not is_present:
-                        hits_with_score[curr_hit['id']] = curr_hits.score(i)
-            # Sort the results based on aggregated BM25 score in decreasing order of scores
-            hits_with_score = sorted(hits_with_score.items(), key=lambda x: x[1], reverse=True)
-            # Return the tool ids
-            return [item[0] for item in hits_with_score[0:int(tool_search_limit)]]
+            rval = self._search_ngrams(cleaned_query, tool_ngram_minsize, tool_ngram_maxsize, tool_search_limit)
+            return rval
         else:
-            parsed_query = parser.parse(cleaned_query + '*')
-            # Perform the search
-            hits = searcher.search(parsed_query, limit=float(tool_search_limit), sortedby='')
+            # Use asterisk Whoosh wildcard so e.g. 'bow' easily matches 'bowtie'
+            parsed_query = self.parser.parse(cleaned_query + '*')
+            hits = self.searcher.search(parsed_query, limit=float(tool_search_limit), sortedby='')
             return [hit['id'] for hit in hits]
+
+    def _search_ngrams(self, cleaned_query, tool_ngram_minsize, tool_ngram_maxsize, tool_search_limit):
+        """
+        Break tokens into ngrams and search on those instead.
+        This should make searching more resistant to typos and unfinished words.
+        See docs at https://whoosh.readthedocs.io/en/latest/ngrams.html
+        """
+        hits_with_score = {}
+        token_analyzer = StandardAnalyzer() | analysis.NgramFilter(minsize=int(tool_ngram_minsize), maxsize=int(tool_ngram_maxsize))
+        ngrams = [token.text for token in token_analyzer(cleaned_query)]
+        for query in ngrams:
+            # Get the tool list with respective scores for each qgram
+            curr_hits = self.searcher.search(self.parser.parse('*' + query + '*'), limit=float(tool_search_limit))
+            for i, curr_hit in enumerate(curr_hits):
+                is_present = False
+                for prev_hit in hits_with_score:
+                    # Check if the tool appears again for the next qgram search
+                    if curr_hit['id'] == prev_hit:
+                        is_present = True
+                        # Add the current score with the previous one if the
+                        # tool appears again for the next qgram
+                        hits_with_score[prev_hit] = curr_hits.score(i) + hits_with_score[prev_hit]
+                # Add the tool if not present to the collection with its score
+                if not is_present:
+                    hits_with_score[curr_hit['id']] = curr_hits.score(i)
+        # Sort the results based on aggregated BM25 score in decreasing order of scores
+        hits_with_score = sorted(hits_with_score.items(), key=lambda x: x[1], reverse=True)
+        # Return the tool ids
+        return [item[0] for item in hits_with_score[0:int(tool_search_limit)]]
 
 
 def _temp_storage(self, name=None):

--- a/test/api/test_tools.py
+++ b/test/api/test_tools.py
@@ -53,10 +53,25 @@ class ToolsTestCase(api.ApiTestCase):
         assert "upload1" in tool_ids
 
     @skip_without_tool("cat1")
-    def test_search(self):
-        url = self._api_url("tools?q=cat")
-        get_response = get(url).json()
+    def test_search_cat(self):
+        url = self._api_url("tools")
+        payload = dict(q="concat")
+        get_response = get(url, payload).json()
         assert "cat1" in get_response
+
+    @skip_without_tool("trimmer")
+    def test_search_trimmer(self):
+        url = self._api_url("tools")
+        payload = dict(q="leading or trailing characters")
+        get_response = get(url, payload).json()
+        assert "trimmer" in get_response
+
+    @skip_without_tool("Grep1")
+    def test_search_grep(self):
+        url = self._api_url("tools")
+        payload = dict(q="Select lines that match an expression")
+        get_response = get(url, payload).json()
+        assert "Grep1" in get_response
 
     def test_no_panel_index(self):
         index = self._get("tools", data=dict(in_panel=False))


### PR DESCRIPTION
Fixes and improvements I've found while looking in too panel search pains.

- use logical OR to join parsed search terms
instead of default AND; however use scaling factor of 0.9
to make sure multi-term-hits are prioritized
- cast every query to lowercase, under some circumstances
the results would differ before
- do not prepend a leading `*` wildcard for the individual terms, this should make things much faster on a big index, it will also yields less, but better results