### PR TITLE
Excplicitly fail dataset upload with invalid extension

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -75,6 +75,11 @@ class LibraryActions(object):
         cntrller = 'api'
         tool_id = 'upload1'
         message = None
+        file_type = kwd.get('file_type')
+        try:
+            upload_common.validate_datatype_extension(datatypes_registry=trans.app.datatypes_registry, ext=file_type)
+        except RequestParameterInvalidException as e:
+            return (400, util.unicodify(e))
         tool = trans.app.toolbox.get_tool(tool_id)
         state = tool.new_state(trans)
         populate_state(trans, tool.inputs, kwd, state.inputs)

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -14,11 +14,20 @@ from sqlalchemy.orm import eagerload_all
 from webob.compat import cgi_FieldStorage
 
 from galaxy import datatypes, util
-from galaxy.exceptions import ConfigDoesNotAllowException, ObjectInvalid
+from galaxy.exceptions import (
+    ConfigDoesNotAllowException,
+    ObjectInvalid,
+    RequestParameterInvalidException,
+)
 from galaxy.model import tags
 from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
+
+
+def validate_datatype_extension(datatypes_registry, ext):
+    if ext and ext not in ('auto', 'data') and not datatypes_registry.get_datatype_by_extension(ext):
+        raise RequestParameterInvalidException("Requested extension '%s' unknown, cannot upload dataset." % ext)
 
 
 def validate_url(url, ip_whitelist):

--- a/lib/galaxy/webapps/galaxy/api/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/api/_fetch_util.py
@@ -12,7 +12,10 @@ from galaxy.model.store.discover import (
     get_required_item,
     replace_request_syntax_sugar,
 )
-from galaxy.tools.actions.upload_common import validate_url
+from galaxy.tools.actions.upload_common import (
+    validate_url,
+    validate_datatype_extension,
+)
 from galaxy.util import (
     relpath,
 )
@@ -72,6 +75,8 @@ def validate_and_normalize_targets(trans, payload):
     def check_src(item):
         if "object_id" in item:
             raise RequestParameterInvalidException("object_id not allowed to appear in the request.")
+
+        validate_datatype_extension(datatypes_registry=trans.app.datatypes_registry, ext=item.get('ext'))
 
         # Normalize file:// URLs into paths.
         if item["src"] == "url" and item["url"].startswith("file://"):


### PR DESCRIPTION
This closes https://github.com/galaxyproject/galaxy/issues/8820. 
If the extension is not known it shouldn't be set (or set to auto), but if it is explicitly specified we should fail if the server doesn't know the extension. 
