### PR TITLE
Move Jobs updated time display logic to client.

### DIFF
--- a/client/galaxy/scripts/components/UtcDate.vue
+++ b/client/galaxy/scripts/components/UtcDate.vue
@@ -1,0 +1,51 @@
+<template>
+    <span class="utc-time" v-if="mode == 'date'" :title="elapsedTime">
+        {{ date }}
+    </span>
+    <span class="utc-time utc-time-elapsed" v-else :title="date">
+        {{ elapsedTime }}
+    </span>
+</template>
+
+<script>
+export default {
+    props: {
+        date: {
+            type: String,
+            required: true
+        },
+        mode: {
+            type: String,
+            default: "date" // or elapsed
+        }
+    },
+    computed: {
+        elapsedTime: function() {
+            var utcUpdate = new Date(this.date);
+            var now = new Date();
+            var utcNow = new Date(
+                now.getUTCFullYear(),
+                now.getUTCMonth(),
+                now.getUTCDate(),
+                now.getUTCHours(),
+                now.getUTCMinutes(),
+                now.getUTCSeconds(),
+                now.getUTCMilliseconds()
+            );
+            const timeDiff = utcNow - utcUpdate;
+            const daysDiff = timeDiff / (1000 * 3600 * 24);
+            const hoursDiff = timeDiff / (1000 * 3600);
+            const minutesDiff = timeDiff / (1000 * 60);
+            let diffStr;
+            if (daysDiff >= 1) {
+                diffStr = `${Math.floor(daysDiff)} days ago`;
+            } else if (hoursDiff >= 1) {
+                diffStr = `${Math.floor(hoursDiff)} hours ago`;
+            } else {
+                diffStr = `${Math.floor(minutesDiff)} minutes ago`;
+            }
+            return diffStr;
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/UtcDate.vue
+++ b/client/galaxy/scripts/components/UtcDate.vue
@@ -1,8 +1,8 @@
 <template>
     <span class="utc-time" v-if="mode == 'date'" :title="elapsedTime">
-        {{ full_date }}
+        {{ fullDate }}
     </span>
-    <span class="utc-time utc-time-elapsed" v-else :title="full_date">
+    <span class="utc-time utc-time-elapsed" v-else :title="fullDate">
         {{ elapsedTime }}
     </span>
 </template>
@@ -25,7 +25,7 @@ export default {
         elapsedTime: function() {
             return moment(moment.utc(this.date)).from(moment().utc());
         },
-        full_date: function() {
+        fullDate: function() {
             return moment.utc(this.date).format();
         }
     }

--- a/client/galaxy/scripts/components/UtcDate.vue
+++ b/client/galaxy/scripts/components/UtcDate.vue
@@ -1,13 +1,15 @@
 <template>
     <span class="utc-time" v-if="mode == 'date'" :title="elapsedTime">
-        {{ date }}
+        {{ full_date }}
     </span>
-    <span class="utc-time utc-time-elapsed" v-else :title="date">
+    <span class="utc-time utc-time-elapsed" v-else :title="full_date">
         {{ elapsedTime }}
     </span>
 </template>
 
 <script>
+import moment from "moment";
+
 export default {
     props: {
         date: {
@@ -21,30 +23,10 @@ export default {
     },
     computed: {
         elapsedTime: function() {
-            var utcUpdate = new Date(this.date);
-            var now = new Date();
-            var utcNow = new Date(
-                now.getUTCFullYear(),
-                now.getUTCMonth(),
-                now.getUTCDate(),
-                now.getUTCHours(),
-                now.getUTCMinutes(),
-                now.getUTCSeconds(),
-                now.getUTCMilliseconds()
-            );
-            const timeDiff = utcNow - utcUpdate;
-            const daysDiff = timeDiff / (1000 * 3600 * 24);
-            const hoursDiff = timeDiff / (1000 * 3600);
-            const minutesDiff = timeDiff / (1000 * 60);
-            let diffStr;
-            if (daysDiff >= 1) {
-                diffStr = `${Math.floor(daysDiff)} days ago`;
-            } else if (hoursDiff >= 1) {
-                diffStr = `${Math.floor(hoursDiff)} hours ago`;
-            } else {
-                diffStr = `${Math.floor(minutesDiff)} minutes ago`;
-            }
-            return diffStr;
+            return moment(moment.utc(this.date)).from(moment().utc());
+        },
+        full_date: function() {
+            return moment.utc(this.date).format();
         }
     }
 };

--- a/client/galaxy/scripts/components/admin/Jobs.vue
+++ b/client/galaxy/scripts/components/admin/Jobs.vue
@@ -166,6 +166,9 @@
                         {{ data.value["id"] }}
                     </b-link>
                 </template>
+                <template v-slot:cell(update_time)="data">
+                    <utc-date :date="data.value" mode="elapsed" />
+                </template>
                 <template v-slot:row-details="row">
                     <b-card>
                         <h5>Command Line</h5>
@@ -181,9 +184,11 @@
 
 <script>
 import { getAppRoot } from "onload/loadConfig";
+import UtcDate from "components/UtcDate";
 import axios from "axios";
 
 export default {
+    components: { UtcDate },
     data() {
         return {
             jobsItems: [],

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
     "latex-parser": "^0.6.2",
     "latex-to-unicode-converter": "^0.5.2",
     "markdown-it": "^8.4.2",
+    "moment": "2.20.1",
     "popper.js": "^1.14.7",
     "pyre-to-regexp": "^0.0.5",
     "raven-js": "^3.27.0",

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1582,14 +1582,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         def prepare_jobs_list(jobs):
             res = []
             for job in jobs:
-                delta = datetime.utcnow() - job.update_time
-                update_time = ""
-                if delta.days > 0:
-                    update_time = '%s hours ago' % (delta.days * 24 + int(delta.seconds / 60 / 60))
-                elif delta > timedelta(minutes=59):
-                    update_time = '%s hours ago' % int(delta.seconds / 60 / 60)
-                else:
-                    update_time = '%s minutes ago' % int(delta.seconds / 60)
                 inputs = ""
                 try:
                     inputs = ", ".join(['{} {}'.format(da.dataset.id, da.dataset.state) for da in job.input_datasets])
@@ -1601,7 +1593,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                         'info_url': "{}?jobid={}".format(web.url_for(controller="admin", action="job_info"), job.id)
                     },
                     'user': job.history.user.email if job.history and job.history.user else 'anonymous',
-                    'update_time': update_time,
+                    'update_time': job.update_time.isoformat(),
                     'tool_id': job.tool_id,
                     'state': job.state,
                     'input_dataset': inputs,


### PR DESCRIPTION
Displays actual time now on mouseover in addition to elapsed time now.

I want this for two reasons - first to eliminate the the admin/jobs web controller, we really should be using the jobs API for this component. This brings us closer to having these two controllers in sync (still quite a bit work to do I'm sure). Second, I want to have a date display component for the invocations grid after merge of #8699 - the time display in those grids is very rough currently.