### PR TITLE
[19.09] check_for_entry_points() more agressively in the condor job runner

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -176,10 +176,7 @@ class CondorJobRunner(AsynchronousJobRunner):
             job_id = cjs.job_id
             galaxy_id_tag = cjs.job_wrapper.get_id_tag()
             try:
-                if os.stat(cjs.user_log).st_size == cjs.user_log_size:
-                    if cjs.job_wrapper.tool.tool_type == 'interactive':
-                        # If running, check for entry points...
-                        cjs.job_wrapper.check_for_entry_points()
+                if cjs.job_wrapper.tool.tool_type != 'interactive' and os.stat(cjs.user_log).st_size == cjs.user_log_size:
                     new_watched.append(cjs)
                     continue
                 s1, s4, s7, s5, s9, log_size = summarize_condor_log(cjs.user_log, job_id)
@@ -194,6 +191,10 @@ class CondorJobRunner(AsynchronousJobRunner):
                 cjs.fail_message = "Cluster could not complete job"
                 self.work_queue.put((self.fail_job, cjs))
                 continue
+
+            if job_running:
+                # If running, check for entry points...
+                cjs.job_wrapper.check_for_entry_points()
 
             if job_running and not cjs.running:
                 log.debug("(%s/%s) job is now running" % (galaxy_id_tag, job_id))

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -177,6 +177,9 @@ class CondorJobRunner(AsynchronousJobRunner):
             galaxy_id_tag = cjs.job_wrapper.get_id_tag()
             try:
                 if os.stat(cjs.user_log).st_size == cjs.user_log_size:
+                    if cjs.job_wrapper.tool.tool_type == 'interactive':
+                        # If running, check for entry points...
+                        cjs.job_wrapper.check_for_entry_points()
                     new_watched.append(cjs)
                     continue
                 s1, s4, s7, s5, s9, log_size = summarize_condor_log(cjs.user_log, job_id)
@@ -191,10 +194,6 @@ class CondorJobRunner(AsynchronousJobRunner):
                 cjs.fail_message = "Cluster could not complete job"
                 self.work_queue.put((self.fail_job, cjs))
                 continue
-
-            if job_running:
-                # If running, check for entry points...
-                cjs.job_wrapper.check_for_entry_points()
 
             if job_running and not cjs.running:
                 log.debug("(%s/%s) job is now running" % (galaxy_id_tag, job_id))


### PR DESCRIPTION
Using the condor job runner, this change is needed as otherwise jobs are missed and a URL is not generated until handler restart.