### PR TITLE
[19.09] Fix data_manager_manual with new data tables + cleanup and fixes

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -79,11 +79,16 @@ class ToolShedRepository(object):
     def get_sharable_url(self, app):
         return common_util.get_tool_shed_repository_url(app, self.tool_shed, self.owner, self.name)
 
-    def get_shed_config_filename(self):
+    @property
+    def shed_config_filename(self):
         shed_config_filename = None
         if self.metadata:
             shed_config_filename = self.metadata.get('shed_config_filename', shed_config_filename)
         return shed_config_filename
+
+    @shed_config_filename.setter
+    def shed_config_filename(self, value):
+        self.metadata['shed_config_filename'] = value
 
     def get_shed_config_dict(self, app, default=None):
         """
@@ -380,11 +385,6 @@ class ToolShedRepository(object):
         if self.tool_shed_status:
             return asbool(self.tool_shed_status.get('revision_update', False))
         return False
-
-    def set_shed_config_filename(self, value):
-        self.metadata['shed_config_filename'] = value
-
-    shed_config_filename = property(get_shed_config_filename, set_shed_config_filename)
 
     def to_dict(self, view='collection', value_mapper=None):
         if value_mapper is None:

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -111,6 +111,7 @@ class ToolShedRepository(object):
         return default
 
     def get_tool_relative_path(self, app):
+        # This is a somewhat public function, used by data_manager_manual for instance
         shed_conf_dict = self.get_shed_config_dict(app)
         tool_path = None
         relative_path = None

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -81,7 +81,7 @@ class ToolShedRepository(object):
 
     @property
     def shed_config_filename(self):
-        return self.metadata.get('shed_config_filename', None)
+        return self.metadata.get('shed_config_filename')
 
     @shed_config_filename.setter
     def shed_config_filename(self, value):
@@ -119,8 +119,7 @@ class ToolShedRepository(object):
 
     def guess_shed_config(self, app, default=None):
         tool_ids = []
-        metadata = self.metadata
-        for tool in metadata.get('tools', []):
+        for tool in self.metadata.get('tools', []):
             tool_ids.append(tool.get('guid'))
         for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
             name = shed_tool_conf_dict['config_filename']
@@ -440,8 +439,8 @@ class ToolShedRepository(object):
         dependencies.
         """
         rd_tups_of_repositories_needed_for_compiling_td = []
-        repository_dependencies = self.metadata.get('repository_dependencies', None)
-        rd_tups = repository_dependencies['repository_dependencies']
+        repository_dependencies = self.metadata.get('repository_dependencies', {})
+        rd_tups = repository_dependencies.get('repository_dependencies', [])
         for rd_tup in rd_tups:
             if len(rd_tup) == 6:
                 tool_shed, name, owner, changeset_revision, prior_installation_required, only_if_compiling_contained_td = rd_tup

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -514,17 +514,12 @@ class Tool(Dictifiable):
     @property
     def tool_shed_repository(self):
         # If this tool is included in an installed tool shed repository, return it.
-        repo_id = self.repository_id
-        if self.repository_id:
-            repo_id = self.app.security.decode_id(self.repository_id)
-
         if self.tool_shed:
             return repository_util.get_installed_repository(self.app,
                                                             tool_shed=self.tool_shed,
                                                             name=self.repository_name,
                                                             owner=self.repository_owner,
-                                                            installed_changeset_revision=self.installed_changeset_revision,
-                                                            repository_id=repo_id)
+                                                            installed_changeset_revision=self.installed_changeset_revision)
 
     @property
     def produces_collections_with_unknown_structure(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -324,7 +324,7 @@ class ToolBox(BaseGalaxyToolBox):
         }
 
     def _get_tool_shed_repository(self, tool_shed, name, owner, installed_changeset_revision):
