### PR TITLE
Prevent potential bug in config loading; test

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -261,7 +261,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         def convert_datatype(key, value):
             datatype = self.appschema[key].get('type')
-            if datatype in type_converters:
+            # check for `not None` explicitly (value can be falsy)
+            if value is not None and datatype in type_converters:
                 return type_converters[datatype](value)
             return value
 
@@ -278,7 +279,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                     return value[len(ignore):]
             return value
 
-        type_converters = {'bool': string_as_bool, 'int': int, 'float': float}
+        type_converters = {'bool': string_as_bool, 'int': int, 'float': float, 'str': str}
 
         for key, value in kwargs.items():
             if key in self.appschema:

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -74,3 +74,26 @@ def test_update_raw_config_from_string_kwargs(mock_init):
     assert type(config._raw_config['property2']) is int
     assert type(config._raw_config['property3']) is float
     assert type(config._raw_config['property4']) is bool
+
+
+def test_update_raw_config_from_kwargs_with_none(mock_init):
+    # should be able to set to null regardless of property's datatype
+    config = GalaxyAppConfiguration(
+        property1=None, property2=None, property3=None, property4=None, property5=None, property6=None,
+    )
+
+    assert config._raw_config['property1'] is None
+    assert config._raw_config['property2'] is None
+    assert config._raw_config['property3'] is None
+    assert config._raw_config['property4'] is None
+    assert config._raw_config['property5'] is None
+    assert config._raw_config['property6'] is None
+
+
+def test_update_raw_config_from_kwargs_falsy_not_none(mock_init):
+    # if kwargs supplies a falsy value, it should not evaluate to null
+    # (ensures code is 'if value is not None' vs. 'if value')
+    config = GalaxyAppConfiguration(property1=0)
+
+    assert config._raw_config['property1'] == '0'  # updated
+    assert type(config._raw_config['property1']) is str  # and converted to str


### PR DESCRIPTION
This ensures that a config option can be set to None regardless of its
datatype. It fixes the case when a config option's datatype has an
associated type converter (currently, int, float, bool): if an option's
value were set to None and the option's datatype were an int, the type
converter function would do `int(None)`, which would raise an error.

This also adds `str` to the type converters (for the unlikely case of
a non-string value supplied for a string option).

The unit tests (a) expose this potential bug, and (b) ensure a falsy
value is not evaluated to `None`.