### PR TITLE
Allow recording more performance statistics to statsd.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -337,6 +337,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get('database_create_tables', 'True'))
         self.database_encoding = kwargs.get('database_encoding')  # Create new databases with this encoding
+        self.database_log_query_counts = string_as_bool(kwargs.get("database_log_query_counts", 'False'))
         self.thread_local_log = None
         if self.enable_per_request_sql_debugging:
             self.thread_local_log = threading.local()
@@ -914,7 +915,8 @@ def init_models_from_config(config, map_install_models=False, object_store=None,
         trace_logger=trace_logger,
         use_pbkdf2=config.get_bool('use_pbkdf2', True),
         slow_query_log_threshold=config.slow_query_log_threshold,
-        thread_local_log=config.thread_local_log
+        thread_local_log=config.thread_local_log,
+        log_query_counts=config.database_log_query_counts,
     )
     return model
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -2,7 +2,6 @@
 Base classes for job runner plugins.
 """
 import datetime
-import logging
 import os
 import string
 import subprocess
@@ -39,10 +38,11 @@ from galaxy.util import (
     unicodify,
 )
 from galaxy.util.bunch import Bunch
+from galaxy.util.logging import get_logger
 from galaxy.util.monitors import Monitors
 from .state_handler_factory import build_state_handlers
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 STOP_SIGNAL = object()
 
@@ -129,7 +129,13 @@ class BaseJobRunner(object):
             except Exception:
                 name = 'unknown'
             try:
+                action_str = 'galaxy.jobs.runners.%s.%s' % (self.__class__.__name__.lower(), name)
+                action_timer = self.app.execution_timer_factory.get_timer(
+                    'internals.%s' % action_str,
+                    'job runner action %s for job ${job_id} executed' % (action_str)
+                )
                 method(arg)
+                log.trace(action_timer.to_str(job_id=job_id))
             except Exception:
                 log.exception("(%s) Unhandled exception calling %s" % (job_id, name))
                 if not isinstance(arg, JobState):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2826,7 +2826,7 @@ model.WorkflowInvocation.update = _workflow_invocation_update
 
 def init(file_path, url, engine_options=None, create_tables=False, map_install_models=False,
         database_query_profiling_proxy=False, object_store=None, trace_logger=None, use_pbkdf2=True,
-        slow_query_log_threshold=0, thread_local_log=None):
+        slow_query_log_threshold=0, thread_local_log=None, log_query_counts=False):
     """Connect mappings to the database"""
     if engine_options is None:
         engine_options = {}
@@ -2837,7 +2837,7 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     # Use PBKDF2 password hashing?
     model.User.use_pbkdf2 = use_pbkdf2
     # Load the appropriate db module
-    engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold, thread_local_log=thread_local_log)
+    engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold, thread_local_log=thread_local_log, log_query_counts=log_query_counts)
 
     # Connect the metadata to the database.
     metadata.bind = engine

--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 import time
 
 from sqlalchemy import create_engine, event
@@ -6,8 +7,24 @@ from sqlalchemy.engine import Engine
 
 log = logging.getLogger(__name__)
 
+QUERY_COUNT_LOCAL = threading.local()
 
-def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0, thread_local_log=None):
+
+def reset_request_query_counts():
+    QUERY_COUNT_LOCAL.times = []
+
+
+def log_request_query_counts(req_id):
+    try:
+        times = QUERY_COUNT_LOCAL.times
+        if times:
+            log.info("Executed [%s] SQL requests in for web request [%s] (%f(s)ms)" % (len(times), req_id, sum(times) * 1000.))
+    except AttributeError:
+        # Didn't record anything so don't worry.
+        pass
+
+
+def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0, thread_local_log=None, log_query_counts=False):
     # Should we use the logging proxy?
     if database_query_profiling_proxy:
         import galaxy.model.orm.logging_connection_proxy as logging_connection_proxy
@@ -18,7 +35,7 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
         proxy = logging_connection_proxy.TraceLoggerProxy(trace_logger)
     else:
         proxy = None
-    if slow_query_log_threshold or thread_local_log:
+    if slow_query_log_threshold or thread_local_log or log_query_counts:
         @event.listens_for(Engine, "before_execute")
         def before_execute(conn, clauseelement, multiparams, params):
             conn.info.setdefault('query_start_time', []).append(time.time())
@@ -29,6 +46,12 @@ def build_engine(url, engine_options, database_query_profiling_proxy=False, trac
             total = time.time() - conn.info['query_start_time'].pop(-1)
             if total > slow_query_log_threshold:
                 log.debug("Slow query: %f(s)\n%s\nParameters: %s" % (total, statement, parameters))
+            if log_query_counts:
+                try:
+                    QUERY_COUNT_LOCAL.times.append(total)
+                except AttributeError:
+                    # Not a web thread.
+                    pass
             if thread_local_log is not None:
                 try:
                     if thread_local_log.log:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -78,7 +78,6 @@ from galaxy.tools.parameters.wrapped_json import json_wrap
 from galaxy.tools.test import parse_tests
 from galaxy.tools.toolbox import BaseGalaxyToolBox
 from galaxy.util import (
-    ExecutionTimer,
     in_directory,
     listify,
     Params,
@@ -1413,7 +1412,10 @@ class Tool(Dictifiable):
                 'Failure executing tool (cannot create multiple jobs when remapping existing job).')
 
         # Process incoming data
-        validation_timer = ExecutionTimer()
+        validation_timer = self.app.execution_timer_factory.get_timer(
+            'internals.galaxy.tools.validation',
+            'Validated and populated state for tool request',
+        )
         all_errors = []
         all_params = []
         for expanded_incoming in expanded_incomings:
@@ -1438,7 +1440,7 @@ class Tool(Dictifiable):
             all_params.append(params)
         unset_dataset_matcher_factory(request_context)
 
-        log.debug('Validated and populated state for tool request %s' % validation_timer)
+        log.info(validation_timer)
         return all_params, all_errors, rerun_remap_job_id, collection_info
 
     def handle_input(self, trans, incoming, history=None, use_cached_job=False):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -515,7 +515,10 @@ class DefaultToolAction(object):
                     handle_output(name, output)
                     log.info("Handled output named %s for tool %s %s" % (name, tool.id, handle_output_timer))
 
-        add_datasets_timer = ExecutionTimer()
+        add_datasets_timer = tool.app.execution_timer_factory.get_timer(
+            'internals.galaxy.tools.actions.add_datasets',
+            'Added output datasets to history',
+        )
         # Add all the top-level (non-child) datasets to the history unless otherwise specified
         datasets_to_persist = []
         for name, data in out_data.items():
@@ -531,7 +534,7 @@ class DefaultToolAction(object):
             child_dataset = out_data[child_name]
             parent_dataset.children.append(child_dataset)
 
-        log.info("Added output datasets to history %s" % add_datasets_timer)
+        log.info(add_datasets_timer)
         job_setup_timer = ExecutionTimer()
         # Create the job object
         job, galaxy_session = self._new_job_for_session(trans, tool, history)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1718,6 +1718,30 @@ class ExecutionTimer(object):
         return (time.time() - self.begin)
 
 
+class StructuredExecutionTimer(object):
+
+    def __init__(self, timer_id, template, **tags):
+        self.begin = time.time()
+        self.timer_id = timer_id
+        self.template = template
+        self.tags = tags
+
+    def __str__(self):
+        return self.to_str()
+
+    def to_str(self, **kwd):
+        if kwd:
+            message = string.Template(self.template).safe_substitute(kwd)
+        else:
+            message = self.template
+        log_message = message + " (%0.3f ms)" % (self.elapsed * 1000)
+        return log_message
+
+    @property
+    def elapsed(self):
+        return (time.time() - self.begin)
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(sys.modules[__name__], verbose=False)

--- a/lib/galaxy/web/framework/middleware/sqldebug.py
+++ b/lib/galaxy/web/framework/middleware/sqldebug.py
@@ -3,6 +3,8 @@ Per-request SQL debugging middleware.
 """
 import logging
 