-        # Abstract toolbox doesn't have a dependency on the the database, so
+        # Abstract toolbox doesn't have a dependency on the database, so
         # override _get_tool_shed_repository here to provide this information.
 
         return repository_util.get_installed_repository(
@@ -514,14 +514,17 @@ class Tool(Dictifiable):
     @property
     def tool_shed_repository(self):
         # If this tool is included in an installed tool shed repository, return it.
+        repo_id = self.repository_id
+        if self.repository_id:
+            repo_id = self.app.security.decode_id(self.repository_id)
+
         if self.tool_shed:
             return repository_util.get_installed_repository(self.app,
                                                             tool_shed=self.tool_shed,
                                                             name=self.repository_name,
                                                             owner=self.repository_owner,
                                                             installed_changeset_revision=self.installed_changeset_revision,
-                                                            repository_id=self.repository_id,
-                                                            from_cache=True)
+                                                            repository_id=repo_id)
 
     @property
     def produces_collections_with_unknown_structure(self):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -519,7 +519,8 @@ class Tool(Dictifiable):
                                                             tool_shed=self.tool_shed,
                                                             name=self.repository_name,
                                                             owner=self.repository_owner,
-                                                            installed_changeset_revision=self.installed_changeset_revision)
+                                                            installed_changeset_revision=self.installed_changeset_revision,
+                                                            from_cache=True)
 
     @property
     def produces_collections_with_unknown_structure(self):

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -72,7 +72,7 @@ class DataManagers(object):
                 # File does not exist
                 return None
         except Exception:
-            log.error("Error loading data_manager", exc_info=True)
+            log.exception("Error loading data_manager")
             return None
         if add_manager:
             self.add_manager(data_manager)
@@ -145,7 +145,7 @@ class DataManager(object):
         if path is None:
             tool_elem = elem.find('tool')
             assert tool_elem is not None, "Error loading tool for data manager. Make sure that a tool_file attribute or a tool tag set has been defined:\n%s" % (util.xml_to_string(elem))
-            path = tool_elem.get("file", path)
+            path = tool_elem.get("file")
             tool_guid = tool_elem.get("guid", None)
             # need to determine repository info so that dependencies will work correctly
             tool_shed_repository = self.data_managers.app.toolbox.get_tool_repository_from_xml_item(tool_elem, path)
@@ -154,7 +154,7 @@ class DataManager(object):
                                                        owner=tool_shed_repository.owner,
                                                        installed_changeset_revision=tool_shed_repository.installed_changeset_revision)
             # use shed_conf_file to determine tool_path
-            shed_conf_file = elem.get("shed_conf_file", None)
+            shed_conf_file = elem.get("shed_conf_file")
             if shed_conf_file:
                 shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(os.path.abspath(shed_conf_file), None)
                 if shed_conf:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -158,7 +158,7 @@ class DataManager(object):
             # use shed_conf_file to determine tool_path
             shed_conf_file = elem.get("shed_conf_file", None)
             if shed_conf_file:
-                shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(shed_conf_file, None)
+                shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(os.path.abspath(shed_conf_file), None)
                 if shed_conf:
                     tool_path = shed_conf.get("tool_path", tool_path)
         assert path is not None, "A tool file path could not be determined:\n%s" % (util.xml_to_string(elem))

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -143,6 +143,7 @@ class DataManager(object):
         self.guid = elem.get('guid', None)
         path = elem.get('tool_file', None)
         self.version = elem.get('version', self.version)
+        tool_shed_repository = None
         tool_shed_repository_id = None
         tool_guid = None
 

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -140,7 +140,6 @@ class DataManager(object):
         path = elem.get('tool_file', None)
         self.version = elem.get('version', self.version)
         tool_shed_repository = None
-        tool_shed_repository_id = None
         tool_guid = None
 
         if path is None:
@@ -154,7 +153,6 @@ class DataManager(object):
                                                        name=tool_shed_repository.name,
                                                        owner=tool_shed_repository.owner,
                                                        installed_changeset_revision=tool_shed_repository.installed_changeset_revision)
