### PR TITLE
[WIP] Add is_set(property) method to config; test

### DIFF
--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -15,7 +15,7 @@ class AuthManager(object):
     def __init__(self, app):
         self.__app = app
         self.redact_username_in_logs = app.config.redact_username_in_logs
-        self.authenticators = get_authenticators(app.config.auth_config_file, app.config.auth_config_file_set)
+        self.authenticators = get_authenticators(app.config.auth_config_file, app.config.is_set('auth_config_file'))
 
     def check_registration_allowed(self, email, username, password):
         """Checks if the provided email/username is allowed to register."""

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -173,7 +173,6 @@ class BaseAppConfiguration(object):
         for var, values in defaults.items():
             if config_kwargs.get(var) is not None:
                 path = config_kwargs.get(var)
-                setattr(self, var + '_set', True)
             else:
                 for value in values:
                     if os.path.exists(os.path.join(self.root, value)):
@@ -181,14 +180,12 @@ class BaseAppConfiguration(object):
                         break
                 else:
                     path = values[-1]
-                setattr(self, var + '_set', False)
             setattr(self, var, os.path.join(self.root, path))
 
         for var, values in listify_defaults.items():
             paths = []
             if config_kwargs.get(var) is not None:
                 paths = listify(config_kwargs.get(var))
-                setattr(self, var + '_set', True)
             else:
                 for value in values:
                     for path in listify(value):
@@ -199,7 +196,6 @@ class BaseAppConfiguration(object):
                         break
                 else:
                     paths = listify(values[-1])
-                setattr(self, var + '_set', False)
             setattr(self, var, [os.path.join(self.root, x) for x in paths])
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -608,7 +608,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             with open(self.user_preferences_extra_conf_path, 'r') as stream:
                 self.user_preferences_extra = yaml.safe_load(stream)
         except Exception:
-            if self.user_preferences_extra_conf_path_set:
+            if self.is_set('user_preferences_extra_conf_path'):
                 log.warning('Config file (%s) could not be found or is malformed.' % self.user_preferences_extra_conf_path)
             self.user_preferences_extra = {'preferences': {}}
 
@@ -725,6 +725,11 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
         else:
             return None
+
+    def is_set(self, property):
+        if property not in self._raw_config:
+            raise Exception("Property does not exist: '%s'" % property)
+        return self._raw_config[property] != self.appschema[property].get('default')
 
     def parse_config_file_options(self, kwargs):
         """
@@ -1006,7 +1011,7 @@ class ConfiguresGalaxyMixin(object):
         # is in use, and warn if we suspect there to be problems.
         if self.config.shed_tool_config_file not in tool_configs:
             # This seems like the likely case for problems in older deployments
-            if self.config.tool_config_file_set and not self.config.shed_tool_config_file_set:
+            if self.config.is_set('tool_config_file') and not self.config.is_set('shed_tool_config_file'):
                 log.warning(
                     "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
                     "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
@@ -1068,7 +1073,7 @@ class ConfiguresGalaxyMixin(object):
                                                         from_shed_config=from_shed_config)
         except (OSError, IOError) as exc:
             # Missing shed_tool_data_table_config is okay if it's the default
-            if exc.errno != errno.ENOENT or self.config.shed_tool_data_table_config_set:
+            if exc.errno != errno.ENOENT or self.config.is_set('shed_tool_data_table_config'):
                 raise
 
     def _configure_datatypes_registry(self, installed_repository_manager=None):

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -33,14 +33,14 @@ class DataManagers(object):
             try:
                 self.load_from_xml(self.app.config.shed_data_manager_config_file, store_tool_path=True)
             except (OSError, IOError) as exc:
-                if exc.errno != errno.ENOENT or self.app.config.shed_data_manager_config_file_set:
+                if exc.errno != errno.ENOENT or self.app.config.is_set('shed_data_manager_config_file'):
                     raise
 
     def load_from_xml(self, xml_filename, store_tool_path=True):
         try:
             tree = util.parse_xml(xml_filename)
         except (IOError, OSError) as e:
-            if e.errno != errno.ENOENT or self.app.config.data_manager_config_file_set:
+            if e.errno != errno.ENOENT or self.app.config.is_set('data_manager_config_file'):
                 raise
             return  # default config option and it doesn't exist, which is fine
         except Exception as e:

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -176,7 +176,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
     def __init_schedulers(self):
         config_file = self.app.config.workflow_schedulers_config_file
         use_default_scheduler = False
-        if not config_file or (not os.path.exists(config_file) and not self.app.config.workflow_schedulers_config_file_set):
+        if not config_file or (not os.path.exists(config_file) and not self.app.config.is_set('workflow_schedulers_config_file')):
             log.info("No workflow schedulers plugin config file defined, using default scheduler.")
             use_default_scheduler = True
         elif not os.path.exists(config_file):

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -97,3 +97,27 @@ def test_update_raw_config_from_kwargs_falsy_not_none(mock_init):
 
     assert config._raw_config['property1'] == '0'  # updated
     assert type(config._raw_config['property1']) is str  # and converted to str
+
+
+def test_is_set(mock_init):
+    # if an option is set from kwargs, is_set() returns True, otherwise False
+    # Note: is_set() here means 'value is set by user', which includes setting to None.
+    config = GalaxyAppConfiguration(property1='b', property2=None, property4=False, property6='foo')
+
+    assert len(config._raw_config) == 6
+    assert config._raw_config['property1'] == 'b'
+    assert config._raw_config['property2'] is None
+    assert config._raw_config['property3'] == 1.0
+    assert config._raw_config['property4'] is False
+    assert config._raw_config['property5'] is None
+    assert config._raw_config['property6'] == 'foo'
+
+    assert config.is_set('property1')
+    assert config.is_set('property2')
+    assert not config.is_set('property3')
+    assert config.is_set('property4')
+    assert not config.is_set('property5')
+    assert config.is_set('property6')
+
+    with pytest.raises(Exception):
+        assert config.is_set('invalid property')

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -167,9 +167,9 @@ class MockAppConfig(Bunch):
         return self.dict()
 
     def __getattr__(self, name):
-        # Handle the automatic config file _set options
-        if name.endswith('_file_set'):
-            return False
+        # Handle the automatic [option]_set options: for tests, assume none are set
+        if name == 'is_set':
+            return lambda x: False
         return super(MockAppConfig, self).__getattr__(name)
 
     def __del__(self):


### PR DESCRIPTION
`app.config.is_set(property)` will return `True` if property was set by the user (including setting to `None`), and `False` otherwise. If property is not defined in the schema, an exception is raised.

Purpose: will soon replace the `[property]_set` attribute created for config file options here:
https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/__init__.py#L156

Source: discussion with @natefoo .

Limitations: this covers config options defined in the schema only. So, if there's a `foo` attribute defined on `app.config`, which may be set by the user, calling `is_set('foo')` will raise an exception. But, I think, it's best to cross that bridge when we get there.

UPDATE: references to all `_set` attributes replaced with calls to `is_set()` (+attributes themselves no longer created during config loading).