### PR TITLE
[19.09] Don't use a thread local ToolShedRepositoryCache, this may have been …

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -137,6 +137,7 @@ class ToolShedRepositoryCache(object):
         # Repositories loaded from database
         self.repositories = []
         self.repos_by_tuple = defaultdict(list)
+        self.rebuild()
 
     def add_local_repository(self, repository):
         self.local_repositories.append(repository)

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -1,13 +1,7 @@
 import logging
 import os
 from collections import defaultdict
-from threading import (
-    local,
-    Lock,
-)
-
-from sqlalchemy import inspect
-from sqlalchemy.orm.exc import DetachedInstanceError
+from threading import Lock
 
 from galaxy.util import unicodify
 from galaxy.util.hash_util import md5_hash_file
@@ -138,66 +132,29 @@ class ToolShedRepositoryCache(object):
 
     def __init__(self, app):
         self.app = app
-        self.cache = local()
+        self.local_repositories = []
+        self.repositories = []
+        self.repos_by_tuple = defaultdict(list)
 
     def add_local_repository(self, repository):
-        self.cache.repositories.append(repository)
-        self.cache.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
-
-    @property
-    def tool_shed_repositories(self):
-        try:
-            repositories = self.cache.repositories
-        except AttributeError:
-            self.rebuild()
-            repositories = self.cache.repositories
-        tool_shed_repositories = [repo for repo in repositories if isinstance(repo, self.app.install_model.ToolShedRepository)]
-        if tool_shed_repositories and inspect(tool_shed_repositories[0]).detached:
-            self.rebuild()
-            repositories = self.cache.repositories
-        return repositories
-
-    @property
-    def tool_shed_repos_by_tuple(self):
-        try:
-            return self.cache.repos_by_tuple
-        except AttributeError:
-            self.rebuild()
-            return self.cache.repos_by_tuple
+        self.local_repositories.append(repository)
+        self.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
 
     def rebuild(self):
-        repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).all()
-        self.cache.repositories = repositories
+        self.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).all()
         repos_by_tuple = defaultdict(list)
-        for repository in repositories:
+        for repository in self.repositories + self.local_repositories:
             repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
-        self.cache.repos_by_tuple = repos_by_tuple
+        self.repos_by_tuple = repos_by_tuple
 
     def get_installed_repository(self, tool_shed=None, name=None, owner=None, installed_changeset_revision=None, changeset_revision=None, repository_id=None):
-        try:
-            return self._get_installed_repository(tool_shed=tool_shed,
-                                                  name=name,
-                                                  owner=owner,
-                                                  installed_changeset_revision=installed_changeset_revision,
-                                                  changeset_revision=changeset_revision,
-                                                  repository_id=repository_id)
-        except DetachedInstanceError:
-            self.rebuild()
-            return self._get_installed_repository(tool_shed=tool_shed,
-                                                  name=name,
-                                                  owner=owner,
-                                                  installed_changeset_revision=installed_changeset_revision,
-                                                  changeset_revision=changeset_revision,
-                                                  repository_id=repository_id)
-
-    def _get_installed_repository(self, tool_shed=None, name=None, owner=None, installed_changeset_revision=None, changeset_revision=None, repository_id=None):
         if repository_id:
-            repos = [repo for repo in self.tool_shed_repositories if repo.id == repository_id]
+            repos = [repo for repo in self.repositories if repo.id == repository_id]
             if repos:
                 return repos[0]
             else:
                 return None
-        repos = self.tool_shed_repos_by_tuple[(tool_shed, owner, name)]
+        repos = self.repos_by_tuple[(tool_shed, owner, name)]
         for repo in repos:
             if installed_changeset_revision and repo.installed_changeset_revision != installed_changeset_revision:
                 continue

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -132,7 +132,9 @@ class ToolShedRepositoryCache(object):
 
     def __init__(self, app):
         self.app = app
