### PR TITLE
Implement extended job metadata collection

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -39,6 +39,7 @@ from galaxy.jobs.actions.post import ActionBox
 from galaxy.jobs.mapper import JobMappingException, JobRunnerMapper
 from galaxy.jobs.runners import BaseJobRunner, JobState
 from galaxy.metadata import get_metadata_compute_strategy
+from galaxy.model import store
 from galaxy.objectstore import ObjectStorePopulator
 from galaxy.tool_util.deps import requirements
 from galaxy.tool_util.output_checker import check_output, DETECTED_JOB_STATE
@@ -886,7 +887,10 @@ class JobWrapper(HasResourceParameters):
         self.output_hdas_and_paths = None
         self.tool_provided_job_metadata = None
         # Wrapper holding the info required to restore and clean up from files used for setting metadata externally
-        self.external_output_metadata = get_metadata_compute_strategy(self.app.config, job.id)
+        metadata_strategy_override = None
+        if job.tasks:
+            metadata_strategy_override = "directory"
+        self.external_output_metadata = get_metadata_compute_strategy(self.app.config, job.id, metadata_strategy_override=metadata_strategy_override)
         self.job_runner_mapper = JobRunnerMapper(self, queue.dispatcher.url_to_destination, self.app.job_config)
         self.params = None
         if job.params:
@@ -1562,6 +1566,8 @@ class JobWrapper(HasResourceParameters):
             # the tasks failed. So include the stderr, stdout, and exit code:
             return fail()
 
+        extended_metadata = self.external_output_metadata.extended
+
         # We collect the stderr from tools that write their stderr to galaxy.json
         tool_provided_metadata = self.get_tool_provided_job_metadata()
 
@@ -1608,15 +1614,35 @@ class JobWrapper(HasResourceParameters):
                         return self.fail("Job %s's output dataset(s) could not be read" % job.id)
 
         job_context = ExpressionContext(dict(stdout=job.stdout, stderr=job.stderr))
-        for dataset_assoc in job.output_datasets + job.output_library_datasets:
+        output_dataset_associations = job.output_datasets + job.output_library_datasets
+        if extended_metadata:
+            try:
+                import_options = store.ImportOptions(allow_dataset_object_edit=True, allow_edit=True)
+                import_model_store = store.get_import_model_store_for_directory(os.path.join(self.working_directory, 'metadata', 'outputs_populated'), app=self.app, import_options=import_options)
+                import_model_store.perform_import(history=job.history)
+            except Exception:
+                log.exception("problem importing job outputs. stdout [%s] stderr [%s]" % (job.stdout, job.stderr))
+                raise
+        for dataset_assoc in output_dataset_associations:
             context = self.get_dataset_finish_context(job_context, dataset_assoc)
             # should this also be checking library associations? - can a library item be added from a history before the job has ended? -
             # lets not allow this to occur
             # need to update all associated output hdas, i.e. history was shared with job running
             for dataset in dataset_assoc.dataset.dataset.history_associations + dataset_assoc.dataset.dataset.library_associations:
-                self._finish_dataset(
-                    dataset_assoc.name, dataset, job, context, final_job_state, remote_metadata_directory
-                )
+                output_name = dataset_assoc.name
+                standard_job_finish = not extended_metadata
+                if extended_metadata:
+                    if job.states.ERROR == final_job_state:
+                        dataset.blurb = "error"
+                        dataset.mark_unhidden()
+
+                if standard_job_finish:
+                    # Handles retry internally on error for instance...
+                    self._finish_dataset(
+                        output_name, dataset, job, context, final_job_state, remote_metadata_directory
+                    )
+
+        for dataset_assoc in output_dataset_associations:
             if job.states.ERROR == final_job_state:
                 log.debug("(%s) setting dataset %s state to ERROR", job.id, dataset_assoc.dataset.dataset.id)
                 # TODO: This is where the state is being set to error. Change it!
