### PR TITLE
[19.09] Fix toolshed selection display glitch

### DIFF
--- a/client/galaxy/scripts/components/Toolshed/ServerSelection.vue
+++ b/client/galaxy/scripts/components/Toolshed/ServerSelection.vue
@@ -40,3 +40,8 @@ export default {
     }
 };
 </script>
+<style scoped>
+span.dropdown {
+    display: inline-block;
+}
+</style>


### PR DESCRIPTION
Noticed the following bug in firefox when testing #8850 (this bug is unrelated to that code change, though).  When you click the dropdown, the whole thing jumps out into a separate left aligned block.

![image](https://user-images.githubusercontent.com/155398/67395064-4dfd4980-f573-11e9-9515-62db924ff7ab.png)