+from galaxy.model.orm.engine_factory import log_request_query_counts, reset_request_query_counts
+
 log = logging.getLogger(__name__)
 
 
@@ -19,4 +21,8 @@ class SQLDebugMiddleware(object):
             if galaxy.app.app.model.thread_local_log:
                 galaxy.app.app.model.thread_local_log.log = True
 
-        return self.application(environ, start_response)
+        try:
+            reset_request_query_counts()
+            return self.application(environ, start_response)
+        finally:
+            log_request_query_counts(environ.get("PATH_INFO"))

--- a/lib/galaxy/web/framework/middleware/statsd.py
+++ b/lib/galaxy/web/framework/middleware/statsd.py
@@ -1,16 +1,12 @@
 """
-Middleware for sending request statistics to statsd
+Middleware for sending request statistics to statsd.
 """
 from __future__ import absolute_import
 
 import time
 
-try:
-    import statsd
-except ImportError:
-    # This middleware will never be used without statsd.  This block allows
-    # unit tests pass on systems without it.
-    statsd = None
+from galaxy.model.orm.engine_factory import QUERY_COUNT_LOCAL
+from galaxy.web.statsd_client import GalaxyStatsdClient
 
 
 class StatsdMiddleware(object):
@@ -25,15 +21,13 @@ class StatsdMiddleware(object):
                  statsd_port,
                  statsd_prefix,
                  statsd_influxdb):
-        if not statsd:
-            raise ImportError("Statsd middleware configured, but no statsd python module found. "
-                           "Please install the python statsd module to use this functionality.")
         self.application = application
