### PR TITLE
Update check_py3_compatibility script for new ack versions.

### DIFF
--- a/.ci/check_py3_compatibility.sh
+++ b/.ci/check_py3_compatibility.sh
@@ -6,17 +6,6 @@ else
     ACK=ack
 fi
 
-export ACK_OPTIONS=" --type python \
---ignore-dir=.git \
---ignore-dir=.tox \
---ignore-dir=.venv \
---ignore-dir=.venv3 \
---ignore-dir=client/node_modules \
---ignore-dir=database \
---ignore-dir=doc/build \
---ignore-dir=eggs \
---ignore-dir=static/maps \
---ignore-dir=static/scripts"
 
 PYTHON2_ONLY_MODULES="__builtin__ _winreg BaseHTTPServer CGIHTTPServer \
 ConfigParser Cookie cookielib copy_reg cPickle cStringIO Dialog dummy_thread \
@@ -28,7 +17,18 @@ xmlrpclib"
 
 ret=0
 for mod in $PYTHON2_ONLY_MODULES; do
-    $ACK "^import $mod(\n|\.)|^from $mod import "
+    $ACK " --type python \
+    --ignore-dir=.git \
+    --ignore-dir=.tox \
+    --ignore-dir=.venv \
+    --ignore-dir=.venv3 \
+    --ignore-dir=client/node_modules \
+    --ignore-dir=database \
+    --ignore-dir=doc/build \
+    --ignore-dir=eggs \
+    --ignore-dir=static/maps \
+    --ignore-dir=static/scripts \
+    ^import $mod(\n|\.)|^from $mod import "
     if [ $? -eq 0 ]; then ret=1; fi
 done
 

--- a/.ci/check_py3_compatibility.sh
+++ b/.ci/check_py3_compatibility.sh
@@ -17,7 +17,7 @@ xmlrpclib"
 
 ret=0
 for mod in $PYTHON2_ONLY_MODULES; do
-    $ACK " --type python \
+    $ACK --type python \
     --ignore-dir=.git \
     --ignore-dir=.tox \
     --ignore-dir=.venv \
@@ -28,7 +28,7 @@ for mod in $PYTHON2_ONLY_MODULES; do
     --ignore-dir=eggs \
     --ignore-dir=static/maps \
     --ignore-dir=static/scripts \
-    ^import $mod(\n|\.)|^from $mod import "
+    "^import $mod(\n|\.)|^from $mod import "
     if [ $? -eq 0 ]; then ret=1; fi
 done
 


### PR DESCRIPTION
ACK_OPTIONS is no longer an option; just include them directly in command invocation.