### PR TITLE
[19.09] Fix unspecified shed_tool_config_file taking precedence over old shed_tool_conf.xml

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1109,7 +1109,7 @@ class ConfiguresGalaxyMixin(object):
                 log.warning(
                     "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
                     "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
-                    "config file"
+                    "config file", self.config.shed_tool_config_file
                 )
             tool_configs.append(self.config.shed_tool_config_file)
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1097,28 +1097,27 @@ class ConfiguresGalaxyMixin(object):
         from galaxy.managers.tools import DynamicToolManager
         self.dynamic_tools_manager = DynamicToolManager(self)
         self._toolbox_lock = threading.RLock()
-        # Initialize the tools, making sure the list of tool configs includes automatically generated dynamic
-        # (shed-enabled) tool configs, which are created on demand.
-        tool_configs = self.config.tool_configs
-        # If the user has configured a shed tool config in tool_config_file this would add a second, but since we're not
-        # parsing them yet we don't know if that's the case. We'll assume that the standard shed_tool_conf.xml location
-        # is in use, and warn if we suspect there to be problems.
-        if self.config.shed_tool_config_file not in tool_configs:
+        # shed_tool_config_file has been set, add it to tool_configs
+        if self.config.shed_tool_config_file_set:
+            self.config.tool_configs.append(self.config.shed_tool_config_file)
+        # The value of migrated_tools_config is the file reserved for containing only those tools that have been
+        # eliminated from the distribution and moved to the tool shed. If migration checking is disabled, only add it if
+        # it exists (since this may be an existing deployment where migrations were previously run).
+        if ((self.config.check_migrate_tools or os.path.exists(self.config.migrated_tools_config))
+                and self.config.migrated_tools_config not in self.config.tool_configs):
+            self.config.tool_configs.append(self.config.migrated_tools_config)
+        self.toolbox = tools.ToolBox(self.config.tool_configs, self.config.tool_path, self)
+        # If no shed-enabled tool config file has been loaded, we append a default shed_tool_conf.xml
+        if not self.config.shed_tool_config_file_set and not self.toolbox.dynamic_confs():
             # This seems like the likely case for problems in older deployments
-            if self.config.tool_config_file_set and not self.config.shed_tool_config_file_set:
+            if self.config.tool_config_file_set:
                 log.warning(
                     "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
                     "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
                     "config file", self.config.shed_tool_config_file
                 )
