### PR TITLE
[19.09] Fix 'NoneType' object has no attribute 'get_tool_relative_path' with data_manager_manual

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -324,7 +324,7 @@ class ToolBox(BaseGalaxyToolBox):
         }
 
     def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):
-        # Abstract toolbox doesn't have a dependency on the the database, so
+        # Abstract toolbox doesn't have a dependency on the database, so
         # override _get_tool_shed_repository here to provide this information.
 
         return repository_util.get_installed_repository(
@@ -513,13 +513,17 @@ class Tool(Dictifiable):
     @property
     def tool_shed_repository(self):
         # If this tool is included in an installed tool shed repository, return it.
+        repo_id = self.repository_id
+        if self.repository_id:
+            repo_id = self.app.security.decode_id(self.repository_id)
+
         if self.tool_shed:
             return repository_util.get_installed_repository(self.app,
                                                             tool_shed=self.tool_shed,
                                                             name=self.repository_name,
                                                             owner=self.repository_owner,
                                                             installed_changeset_revision=self.installed_changeset_revision,
-                                                            repository_id=self.repository_id)
+                                                            repository_id=repo_id)
 
     @property
     def produces_collections_with_unknown_structure(self):

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -201,7 +201,8 @@ class DataManager(object):
         self.load_tool(os.path.join(tool_path, path),
                        guid=tool_guid,
                        data_manager_id=self.id,
-                       tool_shed_repository_id=tool_shed_repository_id)
+                       tool_shed_repository_id=tool_shed_repository_id,
+                       tool_shed_repository=tool_shed_repository)
         self.name = elem.get('name', self.tool.name)
         self.description = elem.get('description', self.tool.description)
         self.undeclared_tables = util.asbool(elem.get('undeclared_tables', self.undeclared_tables))


### PR DESCRIPTION
While running biomaj2galaxy tests with Galaxy 19.05 I get this error when trying to populate a data table with the [manual data manager](https://github.com/galaxyproject/tools-iuc/tree/master/data_managers/data_manager_manual):

```
Traceback (most recent call last):
  File "lib/galaxy/jobs/runners/__init__.py", line 224, in prepare_job
    job_wrapper.prepare()
  File "lib/galaxy/jobs/__init__.py", line 863, in prepare
    tool_evaluator.set_compute_environment(compute_environment, get_special=get_special)
  File "lib/galaxy/tools/evaluation.py", line 118, in set_compute_environment
    out_data=out_data, tool=self.tool, param_dict=incoming)
  File "lib/galaxy/tools/__init__.py", line 1719, in call_hook
    return code(*args, **kwargs)
  File "../shed_tools/toolshed.g2.bx.psu.edu/repos/iuc/data_manager_manual/6524e573d9c2/data_manager_manual/data_manager/data_manager_manual.py", line 57, in exec_before_job
    target_dir, tool_path, relative_target_dir = tdtm.get_target_install_dir( tool_shed_repository )
  File "lib/tool_shed/tools/data_table_manager.py", line 111, in get_target_install_dir
    tool_path, relative_target_dir = tool_shed_repository.get_tool_relative_path(self.app)
AttributeError: Error in 'Manual Data Manager' hook 'exec_before_job', original message: 'NoneType' object has no attribute 'get_tool_relative_path'
```

I guess the bug was introduced in #7316, a tool_shed_repository object was no longer accessible from the data manager code.

I tested the patch with 19.05, but it should work the same with 19.09 (too late to test this week :) )

It would be cool to have it backported to 19.05 too (I have a branch ready for that if needed https://github.com/galaxyproject/galaxy/compare/release_19.05...abretaud:dmfix1905?expand=1)

(There's another PR in IUC to fix another problem in the data manager https://github.com/galaxyproject/tools-iuc/pull/2634)