### PR TITLE
[19.09] Install manager unit test and python 3 hg util exception handling fixes

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -1171,17 +1171,17 @@ class AdminToolshed(AdminGalaxy):
                 suc.clean_dependency_relationships(trans, new_meta, tool_shed_repository, tool_shed_url)
             # The repository's status must be updated from 'Uninstalled' to 'New' when initiating reinstall
             # so the repository_installation_updater will function.
-            tool_shed_repository = repository_util.create_or_update_tool_shed_repository(trans.app,
-                                                                                         tool_shed_repository.name,
-                                                                                         tool_shed_repository.description,
-                                                                                         tool_shed_repository.installed_changeset_revision,
-                                                                                         tool_shed_repository.ctx_rev,
-                                                                                         repository_clone_url,
-                                                                                         trans.install_model.ToolShedRepository.installation_status.NEW,
-                                                                                         metadata,
-                                                                                         tool_shed_repository.changeset_revision,
-                                                                                         tool_shed_repository.owner,
-                                                                                         tool_shed_repository.dist_to_shed)
+            tool_shed_repository = repository_util.create_or_update_tool_shed_repository(app=trans.app,
+                                                                                         name=tool_shed_repository.name,
+                                                                                         description=tool_shed_repository.description,
+                                                                                         installed_changeset_revision=tool_shed_repository.installed_changeset_revision,
+                                                                                         changeset_revision=tool_shed_repository.ctx_rev,
+                                                                                         repository_clone_url=repository_clone_url,
+                                                                                         status=trans.install_model.ToolShedRepository.installation_status.NEW,
+                                                                                         metadata_dict=metadata,
+                                                                                         current_changeset_revision=tool_shed_repository.changeset_revision,
+                                                                                         owner=tool_shed_repository.owner,
+                                                                                         dist_to_shed=tool_shed_repository.dist_to_shed)
         ctx_rev = suc.get_ctx_rev(trans.app,
                                   tool_shed_url,
                                   tool_shed_repository.name,
@@ -1619,10 +1619,10 @@ class AdminToolshed(AdminGalaxy):
             else:
                 irm = install_manager.InstallRepositoryManager(trans.app)
                 install_dependencies, irmm_metadata_dict = irm.update_tool_shed_repository(
-                    repository,
-                    tool_shed_url,
-                    latest_ctx_rev,
-                    latest_changeset_revision,
+                    repository=repository,
+                    tool_shed_url=tool_shed_url,
+                    latest_ctx_rev=latest_ctx_rev,
+                    latest_changeset_revision=latest_changeset_revision,
                     install_new_dependencies=False
                 )
                 if install_dependencies == 'repository':

--- a/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin_toolshed.py
@@ -1175,7 +1175,7 @@ class AdminToolshed(AdminGalaxy):
                                                                                          name=tool_shed_repository.name,
                                                                                          description=tool_shed_repository.description,
                                                                                          installed_changeset_revision=tool_shed_repository.installed_changeset_revision,
-                                                                                         changeset_revision=tool_shed_repository.ctx_rev,
+                                                                                         ctx_rev=tool_shed_repository.ctx_rev,
                                                                                          repository_clone_url=repository_clone_url,
                                                                                          status=trans.install_model.ToolShedRepository.installation_status.NEW,
                                                                                          metadata_dict=metadata,

--- a/lib/galaxy/webapps/tool_shed/api/repositories.py
+++ b/lib/galaxy/webapps/tool_shed/api/repositories.py
@@ -857,17 +857,6 @@ class RepositoriesController(BaseAPIController):
                                                           id=encoded_repository_metadata_id)
             if 'tools' in repository_metadata.metadata:
                 repository_metadata_dict['valid_tools'] = repository_metadata.metadata['tools']
