### PR TITLE
Eliminate interactive debugging middleware

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -29,10 +29,8 @@
 
 :Description:
     By default, Galaxy uses a SQLite database at
-    'database/universe.sqlite'.  You may use a SQLAlchemy connection
-    string to specify an external database instead.  This string takes
-    many options which are explained in detail in the config file
-    documentation.
+    '<data_dir>/universe.sqlite'.  You may use a SQLAlchemy connection
+    string to specify an external database instead.
     Sample default
     'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
 :Default: ``None``
@@ -255,7 +253,9 @@
     this option is preferable. This file will be created automatically
     upon tool installation, whereas Galaxy will fail to start if any
     files in tool_config_file cannot be read.
-:Default: ``config/shed_tool_conf.xml``
+    The value of this option will be resolved with respect to
+    <mutable_config_dir>.
+:Default: ``shed_tool_conf.xml``
 :Type: str
 
 
@@ -284,8 +284,8 @@
     migration scripts to install tools that have been migrated to the
     tool shed upon a new release, they will be added to this tool
     config file.
-    Default value will be resolved to 'config/migrated_tools_conf.xml'
-    where 'config' is the default value of the 'config_dir' option).
+    The value of this option will be resolved with respect to
+    <config_dir>.
 :Default: ``migrated_tools_conf.xml``
 :Type: str
 
@@ -329,8 +329,8 @@
     handling. If this option is set to none or an invalid path,
     installing tools with dependencies from the Tool Shed or in Conda
     will fail.
-    Default value will be resolved to 'database/dependencies' where
-    'database' is the default value of the 'data_dir' option).
+    The value of this option will be resolved with respect to
+    <data_dir>.
 :Default: ``dependencies``
 :Type: str
 
@@ -347,7 +347,9 @@
     then use Conda if available. See
     https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/dependency_resolvers.rst
     for more information on these options.
-:Default: ``config/dependency_resolvers_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``dependency_resolvers_conf.xml``
 :Type: str
 
 
@@ -496,7 +498,9 @@
     File containing the Galaxy Tool Sheds that should be made
     available to install from in the admin interface (.sample used if
     default does not exist).
-:Default: ``config/tool_sheds_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``tool_sheds_conf.xml``
 :Type: str
 
 
@@ -603,7 +607,8 @@
     the Galaxy host. This is ignored if the relevant container
     resolver isn't enabled, and will install on demand unless
     involucro_auto_init is set to false.
-    Value will be resolved with respect to '<tool_dependency_dir>'.
+    The value of this option will be resolved with respect to
+    <tool_dependency_dir>.
 :Default: ``involucro``
 :Type: str
 
@@ -696,7 +701,9 @@
     installation, these entries are automatically added to the
     following file, which is parsed and applied to the
     ToolDataTableManager at server start up.
-:Default: ``config/shed_tool_data_table_conf.xml``
+    The value of this option will be resolved with respect to
+    <mutable_config_dir>.
+:Default: ``shed_tool_data_table_conf.xml``
 :Type: str
 
 
@@ -747,8 +754,9 @@
 ~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    File containing old-style genome builds. Value will be resolved
-    with respect to <tool_data_path>.
+    File containing old-style genome builds.
+    The value of this option will be resolved with respect to
+    <tool_data_path>.
 :Default: ``shared/ucsc/builds.txt``
 :Type: str
 
@@ -759,7 +767,8 @@
 
 :Description:
     Directory where chrom len files are kept, currently mainly used by
-    trackster. Value will be resolved with respect to
+    trackster.
+    The value of this option will be resolved with respect to
     <tool_data_path>.
 :Default: ``shared/ucsc/chrom``
 :Type: str
@@ -869,8 +878,8 @@
     Each job is given a unique empty directory as its current working
     directory. This option defines in what parent directory those
     directories will be created.
-    Default value will be resolved to 'database/jobs_directory' where
-    'database' is the default value of the 'data_dir' option).
+    The value of this option will be resolved with respect to
+    <data_dir>.
 :Default: ``jobs_directory``
 :Type: str
 
@@ -992,7 +1001,9 @@
 :Description:
     Configuration file for the object store If this is set and exists,
     it overrides any other objectstore settings.
-:Default: ``config/object_store_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``object_store_conf.xml``
 :Type: str
 
 
