### PR TITLE
[19.09] Discard messages created before QueueWorker was started

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -30,7 +30,7 @@ logging.getLogger('kombu').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
 
 
-def send_local_control_task(app, task, kwargs=None):
+def send_local_control_task(app, task, get_response=False, kwargs=None):
     """
     This sends a message to the process-local control worker, which is useful
     for one-time asynchronous tasks like recalculating user disk usage.
@@ -42,7 +42,7 @@ def send_local_control_task(app, task, kwargs=None):
                'kwargs': kwargs}
     routing_key = 'control.%s@%s' % (app.config.server_name, socket.gethostname())
     control_task = ControlTask(app.queue_worker)
-    control_task.send_task(payload, routing_key, local=True, get_response=False)
+    return control_task.send_task(payload, routing_key, local=True, get_response=get_response)
 
 
 def send_control_task(app, task, noop_self=False, get_response=False, routing_key='control.*', kwargs=None):

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -5,12 +5,16 @@ reloading the toolbox, etc., across multiple processes.
 
 import importlib
 import logging
-import math
 import socket
 import sys
 import threading
 import time
 from inspect import ismodule
+try:
+    from math import inf
+except ImportError:
+    # python 2 doesn't have math.inf, but can use float('inf')
+    inf = float('inf')
 
 from kombu import (
     Consumer,
@@ -362,7 +366,7 @@ class GalaxyQueueWorker(ConsumerProducerMixin, threading.Thread):
             if body.get('noop', None) != self.app.config.server_name:
                 try:
                     f = self.task_mapping[body['task']]
-                    if message.headers.get('epoch', math.inf) > self.epoch:
+                    if message.headers.get('epoch', inf) > self.epoch:
                         # Message was created after QueueWorker was started, execute
                         log.info("Instance '%s' received '%s' task, executing now.", self.app.config.server_name, body['task'])
                         result = f(self.app, **body['kwargs'])

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -1,6 +1,10 @@
 import datetime
-import math
 import time
+try:
+    from math import inf
+except ImportError:
+    # python 2 doesn't have math.inf, but can use float('inf')
+    inf = float('inf')
 
 import pytest
 
@@ -89,7 +93,7 @@ def test_send_local_control_task(queue_worker_factory):
 
 def test_send_local_control_task_with_past_message(queue_worker_factory):
     app = queue_worker_factory()
-    app.queue_worker.epoch = math.inf
+    app.queue_worker.epoch = inf
     response = send_local_control_task(app=app, task='echo', get_response=True)
     assert len(app.tasks_executed) == 0
     assert response == 'NO_OP'

--- a/test/unit/queue_worker/test_queue_worker.py
+++ b/test/unit/queue_worker/test_queue_worker.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 import time
 
 import pytest
@@ -84,6 +85,14 @@ def test_send_local_control_task(queue_worker_factory):
     send_local_control_task(app=app, task='echo')
     wait_for_var(app, 'some_var', 'bar')
     assert len(app.tasks_executed) == 1
+
+
+def test_send_local_control_task_with_past_message(queue_worker_factory):
+    app = queue_worker_factory()
+    app.queue_worker.epoch = math.inf
+    response = send_local_control_task(app=app, task='echo', get_response=True)
+    assert len(app.tasks_executed) == 0
+    assert response == 'NO_OP'
 
 
 def test_send_local_control_task_with_non_target_listeners(queue_worker_factory):


### PR DESCRIPTION
And don't delete the local control queue. Deleting the local
control queue may throw off other consumers bound to that control
queue. This shouldn't happen, but apparently it can if Galaxy
runs in zerg mode ?