### PR TITLE
Refactor default_locale config option; test

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -601,8 +601,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                 log.warning('Config file (%s) could not be found or is malformed.' % self.user_preferences_extra_conf_path)
             self.user_preferences_extra = {'preferences': {}}
 
-        self.default_locale = kwargs.get('default_locale', None)
-
         # Experimental: This will not be enabled by default and will hide
         # nonproduction code.
         # The api_folders refers to whether the API exposes the /folders section.

--- a/templates/webapps/galaxy/galaxy.masthead.mako
+++ b/templates/webapps/galaxy/galaxy.masthead.mako
@@ -13,7 +13,7 @@
             'remote_user_logout_href'   : app.config.remote_user_logout_href,
             'enable_cloud_launch'       : app.config.get_bool('enable_cloud_launch', False),
             'lims_doc_url'              : app.config.get("lims_doc_url", "https://usegalaxy.org/u/rkchak/p/sts"),
-            'default_locale'            : app.config.get("default_locale",  "auto"),
+            'default_locale'            : app.config.default_locale,
             'support_url'               : app.config.get("support_url", "https://galaxyproject.org/support"),
             'search_url'                : app.config.get("search_url", "http://galaxyproject.org/search/"),
             'mailing_lists'             : app.config.get("mailing_lists", "https://galaxyproject.org/mailing-lists"),

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -107,7 +107,8 @@ DO_NOT_TEST = [
     'object_store_store_by',  # broken: default overridden
     'pretty_datetime_format',  # untestable; refactor config/__init__ to test
     'user_preferences_extra_conf_path',  # broken: remove 'config/' prefix from schema
-    'default_locale',  # broken
+    'galaxy_infrastructure_url',  # broken
+    'galaxy_infrastructure_web_port',  # broken
     'chunk_upload_size',  # broken: default overridden
     'monitor_thread_join_timeout',  # broken: default overridden
     'heartbeat_log',  # untestable; refactor config/__init__ to test


### PR DESCRIPTION
Also, edit mako template to use the config's default

NOTE: This is cherry-picked from #8795