@@ -1325,7 +1336,7 @@
     Format string used when showing date and time information. The
     string may contain: - the directives used by Python
     time.strftime() function (see
-    https://docs.python.org/library/time.html#time.strftime ), -
+    https://docs.python.org/library/time.html#time.strftime), -
     $locale (complete format string for the server locale), - $iso8601
     (complete format string as specified by ISO 8601 international
     standard).
@@ -1340,7 +1351,9 @@
 :Description:
     Location of the configuration file containing extra user
     preferences.
-:Default: ``config/user_preferences_extra_conf.yml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``user_preferences_extra_conf.yml``
 :Type: str
 
 
@@ -2093,8 +2106,8 @@
 
 :Description:
     Debug enables access to various config options useful for
-    development and debugging: use_lint, use_profile, use_printdebug
-    and use_interactive.  It also causes the files used by PBS/SGE
+    development and debugging: use_lint, use_profile, and
+    use_printdebug.  It also causes the files used by PBS/SGE
     (submission script, output, and error) to remain on disk after the
     job is complete.
 :Default: ``false``
@@ -2128,17 +2141,6 @@
 :Description:
     Intercept print statements and show them on the returned page.
 :Default: ``true``
-:Type: bool
-
-
-~~~~~~~~~~~~~~~~~~~
-``use_interactive``
-~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Enable live debugging in your browser.  This should NEVER be
-    enabled on a public site.
-:Default: ``false``
 :Type: bool
 
 
@@ -2970,7 +2972,9 @@
 
 :Description:
     Sets the path to OIDC configuration file.
-:Default: ``config/oidc_config.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``oidc_config.xml``
 :Type: str
 
 
@@ -2980,7 +2984,9 @@
 
 :Description:
     Sets the path to OIDC backends configuration file.
-:Default: ``config/oidc_backends_config.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``oidc_backends_config.xml``
 :Type: str
 
 
@@ -2992,7 +2998,9 @@
     XML config file that allows the use of different authentication
     providers (e.g. LDAP) instead or in addition to local
     authentication (.sample is used if default does not exist).
-:Default: ``config/auth_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``auth_conf.xml``
 :Type: str
 
 
@@ -3213,7 +3221,9 @@
 :Description:
     File where Tool Shed based Data Managers are configured. This file
     will be created automatically upon data manager installation.
-:Default: ``config/shed_data_manager_conf.xml``
+    The value of this option will be resolved with respect to
+    <mutable_config_dir>.
+:Default: ``shed_data_manager_conf.xml``
 :Type: str
 
 
@@ -3459,9 +3469,9 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) this script is used to run the
-    job script Galaxy generates for a tool execution.
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+    jobs-as-the-real-user) this script is used to run the job script
+    Galaxy generates for a tool execution.
     Example value 'sudo -E scripts/drmaa_external_runner.py
     --assign_all_groups'
 :Default: ``None``
@@ -3474,9 +3484,9 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) this script is used to kill
-    such jobs by Galaxy (e.g. if the user cancels the job).
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+    jobs-as-the-real-user) this script is used to kill such jobs by
+    Galaxy (e.g. if the user cancels the job).
     Example value 'sudo -E scripts/drmaa_external_killer.py'
 :Default: ``None``
 :Type: str
@@ -3488,10 +3498,10 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) this script is used transfer
-    permissions back and forth between the Galaxy user and the user
-    that is running the job.
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+    jobs-as-the-real-user) this script is used transfer permissions
+    back and forth between the Galaxy user and the user that is
+    running the job.
     Example value 'sudo -E scripts/external_chown_script.py'
 :Default: ``None``
 :Type: str
@@ -3503,14 +3513,14 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) Galaxy can extract the user
-    name from the email address (actually the local-part before the @)
-    or the username which are both stored in the Galaxy data base. The
-    latter option is particularly useful for installations that get
-    the authentication from LDAP. Also, Galaxy can accept the name of
-    a common system user (eg. galaxy_worker) who can run every job
-    being submitted. This user should not be the same user running the
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+    jobs-as-the-real-user) Galaxy can extract the user name from the
+    email address (actually the local-part before the @) or the
+    username which are both stored in the Galaxy data base. The latter
+    option is particularly useful for installations that get the
+    authentication from LDAP. Also, Galaxy can accept the name of a
+    common system user (eg. galaxy_worker) who can run every job being
+    submitted. This user should not be the same user running the
     galaxy system. Possible values are user_email (default), username
     or <common_system_user>
 :Default: ``user_email``
