### PR TITLE
Simplify Python deps installation in `testing-base` Dockerfile

### DIFF
--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -3,7 +3,7 @@
 Setup Docker environment for use with testing using the following
 commands.
 
-    % cd test/base
+    % cd test/docker/base
     % docker build -t galaxy/testing-base .
 
 Alternatively, this can be fetched from [Dockerhub](https://hub.docker.com/).

--- a/test/docker/base/Dockerfile
+++ b/test/docker/base/Dockerfile
@@ -71,16 +71,11 @@ RUN mkdir /etc/galaxy && cd /tmp/ansible && mkdir roles && \
 RUN cd $GALAXY_ROOT && \
     virtualenv -p /usr/bin/python3 $GALAXY_VIRTUAL_ENV_3 && \
     for VENV in $GALAXY_VIRTUAL_ENV_2 $GALAXY_VIRTUAL_ENV_3; do \
-        export GALAXY_VIRTUAL_ENV=$VENV && \
-        ./scripts/common_startup.sh && \
-        dev_requirements=./lib/galaxy/dependencies/dev-requirements.txt && \
-        [ -f $dev_requirements ] && $VENV/bin/pip install -r $dev_requirements; done
+        GALAXY_VIRTUAL_ENV=$VENV ./scripts/common_startup.sh --dev-wheels && \
+        $VENV/bin/pip install psycopg2-binary; done && \
+    rm -rf ~/.cache/pip
 
-RUN for VENV in $GALAXY_VIRTUAL_ENV_3 $GALAXY_VIRTUAL_ENV_2; do \
-        export GALAXY_VIRTUAL_ENV=$VENV && \
-        . $GALAXY_VIRTUAL_ENV/bin/activate && \
-        pip install psycopg2-binary; done && \
-    cd $GALAXY_ROOT && \
+RUN cd $GALAXY_ROOT && \
     echo "Prepopulating postgres database" && \
     su -c '/usr/lib/postgresql/${POSTGRES_MAJOR}/bin/pg_ctl -o "-F" start -D /opt/galaxy/db' postgres && \
     sleep 3 && \

--- a/test/docker/base/provision.yml
+++ b/test/docker/base/provision.yml
@@ -2,15 +2,15 @@
   connection: local
   roles:
     - role: galaxyprojectdotorg.galaxy-os
+      become: true
       tags: image
-      sudo: yes
     - role: galaxyprojectdotorg.cloudman-database
-      sudo: yes
-      sudo_user: postgres
+      become: true
+      become_user: postgres
       tags: database
     - role: galaxyprojectdotorg.galaxy
-      sudo: yes
+      become: true
       tags: galaxy
     - role: galaxyprojectdotorg.galaxy-toolshed
-      sudo: yes
+      become: true
       tags: toolshed


### PR DESCRIPTION
Also use `become` instead of `sudo` in Ansible playbook (`sudo` is deprecated since Ansible 1.9).

