### PR TITLE
Refactor infrastructure_url/port values; fix tests

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -570,27 +570,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             if section.startswith('server:'):
                 self.server_names.append(section.replace('server:', '', 1))
 
-        # Default URL (with schema http/https) of the Galaxy instance within the
-        # local network - used to remotely communicate with the Galaxy API.
-        web_port = kwargs.get("galaxy_infrastructure_web_port", None)
-        self.galaxy_infrastructure_web_port = web_port
-        galaxy_infrastructure_url = kwargs.get('galaxy_infrastructure_url', None)
-        galaxy_infrastructure_url_set = True
-        if galaxy_infrastructure_url is None:
-            # Still provide a default but indicate it was not explicitly set
-            # so dependending on the context a better default can be used (
-            # request url in a web thread, Docker parent in IE stuff, etc...)
-            galaxy_infrastructure_url = "http://localhost"
-            web_port = self.galaxy_infrastructure_web_port
-            if web_port:
-                galaxy_infrastructure_url += ":%s" % (web_port)
-            galaxy_infrastructure_url_set = False
-        if "HOST_IP" in galaxy_infrastructure_url:
-            galaxy_infrastructure_url = string.Template(galaxy_infrastructure_url).safe_substitute({
-                'HOST_IP': socket.gethostbyname(socket.gethostname())
-            })
-        self.galaxy_infrastructure_url = galaxy_infrastructure_url
-        self.galaxy_infrastructure_url_set = galaxy_infrastructure_url_set
+        self._set_galaxy_infrastructure_url(kwargs)
 
         # Asynchronous execution process pools - limited functionality for now, attach_to_pools is designed to allow
         # webless Galaxy server processes to attach to arbitrary message queues (e.g. as job handlers) so they do not
@@ -703,6 +683,16 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                 'filename': kwargs['log_destination'],
                 'filters': ['stack']
             }
+
+    def _set_galaxy_infrastructure_url(self, kwargs):
+        # indicate if this was not set explicitly, so dependending on the context a better default
+        # can be used (request url in a web thread, Docker parent in IE stuff, etc.)
+        self.galaxy_infrastructure_url_set = kwargs.get('galaxy_infrastructure_url') is not None
+
+        if "HOST_IP" in self.galaxy_infrastructure_url:
+            self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
+                'HOST_IP': socket.gethostbyname(socket.gethostname())
+            })
 
     @property
     def admin_users(self):

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -108,8 +108,6 @@ DO_NOT_TEST = [
     'pretty_datetime_format',  # untestable; refactor config/__init__ to test
     'user_preferences_extra_conf_path',  # broken: remove 'config/' prefix from schema
     'default_locale',  # broken
-    'galaxy_infrastructure_url',  # broken
-    'galaxy_infrastructure_web_port',  # broken
     'chunk_upload_size',  # broken: default overridden
     'monitor_thread_join_timeout',  # broken: default overridden
     'heartbeat_log',  # untestable; refactor config/__init__ to test


### PR DESCRIPTION
This edit is possible because schema default values are loaded
automatically.

Here's what the code did:
- web_port was read from kwargs, assigned null by default
- galaxy_infrastructure_url was read from kwargs, assigned null by default
- as a result, schema defaults were never used; however:
- if the url was not set in kwargs, it was rebuilt to the same value as
  the schema default minus the port, which was later specified in a
  different location.
- set an attribute indicating if the url was set from kwargs
- substitute 'HOST_IP' in url

Given that the schema defaults are now preloaded, most of this logic is
now redundant.

Updated logic:
- set an attribute indicating if the url was set from kwargs
- substitute 'HOST_IP' in url

I have removed the comments that duplicate the text in the schema.

Potential side effect: now galaxy_infrastructure_url always contains the
default port unless it is explicitly set to null. I don't expect this to
be an issue, but I am not completely sure.

Integration tests for both defaults should pass.

NOTE: This is cherry-picked from #8795