@@ -3545,7 +3555,9 @@
     definition. These fields will be presented to users in the tool
     forms and allow them to overwrite default job resources such as
     number of processors, memory and walltime.
-:Default: ``config/job_resource_params_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``job_resource_params_conf.xml``
 :Type: str
 
 
@@ -3559,7 +3571,9 @@
     requires both a description of the fields available (which
     defaults to the definitions in job_resource_params_file if not
     set).
-:Default: ``config/workflow_resource_params_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``workflow_resource_params_conf.xml``
 :Type: str
 
 
@@ -3588,7 +3602,9 @@
 :Description:
     Optional configuration file similar to `job_config_file` to
     specify which Galaxy processes should schedule workflows.
-:Default: ``config/workflow_schedulers_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``workflow_schedulers_conf.xml``
 :Type: str
 
 

--- a/doc/source/admin/production.md
+++ b/doc/source/admin/production.md
@@ -41,10 +41,9 @@ The steps to install Galaxy mostly follow those of the [regular instructions](ht
 
 ### Disable the developer settings
 
-Two options are set in the sample `config/galaxy.yml` which should not be enabled on a production server. You should set both to `false`:
+Debugging options are set in the sample `config/galaxy.yml` which should not be enabled on a production server.  Check the following items:
 
 * `debug: false` - Disable middleware that loads the entire response in memory for displaying debugging information in the page.  If left enabled, the proxy server may timeout waiting for a response or your Galaxy process may run out of memory if it's serving large files.
-* `use_interactive: false` - Disables displaying and live debugging of tracebacks via the web.  Leaving it enabled will expose your configuration (database password, id_secret, etc.).
 * Disable `filter-with: gzip`.  Leaving the gzip filter enabled will cause UI failures because of the way templates are streamed once `debug` is set to `False`.  You will still be able (and are encouraged) to enable gzip in the proxy server.
 
 During deployment, you may run into problems with failed jobs.  By default, Galaxy removes files related to job execution. You can instruct Galaxy to keep files of failed jobs with: `cleanup_job: onsuccess`

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -74,16 +74,6 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~~
-``use_interactive``
-~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    NEVER enable this on a public site (even test or QA)
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~
 ``use_heartbeat``
 ~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -275,7 +275,6 @@ OPTION_ACTIONS = {
     'debug': _ProductionUnsafe(True),
     'serve_xss_vulnerable_mimetypes': _ProductionUnsafe(True),
     'use_printdebug': _ProductionUnsafe(True),
-    'use_interactive': _ProductionUnsafe(True),
     'id_secret': _ProductionUnsafe('USING THE DEFAULT IS NOT SECURE!'),
     'master_api_key': _ProductionUnsafe('changethis'),
     'external_service_type_config_file': _DeprecatedAndDroppedAction(),

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -110,10 +110,8 @@ galaxy:
   #data_dir: null
 
   # By default, Galaxy uses a SQLite database at
-  # 'database/universe.sqlite'.  You may use a SQLAlchemy connection
-  # string to specify an external database instead.  This string takes
-  # many options which are explained in detail in the config file
-  # documentation.
+  # '<data_dir>/universe.sqlite'.  You may use a SQLAlchemy connection
+  # string to specify an external database instead.
   # Sample default
   # 'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
   #database_connection: null
@@ -215,7 +213,9 @@ galaxy:
   # preferable. This file will be created automatically upon tool
   # installation, whereas Galaxy will fail to start if any files in
   # tool_config_file cannot be read.
-  #shed_tool_config_file: config/shed_tool_conf.xml
+  # The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
+  #shed_tool_config_file: shed_tool_conf.xml
 
   # Enable / disable checking if any tools defined in the above non-shed
   # tool_config_files (i.e., tool_conf.xml) have been migrated from the
@@ -229,8 +229,8 @@ galaxy:
   # migration scripts to install tools that have been migrated to the
   # tool shed upon a new release, they will be added to this tool config
   # file.
-  # Default value will be resolved to 'config/migrated_tools_conf.xml'
-  # where 'config' is the default value of the 'config_dir' option).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
   #migrated_tools_config: migrated_tools_conf.xml
 
   # File that contains the XML section and tool tags from all tool panel
@@ -253,8 +253,8 @@ galaxy:
   # handling. If this option is set to none or an invalid path,
   # installing tools with dependencies from the Tool Shed or in Conda
   # will fail.
-  # Default value will be resolved to 'database/dependencies' where
-  # 'database' is the default value of the 'data_dir' option).
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
   #tool_dependency_dir: dependencies
 
   # The dependency resolvers config file specifies an ordering and
@@ -264,7 +264,9 @@ galaxy:
   # Conda if available. See
   # https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/dependency_resolvers.rst
   # for more information on these options.
-  #dependency_resolvers_config_file: config/dependency_resolvers_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #dependency_resolvers_config_file: dependency_resolvers_conf.xml
 
   # conda_prefix is the location on the filesystem where Conda packages
   # and environments are installed.
@@ -328,7 +330,9 @@ galaxy:
   # File containing the Galaxy Tool Sheds that should be made available
   # to install from in the admin interface (.sample used if default does
   # not exist).
-  #tool_sheds_config_file: config/tool_sheds_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #tool_sheds_config_file: tool_sheds_conf.xml
 
   # Monitor the tools and tool directories listed in any tool config
   # file specified in tool_config_file option.  If changes are found,
@@ -386,7 +390,8 @@ galaxy:
   # the Galaxy host. This is ignored if the relevant container resolver
   # isn't enabled, and will install on demand unless involucro_auto_init
   # is set to false.
-  # Value will be resolved with respect to '<tool_dependency_dir>'.
+  # The value of this option will be resolved with respect to
+  # <tool_dependency_dir>.
   #involucro_path: involucro
 
   # Install involucro as needed to build Docker or Singularity
@@ -430,7 +435,9 @@ galaxy:
   # these entries are automatically added to the following file, which
   # is parsed and applied to the ToolDataTableManager at server start
   # up.
-  #shed_tool_data_table_config: config/shed_tool_data_table_conf.xml
+  # The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
+  #shed_tool_data_table_config: shed_tool_data_table_conf.xml
 
   # Directory where data used by tools is located.  See the samples in
   # that directory and the Galaxy Community Hub for help:
@@ -453,12 +460,15 @@ galaxy:
   # scenarios than the watchdog default.
   #watch_tool_data_dir: 'false'
 
-  # File containing old-style genome builds. Value will be resolved with
-  # respect to <tool_data_path>.
+  # File containing old-style genome builds.
+  # The value of this option will be resolved with respect to
+  # <tool_data_path>.
   #builds_file_path: shared/ucsc/builds.txt
 
   # Directory where chrom len files are kept, currently mainly used by
-  # trackster. Value will be resolved with respect to <tool_data_path>.
+  # trackster.
+  # The value of this option will be resolved with respect to
+  # <tool_data_path>.
   #len_file_path: shared/ucsc/chrom
 
   # Datatypes config file(s), defines what data (file) types are
@@ -511,8 +521,8 @@ galaxy:
   # Each job is given a unique empty directory as its current working
   # directory. This option defines in what parent directory those
   # directories will be created.
-  # Default value will be resolved to 'database/jobs_directory' where
-  # 'database' is the default value of the 'data_dir' option).
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
   #job_working_directory: jobs_directory
 
   # If using a cluster, Galaxy will write job scripts and stdout/stderr
@@ -564,7 +574,9 @@ galaxy:
 
   # Configuration file for the object store If this is set and exists,
   # it overrides any other objectstore settings.
-  #object_store_config_file: config/object_store_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #object_store_config_file: object_store_conf.xml
 
   # What Dataset attribute is used to reference files in an ObjectStore
   # implementation, default is 'id' but can also be set to 'uuid' for
@@ -711,14 +723,16 @@ galaxy:
   # Format string used when showing date and time information. The
   # string may contain: - the directives used by Python time.strftime()
   # function (see
-  # https://docs.python.org/library/time.html#time.strftime ), - $locale
+  # https://docs.python.org/library/time.html#time.strftime), - $locale
   # (complete format string for the server locale), - $iso8601 (complete
   # format string as specified by ISO 8601 international   standard).
   #pretty_datetime_format: $locale (UTC)
 
   # Location of the configuration file containing extra user
   # preferences.
-  #user_preferences_extra_conf_path: config/user_preferences_extra_conf.yml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #user_preferences_extra_conf_path: user_preferences_extra_conf.yml
 
   # Default localization for Galaxy UI. Allowed values are listed at the
   # end of client/galaxy/scripts/nls/locale.js. With the default value
@@ -864,8 +878,8 @@ galaxy:
   # prevent a class of attack called clickjacking
   # (https://www.owasp.org/index.php/Clickjacking).  If you configure a
   # proxy in front of Galaxy - please ensure this header remains intact
-  # to protect your users.  Uncomment and leave empty to not set the `X
-  # -Frame-Options` header.
+  # to protect your users.  Uncomment and leave empty to not set the
+  # `X-Frame-Options` header.
   #x_frame_options: SAMEORIGIN
 
   # nginx can also handle file uploads (user-to-Galaxy) via
@@ -1041,8 +1055,8 @@ galaxy:
   #trust_jupyter_notebook_conversion: false
 
   # Debug enables access to various config options useful for
-  # development and debugging: use_lint, use_profile, use_printdebug and
-  # use_interactive.  It also causes the files used by PBS/SGE
+  # development and debugging: use_lint, use_profile, and
+  # use_printdebug.  It also causes the files used by PBS/SGE
   # (submission script, output, and error) to remain on disk after the
   # job is complete.
   #debug: false
@@ -1055,10 +1069,6 @@ galaxy:
 
   # Intercept print statements and show them on the returned page.
   #use_printdebug: true
-
-  # Enable live debugging in your browser.  This should NEVER be enabled
-  # on a public site.
-  #use_interactive: false
 
   # When stopping Galaxy cleanly, how much time to give various
   # monitoring/polling threads to finish before giving up on joining
@@ -1458,15 +1468,21 @@ galaxy:
   #enable_oidc: false
 
   # Sets the path to OIDC configuration file.
-  #oidc_config_file: config/oidc_config.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #oidc_config_file: oidc_config.xml
 
   # Sets the path to OIDC backends configuration file.
-  #oidc_backends_config_file: config/oidc_backends_config.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #oidc_backends_config_file: oidc_backends_config.xml
 
   # XML config file that allows the use of different authentication
   # providers (e.g. LDAP) instead or in addition to local authentication
   # (.sample is used if default does not exist).
-  #auth_config_file: config/auth_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #auth_config_file: auth_conf.xml
 
   # Optional list of email addresses of API users who can make calls on
   # behalf of other users.
@@ -1554,7 +1570,9 @@ galaxy:
 
   # File where Tool Shed based Data Managers are configured. This file
   # will be created automatically upon data manager installation.
-  #shed_data_manager_config_file: config/shed_data_manager_conf.xml
+  # The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
+  #shed_data_manager_config_file: shed_data_manager_conf.xml
 
   # Directory to store Data Manager based tool-data; defaults to
   # tool_data_path.
@@ -1680,39 +1698,38 @@ galaxy:
   #cleanup_job: always
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) this script is used to run the
-  # job script Galaxy generates for a tool execution.
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+  # jobs-as-the-real-user) this script is used to run the job script
+  # Galaxy generates for a tool execution.
   # Example value 'sudo -E scripts/drmaa_external_runner.py
   # --assign_all_groups'
   #drmaa_external_runjob_script: null
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) this script is used to kill such
-  # jobs by Galaxy (e.g. if the user cancels the job).
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+  # jobs-as-the-real-user) this script is used to kill such jobs by
+  # Galaxy (e.g. if the user cancels the job).
   # Example value 'sudo -E scripts/drmaa_external_killer.py'
   #drmaa_external_killjob_script: null
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) this script is used transfer
-  # permissions back and forth between the Galaxy user and the user that
-  # is running the job.
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+  # jobs-as-the-real-user) this script is used transfer permissions back
+  # and forth between the Galaxy user and the user that is running the
+  # job.
   # Example value 'sudo -E scripts/external_chown_script.py'
   #external_chown_script: null
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) Galaxy can extract the user name
-  # from the email address (actually the local-part before the @) or the
-  # username which are both stored in the Galaxy data base. The latter
-  # option is particularly useful for installations that get the
-  # authentication from LDAP. Also, Galaxy can accept the name of a
-  # common system user (eg. galaxy_worker) who can run every job being
-  # submitted. This user should not be the same user running the galaxy
-  # system. Possible values are user_email (default), username or
-  # <common_system_user>
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-
+  # jobs-as-the-real-user) Galaxy can extract the user name from the
+  # email address (actually the local-part before the @) or the username
+  # which are both stored in the Galaxy data base. The latter option is
+  # particularly useful for installations that get the authentication
+  # from LDAP. Also, Galaxy can accept the name of a common system user
+  # (eg. galaxy_worker) who can run every job being submitted. This user
+  # should not be the same user running the galaxy system. Possible
+  # values are user_email (default), username or <common_system_user>
   #real_system_username: user_email
 
   # File to source to set up the environment when running jobs.  By
