### PR TITLE
[19.09] Validate tag strings as well as list of tags

### DIFF
--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -139,10 +139,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
                 val = validation.validate_and_sanitize_basestring(key, val)
                 validated_payload[key] = val
             if key in ('tags'):
-                if isinstance(val, list):
-                    val = validation.validate_and_sanitize_basestring_list(key, val)
-                else:
-                    val = validation.validate_and_sanitize_basestring(key, val)
+                val = validation.validate_and_sanitize_basestring_list(key, util.listify(val))
                 validated_payload[key] = val
         return validated_payload
 

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -139,7 +139,10 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
                 val = validation.validate_and_sanitize_basestring(key, val)
                 validated_payload[key] = val
             if key in ('tags'):
-                val = validation.validate_and_sanitize_basestring_list(key, val)
+                if isinstance(val, list):
+                    val = validation.validate_and_sanitize_basestring_list(key, val)
+                else:
+                    val = validation.validate_and_sanitize_basestring(key, val)
                 validated_payload[key] = val
         return validated_payload
 


### PR DESCRIPTION
I think it'd be better if we consistently used lists for tags,
but it seems too late in 19.09 to make possibly bigger changes
here. Fixes https://github.com/galaxyproject/galaxy/issues/8851
broken in https://github.com/galaxyproject/galaxy/pull/8530.