-        self.metric_infix = ''
-        if statsd_influxdb:
-            statsd_prefix = statsd_prefix.strip(',')
-            self.metric_infix = ',path='
-        self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prefix)
+        self.galaxy_stasd_client = GalaxyStatsdClient(
+            statsd_host,
+            statsd_port,
+            statsd_prefix,
+            statsd_influxdb
+        )
 
     def __call__(self, environ, start_response):
         start_time = time.time()
@@ -41,5 +35,12 @@ class StatsdMiddleware(object):
         dt = int((time.time() - start_time) * 1000)
 
         page = environ.get('controller_action_key', None) or environ.get('PATH_INFO', "NOPATH").strip('/').replace('/', '.')
-        self.statsd_client.timing(self.metric_infix + page, dt)
+        self.galaxy_stasd_client.timing(page, dt)
+        try:
+            times = QUERY_COUNT_LOCAL.times
+            self.galaxy_stasd_client.timing("sql." + page, sum(times) * 1000.)
+            self.galaxy_stasd_client.incr("sqlqueries." + page, len(times))
+        except AttributeError:
+            # Not logging query counts, skip
+            pass
         return req

--- a/lib/galaxy/web/statsd_client.py
+++ b/lib/galaxy/web/statsd_client.py
@@ -1,0 +1,40 @@
+try:
+    import statsd
+except ImportError:
+    statsd = None
+
+
+# TODO: optimize with two separate implementations around statsd_influxdb?
+class GalaxyStatsdClient(object):
+
+    def __init__(self,
+                 statsd_host,
+                 statsd_port,
+                 statsd_prefix,
+                 statsd_influxdb):
+        if not statsd:
+            raise ImportError("Statsd logging configured, but no statsd python module found. "
+                           "Please install the python statsd module to use this functionality.")
+
+        self.metric_infix = ''
+        self.statsd_influxdb = statsd_influxdb
+        if self.statsd_influxdb:
+            statsd_prefix = statsd_prefix.strip(',')
+        self.statsd_client = statsd.StatsClient(statsd_host, statsd_port, prefix=statsd_prefix)
+
+    def timing(self, path, time, tags=None):
+        infix = self._effective_infix(path, tags)
+        self.statsd_client.timing(infix + path, time)
+
+    def incr(self, path, n=1, tags=None):
+        infix = self._effective_infix(path, tags)
+        self.statsd_client.incr(infix + path, n)
+
+    def _effective_infix(self, path, tags):
+        tags = tags or {}
+        if self.statsd_influxdb and tags:
+            return ',' + ",".join(["%s=%s" % (k, v) for (k, v) in tags.items()]) + ",path="
+        if self.statsd_influxdb:
+            return ',path='
+        else:
+            return ''

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -105,6 +105,18 @@ mapping:
           template database. This will set that. This is probably only useful for testing but
           documentation is included here for completeness.
 
+      database_log_query_counts:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Log number of SQL queries executed and total time spent dispatching SQL statements for
+          each web request. If statsd is also enabled this information will be logged there as well.
+          This should be considered somewhat experimental, we are unsure of the performance costs of
+          running this in production. This is useful information for optimizing database interaction
+          performance. Similar information can be obtained on a per-request basis by enabling the
+          sql_debug middleware and adding sql_debug=1 to a request string.
+
       slow_query_log_threshold:
         type: float
         default: 0.0

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -16,6 +16,7 @@ from galaxy.jobs.manager import NoopManager
 from galaxy.model import mapping, tags
 from galaxy.security import idencoding
 from galaxy.tool_util.deps.containers import NullContainerFinder
+from galaxy.util import StructuredExecutionTimer
 from galaxy.util.bunch import Bunch
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.web_stack import ApplicationStack
@@ -80,6 +81,7 @@ class MockApp(object):
         self.job_manager = NoopManager()
         self.application_stack = ApplicationStack()
         self.auth_manager = AuthManager(self)
+        self.execution_timer_factory = Bunch(get_timer=StructuredExecutionTimer)
 
         def url_for(*args, **kwds):
             return "/mock/url"


### PR DESCRIPTION
- If ``database_log_query_count`` is set, record `sql.<route>` as time spent in database queries across the API request and a statsd counter for `sqlqueries.<route>` as the number of sqlalchemy queries executed. These statistics were super useful in optimizing tool execution code for all the PRs that came out of the work on #6563, I recovered them from logs in the past though.
- Migrate a bunch of ExecutionTimers I used for profiling this code into new StructuredExecutionTimers that now record their timings into statsd. Prefix the random timings with the `internal.<python_module>` to come up with something of a namespace to identify these timings.
- Add new timings for job running, job handler, and workflow scheduling activities to try to start getting a grasp on the throughput of that code in production.
