### PR TITLE
[19.09] Only use cached repositories where needed & safe

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -332,7 +332,8 @@ class ToolBox(BaseGalaxyToolBox):
             tool_shed=tool_shed,
             name=name,
             owner=owner,
-            installed_changeset_revision=installed_changeset_revision
+            installed_changeset_revision=installed_changeset_revision,
+            from_cache=True,
         )
 
     def __build_tool_version_select_field(self, tools, tool_id, set_selected):
@@ -519,7 +520,8 @@ class Tool(Dictifiable):
                                                             name=self.repository_name,
                                                             owner=self.repository_owner,
                                                             installed_changeset_revision=self.installed_changeset_revision,
-                                                            repository_id=self.repository_id)
+                                                            repository_id=self.repository_id,
+                                                            from_cache=True)
 
     @property
     def produces_collections_with_unknown_structure(self):

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -180,7 +180,8 @@ class DataManager(object):
                                                              tool_shed=tool_shed,
                                                              name=repository_name,
                                                              owner=repository_owner,
-                                                             installed_changeset_revision=installed_changeset_revision)
+                                                             installed_changeset_revision=installed_changeset_revision,
+                                                             from_cache=True)
                 if tool_shed_repository is None:
                     log.warning('Could not determine tool shed repository from database. This should only ever happen when running tests.')
                     # we'll set tool_path manually here from shed_conf_file

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -891,7 +891,6 @@ class InstallRepositoryManager(object):
                                               shed_tool_conf=shed_tool_conf,
                                               reinstalling=reinstalling,
                                               tool_panel_section_mapping=tool_panel_section_mapping)
-            self.install_model.context.refresh(tool_shed_repository)
             metadata = tool_shed_repository.metadata
             if 'tools' in metadata and install_resolver_dependencies:
                 self.update_tool_shed_repository_status(tool_shed_repository,

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -356,14 +356,14 @@ def get_ids_of_tool_shed_repositories_being_installed(app, as_string=False):
     return installing_repository_ids
 
 
-def get_installed_repository(app, tool_shed=None, name=None, owner=None, changeset_revision=None, installed_changeset_revision=None, repository_id=None, refresh=False):
+def get_installed_repository(app, tool_shed=None, name=None, owner=None, changeset_revision=None, installed_changeset_revision=None, repository_id=None, refresh=False, from_cache=False):
     """
     Return a tool shed repository database record defined by the combination of a toolshed, repository name,
     repository owner and either current or originally installed changeset_revision.
     """
     # We store the port, if one exists, in the database.
     tool_shed = common_util.remove_protocol_from_tool_shed_url(tool_shed)
-    if hasattr(app, 'tool_shed_repository_cache'):
+    if from_cache and hasattr(app, 'tool_shed_repository_cache'):
         if refresh:
             app.tool_shed_repository_cache.rebuild()
         return app.tool_shed_repository_cache.get_installed_repository(tool_shed=tool_shed,
@@ -397,7 +397,7 @@ def get_installed_tool_shed_repository(app, id):
     if hasattr(app, 'tool_shed_repository_cache'):
         app.tool_shed_repository_cache.rebuild()
     repository_ids = [app.security.decode_id(i) for i in id]
-    rval = [get_installed_repository(app=app, repository_id=repo_id) for repo_id in repository_ids]
+    rval = [get_installed_repository(app=app, repository_id=repo_id, from_cache=False) for repo_id in repository_ids]
     if return_list:
         return rval
     return rval[0]


### PR DESCRIPTION
We only need them when loading tools and data managers, for repository operations such as install/uninstall/modify we should get repos directly from the database.

Fixes ` InvalidRequestError: Object '<ToolShedRepository at 0x12c086ed0>' is already attached to session '60' (this is '36')` when uninstalling repositories. discovered by @guerler 