### PR TITLE
[19.09] Fix non-version (minor) tool shed repository updates when installing revisions through the API

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -18,10 +18,7 @@ from tool_shed.galaxy_install.grids import admin_toolshed_grids
 from tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
 from tool_shed.galaxy_install.metadata.installed_repository_metadata_manager import InstalledRepositoryMetadataManager
 from tool_shed.galaxy_install.repository_dependencies import repository_dependency_manager
-from tool_shed.galaxy_install.tools import (
-    data_manager,
-    tool_panel_manager
-)
+from tool_shed.galaxy_install.tools import tool_panel_manager
 from tool_shed.util import (
     common_util,
     encoding_util,
@@ -1180,8 +1177,8 @@ class AdminToolshed(AdminGalaxy):
                                                                                          tool_shed_repository.installed_changeset_revision,
                                                                                          tool_shed_repository.ctx_rev,
                                                                                          repository_clone_url,
-                                                                                         metadata,
                                                                                          trans.install_model.ToolShedRepository.installation_status.NEW,
+                                                                                         metadata,
                                                                                          tool_shed_repository.changeset_revision,
                                                                                          tool_shed_repository.owner,
                                                                                          tool_shed_repository.dist_to_shed)
@@ -1616,148 +1613,47 @@ class AdminToolshed(AdminGalaxy):
                                                               owner=owner,
                                                               changeset_revision=changeset_revision,
                                                               refresh=True)
-        original_metadata_dict = repository.metadata
-        original_repository_dependencies_dict = original_metadata_dict.get('repository_dependencies', {})
-        original_repository_dependencies = original_repository_dependencies_dict.get('repository_dependencies', [])
-        original_tool_dependencies_dict = original_metadata_dict.get('tool_dependencies', {})
         if changeset_revision and latest_changeset_revision and latest_ctx_rev:
             if changeset_revision == latest_changeset_revision:
                 message = "The installed repository named '%s' is current, there are no updates available.  " % name
             else:
