### PR TITLE
[19.09] Stop trying to guess a web port

### DIFF
--- a/lib/galaxy/visualization/plugins/interactive_environments.py
+++ b/lib/galaxy/visualization/plugins/interactive_environments.py
@@ -199,7 +199,7 @@ class InteractiveEnvironmentRequest(object):
         }
 
         web_port = self.attr.galaxy_config.galaxy_infrastructure_web_port
-        conf_file['galaxy_web_port'] = web_port or self.attr.galaxy_config.guess_galaxy_port()
+        conf_file['galaxy_web_port'] = web_port
 
         if self.attr.viz_config.has_option("docker", "galaxy_url"):
             conf_file['galaxy_url'] = self.attr.viz_config.get("docker", "galaxy_url")


### PR DESCRIPTION
Ref:
 https://github.com/galaxyproject/galaxy/pull/8802

This is a call to a nonexistent method.

It was removed here:
https://github.com/galaxyproject/galaxy/commit/d187b289518288eb595ccc777bf67bce716defd6