### PR TITLE
[19.09] Fix `TypeError` in logging commands

### DIFF
--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -106,7 +106,7 @@ def main():
     now = strftime("%Y-%m-%d %H:%M:%S")
 
     log.info("##########################################")
-    log.info("\n# %s - Handling stuff older than %i days" % (now, args.days))
+    log.info("\n# %s - Handling stuff older than %d days", now, args.days)
 
     if args.info_only:
         log.info("# Displaying info only ( --info_only )\n")
@@ -149,14 +149,14 @@ def delete_userless_histories(app, cutoff_time, info_only=False, force_retry=Fal
                                                app.model.History.table.c.update_time < cutoff_time))
     for history in histories:
         if not info_only:
-            log.info("Deleting history id ", history.id)
+            log.info("Deleting history id %d", history.id)
             history.deleted = True
             app.sa_session.add(history)
             app.sa_session.flush()
         history_count += 1
     stop = time.time()
-    log.info("Deleted %d histories" % history_count)
-    log.info("Elapsed time: ", stop - start)
+    log.info("Deleted %d histories", history_count)
+    log.info("Elapsed time: %f", stop - start)
     log.info("##########################################")
 
 
@@ -180,7 +180,7 @@ def purge_histories(app, cutoff_time, remove_from_disk, info_only=False, force_r
                                                app.model.History.table.c.update_time < cutoff_time)) \
                                   .options(eagerload('datasets'))
     for history in histories:
-        log.info("### Processing history id %d (%s)" % (history.id, unicodify(history.name)))
+        log.info("### Processing history id %d (%s)", history.id, unicodify(history.name))
         for dataset_assoc in history.datasets:
             _purge_dataset_instance(dataset_assoc, app, remove_from_disk, info_only=info_only)  # mark a DatasetInstance as deleted, clear associated files, and mark the Dataset as deleted if it is deletable
         if not info_only:
