### PR TITLE
[19.05] Backported cryptography update;

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -42,7 +42,7 @@ cloudauthz==0.2.0
 cloudbridge==2.0.0
 cmd2==0.8.9
 contextlib2==0.5.5 ; python_version < '3.5'
-cryptography==2.6.1
+cryptography==2.8
 cwltool==1.0.20180721142728
 debtcollector==1.21.0
 decorator==4.4.0

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -3,7 +3,6 @@
 adal==1.2.1
 amqp==2.4.2
 appdirs==1.4.3
-asn1crypto==0.24.0
 avro==1.8.1 ; python_version < '3'
 azure-common==1.1.14
 azure-cosmosdb-nspkg==2.0.2


### PR DESCRIPTION
This turns out to be the culprit causing python startups on catalina to fail (though I don't know exactly why -- has to do with openssl ).

xref #8843 