### PR TITLE
Normalize myexperiment_target_url / myexperiment_url

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -432,7 +432,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # activation_email was used until release_15.03
         activation_email = kwargs.get('activation_email')
         self.email_from = self.email_from or activation_email
-        self.myexperiment_target_url = kwargs.get('my_experiment_target_url', 'www.myexperiment.org')
 
         #  Get the disposable email domains blacklist file and its contents
         self.blacklist_content = None

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2284,7 +2284,7 @@ mapping:
           When false, the most recently added compatible item in the history will
           be used for each "Set at Runtime" input, independent of others in the workflow.
 
-      myexperiment_url:
+      myexperiment_target_url:
         type: str
         default: www.myexperiment.org:80
         required: false

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -181,8 +181,6 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
     stored_list_grid = StoredWorkflowListGrid()
     published_list_grid = StoredWorkflowAllPublishedGrid()
 
-    __myexp_url = "www.myexperiment.org:80"
-
     @web.expose
     @web.require_login("use Galaxy workflows")
     def list_grid(self, trans, **kwargs):
@@ -708,7 +706,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         # Do request and get result.
         auth_header = base64.b64encode('%s:%s' % (myexp_username, myexp_password))
         headers = {"Content-type": "text/xml", "Accept": "text/xml", "Authorization": "Basic %s" % auth_header}
-        myexp_url = trans.app.config.get("myexperiment_url", self.__myexp_url)
+        myexp_url = trans.app.config.myexperiment_target_url
         conn = HTTPConnection(myexp_url)
         # NOTE: blocks web thread.
         conn.request("POST", "/workflow.xml", request, headers)

--- a/test/unit/config/config_manage/1607_root_filters/config/galaxy.ini
+++ b/test/unit/config/config_manage/1607_root_filters/config/galaxy.ini
@@ -1022,7 +1022,7 @@ use_interactive = True
 #enable_unique_workflow_defaults = False
 
 # The URL to the myExperiment instance being used (omit scheme but include port)
-#myexperiment_url = www.myexperiment.org:80
+#myexperiment_target_url = www.myexperiment.org:80
 
 # Enable Galaxy's "Upload via FTP" interface.  You'll need to install and
 # configure an FTP server (we've used ProFTPd since it can use Galaxy's

--- a/test/unit/config/config_manage/1607_root_samples/config/galaxy.ini
+++ b/test/unit/config/config_manage/1607_root_samples/config/galaxy.ini
@@ -1022,7 +1022,7 @@ use_interactive = True
 #enable_unique_workflow_defaults = False
 
 # The URL to the myExperiment instance being used (omit scheme but include port)
-#myexperiment_url = www.myexperiment.org:80
+#myexperiment_target_url = www.myexperiment.org:80
 
 # Enable Galaxy's "Upload via FTP" interface.  You'll need to install and
 # configure an FTP server (we've used ProFTPd since it can use Galaxy's


### PR DESCRIPTION
Remove duplication; rely on schema to provide default.

I assume these 2 are the same thing (I briefly checked with @dannon ). I selected the `...target_url` (not to change this: `client/galaxy/scripts/components/Workflow/WorkflowImport.vue`). 

The only change in values is here: now the assigned default will contain port 80:
https://github.com/galaxyproject/galaxy/compare/dev...ic4f:sg_config34?expand=1#diff-46f86ea0d82b84642e4218279ef61442L436

@jmchilton , @guerler : is this correct?