### PR TITLE
[19.09] Make repository updates more robust

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -92,6 +92,8 @@ class ToolShedRepository(object):
         Return the in-memory version of the shed_tool_conf file, which is stored in the config_elems entry
         in the shed_tool_conf_dict.
         """
+        if default is None:
+            default = {}
 
         def _is_valid_shed_config_filename(filename):
             for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
@@ -137,12 +139,12 @@ class ToolShedRepository(object):
                             if tool_id in tool_ids:
                                 self.shed_config_filename = name
                                 return shed_tool_conf_dict
-        if self.includes_datatypes or self.includes_data_managers:
+        if self.includes_datatypes or self.includes_data_managers or not default:
             # We need to search by file paths here, which is less desirable.
             tool_shed = common_util.remove_protocol_and_port_from_tool_shed_url(self.tool_shed)
             for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
                 tool_path = shed_tool_conf_dict['tool_path']
-                relative_path = os.path.join(tool_path, tool_shed, 'repos', self.owner, self.name, self.installed_changeset_revision)
+                relative_path = os.path.join(tool_path, tool_shed, 'repos', self.owner, self.name)
                 if os.path.exists(relative_path):
                     self.shed_config_filename = shed_tool_conf_dict['config_filename']
                     return shed_tool_conf_dict

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -87,13 +87,11 @@ class ToolShedRepository(object):
     def shed_config_filename(self, value):
         self.metadata['shed_config_filename'] = value
 
-    def get_shed_config_dict(self, app, default=None):
+    def get_shed_config_dict(self, app):
         """
         Return the in-memory version of the shed_tool_conf file, which is stored in the config_elems entry
         in the shed_tool_conf_dict.
         """
-        if default is None:
-            default = {}
 
         def _is_valid_shed_config_filename(filename):
             for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
@@ -102,12 +100,11 @@ class ToolShedRepository(object):
             return False
 
         if not self.shed_config_filename or not _is_valid_shed_config_filename(self.shed_config_filename):
-            self.guess_shed_config(app, default=default)
-        if self.shed_config_filename:
-            for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
-                if self.shed_config_filename == shed_tool_conf_dict['config_filename']:
-                    return shed_tool_conf_dict
-        return default
+            return self.guess_shed_config(app)
+        for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
+            if self.shed_config_filename == shed_tool_conf_dict['config_filename']:
+                return shed_tool_conf_dict
+        return {}
 
     def get_tool_relative_path(self, app):
         # This is a somewhat public function, used by data_manager_manual for instance
@@ -119,7 +116,7 @@ class ToolShedRepository(object):
             relative_path = os.path.join(self.tool_shed_path_name, 'repos', self.owner, self.name, self.installed_changeset_revision)
         return tool_path, relative_path
 
-    def guess_shed_config(self, app, default=None):
+    def guess_shed_config(self, app):
         tool_ids = []
         for tool in self.metadata.get('tools', []):
             tool_ids.append(tool.get('guid'))
@@ -148,7 +145,7 @@ class ToolShedRepository(object):
                 if os.path.exists(relative_path):
                     self.shed_config_filename = shed_tool_conf_dict['config_filename']
                     return shed_tool_conf_dict
-        return default
+        return {}
 
     @property
     def has_readme_files(self):

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -136,15 +136,14 @@ class ToolShedRepository(object):
                             if tool_id in tool_ids:
                                 self.shed_config_filename = name
                                 return shed_tool_conf_dict
-        if self.includes_datatypes or self.includes_data_managers or not default:
-            # We need to search by file paths here, which is less desirable.
-            tool_shed = common_util.remove_protocol_and_port_from_tool_shed_url(self.tool_shed)
-            for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
-                tool_path = shed_tool_conf_dict['tool_path']
-                relative_path = os.path.join(tool_path, tool_shed, 'repos', self.owner, self.name)
-                if os.path.exists(relative_path):
-                    self.shed_config_filename = shed_tool_conf_dict['config_filename']
-                    return shed_tool_conf_dict
+        # We need to search by file paths here, which is less desirable.
+        tool_shed = common_util.remove_protocol_and_port_from_tool_shed_url(self.tool_shed)
+        for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
+            tool_path = shed_tool_conf_dict['tool_path']
+            relative_path = os.path.join(tool_path, tool_shed, 'repos', self.owner, self.name)
+            if os.path.exists(relative_path):
+                self.shed_config_filename = shed_tool_conf_dict['config_filename']
+                return shed_tool_conf_dict
         return {}
 
     @property

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -702,7 +702,7 @@ class InstallRepositoryManager(object):
                 owner=owner,
                 changeset_revision=repository_revision_dict['changeset_revision'],
             )
-            if repo:
+            if repo and repo.is_installed:
                 # Repo installed. Returning empty list indicated repo already installed.
                 return []
         installed_tool_shed_repositories = self.__initiate_and_install_repositories(
@@ -966,6 +966,8 @@ class InstallRepositoryManager(object):
         else:
             repo_files_dir = os.path.abspath(os.path.join(relative_install_dir, repository.name))
         repository_clone_url = os.path.join(tool_shed_url, 'repos', repository.owner, repository.name)
+        # Set a status, even though we're probably not cloning.
+        self.update_tool_shed_repository_status(repository, status=repository.installation_status.CLONING)
         log.info("Updating repository '%s' to %s:%s", repository.name, latest_ctx_rev, latest_changeset_revision)
         if not os.path.exists(repo_files_dir):
             log.debug("Repository directory '%s' does not exist, cloning repository instead of updating repository", repo_files_dir)
@@ -991,6 +993,7 @@ class InstallRepositoryManager(object):
                                                   persist=True)
         irmm.generate_metadata_for_changeset_revision()
         irmm_metadata_dict = irmm.get_metadata_dict()
+        self.update_tool_shed_repository_status(repository, status=repository.installation_status.INSTALLED)
         if 'tools' in irmm_metadata_dict:
             tool_panel_dict = irmm_metadata_dict.get('tool_panel_section', None)
             if tool_panel_dict is None:

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -890,7 +890,7 @@ class InstallRepositoryManager(object):
         relative_clone_dir = repository_util.generate_tool_shed_repository_install_dir(repository_clone_url,
                                                                                        tool_shed_repository.installed_changeset_revision)
         relative_install_dir = os.path.join(relative_clone_dir, tool_shed_repository.name)
-        install_dir = os.path.join(tool_path, relative_install_dir)
+        install_dir = os.path.abspath(os.path.join(tool_path, relative_install_dir))
         log.info("Cloning repository '%s' at %s:%s", repository_clone_url, ctx_rev, tool_shed_repository.changeset_revision)
         if os.path.exists(install_dir):
             # May exist from a previous failed install attempt, just try updating instead of cloning.

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -955,6 +955,9 @@ class InstallRepositoryManager(object):
             repo_files_dir = os.path.abspath(os.path.join(relative_install_dir, repository.name))
         repository_clone_url = os.path.join(tool_shed_url, 'repos', repository.owner, repository.name)
         log.info("Updating repository '%s' to %s:%s", repository.name, latest_ctx_rev, latest_changeset_revision)
+        if not os.path.exists(repo_files_dir):
+            log.debug("Repository directory '%s' does not exist, cloning repository instead of updating repository", repo_files_dir)
+            hg_util.clone_repository(repository_clone_url=repository_clone_url, repository_file_dir=repo_files_dir, ctx_rev=latest_ctx_rev)
         hg_util.pull_repository(repo_files_dir, repository_clone_url, latest_ctx_rev)
         hg_util.update_repository(repo_files_dir, latest_ctx_rev)
         # Remove old Data Manager entries

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -693,6 +693,18 @@ class InstallRepositoryManager(object):
                                                                                            name,
                                                                                            owner,
                                                                                            changeset_revision)
+        if changeset_revision != repository_revision_dict['changeset_revision']:
+            # Demanded installation of a non-installable revision. Stop here if repository already installed.
+            repo = repository_util.get_installed_repository(
+                app=self.app,
+                tool_shed=tool_shed_url,
+                name=name,
+                owner=owner,
+                changeset_revision=repository_revision_dict['changeset_revision'],
+            )
+            if repo:
+                # Repo installed. Returning empty list indicated repo already installed.
+                return []
         installed_tool_shed_repositories = self.__initiate_and_install_repositories(
             tool_shed_url,
             repository_revision_dict,
@@ -718,7 +730,7 @@ class InstallRepositoryManager(object):
             includes_tools_for_display_in_tool_panel = repository_revision_dict['includes_tools_for_display_in_tool_panel']
         except KeyError:
             raise exceptions.InternalServerError("Tool shed response missing required parameter 'includes_tools_for_display_in_tool_panel'.")
-        # Get the information about the Galaxy components (e.g., tool pane section, tool config file, etc) that will contain the repository information.
+        # Get the information about the Galaxy components (e.g., tool panel section, tool config file, etc) that will contain the repository information.
         install_repository_dependencies = install_options.get('install_repository_dependencies', False)
         install_resolver_dependencies = install_options.get('install_resolver_dependencies', False)
         install_tool_dependencies = install_options.get('install_tool_dependencies', False)

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -744,9 +744,13 @@ class InstallRepositoryManager(object):
             shed_conf_dict = self.tpm.get_shed_tool_conf_dict(shed_tool_conf)
             tool_path = shed_conf_dict['tool_path']
         else:
-            # Don't use migrated_tools_conf.xml.
+            # Don't use migrated_tools_conf.xml and prefer shed_tool_config_file.
             try:
-                shed_config_dict = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False)[0]
+                for shed_config_dict in self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False):
+                    if shed_config_dict.get('config_filename') == self.app.config.shed_tool_config_file:
+                        break
+                else:
+                    shed_config_dict = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False)[0]
             except IndexError:
                 raise exceptions.RequestParameterMissingException("Missing required parameter 'shed_tool_conf'.")
             shed_tool_conf = shed_config_dict['config_filename']

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -892,7 +892,13 @@ class InstallRepositoryManager(object):
         relative_install_dir = os.path.join(relative_clone_dir, tool_shed_repository.name)
         install_dir = os.path.join(tool_path, relative_install_dir)
         log.info("Cloning repository '%s' at %s:%s", repository_clone_url, ctx_rev, tool_shed_repository.changeset_revision)
-        cloned_ok, error_message = hg_util.clone_repository(repository_clone_url, os.path.abspath(install_dir), ctx_rev)
+        if os.path.exists(install_dir):
+            # May exist from a previous failed install attempt, just try updating instead of cloning.
+            hg_util.pull_repository(install_dir, repository_clone_url, ctx_rev)
+            hg_util.update_repository(install_dir, ctx_rev)
+            cloned_ok = True
+        else:
+            cloned_ok, error_message = hg_util.clone_repository(repository_clone_url, install_dir, ctx_rev)
         if cloned_ok:
             if reinstalling:
                 # Since we're reinstalling the repository we need to find the latest changeset revision to

--- a/lib/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -72,7 +72,11 @@ class InstalledRepositoryMetadataManager(metadata_generator.MetadataGenerator):
                     load_relative_path = os.path.join(shed_conf_dict.get('tool_path'), relative_path)
                 guid = tool_dict.get('guid', None)
                 if relative_path and guid:
-                    tool = self.app.toolbox.load_tool(os.path.abspath(load_relative_path), guid=guid, use_cached=False)
+                    try:
+                        tool = self.app.toolbox.load_tool(os.path.abspath(load_relative_path), guid=guid, use_cached=False)
+                    except Exception:
+                        log.exception("Error while loading tool at path '%s'", load_relative_path)
+                        tool = None
                 else:
                     tool = None
                 if tool:

--- a/lib/tool_shed/metadata/metadata_generator.py
+++ b/lib/tool_shed/metadata/metadata_generator.py
@@ -1064,7 +1064,7 @@ class MetadataGenerator(object):
                 self.set_changeset_revision(self.repository.changeset_revision)
             else:
                 self.set_changeset_revision(changeset_revision)
-            self.shed_config_dict = repository.get_shed_config_dict(self.app, {})
+            self.shed_config_dict = repository.get_shed_config_dict(self.app)
             self.metadata_dict = {'shed_config_filename': self.shed_config_dict.get('config_filename', None)}
         else:
             if relative_install_dir is None and self.repository is not None:

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -1,0 +1,108 @@
+import os
+from collections import namedtuple
+
+from base import integration_util
+from base.populators import DatasetPopulator
+
+from tool_shed.util import hg_util
+from .uses_shed import UsesShed
+
+REPO = namedtuple('Repository', 'name owner changeset')(
+    'collection_column_join',
+    'iuc',
+    'dfde09461b1e',  # revision 2, a known installable revision
+)
+REVISION_3 = '58228a4d58fe'
+REVISION_4 = '071084070619'
+
+
+class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):
+
+    """Test data manager installation and table reload through the API"""
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls.configure_shed(config)
+
+    def setUp(self):
+        super(TestRepositoryInstallIntegrationTestCase, self).setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def tearDown(self):
+        self.reset_shed_tools()
+
+    def test_repository_installation(self):
+        """
+        Test that we can install a given revision.
+        """
+        self._install_repository()
+
+    def test_repository_uninstall(self):
+        """Test that we can uninstall a repository"""
+        self._install_repository()
+        self._uninstall_repository()
+
+    def test_repository_update(self):
+        response = self._install_repository(revision=REVISION_4, version="0.0.3")[0]
+        assert response['ctx_rev'] == '4'
+        repo_response = self._get("/api/tool_shed_repositories/%s" % response['id']).json()
+        assert repo_response['tool_shed_status']['revision_update'] == 'False'  # that should really be a boolean
+        # now checkout revision 3 and attempt an update
+        path_components = [
+            self._app.config.shed_tools_dir,
+            'toolshed.g2.bx.psu.edu',
+            'repos',
+            REPO.owner,
+            REPO.name,
+            REVISION_3,
+            REPO.name
+        ]
+        revision_3_path = os.path.join(*path_components[:6])
+        revision_4_path = os.path.join(*path_components[:5] + [REVISION_4])
+        repository_path = os.path.join(*path_components)
+        # Move repo to location expected before minor update
+        os.rename(revision_4_path, revision_3_path)
+        # Checkout revision 3
+        hg_util.update_repository(repository_path, ctx_rev='3')
+        # change repo to revision 3 in database
+        model = self._app.install_model
+        tsr = model.context.query(model.ToolShedRepository).first()
+        assert tsr.name == REPO.name
+        assert tsr.changeset_revision == REVISION_4
+        assert tsr.ctx_rev == '4'
+        tsr.ctx_rev = '3'
+        tsr.installed_changeset_revision = REVISION_3
+        tsr.changeset_revision = REVISION_3
+        model.context.flush()
+        # update shed_tool_conf.xml to look like revision 3 was the installed_changeset_revision
+        with open(self._app.config.shed_tool_config_file) as shed_config:
+            shed_text = shed_config.read().replace(REVISION_4, REVISION_3)
+        with open(self._app.config.shed_tool_config_file, 'w') as shed_config:
+            shed_config.write(shed_text)
+        self._get('/api/tool_shed_repositories/check_for_updates', data={'id': response['id']}).json()
+        # At this point things should look like there is minor update available
+        repo_response = self._get("/api/tool_shed_repositories/%s" % response['id']).json()
+        assert repo_response['tool_shed_status']['revision_update'] == 'True'
+        assert repo_response['changeset_revision'] == REVISION_3
+        assert repo_response['ctx_rev'] == '3'
+        # now install revision 4 (a.k.a a minor update)
+        response = self._install_repository(revision=REVISION_4, version="0.0.3", verify_tool_absent=False)[0]
+        assert response['changeset_revision'] == REVISION_4
+        assert response['installed_changeset_revision'] == REVISION_3
+        assert response['ctx_rev'] == '4'
+
+    def _uninstall_repository(self):
+        tool = self._get('/api/tools/collection_column_join').json()
+        assert tool['version'] == "0.0.2"
+        self.uninstall_repository(REPO.owner, REPO.name, REPO.changeset)
+        response = self._get('/api/tools/collection_column_join').json()
+        assert response['err_msg']
+
+    def _install_repository(self, revision=None, version="0.0.2", verify_tool_absent=True):
+        if verify_tool_absent:
+            response = self._get('/api/tools/collection_column_join').json()
+            assert response['err_msg']
+        install_response = self.install_repository(REPO.owner, REPO.name, revision or REPO.changeset)
+        tool = self._get('/api/tools/collection_column_join').json()
+        assert tool['version'] == version
+        return install_response

--- a/test/integration/uses_shed.py
+++ b/test/integration/uses_shed.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import string
 import tempfile
 
@@ -27,16 +28,12 @@ SHED_DATA_TABLES = """<?xml version="1.0"?>
 class UsesShed(object):
 
     @classmethod
