### PR TITLE
Config: drop redundant `template_cache` attribute

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -151,7 +151,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self.visualizations_registry = VisualizationsRegistry(
             self,
             directories_setting=self.config.visualization_plugins_directory,
-            template_cache_dir=self.config.template_cache)
+            template_cache_dir=self.config.template_cache_path)
         # Tours registry
         self.tour_registry = ToursRegistry(self.config.tour_config_dir)
         # Webhooks registry

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -429,7 +429,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             if len(ip.strip()) > 0
         ]
         self.template_path = os.path.join(self.root, kwargs.get("template_path", "templates"))
-        self.template_cache = self.template_cache_path
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
         self.cluster_files_directory = self.resolve_path(self.cluster_files_directory)
 
@@ -811,7 +810,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                 except Exception as e:
                     raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
         # Create the directories that it makes sense to create
-        for path in (self.new_file_path, self.template_cache, self.ftp_upload_dir,
+        for path in (self.new_file_path, self.template_cache_path, self.ftp_upload_dir,
                      self.library_import_dir, self.user_library_import_dir,
                      self.nginx_upload_store, self.object_store_cache_path):
             self._ensure_directory(path)

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -99,7 +99,7 @@ class WebApplication(base.WebApplication):
         paths.append(template_path)
         # Create TemplateLookup with a small cache
         return mako.lookup.TemplateLookup(directories=paths,
-                                          module_directory=galaxy_app.config.template_cache,
+                                          module_directory=galaxy_app.config.template_cache_path,
                                           collection_size=500)
 
     def handle_controller_exception(self, e, trans, **kwargs):

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -35,7 +35,7 @@ class Configuration(object):
         self.use_remote_user = string_as_bool(kwargs.get("use_remote_user", "False"))
         self.require_login = string_as_bool(kwargs.get("require_login", "False"))
         self.template_path = resolve_path(kwargs.get("template_path", "templates"), self.root)
-        self.template_cache = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates/reports"), self.root)
+        self.template_cache_path = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates/reports"), self.root)
         self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
         self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
         self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))

--- a/lib/galaxy/webapps/tool_shed/config.py
+++ b/lib/galaxy/webapps/tool_shed/config.py
@@ -101,7 +101,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
         self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
         self.template_path = resolve_path(kwargs.get("template_path", "templates"), self.root)
-        self.template_cache = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates/community"), self.root)
+        self.template_cache_path = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates/community"), self.root)
         self.admin_users = kwargs.get("admin_users", "")
         self.admin_users_list = [u.strip() for u in self.admin_users.split(',') if u]
         self.mailing_join_addr = kwargs.get('mailing_join_addr', "galaxy-announce-join@bx.psu.edu")
@@ -206,7 +206,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
                     raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
         # Create the directories that it makes sense to create.
         for path in self.file_path, \
-            self.template_cache, \
+            self.template_cache_path, \
                 os.path.join(self.tool_data_path, 'shared', 'jars'):
             if path not in [None, False] and not os.path.isdir(path):
                 try:

--- a/test/unit/test_routes.py
+++ b/test/unit/test_routes.py
@@ -20,7 +20,7 @@ class TestWebapp(WebApplication):
 
 
 def test_galaxy_routes():
-    test_config = Bunch(template_path="/tmp", template_cache="/tmp")
+    test_config = Bunch(template_path="/tmp", template_cache_path="/tmp")
     app = Bunch(config=test_config, security=object(), trace_logger=None)
     test_webapp = TestWebapp(app)
 


### PR DESCRIPTION
Just use `template_cache_path` everywhere.