### PR TITLE
[19.09] Fix package requirements

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -48,12 +48,12 @@ from galaxy.web_stack import (
     get_stack_facts,
     register_postfork_function
 )
+from galaxy.webapps.galaxy import GALAXY_CONFIG_SCHEMA_PATH
 from ..version import VERSION_MAJOR
 
 log = logging.getLogger(__name__)
 
 GALAXY_APP_NAME = 'galaxy'
-GALAXY_CONFIG_SCHEMA_PATH = 'lib/galaxy/webapps/galaxy/config_schema.yml'
 LOGGING_CONFIG_DEFAULT = {
     'disable_existing_loggers': False,
     'version': 1,

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -36,6 +36,7 @@ from galaxy.util.yaml_util import (
     ordered_dump,
     ordered_load,
 )
+from galaxy.webapps.galaxy import UWSGI_SCHEMA_PATH
 
 
 DESCRIPTION = "Convert configuration files."
@@ -50,7 +51,6 @@ UNHANDLED_FILTER_TYPE_MESSAGE = "Unhandled filter type encountered [%s] for sect
 NO_APP_MAIN_MESSAGE = "No app:main section found, using application defaults throughout."
 YAML_COMMENT_WRAPPER = TextWrapper(initial_indent="# ", subsequent_indent="# ")
 RST_DESCRIPTION_WRAPPER = TextWrapper(initial_indent="    ", subsequent_indent="    ")
-UWSGI_SCHEMA_PATH = "lib/galaxy/webapps/uwsgi_schema.yml"
 
 App = namedtuple(
     "App",
@@ -444,9 +444,8 @@ def _build_uwsgi_schema(args, app_desc):
         "desc": "uwsgi definition, see https://uwsgi-docs.readthedocs.io/en/latest/Options.html",
         "mapping": options
     }
-    path = os.path.join(args.galaxy_root, UWSGI_SCHEMA_PATH)
     contents = ordered_dump(schema)
-    _write_to_file(args, contents, path)
+    _write_to_file(args, contents, UWSGI_SCHEMA_PATH)
 
 
 def _find_config(args, app_desc):

--- a/lib/galaxy/webapps/galaxy/__init__.py
+++ b/lib/galaxy/webapps/galaxy/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+HERE = os.path.dirname(os.path.realpath(__file__))
+GALAXY_CONFIG_SCHEMA_PATH = os.path.join(HERE, 'config_schema.yml')
+UWSGI_SCHEMA_PATH = os.path.join(HERE, 'uwsgi_schema.yml')

--- a/packages/app/requirements.txt
+++ b/packages/app/requirements.txt
@@ -2,3 +2,5 @@ galaxy-auth
 galaxy-job-execution
 galaxy-web-framework
 galaxy-web-stack
+kombu
+uwsgi

--- a/packages/job_execution/requirements.txt
+++ b/packages/job_execution/requirements.txt
@@ -1,1 +1,2 @@
 galaxy-data
+pulsar-galaxy-lib

--- a/packages/web_apps/requirements.txt
+++ b/packages/web_apps/requirements.txt
@@ -1,2 +1,1 @@
 galaxy-app
-

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -1,1 +1,2 @@
 galaxy-data
+paste

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -1,2 +1,4 @@
+babel
 galaxy-data
+mako
 paste


### PR DESCRIPTION
Seems needed for running the `galaxy-config` script:
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy-packaging/.venv/bin/galaxy-config", line 11, in <module>
    load_entry_point('galaxy-app', 'console_scripts', 'galaxy-config')()
  File "/Users/mvandenb/src/galaxy-packaging/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/mvandenb/src/galaxy-packaging/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
    return ep.load()
  File "/Users/mvandenb/src/galaxy-packaging/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2443, in load
    return self.resolve()
  File "/Users/mvandenb/src/galaxy-packaging/.venv/lib/python3.7/site-packages/pkg_resources/__init__.py", line 2449, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/mvandenb/src/galaxy/packages/app/galaxy/config/__init__.py", line 46, in <module>
    from galaxy.web.formatting import expand_pretty_datetime_format
  File "/Users/mvandenb/src/galaxy/packages/web_framework/galaxy/web/__init__.py", line 5, in <module>
    from .framework import url_for
  File "/Users/mvandenb/src/galaxy/packages/web_framework/galaxy/web/framework/__init__.py", line 5, in <module>
    from . import base
  File "/Users/mvandenb/src/galaxy/packages/web_framework/galaxy/web/framework/base.py", line 19, in <module>
    from paste.request import get_cookies
ModuleNotFoundError: No module named 'paste'
```