### PR TITLE
[19.09] Galaxy InteractiveTools cluster support fixes from EU

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -335,6 +335,9 @@ class DRMAAJobRunner(AsynchronousJobRunner):
                     state = ajs.old_state
                 else:
                     continue
+            if ajs.running:
+                # TODO: stop checking at some point
+                ajs.job_wrapper.check_for_entry_points()
             if ajs.check_limits():
                 self.work_queue.put((self.fail_job, ajs))
                 continue

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -1,15 +1,16 @@
 import json
-import time
 import os
-import subprocess
 import socket
+import subprocess
 import sys
 import tempfile
+import time
 
 # insert *this* galaxy before all others on sys.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)))
 
 from galaxy.tool_util.deps import docker_util
+
 
 def parse_ports(container_name, connection_configuration):
     while True:
@@ -23,6 +24,7 @@ def parse_ports(container_name, connection_configuration):
                 stdout_file.seek(0)
                 ports_raw = stdout_file.read()
                 return ports_raw
+
 
 def main():
     with open("container_config.json", "r") as f:

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -1,6 +1,8 @@
 import json
+import time
 import os
 import subprocess
+import socket
 import sys
 import tempfile
 
@@ -9,6 +11,18 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pa
 
 from galaxy.tool_util.deps import docker_util
 
+def parse_ports(container_name, connection_configuration):
+    while True:
+        ports_command = docker_util.build_docker_simple_command("port", container_name=container_name, **connection_configuration)
+        with tempfile.TemporaryFile(prefix="docker_port_") as stdout_file:
+            exit_code = subprocess.call(ports_command,
+                                        shell=True,
+                                        stdout=stdout_file,
+                                        preexec_fn=os.setpgrp)
+            if exit_code == 0:
+                stdout_file.seek(0)
+                ports_raw = stdout_file.read()
+                return ports_raw
 
 def main():
     with open("container_config.json", "r") as f:
@@ -21,27 +35,24 @@ def main():
         raise Exception("Monitoring container type [%s], not yet implemented." % container_type)
 
     ports_raw = None
-    try:
-        while True:
-            ports_command = docker_util.build_docker_simple_command("port", container_name=container_name, **connection_configuration)
-            with tempfile.TemporaryFile() as stdout_file:
-                exit_code = subprocess.call(ports_command,
-                                            shell=True,
-                                            stdout=stdout_file,
-                                            preexec_fn=os.setpgrp)
-                if exit_code == 0:
-                    stdout_file.seek(0)
-                    ports_raw = stdout_file.read()
-                    break
-
-        if ports_raw is not None:
-            with open("container_runtime.json", "w") as f:
-                json.dump(docker_util.parse_port_text(ports_raw), f)
-        else:
-            raise Exception("Failed to recover ports...")
-    except Exception as e:
-        with open("exception.txt", "w") as f:
-            f.write(str(e))
+    for i in range(10):
+        try:
+            ports_raw = parse_ports(container_name, connection_configuration)
+            if ports_raw is not None:
+                host_ip = socket.gethostbyname(socket.gethostname())
+                with open("container_runtime.json", "w") as f:
+                    # Override the IPs
+                    ports = docker_util.parse_port_text(ports_raw)
+                    for key in ports:
+                        ports[key]['host'] = host_ip
+                    json.dump(ports, f)
+                break
+            else:
+                raise Exception("Failed to recover ports...")
+        except Exception as e:
+            with open("container_monitor_exception.txt", "a") as f:
+                f.write(str(e))
+        time.sleep(i * 2)
 
 
 if __name__ == "__main__":

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -39,7 +39,7 @@
             ## copy default notebook
             cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
             jupyter trust ./ipython_galaxy_notebook.ipynb &&
-            jupyter lab --no-browser --NotebookApp.shutdown_button=True &&
+            jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
 
         #else:
@@ -50,7 +50,7 @@
             #if $mode.run_it:
                 jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
             #else:
-                jupyter lab --no-browser --NotebookApp.shutdown_button=True &&
+                jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             #end if
             cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
         #end if
@@ -88,13 +88,13 @@
     The Jupyter Notebook is an open-source web application that allows you to create and share documents that contain live code, equations,
     visualizations and narrative text. Uses include: data cleaning and transformation, numerical simulation, statistical modeling, data visualization,
     machine learning, and much more.
-    
+
     Galaxy offers you to use Jupyter Notebooks directly in Galaxy accessing and interacting with Galaxy datasets as you like. A very common use-case is to
     do the heavy lifting and data reduction steps in Galaxy and the plotting and more `interactive` part on smaller datasets in Jupyter.
-    
+
     You can start with a new Jupyter notebook from scratch or load an already existing one, e.g. from your collegue and execute it on your dataset.
     If you have a defined input dataset you can even execute a Jupyter notebook in a workflow, given that the notebook is writing the output back to the history.
-    
+
     You can import data into the notebook via a predefined `get()` function and write results back to Galaxy with a `put()` function.
     </help>
 </tool>


### PR DESCRIPTION
Fixes from @erasche and @bgruening who were the real victims - I am simply upstreaming their work. And basic DRMAA support.

The container resolver sets up a signal 0 trap to kill the container, but even setting up a trap on `SIGKILL`, `SIGINT`, `ERR`, and  `EXIT`, I was unable to cause the container to terminate when running under Slurm. So for the moment in my testbed I'm using a Slurm Epilog script like so:

```bash
#!/bin/bash

[ -n "$SLURM_JOB_ID" ] || { echo "No job id!"; exit 1; }

(
workdir=$(scontrol show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)WorkDir=\([^ ]*\)\( \|$\).*/\2/p;d')
container_config="${workdir}/container_config.json"

if [ -d "$workdir" -a -f "$container_config" ]; then
    container_id=$(jq -r '.container_name'  "$container_config")
    docker kill "$container_id"
fi
) 2>&1 >/dev/null #>/tmp/epilog."$SLURM_JOB_ID"

exit 0
```

I'm not running this on Test or Main, and when I do get GITs on them, I plan to be using Singularity  containers, which can't escape Slurm.