+        # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []
+        # Repositories loaded from database
         self.repositories = []
         self.repos_by_tuple = defaultdict(list)
 

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -1,0 +1,117 @@
+import pytest
+
+from galaxy.model import tool_shed_install
+from galaxy.model.tool_shed_install import mapping
+from galaxy.tools.cache import ToolShedRepositoryCache
+from galaxy.tools.toolbox.base import ToolConfRepository
+from galaxy.util import bunch
+
+
+@pytest.fixture
+def mock_app():
+    app = bunch.Bunch()
+    app.install_model = mapping.init("sqlite:///:memory:", create_tables=True)
+    return app
+
+
+@pytest.fixture
+def tool_shed_repository_cache(mock_app):
+    tool_shed_repository_cache = ToolShedRepositoryCache(app=mock_app)
+    return tool_shed_repository_cache
+
+
+@pytest.fixture
+def repos(mock_app):
+    repositories = [create_repo(mock_app, changeset=i + 1, installed_changeset=i) for i in range(10)]
+    mock_app.install_model.context.flush()
+    return repositories
+
+
+@pytest.fixture
+def tool_conf_repos(tool_shed_repository_cache):
+    for i in range(10, 20):
+        repo = ToolConfRepository(
+            'github.com',
+            'example',
+            'galaxyproject',
+            str(i),
+            str(i + 1),
+            None,
+        )
+        tool_shed_repository_cache.add_local_repository(repo)
+
+
+def create_repo(app, changeset, installed_changeset, config_filename=None):
+    metadata = {
+        'tools': [{
+            'add_to_tool_panel': False,  # to have repository.includes_tools_for_display_in_tool_panel=False in InstalledRepositoryManager.activate_repository()
+            'guid': "github.com/galaxyproject/example/test_tool/0.%s" % changeset,
+            'tool_config': 'tool.xml'
+        }],
+    }
+    if config_filename:
+        metadata['shed_config_filename'] = config_filename
+    repository = tool_shed_install.ToolShedRepository(metadata=metadata)
+    repository.tool_shed = "github.com"
+    repository.owner = "galaxyproject"
+    repository.name = "example"
+    repository.changeset_revision = str(changeset)
+    repository.installed_changeset_revision = str(installed_changeset)
+    repository.deleted = False
+    repository.uninstalled = False
+    app.install_model.context.add(repository)
+    return repository
+
+
+def test_empty_repo_cache(tool_shed_repository_cache):
+    assert len(tool_shed_repository_cache.repositories) == 0
+    assert len(tool_shed_repository_cache.local_repositories) == 0
+
+
+def test_add_repository_to_repository_cache(tool_shed_repository_cache, repos):
+    tool_shed_repository_cache.rebuild()
+    assert len(tool_shed_repository_cache.repositories) == 10
+    assert len(tool_shed_repository_cache.local_repositories) == 0
+
+
+def test_add_repository_and_tool_conf_repository_to_repository_cache(tool_shed_repository_cache, repos, tool_conf_repos):
+    tool_shed_repository_cache.rebuild()
+    assert len(tool_shed_repository_cache.repositories) == 10
+    assert len(tool_shed_repository_cache.local_repositories) == 10
+    tool_shed_repository_cache.rebuild()
+    assert len(tool_shed_repository_cache.repositories) == 10
+    assert len(tool_shed_repository_cache.local_repositories) == 10
+    create_repo(tool_shed_repository_cache.app, '21', '20')
+    tool_shed_repository_cache.app.install_model.context.flush()
+    tool_shed_repository_cache.rebuild()
+    assert len(tool_shed_repository_cache.repositories) == 11
+    assert len(tool_shed_repository_cache.local_repositories) == 10
+
+
+@pytest.mark.parametrize('tool_shed,name,owner,changeset_revision,installed_changeset_revision,repository_id,repo_exists', [
+    ('github.com', 'example', 'galaxyproject', None, None, None, True),
+    ('github.com', 'example', 'noone', None, None, None, False),
+    ('github.com', 'example', 'galaxyproject', '1', None, None, True),
+    ('github.com', 'example', 'galaxyproject', None, '1', None, True),
+    ('github.com', 'example', 'galaxyproject', '2', '1', None, True),
+    ('github.com', 'example', 'galaxyproject', '500', '1', None, False),
+    ('github.com', 'example', 'galaxyproject', '1', '500', None, False),
+    ('github.com', 'example', 'galaxyproject', '2', '1', 1, True),
+    ('github.com', 'example', 'galaxyproject', '2', '1', 500, False),
+    ('github.com', 'example', 'galaxyproject', '19', '18', None, True),
+])
+def test_get_installed_repository(tool_shed_repository_cache, repos, tool_shed, tool_conf_repos, name, owner, changeset_revision, installed_changeset_revision, repository_id, repo_exists):
+    tool_shed_repository_cache.rebuild()
+    print(tool_shed_repository_cache.local_repositories)
+    repo = tool_shed_repository_cache.get_installed_repository(
+        tool_shed=tool_shed,
+        name=name,
+        owner=owner,
+        installed_changeset_revision=installed_changeset_revision,
+        changeset_revision=changeset_revision,
+        repository_id=repository_id
+    )
+    if repo_exists:
+        assert repo
+    else:
+        assert repo is None

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -100,9 +100,8 @@ def test_add_repository_and_tool_conf_repository_to_repository_cache(tool_shed_r
     ('github.com', 'example', 'galaxyproject', '2', '1', 500, False),
     ('github.com', 'example', 'galaxyproject', '19', '18', None, True),
 ])
-def test_get_installed_repository(tool_shed_repository_cache, repos, tool_shed, tool_conf_repos, name, owner, changeset_revision, installed_changeset_revision, repository_id, repo_exists):
+def test_get_installed_repository(tool_shed_repository_cache, repos, tool_conf_repos, tool_shed, name, owner, changeset_revision, installed_changeset_revision, repository_id, repo_exists):
     tool_shed_repository_cache.rebuild()
-    print(tool_shed_repository_cache.local_repositories)
     repo = tool_shed_repository_cache.get_installed_repository(
         tool_shed=tool_shed,
         name=name,


### PR DESCRIPTION
…a memory leak

Every thread would need to build the cache again when first accessing it. Now that we eagerload the relationships (https://github.com/galaxyproject/galaxy/pull/8791 only went into dev) we shouldn't need to keep the cache thread local. This should be faster and more memory efficient, and actually it looks like the thread-local cache didn't work as intended before (writing tests now to verify it does work now).