### PR TITLE
Refactor some workflow editor plumbing to VueJS

### DIFF
--- a/client/galaxy/scripts/bundleEntries.js
+++ b/client/galaxy/scripts/bundleEntries.js
@@ -10,7 +10,6 @@
 import $ from "jquery";
 import "bootstrap";
 export { getGalaxyInstance, setGalaxyInstance } from "app";
-import WorkflowView from "mvc/workflow/workflow-view";
 import { TracksterUIView } from "viz/trackster";
 export { TracksterUI } from "viz/trackster";
 import Circster from "viz/circster";
@@ -41,10 +40,6 @@ export function trackster(options) {
 
 export function circster(options) {
     new Circster.GalaxyApp(options);
-}
-
-export function workflow(options) {
-    new WorkflowView(options);
 }
 
 export function library(options) {

--- a/client/galaxy/scripts/bundleEntries.js
+++ b/client/galaxy/scripts/bundleEntries.js
@@ -98,6 +98,7 @@ export { panelManagement } from "onload/globalInits/panelManagement";
 export { mountMakoTags } from "components/Tags";
 export { mountJobMetrics } from "components/JobMetrics";
 export { mountJobParameters } from "components/JobParameters";
+export { mountWorkflowEditor } from "components/Workflow/Editor/mount";
 
 // Used in common.mako
 export { default as store } from "storemodern";

--- a/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
+++ b/client/galaxy/scripts/components/Markdown/MarkdownEditor.vue
@@ -1,5 +1,5 @@
 <template>
-    <textarea class="markdown-textarea" id="workflow-report-editor" :value="input" @input="update"> </textarea>
+    <textarea class="markdown-textarea" id="workflow-report-editor" v-model="input" @input="update"> </textarea>
 </template>
 
 <script>
@@ -31,7 +31,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .markdown-textarea {
     border: none;
     border-right: 1px solid #ccc;
@@ -42,8 +42,6 @@ export default {
     font-size: 14px;
     font-family: "Monaco", courier, monospace;
     padding: 20px;
-
     width: 100%;
-    height: 95%; /* what now? this is needed or the editor overtakes workflow toolbar when too much text is added */
 }
 </style>

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -61,3 +61,15 @@ export default {
     }
 }
 </script>
+
+<style scoped>
+    #center {
+        z-index: 0;
+    }
+    .workflow-report-content { display: none; }
+</style>
+
+<style>
+   canvas { position: absolute; z-index: 10; }
+   canvas.dragging { position: absolute; z-index: 1000; }
+</style>

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -5,22 +5,67 @@
                 <span class="sr-only">Workflow Editor&nbsp;</span>
                 {{ editorConfig["name"] }}
                 <div class="panel-header-buttons">
-                    <a id="workflow-run-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
+                    <a
+                        id="workflow-run-button"
+                        class="panel-header-button workflow-canvas-content"
+                        href="javascript:void(0)"
+                        role="button"
+                        title="Run"
+                        style="display: inline-block;"
+                        aria-label="Run"
+                    >
                         <span class="fa fa-play"></span>
                     </a>
-                    <a id="workflow-save-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Save" style="display: inline-block;" aria-label="Save">
+                    <a
+                        id="workflow-save-button"
+                        class="panel-header-button workflow-canvas-content"
+                        href="javascript:void(0)"
+                        role="button"
+                        title="Save"
+                        style="display: inline-block;"
+                        aria-label="Save"
+                    >
                         <span class="fa fa-floppy-o"></span>
                     </a>
-                    <a id="workflow-report-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Edit Report" aria-label="Edit Report">
+                    <a
+                        id="workflow-report-button"
+                        class="panel-header-button workflow-canvas-content"
+                        href="javascript:void(0)"
+                        role="button"
+                        title="Edit Report"
+                        aria-label="Edit Report"
+                    >
                         <span class="fa fa-edit"></span>
                     </a>
-                    <a id="workflow-report-help-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Report Syntax Help" aria-label="Report Syntax Help">
+                    <a
+                        id="workflow-report-help-button"
+                        class="panel-header-button workflow-report-content"
+                        href="javascript:void(0)"
+                        role="button"
+                        title="Report Syntax Help"
+                        aria-label="Report Syntax Help"
+                    >
                         <span class="fa fa-question"></span>
                     </a>
-                    <a id="workflow-canvas-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Edit Workflow" aria-label="Edit Workflow">
+                    <a
+                        id="workflow-canvas-button"
+                        class="panel-header-button workflow-report-content"
+                        href="javascript:void(0)"
+                        role="button"
+                        title="Edit Workflow"
+                        aria-label="Edit Workflow"
+                    >
                         <span class="fa fa-sitemap fa-rotate-270"></span>
                     </a>
-                    <a id="workflow-options-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Workflow options" style="display: inline-block;" aria-label="Workflow options">
+                    <a
+                        id="workflow-options-button"
+                        class="panel-header-button workflow-canvas-content"
+                        href="javascript:void(0)"
+                        role="button"
+                        title="Workflow options"
+                        style="display: inline-block;"
+                        aria-label="Workflow options"
+                    >
                         <span class="fa fa-cog"></span>
                     </a>
                 </div>
@@ -30,21 +75,37 @@
             <div id="canvas-viewport" class="workflow-canvas-content">
                 <div id="canvas-container" style="position: absolute; width: 100%; height: 100%;"></div>
             </div>
-            <div id="report-editor-container" class="workflow-report-content" style="position: absolute; width: 100%; height: 100%; display: none">
+            <div
+                id="report-editor-container"
+                class="workflow-report-content"
+                style="position: absolute; width: 100%; height: 100%; display: none"
+            >
                 <textarea id="workflow-report-editor" style="width: 100%; height: 100%;"></textarea>
             </div>
-            <div id='workflow-parameters-box' style="display:none; position: absolute; right:0px; border: solid grey 1px; padding: 5px; background: #EEEEEE; z-index: 20000; overflow: auto; max-width: 300px; max-height: 300px;">
+            <div
+                id="workflow-parameters-box"
+                style="display:none; position: absolute; right:0px; border: solid grey 1px; padding: 5px; background: #EEEEEE; z-index: 20000; overflow: auto; max-width: 300px; max-height: 300px;"
+            >
                 <div style="margin-bottom:5px;">
                     <b>Workflow Parameters</b>
                 </div>
-                <div id="workflow-parameters-container">
-                </div>
+                <div id="workflow-parameters-container"></div>
             </div>
             <div class="workflow-overview workflow-canvas-content" aria-hidden="true">
-                <div style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;">
+                <div
+                    style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;"
+                >
                     <div id="overview" style="position: absolute;">
-                        <canvas width="0" height="0" style="background: white; width: 100%; height: 100%;" id="overview-canvas"></canvas>
-                        <div id="overview-viewport" style="position: absolute; width: 0px; height: 0px; border: solid blue 1px; z-index: 10;"></div>
+                        <canvas
+                            width="0"
+                            height="0"
+                            style="background: white; width: 100%; height: 100%;"
+                            id="overview-canvas"
+                        ></canvas>
+                        <div
+                            id="overview-viewport"
+                            style="position: absolute; width: 0px; height: 0px; border: solid blue 1px; z-index: 10;"
+                        ></div>
                     </div>
                 </div>
             </div>
@@ -53,29 +114,36 @@
 </template>
 
 <script>
-
 import WorkflowView from "mvc/workflow/workflow-view";
 
 export default {
     props: {
         editorConfig: {
-            type: Object,
+            type: Object
         }
     },
     mounted() {
         new WorkflowView(this.editorConfig);
     }
-}
+};
 </script>
 
 <style scoped>
