### PR TITLE
Enable secondary authorization

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -254,8 +254,9 @@ class AuthnzManager(object):
             if success is False:
                 return False, message, (None, None)
             return True, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
-        except Exception:
-            msg = 'An error occurred when handling callback from `{}` identity provider'.format(provider)
+        except Exception as e:
+            msg = 'The following error occurred when handling callback from `{}` identity provider: ' \
+                  '{}'.format(provider, e.message)
             log.exception(msg)
             return False, msg, (None, None)
 

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -1,3 +1,5 @@
+import json
+import requests
 import six
 from social_core.actions import do_auth, do_complete, do_disconnect
 from social_core.backends.utils import get_backend
@@ -48,6 +50,8 @@ AUTH_PIPELINE = (
     # Checks if the decoded response contains all the required fields such
     # as an ID token or a refresh token.
     'galaxy.authnz.psa_authnz.contains_required_data',
+
+    'galaxy.authnz.psa_authnz.verify',
 
     # Checks if the current social-account is already associated in the site.
     'social_core.pipeline.social_auth.social_user',
@@ -107,6 +111,11 @@ class PSAAuthnz(IdentityProvider):
         if provider in BACKENDS_NAME:
             self._setup_idp(oidc_backend_config)
 
+        # Secondary AuthZ with Google identities is currently supported
+        if provider is not "google":
+            del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
+            del self.config["SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT"]
+
     def _setup_idp(self, oidc_backend_config):
         self.config[setting_name('AUTH_EXTRA_ARGUMENTS')] = {'access_type': 'offline'}
         self.config['KEY'] = oidc_backend_config.get('client_id')
@@ -134,6 +143,10 @@ class PSAAuthnz(IdentityProvider):
         on_the_fly_config(trans.sa_session)
         strategy = Strategy(trans.request, trans.session, Storage, self.config)
         backend = self._load_backend(strategy, self.config['redirect_uri'])
+        if backend.name is BACKENDS_NAME["google"] and \
+                "SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER" in self.config and \
+                "SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT" in self.config:
+            backend.DEFAULT_SCOPE.append("https://www.googleapis.com/auth/cloud-platform")
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):
@@ -314,6 +327,39 @@ def contains_required_data(response=None, is_new=False, **kwargs):
         # The solution is to revoke the consent by visiting the identity provider's
         # website, and then retry the login process.
         raise MalformedContents(err_msg="Missing refresh token. {}".format(hint_msg))
+
+
+def verify(strategy=None, response=None, details=None, **kwargs):
+    provider = strategy.config.get("SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER")
+    endpoint = strategy.config.get("SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT")
+    if provider is None or endpoint is None:
+        # Either the secondary authorization is not configured or OIDC IdP
+        # is not compatible, so allow user login.
+        return
+
+    if provider.lower() == "gcp":
+        result = requests.post(
+            "https://iam.googleapis.com/v1/projects/-/serviceAccounts/{}:getIamPolicy".format(endpoint),
+            headers={
+                'Authorization': 'Bearer {}'.format(response.get("access_token")),
+                'Accept': 'application/json'})
+        res = json.loads(result.content)
+        if result.status_code == requests.codes.ok:
+            email_addresses = res["bindings"][0]["members"]
+            email_addresses = [x.lower().replace("user:", "").strip() for x in email_addresses]
+            if details.get("email") in email_addresses:
+                # Secondary authorization successful, so allow user login.
+                pass
+            else:
+                raise Exception("Not authorized by GCP IAM.")
+        else:
+            # The message of the raised exception is shown to the user; hence,
+            # the following way of handling exception is better than using
+            # result.raise_for_status(), since raise_for_status may report
+            # sensitive information that should not be exposed to users.
+            raise Exception(res["error"]["message"])
+    else:
+        raise Exception("`{}` is an unsupported secondary authorization provider, contact admin.".format(provider))
 
 
 def allowed_to_disconnect(name=None, user=None, user_storage=None, strategy=None,

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -1,4 +1,5 @@
 import json
+
 import requests
 import six
 from social_core.actions import do_auth, do_complete, do_disconnect
@@ -112,7 +113,7 @@ class PSAAuthnz(IdentityProvider):
             self._setup_idp(oidc_backend_config)
 
         # Secondary AuthZ with Google identities is currently supported
-        if provider is not "google":
+        if provider != "google":
             del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
             del self.config["SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT"]
 

--- a/lib/galaxy/config/sample/oidc_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_config.xml.sample
@@ -18,4 +18,10 @@ Note that the values of these attributes are case-sensitive.
     <!-- The unit of value is seconds -->
     <Setter Property="ID_TOKEN_MAX_AGE" Value="3600" Type="float"/>
     <!-- The unit of value is seconds -->
+
+    <!--  -->
+    <!--
+    <Setter Property="SECONDARY_AUTH_PROVIDER" Value="..." Type="str" />
+    <Setter Property="SECONDARY_AUTH_ENDPOINT" Value="..." Type="str" />
+    -->
 </OIDC>

--- a/lib/galaxy/config/sample/oidc_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_config.xml.sample
@@ -19,7 +19,7 @@ Note that the values of these attributes are case-sensitive.
     <Setter Property="ID_TOKEN_MAX_AGE" Value="3600" Type="float"/>
     <!-- The unit of value is seconds -->
 
-    <!--  -->
+    <!-- If configured, sets secondary authorization provider and endpoint. -->
     <!--
     <Setter Property="SECONDARY_AUTH_PROVIDER" Value="..." Type="str" />
     <Setter Property="SECONDARY_AUTH_ENDPOINT" Value="..." Type="str" />


### PR DESCRIPTION
adds option to authz users against external authz providers, e.g., gcp. 