@@ -1731,13 +1748,17 @@ galaxy:
   # These fields will be presented to users in the tool forms and allow
   # them to overwrite default job resources such as number of
   # processors, memory and walltime.
-  #job_resource_params_file: config/job_resource_params_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #job_resource_params_file: job_resource_params_conf.xml
 
   # Similar to the above parameter, workflows can describe parameters
   # used to influence scheduling of jobs within the workflow. This
   # requires both a description of the fields available (which defaults
   # to the definitions in job_resource_params_file if not set).
-  #workflow_resource_params_file: config/workflow_resource_params_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #workflow_resource_params_file: workflow_resource_params_conf.xml
 
   # This parameter describes how to map users and workflows to a set of
   # workflow resource parameter to present (typically input IDs from
@@ -1752,7 +1773,9 @@ galaxy:
 
   # Optional configuration file similar to `job_config_file` to specify
   # which Galaxy processes should schedule workflows.
-  #workflow_schedulers_config_file: config/workflow_schedulers_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #workflow_schedulers_config_file: workflow_schedulers_conf.xml
 
   # If using job concurrency limits (configured in job_config_file),
   # several extra database queries must be performed to determine the

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -106,9 +106,6 @@ reports:
   # Check for WSGI compliance.
   #use_lint: false
 
-  # NEVER enable this on a public site (even test or QA)
-  #use_interactive: false
-
   # Write thread status periodically to 'heartbeat.log' (careful, uses
   # disk space rapidly!)
   #use_heartbeat: true

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -216,9 +216,6 @@ tool_shed:
   # Intercept print statements and show them on the returned page.
   #use_printdebug: true
 