-                shed_tool_conf, tool_path, relative_install_dir = suc.get_tool_panel_config_tool_path_install_dir(trans.app, repository)
-                if relative_install_dir:
-                    if tool_path:
-                        repo_files_dir = os.path.abspath(os.path.join(tool_path, relative_install_dir, name))
-                    else:
-                        repo_files_dir = os.path.abspath(os.path.join(relative_install_dir, name))
-                    repository_clone_url = os.path.join(tool_shed_url, 'repos', owner, name)
-                    hg_util.pull_repository(repo_files_dir, repository_clone_url, latest_ctx_rev)
-                    hg_util.update_repository(repo_files_dir, latest_ctx_rev)
-                    # Remove old Data Manager entries
-                    if repository.includes_data_managers:
-                        dmh = data_manager.DataManagerHandler(trans.app)
-                        dmh.remove_from_data_manager(repository)
-                    # Update the repository metadata.
-                    tpm = tool_panel_manager.ToolPanelManager(trans.app)
-                    irmm = InstalledRepositoryMetadataManager(app=trans.app,
-                                                              tpm=tpm,
-                                                              repository=repository,
-                                                              changeset_revision=latest_changeset_revision,
-                                                              repository_clone_url=repository_clone_url,
-                                                              shed_config_dict=repository.get_shed_config_dict(trans.app),
-                                                              relative_install_dir=relative_install_dir,
-                                                              repository_files_dir=None,
-                                                              resetting_all_metadata_on_repository=False,
-                                                              updating_installed_repository=True,
-                                                              persist=True)
-                    irmm.generate_metadata_for_changeset_revision()
-                    irmm_metadata_dict = irmm.get_metadata_dict()
-                    if 'tools' in irmm_metadata_dict:
-                        tool_panel_dict = irmm_metadata_dict.get('tool_panel_section', None)
-                        if tool_panel_dict is None:
-                            tool_panel_dict = tpm.generate_tool_panel_dict_from_shed_tool_conf_entries(repository)
-                        repository_tools_tups = irmm.get_repository_tools_tups()
-                        tpm.add_to_tool_panel(repository_name=str(repository.name),
-                                              repository_clone_url=repository_clone_url,
-                                              changeset_revision=str(repository.installed_changeset_revision),
-                                              repository_tools_tups=repository_tools_tups,
-                                              owner=str(repository.owner),
-                                              shed_tool_conf=shed_tool_conf,
-                                              tool_panel_dict=tool_panel_dict,
-                                              new_install=False)
-                        # Add new Data Manager entries
-                        if 'data_manager' in irmm_metadata_dict:
-                            dmh = data_manager.DataManagerHandler(trans.app)
-                            dmh.install_data_managers(trans.app.config.shed_data_manager_config_file,
-                                                      irmm_metadata_dict,
-                                                      repository.get_shed_config_dict(trans.app),
-                                                      os.path.join(relative_install_dir, name),
-                                                      repository,
-                                                      repository_tools_tups)
-                    if 'repository_dependencies' in irmm_metadata_dict or 'tool_dependencies' in irmm_metadata_dict:
-                        new_repository_dependencies_dict = irmm_metadata_dict.get('repository_dependencies', {})
-                        new_repository_dependencies = new_repository_dependencies_dict.get('repository_dependencies', [])
-                        new_tool_dependencies_dict = irmm_metadata_dict.get('tool_dependencies', {})
-                        if new_repository_dependencies:
-                            # [[http://localhost:9009', package_picard_1_56_0', devteam', 910b0b056666', False', False']]
-                            proceed_to_install = False
-                            if new_repository_dependencies == original_repository_dependencies:
-                                for new_repository_tup in new_repository_dependencies:
-                                    # Make sure all dependencies are installed.
-                                    # TODO: Repository dependencies that are not installed should be displayed to the user,
-                                    # giving them the option to install them or not. This is the same behavior as when initially
-                                    # installing and when re-installing.
-                                    new_tool_shed, new_name, new_owner, new_changeset_revision, new_pir, new_oicct = \
-                                        common_util.parse_repository_dependency_tuple(new_repository_tup)
-                                    # Mock up a repo_info_tupe that has the information needed to see if the repository dependency
-                                    # was previously installed.
-                                    repo_info_tuple = ('', new_tool_shed, new_changeset_revision, '', new_owner, [], [])
-                                    # Since the value of new_changeset_revision came from a repository dependency
-                                    # definition, it may occur earlier in the Tool Shed's repository changelog than
-                                    # the Galaxy tool_shed_repository.installed_changeset_revision record value, so
-                                    # we set from_tip to True to make sure we get the entire set of changeset revisions
-                                    # from the Tool Shed.
-                                    new_repository_db_record, installed_changeset_revision = \
-                                        repository_util.repository_was_previously_installed(trans.app,
-                                                                                            tool_shed_url,
-                                                                                            new_name,
-                                                                                            repo_info_tuple,
-                                                                                            from_tip=True)
-                                    if new_repository_db_record:
-                                        if new_repository_db_record.status in [trans.install_model.ToolShedRepository.installation_status.ERROR,
-                                                                               trans.install_model.ToolShedRepository.installation_status.NEW,
-                                                                               trans.install_model.ToolShedRepository.installation_status.UNINSTALLED]:
-                                            proceed_to_install = True
-                                            break
-                                    else:
-                                        proceed_to_install = True
-                                        break
-                            if proceed_to_install:
-                                # Updates received include newly defined repository dependencies, so allow the user
-                                # the option of installting them.  We cannot update the repository with the changes
-                                # until that happens, so we have to send them along.
-                                new_kwd = dict(tool_shed_url=tool_shed_url,
-                                               updating_repository_id=trans.security.encode_id(repository.id),
-                                               updating_to_ctx_rev=latest_ctx_rev,
-                                               updating_to_changeset_revision=latest_changeset_revision,
-                                               encoded_updated_metadata=encoding_util.tool_shed_encode(irmm_metadata_dict),
-                                               updating=True)
-                                return self.prepare_for_install(trans, **new_kwd)
-                        # Updates received did not include any newly defined repository dependencies but did include
-                        # newly defined tool dependencies.  If the newly defined tool dependencies are not the same
-                        # as the originally defined tool dependencies, we need to install them.
-                        proceed_to_install = False
-                        for new_key, new_val in new_tool_dependencies_dict.items():
-                            if new_key not in original_tool_dependencies_dict:
-                                proceed_to_install = True
-                                break
-                            original_val = original_tool_dependencies_dict[new_key]
-                            if new_val != original_val:
-                                proceed_to_install = True
-                                break
-                        if proceed_to_install:
-                            encoded_tool_dependencies_dict = encoding_util.tool_shed_encode(irmm_metadata_dict.get('tool_dependencies', {}))
-                            encoded_relative_install_dir = encoding_util.tool_shed_encode(relative_install_dir)
-                            new_kwd = dict(updating_repository_id=trans.security.encode_id(repository.id),
-                                           updating_to_ctx_rev=latest_ctx_rev,
-                                           updating_to_changeset_revision=latest_changeset_revision,
-                                           encoded_updated_metadata=encoding_util.tool_shed_encode(irmm_metadata_dict),
-                                           encoded_relative_install_dir=encoded_relative_install_dir,
-                                           encoded_tool_dependencies_dict=encoded_tool_dependencies_dict,
-                                           message=message,
-                                           status=status)
-                            return self.install_tool_dependencies_with_update(trans, **new_kwd)
-                    # Updates received did not include any newly defined repository dependencies or newly defined
-                    # tool dependencies that need to be installed.
-                    repository = trans.app.update_repository_manager.update_repository_record(repository=repository,
-                                                                                              updated_metadata_dict=irmm_metadata_dict,
-                                                                                              updated_changeset_revision=latest_changeset_revision,
-                                                                                              updated_ctx_rev=latest_ctx_rev)
-                    message = "The installed repository named '%s' has been updated to change set revision '%s'.  " % \
-                        (name, latest_changeset_revision)
-                else:
-                    message = "The directory containing the installed repository named '%s' cannot be found.  " % name
-                    status = 'error'
+                irm = install_manager.InstallRepositoryManager(trans.app)
+                install_dependencies, irmm_metadata_dict = irm.update_tool_shed_repository(
+                    repository,
+                    tool_shed_url,
+                    latest_ctx_rev,
+                    latest_changeset_revision,
+                    install_new_dependencies=False
+                )
+                if install_dependencies == 'repository':
+                    # Updates received include newly defined repository dependencies, so allow the user
+                    # the option of installting them.  We cannot update the repository with the changes
+                    # until that happens, so we have to send them along.
+                    new_kwd = dict(tool_shed_url=tool_shed_url,
+                                   updating_repository_id=trans.security.encode_id(repository.id),
+                                   updating_to_ctx_rev=latest_ctx_rev,
+                                   updating_to_changeset_revision=latest_changeset_revision,
+                                   encoded_updated_metadata=encoding_util.tool_shed_encode(irmm_metadata_dict),
+                                   updating=True)
+                    return self.prepare_for_install(trans, **new_kwd)
+                elif install_dependencies == 'tool':
+                    # Updates received did not include any newly defined repository dependencies but did include
+                    # newly defined tool dependencies.  If the newly defined tool dependencies are not the same
+                    # as the originally defined tool dependencies, we need to install them.
+                    relative_install_dir = suc.get_tool_panel_config_tool_path_install_dir(trans.app, repository)[2]
+                    encoded_tool_dependencies_dict = encoding_util.tool_shed_encode(irmm_metadata_dict.get('tool_dependencies', {}))
+                    encoded_relative_install_dir = encoding_util.tool_shed_encode(relative_install_dir)
+                    new_kwd = dict(updating_repository_id=trans.security.encode_id(repository.id),
+                                   updating_to_ctx_rev=latest_ctx_rev,
+                                   updating_to_changeset_revision=latest_changeset_revision,
+                                   encoded_updated_metadata=encoding_util.tool_shed_encode(irmm_metadata_dict),
+                                   encoded_relative_install_dir=encoded_relative_install_dir,
+                                   encoded_tool_dependencies_dict=encoded_tool_dependencies_dict,
+                                   message=message,
+                                   status=status)
+                    return self.install_tool_dependencies_with_update(trans, **new_kwd)
+                message = "The installed repository named '%s' has been updated to change set revision '%s'.  " % \
+                    (name, latest_changeset_revision)
         else:
             message = "The latest changeset revision could not be retrieved for the installed repository named '%s'.  " % name
             status = 'error'

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -20,7 +20,7 @@ from tool_shed.galaxy_install.tool_dependencies.recipe.recipe_manager import Ste
 from tool_shed.galaxy_install.tool_dependencies.recipe.recipe_manager import TagManager
 from tool_shed.galaxy_install.tools import data_manager, tool_panel_manager
 from tool_shed.tools.data_table_manager import ShedToolDataTableManager