-    def configure_shed_and_conda(cls, config):
-        cls.conda_tmp_prefix = tempfile.mkdtemp()
+    def configure_shed(cls, config):
         cls.shed_tools_dir = tempfile.mkdtemp()
         cls.shed_tool_data_dir = tempfile.mkdtemp()
-        cls._test_driver.temp_directories.extend([cls.conda_tmp_prefix, cls.shed_tool_data_dir, cls.shed_tools_dir])
-        config["conda_auto_init"] = True
-        config["conda_auto_install"] = True
-        config["conda_prefix"] = os.environ.get('GALAXY_TEST_CONDA_PREFIX') or os.path.join(cls.conda_tmp_prefix, 'conda')
-        config["tool_sheds_config_file"] = TOOL_SHEDS_CONF
+        cls._test_driver.temp_directories.extend([cls.shed_tool_data_dir, cls.shed_tools_dir])
         shed_tool_config = os.path.join(cls.shed_tools_dir, 'shed_tool_conf.xml')
+        config["tool_sheds_config_file"] = TOOL_SHEDS_CONF
         config["tool_config_file"] = "%s,%s" % (FRAMEWORK_UPLOAD_TOOL_CONF, shed_tool_config)
         config["shed_data_manager_config_file"] = os.path.join(cls.shed_tool_data_dir, 'shed_data_manager_config_file')
         config["shed_tool_data_table_config"] = os.path.join(cls.shed_tool_data_dir, 'shed_data_table_conf.xml')
