### PR TITLE
[19.09] do not force library tags to be `name:` tags + backport

### DIFF
--- a/client/galaxy/scripts/mvc/library/library-dataset-view.js
+++ b/client/galaxy/scripts/mvc/library/library-dataset-view.js
@@ -438,7 +438,7 @@ var LibraryDatasetView = Backbone.View.extend({
             }
         }
         var new_info = this.$el.find(".input_dataset_misc_info").val();
-        if (typeof new_info !== "undefined" && new_info !== ld.get("misc_info")) {
+        if (typeof new_info !== "undefined" && new_info !== ld.get("misc_info").trim()) {
             ld.set("misc_info", new_info);
             is_changed = true;
         }

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -86,7 +86,6 @@ body {
     @extend .p-0;
     @extend .w-100;
     @extend .h-100;
-    @extend .overflow-hidden;
     @extend .position-absolute;
     background: $body-bg;
     color: $text-color;

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -105,11 +105,9 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         new_tags = new_data.get('tags', None)
         if new_tags is not None and new_tags != ldda.tags:
             self.tag_handler.delete_item_tags(item=ldda, user=trans.user)
-            for tag in new_tags:
-                new_tag = tag
-                if new_tag.startswith("name:"):
-                    new_tag = new_tag[5:]
-                self.tag_handler.apply_item_tag(item=ldda, user=trans.user, name='name', value=new_tag)
+            tag_list = self.tag_handler.parse_tags_list(new_tags)
+            for tag in tag_list:
+                self.tag_handler.apply_item_tag(item=ldda, user=trans.user, name=tag[0], value=tag[1])
             changed = True
         if changed:
             ldda.update_parent_folder_update_times()

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -106,7 +106,10 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
         if new_tags is not None and new_tags != ldda.tags:
             self.tag_handler.delete_item_tags(item=ldda, user=trans.user)
             for tag in new_tags:
-                self.tag_handler.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag)
+                new_tag = tag
+                if new_tag.startswith("name:"):
+                    new_tag = new_tag[5:]
+                self.tag_handler.apply_item_tag(item=ldda, user=trans.user, name='name', value=new_tag)
             changed = True
         if changed:
             ldda.update_parent_folder_update_times()

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -257,8 +257,9 @@ class TagHandler(object):
         Return a list of tag tuples (name, value) pairs derived from a string.
 
         >>> th = TagHandler("bridge_of_death")
-        >>> th.parse_tags(u"name:Lancelot of Camelot;#Holy Grail;blue")
-        [(u'name', u'LancelotofCamelot'), (u'name', u'HolyGrail'), (u'blue', None)]
+        >>> assert th.parse_tags("#ARTHUR") == [('name', 'ARTHUR')]
+        >>> tags = th.parse_tags("name:Lancelot of Camelot;#Holy Grail;blue")
+        >>> assert tags == [('name', 'LancelotofCamelot'), ('name', 'HolyGrail'), ('blue', None)]
         """
         # Gracefully handle None.
         if not tag_str:
@@ -276,8 +277,8 @@ class TagHandler(object):
         Method scrubs tag names and values as well.
 
         >>> th = TagHandler("bridge_of_death")
-        >>> th.parse_tags_list(["name:Lancelot of Camelot", "#Holy Grail", "blue"])
-        [('name', 'LancelotofCamelot'), ('name', 'HolyGrail'), ('blue', None)]
+        >>> tags = th.parse_tags_list(["name:Lancelot of Camelot", "#Holy Grail", "blue"])
+        >>> assert tags == [('name', 'LancelotofCamelot'), ('name', 'HolyGrail'), ('blue', None)]
         """
         name_value_pairs = []
         for raw_tag in tags_list:

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -254,8 +254,11 @@ class TagHandler(object):
 
     def parse_tags(self, tag_str):
         """
-        Returns a list of raw (tag-name, value) pairs derived from a string; method scrubs tag names and values as well.
-        Return value is a list of (tag_name, tag_value) tuples.
+        Return a list of tag tuples (name, value) pairs derived from a string.
+
+        >>> th = TagHandler("bridge_of_death")
+        >>> th.parse_tags(u"name:Lancelot of Camelot;#Holy Grail;blue")
+        [(u'name', u'LancelotofCamelot'), (u'name', u'HolyGrail'), (u'blue', None)]
         """
         # Gracefully handle None.
         if not tag_str:
@@ -265,9 +268,19 @@ class TagHandler(object):
         # Split tags based on separators.
         reg_exp = re.compile('[' + self.tag_separators + ']')
         raw_tags = reg_exp.split(tag_str)
-        # Extract name-value pairs.
+        return self.parse_tags_list(raw_tags)
+
+    def parse_tags_list(self, tags_list):
+        """
+        Return a list of tag tuples (name, value) pairs derived from a list.
+        Method scrubs tag names and values as well.
+
+        >>> th = TagHandler("bridge_of_death")
+        >>> th.parse_tags_list(["name:Lancelot of Camelot", "#Holy Grail", "blue"])
+        [('name', 'LancelotofCamelot'), ('name', 'HolyGrail'), ('blue', None)]
+        """
         name_value_pairs = []
-        for raw_tag in raw_tags:
+        for raw_tag in tags_list:
             nv_pair = self._get_name_value_pair(raw_tag)
             scrubbed_name = self._scrub_tag_name(nv_pair[0])
             scrubbed_value = self._scrub_tag_value(nv_pair[1])

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -291,8 +291,9 @@ def new_upload(trans, cntrller, uploaded_dataset, library_bunch=None, history=No
     if library_bunch:
         upload_target_dataset_instance = __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state)
         if library_bunch.tags and not uploaded_dataset.tags:
-            for tag in library_bunch.tags:
-                trans.app.tag_handler.apply_item_tag(user=trans.user, item=upload_target_dataset_instance, name='name', value=tag)
+            new_tags = trans.app.tag_handler.parse_tags_list(library_bunch.tags)
+            for tag in new_tags:
+                trans.app.tag_handler.apply_item_tag(user=trans.user, item=upload_target_dataset_instance, name=tag[0], value=tag[1])
     else:
         upload_target_dataset_instance = __new_history_upload(trans, uploaded_dataset, history=history, state=state)
 

--- a/test/api/test_libraries.py
+++ b/test/api/test_libraries.py
@@ -287,6 +287,14 @@ class LibrariesApiTestCase(api.ApiTestCase, TestsDatasets):
         self._assert_status_code_is(create_response, 200)
         self._assert_has_keys(create_response.json(), "name", "file_ext", "misc_info", "genome_build")
 
+    def test_update_dataset_tags(self):
+        ld = self._create_dataset_in_folder_in_library("ForTagtestDataset")
+        data = {"tags": ["#Lancelot", "name:Holy Grail", "blue"]}
+        create_response = self._patch("libraries/datasets/%s" % ld.json()["id"], data=data)
+        self._assert_status_code_is(create_response, 200)
+        self._assert_has_keys(create_response.json(), "tags")
+        assert create_response.json()["tags"] == "name:Lancelot, name:HolyGrail, blue"
+
     def test_invalid_update_dataset_in_folder(self):
         ld = self._create_dataset_in_folder_in_library("ForInvalidUpdateDataset")
         data = {'file_ext': 'nonexisting_type'}


### PR DESCRIPTION
similar to https://github.com/galaxyproject/galaxy/pull/8947/files#diff-698ed36fb7f872235431642ca06a0dfcR108

cc @mvdbeek @nsoranzo 