### PR TITLE
Prettier upgrade, and an attempt to fix vue component html formatting.

### DIFF
--- a/client/galaxy/scripts/components/DataDialog/services.js
+++ b/client/galaxy/scripts/components/DataDialog/services.js
@@ -68,9 +68,7 @@ export class Services {
         } else if (record.type == "file") {
             record.src = "ldda";
             record.label = record.name;
-            record.download = `${this.host}${this.root}api/libraries/datasets/download/uncompressed?ld_ids=${
-                record.id
-            }`;
+            record.download = `${this.host}${this.root}api/libraries/datasets/download/uncompressed?ld_ids=${record.id}`;
             return record;
         }
     }

--- a/client/galaxy/scripts/components/PageEditor/PageEditorHtml.vue
+++ b/client/galaxy/scripts/components/PageEditor/PageEditorHtml.vue
@@ -379,9 +379,7 @@ WYMeditor.editor.prototype.dialog = function(dialogType, dialogFeatures, bodyHtm
                             ) {
                                 // User selected no text; create link from scratch and use default text.
                                 wym.insert(
-                                    `<a href='${returned_item_info.link}'>${item_info.singular} '${
-                                        returned_item_info.name
-                                    }'</a>`
+                                    `<a href='${returned_item_info.link}'>${item_info.singular} '${returned_item_info.name}'</a>`
                                 );
                             } else {
                                 // Link created from selected text; add href and title.

--- a/client/galaxy/scripts/components/Tags/tagService.js
+++ b/client/galaxy/scripts/components/Tags/tagService.js
@@ -73,9 +73,7 @@ export class TagService {
     async delete(rawTag) {
         const { id, itemClass, context } = this;
         const tag = createTag(rawTag);
-        const url = `/tag/remove_tag_async?item_id=${id}&item_class=${itemClass}&context=${context}&tag_name=${
-            tag.text
-        }`;
+        const url = `/tag/remove_tag_async?item_id=${id}&item_class=${itemClass}&context=${context}&tag_name=${tag.text}`;
         const response = await axios.get(url);
         if (response.status !== 200) {
             throw new Error(`Unable to delete tag: ${tag}`);

--- a/client/galaxy/scripts/components/User/UserPreferences.vue
+++ b/client/galaxy/scripts/components/User/UserPreferences.vue
@@ -128,9 +128,7 @@ export default {
                 $.post(`${Galaxy.root}history/make_private`, { all_histories: true }, () => {
                     Galaxy.modal.show({
                         title: _l("Datasets are now private"),
-                        body: `All of your histories and datsets have been made private.  If you'd like to make all *future* histories private please use the <a href="${
-                            Galaxy.root
-                        }user/permissions">User Permissions</a> interface.`,
+                        body: `All of your histories and datsets have been made private.  If you'd like to make all *future* histories private please use the <a href="${Galaxy.root}user/permissions">User Permissions</a> interface.`,
                         buttons: {
                             Close: function() {
                                 Galaxy.modal.hide();

--- a/client/galaxy/scripts/components/Workflow/WorkflowImport.vue
+++ b/client/galaxy/scripts/components/Workflow/WorkflowImport.vue
@@ -36,9 +36,7 @@ export default {
             sourceFile: null,
             sourceURL: null,
             errorMessage: null,
-            myexperiment_target_url: `http://${Galaxy.config.myexperiment_target_url}/galaxy?galaxy_url=${
-                window.location.protocol
-            }//${window.location.host}`
+            myexperiment_target_url: `http://${Galaxy.config.myexperiment_target_url}/galaxy?galaxy_url=${window.location.protocol}//${window.location.host}`
         };
     },
     computed: {

--- a/client/galaxy/scripts/layout/modal.js
+++ b/client/galaxy/scripts/layout/modal.js
@@ -142,9 +142,7 @@ export function show_in_overlay(options) {
         closeButton: true,
         title: "&nbsp;",
         body: $(
-            `<div style='margin: -5px;'><iframe style='margin: 0; padding: 0;' src='${
-                options.url
-            }' width='${width}' height='${height}' scrolling='${scroll}' frameborder='0'></iframe></div>`
+            `<div style='margin: -5px;'><iframe style='margin: 0; padding: 0;' src='${options.url}' width='${width}' height='${height}' scrolling='${scroll}' frameborder='0'></iframe></div>`
         )
     });
     modal.show({ backdrop: true });

--- a/client/galaxy/scripts/legacy/grid/grid-template.js
+++ b/client/galaxy/scripts/legacy/grid/grid-template.js
@@ -51,9 +51,7 @@ export default {
                     '<div popupmenu="popup-global-actions">';
             }
             for (let action of options.global_actions) {
-                tmpl += `<li><a class="action-button use-target" target="${action.target}" href="${
-                    action.url_args
-                }" onclick="return false;" >${action.label}</a></li>`;
+                tmpl += `<li><a class="action-button use-target" target="${action.target}" href="${action.url_args}" onclick="return false;" >${action.label}</a></li>`;
             }
             if (show_popup) {
                 tmpl += "</div>";
@@ -131,9 +129,7 @@ export default {
 
             // Item selection column
             if (options.show_item_checkboxes) {
-                tmpl += `<td style="width: 1.5em;"><input type="checkbox" name="id" value="${item.encode_id}" id="${
-                    item.encode_id
-                }" class="grid-row-select-checkbox" /></td>`;
+                tmpl += `<td style="width: 1.5em;"><input type="checkbox" name="id" value="${item.encode_id}" id="${item.encode_id}" class="grid-row-select-checkbox" /></td>`;
             }
 
             // Data columns
@@ -288,9 +284,7 @@ export default {
             // configure buttons for operations
             for (let operation of options.operations) {
                 if (operation.allow_multiple) {
-                    tmpl += `<input type="button" value="${
-                        operation.label
-                    }" class="operation-button action-button">&nbsp;`;
+                    tmpl += `<input type="button" value="${operation.label}" class="operation-button action-button">&nbsp;`;
                 }
             }
 
@@ -439,9 +433,7 @@ export default {
                         if (column.is_text) {
                             filter_value = JSON.stringify(filter_value);
                         }
-                        tmpl += `<input type="hidden" id="${column.key}" name="f-${
-                            column.key
-                        }" value="${filter_value}"/>`;
+                        tmpl += `<input type="hidden" id="${column.key}" name="f-${column.key}" value="${filter_value}"/>`;
                     }
                 }
             }

--- a/client/galaxy/scripts/mvc/grid/grid-template.js
+++ b/client/galaxy/scripts/mvc/grid/grid-template.js
@@ -68,9 +68,7 @@ export default {
                     '<div popupmenu="popup-global-actions">';
             }
             for (const action of options.global_actions) {
-                tmpl += `<li><a class="action-button use-target" target="${action.target}" href="${
-                    action.url_args
-                }" onclick="return false;" >${action.label}</a></li>`;
+                tmpl += `<li><a class="action-button use-target" target="${action.target}" href="${action.url_args}" onclick="return false;" >${action.label}</a></li>`;
             }
             if (show_popup) {
                 tmpl += "</div>";
@@ -110,9 +108,7 @@ export default {
             if (column.visible) {
                 tmpl += `<th id="${column.key}-header">`;
                 if (column.sortable) {
-                    tmpl += `<a href="javascript:void(0)" class="sort-link" sort_key="${column.key}">${
-                        column.label
-                    }</a>`;
+                    tmpl += `<a href="javascript:void(0)" class="sort-link" sort_key="${column.key}">${column.label}</a>`;
                 } else {
                     tmpl += column.label;
                 }
@@ -150,9 +146,7 @@ export default {
 
             // Item selection column
             if (options.show_item_checkboxes) {
-                tmpl += `<td style="width: 1.5em;"><input type="checkbox" name="id" value="${item.encode_id}" id="${
-                    item.encode_id
-                }" class="grid-row-select-checkbox" /></td>`;
+                tmpl += `<td style="width: 1.5em;"><input type="checkbox" name="id" value="${item.encode_id}" id="${item.encode_id}" class="grid-row-select-checkbox" /></td>`;
             }
 
             // Data columns
@@ -188,9 +182,7 @@ export default {
 
                     // Determine cell content
                     if (column.delayed) {
-                        tmpl += `<div class="delayed-value-${column.key}" data-id="${
-                            item.encode_id
-                        }" data-value="${value}"><span class="fa fa-spinner fa-spin"></span></div>`;
+                        tmpl += `<div class="delayed-value-${column.key}" data-id="${item.encode_id}" data-value="${value}"><span class="fa fa-spinner fa-spin"></span></div>`;
                     } else if (column.attach_popup && link) {
                         tmpl += `<div class="btn-group">
                                     <button class="btn btn-secondary use-target" target="${target}" href="${link}" onclick="return false;">${value}</button>
@@ -304,9 +296,7 @@ export default {
             // configure buttons for operations
             for (const operation of options.operations) {
                 if (operation.allow_multiple) {
-                    tmpl += `<input type="button" value="${
-                        operation.label
-                    }" class="operation-button action-button">&nbsp;`;
+                    tmpl += `<input type="button" value="${operation.label}" class="operation-button action-button">&nbsp;`;
                 }
             }
 
@@ -455,9 +445,7 @@ export default {
                         if (column.is_text) {
                             filter_value = JSON.stringify(filter_value);
                         }
-                        tmpl += `<input type="hidden" id="${column.key}" name="f-${
-                            column.key
-                        }" value="${filter_value}"/>`;
+                        tmpl += `<input type="hidden" id="${column.key}" name="f-${column.key}" value="${filter_value}"/>`;
                     }
                 }
             }

--- a/client/galaxy/scripts/mvc/ui/ui-table.js
+++ b/client/galaxy/scripts/mvc/ui/ui-table.js
@@ -161,9 +161,7 @@ var View = Backbone.View.extend({
 
     /** Template */
     _template: function() {
-        return `<div><table class="${this.options.cls}"><thead/><tbody/></table><tmessage>${
-            this.options.content
-        }</tmessage><div>`;
+        return `<div><table class="${this.options.cls}"><thead/><tbody/></table><tmessage>${this.options.content}</tmessage><div>`;
     }
 });
 

--- a/client/galaxy/scripts/mvc/upload/collection/collection-row.js
+++ b/client/galaxy/scripts/mvc/upload/collection/collection-row.js
@@ -158,10 +158,6 @@ export default Backbone.View.extend({
 
     /** View template */
     _template: function(options) {
-        return `<tr id="upload-row-${
-            options.id
-        }" class="upload-row"><td><div class="upload-text-column"><div class="upload-mode"/><div class="upload-title-extended"/><div class="upload-text"><div class="upload-text-info">Download data from the web by entering URLs (one per line) or directly paste content.</div><textarea class="upload-text-content form-control"/></div></div></td><td><div class="upload-size"/></td><td><div class="upload-info"><div class="upload-info-text"/><div class="upload-info-progress progress"><div class="upload-progress-bar progress-bar progress-bar-success"/><div class="upload-percentage">0%</div></div></div></td><td><div class="upload-symbol ${
-            this.status_classes.init
-        }"/></td></tr>`;
+        return `<tr id="upload-row-${options.id}" class="upload-row"><td><div class="upload-text-column"><div class="upload-mode"/><div class="upload-title-extended"/><div class="upload-text"><div class="upload-text-info">Download data from the web by entering URLs (one per line) or directly paste content.</div><textarea class="upload-text-content form-control"/></div></div></td><td><div class="upload-size"/></td><td><div class="upload-info"><div class="upload-info-text"/><div class="upload-info-progress progress"><div class="upload-progress-bar progress-bar progress-bar-success"/><div class="upload-percentage">0%</div></div></div></td><td><div class="upload-symbol ${this.status_classes.init}"/></td></tr>`;
     }
 });

--- a/client/galaxy/scripts/mvc/upload/collection/collection-view.js
+++ b/client/galaxy/scripts/mvc/upload/collection/collection-view.js
@@ -425,9 +425,7 @@ export default Backbone.View.extend({
             }
         } else {
             if (this.counter.running == 0) {
-                message = `You added ${
-                    this.counter.announce
-                } file(s) to the queue. Add more files or click 'Start' to proceed.`;
+                message = `You added ${this.counter.announce} file(s) to the queue. Add more files or click 'Start' to proceed.`;
             } else {
                 message = `Please wait...${this.counter.announce} out of ${this.counter.running} remaining.`;
             }

--- a/client/galaxy/scripts/mvc/upload/default/default-view.js
+++ b/client/galaxy/scripts/mvc/upload/default/default-view.js
@@ -211,9 +211,7 @@ export default Backbone.View.extend({
             }
         } else {
             if (this.counter.running === 0) {
-                message = `You added ${
-                    this.counter.announce
-                } file(s) to the queue. Add more files or click 'Start' to proceed.`;
+                message = `You added ${this.counter.announce} file(s) to the queue. Add more files or click 'Start' to proceed.`;
             } else {
                 message = `Please wait...${this.counter.announce} out of ${this.counter.running} remaining.`;
             }

--- a/client/galaxy/scripts/mvc/upload/upload-ftp.js
+++ b/client/galaxy/scripts/mvc/upload/upload-ftp.js
@@ -15,9 +15,7 @@ export default Backbone.View.extend({
             class_partial: "upload-icon-button fa fa-minus-square-o",
             help_enabled: true,
             oidc_text: `<br/>If you are signed-in to Galaxy using a third-party identity and you <strong>do not have a Galaxy password</strong> please use the reset password option in the login form with your email to create a password for your account.`,
-            help_text: `This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at <strong>${
-                options.ftp_upload_site
-            }</strong> using your Galaxy credentials.
+            help_text: `This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at <strong>${options.ftp_upload_site}</strong> using your Galaxy credentials.
             For help visit the <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.`,
             collection: null,
             onchange: function() {},

--- a/client/package.json
+++ b/client/package.json
@@ -116,7 +116,7 @@
     "phantomjs-polyfill": "0.0.2",
     "phantomjs-prebuilt": "^2.1.7",
     "postcss-loader": "^3.0.0",
-    "prettier": "^1.16.4",
+    "prettier": "^1.18.2",
     "qunitjs": "^2.4.1",
     "raw-loader": "^2.0.0",
     "sass-loader": "^7.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10245,10 +10245,10 @@ prettier@1.16.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.3.tgz#8c62168453badef702f34b45b6ee899574a6a65d"
   integrity sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==
 
-prettier@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-hrtime@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
First commit is a straight prettier version bump that adjusts formatting in a few cases that seem reasonable.

~Second commit (which I'm likely going to strip) is an attempt to fix stuff like:

https://github.com/galaxyproject/galaxy/compare/dev...dannon:prettier_update?expand=1#diff-95ec00a060183da5b53d841e69cb1500L13

It's not ideal, but there's an outstanding prettier issue tracking this which will hopefully have a better resolution moving forward -- allowing a 'htmlBracketSameLine' type option as they currently have for jsx.


(edit: second commit was stripped; it's not safe to do since we do depend on the whitespace in various places.)