@@ -48,12 +45,54 @@ class UsesShed(object):
         with open(config["shed_tool_data_table_config"], 'w') as shed_data_table_config:
             shed_data_table_config.write(SHED_DATA_TABLES)
 
-    def install_repository(self, owner, name, changeset, tool_shed_url='https://toolshed.g2.bx.psu.edu'):
+    @classmethod
+    def configure_shed_and_conda(cls, config):
+        cls.configure_shed(config)
+        cls.conda_tmp_prefix = tempfile.mkdtemp()
+        cls._test_driver.temp_directories.append(cls.conda_tmp_prefix)
+        config["conda_auto_init"] = True
+        config["conda_auto_install"] = True
+        config["conda_prefix"] = os.environ.get('GALAXY_TEST_CONDA_PREFIX') or os.path.join(cls.conda_tmp_prefix, 'conda')
+
+    def reset_shed_tools(self):
+        shutil.rmtree(self._app.config.shed_tools_dir)
+        os.makedirs(self._app.config.shed_tools_dir)
+        with open(self._app.config.shed_tool_config_file, "w") as tool_conf_file:
+            tool_conf_file.write(SHED_TOOL_CONF.substitute(shed_tools_path=self._app.config.shed_tools_dir))
+        # deleting the containing folder doesn't trigger a toolbox reload, so signal it now and wait until it's done
+        self._app.queue_worker.send_control_task('reload_toolbox', get_response=True)
+        model = self._app.install_model
+        models_to_delete = [
+            model.RepositoryRepositoryDependencyAssociation,
+            model.RepositoryDependency,
+            model.ToolVersion,
+            model.ToolVersionAssociation,
+            model.ToolShedRepository,
+            model.ToolDependency
+        ]
+        for item in models_to_delete:
+            model.context.query(item).delete()
+        model.context.flush()
+
+    def delete_repo_request(self, payload):
+        return self._delete('/tool_shed_repositories', data=payload, admin=True)
+
+    def install_repo_request(self, payload):
+        return self._post('/tool_shed_repositories/new/install_repository_revision', data=payload, admin=True)
+
+    def repository_operation(self, operation, owner, name, changeset, tool_shed_url='https://toolshed.g2.bx.psu.edu'):
         payload = {
             'tool_shed_url': tool_shed_url,
             'name': name,
             'owner': owner,
             'changeset_revision': changeset
         }
-        create_response = self._post('/tool_shed_repositories/new/install_repository_revision', data=payload, admin=True)
+        create_response = operation(payload)
         self._assert_status_code_is(create_response, 200)
+        return create_response.json()
+
+    def install_repository(self, owner, name, changeset, tool_shed_url='https://toolshed.g2.bx.psu.edu'):
+        return self.repository_operation(operation=self.install_repo_request, owner=owner, name=name, changeset=changeset, tool_shed_url=tool_shed_url)
+
+    def uninstall_repository(self, owner, name, changeset, tool_shed_url='https://toolshed.g2.bx.psu.edu'):
+        return self.repository_operation(operation=self.delete_repo_request, owner=owner, name=name, changeset=changeset, tool_shed_url=tool_shed_url)


### PR DESCRIPTION
Fixes the tracebacks in #8952 and skips repository installation if requesting an uninstallable revision whose next installable revision is already installed. Should also be more resilient towards on disk repositories being on disk when installing a repository (use fetch+pull instead of clone) and repositories being absent when updating (use clone instead of fetch). Also prefers installing repos into shed_tool_conf.xml files. Includes integration tests for install/uninstall/update