### PR TITLE
[19.09] Don't fail container resolution if `docker images` is b…

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -63,7 +63,11 @@ CachedV2MulledImageMultiTarget.package_hash = _package_hash
 
 def list_docker_cached_mulled_images(namespace=None, hash_func="v2"):
     command = build_docker_images_command(truncate=True, sudo=False, to_str=False)
-    images_and_versions = unicodify(subprocess.check_output(command)).strip().splitlines()
+    try:
+        images_and_versions = unicodify(subprocess.check_output(command)).strip().splitlines()
+    except subprocess.CalledProcessError:
+        log.info("Call to `docker images` failed, configured container resolution may be broken")
+        return []
     images_and_versions = [l.split()[0:2] for l in images_and_versions[1:]]
     name_filter = get_filter(namespace)
 


### PR DESCRIPTION
This is part of the default container resolution strategy in 19.09 so we probably shouldn't fail so easily.