@@ -189,16 +189,16 @@ def purge_histories(app, cutoff_time, remove_from_disk, info_only=False, force_r
             # if we should ever delete info like this from the db though, so commented out for now...
             # for dhp in history.default_permissions:
             #     dhp.delete()
-            log.info("Purging history id ", history.id)
+            log.info("Purging history id %d", history.id)
             history.purged = True
             app.sa_session.add(history)
             app.sa_session.flush()
         else:
-            log.info("History id %d will be purged (without 'info_only' mode)" % history.id)
+            log.info("History id %d will be purged (without 'info_only' mode)", history.id)
         history_count += 1
     stop = time.time()
-    log.info('Purged %d histories.' % history_count)
-    log.info("Elapsed time: ", stop - start)
+    log.info('Purged %d histories.', history_count)
+    log.info("Elapsed time: %f", stop - start)
     log.info("##########################################")
 
 
@@ -222,14 +222,14 @@ def purge_libraries(app, cutoff_time, remove_from_disk, info_only=False, force_r
     for library in libraries:
         _purge_folder(library.root_folder, app, remove_from_disk, info_only=info_only)
         if not info_only:
-            log.info("Purging library id ", library.id)
+            log.info("Purging library id %d", library.id)
             library.purged = True
             app.sa_session.add(library)
             app.sa_session.flush()
         library_count += 1
     stop = time.time()
-    log.info('# Purged %d libraries .' % library_count)
-    log.info("Elapsed time: ", stop - start)
+    log.info('# Purged %d libraries .', library_count)
+    log.info("Elapsed time: %f", stop - start)
     log.info("##########################################")
 
 
@@ -254,8 +254,8 @@ def purge_folders(app, cutoff_time, remove_from_disk, info_only=False, force_ret
         _purge_folder(folder, app, remove_from_disk, info_only=info_only)
         folder_count += 1
     stop = time.time()
-    log.info('# Purged %d folders.' % folder_count)
-    log.info("Elapsed time: ", stop - start)
+    log.info('# Purged %d folders.', folder_count)
+    log.info("Elapsed time: %f", stop - start)
     log.info("##########################################")
 
 
@@ -301,7 +301,7 @@ def delete_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_r
     library_dataset_ids = [row.id for row in library_dataset_ids_query.execute()]
     dataset_ids = []
     for library_dataset_id in library_dataset_ids:
-        log.info("######### Processing LibraryDataset id:", library_dataset_id)
+        log.info("######### Processing LibraryDataset id: %d", library_dataset_id)
         # Get the LibraryDataset and the current LibraryDatasetDatasetAssociation objects
         ld = app.sa_session.query(app.model.LibraryDataset).get(library_dataset_id)
         ldda = ld.library_dataset_dataset_association
@@ -311,16 +311,16 @@ def delete_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_r
         if not ldda.deleted:
             ldda.deleted = True
             app.sa_session.add(ldda)
-            log.info("Marked associated LibraryDatasetDatasetAssociation id %d as deleted" % ldda.id)
+            log.info("Marked associated LibraryDatasetDatasetAssociation id %d as deleted", ldda.id)
         for expired_ldda in ld.expired_datasets:
             if not expired_ldda.deleted:
                 expired_ldda.deleted = True
                 app.sa_session.add(expired_ldda)
-                log.info("Marked associated expired LibraryDatasetDatasetAssociation id %d as deleted" % ldda.id)
+                log.info("Marked associated expired LibraryDatasetDatasetAssociation id %d as deleted", ldda.id)
         # Mark the LibraryDataset as purged
         ld.purged = True
         app.sa_session.add(ld)
-        log.info("Marked LibraryDataset id %d as purged" % ld.id)
+        log.info("Marked LibraryDataset id %d as purged", ld.id)
         app.sa_session.flush()
     # Add all datasets associated with Histories to our list
     dataset_ids.extend([row.id for row in history_dataset_ids_query.execute()])
@@ -330,7 +330,7 @@ def delete_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_r
         if dataset.id in skip:
             continue
         skip.append(dataset.id)
-        log.info("######### Processing dataset id:", dataset_id)
+        log.info("######### Processing dataset id: %d", dataset_id)
         if not _dataset_is_deletable(dataset):
             log.info("Dataset is not deletable (shared between multiple histories/libraries, at least one is not deleted)")
             continue
@@ -340,8 +340,8 @@ def delete_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_r
             _purge_dataset_instance(dataset_instance, app, remove_from_disk, info_only=info_only, is_deletable=True)
             deleted_instance_count += 1
     stop = time.time()
-    log.info("Examined %d datasets, marked %d datasets and %d dataset instances (HDA) as deleted" % (len(skip), deleted_dataset_count, deleted_instance_count))
-    log.info("Total elapsed time: ", stop - start)
+    log.info("Examined %d datasets, marked %d datasets and %d dataset instances (HDA) as deleted", len(skip), deleted_dataset_count, deleted_instance_count)
+    log.info("Total elapsed time: %f", stop - start)
     log.info("##########################################")
 
 
@@ -371,10 +371,10 @@ def purge_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_re
         except Exception:
             pass
     stop = time.time()
-    log.info('Purged %d datasets' % dataset_count)
+    log.info('Purged %d datasets', dataset_count)
     if remove_from_disk:
-        log.info('Freed disk space: ', disk_space)
-    log.info("Elapsed time: ", stop - start)
+        log.info("Freed disk space: %d", disk_space)
+    log.info("Elapsed time: %f", stop - start)
     log.info("##########################################")
 
 
@@ -382,24 +382,24 @@ def _purge_dataset_instance(dataset_instance, app, remove_from_disk, info_only=F
     # A dataset_instance is either a HDA or an LDDA.  Purging a dataset instance marks the instance as deleted,
     # and marks the associated dataset as deleted if it is not associated with another active DatsetInstance.
     if not info_only:
-        log.info("Marking as deleted: %s id %d (for dataset id %d)" %
-              (dataset_instance.__class__.__name__, dataset_instance.id, dataset_instance.dataset.id))
+        log.info("Marking as deleted: %s id %d (for dataset id %d)",
+              dataset_instance.__class__.__name__, dataset_instance.id, dataset_instance.dataset.id)
         dataset_instance.mark_deleted()
         dataset_instance.clear_associated_files()
         app.sa_session.add(dataset_instance)
         app.sa_session.flush()
         app.sa_session.refresh(dataset_instance.dataset)
     else:
-        log.info("%s id %d (for dataset id %d) will be marked as deleted (without 'info_only' mode)" %
-              (dataset_instance.__class__.__name__, dataset_instance.id, dataset_instance.dataset.id))
+        log.info("%s id %d (for dataset id %d) will be marked as deleted (without 'info_only' mode)",
+              dataset_instance.__class__.__name__, dataset_instance.id, dataset_instance.dataset.id)
     if is_deletable or _dataset_is_deletable(dataset_instance.dataset):
         # Calling methods may have already checked _dataset_is_deletable, if so, is_deletable should be True
         _delete_dataset(dataset_instance.dataset, app, remove_from_disk, info_only=info_only, is_deletable=is_deletable)
     else:
         if info_only:
-            log.info("Not deleting dataset ", dataset_instance.dataset.id, " (will be possibly deleted without 'info_only' mode)")
+            log.info("Not deleting dataset %d, (will be possibly deleted without 'info_only' mode)", dataset_instance.dataset.id)
         else:
-            log.info("Not deleting dataset %d (shared between multiple histories/libraries, at least one not deleted)" % dataset_instance.dataset.id)
+            log.info("Not deleting dataset %d (shared between multiple histories/libraries, at least one not deleted)", dataset_instance.dataset.id)
 
 
 def _dataset_is_deletable(dataset):
@@ -411,7 +411,7 @@ def _delete_dataset(dataset, app, remove_from_disk, info_only=False, is_deletabl
     # Marks a base dataset as deleted, hdas/lddas associated with dataset can no longer be undeleted.
     # Metadata files attached to associated dataset Instances is removed now.
     if not is_deletable and not _dataset_is_deletable(dataset):
-        log.info("This Dataset (%i) is not deletable, associated Metadata Files will not be removed.\n" % (dataset.id))
+        log.info("This Dataset (%d) is not deletable, associated Metadata Files will not be removed.\n", dataset.id)
     else:
         # Mark all associated MetadataFiles as deleted and purged and remove them from disk
         metadata_files = []
@@ -429,29 +429,29 @@ def _delete_dataset(dataset, app, remove_from_disk, info_only=False, is_deletabl
             if remove_from_disk:
                 op_description = op_description + " and purged from disk"
             if info_only:
-                log.info("The following metadata files attached to associations of Dataset '%s' will be %s (without 'info_only' mode):" % (dataset.id, op_description))
+                log.info("The following metadata files attached to associations of Dataset '%d' will be %s (without 'info_only' mode):", dataset.id, op_description)
             else:
-                log.info("The following metadata files attached to associations of Dataset '%s' have been %s:" % (dataset.id, op_description))
+                log.info("The following metadata files attached to associations of Dataset '%d' have been %s:", dataset.id, op_description)
                 if remove_from_disk:
                     try:
-                        log.info("Removing disk file ", metadata_file.file_name)
+                        log.info("Removing disk file %s", metadata_file.file_name)
                         os.unlink(metadata_file.file_name)
                     except Exception as e:
-                        log.info("Error, exception: %s caught attempting to purge metadata file %s\n" % (str(e), metadata_file.file_name))
+                        log.info("Error, exception: %s caught attempting to purge metadata file %s\n", unicodify(e), metadata_file.file_name)
                     metadata_file.purged = True
                     app.sa_session.add(metadata_file)
                     app.sa_session.flush()
                 metadata_file.deleted = True
                 app.sa_session.add(metadata_file)
                 app.sa_session.flush()
-            log.info("%s" % metadata_file.file_name)
+            log.info(metadata_file.file_name)
         if not info_only:
-            log.info("Deleting dataset id", dataset.id)
+            log.info("Deleting dataset id %d", dataset.id)
             dataset.deleted = True
             app.sa_session.add(dataset)
             app.sa_session.flush()
         else:
-            log.info("Dataset %i will be deleted (without 'info_only' mode)" % (dataset.id))
+            log.info("Dataset %d will be deleted (without 'info_only' mode)", dataset.id)
 
 
 def _purge_dataset(app, dataset, remove_from_disk, info_only=False):
@@ -462,7 +462,7 @@ def _purge_dataset(app, dataset, remove_from_disk, info_only=False):
                     # Remove files from disk and update the database
                     if remove_from_disk:
                         # TODO: should permissions on the dataset be deleted here?
-                        log.info("Removing disk, file ", dataset.file_name)
+                        log.info("Removing disk, file %s", dataset.file_name)
                         os.unlink(dataset.file_name)
                         # Remove associated extra files from disk if they exist
                         if dataset.extra_files_path and os.path.exists(dataset.extra_files_path):
@@ -476,32 +476,32 @@ def _purge_dataset(app, dataset, remove_from_disk, info_only=False):
                         for user in usage_users:
                             user.adjust_total_disk_usage(-dataset.get_total_size())
                             app.sa_session.add(user)
-                    log.info("Purging dataset id", dataset.id)
+                    log.info("Purging dataset id %d", dataset.id)
                     dataset.purged = True
                     app.sa_session.add(dataset)
                     app.sa_session.flush()
                 else:
-                    log.info("Dataset %i will be purged (without 'info_only' mode)" % (dataset.id))
+                    log.info("Dataset %d will be purged (without 'info_only' mode)", dataset.id)
             else:
-                log.info("This dataset (%i) is not purgable, the file (%s) will not be removed.\n" % (dataset.id, dataset.file_name))
+                log.info("This dataset (%d) is not purgable, the file (%s) will not be removed.\n", dataset.id, dataset.file_name)
         except OSError as exc:
-            log.error("Error, dataset file has already been removed: %s" % str(exc))
-            log.error("Purging dataset id", dataset.id)
+            log.error("Error, dataset file has already been removed: %s", unicodify(exc))
+            log.error("Purging dataset id %d", dataset.id)
             dataset.purged = True
             app.sa_session.add(dataset)
             app.sa_session.flush()
         except ObjectNotFound:
-            log.error("Dataset %i cannot be found in the object store" % dataset.id)
+            log.error("Dataset %d cannot be found in the object store", dataset.id)
         except Exception as exc:
-            log.error("Error attempting to purge data file: ", dataset.file_name, " error: ", str(exc))
+            log.error("Error attempting to purge data file: %s error: %s", dataset.file_name, unicodify(exc))
     else:
-        log.info("Error: '%s' has not previously been deleted, so it cannot be purged\n" % dataset.file_name)
+        log.info("Error: '%s' has not previously been deleted, so it cannot be purged\n", dataset.file_name)
 
 
 def _purge_folder(folder, app, remove_from_disk, info_only=False):
     """Purges a folder and its contents, recursively"""
     for ld in folder.datasets:
-        log.info("Deleting library dataset id ", ld.id)
+        log.info("Deleting library dataset id %d", ld.id)
         ld.deleted = True
         for ldda in [ld.library_dataset_dataset_association] + ld.expired_datasets:
             _purge_dataset_instance(ldda, app, remove_from_disk, info_only=info_only)  # mark a DatasetInstance as deleted, clear associated files, and mark the Dataset as deleted if it is deletable
@@ -509,7 +509,7 @@ def _purge_folder(folder, app, remove_from_disk, info_only=False):
         _purge_folder(sub_folder, app, remove_from_disk, info_only=info_only)
     if not info_only:
         # TODO: should the folder permissions be deleted here?
-        log.info("Purging folder id ", folder.id)
+        log.info("Purging folder id %s", folder.id)
         folder.purged = True
         app.sa_session.add(folder)
         app.sa_session.flush()


### PR DESCRIPTION
Fix the following exception:
```
TypeError: not all arguments converted during string formatting
```

Also, make other log format strings more consistent: %d for numeric object IDs.

NOTE: `pgcleanup.py` has the same issue; I'll cleanup if this one is OK.