### PR TITLE
Restore portlet section style for repeat blocks

### DIFF
--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -213,13 +213,13 @@ export var View = Backbone.View.extend({
             .append(
                 $("<div/>")
                     .addClass("portlet-header")
+                    .append($("<div/>").addClass("portlet-operations"))
                     .append(
                         $("<div/>")
                             .addClass("portlet-title")
                             .append($("<i/>").addClass("portlet-title-icon"))
                             .append($("<span/>").addClass("portlet-title-text"))
                     )
-                    .append($("<div/>").addClass("portlet-operations"))
             )
             .append(
                 $("<div/>")

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -192,7 +192,6 @@ $ui-margin-horizontal-large: $margin-v * 2;
         @extend .rounded;
         background: $portlet-bg-color;
         .portlet-title {
-            float: left;
             .portlet-title-text.collapsible {
                 cursor: pointer;
                 text-decoration: underline;


### PR DESCRIPTION
Fixes the misaligned repeat section title shown below (see: 1: Columns):

<img width="410" alt="Screen Shot 2019-10-23 at 9 07 32 PM" src="https://user-images.githubusercontent.com/2105447/67445027-42dd0480-f5d9-11e9-8a9f-4388c5e9cc2a.png">