-    #center {
-        z-index: 0;
-    }
-    .workflow-report-content { display: none; }
+#center {
+    z-index: 0;
+}
+.workflow-report-content {
+    display: none;
+}
 </style>
 
 <style>
-   canvas { position: absolute; z-index: 10; }
-   canvas.dragging { position: absolute; z-index: 1000; }
+canvas {
+    position: absolute;
+    z-index: 10;
+}
+canvas.dragging {
+    position: absolute;
+    z-index: 1000;
+}
 </style>

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -12,6 +12,7 @@
                         role="button"
                         title="Run"
                         aria-label="Run"
+                        @click="navigateToRun"
                         v-show="mode == 'canvas'"
                     >
                         <span class="fa fa-play"></span>
@@ -104,6 +105,7 @@
 <script>
 import WorkflowView from "mvc/workflow/workflow-view";
 import MarkdownEditor from "components/Markdown/MarkdownEditor";
+import { getAppRoot } from "onload/loadConfig";
 
 export default {
     components: { MarkdownEditor },
@@ -126,6 +128,9 @@ export default {
         },
         onReportUpdate(markdown) {
             this.workflowView.report_changed(markdown);
+        },
+        navigateToRun() {
+            window.location = `${getAppRoot()}workflows/run?id=${this.editorConfig.id}`;
         }
     }
 };

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -24,6 +24,7 @@
                         role="button"
                         title="Save"
                         aria-label="Save"
+                        @click="save"
                         v-show="mode == 'canvas'"
                     >
                         <span class="fa fa-floppy-o"></span>
@@ -131,6 +132,9 @@ export default {
         },
         navigateToRun() {
             window.location = `${getAppRoot()}workflows/run?id=${this.editorConfig.id}`;
+        },
+        save() {
+            this.workflowView.save_current_workflow();
         }
     }
 };

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -48,6 +48,7 @@
                         role="button"
                         title="Report Syntax Help"
                         aria-label="Report Syntax Help"
+                        @click="showReportHelp"
                         v-show="mode == 'report'"
                     >
                         <span class="fa fa-question"></span>
@@ -107,6 +108,7 @@
 import WorkflowView from "mvc/workflow/workflow-view";
 import MarkdownEditor from "components/Markdown/MarkdownEditor";
 import { getAppRoot } from "onload/loadConfig";
+import { showReportHelp } from "./reportHelp";
 
 export default {
     components: { MarkdownEditor },
@@ -135,6 +137,9 @@ export default {
         },
         save() {
             this.workflowView.save_current_workflow();
+        },
+        showReportHelp() {
+            showReportHelp();
         }
     }
 };

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -7,80 +7,81 @@
                 <div class="panel-header-buttons">
                     <a
                         id="workflow-run-button"
