### PR TITLE
[19.09] Fix send local control task usage

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -225,7 +225,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
             # while sometimes, so we don't want to block on logout.
             send_local_control_task(trans.app,
                                     "recalculate_user_disk_usage",
-                                    {"user_id": trans.security.encode_id(trans.user.id)})
+                                    kwargs={"user_id": trans.security.encode_id(trans.user.id)})
         # Since logging an event requires a session, we'll log prior to ending the session
         trans.log_event("User logged out")
         trans.handle_user_logout(logout_all=logout_all)


### PR DESCRIPTION
`kwargs` used to be the second argument, but it is now being interpreted
as `get_response`. Since there's no response coming it'll hang until a
timeout occurs.
Fixes
```
galaxy.queue_worker: ERROR: Error waiting for task: '{'kwargs': {}, 'task': 'recalculate_user_disk_usage'}' sent with routing key 'control.main@613c834ba62c'
Traceback (most recent call last):
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/virtual/base.py", line 979, in drain_events
    get(self._deliver, timeout=timeout)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/utils/scheduling.py", line 56, in get
    return self.fun(resource, callback, **kwargs)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/virtual/base.py", line 1017, in _drain_channel
    return channel.drain_events(callback=callback, timeout=timeout)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/virtual/base.py", line 761, in drain_events
    return self._poll(self.cycle, callback, timeout=timeout)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/virtual/base.py", line 402, in _poll
    return cycle.get(callback)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/utils/scheduling.py", line 56, in get
    return self.fun(resource, callback, **kwargs)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/virtual/base.py", line 405, in _get_and_deliver
    message = self._get(queue)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/sqlalchemy/__init__.py", line 109, in _get
    raise Empty()
queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/galaxy/lib/galaxy/queue_worker.py", line 130, in send_task
    self.connection.drain_events(timeout=timeout)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/connection.py", line 321, in drain_events
    return self.transport.drain_events(self.connection, **kwargs)
  File "/galaxy_venv3/lib/python3.5/site-packages/kombu/transport/virtual/base.py", line 982, in drain_events
    raise socket.timeout()
socket.timeout
```
That occasionally occurs in the selenium tests.