### PR TITLE
[WIP] Implement celery task queue for out of band tasks

### DIFF
--- a/lib/celery-galaxy.py
+++ b/lib/celery-galaxy.py
@@ -1,0 +1,6 @@
+"""Standlone entry point for starting a Celery worker that can execute Galaxy tasks"""
+from galaxy.queue_worker import get_celery_app
+
+
+# TODO: figure out how to build Galaxy app object using celery command line options
+app = get_celery_app(None)

--- a/lib/celery-galaxy.py
+++ b/lib/celery-galaxy.py
@@ -1,6 +1,50 @@
 """Standlone entry point for starting a Celery worker that can execute Galaxy tasks"""
-from galaxy.queue_worker import get_celery_app
+import os
+import sys
 
+from celery import bootsteps
+from celery.bin import Option
+
+from galaxy.app import UniverseApplication
+from galaxy.queue_worker import get_celery_app
+from galaxy.util.properties import load_app_properties
+from galaxy.web_stack import get_app_kwds
+
+GALAXY_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
+if not os.path.exists(os.path.join(GALAXY_ROOT_DIR, 'run.sh')):
+    # Galaxy is installed
+    GALAXY_ROOT_DIR = None
+else:
+    GALAXY_LIB_DIR = os.path.join(GALAXY_ROOT_DIR, "lib")
+    try:
+        sys.path.insert(1, GALAXY_LIB_DIR)
+    except Exception:
+        sys.exit("Failed to add Galaxy to sys.path")
 
 # TODO: figure out how to build Galaxy app object using celery command line options
 app = get_celery_app(None)
+app.user_options['worker'].add(
+    Option(
+        '--galaxy_config_file',
+        dest='galaxy_config_file',
+        default='../config/galaxy.yml',
+        type=str,
+        help='Path to galaxy config file',
+    )
+)
+
+
+class GalaxyWorkerStep(bootsteps.StartStopStep):
+    requires = {'celery.worker.components:Pool'}
+
+    def __init__(self, worker, galaxy_config_file=None, **options):
+        app.conf['galaxy_config_file'] = galaxy_config_file = galaxy_config_file[0] if isinstance(galaxy_config_file, list) else galaxy_config_file
+        kwds = get_app_kwds('galaxy')
+        kwds = load_app_properties(config_file=galaxy_config_file, **kwds)
+        kwds['config_file'] = galaxy_config_file
+        kwds['root_dir'] = GALAXY_ROOT_DIR
+        print(kwds)
+        app.conf['galaxy_app'] = UniverseApplication(**kwds)
+
+
+app.steps['worker'].add(GalaxyWorkerStep)

--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -47,6 +47,7 @@ cwltool = "==1.0.20180721142728"
 ipaddress = {version = "*", markers = "python_version < '3.3'"}
 isa-rwval = "*"
 boltons = "*"
+celery = "*"
 Paste = "*"
 docutils = "*"
 Routes = "*"

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -33,6 +33,7 @@ bx-python==0.8.4
 bz2file==0.98 ; python_version < '3.3'
 cachecontrol==0.11.7
 cachetools==3.1.1
+celery==4.3.0
 certifi==2019.9.11
 cffi==1.13.1
 chardet==3.0.4

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -36,7 +36,7 @@ from galaxy import util
 class TaskFormatter(logging.Formatter):
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(TaskFormatter, self).__init__(*args, **kwargs)
         try:
             from celery._state import get_current_task
             self.get_current_task = get_current_task

--- a/lib/galaxy/queues.py
+++ b/lib/galaxy/queues.py
@@ -15,6 +15,10 @@ ALL_CONTROL = "control.*"
 galaxy_exchange = Exchange('galaxy_core_exchange', type='topic')
 
 
+def get_process_name(server_name):
+    return "{server_name}@{hostname}".format(server_name=server_name, hostname=socket.gethostname())
+
+
 def all_control_queues_for_declare(application_stack):
     """
     For in-memory routing (used by sqlalchemy-based transports), we need to be able to
@@ -30,8 +34,7 @@ def control_queues_from_config(config):
     Returns a Queue instance with the correct name and routing key for this
     galaxy process's config
     """
-    hostname = socket.gethostname()
-    process_name = "{server_name}@{hostname}".format(server_name=config.server_name, hostname=hostname)
+    process_name = get_process_name(server_name=config.server_name)
     exchange_queue = Queue("control.%s" % process_name, galaxy_exchange, routing_key='control.%s' % process_name)
     non_exchange_queue = Queue("control.%s" % process_name, routing_key='control.%s' % process_name)
     return exchange_queue, non_exchange_queue

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1675,7 +1675,9 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 new_whitelist = sorted([tid for tid in tools_to_whitelist if tid in trans.app.toolbox.tools_by_id])
                 f.write("\n".join(new_whitelist))
             trans.app.config.sanitize_whitelist = new_whitelist
-            trans.app.queue_worker.send_control_task('reload_sanitize_whitelist', noop_self=True)
+            # trans.app.queue_worker.send_control_task('reload_sanitize_whitelist', noop_self=True)
+            trans.app.queue_worker.reload_sanitize_whitelist.delay()
+            # reload_sanitize_whitelist.delay()
             # dispatch a message to reload list for other processes
         return trans.fill_template('/webapps/galaxy/admin/sanitize_whitelist.mako',
                                    sanitize_all=trans.app.config.sanitize_all_html,


### PR DESCRIPTION
Super-basic celery worker starting with Galaxy and standalone entry-point for `celery -A celery-galaxy worker`.
You'd probably not want to start celery workers with Galaxy but go with "standard" standalone celery workers, but it's easy enough to start a handful of threads with Galaxy so we can safely make the assumption that we can use Celery in all setups (e.g run.sh).

I'm still figuring out how these pieces can fit together. but I think this isn't going to replace the task messaging we currently have in place for reloading attributes within the Galaxy app (toolbox reload), as Galaxy proper shouldn't be in the same process space as Celery.

I'm thinking this would be more appropriate for longer running out of band tasks where results either don't need to be communicated back (cronjob style whoosh index building for instance) or where status updates can happen via the database (async toolshed repos installs) or a to-be-implemented view or callback for running and queued-up tasks (dependency installations, heavy IO operations such as moving data tables into place and moving discovered datasets).