-from tool_shed.util import basic_util, encoding_util, hg_util, repository_util
+from tool_shed.util import basic_util, common_util, encoding_util, hg_util, repository_util
 from tool_shed.util import shed_util_common as suc, tool_dependency_util
 from tool_shed.util import tool_util, xml_util
 
@@ -796,9 +796,9 @@ class InstallRepositoryManager(object):
                 install_tool_dependencies=install_tool_dependencies,
                 tool_panel_section_mapping=tool_panel_section_mapping,
             )
-            return self.install_repositories(tsr_ids, decoded_kwd, reinstalling=False)
+            return self.install_repositories(tsr_ids, decoded_kwd, reinstalling=False, install_options=install_options)
 
-    def install_repositories(self, tsr_ids, decoded_kwd, reinstalling):
+    def install_repositories(self, tsr_ids, decoded_kwd, reinstalling, install_options=None):
         shed_tool_conf = decoded_kwd.get('shed_tool_conf', '')
         tool_path = decoded_kwd['tool_path']
         tool_panel_section_keys = util.listify(decoded_kwd['tool_panel_section_keys'])
@@ -850,7 +850,8 @@ class InstallRepositoryManager(object):
         return installed_tool_shed_repositories
 
     def install_tool_shed_repository(self, tool_shed_repository, repo_info_dict, tool_panel_section_key, shed_tool_conf, tool_path,
-                                     install_resolver_dependencies, install_tool_dependencies, reinstalling=False, tool_panel_section_mapping={}):
+                                     install_resolver_dependencies, install_tool_dependencies, reinstalling=False,
+                                     tool_panel_section_mapping={}, install_options=None):
         self.app.install_model.context.flush()
         if tool_panel_section_key:
             _, tool_section = self.app.toolbox.get_section(tool_panel_section_key)
