### PR TITLE
grouping: strip newlines

### DIFF
--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -124,7 +124,9 @@ def main():
             item = line.split("\t")[group_col]
         except IndexError:
             stop_err("The following line didn't have %s columns: %s" % (group_col + 1, line))
-
+        # in case of grouping by the last column the newline character needs to be removed
+        # removal of other white spaces seems also useful
+        item = item.strip()
         if ignorecase == 1:
             return item.lower()
         return item

--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -121,12 +121,9 @@ def main():
 
     def is_new_item(line):
         try:
-            item = line.split("\t")[group_col]
+            item = line.rstrip("\r\n").split("\t")[group_col]
         except IndexError:
             stop_err("The following line didn't have %s columns: %s" % (group_col + 1, line))
-        # in case of grouping by the last column the newline character needs to be removed
-        # removal of other white spaces seems also useful
-        item = item.strip()
         if ignorecase == 1:
             return item.lower()
         return item

--- a/tools/stats/grouping.xml
+++ b/tools/stats/grouping.xml
@@ -1,4 +1,4 @@
-<tool id="Grouping1" name="Group" version="2.1.3">
+<tool id="Grouping1" name="Group" version="2.1.4">
   <description>data by a column and perform aggregate operation on other columns.</description>
   <requirements>
     <requirement type="package" version="1.15.4">numpy</requirement>


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/8383

more generally: if grouping is done on the last column then the newline was retained and contained in the output.

Alternatively one could call something like `line.rstrip("\r\n")` if stripping of arbitrary white spaces from the grouping column might be to intrusive.