-            tool_shed_repository_id = self.data_managers.app.security.encode_id(tool_shed_repository.id)
             # use shed_conf_file to determine tool_path
             shed_conf_file = elem.get("shed_conf_file", None)
             if shed_conf_file:
@@ -165,7 +163,6 @@ class DataManager(object):
         self.load_tool(os.path.join(tool_path, path),
                        guid=tool_guid,
                        data_manager_id=self.id,
-                       tool_shed_repository_id=tool_shed_repository_id,
                        tool_shed_repository=tool_shed_repository)
         self.name = elem.get('name', self.tool.name)
         self.description = elem.get('description', self.tool.description)

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -75,8 +75,8 @@ class DataManagers(object):
             if e.errno == errno.ENOENT:
                 # File does not exist
                 return None
-        except Exception as e:
-            log.error("Error loading data_manager '%s':\n%s" % (e, util.xml_to_string(data_manager_elem)))
+        except Exception:
+            log.error("Error loading data_manager", exc_info=True)
             return None
         if add_manager:
             self.add_manager(data_manager)

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -149,52 +149,18 @@ class DataManager(object):
             path = tool_elem.get("file", path)
             tool_guid = tool_elem.get("guid", None)
             # need to determine repository info so that dependencies will work correctly
-            if hasattr(self.data_managers.app, 'tool_cache') and tool_guid in self.data_managers.app.tool_cache._tool_paths_by_id:
-                path = self.data_managers.app.tool_cache._tool_paths_by_id[tool_guid]
-                tool = self.data_managers.app.tool_cache.get_tool(path)
-                tool_shed_repository = tool.tool_shed_repository
-                self.tool_shed_repository_info_dict = dict(tool_shed=tool_shed_repository.tool_shed,
-                                                           name=tool_shed_repository.name,
-                                                           owner=tool_shed_repository.owner,
-                                                           installed_changeset_revision=tool_shed_repository.installed_changeset_revision)
-                tool_shed_repository_id = self.data_managers.app.security.encode_id(tool_shed_repository.id)
-                tool_path = ""
-            else:
-                tool_shed_url = tool_elem.find('tool_shed').text
-                # Handle protocol changes.
-                tool_shed_url = common_util.get_tool_shed_url_from_tool_shed_registry(self.data_managers.app, tool_shed_url)
-                # The protocol is not stored in the database.
-                tool_shed = common_util.remove_protocol_from_tool_shed_url(tool_shed_url)
-                repository_name = tool_elem.find('repository_name').text
-                repository_owner = tool_elem.find('repository_owner').text
-                installed_changeset_revision = tool_elem.find('installed_changeset_revision').text
-                self.tool_shed_repository_info_dict = dict(tool_shed=tool_shed,
-                                                           name=repository_name,
-                                                           owner=repository_owner,
-                                                           installed_changeset_revision=installed_changeset_revision)
-                tool_shed_repository = \
-                    repository_util.get_installed_repository(self.data_managers.app,
-                                                             tool_shed=tool_shed,
-                                                             name=repository_name,
-                                                             owner=repository_owner,
-                                                             installed_changeset_revision=installed_changeset_revision,
-                                                             from_cache=True)
-                if tool_shed_repository is None:
-                    log.warning('Could not determine tool shed repository from database. This should only ever happen when running tests.')
-                    # we'll set tool_path manually here from shed_conf_file
-                    tool_shed_repository_id = None
-                    try:
-                        tool_path = util.parse_xml(elem.get('shed_conf_file')).getroot().get('tool_path', tool_path)
-                    except Exception as e:
-                        log.error('Error determining tool_path for Data Manager during testing: %s', e)
-                else:
-                    tool_shed_repository_id = self.data_managers.app.security.encode_id(tool_shed_repository.id)
-                # use shed_conf_file to determine tool_path
-                shed_conf_file = elem.get("shed_conf_file", None)
-                if shed_conf_file:
-                    shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(shed_conf_file, None)
-                    if shed_conf:
-                        tool_path = shed_conf.get("tool_path", tool_path)
+            tool_shed_repository = self.data_managers.app.toolbox.get_tool_repository_from_xml_item(tool_elem, path)
+            self.tool_shed_repository_info_dict = dict(tool_shed=tool_shed_repository.tool_shed,
+                                                       name=tool_shed_repository.name,
+                                                       owner=tool_shed_repository.owner,
+                                                       installed_changeset_revision=tool_shed_repository.installed_changeset_revision)
+            tool_shed_repository_id = self.data_managers.app.security.encode_id(tool_shed_repository.id)
+            # use shed_conf_file to determine tool_path
+            shed_conf_file = elem.get("shed_conf_file", None)
+            if shed_conf_file:
+                shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(shed_conf_file, None)
+                if shed_conf:
+                    tool_path = shed_conf.get("tool_path", tool_path)
         assert path is not None, "A tool file path could not be determined:\n%s" % (util.xml_to_string(elem))
         self.load_tool(os.path.join(tool_path, path),
                        guid=tool_guid,

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -202,7 +202,8 @@ class DataManager(object):
         self.load_tool(os.path.join(tool_path, path),
                        guid=tool_guid,
                        data_manager_id=self.id,
-                       tool_shed_repository_id=tool_shed_repository_id)
+                       tool_shed_repository_id=tool_shed_repository_id,
+                       tool_shed_repository=tool_shed_repository)
         self.name = elem.get('name', self.tool.name)
         self.description = elem.get('description', self.tool.description)
         self.undeclared_tables = util.asbool(elem.get('undeclared_tables', self.undeclared_tables))

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -9,10 +9,6 @@ from six import string_types
 from galaxy import util
 from galaxy.tools.data import TabularToolDataTable
 from galaxy.util.template import fill_template
