### PR TITLE
Do not re-compute job input_ext/dbkey in job finish.

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -283,7 +283,9 @@ class JobSearch(object):
             # parameter as these are not passed along when expanding tool parameters
             # and they can differ without affecting the resulting dataset.
             for parameter in job.parameters:
-                if parameter.name in {'__workflow_invocation_uuid__', 'chromInfo', 'dbkey'} or parameter.name.endswith('|__identifier__'):
+                if parameter.name.startswith("__"):
+                    continue
+                if parameter.name in {'chromInfo', 'dbkey'} or parameter.name.endswith('|__identifier__'):
                     continue
                 n_parameters += 1
             if not n_parameters == len(param_dump):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -334,6 +334,7 @@ class DefaultToolAction(object):
 
         # Add the dbkey to the incoming parameters
         incoming["dbkey"] = input_dbkey
+        incoming["__input_ext"] = input_ext
         # wrapped params are used by change_format action and by output.label; only perform this wrapping once, as needed
         wrapped_params = self._wrapped_params(trans, tool, incoming, inp_data)
 


### PR DESCRIPTION
Remote metadata computation needs input_ext in the job parameters (like dbkey) so no need to re-loop through the inp_data to recompute it.

Additionally the loop here in discover_outputs in the job or job handler might be running on a different Python version or different Galaxy version than the tool action in the web controller - and this is a dict not a list. Therefore the loop might result in a different value for input_ext. For this reason, it is better to just compute it once and reuse it anyway for a greater guarantee of consistency.

Work from https://github.com/galaxyproject/galaxy/pull/7058/commits.
