### PR TITLE
[19.09] Don't re-determine if job failed in exec_after_process hook

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1638,7 +1638,7 @@ class JobWrapper(HasResourceParameters):
         # Certain tools require tasks to be completed after job execution
         # ( this used to be performed in the "exec_after_process" hook, but hooks are deprecated ).
         param_dict = self.get_param_dict(job)
-        self.tool.exec_after_process(self.app, inp_data, out_data, param_dict, job=job)
+        self.tool.exec_after_process(self.app, inp_data, out_data, param_dict, job=job, final_job_state=final_job_state)
         # Call 'exec_after_process' hook
         self.tool.call_hook('exec_after_process', self.app, inp_data=inp_data,
                             out_data=out_data, param_dict=param_dict,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -43,6 +43,7 @@ from galaxy.tool_util.loader import (
     raw_tool_xml_tree,
     template_macro_params
 )
+from galaxy.tool_util.output_checker import DETECTED_JOB_STATE
 from galaxy.tool_util.parser import (
     get_tool_source,
     get_tool_source_from_representation,
@@ -1747,7 +1748,7 @@ class Tool(Dictifiable):
     def exec_before_job(self, app, inp_data, out_data, param_dict={}):
         pass
 
-    def exec_after_process(self, app, inp_data, out_data, param_dict, job=None):
+    def exec_after_process(self, app, inp_data, out_data, param_dict, job=None, **kwds):
         pass
 
     def job_failed(self, job_wrapper, message, exception=False):
@@ -2415,7 +2416,7 @@ class SetMetadataTool(Tool):
                 history.id, job.user, incoming={'input1': hda}, overwrite=False
             )
 
-    def exec_after_process(self, app, inp_data, out_data, param_dict, job=None):
+    def exec_after_process(self, app, inp_data, out_data, param_dict, job=None, **kwds):
         working_directory = app.object_store.get_filename(
             job, base_dir='job_work', dir_only=True, obj_dir=True
         )
@@ -2499,17 +2500,13 @@ class DataManagerTool(OutputParameterJSONTool):
         if self.data_manager_id is None:
             self.data_manager_id = self.id
 
-    def exec_after_process(self, app, inp_data, out_data, param_dict, job=None, **kwds):
+    def exec_after_process(self, app, inp_data, out_data, param_dict, job=None, final_job_state=None, **kwds):
         assert self.allow_user_access(job.user), "You must be an admin to access this tool."
+        if final_job_state != DETECTED_JOB_STATE.OK:
+            return
         # run original exec_after_process
         super(DataManagerTool, self).exec_after_process(app, inp_data, out_data, param_dict, job=job, **kwds)
         # process results of tool
-        if job and job.state == job.states.ERROR:
-            return
-        # Job state may now be 'running' instead of previous 'error', but datasets are still set to e.g. error
-        for dataset in out_data.values():
-            if dataset.state != dataset.states.OK:
-                return
         data_manager_id = job.data_manager_association.data_manager_id
         data_manager = self.app.data_managers.get_manager(data_manager_id, None)
         assert data_manager is not None, "Invalid data manager (%s) requested. It may have been removed before the job completed." % (data_manager_id)

--- a/test/functional/tools/data_manager.xml
+++ b/test/functional/tools/data_manager.xml
@@ -2,13 +2,15 @@
     <configfiles>
         <configfile name="static_test_data">{"data_tables": {"testbeta": [{"value": "newvalue", "path": "newvalue.txt"}]}}</configfile>
     </configfiles>
-    <command>
+    <command detect_errors="exit_code">
         mkdir $out_file.files_path ;
-        echo "A new value" > $out_file.files_path/newvalue.txt;
-        cp $static_test_data $out_file
+        echo "A new value" > '$out_file.files_path/newvalue.txt';
+        cp '$static_test_data' '$out_file';
+        exit $exit_code
     </command>
     <inputs>
         <param type="text" name="ignored_value" value="" label="Ignored" />
+        <param type="integer" name="exit_code" value="0" label="Exit code"/>
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json"/>

--- a/test/functional/tools/data_manager_add.xml
+++ b/test/functional/tools/data_manager_add.xml
@@ -1,14 +1,16 @@
-<tool id="data_manager" name="Test Data Manager" tool_type="manage_data" version="0.0.1">
+<tool id="data_manager_add_test" name="Test Data Manager add" tool_type="manage_data" version="0.0.1">
     <configfiles>
         <configfile name="static_test_data">{"data_tables": {"testbeta": { "add": [{"value": "newvalue", "path": "newvalue.txt"}]}}}</configfile>
     </configfiles>
-    <command>
+    <command detect_errors="exit_code">
         mkdir $out_file.files_path ;
-        echo "A new value" > $out_file.files_path/newvalue.txt;
-        cp $static_test_data $out_file
+        echo "A new value" > '$out_file.files_path/newvalue.txt';
+        cp '$static_test_data' '$out_file';
+        exit $exit_code
     </command>
     <inputs>
         <param type="text" name="ignored_value" value="" label="Ignored" />
+        <param type="integer" name="exit_code" value="0" label="Exit code"/>
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json"/>

--- a/test/functional/tools/data_manager_add_remove.xml
+++ b/test/functional/tools/data_manager_add_remove.xml
@@ -1,14 +1,16 @@
-<tool id="data_manager" name="Test Data Manager" tool_type="manage_data" version="0.0.1">
+<tool id="data_manager_add_remove_test" name="Test Data Manager add and remove" tool_type="manage_data" version="0.0.1">
     <configfiles>
         <configfile name="static_test_data">{"data_tables": {"testbeta": { "add": [{"value": "newvalue", "path": "newvalue.txt"}, {"value": "newvalue2", "path": "newvalue2.txt"}], "remove": [{"value": "newvalue", "path": "newvalue.txt"}]}}}</configfile>
     </configfiles>
-    <command>
+    <command detect_errors="exit_code">
         mkdir $out_file.files_path ;
-        echo "A new value" > $out_file.files_path/newvalue.txt;
-        cp $static_test_data $out_file
+        echo "A new value" > '$out_file.files_path/newvalue.txt';
+        cp '$static_test_data' '$out_file';
+        exit $exit_code
     </command>
     <inputs>
         <param type="text" name="ignored_value" value="" label="Ignored" />
+        <param type="integer" name="exit_code" value="0" label="Exit Code" />
     </inputs>
     <outputs>
         <data name="out_file" format="data_manager_json"/>


### PR DESCRIPTION
This was all working correctly in my test, but removes some custom logic.
It was theoretically possible for the old logic to fail if there was
no output dataset for the job (though then the data manager moving would fail as well).