-  # NEVER enable this on a public site (even test or QA)
-  #use_interactive: false
-
   # Administrative users - set this to a comma-separated list of valid
   # Tool Shed users (email addresses).  These users will have access to
   # the Admin section of the server, and will have access to create

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -177,8 +177,8 @@ tool_shed:
   # User authentication can be delegated to an upstream proxy server
   # (usually Apache).  The upstream proxy should set a REMOTE_USER
   # header in the request. Enabling remote user disables regular logins.
-  # For more information, see: https://galaxyproject.org/admin/config
-  # /apache-external-user-auth/
+  # For more information, see:
+  # https://galaxyproject.org/admin/config/apache-external-user-auth/
   #use_remote_user: false
 
   # If use_remote_user is enabled, anyone who can log in to the Galaxy

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -159,10 +159,6 @@ class ConditionalDependencies(object):
     def check_statsd(self):
         return self.config.get("statsd_host", None) is not None
 
-    def check_weberror(self):
-        return (asbool(self.config["debug"]) and
-                asbool(self.config["use_interactive"]))
-
     def check_python_ldap(self):
         return ('ldap' in self.authenticators or
                 'activedirectory' in self.authenticators)

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -1,6 +1,5 @@
 # These dependencies are only required when certain config options are set
 psycopg2-binary==2.7.4
