### PR TITLE
Remove 'area/cleanup', edit 'kind/refactoring'

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -74,8 +74,8 @@ request/report to separate enhancements and new features from bugs, etc.
 -  ``kind/bug`` - something is broken, and it needs fixing
 -  ``kind/enhancement`` - polish to an existing feature or interface
 -  ``kind/feature`` - something brand new
--  ``kind/refactoring`` - refactoring of existing code, no functional
-   changes
+-  ``kind/refactoring`` - cleanup or refactoring of existing code, no
+   functional changes
 
 Status Labels
 -------------
@@ -107,7 +107,6 @@ particular domain, as well as more organized release notes.
 - ``area/admin`` - Changes to admin functionality of the Galaxy webapp
 - ``area/API``
 - ``area/auth`` - Authentication and authorization
-- ``area/cleanup`` - General code cleanup
 - ``area/client-build``
 - ``area/compliance``
 - ``area/configuration`` - Galaxy's configuration system


### PR DESCRIPTION
Use 'kind/refactoring' for refactoring AND any kind of code cleanup. The
'area/cleanup' is removed as redundant and not really describing a
"focus area" or "domain" (as per description of area labels).