-from tool_shed.util import (
-    common_util,
-    repository_util
-)
 
 log = logging.getLogger(__name__)
 
@@ -150,7 +146,7 @@ class DataManager(object):
         if path is None:
             tool_elem = elem.find('tool')
             assert tool_elem is not None, "Error loading tool for data manager. Make sure that a tool_file attribute or a tool tag set has been defined:\n%s" % (util.xml_to_string(elem))
-            path = tool_elem.get("file", None)
+            path = tool_elem.get("file", path)
             tool_guid = tool_elem.get("guid", None)
             # need to determine repository info so that dependencies will work correctly
             if hasattr(self.data_managers.app, 'tool_cache') and tool_guid in self.data_managers.app.tool_cache._tool_paths_by_id:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -135,9 +135,9 @@ class DataManager(object):
 
     def load_from_element(self, elem, tool_path):
         assert elem.tag == 'data_manager', 'A data manager configuration must have a "data_manager" tag as the root. "%s" is present' % (elem.tag)
-        self.declared_id = elem.get('id', None)
-        self.guid = elem.get('guid', None)
-        path = elem.get('tool_file', None)
+        self.declared_id = elem.get('id')
+        self.guid = elem.get('guid')
+        path = elem.get('tool_file')
         self.version = elem.get('version', self.version)
         tool_shed_repository = None
         tool_guid = None
@@ -146,7 +146,7 @@ class DataManager(object):
             tool_elem = elem.find('tool')
             assert tool_elem is not None, "Error loading tool for data manager. Make sure that a tool_file attribute or a tool tag set has been defined:\n%s" % (util.xml_to_string(elem))
             path = tool_elem.get("file")
