### PR TITLE
Refactor database_connection config loading

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -327,18 +327,19 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.gid = os.getgid()  # if running under newgrp(1) we'll need to fix the group of data created on the cluster
 
         self.version_major = VERSION_MAJOR
+
         # Database related configuration
         self.check_migrate_databases = kwargs.get('check_migrate_databases', True)
-        self.database_connection = kwargs.get("database_connection",
-                                              "sqlite:///%s?isolation_level=IMMEDIATE" % os.path.join(self.data_dir, "universe.sqlite"))
+        if not self.database_connection:  # Provide default if not supplied by user
+            db_path = os.path.join(self.data_dir, 'universe.sqlite')
+            self.database_connection = 'sqlite:///%s?isolation_level=IMMEDIATE' % db_path
         self.database_engine_options = get_database_engine_options(kwargs)
-        self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
-        self.database_encoding = kwargs.get("database_encoding", None)  # Create new databases with this encoding.
+        self.database_create_tables = string_as_bool(kwargs.get('database_create_tables', 'True'))
+        self.database_encoding = kwargs.get('database_encoding')  # Create new databases with this encoding
         self.thread_local_log = None
-        if string_as_bool(kwargs.get("enable_per_request_sql_debugging", "False")):
+        if self.enable_per_request_sql_debugging:
             self.thread_local_log = threading.local()
-
-        # Install database related configuration (if different).
+        # Install database related configuration (if different)
         self.install_database_engine_options = get_database_engine_options(kwargs, model_prefix="install_")
 
         override_tempdir = string_as_bool(kwargs.get("override_tempdir", "True"))

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -47,10 +47,9 @@ mapping:
         type: str
         required: false
         desc: |
-          By default, Galaxy uses a SQLite database at 'database/universe.sqlite'.  You
+          By default, Galaxy uses a SQLite database at '<data_dir>/universe.sqlite'.  You
           may use a SQLAlchemy connection string to specify an external database
-          instead.  This string takes many options which are explained in detail in the
-          config file documentation.
+          instead.
 
           Sample default 'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
 


### PR DESCRIPTION
1. Do not check kwargs for schema options: that has been done

2. Assign default only if not supplied by user (read previously from kwargs)

3. Use single quotes for consistency (no special need for double quotes)

4. Do not specify `None` as default in kwargs.get(): it is the default

5. Start removing periods after comments for consistency (Unless it's a
long sentence, or more than one sentence. I'm fine with vise-versa, but
then comments should be added where missing).

6. Schema: remove line from description of `database_connection` because
it is self-referential: there's no additional info in the config
documentation file other than this description. Linking to sqlalchemy
docs seems excessive.

7. `database_connection` is untestable with current setup as it is
overridden for test purposes in `base/driver_util.py`. I'm leaving this
as an empty test+comment as a reminder to address this in the future.

NOTE: This is cherry-picked from https://github.com/galaxyproject/galaxy/pull/8795
(I intended to submit that one as one PR combining many related commits, but I believe *not* grouping those commits into a single PR will make it easier for everyone.) 