-weberror==0.10.3
 mysqlclient
 fluent-logger
 raven

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -18,6 +18,10 @@ import galaxy.web.framework.webapp
 from galaxy import util
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
+from galaxy.web.framework.middleware.batch import BatchMiddleware
+from galaxy.web.framework.middleware.error import ErrorMiddleware
+from galaxy.web.framework.middleware.request_id import RequestIDMiddleware
+from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
 from galaxy.webapps.util import wrap_if_allowed
 
 log = logging.getLogger(__name__)
@@ -1177,20 +1181,16 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
             from paste.debug import profile
             app = wrap_if_allowed(app, stack, profile.ProfileMiddleware, args=(conf,))
     # Error middleware
-    import galaxy.web.framework.middleware.error
-    app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
+    app = wrap_if_allowed(app, stack, ErrorMiddleware, args=(conf,))
     # Transaction logging (apache access.log style)
     if asbool(conf.get('use_translogger', True)):
         from galaxy.web.framework.middleware.translogger import TransLogger
         app = wrap_if_allowed(app, stack, TransLogger)
     # X-Forwarded-Host handling
-    from galaxy.web.framework.middleware.xforwardedhost import XForwardedHostMiddleware
     app = wrap_if_allowed(app, stack, XForwardedHostMiddleware)
     # Request ID middleware