-            tool_guid = tool_elem.get("guid", None)
+            tool_guid = tool_elem.get("guid")
             # need to determine repository info so that dependencies will work correctly
             tool_shed_repository = self.data_managers.app.toolbox.get_tool_repository_from_xml_item(tool_elem, path)
             self.tool_shed_repository_info_dict = dict(tool_shed=tool_shed_repository.tool_shed,

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -624,7 +624,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                     # In that case recreating the tool will correct the cached version.
                     from_cache = False
             if guid and not from_cache:  # tool was not in cache and is a tool shed tool
-                tool_shed_repository = self.get_tool_repository_from_xml_item(item, path)
+                tool_shed_repository = self.get_tool_repository_from_xml_item(item.elem)
                 if tool_shed_repository:
                     if hasattr(tool_shed_repository, 'deleted'):
                         # The shed tool is in the install database
@@ -659,14 +659,14 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         except Exception:
             log.exception("Error reading tool from path: %s", path)
 
-    def get_tool_repository_from_xml_item(self, item, path):
-        tool_shed = item.elem.find("tool_shed").text
-        repository_name = item.elem.find("repository_name").text
-        repository_owner = item.elem.find("repository_owner").text
-        installed_changeset_revision_elem = item.elem.find("installed_changeset_revision")
+    def get_tool_repository_from_xml_item(self, elem):
+        tool_shed = elem.find("tool_shed").text
+        repository_name = elem.find("repository_name").text
+        repository_owner = elem.find("repository_owner").text
+        installed_changeset_revision_elem = elem.find("installed_changeset_revision")
         if installed_changeset_revision_elem is None:
             # Backward compatibility issue - the tag used to be named 'changeset_revision'.
-            installed_changeset_revision_elem = item.elem.find("changeset_revision")
+            installed_changeset_revision_elem = elem.find("changeset_revision")
         installed_changeset_revision = installed_changeset_revision_elem.text
         repository = self._get_tool_shed_repository(tool_shed=tool_shed,
                                                     name=repository_name,

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -8,16 +8,30 @@ from nose.plugins.skip import SkipTest
 from .uses_shed import CONDA_AUTO_INSTALL_JOB_TIMEOUT, UsesShed
 
 FETCH_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2'
-FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {"dbkey_source|dbkey_source_selector": "new",
-                                       "dbkey_source|dbkey": "NC_001617.1",
-                                       "dbkey_source|dbkey_name": "NC_001617.1",
-                                       "sequence_name": "NC_001617.1",
-                                       "sequence_id": "NC_001617.1",
-                                       "reference_source|reference_source_selector": "url",
-                                       "reference_source|user_url": "https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/NC_001617.1.fasta",
-                                       "sorting|sort_selector": "as_is"}
+FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {
+    "dbkey_source|dbkey_source_selector": "new",
+    "dbkey_source|dbkey": "NC_001617.1",
+    "dbkey_source|dbkey_name": "NC_001617.1",
+    "sequence_name": "NC_001617.1",
+    "sequence_id": "NC_001617.1",
+    "reference_source|reference_source_selector": "url",
+    "reference_source|user_url": "https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/NC_001617.1.fasta",
+    "sorting|sort_selector": "as_is"
+}
 SAM_FASTA_ID = "toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder/sam_fasta_index_builder/0.0.2"
 SAM_FASTA_INPUT = {"all_fasta_source": "NC_001617.1", "sequence_name": "", "sequence_id": ""}
+DATA_MANAGER_MANUAL_ID = 'toolshed.g2.bx.psu.edu/repos/iuc/data_manager_manual/data_manager_manual/0.0.2'
+DATA_MANAGER_MANUAL_INPUT = {
+    "data_tables_0|data_table_name": "all_fasta",
+    "data_tables_0|columns_0|data_table_column_name": "value",
+    "data_tables_0|columns_0|data_table_column_value": "dm6",
+    "data_tables_0|columns_1|data_table_column_name": "name",
+    "data_tables_0|columns_1|data_table_column_value": "dm6",
+    "data_tables_0|columns_2|data_table_column_name": "dbkey",
+    "data_tables_0|columns_2|data_table_column_value": "dm6",
+    "data_tables_0|columns_3|data_table_column_name": "path",
+    "data_tables_0|columns_3|data_table_column_value": "dm6.fa",
+}
 
 
 class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):
@@ -61,6 +75,17 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
                                                                history_id=history_id,
                                                                assert_ok=False)
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
+
+    def test_data_manager_manual(self):
+        """
+        Test that data_manager_manual works, which uses a signigicant amount of Galaxy-internal code
+        """
+        self.install_repository('iuc', 'data_manager_manual', '1ed87dee9e68')
+        with self._different_user(email="%s@galaxy.org" % self.username):
+            with self.dataset_populator.test_history() as history_id:
+                self.dataset_populator.run_tool(tool_id=DATA_MANAGER_MANUAL_ID,
+                                                inputs=DATA_MANAGER_MANUAL_INPUT,
+                                                history_id=history_id)
 
     @classmethod
     def get_secure_ascii_digits(cls, n=12):

