### PR TITLE
[19.09] Fix excessive memory consumption by not loading repository.metadata column

### DIFF
--- a/lib/galaxy/model/tool_shed_install/mapping.py
+++ b/lib/galaxy/model/tool_shed_install/mapping.py
@@ -89,16 +89,14 @@ install_model.MigrateTools.table = Table("migrate_tools", metadata,
 mapper(install_model.ToolShedRepository, install_model.ToolShedRepository.table,
        properties=dict(tool_versions=relation(install_model.ToolVersion,
                                               primaryjoin=(install_model.ToolShedRepository.table.c.id == install_model.ToolVersion.table.c.tool_shed_repository_id),
-                                              backref='tool_shed_repository',
-                                              lazy='joined'),
+                                              backref='tool_shed_repository'),
                        tool_dependencies=relation(install_model.ToolDependency,
                                                   primaryjoin=(install_model.ToolShedRepository.table.c.id == install_model.ToolDependency.table.c.tool_shed_repository_id),
                                                   order_by=install_model.ToolDependency.table.c.name,
                                                   backref='tool_shed_repository',
                                                   lazy='joined'),
                        required_repositories=relation(install_model.RepositoryRepositoryDependencyAssociation,
-                                                      primaryjoin=(install_model.ToolShedRepository.table.c.id == install_model.RepositoryRepositoryDependencyAssociation.table.c.tool_shed_repository_id),
-                                                      lazy='joined')))
+                                                      primaryjoin=(install_model.ToolShedRepository.table.c.id == install_model.RepositoryRepositoryDependencyAssociation.table.c.tool_shed_repository_id))))
 
 mapper(install_model.RepositoryRepositoryDependencyAssociation, install_model.RepositoryRepositoryDependencyAssociation.table,
        properties=dict(repository=relation(install_model.ToolShedRepository,

--- a/lib/galaxy/model/tool_shed_install/mapping.py
+++ b/lib/galaxy/model/tool_shed_install/mapping.py
@@ -93,8 +93,7 @@ mapper(install_model.ToolShedRepository, install_model.ToolShedRepository.table,
                        tool_dependencies=relation(install_model.ToolDependency,
                                                   primaryjoin=(install_model.ToolShedRepository.table.c.id == install_model.ToolDependency.table.c.tool_shed_repository_id),
                                                   order_by=install_model.ToolDependency.table.c.name,
-                                                  backref='tool_shed_repository',
-                                                  lazy='joined'),
+                                                  backref='tool_shed_repository'),
                        required_repositories=relation(install_model.RepositoryRepositoryDependencyAssociation,
                                                       primaryjoin=(install_model.ToolShedRepository.table.c.id == install_model.RepositoryRepositoryDependencyAssociation.table.c.tool_shed_repository_id))))
 

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -3,6 +3,8 @@ import os
 from collections import defaultdict
 from threading import Lock
 
+from sqlalchemy.orm import defer
+
 from galaxy.util import unicodify
 from galaxy.util.hash_util import md5_hash_file
 
@@ -144,7 +146,7 @@ class ToolShedRepositoryCache(object):
         self.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
 
     def rebuild(self):
-        self.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).all()
+        self.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).options(defer(self.app.install_model.ToolShedRepository.metadata)).all()
         repos_by_tuple = defaultdict(list)
         for repository in self.repositories + self.local_repositories:
             repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -3,7 +3,10 @@ import os
 from collections import defaultdict
 from threading import Lock
 
-from sqlalchemy.orm import defer
+from sqlalchemy.orm import (
+    defer,
+    joinedload,
+)
 
 from galaxy.util import unicodify
 from galaxy.util.hash_util import md5_hash_file
@@ -146,7 +149,10 @@ class ToolShedRepositoryCache(object):
         self.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
 
     def rebuild(self):
-        self.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).options(defer(self.app.install_model.ToolShedRepository.metadata)).all()
+        self.repositories = self.app.install_model.context.current.query(self.app.install_model.ToolShedRepository).options(
+            defer(self.app.install_model.ToolShedRepository.metadata),
+            joinedload('tool_dependencies'),
+        ).all()
         repos_by_tuple = defaultdict(list)
         for repository in self.repositories + self.local_repositories:
             repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -1064,7 +1064,7 @@ class MetadataGenerator(object):
                 self.set_changeset_revision(self.repository.changeset_revision)
             else:
                 self.set_changeset_revision(changeset_revision)
-            self.shed_config_dict = repository.get_shed_config_dict(self.app)
+            self.shed_config_dict = repository.get_shed_config_dict(self.app, {})
             self.metadata_dict = {'shed_config_filename': self.shed_config_dict.get('config_filename', None)}
         else:
             if relative_install_dir is None and self.repository is not None:


### PR DESCRIPTION
This reduces the memory consumed by the ToolShedRepositoryCache for a full rebuild of main's install database from 684 MB to 14 MB. The largest chunk of savings comes from `defer(self.app.install_model.ToolShedRepository.metadata)`. Not eagerloading the unused (except in the galaxy_install module, where we don't load repos from the cache) the metadata makes up the biggest chunk, reducing the memory footprint to 58MB.

Also fixes the metadata generator. I used metadata resetting for all repos as a "benchmark". Total memory consumption doesn't go higher than 782M now.