### PR TITLE
[19.05] Fix test repository self reference URL broken in dev.

### DIFF
--- a/test/selenium_tests/test_workflow_management.py
+++ b/test/selenium_tests/test_workflow_management.py
@@ -110,5 +110,5 @@ class WorkflowManagementTestCase(SeleniumTestCase):
 
     def _workflow_import_from_url(self):
         self.workflow_index_click_import()
-        url = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test/base/data/test_workflow_1.ga"
+        url = "https://raw.githubusercontent.com/galaxyproject/galaxy/release_19.09/test/base/data/test_workflow_1.ga"
         self.workflow_import_submit_url(url)


### PR DESCRIPTION
Targeting a branch without the change instead of dev should be more stable anyway.