--- a/test/unit/tools/conftest.py
+++ b/test/unit/tools/conftest.py
@@ -43,6 +43,7 @@ def tool_conf_repos(tool_shed_repository_cache):
             tool_path='../shed_tools',
         )
         tool_shed_repository_cache.add_local_repository(repo)
+    return tool_shed_repository_cache.local_repositories
 
 
 def create_repo(app, changeset, installed_changeset, config_filename=None):

--- a/test/unit/tools/conftest.py
+++ b/test/unit/tools/conftest.py
@@ -1,0 +1,67 @@
+from tempfile import mkdtemp
+
+import pytest
+
+from galaxy.model import tool_shed_install
+from galaxy.model.tool_shed_install import mapping
+from galaxy.tools.cache import ToolShedRepositoryCache
+from galaxy.tools.toolbox.base import ToolConfRepository
+from galaxy.util import bunch
+
+
+@pytest.fixture
+def mock_app():
+    app = bunch.Bunch()
+    app.install_model = mapping.init("sqlite:///:memory:", create_tables=True)
+    return app
+
+
+@pytest.fixture
+def tool_shed_repository_cache(mock_app):
+    tool_shed_repository_cache = ToolShedRepositoryCache(app=mock_app)
+    return tool_shed_repository_cache
+
+
+@pytest.fixture
+def repos(mock_app):
+    repositories = [create_repo(mock_app, changeset=i + 1, installed_changeset=i) for i in range(10)]
+    mock_app.install_model.context.flush()
+    return repositories
+
+
+@pytest.fixture
+def tool_conf_repos(tool_shed_repository_cache):
+    for i in range(10, 20):
+        repo = ToolConfRepository(
+            'github.com',
+            'example',
+            'galaxyproject',
+            str(i),
+            str(i + 1),
+            None,
+            repository_path=mkdtemp(prefix='repository_path'),
+            tool_path='../shed_tools',
+        )
+        tool_shed_repository_cache.add_local_repository(repo)
+
+
+def create_repo(app, changeset, installed_changeset, config_filename=None):
+    metadata = {
+        'tools': [{
+            'add_to_tool_panel': False,  # to have repository.includes_tools_for_display_in_tool_panel=False in InstalledRepositoryManager.activate_repository()
+            'guid': "github.com/galaxyproject/example/test_tool/0.%s" % changeset,
+            'tool_config': 'tool.xml'
+        }],
+    }
+    if config_filename:
+        metadata['shed_config_filename'] = config_filename
+    repository = tool_shed_install.ToolShedRepository(metadata=metadata)
+    repository.tool_shed = "github.com"
+    repository.owner = "galaxyproject"
+    repository.name = "example"
+    repository.changeset_revision = str(changeset)
+    repository.installed_changeset_revision = str(installed_changeset)
+    repository.deleted = False
+    repository.uninstalled = False
+    app.install_model.context.add(repository)
+    return repository

