### PR TITLE
Fix rare bug in config loading + add unit test

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -283,7 +283,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         for key, value in kwargs.items():
             if key in self.appschema:
                 value = convert_datatype(key, value)
-                value = strip_deprecated_dir(key, value)
+                if value:
+                    value = strip_deprecated_dir(key, value)
                 self._raw_config[key] = value
 
     def _create_attributes_from_raw_config(self):

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -139,3 +139,14 @@ def test_kwargs_relative_path_old_prefix_empty_after_strip(mock_init):
     assert config.path1 == 'my-config/'  # stripped of old prefix, then resolved
     assert config.path2 == 'my-data/my-data-files'  # stripped of old prefix, then resolved
     assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_set_to_null(mock_init):
+    # Expected: allow overriding with null, then resolve
+    # This is not a common scenario, but it does happen: one example is
+    # `job_config` set to `None` when testing
+    config = GalaxyAppConfiguration(path1=None)
+
+    assert config.path1 == 'my-config'  # resolved
+    assert config.path2 == 'my-data/my-data-files'  # resolved
+    assert config.path3 == 'my-other-files'  # no change


### PR DESCRIPTION
The value of a path segment may be None if the config option is set to None in kwargs.
This may be a rare scenario, but it may happen, and it does happen when
running integration tests: job_config_file is overridden with `None`.

PR includes fix + new unit test that exposes the bug.