### PR TITLE
[19.09] Broaden library description/info/message

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -129,6 +129,9 @@ class FolderContentsController(BaseAPIController, UsesLibraryMixin, UsesLibraryM
                                         tags=ldda_tags))
                 if content_item.library_dataset_dataset_association.message:
                     return_item.update(dict(message=content_item.library_dataset_dataset_association.message))
+                elif content_item.library_dataset_dataset_association.info:
+                    # There is no message but ldda info contains something so we display that instead.
+                    return_item.update(dict(message=content_item.library_dataset_dataset_association.info))
 
             # For every item include the default metadata
             return_item.update(dict(id=encoded_id,


### PR DESCRIPTION
This is a bit of a hack but given the lack of clarity of what
field does what on what object (info/message/description on ldda/ld/folder)
it should help with the data presentation.

Will allow things like this to work well: https://github.com/usegalaxy-eu/shared-data/pull/5

cc @bgruening 