### PR TITLE
Ensure app.config.config_file is an absolute path

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -110,7 +110,7 @@ class BaseAppConfiguration(object):
         self.global_conf = config_kwargs.get('global_conf', None)
         self.global_conf_parser = configparser.ConfigParser()
         if not self.config_file and self.global_conf and "__file__" in self.global_conf:
-            self.config_file = self.global_conf['__file__']
+            self.config_file = os.path.join(self.root, self.global_conf['__file__'])
         if self.config_file is None:
             log.warning("No Galaxy config file found, running from current working directory: %s", os.getcwd())
         else:


### PR DESCRIPTION
Also, added integration tests for base config dirs. (I'll add all other config options that are paths in a follow-up)

RATIONALE:
If `galaxy.yml` exists, then `config.config_file` is an ABSOLUTE path. Because `__find_config_files()` in `util/properties` uses `os.getcwd()` to build a list of directories - and that results in an absolute path.
(see https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/util/properties.py#L56)
If `galaxy.yml` does NOT exist (testing is one use case), then `config.config_file` is set to a RELATIVE path. Because it uses the value of `__file__` in `global_conf` dictionary passed in `kwargs` and set in the galaxy-main script. (see https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/__init__.py#L113)

As a result, the value of `config.config_dir` will be relative OR absolute (`os.path.dirname()` of `config_file`) (https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/__init__.py#L124)
And that leads to config files (initially) being resolved to a relative OR an absolute path.

It is all fixed in the end in `_parse_config_file_options()` where everything is resolved w.r.t. `config.root` (so with an absolute path, the path is left as is, but with a relative path, it is resolved w.r.t root). However, because conceptually it doesn't feel right (I think, in the end, `config_file` should be relative OR absolute, regardless of what file was loaded and how it was discovered); and because it causes problems during testing (when galaxy is run without a preset config file, so all config properties containing paths to config files become relative), ensuring `config_file` is always an absolute path, seems the logical choice. I've consulted with @natefoo  on this.

(marking this a bug; although it's not quite a bug: it's resolved in the end, but it shouldn't have to be).