@@ -861,15 +862,24 @@ class InstallRepositoryManager(object):
             tool_section = None
         if isinstance(repo_info_dict, string_types):
             repo_info_dict = encoding_util.tool_shed_decode(repo_info_dict)
+        repo_info_tuple = repo_info_dict[tool_shed_repository.name]
+        description, repository_clone_url, changeset_revision, ctx_rev, repository_owner, repository_dependencies, tool_dependencies = repo_info_tuple
+        if changeset_revision != tool_shed_repository.changeset_revision:
+            # This is an update
+            tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(self.app, tool_shed_repository.tool_shed)
+            return self.update_tool_shed_repository(tool_shed_repository,
+                                                    tool_shed_url,
+                                                    ctx_rev,
+                                                    changeset_revision,
+                                                    install_options=install_options)
         # Clone the repository to the configured location.
         self.update_tool_shed_repository_status(tool_shed_repository,
                                                 self.install_model.ToolShedRepository.installation_status.CLONING)
-        repo_info_tuple = repo_info_dict[tool_shed_repository.name]
-        description, repository_clone_url, changeset_revision, ctx_rev, repository_owner, repository_dependencies, tool_dependencies = repo_info_tuple
         relative_clone_dir = repository_util.generate_tool_shed_repository_install_dir(repository_clone_url,
                                                                                        tool_shed_repository.installed_changeset_revision)
         relative_install_dir = os.path.join(relative_clone_dir, tool_shed_repository.name)
         install_dir = os.path.join(tool_path, relative_install_dir)
