### PR TITLE
[19.09] Use path as source of truth for installed_changeset_revision

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -927,8 +927,10 @@ class Tool(Dictifiable):
 
         if getattr(self, 'tool_shed', None):
             tool_dir = Path(self.tool_dir)
+            if tool_dir.parts[-1] == self.repository_name:
+                return str(tool_dir)
             for parent in tool_dir.parents:
-                if parent == self.repository_name:
+                if parent.parts[-1] == self.repository_name:
                     return str(parent)
             else:
                 log.error("Problem finding repository dir for tool [%s]" % self.id)

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -673,8 +673,14 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         # The definition of `installed_changeset_revision` for a repository is that it has been cloned at <tool_path/toolshed/repos/owner/name/installed_changeset_revision>
         # so if we load a tool it needs to be at a path that contains `installed_changeset_revision`.
         path_to_installed_changeset_revision = os.path.join(tool_shed, 'repos', repository_owner, repository_name)
-        assert path_to_installed_changeset_revision in path
-        installed_changeset_revision = path[path.index(path_to_installed_changeset_revision) + len(path_to_installed_changeset_revision):].split(os.path.sep)[1]
+        if path_to_installed_changeset_revision in path:
+            installed_changeset_revision = path[path.index(path_to_installed_changeset_revision) + len(path_to_installed_changeset_revision):].split(os.path.sep)[1]
+        else:
+            installed_changeset_revision_elem = elem.find("installed_changeset_revision")
+            if installed_changeset_revision_elem is None:
+                # Backward compatibility issue - the tag used to be named 'changeset_revision'.
+                installed_changeset_revision_elem = elem.find("changeset_revision")
+            installed_changeset_revision = installed_changeset_revision_elem.text
         repository = self._get_tool_shed_repository(tool_shed=tool_shed,
                                                     name=repository_name,
                                                     owner=repository_owner,

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -670,11 +670,11 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         tool_shed = elem.find("tool_shed").text
         repository_name = elem.find("repository_name").text
         repository_owner = elem.find("repository_owner").text
-        installed_changeset_revision_elem = elem.find("installed_changeset_revision")
-        if installed_changeset_revision_elem is None:
-            # Backward compatibility issue - the tag used to be named 'changeset_revision'.
-            installed_changeset_revision_elem = elem.find("changeset_revision")
-        installed_changeset_revision = installed_changeset_revision_elem.text
+        # The definition of `installed_changeset_revision` for a repository is that it has been cloned at <tool_path/toolshed/repos/owner/name/installed_changeset_revision>
+        # so if we load a tool it needs to be at a path that contains `installed_changeset_revision`.
+        path_to_installed_changeset_revision = os.path.join(tool_shed, 'repos', repository_owner, repository_name)
+        assert path_to_installed_changeset_revision in path
+        installed_changeset_revision = path[path.index(path_to_installed_changeset_revision) + len(path_to_installed_changeset_revision):].split(os.path.sep)[1]
         repository = self._get_tool_shed_repository(tool_shed=tool_shed,
                                                     name=repository_name,
                                                     owner=repository_owner,


### PR DESCRIPTION
It appears that the xml tag in shed_tool_conf.xml is frequently wrong.
Fixes https://github.com/galaxyproject/galaxy/issues/8892