### PR TITLE
Add separate knob for masthead colors

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -350,7 +350,7 @@ body {
 #masthead {
     @extend .p-0;
     @extend .mb-0;
-    background-color: $brand-dark;
+    background-color: $brand-masthead;
     height: $masthead-height;
     .navbar-nav {
         min-height: 100%;
@@ -361,23 +361,23 @@ body {
             display: flex;
             align-items: center;
             &.active {
-                background: darken($brand-dark, 10%);
+                background: darken($brand-masthead, 10%);
                 .nav-link {
-                    color: $white;
+                    color: $brand-masthead-text-active;
                 }
             }
             .nav-link {
                 cursor: pointer;
                 text-decoration: none;
-                color: $gray-300;
+                color: $brand-masthead-text;
                 &:hover {
-                    color: $brand-toggle;
+                    color: $brand-masthead-text-hover;
                 }
                 &.nav-icon {
                     font-size: 1.7em;
                 }
                 &.toggle {
-                    color: $brand-toggle;
+                    color: $brand-masthead-text-hover;
                 }
             }
             .nav-note {
@@ -386,7 +386,7 @@ body {
                 right: 0.4rem;
                 top: 0.7rem;
                 font-size: 0.7rem;
-                color: $brand-toggle;
+                color: $brand-masthead-text-hover;
                 width: 0;
             }
         }
@@ -398,7 +398,7 @@ body {
         top: 0;
         font-family: verdana;
         font-size: 1.25rem;
-        color: $gray-300;
+        color: $brand-masthead-text-active;
         text-decoration: none;
         .navbar-brand-image {
             display: inline;
@@ -407,7 +407,7 @@ body {
             border: none;
         }
         .navbar-brand-title {
-            color: $white;
+            color: $brand-masthead-text;
         }
     }
 }

--- a/client/galaxy/style/scss/theme/blue.scss
+++ b/client/galaxy/style/scss/theme/blue.scss
@@ -9,6 +9,12 @@ $brand-light: #f8f9fa;
 $brand-dark: #2c3143;
 $brand-toggle: gold;
 
+// Masthead colors
+$brand-masthead: $brand-dark;
+$brand-masthead-text: $brand-light;
+$brand-masthead-text-active: lighten($brand-light, 15%);
+$brand-masthead-text-hover: $brand-toggle;
+
 // Text colors
 $text-color: $brand-dark;
 $text-muted: lighten($text-color, 10%);


### PR DESCRIPTION
This PR adds four optional theme knobs which allow to specific customization of masthead background and text colors.