-            # Get the repo_info_dict for installing the repository.
-            repo_info_dict, \
-                includes_tools, \
-                includes_tool_dependencies, \
-                includes_tools_for_display_in_tool_panel, \
-                has_repository_dependencies, \
-                has_repository_dependencies_only_if_compiling_contained_td = \
-                repository_util.get_repo_info_dict(self.app,
-                                                   trans.user,
-                                                   id,
-                                                   changeset)
             return repository_metadata_dict
         else:
             log.debug("Unable to locate repository_metadata record for repository id %s and changeset_revision %s" %

--- a/lib/galaxy/webapps/tool_shed/controllers/repository.py
+++ b/lib/galaxy/webapps/tool_shed/controllers/repository.py
@@ -1570,7 +1570,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             changeset_revision = metadata_util.get_next_downloadable_changeset_revision(trans.app, repository, after_changeset_revision=changeset_revision)
             repository_metadata = metadata_util.get_repository_metadata_by_changeset_revision(trans.app, repository_id, changeset_revision)
         repo_path = repository.repo_path(trans.app)
-        ctx_rev = hg_util.changeset2rev(repo_path, changeset_revision)
+        ctx_rev = str(hg_util.changeset2rev(repo_path, changeset_revision))
         repo_info_dict = repository_util.create_repo_info_dict(app=trans.app,
                                                                repository_clone_url=repository_clone_url,
                                                                changeset_revision=changeset_revision,

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -461,7 +461,7 @@ class InstallRepositoryManager(object):
             raw_text = util.url_get(tool_shed_url, password_mgr=self.app.tool_shed_registry.url_auth(tool_shed_url), pathspec=pathspec, params=params)
         except Exception:
             message = "Error attempting to retrieve installation information from tool shed "
-            message += "%s for revision %s of repository %s owned by %s:" % \
+            message += "%s for revision %s of repository %s owned by %s" % \
                 (tool_shed_url, changeset_revision, name, owner)
             log.exception(message)
             raise exceptions.InternalServerError(message)

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -120,10 +120,10 @@ class InstallToolDependencyManager(object):
             # There is currently only one fabric method.
             tool_dependency = self.install_and_build_package(install_environment, tool_dependency, actions_dict)
         except Exception as e:
-            log.exception('Error installing tool dependency %s version %s.', str(tool_dependency.name), str(tool_dependency.version))
+            log.exception('Error installing tool dependency %s version %s.', tool_dependency.name, tool_dependency.version)
             # Since there was an installation error, update the tool dependency status to Error. The remove_installation_path option must
             # be left False here.
-            error_message = '%s\n%s' % (self.format_traceback(), str(e))
+            error_message = '%s\n%s' % (self.format_traceback(), util.unicodify(e))
             tool_dependency = tool_dependency_util.set_tool_dependency_attributes(self.app,
                                                                                   tool_dependency=tool_dependency,
                                                                                   status=self.app.install_model.ToolDependency.installation_status.ERROR,
@@ -453,17 +453,17 @@ class InstallRepositoryManager(object):
         return None, None
 
     def __get_install_info_from_tool_shed(self, tool_shed_url, name, owner, changeset_revision):
-        params = dict(name=str(name),
-                      owner=str(owner),
-                      changeset_revision=str(changeset_revision))
+        params = dict(name=name,
+                      owner=owner,
+                      changeset_revision=changeset_revision)
         pathspec = ['api', 'repositories', 'get_repository_revision_install_info']
         try:
             raw_text = util.url_get(tool_shed_url, password_mgr=self.app.tool_shed_registry.url_auth(tool_shed_url), pathspec=pathspec, params=params)
-        except Exception as e:
+        except Exception:
             message = "Error attempting to retrieve installation information from tool shed "
-            message += "%s for revision %s of repository %s owned by %s: %s" % \
-                (str(tool_shed_url), str(changeset_revision), str(name), str(owner), str(e))
-            log.warning(message)
+            message += "%s for revision %s of repository %s owned by %s:" % \
+                (tool_shed_url, changeset_revision, name, owner)
+            log.exception(message)
             raise exceptions.InternalServerError(message)
         if raw_text:
             # If successful, the response from get_repository_revision_install_info will be 3
@@ -482,10 +482,10 @@ class InstallRepositoryManager(object):
         if not repository_revision_dict or not repo_info_dict:
             invalid_parameter_message = "No information is available for the requested repository revision.\n"
             invalid_parameter_message += "One or more of the following parameter values is likely invalid:\n"
-            invalid_parameter_message += "tool_shed_url: %s\n" % str(tool_shed_url)
-            invalid_parameter_message += "name: %s\n" % str(name)
-            invalid_parameter_message += "owner: %s\n" % str(owner)
-            invalid_parameter_message += "changeset_revision: %s\n" % str(changeset_revision)
+            invalid_parameter_message += "tool_shed_url: %s\n" % tool_shed_url
+            invalid_parameter_message += "name: %s\n" % name
+            invalid_parameter_message += "owner: %s\n" % owner
+            invalid_parameter_message += "changeset_revision: %s\n" % changeset_revision
             raise exceptions.RequestParameterInvalidException(invalid_parameter_message)
         repo_info_dicts = [repo_info_dict]
         return repository_revision_dict, repo_info_dicts
@@ -1110,8 +1110,7 @@ class InstallRepositoryManager(object):
         Update the status of a tool shed repository in the process of being installed into Galaxy.
         """
         tool_shed_repository.status = status
-        if error_message:
-            tool_shed_repository.error_message = str(error_message)
+        tool_shed_repository.error_message = error_message
         self.install_model.context.add(tool_shed_repository)
         self.install_model.context.flush()
 

--- a/lib/tool_shed/galaxy_install/repair_repository_manager.py
+++ b/lib/tool_shed/galaxy_install/repair_repository_manager.py
@@ -1,6 +1,7 @@
 import logging
 import tempfile
 
+from galaxy.util import unicodify
 from tool_shed.galaxy_install import install_manager
 from tool_shed.galaxy_install.repository_dependencies import repository_dependency_manager
 from tool_shed.galaxy_install.tools import tool_panel_manager
@@ -162,7 +163,7 @@ class RepairRepositoryManager():
             try:
                 self.app.installed_repository_manager.activate_repository(repository)
             except Exception as e:
-                error_message = "Error activating repository %s: %s" % (repository.name, str(e))
+                error_message = "Error activating repository %s: %s" % (repository.name, unicodify(e))
                 log.debug(error_message)
                 repair_dict[repository.name] = error_message
         elif repository.status not in [self.app.install_model.ToolShedRepository.installation_status.INSTALLED]:

--- a/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -310,7 +310,7 @@ class RepositoryDependencyInstallManager(object):
         try:
             raw_text = url_get(tool_shed_url, password_mgr=app.tool_shed_registry.url_auth(tool_shed_url), pathspec=pathspec, params=params)
         except Exception:
-            log.exception("The URL\n%s\nraised the exception:\n%s\n", build_url(tool_shed_url, pathspec=pathspec, params=params))
+            log.exception("Error while trying to get URL: %s", build_url(tool_shed_url, pathspec=pathspec, params=params))
             return ''
         if len(raw_text) > 2:
             encoded_text = json.loads(raw_text)

--- a/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
+++ b/lib/tool_shed/galaxy_install/repository_dependencies/repository_dependency_manager.py
@@ -108,10 +108,10 @@ class RepositoryDependencyInstallManager(object):
                                 repository_dependency = self.get_repository_dependency_by_repository_id(install_model,
                                                                                                         required_repository.id)
                                 if not repository_dependency:
-                                    log.debug('Creating new repository_dependency record for installed revision %s of repository: %s owned by %s.' %
-                                              (str(required_repository.installed_changeset_revision),
-                                               str(required_repository.name),
-                                               str(required_repository.owner)))
+                                    log.debug('Creating new repository_dependency record for installed revision %s of repository: %s owned by %s.',
+                                              required_repository.installed_changeset_revision,
+                                              required_repository.name,
+                                              required_repository.owner)
                                     repository_dependency = install_model.RepositoryDependency(tool_shed_repository_id=required_repository.id)
                                     install_model.context.add(repository_dependency)
                                     install_model.context.flush()
@@ -182,7 +182,7 @@ class RepositoryDependencyInstallManager(object):
                                 and repository_db_record.status == install_model.ToolShedRepository.installation_status.INSTALLED):
                             log.info(
                                 "Repository '%s' already present at revision %s, will be updated to revision %s",
-                                str(repository_db_record.name), str(installed_changeset_revision), str(changeset_revision))
+                                repository_db_record.name, installed_changeset_revision, changeset_revision)
                             can_update_db_record = True
                             clear_metadata = False
                         elif repository_db_record.status in [install_model.ToolShedRepository.installation_status.INSTALLED,
@@ -192,9 +192,9 @@ class RepositoryDependencyInstallManager(object):
                                                            install_model.ToolShedRepository.installation_status.INSTALLING_TOOL_DEPENDENCIES,
                                                            install_model.ToolShedRepository.installation_status.LOADING_PROPRIETARY_DATATYPES]:
                             info_msg = "Skipping installation of revision %s of repository '%s' because it was installed " % \
-                                (str(changeset_revision), str(repository_db_record.name))
+                                (changeset_revision, repository_db_record.name)
                             info_msg += "with the (possibly updated) revision %s and its current installation status is '%s'." % \
-                                (str(installed_changeset_revision), str(repository_db_record.status))
+                                (installed_changeset_revision, repository_db_record.status)
                             log.info(info_msg)
                             can_update_db_record = False
                         else:
@@ -309,8 +309,8 @@ class RepositoryDependencyInstallManager(object):
         pathspec = ['repository', 'get_repository_dependencies']
         try:
             raw_text = url_get(tool_shed_url, password_mgr=app.tool_shed_registry.url_auth(tool_shed_url), pathspec=pathspec, params=params)
-        except Exception as e:
-            log.error("The URL\n%s\nraised the exception:\n%s\n", build_url(tool_shed_url, pathspec=pathspec, params=params), str(e))
+        except Exception:
+            log.exception("The URL\n%s\nraised the exception:\n%s\n", build_url(tool_shed_url, pathspec=pathspec, params=params))
             return ''
         if len(raw_text) > 2:
             encoded_text = json.loads(raw_text)
@@ -477,13 +477,13 @@ class RepositoryDependencyInstallManager(object):
         will be set to the default NEW state.  This will enable the repository to be
         freshly installed.
         """
-        debug_msg = "Resetting tool_shed_repository '%s' for installation.\n" % str(repository.name)
+        debug_msg = "Resetting tool_shed_repository '%s' for installation.\n" % repository.name
         debug_msg += "The current state of the tool_shed_repository is:\n"
-        debug_msg += "deleted: %s\n" % str(repository.deleted)
-        debug_msg += "tool_shed_status: %s\n" % str(repository.tool_shed_status)
-        debug_msg += "uninstalled: %s\n" % str(repository.uninstalled)
-        debug_msg += "status: %s\n" % str(repository.status)
-        debug_msg += "error_message: %s\n" % str(repository.error_message)
+        debug_msg += "deleted: %s\n" % repository.deleted
+        debug_msg += "tool_shed_status: %s\n" % repository.tool_shed_status
+        debug_msg += "uninstalled: %s\n" % repository.uninstalled
+        debug_msg += "status: %s\n" % repository.status
+        debug_msg += "error_message: %s\n" % repository.error_message
         log.debug(debug_msg)
         repository.deleted = False
         repository.tool_shed_status = None

--- a/lib/tool_shed/galaxy_install/tool_migration_manager.py
+++ b/lib/tool_shed/galaxy_install/tool_migration_manager.py
@@ -586,7 +586,7 @@ class ToolMigrationManager(object):
                 irm.update_tool_shed_repository_status(tool_shed_repository,
                                                        self.app.install_model.ToolShedRepository.installation_status.INSTALLED)
             else:
-                log.error('Error attempting to clone repository %s: %s', str(tool_shed_repository.name), str(error_message))
+                log.error('Error attempting to clone repository %s: %s', tool_shed_repository.name, error_message)
                 irm.update_tool_shed_repository_status(tool_shed_repository,
                                                        self.app.install_model.ToolShedRepository.installation_status.ERROR,
                                                        error_message=error_message)

--- a/lib/tool_shed/galaxy_install/tool_migration_manager.py
+++ b/lib/tool_shed/galaxy_install/tool_migration_manager.py
@@ -146,9 +146,9 @@ class ToolMigrationManager(object):
                                 # Make sure all repository dependency records exist (as tool_shed_repository
                                 # table rows) in the Galaxy database.
                                 created_tool_shed_repositories = \
-                                    self.create_or_update_tool_shed_repository_records(name,
-                                                                                       changeset_revision,
-                                                                                       repository_dependencies_dict)
+                                    self.create_or_update_tool_shed_repository_records(name=name,
+                                                                                       changeset_revision=changeset_revision,
+                                                                                       repository_dependencies_dict=repository_dependencies_dict)
                                 # Order the repositories for proper installation.  This process is similar to the
                                 # process used when installing tool shed repositories, but does not handle managing
                                 # tool panel sections and other components since repository dependency definitions
@@ -192,8 +192,8 @@ class ToolMigrationManager(object):
                                                                                          installed_changeset_revision=changeset_revision,
                                                                                          ctx_rev=ctx_rev,
                                                                                          repository_clone_url=repository_clone_url,
-                                                                                         metadata_dict={},
                                                                                          status=self.app.install_model.ToolShedRepository.installation_status.NEW,
+                                                                                         metadata_dict={},
                                                                                          current_changeset_revision=None,
                                                                                          owner=self.repository_owner,
                                                                                          dist_to_shed=True)

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -43,7 +43,7 @@ def clone_repository(repository_clone_url, repository_file_dir, ctx_rev=None):
     """
     cmd = ['hg', 'clone']
     if ctx_rev:
-        cmd.extend(['-r', ctx_rev])
+        cmd.extend(['-r', str(ctx_rev)])
     cmd.extend([repository_clone_url, repository_file_dir])
     # Make sure the destination path actually exists before attempting to clone
     if not os.path.exists(repository_file_dir):
@@ -404,7 +404,7 @@ def init_repository(repo_path):
 
 def changeset2rev(repo_path, changeset_revision):
     """
-    Return the revision number corresponding to a specified changeset revision.
+    Return the revision number (as an int) corresponding to a specified changeset revision.
     """
     try:
         rev = subprocess.check_output(['hg', 'id', '-r', changeset_revision, '-n'], stderr=subprocess.STDOUT, cwd=repo_path)

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -5,6 +5,7 @@ import tempfile
 from datetime import datetime
 from time import gmtime
 
+from galaxy.util import unicodify
 from tool_shed.util import basic_util
 
 log = logging.getLogger(__name__)
@@ -16,7 +17,7 @@ def add_changeset(repo_path, path_to_filename_in_archive):
     try:
         subprocess.check_output(['hg', 'add', path_to_filename_in_archive], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = "Error adding '%s' to repository: %s" % (path_to_filename_in_archive, e)
+        error_message = "Error adding '%s' to repository: %s" % (path_to_filename_in_archive, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
             error_message += "\nOutput was:\n%s" % e.output
         raise Exception(error_message)
@@ -28,9 +29,9 @@ def archive_repository_revision(app, repository, archive_dir, changeset_revision
     try:
         subprocess.check_output(['hg', 'archive', '-r', changeset_revision, archive_dir], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = "Error attempting to archive revision '%s' of repository '%s': %s" % (changeset_revision, repository.name, e)
+        error_message = "Error attempting to archive revision '%s' of repository '%s': %s" % (changeset_revision, repository.name, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         log.exception(error_message)
         raise Exception(error_message)
 
@@ -51,9 +52,9 @@ def clone_repository(repository_clone_url, repository_file_dir, ctx_rev=None):
         subprocess.check_output(cmd, stderr=subprocess.STDOUT)
         return True, None
     except Exception as e:
-        error_message = 'Error cloning repository: %s' % e
+        error_message = 'Error cloning repository: %s' % unicodify(e)
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         log.error(error_message)
         return False, error_message
 
@@ -62,11 +63,11 @@ def commit_changeset(repo_path, full_path_to_changeset, username, message):
     try:
         subprocess.check_output(['hg', 'commit', '-u', username, '-m', message, full_path_to_changeset], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = "Error committing '%s' to repository: %s" % (full_path_to_changeset, e)
+        error_message = "Error committing '%s' to repository: %s" % (full_path_to_changeset, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
-            if e.returncode == 1 and 'nothing changed' in e.output:
+            if e.returncode == 1 and 'nothing changed' in unicodify(e.output):
                 return
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
 
 
@@ -96,7 +97,7 @@ def create_hgrc_file(app, repository):
     # in the Mercurial API.
     repo_path = repository.repo_path(app)
     hgrc_path = os.path.join(repo_path, '.hg', 'hgrc')
-    with open(hgrc_path, 'wb') as fp:
+    with open(hgrc_path, 'w') as fp:
         fp.write('[paths]\n')
         fp.write('default = .\n')
         fp.write('default-push = .\n')
@@ -306,9 +307,9 @@ def pull_repository(repo_path, repository_clone_url, ctx_rev):
     try:
         subprocess.check_output(['hg', 'pull', '-r', ctx_rev, repository_clone_url], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = "Error pulling revision '%s': %s" % (ctx_rev, e)
+        error_message = "Error pulling revision '%s': %s" % (ctx_rev, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
 
 
@@ -320,9 +321,9 @@ def remove_file(repo_path, selected_file, force=True):
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = "Error removing file '%s': %s" % (selected_file, e)
+        error_message = "Error removing file '%s': %s" % (selected_file, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
 
 
@@ -382,9 +383,9 @@ def update_repository(repo_path, ctx_rev=None):
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = 'Error updating repository: %s' % e
+        error_message = 'Error updating repository: %s' % unicodify(e)
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
 
 
@@ -395,9 +396,9 @@ def init_repository(repo_path):
     try:
         subprocess.check_output(['hg', 'init'], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = 'Error initializing repository: %s' % e
+        error_message = 'Error initializing repository: %s' % unicodify(e)
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
 
 
@@ -408,8 +409,8 @@ def changeset2rev(repo_path, changeset_revision):
     try:
         rev = subprocess.check_output(['hg', 'id', '-r', changeset_revision, '-n'], stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = "Error looking for changeset '%s': %s" % (changeset_revision, e)
+        error_message = "Error looking for changeset '%s': %s" % (changeset_revision, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
     return int(rev.strip())

--- a/lib/tool_shed/util/metadata_util.py
+++ b/lib/tool_shed/util/metadata_util.py
@@ -124,7 +124,7 @@ def get_metadata_revisions(app, repository, sort_revisions=True, reverse=False, 
         if repository_metadata.numeric_revision == -1 or repository_metadata.numeric_revision is None:
             try:
                 rev = hg_util.changeset2rev(repo_path, repository_metadata.changeset_revision)
-                repository_metadata.numeric_revision = int(rev)
+                repository_metadata.numeric_revision = rev
                 sa_session.add(repository_metadata)
                 sa_session.flush()
             except Exception:

--- a/lib/tool_shed/util/metadata_util.py
+++ b/lib/tool_shed/util/metadata_util.py
@@ -124,7 +124,7 @@ def get_metadata_revisions(app, repository, sort_revisions=True, reverse=False, 
         if repository_metadata.numeric_revision == -1 or repository_metadata.numeric_revision is None:
             try:
                 rev = hg_util.changeset2rev(repo_path, repository_metadata.changeset_revision)
-                repository_metadata.numeric_revision = rev
+                repository_metadata.numeric_revision = int(rev)
                 sa_session.add(repository_metadata)
                 sa_session.flush()
             except Exception:

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -180,7 +180,7 @@ def create_repo_info_dict(app, repository_clone_url, changeset_revision, ctx_rev
         if repository_metadata:
             metadata = repository_metadata.metadata
             if metadata:
-                tool_shed_url = str(web.url_for('/', qualified=True)).rstrip('/')
+                tool_shed_url = web.url_for('/', qualified=True).rstrip('/')
                 rb = tool_shed.dependencies.repository.relation_builder.RelationBuilder(app, repository, repository_metadata, tool_shed_url)
                 # Get a dictionary of all repositories upon which the contents of the received repository depends.
                 repository_dependencies = rb.get_repository_dependencies_for_changeset_revision()
@@ -202,14 +202,13 @@ def create_repo_info_dict(app, repository_clone_url, changeset_revision, ctx_rev
                 requirements_dict['changeset_revision'] = changeset_revision
                 new_tool_dependencies[dependency_key] = requirements_dict
         tool_dependencies = new_tool_dependencies
-    # Cast unicode to string, with the exception of description, since it is free text and can contain special characters.
-    repo_info_dict[str(repository.name)] = (repository.description,
-                                            str(repository_clone_url),
-                                            str(changeset_revision),
-                                            str(ctx_rev),
-                                            str(repository_owner),
-                                            repository_dependencies,
-                                            tool_dependencies)
+    repo_info_dict[repository.name] = (repository.description,
+                                       repository_clone_url,
+                                       changeset_revision,
+                                       ctx_rev,
+                                       repository_owner,
+                                       repository_dependencies,
+                                       tool_dependencies)
     return repo_info_dict
 
 
@@ -951,9 +950,9 @@ def set_repository_attributes(app, repository, status, error_message, deleted, u
             clone_dir = os.path.abspath(relative_install_dir)
             try:
                 shutil.rmtree(clone_dir)
-                log.debug("Removed repository installation directory: %s" % str(clone_dir))
+                log.debug("Removed repository installation directory: %s", clone_dir)
             except Exception as e:
-                log.debug("Error removing repository installation directory %s: %s" % (str(clone_dir), str(e)))
+                log.debug("Error removing repository installation directory %s: %s", clone_dir, util.unicodify(e))
     repository.error_message = error_message
     repository.status = status
     repository.deleted = deleted

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -89,7 +89,7 @@ def create_or_update_tool_shed_repository(app, name, description, installed_chan
     If a record defined by the received tool shed, repository name and owner does not exist, create
     a new record with the received information.
     """
-    metadata_dict = metadata_dict if metadata_dict is not None else {}
+    metadata_dict = metadata_dict or {}
     # The received value for dist_to_shed will be True if the ToolMigrationManager is installing a repository
     # that contains tools or datatypes that used to be in the Galaxy distribution, but have been moved
     # to the main Galaxy tool shed.

--- a/lib/tool_shed/util/repository_util.py
+++ b/lib/tool_shed/util/repository_util.py
@@ -468,7 +468,7 @@ def get_repo_info_dict(app, user, repository_id, changeset_revision):
         includes_tool_dependencies = False
         includes_tools_for_display_in_tool_panel = False
     repo_path = repository.repo_path(app)
-    ctx_rev = hg_util.changeset2rev(repo_path, changeset_revision)
+    ctx_rev = str(hg_util.changeset2rev(repo_path, changeset_revision))
     repo_info_dict = create_repo_info_dict(app=app,
                                            repository_clone_url=repository_clone_url,
                                            changeset_revision=changeset_revision,

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -1,4 +1,5 @@
 from tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
+from tool_shed.util import repository_util
 from ..tools.test_toolbox import BaseToolBoxTestCase
 
 
@@ -18,6 +19,23 @@ class InstalledRepositoryManagerTestCase(BaseToolBoxTestCase):
         irm, repository = self._deactivate_repository()
         irm.activate_repository(repository)
         assert repository.status == self.app.install_model.ToolShedRepository.installation_status.INSTALLED
+
+    def test_create_or_update_tool_shed_repository(self):
+        repository = self._setup_repository()
+        new_repository = repository_util.create_or_update_tool_shed_repository(
+            app=self.app,
+            name=repository.name,
+            description=repository.description,
+            installed_changeset_revision=repository.installed_changeset_revision,
+            ctx_rev=repository.changeset_revision,
+            repository_clone_url='https://github.com/galaxyproject/example/test_tool/0.%s' % repository.installed_changeset_revision,  # not needed if owner is given
+            status=repository.status,
+            metadata_dict=None,
+            current_changeset_revision=str(int(repository.changeset_revision) + 1),
+            owner=repository.owner,
+            dist_to_shed=False
+        )
+        assert new_repository.changeset_revision == str(int(repository.changeset_revision) + 1)
 
     def _deactivate_repository(self):
         repository = self._setup_repository()

--- a/test/unit/shed_unit/test_installed_repository_manager.py
+++ b/test/unit/shed_unit/test_installed_repository_manager.py
@@ -1,27 +1,115 @@
+import os
+
+from mock import MagicMock
+
+from tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
-from tool_shed.util import repository_util
-from ..tools.test_toolbox import BaseToolBoxTestCase
+from tool_shed.galaxy_install.update_repository_manager import UpdateRepositoryManager
+from tool_shed.util import (
+    common_util,
+    hg_util,
+    repository_util,
+)
+from ..tools.test_toolbox import (
+    BaseToolBoxTestCase,
+    DEFAULT_TEST_REPO
+)
 
 
-class InstalledRepositoryManagerTestCase(BaseToolBoxTestCase):
+class ToolShedRepoBaseTestCase(BaseToolBoxTestCase):
+
+    def setUp(self):
+        super(ToolShedRepoBaseTestCase, self).setUp()
+        self._init_dynamic_tool_conf()
+        self.app.config.tool_configs = self.config_files
+        self.app.config.manage_dependency_relationships = False
+        self.app.toolbox = self.toolbox
+
+    def _setup_repository(self):
+        return self._repo_install(changeset='1', config_filename=self.config_files[0])
+
+
+class InstallRepositoryManagerTestCase(ToolShedRepoBaseTestCase):
+
+    def setUp(self):
+        super(InstallRepositoryManagerTestCase, self).setUp()
+        self.irm = InstallRepositoryManager(self.app)
+        self.app.config.enable_tool_shed_check = False
+        self.app.update_repository_manager = UpdateRepositoryManager(self.app)
+
+    def test_tool_shed_repository_install(self):
+        hg_util.clone_repository = MagicMock(return_value=(True, None))
+        self._install_tool_shed_repository(start_status='New', end_status='Installed', changeset_revision='1')
+        hg_util.clone_repository.assert_called_with(
+            'github.com/repos/galaxyproject/example',
+            os.path.abspath(os.path.join('../shed_tools', 'github.com/repos/galaxyproject/example/1/example')),
+            '1',
+        )
+
+    def test_tool_shed_repository_update(self):
+        common_util.get_tool_shed_url_from_tool_shed_registry = MagicMock(return_value='https://github.com')
+        repository_util.get_tool_shed_status_for_installed_repository = MagicMock(return_value={'revision_update': 'false'})
+        hg_util.pull_repository = MagicMock()
+        hg_util.update_repository = MagicMock(return_value=(True, None))
+        self._install_tool_shed_repository(start_status='Installed', end_status='Installed', changeset_revision='2')
+        assert hg_util.pull_repository.call_args[0][0].endswith('github.com/repos/galaxyproject/example/1/example')
+        assert hg_util.pull_repository.call_args[0][1] == 'https://github.com/repos/galaxyproject/example'
+        assert hg_util.pull_repository.call_args[0][2] == '2'
+        assert hg_util.update_repository.call_args[0][0].endswith('github.com/repos/galaxyproject/example/1/example')
+        assert hg_util.update_repository.call_args[0][1] == '2'
+
+    def _install_tool_shed_repository(self, start_status, end_status, changeset_revision):
+        repository = self._setup_repository()
+        repository.status = start_status
+        repo_info_dict = {
+            'example': (
+                'description', 'github.com/repos/galaxyproject/example', changeset_revision, changeset_revision, 'galaxyproject', [], [],
+            )
+        }
+        self.irm.install_tool_shed_repository(
+            repository,
+            repo_info_dict,
+            'section_key',
+            self.app.config.tool_configs[0],
+            '../shed_tools',
+            False,
+            False,
+            reinstalling=False,
+        )
+        assert repository.status == end_status
+        assert repository.changeset_revision == changeset_revision
+
+
+class InstalledRepositoryManagerTestCase(ToolShedRepoBaseTestCase):
+
+    def setUp(self):
+        super(InstalledRepositoryManagerTestCase, self).setUp()
+        self.irm = InstalledRepositoryManager(self.app)
 
     def test_uninstall_repository(self):
         repository = self._setup_repository()
         assert repository.uninstalled is False
-        irm = InstalledRepositoryManager(self.app)
-        irm.uninstall_repository(repository=repository, remove_from_disk=True)
+        self.irm.uninstall_repository(repository=repository, remove_from_disk=True)
         assert repository.uninstalled is True
 
     def test_deactivate_repository(self):
         self._deactivate_repository()
 
     def test_activate_repository(self):
-        irm, repository = self._deactivate_repository()
-        irm.activate_repository(repository)
+        repository = self._deactivate_repository()
+        self.irm.activate_repository(repository)
         assert repository.status == self.app.install_model.ToolShedRepository.installation_status.INSTALLED
 
-    def test_create_or_update_tool_shed_repository(self):
+    def test_create_or_update_tool_shed_repository_update(self):
         repository = self._setup_repository()
+        self._create_or_update_tool_shed_repository(repository=repository, changeset_revision='2')
+
+    def test_create_or_update_tool_shed_repository_create(self):
+        self._create_or_update_tool_shed_repository(repository=None, changeset_revision='2')
+
+    def _create_or_update_tool_shed_repository(self, repository=None, changeset_revision='2'):
+        if repository is None:
+            repository = DEFAULT_TEST_REPO
         new_repository = repository_util.create_or_update_tool_shed_repository(
             app=self.app,
             name=repository.name,
@@ -35,20 +123,12 @@ class InstalledRepositoryManagerTestCase(BaseToolBoxTestCase):
             owner=repository.owner,
             dist_to_shed=False
         )
-        assert new_repository.changeset_revision == str(int(repository.changeset_revision) + 1)
+        assert new_repository.changeset_revision == changeset_revision
 
     def _deactivate_repository(self):
         repository = self._setup_repository()
         assert repository.uninstalled is False
-        irm = InstalledRepositoryManager(self.app)
-        irm.uninstall_repository(repository=repository, remove_from_disk=False)
+        self.irm.uninstall_repository(repository=repository, remove_from_disk=False)
         assert repository.uninstalled is False
         assert repository.status == self.app.install_model.ToolShedRepository.installation_status.DEACTIVATED
-        return irm, repository
-
-    def _setup_repository(self):
-        self._init_dynamic_tool_conf()
-        self.app.config.tool_configs = self.config_files
-        self.app.config.manage_dependency_relationships = False
-        self.app.toolbox = self.toolbox
-        return self._repo_install(changeset='1', config_filename=self.config_files[0])
+        return repository

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import logging
 import os
@@ -34,6 +35,11 @@ CONFIG_TEST_TOOL_VERSION_TEMPLATE = string.Template(
 )
 CONFIG_TEST_TOOL_VERSION_1 = CONFIG_TEST_TOOL_VERSION_TEMPLATE.safe_substitute(dict(version="1"))
 CONFIG_TEST_TOOL_VERSION_2 = CONFIG_TEST_TOOL_VERSION_TEMPLATE.safe_substitute(dict(version="2"))
+
+DEFAULT_TEST_REPO = collections.namedtuple(
+    'DEFAULT_TEST_REPO',
+    'tool_shed owner name changeset_revision installed_changeset_revision description status',
+)('github.com', 'galaxyproject', 'example', '1', '1', 'description', 'OK')
 
 
 class BaseToolBoxTestCase(unittest.TestCase, UsesApp, UsesTools):
@@ -82,9 +88,9 @@ class BaseToolBoxTestCase(unittest.TestCase, UsesApp, UsesTools):
         if config_filename:
             metadata['shed_config_filename'] = config_filename
         repository = tool_shed_install.ToolShedRepository(metadata=metadata)
-        repository.tool_shed = "github.com"
-        repository.owner = "galaxyproject"
-        repository.name = "example"
+        repository.tool_shed = DEFAULT_TEST_REPO.tool_shed
+        repository.owner = DEFAULT_TEST_REPO.owner
+        repository.name = DEFAULT_TEST_REPO.name
         repository.changeset_revision = changeset
         repository.installed_changeset_revision = changeset
         repository.deleted = False


### PR DESCRIPTION
On the install manager side these are only cosmetic fixes in normal operation, but I think this has the potential to be buggy when errors occur on python 3. Same for the hg_util fixes.
The unit test is more of a poor excuse, but at least it exercises installation and update (with the actual cloning and TS interaction mocked out and pretending there is no tool to load).