-    from galaxy.web.framework.middleware.request_id import RequestIDMiddleware
     app = wrap_if_allowed(app, stack, RequestIDMiddleware)
     # api batch call processing middleware
-    from galaxy.web.framework.middleware.batch import BatchMiddleware
     app = wrap_if_allowed(app, stack, BatchMiddleware, args=(webapp, {}))
     if asbool(conf.get('enable_per_request_sql_debugging', False)):
         from galaxy.web.framework.middleware.sqldebug import SQLDebugMiddleware

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -18,12 +18,7 @@ import galaxy.web.framework.webapp
 from galaxy import util
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
-from galaxy.webapps.util import (
-    build_template_error_formatters,
-    MiddlewareWrapUnsupported,
-    wrap_if_allowed,
-    wrap_if_allowed_or_fail
-)
+from galaxy.webapps.util import wrap_if_allowed
 
 log = logging.getLogger(__name__)
 
@@ -1181,19 +1176,6 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         if asbool(conf.get('use_profile', False)):
             from paste.debug import profile
             app = wrap_if_allowed(app, stack, profile.ProfileMiddleware, args=(conf,))
-    if debug and asbool(conf.get('use_interactive', False)):
-        # Interactive exception debugging, scary dangerous if publicly
-        # accessible, if not enabled we'll use the regular error printing
-        # middleware.
-        try:
-            from weberror import evalexception
-            app = wrap_if_allowed_or_fail(app, stack, evalexception.EvalException,
-                                          args=(conf,),
-                                          kwargs=dict(templating_formatters=build_template_error_formatters()))
-        except MiddlewareWrapUnsupported as exc:
-            log.warning(util.unicodify(exc))
-            import galaxy.web.framework.middleware.error
-            app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
     else:
         # Not in interactive debug mode, just use the regular error middleware
         import galaxy.web.framework.middleware.error

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1176,10 +1176,9 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         if asbool(conf.get('use_profile', False)):
             from paste.debug import profile
             app = wrap_if_allowed(app, stack, profile.ProfileMiddleware, args=(conf,))
-    else:
-        # Not in interactive debug mode, just use the regular error middleware
-        import galaxy.web.framework.middleware.error
-        app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
+    # Error middleware
+    import galaxy.web.framework.middleware.error
+    app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
     # Transaction logging (apache access.log style)
     if asbool(conf.get('use_translogger', True)):
         from galaxy.web.framework.middleware.translogger import TransLogger

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1558,9 +1558,9 @@ mapping:
         default: false
         required: false
         desc: |
-          Debug enables access to various config options useful for development and
-          debugging: use_lint, use_profile, use_printdebug and use_interactive.  It
-          also causes the files used by PBS/SGE (submission script, output, and error)
+          Debug enables access to various config options useful for development
+          and debugging: use_lint, use_profile, and use_printdebug.  It also
+          causes the files used by PBS/SGE (submission script, output, and error)
           to remain on disk after the job is complete.
 
       use_lint:
@@ -1583,14 +1583,6 @@ mapping:
         required: false
         desc: |
           Intercept print statements and show them on the returned page.
-
-      use_interactive:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          Enable live debugging in your browser.  This should NEVER be enabled on a
-          public site.
 
       monitor_thread_join_timeout:
         type: int

--- a/lib/galaxy/webapps/reports/config_schema.yml
+++ b/lib/galaxy/webapps/reports/config_schema.yml
@@ -7,14 +7,14 @@ mapping:
     desc: |
       Galaxy Reports configuration options.
     mapping:
-      
+
       log_level:
         type: str
         default: DEBUG
         desc: |
           Verbosity of console log messages.  Acceptable values can be found here:
           https://docs.python.org/2/library/logging.html#logging-levels
-      
+
       database_connection:
         type: str
         default: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
@@ -23,62 +23,56 @@ mapping:
           Galaxy Reports are intended for production Galaxy instances, so sqlite (and the default value
           below) is not supported. An SQLAlchemy connection string should be used specify an external
           database.
-      
+
       file_path:
         type: str
         default: database/files
         desc: |
           Where dataset files are stored.
-      
+
       new_file_path:
         type: str
         default: database/tmp
         desc: |
           Where temporary files are stored.
-      
+
       template_cache_path:
         type: str
         default: database/compiled_templates/reports
         desc: |
           Mako templates are compiled as needed and cached for reuse, this directory is
           used for the cache