-                        class="panel-header-button workflow-canvas-content"
+                        class="panel-header-button"
                         href="javascript:void(0)"
                         role="button"
                         title="Run"
                         style="display: inline-block;"
                         aria-label="Run"
+                        v-show="mode == 'canvas'"
                     >
                         <span class="fa fa-play"></span>
                     </a>
                     <a
                         id="workflow-save-button"
-                        class="panel-header-button workflow-canvas-content"
+                        class="panel-header-button"
                         href="javascript:void(0)"
                         role="button"
                         title="Save"
                         style="display: inline-block;"
                         aria-label="Save"
+                        v-show="mode == 'canvas'"
                     >
                         <span class="fa fa-floppy-o"></span>
                     </a>
                     <a
                         id="workflow-report-button"
-                        class="panel-header-button workflow-canvas-content"
+                        class="panel-header-button"
                         href="javascript:void(0)"
                         role="button"
                         title="Edit Report"
                         aria-label="Edit Report"
+                        v-show="mode == 'canvas'"
+                        @click="setMode('report')"
                     >
                         <span class="fa fa-edit"></span>
                     </a>
                     <a
                         id="workflow-report-help-button"
-                        class="panel-header-button workflow-report-content"
+                        class="panel-header-button"
                         href="javascript:void(0)"
                         role="button"
                         title="Report Syntax Help"
                         aria-label="Report Syntax Help"
+                        v-show="mode == 'report'"
                     >
                         <span class="fa fa-question"></span>
                     </a>
                     <a
                         id="workflow-canvas-button"
-                        class="panel-header-button workflow-report-content"
+                        class="panel-header-button"
                         href="javascript:void(0)"
                         role="button"
                         title="Edit Workflow"
                         aria-label="Edit Workflow"
+                        @click="setMode('canvas')"
+                        v-show="mode == 'report'"
                     >
                         <span class="fa fa-sitemap fa-rotate-270"></span>
                     </a>
                     <a
                         id="workflow-options-button"
-                        class="panel-header-button workflow-canvas-content"
+                        class="panel-header-button"
                         href="javascript:void(0)"
                         role="button"
                         title="Workflow options"
                         style="display: inline-block;"
                         aria-label="Workflow options"
+                        v-show="mode == 'canvas'"
                     >
                         <span class="fa fa-cog"></span>
                     </a>
                 </div>
             </div>
         </div>
-        <div class="unified-panel-body" id="workflow-canvas-body">
+        <div class="unified-panel-body" id="workflow-canvas-body" v-show="mode == 'canvas'">
             <div id="canvas-viewport" class="workflow-canvas-content">
                 <div id="canvas-container" style="position: absolute; width: 100%; height: 100%;"></div>
-            </div>
-            <div
-                id="report-editor-container"
-                class="workflow-report-content"
-                style="position: absolute; width: 100%; height: 100%; display: none"
-            >
-                <textarea id="workflow-report-editor" style="width: 100%; height: 100%;"></textarea>
             </div>
             <div
                 id="workflow-parameters-box"
@@ -91,7 +92,7 @@
                 </div>
                 <div id="workflow-parameters-container"></div>
             </div>
-            <div class="workflow-overview workflow-canvas-content" aria-hidden="true">
+            <div class="workflow-overview" v-show="mode == 'canvas'" aria-hidden="true">
                 <div
                     style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;"
                 >
@@ -110,20 +111,38 @@
                 </div>
             </div>
         </div>
+        <div class="unified-panel-body workflow-report-body" v-show="mode == 'report'">
+            <markdown-editor ref="report-editor" initial-markdown="" :onupdate="onReportUpdate" />
+        </div>
     </div>
 </template>
 
 <script>
 import WorkflowView from "mvc/workflow/workflow-view";
+import MarkdownEditor from "components/Markdown/MarkdownEditor";
 
 export default {
+    components: { MarkdownEditor },
     props: {
         editorConfig: {
             type: Object
         }
     },
+    data() {
+        return {
+            mode: "canvas"
+        };
+    },
     mounted() {
-        new WorkflowView(this.editorConfig);
+        this.workflowView = new WorkflowView(this.editorConfig, this.$refs["report-editor"]);
+    },
+    methods: {
+        setMode(mode) {
+            this.mode = mode;
+        },
+        onReportUpdate(markdown) {
+            this.workflowView.report_changed(markdown);
+        }
     }
 };
 </script>
@@ -131,9 +150,13 @@ export default {
 <style scoped>
 #center {
     z-index: 0;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
 }