--- a/test/unit/tools/test_tool_conf_repository.py
+++ b/test/unit/tools/test_tool_conf_repository.py
@@ -1,0 +1,3 @@
+def test_tool_conf_repository_get_tool_relative_path(tool_conf_repos):
+    tool_conf_repo = tool_conf_repos[0]
+    assert tool_conf_repo.get_tool_relative_path() == (tool_conf_repo.tool_path, tool_conf_repo.repository_path)

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import create_repo
+from .conftest import create_repo
 
 
 def test_empty_repo_cache(tool_shed_repository_cache):

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -1,66 +1,6 @@
 import pytest
 
-from galaxy.model import tool_shed_install
-from galaxy.model.tool_shed_install import mapping
-from galaxy.tools.cache import ToolShedRepositoryCache
-from galaxy.tools.toolbox.base import ToolConfRepository
-from galaxy.util import bunch
-
-
-@pytest.fixture
-def mock_app():
-    app = bunch.Bunch()
-    app.install_model = mapping.init("sqlite:///:memory:", create_tables=True)
-    return app
-
-
-@pytest.fixture
-def tool_shed_repository_cache(mock_app):
-    tool_shed_repository_cache = ToolShedRepositoryCache(app=mock_app)
-    return tool_shed_repository_cache
-
-
-@pytest.fixture
-def repos(mock_app):
-    repositories = [create_repo(mock_app, changeset=i + 1, installed_changeset=i) for i in range(10)]
-    mock_app.install_model.context.flush()
-    return repositories
-
-
-@pytest.fixture
-def tool_conf_repos(tool_shed_repository_cache):
-    for i in range(10, 20):
-        repo = ToolConfRepository(
-            'github.com',
-            'example',
-            'galaxyproject',
-            str(i),
-            str(i + 1),
-            None,
-        )
-        tool_shed_repository_cache.add_local_repository(repo)
-
-
-def create_repo(app, changeset, installed_changeset, config_filename=None):
-    metadata = {
-        'tools': [{
-            'add_to_tool_panel': False,  # to have repository.includes_tools_for_display_in_tool_panel=False in InstalledRepositoryManager.activate_repository()
-            'guid': "github.com/galaxyproject/example/test_tool/0.%s" % changeset,
-            'tool_config': 'tool.xml'
-        }],
-    }
-    if config_filename:
-        metadata['shed_config_filename'] = config_filename
-    repository = tool_shed_install.ToolShedRepository(metadata=metadata)
-    repository.tool_shed = "github.com"
-    repository.owner = "galaxyproject"
-    repository.name = "example"
-    repository.changeset_revision = str(changeset)
-    repository.installed_changeset_revision = str(installed_changeset)
-    repository.deleted = False
-    repository.uninstalled = False
-    app.install_model.context.add(repository)
-    return repository
+from conftest import create_repo
 
 
 def test_empty_repo_cache(tool_shed_repository_cache):

--- a/test/unit/web/framework/test_webapp.py
+++ b/test/unit/web/framework/test_webapp.py
@@ -58,7 +58,12 @@ class GalaxyWebTransaction_Headers_TestCase(unittest.TestCase):
         hostnames = config._parse_allowed_origin_hostnames({
             "allowed_origin_hostnames": r"/host\d{2}/,geocities.com,miskatonic.edu"
         })
-        self.assertTrue(isinstance(hostnames[0], re._pattern_type))
+        # re._pattern_type has been changed to re.Pattern in python 3.7
+        try:
+            Pattern = re.Pattern
+        except AttributeError:
+            Pattern = re._pattern_type
+        self.assertTrue(isinstance(hostnames[0], Pattern))
         self.assertTrue(isinstance(hostnames[1], str))
         self.assertTrue(isinstance(hostnames[2], str))
 


### PR DESCRIPTION
Builds on #8792 by @abretaud 

- Fixes and unifies DM loading
- More useful traceback when loading DM failed
- Implement get_tool_relative_path, needed for running data_manager_manual without install db
- Test data_manager_manual in an integration test