@@ -1626,13 +1652,14 @@ class JobWrapper(HasResourceParameters):
                     self.pause(dep_job_assoc.job, "Execution of this dataset's job is paused because its input datasets are in an error state.")
             else:
                 dataset_assoc.dataset.dataset.state = model.Dataset.states.OK
-            # If any of the rest of the finish method below raises an
-            # exception, the fail method will run and set the datasets to
-            # ERROR.  The user will never see that the datasets are in error if
-            # they were flushed as OK here, since upon doing so, the history
-            # panel stops checking for updates.  So allow the
-            # self.sa_session.flush() at the bottom of this method set
-            # the state instead.
+
+        # If any of the rest of the finish method below raises an
+        # exception, the fail method will run and set the datasets to
+        # ERROR.  The user will never see that the datasets are in error if
+        # they were flushed as OK here, since upon doing so, the history
+        # panel stops checking for updates.  So allow the
+        # self.sa_session.flush() at the bottom of this method set
+        # the state instead.
 
         for pja in job.post_job_actions:
             ActionBox.execute(self.app, self.sa_session, pja.post_job_action, job)
@@ -1647,7 +1674,11 @@ class JobWrapper(HasResourceParameters):
             job.exit_code = tool_exit_code
         # custom post process setup
         inp_data, out_data, out_collections = job.io_dicts()
-        self.discover_outputs(job, inp_data, out_data, out_collections)
+        if not extended_metadata:
+            # importing metadata will discover outputs if extended metadata
+            # is enabled.
+            self.discover_outputs(job, inp_data, out_data, out_collections)
+
         # Certain tools require tasks to be completed after job execution
         # ( this used to be performed in the "exec_after_process" hook, but hooks are deprecated ).
         param_dict = self.get_param_dict(job)
@@ -1998,13 +2029,11 @@ class JobWrapper(HasResourceParameters):
             safe_makedirs(os.path.join(self.working_directory, 'metadata'))
             self.app.datatypes_registry.to_xml_file(path=datatypes_config)
 