+        log.info("Cloning repository '%s' at %s:%s", repository_clone_url, ctx_rev, tool_shed_repository.changeset_revision)
         cloned_ok, error_message = hg_util.clone_repository(repository_clone_url, os.path.abspath(install_dir), ctx_rev)
         if cloned_ok:
             if reinstalling:
@@ -931,6 +941,120 @@ class InstallRepositoryManager(object):
                                                       deleted=False,
                                                       uninstalled=False,
                                                       remove_from_disk=True)
+
+    def update_tool_shed_repository(self, repository, tool_shed_url, latest_ctx_rev, latest_changeset_revision,
+                                    install_new_dependencies=True, install_options=None):
+        install_options = install_options or {}
+        original_metadata_dict = repository.metadata
+        original_repository_dependencies_dict = original_metadata_dict.get('repository_dependencies', {})
+        original_repository_dependencies = original_repository_dependencies_dict.get('repository_dependencies', [])
+        original_tool_dependencies_dict = original_metadata_dict.get('tool_dependencies', {})
+        shed_tool_conf, tool_path, relative_install_dir = suc.get_tool_panel_config_tool_path_install_dir(self.app, repository)
+        if tool_path:
+            repo_files_dir = os.path.abspath(os.path.join(tool_path, relative_install_dir, repository.name))
+        else:
+            repo_files_dir = os.path.abspath(os.path.join(relative_install_dir, repository.name))
+        repository_clone_url = os.path.join(tool_shed_url, 'repos', repository.owner, repository.name)
+        log.info("Updating repository '%s' to %s:%s", repository.name, latest_ctx_rev, latest_changeset_revision)
+        hg_util.pull_repository(repo_files_dir, repository_clone_url, latest_ctx_rev)
+        hg_util.update_repository(repo_files_dir, latest_ctx_rev)
+        # Remove old Data Manager entries
+        if repository.includes_data_managers:
+            dmh = data_manager.DataManagerHandler(self.app)
+            dmh.remove_from_data_manager(repository)
+        # Update the repository metadata.
+        tpm = tool_panel_manager.ToolPanelManager(self.app)
+        irmm = InstalledRepositoryMetadataManager(app=self.app,
+                                                  tpm=tpm,
+                                                  repository=repository,
+                                                  changeset_revision=latest_changeset_revision,
+                                                  repository_clone_url=repository_clone_url,
+                                                  shed_config_dict=repository.get_shed_config_dict(self.app),
+                                                  relative_install_dir=relative_install_dir,
+                                                  repository_files_dir=None,
+                                                  resetting_all_metadata_on_repository=False,
+                                                  updating_installed_repository=True,
+                                                  persist=True)
+        irmm.generate_metadata_for_changeset_revision()
+        irmm_metadata_dict = irmm.get_metadata_dict()
+        if 'tools' in irmm_metadata_dict:
+            tool_panel_dict = irmm_metadata_dict.get('tool_panel_section', None)
+            if tool_panel_dict is None:
+                tool_panel_dict = tpm.generate_tool_panel_dict_from_shed_tool_conf_entries(repository)
+            repository_tools_tups = irmm.get_repository_tools_tups()
+            tpm.add_to_tool_panel(repository_name=str(repository.name),
+                                  repository_clone_url=repository_clone_url,
+                                  changeset_revision=str(repository.installed_changeset_revision),
+                                  repository_tools_tups=repository_tools_tups,
+                                  owner=str(repository.owner),
+                                  shed_tool_conf=shed_tool_conf,
+                                  tool_panel_dict=tool_panel_dict,
+                                  new_install=False)
+            # Add new Data Manager entries
+            if 'data_manager' in irmm_metadata_dict:
+                dmh = data_manager.DataManagerHandler(self.app)
+                dmh.install_data_managers(self.app.config.shed_data_manager_config_file,
+                                          irmm_metadata_dict,
+                                          repository.get_shed_config_dict(self.app),
+                                          os.path.join(relative_install_dir, repository.name),
+                                          repository,
+                                          repository_tools_tups)
+        if 'repository_dependencies' in irmm_metadata_dict or 'tool_dependencies' in irmm_metadata_dict:
+            new_repository_dependencies_dict = irmm_metadata_dict.get('repository_dependencies', {})
+            new_repository_dependencies = new_repository_dependencies_dict.get('repository_dependencies', [])
+            new_tool_dependencies_dict = irmm_metadata_dict.get('tool_dependencies', {})
+            if new_repository_dependencies:
+                # [[http://localhost:9009', package_picard_1_56_0', devteam', 910b0b056666', False', False']]
+                if new_repository_dependencies == original_repository_dependencies:
+                    for new_repository_tup in new_repository_dependencies:
+                        # Make sure all dependencies are installed.
+                        # TODO: Repository dependencies that are not installed should be displayed to the user,
+                        # giving them the option to install them or not. This is the same behavior as when initially
+                        # installing and when re-installing.
+                        new_tool_shed, new_name, new_owner, new_changeset_revision, new_pir, new_oicct = \
+                            common_util.parse_repository_dependency_tuple(new_repository_tup)
+                        # Mock up a repo_info_tupe that has the information needed to see if the repository dependency
+                        # was previously installed.
+                        repo_info_tuple = ('', new_tool_shed, new_changeset_revision, '', new_owner, [], [])
+                        # Since the value of new_changeset_revision came from a repository dependency
+                        # definition, it may occur earlier in the Tool Shed's repository changelog than
+                        # the Galaxy tool_shed_repository.installed_changeset_revision record value, so
+                        # we set from_tip to True to make sure we get the entire set of changeset revisions
+                        # from the Tool Shed.
+                        new_repository_db_record, installed_changeset_revision = \
+                            repository_util.repository_was_previously_installed(self.app,
+                                                                                tool_shed_url,
+                                                                                new_name,
+                                                                                repo_info_tuple,
+                                                                                from_tip=True)
+                        if ((new_repository_db_record and new_repository_db_record.status in [
+                                self.install_model.ToolShedRepository.installation_status.ERROR,
+                                self.install_model.ToolShedRepository.installation_status.NEW,
+                                self.install_model.ToolShedRepository.installation_status.UNINSTALLED])
+                                or not new_repository_db_record):
+                            log.debug('Update to %s contains new repository dependency %s/%s', repository.name,
+                                      new_owner, new_name)
+                            if not install_new_dependencies:
+                                return ('repository', irmm_metadata_dict)
+                            else:
+                                self.install(tool_shed_url, new_name, new_owner, new_changeset_revision, install_options)
+            # Updates received did not include any newly defined repository dependencies but did include
+            # newly defined tool dependencies.  If the newly defined tool dependencies are not the same
+            # as the originally defined tool dependencies, we need to install them.
+            if not install_new_dependencies:
+                for new_key, new_val in new_tool_dependencies_dict.items():
+                    if new_key not in original_tool_dependencies_dict:
+                        return ('tool', irmm_metadata_dict)
+                    original_val = original_tool_dependencies_dict[new_key]
+                    if new_val != original_val:
+                        return ('tool', irmm_metadata_dict)
+        # Updates received did not include any newly defined repository dependencies or newly defined
+        # tool dependencies that need to be installed.
+        repository = self.app.update_repository_manager.update_repository_record(repository=repository,
+                                                                                 updated_metadata_dict=irmm_metadata_dict,
+                                                                                 updated_changeset_revision=latest_changeset_revision,
+                                                                                 updated_ctx_rev=latest_ctx_rev)
+        return (None, None)
 
     def order_components_for_installation(self, tsr_ids, repo_info_dicts, tool_panel_section_keys):
         """

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -83,7 +83,7 @@ def check_or_update_tool_shed_status_for_installed_repository(app, repository):
 
 
 def create_or_update_tool_shed_repository(app, name, description, installed_changeset_revision, ctx_rev, repository_clone_url,
-                                          metadata_dict, status, current_changeset_revision=None, owner='', dist_to_shed=False):
+                                          status, metadata_dict=None, current_changeset_revision=None, owner='', dist_to_shed=False):
     """
     Update a tool shed repository record in the Galaxy database with the new information received.
     If a record defined by the received tool shed, repository name and owner does not exist, create