-.workflow-report-content {
-    display: none;
+
+.workflow-report-body {
+    display: flex;
 }
 </style>
 

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -1,0 +1,63 @@
+<template>
+    <div id="center" class="inbound">
+        <div class="unified-panel-header" unselectable="on">
+            <div class="unified-panel-header-inner">
+                <span class="sr-only">Workflow Editor&nbsp;</span>
+                {{ name }}
+                <div class="panel-header-buttons">
+                    <a id="workflow-run-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
+                        <span class="fa fa-play"></span>
+                    </a>
+                    <a id="workflow-save-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Save" style="display: inline-block;" aria-label="Save">
+                        <span class="fa fa-floppy-o"></span>
+                    </a>
+                    <a id="workflow-report-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Edit Report" aria-label="Edit Report">
+                        <span class="fa fa-edit"></span>
+                    </a>
+                    <a id="workflow-report-help-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Report Syntax Help" aria-label="Report Syntax Help">
+                        <span class="fa fa-question"></span>
+                    </a>
+                    <a id="workflow-canvas-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Edit Workflow" aria-label="Edit Workflow">
+                        <span class="fa fa-sitemap fa-rotate-270"></span>
+                    </a>
+                    <a id="workflow-options-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Workflow options" style="display: inline-block;" aria-label="Workflow options">
+                        <span class="fa fa-cog"></span>
+                    </a>
+                </div>
+            </div>
+        </div>
+        <div class="unified-panel-body" id="workflow-canvas-body">
+            <div id="canvas-viewport" class="workflow-canvas-content">
+                <div id="canvas-container" style="position: absolute; width: 100%; height: 100%;"></div>
+            </div>
+            <div id="report-editor-container" class="workflow-report-content" style="position: absolute; width: 100%; height: 100%; display: none">
+                <textarea id="workflow-report-editor" style="width: 100%; height: 100%;"></textarea>
+            </div>
+            <div id='workflow-parameters-box' style="display:none; position: absolute; right:0px; border: solid grey 1px; padding: 5px; background: #EEEEEE; z-index: 20000; overflow: auto; max-width: 300px; max-height: 300px;">
+                <div style="margin-bottom:5px;">
+                    <b>Workflow Parameters</b>
+                </div>
+                <div id="workflow-parameters-container">
+                </div>
+            </div>
+            <div class="workflow-overview workflow-canvas-content" aria-hidden="true">
+                <div style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;">
+                    <div id="overview" style="position: absolute;">
+                        <canvas width="0" height="0" style="background: white; width: 100%; height: 100%;" id="overview-canvas"></canvas>
+                        <div id="overview-viewport" style="position: absolute; width: 0px; height: 0px; border: solid blue 1px; z-index: 10;"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        name: {
+            type: String,
+        } 
+    }
+}
+</script>

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -11,7 +11,6 @@
                         href="javascript:void(0)"
                         role="button"
                         title="Run"
-                        style="display: inline-block;"
                         aria-label="Run"
                         v-show="mode == 'canvas'"
                     >
@@ -23,7 +22,6 @@
                         href="javascript:void(0)"
                         role="button"
                         title="Save"
-                        style="display: inline-block;"
                         aria-label="Save"
                         v-show="mode == 'canvas'"
                     >
@@ -70,7 +68,6 @@
                         href="javascript:void(0)"
                         role="button"
                         title="Workflow options"
-                        style="display: inline-block;"
                         aria-label="Workflow options"
                         v-show="mode == 'canvas'"
                     >
@@ -81,32 +78,19 @@
         </div>
         <div class="unified-panel-body" id="workflow-canvas-body" v-show="mode == 'canvas'">
             <div id="canvas-viewport" class="workflow-canvas-content">
-                <div id="canvas-container" style="position: absolute; width: 100%; height: 100%;"></div>
+                <div id="canvas-container"></div>
             </div>
-            <div
-                id="workflow-parameters-box"
-                style="display:none; position: absolute; right:0px; border: solid grey 1px; padding: 5px; background: #EEEEEE; z-index: 20000; overflow: auto; max-width: 300px; max-height: 300px;"
-            >
-                <div style="margin-bottom:5px;">
-                    <b>Workflow Parameters</b>
-                </div>
+            <div id="workflow-parameters-box">
+                <span class="workflow-parameters-box-title">
+                    Workflow Parameters
+                </span>
                 <div id="workflow-parameters-container"></div>
             </div>
             <div class="workflow-overview" v-show="mode == 'canvas'" aria-hidden="true">
-                <div
-                    style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;"
-                >
-                    <div id="overview" style="position: absolute;">
-                        <canvas
-                            width="0"
-                            height="0"
-                            style="background: white; width: 100%; height: 100%;"
-                            id="overview-canvas"
-                        ></canvas>
-                        <div
-                            id="overview-viewport"
-                            style="position: absolute; width: 0px; height: 0px; border: solid blue 1px; z-index: 10;"
-                        ></div>
+                <div class="workflow-overview-body">
+                    <div id="overview">
+                        <canvas width="0" height="0" id="overview-canvas"></canvas>
+                        <div id="overview-viewport"></div>
                     </div>
                 </div>
             </div>
@@ -157,6 +141,58 @@ export default {
 
 .workflow-report-body {
     display: flex;
+}
+
+.workflow-overview-body {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    height: 100%;
+    border-top: solid gray 1px;
+    border-left: solid grey 1px;
+}
+
+#canvas-container {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+}
+
+#workflow-parameters-box {
+    display: none;
+    position: absolute;
+    right: 0px;
+    border: solid grey 1px;
+    padding: 5px;
+    background: #eeeeee;
+    z-index: 20000;
+    overflow: auto;
+    max-width: 300px;
+    max-height: 300px;
+}
+
+.workflow-parameters-box-title {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+
+#overview {
+    position: absolute;
+}
+
+#overview-canvas {
+    background: white;
+    width: 100%;
+    height: 100%;
+}
+
+#overview-viewport {
+    position: absolute;
+    width: 0px;
+    height: 0px;
+    border: solid blue 1px;
+    z-index: 10;
 }
 </style>
 

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -3,7 +3,7 @@
         <div class="unified-panel-header" unselectable="on">
             <div class="unified-panel-header-inner">
                 <span class="sr-only">Workflow Editor&nbsp;</span>