-        output_datasets = {}
-        for output_dataset_assoc in job.output_datasets + job.output_library_datasets:
-            output_name = output_dataset_assoc.name
-            assert output_name not in output_datasets
-            output_datasets[output_dataset_assoc.name] = output_dataset_assoc.dataset
-
-        command = self.external_output_metadata.setup_external_metadata(output_datasets,
+        inp_data, out_data, out_collections = job.io_dicts()
+        job_metadata = os.path.join(self.tool_working_directory, self.tool.provided_metadata_file)
+        object_store_conf = self.object_store.to_dict()
+        command = self.external_output_metadata.setup_external_metadata(out_data,
+                                                                        out_collections,
                                                                         self.sa_session,
                                                                         exec_dir=exec_dir,
                                                                         tmp_dir=tmp_dir,
@@ -2012,7 +2041,10 @@ class JobWrapper(HasResourceParameters):
                                                                         config_root=config_root,
                                                                         config_file=config_file,
                                                                         datatypes_config=datatypes_config,
-                                                                        job_metadata=os.path.join(self.tool_working_directory, self.tool.provided_metadata_file),
+                                                                        job_metadata=job_metadata,
+                                                                        object_store_conf=object_store_conf,
+                                                                        tool=self.tool,
+                                                                        job=job,
                                                                         max_metadata_value_size=self.app.config.max_metadata_value_size,
                                                                         validate_outputs=self.validate_outputs,
                                                                         **kwds)

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -20,6 +20,7 @@ from six.moves import cPickle
 from sqlalchemy.orm import clear_mappers
 
 import galaxy.model.mapping  # need to load this before we unpickle, in order to setup properties assigned by the mappers
+from galaxy.model import store
 from galaxy.model.custom_types import total_size
 from galaxy.tool_util.provided_metadata import parse_tool_provided_metadata
 from galaxy.util import (
@@ -106,8 +107,83 @@ def set_metadata_portable():
     def set_meta(new_dataset_instance, file_dict):
         set_meta_with_tool_provided(new_dataset_instance, file_dict, set_meta_kwds, datatypes_registry, max_metadata_value_size)
 
+    object_store_conf_path = os.path.join("metadata", "object_store_conf.json")
+    extended_metadata_collection = os.path.exists(object_store_conf_path)
+
+    object_store = None
+    job_context = None
+    version_string = ""
+
+    export_store = None
+    if extended_metadata_collection:
+        from galaxy.tool_util.parser.stdio import ToolStdioRegex, ToolStdioExitCode
+        tool_dict = metadata_params["tool"]
+        stdio_exit_code_dicts, stdio_regex_dicts = tool_dict["stdio_exit_codes"], tool_dict["stdio_regexes"]
+        stdio_exit_codes = list(map(ToolStdioExitCode, stdio_exit_code_dicts))
+        stdio_regexes = list(map(ToolStdioRegex, stdio_regex_dicts))
+
+        with open(object_store_conf_path, "r") as f:
+            config_dict = json.load(f)
+        from galaxy.objectstore import build_object_store_from_config
+        assert config_dict is not None
+        object_store = build_object_store_from_config(None, config_dict=config_dict)
+        galaxy.model.Dataset.object_store = object_store
+
+        outputs_directory = os.path.join(tool_job_working_directory, "outputs")
+        if not os.path.exists(outputs_directory):
+            outputs_directory = tool_job_working_directory
+
+        # TODO: constants...
+        if os.path.exists(os.path.join(outputs_directory, "tool_stdout")):
+            with open(os.path.join(outputs_directory, "tool_stdout"), "rb") as f:
+                tool_stdout = f.read()
+
+            with open(os.path.join(outputs_directory, "tool_stderr"), "rb") as f:
+                tool_stderr = f.read()
+        elif os.path.exists(os.path.join(outputs_directory, "stdout")):
+            # Puslar style working directory.
+            with open(os.path.join(outputs_directory, "stdout"), "rb") as f:
+                tool_stdout = f.read()
+
+            with open(os.path.join(outputs_directory, "stderr"), "rb") as f:
+                tool_stderr = f.read()
+
+        job_id_tag = metadata_params["job_id_tag"]
+
+        # TODO: this clearly needs to be refactored, nothing in runners should be imported here..
+        from galaxy.job_execution.output_collect import default_exit_code_file, read_exit_code_from
+        exit_code_file = default_exit_code_file(".", job_id_tag)
+        tool_exit_code = read_exit_code_from(exit_code_file, job_id_tag)
+
+        from galaxy.tool_util.output_checker import check_output, DETECTED_JOB_STATE
+        check_output_detected_state, tool_stdout, tool_stderr, job_messages = check_output(stdio_regexes, stdio_exit_codes, tool_stdout, tool_stderr, tool_exit_code, job_id_tag)
+        if check_output_detected_state == DETECTED_JOB_STATE.OK and not tool_provided_metadata.has_failed_outputs():
+            final_job_state = galaxy.model.Job.states.OK
+        else:
+            final_job_state = galaxy.model.Job.states.ERROR
+
+        from pulsar.client.staging import COMMAND_VERSION_FILENAME
+        version_string = ""
+        if os.path.exists(COMMAND_VERSION_FILENAME):
+            version_string = open(COMMAND_VERSION_FILENAME).read()
+
+        # TODO: handle outputs_to_working_directory?
+        from galaxy.util.expressions import ExpressionContext
+        job_context = ExpressionContext(dict(stdout=tool_stdout, stderr=tool_stderr))
+
+        # Load outputs.
+        import_model_store = store.imported_store_for_metadata('metadata/outputs_new', object_store=object_store)
+        export_store = store.DirectoryModelExportStore('metadata/outputs_populated', serialize_dataset_objects=True, for_edit=True)
+
     for output_name, output_dict in outputs.items():
-        filename_in = os.path.join("metadata/metadata_in_%s" % output_name)
+        if extended_metadata_collection:
+            dataset_instance_id = output_dict["id"]
+            dataset = import_model_store.sa_session.query(galaxy.model.HistoryDatasetAssociation).find(dataset_instance_id)
+            assert dataset is not None
+        else:
+            filename_in = os.path.join("metadata/metadata_in_%s" % output_name)
+            dataset = cPickle.load(open(filename_in, 'rb'))  # load DatasetInstance
+
         filename_kwds = os.path.join("metadata/metadata_kwds_%s" % output_name)
         filename_out = os.path.join("metadata/metadata_out_%s" % output_name)
         filename_results_code = os.path.join("metadata/metadata_results_%s" % output_name)
@@ -117,7 +193,6 @@ def set_metadata_portable():
         # Same block as below...
         set_meta_kwds = stringify_dictionary_keys(json.load(open(filename_kwds)))  # load kwds; need to ensure our keywords are not unicode
         try:
-            dataset = cPickle.load(open(filename_in, 'rb'))  # load DatasetInstance
             dataset.dataset.external_filename = dataset_filename_override
             store_by = metadata_params.get("object_store_store_by", "id")
             extra_files_dir_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
@@ -135,11 +210,93 @@ def set_metadata_portable():
             if output_dict.get("validate", False):
                 set_validated_state(dataset)
             set_meta(dataset, file_dict)
-            dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
+
+            if extended_metadata_collection:
+                meta = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id)
+                if meta:
+                    context = ExpressionContext(meta, job_context)
+                else:
+                    context = job_context
+
+                # Lazy and unattached
+                # if getattr(dataset, "hidden_beneath_collection_instance", None):
+                #    dataset.visible = False
+                dataset.blurb = 'done'
+                dataset.peek = 'no peek'
+                dataset.info = (dataset.info or '')
+                if context['stdout'].strip():
+                    # Ensure white space between entries
+                    dataset.info = dataset.info.rstrip() + "\n" + context['stdout'].strip()
+                if context['stderr'].strip():
+                    # Ensure white space between entries
+                    dataset.info = dataset.info.rstrip() + "\n" + context['stderr'].strip()
+                dataset.tool_version = version_string
+                dataset.set_size()
+                if 'uuid' in context:
+                    dataset.dataset.uuid = context['uuid']
+                object_store.update_from_file(dataset.dataset, create=True)
+                from galaxy.job_execution.output_collect import collect_extra_files
+                collect_extra_files(object_store, dataset, ".")
+                if galaxy.model.Job.states.ERROR == final_job_state:
+                    dataset.blurb = "error"
+                    dataset.mark_unhidden()
+                else:
+                    # If the tool was expected to set the extension, attempt to retrieve it
+                    if dataset.ext == 'auto':
+                        dataset.extension = context.get('ext', 'data')
+                        dataset.init_meta(copy_from=dataset)
+
+                    # This has already been done:
+                    # else:
+                    #     self.external_output_metadata.load_metadata(dataset, output_name, self.sa_session, working_directory=self.working_directory, remote_metadata_directory=remote_metadata_directory)
+                    line_count = context.get('line_count', None)
+                    try:
+                        # Certain datatype's set_peek methods contain a line_count argument
+                        dataset.set_peek(line_count=line_count)
+                    except TypeError:
+                        # ... and others don't
+                        dataset.set_peek()
+
+                from galaxy.jobs import TOOL_PROVIDED_JOB_METADATA_KEYS
+                for context_key in TOOL_PROVIDED_JOB_METADATA_KEYS:
+                    if context_key in context:
+                        context_value = context[context_key]
+                        setattr(dataset, context_key, context_value)
+
+                if extended_metadata_collection:
+                    export_store.add_dataset(dataset)
+                else:
+                    cPickle.dump(dataset, open(filename_out, 'wb+'))
+            else:
+                dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
+
             json.dump((True, 'Metadata has been set successfully'), open(filename_results_code, 'wt+'))  # setting metadata has succeeded
         except Exception:
             json.dump((False, traceback.format_exc()), open(filename_results_code, 'wt+'))  # setting metadata has failed somehow
 
+    if extended_metadata_collection:
+        # discover extra outputs...
+        from galaxy.job_execution.output_collect import collect_dynamic_outputs, collect_primary_datasets, SessionlessJobContext
+
+        job_context = SessionlessJobContext(metadata_params, tool_provided_metadata, object_store, export_store, import_model_store, os.path.join(tool_job_working_directory, "working"))
+
+        output_collections = {}
+        for name, output_collection in metadata_params["output_collections"].items():
+            output_collections[name] = import_model_store.sa_session.query(galaxy.model.HistoryDatasetCollectionAssociation).find(output_collection["id"])
+        outputs = {}
+        for name, output in metadata_params["outputs"].items():
+            outputs[name] = import_model_store.sa_session.query(galaxy.model.HistoryDatasetAssociation).find(output["id"])
+
+        input_ext = json.loads(metadata_params["job_params"].get("__input_ext", '"data"'))
+        collect_primary_datasets(
+            job_context,
+            outputs,
+            input_ext=input_ext,
+        )
+        collect_dynamic_outputs(job_context, output_collections)
+
+    if export_store:
+        export_store._finalize()
     write_job_metadata(tool_job_working_directory, job_metadata, set_meta, tool_provided_metadata)
 
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1400,3 +1400,10 @@ def get_export_dataset_filename(name, ext, hid):
     """
     base = ''.join(c in FILENAME_VALID_CHARS and c or '_' for c in name)
     return base + "_%s.%s" % (hid, ext)
+
+
+def imported_store_for_metadata(directory, object_store=None):
+    import_options = ImportOptions(allow_dataset_object_edit=True, allow_edit=True)
+    import_model_store = get_import_model_store_for_directory(directory, import_options=import_options, object_store=object_store)
+    import_model_store.perform_import()
+    return import_model_store

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -320,7 +320,8 @@ class UnusedPermissionProvider(PermissionProvider):
         This should only be called as part of job output collection where
         there should be a session available to initialize this from.
         """
-        raise NotImplementedError()
+        # TODO: what should this do in the sessionless context?
+        return
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -368,6 +369,15 @@ class SessionlessModelPersistenceContext(ModelPersistenceContext):
         library_folder.datasets.append(ld)
         ld.order_id = library_folder.item_count
         library_folder.item_count += 1
+
+    def get_library_folder(self, destination):
+        raise NotImplementedError()
+
+    def get_hdca(self, object_id):
+        raise NotImplementedError()
+
+    def create_hdca(name, structure):
+        raise NotImplementedError()
 
     def create_library_folder(self, parent_folder, name, description):
         nested_folder = galaxy.model.LibraryFolder(name=name, description=description, order_id=parent_folder.item_count)

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -90,6 +90,7 @@ class SetMetadataToolAction(ToolAction):
         }
         validate_outputs = asbool(incoming.get("validate", False))
         cmd_line = external_metadata_wrapper.setup_external_metadata(output_datatasets_dict,
+                                                                     {},
                                                                      sa_session,
                                                                      exec_dir=None,
                                                                      tmp_dir=job_working_dir,

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -1,0 +1,52 @@
+"""Integration tests for the Pulsar embedded runner."""
+
+from base import integration_util
+
+TEST_TOOL_IDS = [
+    "multi_output",
+    "multi_output_configured",
+    # "multi_output_assign_primary",
+    "multi_output_recurse",
+    "tool_provided_metadata_1",
+    "tool_provided_metadata_2",
+    "tool_provided_metadata_3",
+    # "tool_provided_metadata_4",
+    "tool_provided_metadata_5",
+    "tool_provided_metadata_6",
+    "tool_provided_metadata_7",
+    "tool_provided_metadata_8",
+    # "tool_provided_metadata_9",
+    "tool_provided_metadata_10",
+    "tool_provided_metadata_11",
+    "tool_provided_metadata_12",
+    "composite_output",
+    "composite_output_tests",
+    "metadata",
+    "metadata_bam",
+    "output_format",
+    "output_auto_format",
+    "collection_paired_test",
+    "collection_paired_structured_like",
+    "collection_nested_test",
+    "collection_creates_list",
+    "collection_creates_dynamic_nested",
+    "collection_creates_dynamic_nested_from_json",
+    "collection_creates_dynamic_nested_from_json_elements",
+]
+
+
+class ExtendedMetadataIntegrationInstance(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with embedded pulsar configured."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["metadata_strategy"] = "extended"
+        config["object_store_store_by"] = "uuid"
+        config["retry_metadata_internally"] = False
+
+
+instance = integration_util.integration_module_instance(ExtendedMetadataIntegrationInstance)
+
+test_tools = integration_util.integration_tool_runner(TEST_TOOL_IDS)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -128,6 +128,9 @@ class MockAppConfig(Bunch):
         self.object_store_config_file = ''
         self.object_store = 'disk'
         self.object_store_check_old_style = False
+        self.object_store_cache_path = '/tmp/cache'
+        self.umask = os.umask(0o77)
+        self.gid = os.getgid()
 
         self.user_activation_on = False
         self.new_user_dataset_access_role_default_private = False


### PR DESCRIPTION
In traditional Galaxy job metadata collection, set_meta results in JSON serialized ``hda.metadata`` attributes for the declared outputs. With extended metadata - a "model store" containing full serialized model objects (including but not limited to their ``metadata`` attributes) for all outputs (declared and discovered datasets as well as collections) is produced. In theory, this model store is all the job needs to communicate back to the Galaxy process in order to get it merged with Galaxy's database and the job complete.

This modality is enabled by:
- Setting the object store to store objects by ``uuid`` (setting ``object_store_store_by`` implemented in https://github.com/galaxyproject/galaxy/pull/7154). This is needed to write 
- Setting ``metadata_strategy`` to ``extended`` (``metadata_strategy`` config option implemented for this work in https://github.com/galaxyproject/galaxy/pull/7470).

In this variant of metadata collection - set_metadata does significantly more work:
 - Loads a JSON serialized description of the object store (serialization implemented in https://github.com/galaxyproject/galaxy/pull/7110 and https://github.com/galaxyproject/galaxy/pull/7085).
 - The job itself decides if the tool failed using https://github.com/galaxyproject/galaxy/pull/7083.
 - Input dbkey and input file extension needed for output discovery and handling are loaded from the job description - using https://github.com/galaxyproject/galaxy/pull/8910.
 - Outputs are written to loaded object store.
 - "Dynamic output discovery" (e.g. discovered datasets ``<discover_datasets>``, unpopulated collections, etc..) happens as part of the job and outputs are written to the object store. Leveraging dozens of refactorings including https://github.com/galaxyproject/galaxy/pull/7471, https://github.com/galaxyproject/galaxy/pull/7595, and  https://github.com/galaxyproject/galaxy/pull/7541.
 - Tool provided metadata is collected and applied to output (hda and hdca) models.

This approach is likely slower for a single job on a single machine - there is more overhead associated with the plumbing of Galaxy jobs - more "work" happens, more has to be serialized, etc.. However, for many jobs over a cluster this massively decentralizes the work that needed to be done by the job handlers. Using Pulsar - currently all job completion tasks are still done by the job handler and outputs need to be streamed back from each worker to the Galaxy server for jobs to be properly complete. The amount of this data is unbounded per job and the number of jobs are as well but one can easily imagine it being hundreds of gigs per job and hundreds of jobs per hour for large analyses. Having to transfer this amount of data to the Galaxy server and then from the Galaxy server to centralized storage is a tremendous amount of overhead and creates a huge bottleneck on the job handling servers/pods/etc..

Pairing this approach with Pulsar - presumably at most a few megabytes per job need to be transferred back to the Galaxy server and Galaxy does not need to read or write to the object store to finalize jobs. This largely eliminates job handlers as a bottleneck and eliminates that hugely wasteful double transfer of output files to their final destination. This is necessary for Galaxy to properly exploit distributed file systems and distributed compute.