@@ -102,7 +102,7 @@ def create_or_update_tool_shed_repository(app, name, description, installed_chan
     tool_shed = get_tool_shed_from_clone_url(repository_clone_url)
     if not owner:
         owner = get_repository_owner_from_clone_url(repository_clone_url)
-    includes_datatypes = 'datatypes' in metadata_dict
+    includes_datatypes = 'datatypes' in (metadata_dict or {})
     if status in [app.install_model.ToolShedRepository.installation_status.DEACTIVATED]:
         deleted = True
         uninstalled = False
@@ -120,11 +120,12 @@ def create_or_update_tool_shed_repository(app, name, description, installed_chan
         tool_shed_repository.description = description
         tool_shed_repository.changeset_revision = current_changeset_revision
         tool_shed_repository.ctx_rev = ctx_rev
-        tool_shed_repository.metadata = metadata_dict
-        tool_shed_repository.includes_datatypes = includes_datatypes
         tool_shed_repository.deleted = deleted
         tool_shed_repository.uninstalled = uninstalled
         tool_shed_repository.status = status
+        if metadata_dict is not None:
+            tool_shed_repository.metadata = metadata_dict
+            tool_shed_repository.includes_datatypes = includes_datatypes
     else:
         log.debug("Adding new row for repository '%s' in the tool_shed_repository table, status set to '%s'." %
                   (str(name), str(status)))
@@ -136,7 +137,7 @@ def create_or_update_tool_shed_repository(app, name, description, installed_chan
                                                  installed_changeset_revision=installed_changeset_revision,
                                                  changeset_revision=current_changeset_revision,
                                                  ctx_rev=ctx_rev,
-                                                 metadata=metadata_dict,
+                                                 metadata=metadata_dict or {},
                                                  includes_datatypes=includes_datatypes,
                                                  dist_to_shed=dist_to_shed,
                                                  deleted=deleted,


### PR DESCRIPTION
~~Incomplete but I wanted to run tests to see what breaks.~~

You still can't install a specific revision if that revision is not the newest "installable" revision (e.g. the ones marked "Repository metadata is associated with this change set." [here](https://toolshed.g2.bx.psu.edu/repository/view_changelog?id=9ff2d127cd7ed6bc)) for a particular tool version, but at least you can do an update like you can from the UI.

There's code that is supposed to update any repo dependencies if new repo deps are added in an update (which I personally think you should not do, but it is currently supported/allowed), this is refactored from the controller method but ~~is incomplete and completely untested~~ didn't work before anyway?? There is also code that is supposed to update any tool dependencies if new tool deps are added in an update, I made no attempt to support these via the API, and do not think doing so is worth the effort.

This could also be targeted against dev as I am a little nervous about all the potential install/upgrade scenarios this could break. Practically every permutation of repo state/deps/contents/etc. has its own code path.

Fixes #6698 #8243 galaxyproject/ephemeris#111 galaxyproject/ephemeris#140