-                {{ name }}
+                {{ editorConfig["name"] }}
                 <div class="panel-header-buttons">
                     <a id="workflow-run-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
                         <span class="fa fa-play"></span>
@@ -53,11 +53,17 @@
 </template>
 
 <script>
+
+import WorkflowView from "mvc/workflow/workflow-view";
+
 export default {
     props: {
-        name: {
-            type: String,
-        } 
+        editorConfig: {
+            type: Object,
+        }
+    },
+    mounted() {
+        new WorkflowView(this.editorConfig);
     }
 }
 </script>

--- a/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/WorkflowEditor.vue
@@ -72,6 +72,7 @@
                         role="button"
                         title="Workflow options"
                         aria-label="Workflow options"
+                        ref="save-button"
                         v-show="mode == 'canvas'"
                     >
                         <span class="fa fa-cog"></span>
@@ -105,10 +106,12 @@
 </template>
 
 <script>
+import $ from "jquery";
 import WorkflowView from "mvc/workflow/workflow-view";
 import MarkdownEditor from "components/Markdown/MarkdownEditor";
 import { getAppRoot } from "onload/loadConfig";
 import { showReportHelp } from "./reportHelp";
+import { make_popupmenu } from "ui/popupmenu";
 
 export default {
     components: { MarkdownEditor },
@@ -124,6 +127,17 @@ export default {
     },
     mounted() {
         this.workflowView = new WorkflowView(this.editorConfig, this.$refs["report-editor"]);
+        make_popupmenu($(this.$refs["save-button"]), {
+            "Save As": () => this.workflowView.workflow_save_as(),
+            "Edit Attributes": () => {
+                this.workflowView.workflow.clear_active_node();
+            },
+            "Auto Re-layout": () => this.workflowView.layout_editor(),
+            Download: {
+                url: `${getAppRoot()}api/workflows/${this.editorConfig.id}/download?format=json-download`,
+                action: function() {}
+            }
+        });
     },
     methods: {
         setMode(mode) {

--- a/client/galaxy/scripts/components/Workflow/Editor/mount.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/mount.js
@@ -1,0 +1,11 @@
+/**
+ * Endpoint for mounting WorkflowEditor from non-Vue environment (editor.mako).
+ */
+import Vue from "vue";
+import WorkflowEditor from "./WorkflowEditor.vue";
+
+export const mountWorkflowEditor = (el, name) => {
+    const propsData = { name };
+    const component = Vue.extend(WorkflowEditor);
+    return new component({ propsData: propsData }).$mount(el);
+};

--- a/client/galaxy/scripts/components/Workflow/Editor/mount.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/mount.js
@@ -4,8 +4,8 @@
 import Vue from "vue";
 import WorkflowEditor from "./WorkflowEditor.vue";
 
-export const mountWorkflowEditor = (el, name) => {
-    const propsData = { name };
+export const mountWorkflowEditor = (editorConfig) => {
+    const propsData = { editorConfig };
     const component = Vue.extend(WorkflowEditor);
-    return new component({ propsData: propsData }).$mount(el);
+    return new component({ propsData: propsData, el: "#center"});
 };

--- a/client/galaxy/scripts/components/Workflow/Editor/mount.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/mount.js
@@ -4,8 +4,8 @@
 import Vue from "vue";
 import WorkflowEditor from "./WorkflowEditor.vue";
 
-export const mountWorkflowEditor = (editorConfig) => {
+export const mountWorkflowEditor = editorConfig => {
     const propsData = { editorConfig };
     const component = Vue.extend(WorkflowEditor);
-    return new component({ propsData: propsData, el: "#center"});
+    return new component({ propsData: propsData, el: "#center" });
 };

--- a/client/galaxy/scripts/components/Workflow/Editor/reportHelp.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/reportHelp.js
@@ -1,0 +1,103 @@
+const reportHelp = `
+<div>
+<h3>Overview</h3>
+
+<p>
+    This document Markdown document will be used to generate a report
+    for invocations of this workflow. This document should be Markdown
+    with embedded command for extracting and displaying parts of the workflow,
+    its invocation metadata, its inputs and outputs, etc.. For an overview
+    of standard Markdown visit the <a href="https://commonmark.org/help/tutorial/">commonmark.org
+    tutorial</a>.
+</p>
+
+<p>
+    The Galaxy extensions to Markdown are represented as code blocks, these blocks start
+    with the line <tt>\`\`\`galaxy</tt> and end with the line <tt>\`\`\`</tt> and have a
+    command with arguments that reference parts of the workflow in the middle.
+</p>
+
+<h3>Workflow Commands</h3>
+
+<p>
+    These commands to do not take any arguments and reference the whole workflow. For
+    instance, the following example would display a representation of the workflow in the
+    resulting report:
+</p>
+
+<pre>
+\`\`\`galaxy
+workflow_display()
+\`\`\`
+</pre>
+<dl>
+<dt><tt>workflow_display</tt></dt>
+<dd>Embed a description of the workflow itself in the resulting report.</dd>
+<dt><tt>invocation_inputs</tt></dt>
+<dd>Embed the labeled workflow inputs in the resulting report.</dd>
+<dt><tt>invocation_outputs</tt></dt>
+<dd>Embed the labeled workflow outputs in the resulting report.</dd>
+</dl>
+
+<h3>Step Commands</h3>
+
+<p>
+    These commands reference a workflow step label and refer to job corresponding
+    to that step. A current limitation is the report will break if these refer to
+    a collection mapping step, these must identify a single job. For instance, the
+    following example would show the job parameters the step labeled 'qc' was run
+    with:
+</p>
+
+<pre>
+\`\`\`galaxy
+job_parameters(step=qc)
+\`\`\`
+</pre>
+
+
+<dt><tt>tool_stderr</tt></dt>
+<dd>Embed the tool standard error stream for this step in the resulting report.</dd>
+<dt><tt>tool_stdout</tt></dt>
+<dd>Embed the tool standard output stream for this step in the resulting report.</dd>
+<dt><tt>job_metrics</tt></dt>
+<dd>Embed the job metrics for this step in the resulting report (if user has permission).</dd>
+<dt><tt>job_parameters</tt></dt>
+<dd>Embed the tool parameters for this step in the resulting report.</dd>
+
+<h3>Input/Output Commands</h3>
+
+<p>
+    These commands reference a workflow input or output by label. For instance, the
+    following example would display the dataset collection corresponding to output "Merged BAM":
+</p>
+
+<pre>
+\`\`\`galaxy
+history_dataset_collection_display(output="Merged Bam")
+\`\`\`
+</pre>
+
+<dt><tt>history_dataset_display</tt></dt>
+<dd>Embed a dataset description in the resulting report.</dd>
+<dt><tt>history_dataset_collection_display</tt></dt>
+<dd>Embed a dataset collection description in the resulting report.</dd>
+<dt><tt>history_dataset_as_image</tt></dt>
+<dd>Embed a dataset as an image in the resulting report - the dataset should be an image datatype.</dd>
+<dt><tt>history_dataset_peek</tt></dt>
+<dd>Embed Galaxy's metadata attribute 'peek' into the resulting report - this is datatype dependent metadata but usually this is a few lines from the start of a file.</dd>
+<dt><tt>history_dataset_info</tt></dt>
+<dd>Embed Galaxy's metadata attribute 'info' into the resulting report - this is datatype dependent metadata but usually this is the program output that generated the dataset.</dd>
+</dl>
+</div>
+`;
+
+import $ from "jquery";
+import { hide_modal, show_modal } from "layout/modal";
+
+export function showReportHelp() {
+    const reportHelpBody = $(reportHelp);
+    show_modal("Workflow Invocation Report Help", reportHelpBody, {
+        Ok: hide_modal
+    });
+}

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -2,28 +2,6 @@ import $ from "jquery";
 import Connector from "mvc/workflow/workflow-connector";
 import { Toast } from "ui/toast";
 
-import Vue from "vue";
-import MarkdownEditor from "components/Markdown/MarkdownEditor";
-
-const DEFAULT_INVOCATION_REPORT = `
-# Workflow Execution Report
-
-## Workflow Inputs
-\`\`\`galaxy
-invocation_inputs()
-\`\`\`
-
-## Workflow Outputs
-\`\`\`galaxy
-invocation_outputs()
-\`\`\`
-
-## Workflow
-\`\`\`galaxy
-workflow_display()
-\`\`\`
-`;
-
 class Workflow {
     constructor(app, canvas_container) {
         this.app = app;
@@ -241,16 +219,6 @@ class Workflow {
         var using_workflow_outputs = false;
         wf.workflow_version = data.version;
         wf.report = data.report || {};
-        const markdownEditorInstance = Vue.extend(MarkdownEditor);
-        new markdownEditorInstance({
-            propsData: {
-                onupdate: markdown => {
-                    this.report_changed(markdown);
-                },
-                initialMarkdown: (data.report && data.report.markdown) || DEFAULT_INVOCATION_REPORT
-            },
-            el: "#workflow-report-editor"
-        });
         $.each(data.steps, (id, step) => {
             var node = wf.app.prebuildNode(step.type, step.name, step.content_id);
             // If workflow being copied into another, wipe UUID and let
@@ -360,10 +328,6 @@ class Workflow {
             this.app.showForm(node.config_form, node);
         }
         this.app.showWorkflowParameters();
-    }
-    report_changed(report_markdown) {
-        this.has_changes = true;
-        this.report.markdown = report_markdown;
     }
     layout() {
         this.check_changes_in_active_form();

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -39,100 +39,6 @@ workflow_display()
 \`\`\`
 `;
 
-const reportHelp = `
-<div>
-<h3>Overview</h3>
-
-<p>
-    This document Markdown document will be used to generate a report
-    for invocations of this workflow. This document should be Markdown
-    with embedded command for extracting and displaying parts of the workflow,
-    its invocation metadata, its inputs and outputs, etc.. For an overview
-    of standard Markdown visit the <a href="https://commonmark.org/help/tutorial/">commonmark.org
-    tutorial</a>.
-</p>
-
-<p>
-    The Galaxy extensions to Markdown are represented as code blocks, these blocks start
-    with the line <tt>\`\`\`galaxy</tt> and end with the line <tt>\`\`\`</tt> and have a
-    command with arguments that reference parts of the workflow in the middle.
-</p>
-
-<h3>Workflow Commands</h3>
-
-<p>
-    These commands to do not take any arguments and reference the whole workflow. For
-    instance, the following example would display a representation of the workflow in the
-    resulting report:
-</p>
-
-<pre>
-\`\`\`galaxy
-workflow_display()
-\`\`\`
-</pre>
-<dl>
-<dt><tt>workflow_display</tt></dt>
-<dd>Embed a description of the workflow itself in the resulting report.</dd>
-<dt><tt>invocation_inputs</tt></dt>
-<dd>Embed the labeled workflow inputs in the resulting report.</dd>
-<dt><tt>invocation_outputs</tt></dt>
-<dd>Embed the labeled workflow outputs in the resulting report.</dd>
-</dl>
-
-<h3>Step Commands</h3>
-
-<p>
-    These commands reference a workflow step label and refer to job corresponding
-    to that step. A current limitation is the report will break if these refer to
-    a collection mapping step, these must identify a single job. For instance, the
-    following example would show the job parameters the step labeled 'qc' was run
-    with:
-</p>
-
-<pre>
-\`\`\`galaxy
-job_parameters(step=qc)
-\`\`\`
-</pre>
-
-
-<dt><tt>tool_stderr</tt></dt>
-<dd>Embed the tool standard error stream for this step in the resulting report.</dd>
-<dt><tt>tool_stdout</tt></dt>
-<dd>Embed the tool standard output stream for this step in the resulting report.</dd>
-<dt><tt>job_metrics</tt></dt>
-<dd>Embed the job metrics for this step in the resulting report (if user has permission).</dd>
-<dt><tt>job_parameters</tt></dt>
-<dd>Embed the tool parameters for this step in the resulting report.</dd>
-
-<h3>Input/Output Commands</h3>
-
-<p>
-    These commands reference a workflow input or output by label. For instance, the
-    following example would display the dataset collection corresponding to output "Merged BAM":
-</p>
-
-<pre>
-\`\`\`galaxy
-history_dataset_collection_display(output="Merged Bam")
-\`\`\`
-</pre>
-
-<dt><tt>history_dataset_display</tt></dt>
-<dd>Embed a dataset description in the resulting report.</dd>
-<dt><tt>history_dataset_collection_display</tt></dt>
-<dd>Embed a dataset collection description in the resulting report.</dd>
-<dt><tt>history_dataset_as_image</tt></dt>
-<dd>Embed a dataset as an image in the resulting report - the dataset should be an image datatype.</dd>
-<dt><tt>history_dataset_peek</tt></dt>
-<dd>Embed Galaxy's metadata attribute 'peek' into the resulting report - this is datatype dependent metadata but usually this is a few lines from the start of a file.</dd>
-<dt><tt>history_dataset_info</tt></dt>
-<dd>Embed Galaxy's metadata attribute 'info' into the resulting report - this is datatype dependent metadata but usually this is the program output that generated the dataset.</dd>
-</dl>
-</div>
-`;
-
 // Reset tool search to start state.
 function reset_tool_search(initValue) {
     // Function may be called in top frame or in tool_menu_frame;
@@ -424,7 +330,6 @@ export default Backbone.View.extend({
         // Load workflow definition
         this.load_workflow(self.options.id, self.options.version);
         if (make_popupmenu) {
-            $("#workflow-report-help-button").click(() => show_report_help());
             make_popupmenu($("#workflow-options-button"), {
                 "Save As": workflow_save_as,
                 "Edit Attributes": function() {
@@ -481,13 +386,6 @@ export default Backbone.View.extend({
             self.workflow.fit_canvas_to_nodes();
             self.scroll_to_nodes();
             self.canvas_manager.draw_overview();
-        }
-
-        function show_report_help() {
-            const reportHelpBody = $(reportHelp);
-            show_modal("Workflow Invocation Report Help", reportHelpBody, {
-                Ok: hide_modal
-            });
         }
 
         // On load, set the size to the pref stored in local storage if it exists

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -476,9 +476,6 @@ export default Backbone.View.extend({
         // Load workflow definition
         this.load_workflow(self.options.id, self.options.version);
         if (make_popupmenu) {
-            $("#workflow-run-button").click(
-                () => (window.location = `${getAppRoot()}workflows/run?id=${self.options.id}`)
-            );
             $("#workflow-save-button").click(() => save_current_workflow());
             $("#workflow-report-help-button").click(() => show_report_help());
             make_popupmenu($("#workflow-options-button"), {

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -10,6 +10,7 @@
     self.overlay_visible=True
     self.editor_config = {
         'id'      : trans.security.encode_id(stored.id),
+        'name'    : stored.name,
         'urls'    : {
             'tool_search'         : h.url_for('/api/tools'),
             'get_datatypes'       : h.url_for('/api/datatypes/mapping'),
@@ -40,13 +41,12 @@
         config.addInitialization(function(galaxy, config) {
             var editorConfig = ${h.dumps(self.editor_config)};
             console.log("workflow/editor.mako, editorConfig", editorConfig);
+            window.bundleEntries.mountWorkflowEditor($("#center")[0], editorConfig["name"]);
             window.bundleEntries.workflow(editorConfig);
         });
     </script>
 
 </%def>
-
-
 
 <%def name="stylesheets()">
 
@@ -229,57 +229,6 @@
 </%def>
 
 <%def name="center_panel()">
-
-    <div class="unified-panel-header" unselectable="on">
-        <div class="unified-panel-header-inner">
-            <span class="sr-only">Workflow Editor&nbsp;</span>
-            ${h.to_unicode( stored.name ) | h}
-            <div class="panel-header-buttons">
-                <a id="workflow-run-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Run" style="display: inline-block;" aria-label="Run">
-                    <span class="fa fa-play"></span>
-                </a>
-                <a id="workflow-save-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Save" style="display: inline-block;" aria-label="Save">
-                    <span class="fa fa-floppy-o"></span>
-                </a>
-                <a id="workflow-report-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Edit Report" aria-label="Edit Report">
-                    <span class="fa fa-edit"></span>
-                </a>
-                <a id="workflow-report-help-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Report Syntax Help" aria-label="Report Syntax Help">
-                    <span class="fa fa-question"></span>
-                </a>
-                <a id="workflow-canvas-button" class="panel-header-button workflow-report-content" href="javascript:void(0)" role="button" title="Edit Workflow" aria-label="Edit Workflow">
-                    <span class="fa fa-sitemap fa-rotate-270"></span>
-                </a>
-                <a id="workflow-options-button" class="panel-header-button workflow-canvas-content" href="javascript:void(0)" role="button" title="Workflow options" style="display: inline-block;" aria-label="Workflow options">
-                    <span class="fa fa-cog"></span>
-                </a>
-            </div>
-        </div>
-    </div>
-    <div class="unified-panel-body" id="workflow-canvas-body">
-        <div id="canvas-viewport" class="workflow-canvas-content">
-            <div id="canvas-container" style="position: absolute; width: 100%; height: 100%;"></div>
-        </div>
-        <div id="report-editor-container" class="workflow-report-content" style="position: absolute; width: 100%; height: 100%; display: none">
-            <textarea id="workflow-report-editor" style="width: 100%; height: 100%;"></textarea>
-        </div>
-        <div id='workflow-parameters-box' style="display:none; position: absolute; right:0px; border: solid grey 1px; padding: 5px; background: #EEEEEE; z-index: 20000; overflow: auto; max-width: 300px; max-height: 300px;">
-            <div style="margin-bottom:5px;">
-                <b>Workflow Parameters</b>
-            </div>
-            <div id="workflow-parameters-container">
-            </div>
-        </div>
-        <div class="workflow-overview workflow-canvas-content" aria-hidden="true">
-            <div style="position: relative; overflow: hidden; width: 100%; height: 100%; border-top: solid gray 1px; border-left: solid grey 1px;">
-                <div id="overview" style="position: absolute;">
-                    <canvas width="0" height="0" style="background: white; width: 100%; height: 100%;" id="overview-canvas"></canvas>
-                    <div id="overview-viewport" style="position: absolute; width: 0px; height: 0px; border: solid blue 1px; z-index: 10;"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-
 </%def>
 
 <%def name="right_panel()">

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -41,8 +41,7 @@
         config.addInitialization(function(galaxy, config) {
             var editorConfig = ${h.dumps(self.editor_config)};
             console.log("workflow/editor.mako, editorConfig", editorConfig);
-            window.bundleEntries.mountWorkflowEditor($("#center")[0], editorConfig["name"]);
-            window.bundleEntries.workflow(editorConfig);
+            window.bundleEntries.mountWorkflowEditor(editorConfig);
         });
     </script>
 

--- a/templates/webapps/galaxy/workflow/editor.mako
+++ b/templates/webapps/galaxy/workflow/editor.mako
@@ -49,21 +49,11 @@
 </%def>
 
 <%def name="stylesheets()">
-
     ## Include "base.css" for styling tool menu and forms (details)
     ${h.css("jquery-ui/smoothness/jquery-ui" )}
 
     ## But make sure styles for the layout take precedence
     ${parent.stylesheets()}
-
-    <style type="text/css">
-    #center {
-        z-index: 0;
-    }
-    canvas { position: absolute; z-index: 10; }
-    canvas.dragging { position: absolute; z-index: 1000; }
-    .workflow-report-content { display: none; }
-    </style>
 </%def>
 
 ## Render a tool in the tool panel


### PR DESCRIPTION
- Move center panel construction into VueJS object.
- Construct ``WorkflowView`` object in VueJS instead of in mako.
- Migrate mako CSS to VueJS - scoping some of it (canvas stuff can't be yet).
