### PR TITLE
[19.09] Fix the running icon wobblies

### DIFF
--- a/client/galaxy/style/scss/dataset.scss
+++ b/client/galaxy/style/scss/dataset.scss
@@ -3,69 +3,23 @@
 
 // ---------------------------------------------------------------------------- dataset states
 //.dataset .state-icon {
+
 .state-icon {
     @extend .fa;
     display: inline-block;
     margin-right: 4px;
     vertical-align: middle;
-    width: 16px;
-    height: 16px;
-    line-height: 16px;
+    width: 14px;
+    height: 14px;
+    line-height: 14px;
     text-align: center;
-    font-size: 16px;
+    font-size: 14px;
 }
 
-// ............................................................................ animated or composite state icons
 .state-icon-running {
-    //TODO: couldn't find a way to do this with fa/spinning.scss as mixin
-    -webkit-animation: spin 2s infinite linear;
-    -moz-animation: spin 2s infinite linear;
-    -o-animation: spin 2s infinite linear;
-    animation: spin 2s infinite linear;
-
-    @-moz-keyframes spin {
-        0% {
-            -moz-transform: rotate(0deg);
-        }
-        100% {
-            -moz-transform: rotate(359deg);
-        }
-    }
-    @-webkit-keyframes spin {
-        0% {
-            -webkit-transform: rotate(0deg);
-        }
-        100% {
-            -webkit-transform: rotate(359deg);
-        }
-    }
-    @-o-keyframes spin {
-        0% {
-            -o-transform: rotate(0deg);
-        }
-        100% {
-            -o-transform: rotate(359deg);
-        }
-    }
-    @-ms-keyframes spin {
-        0% {
-            -ms-transform: rotate(0deg);
-        }
-        100% {
-            -ms-transform: rotate(359deg);
-        }
-    }
-    @keyframes spin {
-        0% {
-            transform: rotate(0deg);
-        }
-        100% {
-            transform: rotate(359deg);
-        }
-    }
-    &:before {
-        content: $fa-var-spinner;
-    }
+    @extend .fa-spin;
+    @extend .fa-spinner;
+    filter: blur(0);
 }
 
 .state-icon-upload {


### PR DESCRIPTION
This fixes running icon 'wobblies'.

I started an upgrade to fa5 which will allow much more flexible usage (svg and js-based glyphs), but this is a good incremental step which makes a big improvement right now without touching much else, so I'm more comfortable with targeting 19.09 with it.