### PR TITLE
[WIP] If skipping client build, skip node install.

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -219,21 +219,21 @@ else
     echo "The Galaxy client build is being skipped due to the SKIP_CLIENT_BUILD environment variable."
 fi
 
-# Install node if not installed
-if [ -n "$VIRTUAL_ENV" ]; then
-    if ! in_venv "$(command -v node)" || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
-        echo "Installing node into $VIRTUAL_ENV with nodeenv."
-        nodeenv -n "$NODE_VERSION" -p
-    fi
-elif [ -n "$CONDA_DEFAULT_ENV" ] && [ -n "$CONDA_EXE" ]; then
-    if ! in_conda_env "$(command -v node)"; then
-        echo "Installing node into '$CONDA_DEFAULT_ENV' Conda environment with conda."
-        $CONDA_EXE install --yes --override-channels --channel conda-forge --channel defaults --name "$CONDA_DEFAULT_ENV" nodejs="$NODE_VERSION"
-    fi
-fi
-
 # Build client if necessary.
 if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
+    # Install node if not installed
+    if [ -n "$VIRTUAL_ENV" ]; then
+        if ! in_venv "$(command -v node)" || [ "$(node --version)" != "v${NODE_VERSION}" ]; then
+            echo "Installing node into $VIRTUAL_ENV with nodeenv."
+            nodeenv -n "$NODE_VERSION" -p
+        fi
+    elif [ -n "$CONDA_DEFAULT_ENV" ] && [ -n "$CONDA_EXE" ]; then
+        if ! in_conda_env "$(command -v node)"; then
+            echo "Installing node into '$CONDA_DEFAULT_ENV' Conda environment with conda."
+            $CONDA_EXE install --yes --override-channels --channel conda-forge --channel defaults --name "$CONDA_DEFAULT_ENV" nodejs="$NODE_VERSION"
+        fi
+    fi
+
     # Ensure dependencies are installed
     if [ -n "$VIRTUAL_ENV" ]; then
         if ! in_venv "$(command -v yarn)"; then


### PR DESCRIPTION
No reason for doc building tests to fail on install node.

https://jenkins.galaxyproject.org/job/doc-building-test/1382

In general there may be times you want node installed despite not needing the client built, but I don't think we setup these install commands (and version pinning) for those use cases we did it for client building.