-            tool_configs.append(self.config.shed_tool_config_file)
-        # The value of migrated_tools_config is the file reserved for containing only those tools that have been
-        # eliminated from the distribution and moved to the tool shed. If migration checking is disabled, only add it if
-        # it exists (since this may be an existing deployment where migrations were previously run).
-        if ((self.config.check_migrate_tools or os.path.exists(self.config.migrated_tools_config))
-                and self.config.migrated_tools_config not in tool_configs):
-            tool_configs.append(self.config.migrated_tools_config)
-        self.toolbox = tools.ToolBox(tool_configs, self.config.tool_path, self)
+            self.config.tool_configs.append(self.config.shed_tool_config_file)
+            self.toolbox._init_tools_from_config(self.config.shed_tool_config_file)
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(getattr(self.config, "file_path"))
         app_info = AppInfo(

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -92,19 +92,11 @@ class ToolShedRepository(object):
         Return the in-memory version of the shed_tool_conf file, which is stored in the config_elems entry
         in the shed_tool_conf_dict.
         """
-
-        def _is_valid_shed_config_filename(filename):
-            for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
-                if filename == shed_tool_conf_dict['config_filename']:
-                    return True
-            return False
-
-        if not self.shed_config_filename or not _is_valid_shed_config_filename(self.shed_config_filename):
-            return self.guess_shed_config(app)
-        for shed_tool_conf_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
-            if self.shed_config_filename == shed_tool_conf_dict['config_filename']:
-                return shed_tool_conf_dict
-        return {}
+        if self.shed_config_filename:
+            shed_config_dict = app.toolbox.get_shed_config_dict_by_filename(self.shed_config_filename)
+            if shed_config_dict:
+                return shed_config_dict
+        return self.guess_shed_config(app)
 
     def get_tool_relative_path(self, app):
         # This is a somewhat public function, used by data_manager_manual for instance
@@ -144,7 +136,10 @@ class ToolShedRepository(object):
             if os.path.exists(relative_path):
                 self.shed_config_filename = shed_tool_conf_dict['config_filename']
                 return shed_tool_conf_dict
-        return {}
+        # Very last resort, get default shed_tool_config file for this instance
+        shed_tool_conf_dict = self.app.toolbox.default_shed_tool_conf_dict()
+        self.shed_config_filename = shed_tool_conf_dict['config_filename']
+        return shed_tool_conf_dict
 
     @property
     def has_readme_files(self):

--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -85,7 +85,7 @@ class ToolShedRepository(object):
 
     @shed_config_filename.setter
     def shed_config_filename(self, value):
-        self.metadata['shed_config_filename'] = value
+        self.metadata['shed_config_filename'] = os.path.abspath(value)
 
     def get_shed_config_dict(self, app):
         """

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -156,7 +156,7 @@ class DataManager(object):
             # use shed_conf_file to determine tool_path
             shed_conf_file = elem.get("shed_conf_file")
             if shed_conf_file:
-                shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(os.path.abspath(shed_conf_file), None)
+                shed_conf = self.data_managers.app.toolbox.get_shed_config_dict_by_filename(shed_conf_file)
                 if shed_conf:
                     tool_path = shed_conf.get("tool_path", tool_path)
         assert path is not None, "A tool file path could not be determined:\n%s" % (util.xml_to_string(elem))

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -263,11 +263,12 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             elif item_type == 'tool_dir':
                 self._load_tooldir_tag_set(item, panel_dict, tool_path, integrated_panel_dict, load_panel_dict=load_panel_dict)
 
-    def get_shed_config_dict_by_filename(self, filename, default=None):
+    def get_shed_config_dict_by_filename(self, filename):
+        filename = os.path.abspath(filename)
         for shed_config_dict in self._dynamic_tool_confs:
-            if shed_config_dict['config_filename'] == os.path.abspath(filename):
+            if shed_config_dict['config_filename'] == filename:
                 return shed_config_dict
-        return default
+        return None
 
     def update_shed_config(self, shed_conf):
         """  Update the in-memory descriptions of tools and write out the changes

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -261,7 +261,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
 
     def get_shed_config_dict_by_filename(self, filename, default=None):
         for shed_config_dict in self._dynamic_tool_confs:
-            if shed_config_dict['config_filename'] == filename:
+            if shed_config_dict['config_filename'] == os.path.abspath(filename):
                 return shed_config_dict
         return default
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -187,11 +187,12 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 return
             raise
         tool_path = tool_conf_source.parse_tool_path()
-        log.debug("Tool path for tool configuration %s is %s", config_filename, tool_path)
         parsing_shed_tool_conf = tool_conf_source.is_shed_tool_conf()
         if parsing_shed_tool_conf:
             # Keep an in-memory list of xml elements to enable persistence of the changing tool config.
             config_elems = []
+        tool_conf_type = 'shed tool' if parsing_shed_tool_conf else 'tool'
+        log.debug("Tool path for %s configuration %s is %s", tool_conf_type, config_filename, tool_path)
         tool_path = self.__resolve_tool_path(tool_path, config_filename)
         # Only load the panel_dict under certain conditions.
         load_panel_dict = not self._integrated_tool_panel_config_has_contents

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -743,13 +743,15 @@ class InstallRepositoryManager(object):
             # Get the tool_path setting.
             shed_config_dict = self.tpm.get_shed_tool_conf_dict(shed_tool_conf)
         else:
-            # Don't use migrated_tools_conf.xml and prefer shed_tool_config_file.
             try:
-                for shed_config_dict in self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False):
-                    if shed_config_dict.get('config_filename') == self.app.config.shed_tool_config_file:
-                        break
-                else:
-                    shed_config_dict = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False)[0]
+                dynamic_confs = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False)
+                # Pick the first tool config that doesn't set `is_shed_conf="false"` and that is not a migrated_tool_conf
+                shed_config_dict = dynamic_confs[0]
+                if self.app.config.shed_tool_config_file_set:
+                    # Use shed_tool_config_file if explicitly set
+                    for shed_config_dict in dynamic_confs:
+                        if shed_config_dict.get('config_filename') == self.app.config.shed_tool_config_file:
+                            break
             except IndexError:
                 raise exceptions.RequestParameterMissingException("Missing required parameter 'shed_tool_conf'.")
         shed_tool_conf = shed_config_dict['config_filename']

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -741,8 +741,7 @@ class InstallRepositoryManager(object):
         shed_tool_conf = install_options.get('shed_tool_conf', None)
         if shed_tool_conf:
             # Get the tool_path setting.
-            shed_conf_dict = self.tpm.get_shed_tool_conf_dict(shed_tool_conf)
-            tool_path = shed_conf_dict['tool_path']
+            shed_config_dict = self.tpm.get_shed_tool_conf_dict(shed_tool_conf)
         else:
             # Don't use migrated_tools_conf.xml and prefer shed_tool_config_file.
             try:
@@ -753,8 +752,8 @@ class InstallRepositoryManager(object):
                     shed_config_dict = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False)[0]
             except IndexError:
                 raise exceptions.RequestParameterMissingException("Missing required parameter 'shed_tool_conf'.")
-            shed_tool_conf = shed_config_dict['config_filename']
-            tool_path = shed_config_dict['tool_path']
+        shed_tool_conf = shed_config_dict['config_filename']
+        tool_path = shed_config_dict['tool_path']
         tool_panel_section_id = self.app.toolbox.find_section_id(install_options.get('tool_panel_section_id', ''))
         # Build the dictionary of information necessary for creating tool_shed_repository database records
         # for each repository being installed.

--- a/lib/tool_shed/galaxy_install/install_manager.py
+++ b/lib/tool_shed/galaxy_install/install_manager.py
@@ -738,22 +738,12 @@ class InstallRepositoryManager(object):
             self.__assert_can_install_dependencies()
         new_tool_panel_section_label = install_options.get('new_tool_panel_section_label', '')
         tool_panel_section_mapping = install_options.get('tool_panel_section_mapping', {})
-        shed_tool_conf = install_options.get('shed_tool_conf', None)
+        shed_tool_conf = install_options.get('shed_tool_conf')
         if shed_tool_conf:
             # Get the tool_path setting.
             shed_config_dict = self.tpm.get_shed_tool_conf_dict(shed_tool_conf)
         else:
-            try:
-                dynamic_confs = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=False)
-                # Pick the first tool config that doesn't set `is_shed_conf="false"` and that is not a migrated_tool_conf
-                shed_config_dict = dynamic_confs[0]
-                if self.app.config.shed_tool_config_file_set:
-                    # Use shed_tool_config_file if explicitly set
-                    for shed_config_dict in dynamic_confs:
-                        if shed_config_dict.get('config_filename') == self.app.config.shed_tool_config_file:
-                            break
-            except IndexError:
-                raise exceptions.RequestParameterMissingException("Missing required parameter 'shed_tool_conf'.")
+            shed_config_dict = self.app.toolbox.default_shed_tool_conf_dict()
         shed_tool_conf = shed_config_dict['config_filename']
         tool_path = shed_config_dict['tool_path']
         tool_panel_section_id = self.app.toolbox.find_section_id(install_options.get('tool_panel_section_id', ''))

--- a/lib/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -155,7 +155,7 @@ class InstalledRepositoryMetadataManager(metadata_generator.MetadataGenerator):
         A tool shed repository is being updated so change the shed_tool_conf file.  Parse the config
         file to generate the entire list of config_elems instead of using the in-memory list.
         """
-        shed_conf_dict = self.repository.get_shed_config_dict(self.app)
+        shed_conf_dict = self.shed_config_dict or self.repository.get_shed_config_dict(self.app)
         shed_tool_conf = shed_conf_dict['config_filename']
         tool_path = shed_conf_dict['tool_path']
         self.tpm.generate_tool_panel_dict_from_shed_tool_conf_entries(self.repository)

--- a/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -2,6 +2,7 @@ import errno
 import logging
 from xml.etree import ElementTree as XmlET
 
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.util import xml_to_string
 from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 from tool_shed.util import basic_util
@@ -328,6 +329,7 @@ class ToolPanelManager(object):
                 file_name = basic_util.strip_path(shed_tool_conf_dict['config_filename'])
                 if shed_tool_conf == file_name:
                     return shed_tool_conf_dict
+        raise RequestParameterInvalidException("Requested shed_tool_conf '%s' is not an active shed_tool_config_file" % shed_tool_conf)
 
     def handle_tool_panel_section(self, toolbox, tool_panel_section_id=None, new_tool_panel_section_label=None):
         """Return a ToolSection object retrieved from the current in-memory tool_panel."""

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -406,12 +406,6 @@ def get_tool_panel_config_tool_path_install_dir(app, repository):
                                                   str(repository.installed_changeset_revision))
     # Get the relative tool installation paths from each of the shed tool configs.
     shed_config_dict = repository.get_shed_config_dict(app)