-      
+
       debug:
         type: bool
         default: false
         desc: |
           Configuration for debugging middleware
-      
+
       use_lint:
         type: bool
         default: false
         desc: |
           Check for WSGI compliance.
-      
-      use_interactive:
-        type: bool
-        default: false
-        desc: |
-          NEVER enable this on a public site (even test or QA)
-      
+
       use_heartbeat:
         type: bool
         default: true
         desc: |
           Write thread status periodically to 'heartbeat.log' (careful, uses disk space rapidly!)
-      
+
       use_profile:
         type: bool
         default: true
         desc: |
           Profiling middleware (cProfile based)
-      
+
       smtp_server:
         type: str
         default: yourserver@yourfacility.edu
         desc: |
           Mail
-      
+
       error_email_to:
         type: str
         default: your_bugs@bx.psu.edu

--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -17,12 +17,7 @@ import galaxy.webapps.tool_shed.model.mapping
 from galaxy import util
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
-from galaxy.webapps.util import (
-    build_template_error_formatters,
-    MiddlewareWrapUnsupported,
-    wrap_if_allowed,
-    wrap_if_allowed_or_fail
-)
+from galaxy.webapps.util import wrap_if_allowed
 
 log = logging.getLogger(__name__)
 
@@ -217,7 +212,6 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
     conf = global_conf.copy()
     conf.update(local_conf)
     debug = asbool(conf.get('debug', False))
-    interactive = asbool(conf.get('use_interactive', False))
     # First put into place httpexceptions, which must be most closely
     # wrapped around the application (it can interact poorly with
     # other middleware):
@@ -271,23 +265,9 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         if asbool(conf.get('use_profile', False)):
             from paste.debug import profile
             app = wrap_if_allowed(app, stack, profile.ProfileMiddleware, args=(conf,))
-        if interactive:
-            # Interactive exception debugging, scary dangerous if publicly
-            # accessible, if not enabled we'll use the regular error printing
-            # middleware.
-            try:
-                from weberror import evalexception
-                app = wrap_if_allowed_or_fail(app, stack, evalexception.EvalException,
-                                              args=(conf,),
-                                              kwargs=dict(templating_formatters=build_template_error_formatters()))
-            except MiddlewareWrapUnsupported as exc:
-                log.warning(util.unicodify(exc))
-                import galaxy.web.framework.middleware.error
-                app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
-        else:
-            # Not in interactive debug mode, just use the regular error middleware
-            import galaxy.web.framework.middleware.error
-            app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
+        # Not in interactive debug mode, just use the regular error middleware
+        import galaxy.web.framework.middleware.error
+        app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
     return app
 
 

--- a/lib/galaxy/webapps/tool_shed/buildapp.py
+++ b/lib/galaxy/webapps/tool_shed/buildapp.py
@@ -265,9 +265,9 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
         if asbool(conf.get('use_profile', False)):
             from paste.debug import profile
             app = wrap_if_allowed(app, stack, profile.ProfileMiddleware, args=(conf,))
-        # Not in interactive debug mode, just use the regular error middleware
-        import galaxy.web.framework.middleware.error
-        app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
+    # Error middleware
+    import galaxy.web.framework.middleware.error
+    app = wrap_if_allowed(app, stack, galaxy.web.framework.middleware.error.ErrorMiddleware, args=(conf,))
     return app
 
 

--- a/lib/galaxy/webapps/tool_shed/config_schema.yml
+++ b/lib/galaxy/webapps/tool_shed/config_schema.yml
@@ -255,13 +255,6 @@ mapping:
         desc: |
           Intercept print statements and show them on the returned page.
 
-      use_interactive:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          NEVER enable this on a public site (even test or QA)
-
       admin_users:
         type: str
         required: false


### PR DESCRIPTION
xref galaxyproject/galaxy#8642 and https://github.com/galaxyproject/galaxy/issues/1715
(check weberror off 1715 when this is merged)

At one point I prototyped a https://palletsprojects.com/p/werkzeug/ implementation of this which could be an alternative to weberror, but that was a long time ago and I 1) don't remember what was broken, but something wasn't quite ready to go and 2) can't find it anyway.  It just doesn't seem like we need to worry about this, these days, though, so it's probably not worth the effort to reimplement and maintain.

(skipping deprecation notice since it's a developer-only feature, and not one many people know about and/or use anymore (per informal survey) anyway)
