### PR TITLE
[19.09] Revert hacking IPs in container monitor script.

### DIFF
--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -225,6 +225,12 @@ def _docker_prefix(
 
 
 def parse_port_text(port_text):
+    """
+
+    >>> slurm_ports = parse_port_text("8888/tcp -> 0.0.0.0:32769")
+    >>> slurm_ports[8888]['host']
+    '0.0.0.0'
+    """
     ports = None
     if port_text is not None:
         ports = {}

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -41,8 +41,16 @@ def main():
         try:
             ports_raw = parse_ports(container_name, connection_configuration)
             if ports_raw is not None:
+                try:
+                    host_ip = socket.gethostbyname(socket.gethostname())
+                except Exception:
+                    # doesn't work on OS X
+                    host_ip = None
                 with open("container_runtime.json", "w") as f:
                     ports = docker_util.parse_port_text(ports_raw)
+                    for key in ports:
+                        if ports[key]['host'] == '0.0.0.0' and host_ip is not None:
+                            ports[key]['host'] = host_ip
                     json.dump(ports, f)
                 break
             else:

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -41,12 +41,8 @@ def main():
         try:
             ports_raw = parse_ports(container_name, connection_configuration)
             if ports_raw is not None:
-                host_ip = socket.gethostbyname(socket.gethostname())
                 with open("container_runtime.json", "w") as f:
-                    # Override the IPs
                     ports = docker_util.parse_port_text(ports_raw)
-                    for key in ports:
-                        ports[key]['host'] = host_ip
                     json.dump(ports, f)
                 break
             else:

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -48,9 +48,10 @@ def main():
                     host_ip = None
                 with open("container_runtime.json", "w") as f:
                     ports = docker_util.parse_port_text(ports_raw)
-                    for key in ports:
-                        if ports[key]['host'] == '0.0.0.0' and host_ip is not None:
-                            ports[key]['host'] = host_ip
+                    if host_ip is not None:
+                        for key in ports:
+                            if ports[key]['host'] == '0.0.0.0':
+                                ports[key]['host'] = host_ip
                     json.dump(ports, f)
                 break
             else:


### PR DESCRIPTION
It breaks the Mac setup and seems just wrong, docker might not be on localhost. This needs to be made more specific in some way and should handle those socker commands not working on OS X.