-    if not shed_config_dict:
-        # Just pick a semi-random shed config.
-        for shed_config_dict in app.toolbox.dynamic_confs(include_migrated_tool_conf=True):
-            if (repository.dist_to_shed and shed_config_dict['config_filename'] == app.config.migrated_tools_config) \
-                    or (not repository.dist_to_shed and shed_config_dict['config_filename'] != app.config.migrated_tools_config):
-                break
     shed_tool_conf = shed_config_dict['config_filename']
     tool_path = shed_config_dict['tool_path']
     return shed_tool_conf, tool_path, relative_install_dir

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -7,7 +7,7 @@ from nose.plugins.skip import SkipTest
 
 from .uses_shed import CONDA_AUTO_INSTALL_JOB_TIMEOUT, UsesShed
 
-FETCH_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.2'
+FETCH_TOOL_ID = 'toolshed.g2.bx.psu.edu/repos/devteam/data_manager_fetch_genome_dbkeys_all_fasta/data_manager_fetch_genome_all_fasta_dbkey/0.0.3'
 FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {
     "dbkey_source|dbkey_source_selector": "new",
     "dbkey_source|dbkey": "NC_001617.1",
@@ -18,7 +18,7 @@ FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT = {
     "reference_source|user_url": "https://raw.githubusercontent.com/galaxyproject/galaxy-test-data/master/NC_001617.1.fasta",
     "sorting|sort_selector": "as_is"
 }
-SAM_FASTA_ID = "toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder/sam_fasta_index_builder/0.0.2"
+SAM_FASTA_ID = "toolshed.g2.bx.psu.edu/repos/devteam/data_manager_sam_fasta_index_builder/sam_fasta_index_builder/0.0.3"
 SAM_FASTA_INPUT = {"all_fasta_source": "NC_001617.1", "sequence_name": "", "sequence_id": ""}
 DATA_MANAGER_MANUAL_ID = 'toolshed.g2.bx.psu.edu/repos/iuc/data_manager_manual/data_manager_manual/0.0.2'
 DATA_MANAGER_MANUAL_INPUT = {
@@ -61,8 +61,8 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         """
         Test that we can install data managers, create a new dbkey, and use that dbkey in a downstream data manager.
         """
-        self.install_repository("devteam", "data_manager_fetch_genome_dbkeys_all_fasta", "b1bc53e9bbc5")
-        self.install_repository("devteam", "data_manager_sam_fasta_index_builder", "406896e00d0e", 'https://testtoolshed.g2.bx.psu.edu')
+        self.install_repository("devteam", "data_manager_fetch_genome_dbkeys_all_fasta", "14eb0fc65c62")
+        self.install_repository("devteam", "data_manager_sam_fasta_index_builder", "cc4ef4d38cf9")
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
                 run_response = self.dataset_populator.run_tool(tool_id=FETCH_TOOL_ID,

--- a/test/integration/uses_shed.py
+++ b/test/integration/uses_shed.py
@@ -55,7 +55,7 @@ class UsesShed(object):
         config["conda_prefix"] = os.environ.get('GALAXY_TEST_CONDA_PREFIX') or os.path.join(cls.conda_tmp_prefix, 'conda')
 
     def reset_shed_tools(self):
-        shutil.rmtree(self._app.config.shed_tools_dir)
+        shutil.rmtree(self._app.config.shed_tools_dir, ignore_errors=True)
         os.makedirs(self._app.config.shed_tools_dir)
         with open(self._app.config.shed_tool_config_file, "w") as tool_conf_file:
             tool_conf_file.write(SHED_TOOL_CONF.substitute(shed_tools_path=self._app.config.shed_tools_dir))

--- a/test/integration/uses_shed.py
+++ b/test/integration/uses_shed.py
@@ -34,7 +34,8 @@ class UsesShed(object):
         cls._test_driver.temp_directories.extend([cls.shed_tool_data_dir, cls.shed_tools_dir])
         shed_tool_config = os.path.join(cls.shed_tools_dir, 'shed_tool_conf.xml')
         config["tool_sheds_config_file"] = TOOL_SHEDS_CONF
-        config["tool_config_file"] = "%s,%s" % (FRAMEWORK_UPLOAD_TOOL_CONF, shed_tool_config)
+        config["tool_config_file"] = FRAMEWORK_UPLOAD_TOOL_CONF
+        config["shed_tool_config_file"] = shed_tool_config
         config["shed_data_manager_config_file"] = os.path.join(cls.shed_tool_data_dir, 'shed_data_manager_config_file')
         config["shed_tool_data_table_config"] = os.path.join(cls.shed_tool_data_dir, 'shed_data_table_conf.xml')
         config["shed_tool_data_path"] = cls.shed_tool_data_dir


### PR DESCRIPTION
This fixes https://github.com/galaxyproject/galaxy/issues/8952#issuecomment-554346736, but this was very hard to diagnose and I also fixed some inconsistencies along the way.

With https://github.com/galaxyproject/galaxy/commit/be5aafd34b1f400704ef863684c9b742e1ca7427 Galaxy now creates/loads a default shed_tool_config_file if it is not part of the tool_config setting. This led to automated installations going to the wrong shed_tool_conf .xml file, one that was never referenced in any config.

The way this was done was also slightly wrong, the actual app.config.tool_config file was never updated, and so any upon toolbox reload would lose this file (xref https://github.com/galaxyproject/galaxy/blob/406e77e05c3d35239b0ecc13f980354187bc09fa/lib/galaxy/queue_worker.py#L186) ... but it would remain in the integrated_tool_panel_conf.xml file

So this PR only loads/creates the default, unspecified shed_tool_config_file if no shed-enabled tool config file has been loaded, and also fixes the way this is done (needs to be added to self.config.tool_configs for reloads).

This PR also unifies the methods for getting a shed_tool_config_dict, fixes or enhances some logging messages and raises appropriate exceptions if no shed_enabled config is loaded and repository installations are attempted and removes now unreachable code.