### PR TITLE
[19.09] Fix galaxy-data package requirements.

### DIFF
--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -10,7 +10,7 @@ numpy<=1.16
 pycryptodome
 pysam
 social_auth_core
-SQLAlchemy==1.2
+SQLAlchemy
 sqlalchemy-migrate
 sqlalchemy-utils
 WebOb


### PR DESCRIPTION
No longer pinning sqlalchemy to 1.2.