### PR TITLE
fix history import and export for real user setups

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -57,6 +57,7 @@ from galaxy.tool_util.output_checker import (
 )
 from galaxy.util import (
     parse_xml_string,
+    RWXRWXRWX,
     safe_makedirs,
     unicodify
 )
@@ -2207,9 +2208,11 @@ class JobWrapper(HasResourceParameters):
     def change_ownership_for_run(self):
         job = self.get_job()
         external_chown_script = self.get_destination_configuration("external_chown_script", None)
-        if job.user is not None:
-            external_chown(self.working_directory, self.user_system_pwent,
+        if job.user is not None and external_chown_script is not None:
+            ret = external_chown(self.working_directory, self.user_system_pwent,
                            external_chown_script, description="working directory")
+            if not ret:
+                os.chmod(self.working_directory, RWXRWXRWX)
 
     def reclaim_ownership(self):
         job = self.get_job()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1930,9 +1930,6 @@ class JobWrapper(HasResourceParameters):
         for (hda, dataset_path) in self.output_hdas_and_paths.values():
             if hda == dataset:
                 return dataset_path
-#         if getattr(dataset, "fake_dataset_association", False):
-#             log.error("GET_OUTPUT_PATH FAKE %s" %(dataset.file_name))
-#             return dataset.file_name
         raise KeyError("Couldn't find job output for [{}] in [{}]".format(dataset, self.output_hdas_and_paths.values()))
 
     def get_mutable_output_fnames(self):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1819,7 +1819,6 @@ class JobWrapper(HasResourceParameters):
                         if e.errno != errno.ENOENT:
                             raise
                 self.external_output_metadata.cleanup_external_metadata(self.sa_session)
-            galaxy.tools.imp_exp.JobExportHistoryArchiveWrapper(self.app, self.job_id).cleanup_after_job()
             galaxy.tools.imp_exp.JobImportHistoryArchiveWrapper(self.app, self.job_id).cleanup_after_job()
             if delete_files:
                 self.object_store.delete(self.get_job(), base_dir='job_work', entire_dir=True, dir_only=True, obj_dir=True)
@@ -1965,7 +1964,7 @@ class JobWrapper(HasResourceParameters):
         self.output_paths = [t[2] for t in results]
         self.output_hdas_and_paths = {t[0]: t[1:] for t in results}
         if special:
-            false_path = dataset_path_rewriter.rewrite_dataset_path(special.dataset, 'output')
+            false_path = dataset_path_rewriter.rewrite_dataset_path(special, 'output')
             dsp = DatasetPath(special.dataset.id, special.dataset.file_name, false_path)
             self.output_paths.append(dsp)
             self.output_hdas_and_paths["output_file"] = [special.fda, dsp]

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -56,9 +56,7 @@ from galaxy.tool_util.output_checker import (
     DETECTED_JOB_STATE,
 )
 from galaxy.util import (
-    commands,
     parse_xml_string,
-    RWXRWXRWX,
     safe_makedirs,
     unicodify,
 )

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -58,7 +58,7 @@ from galaxy.tool_util.output_checker import (
 from galaxy.util import (
     parse_xml_string,
     safe_makedirs,
-    unicodify,
+    unicodify
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.expressions import ExpressionContext

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1922,17 +1922,14 @@ class JobWrapper(HasResourceParameters):
         return [os.path.basename(str(fname)) for fname in self.get_output_fnames()]
 
     def get_output_fnames(self):
-        log.error("GET_OUTPUT_FNAMES")
         if self.output_paths is None:
             self.compute_outputs()
         return self.output_paths
 
     def get_output_path(self, dataset):
-        log.error("GET_OUTPUT_PATH")
         if self.output_paths is None:
             self.compute_outputs()
         for (hda, dataset_path) in self.output_hdas_and_paths.values():
-            log.error("GET_OUTPUT_PATH %s %s" %(hda,dataset))
             if hda == dataset:
                 return dataset_path
 #         if getattr(dataset, "fake_dataset_association", False):
@@ -1941,13 +1938,11 @@ class JobWrapper(HasResourceParameters):
         raise KeyError("Couldn't find job output for [{}] in [{}]".format(dataset, self.output_hdas_and_paths.values()))
 
     def get_mutable_output_fnames(self):
-        log.error("GET_MUTABLE_OUTPUT_FNAME")
         if self.output_paths is None:
             self.compute_outputs()
         return [dsp for dsp in self.output_paths if dsp.mutable]
 
     def get_output_hdas_and_fnames(self):
-        log.error("GET_OUTPUT_HDAS_AND_FNAMES")
         if self.output_hdas_and_paths is None:
             self.compute_outputs()
         return self.output_hdas_and_paths
@@ -1956,8 +1951,6 @@ class JobWrapper(HasResourceParameters):
         dataset_path_rewriter = self.dataset_path_rewriter
 
         job = self.get_job()
-        log.error("JOB %s " %(job))
-        log.error("JOB DIR %s " %(dir(job)))
         # Job output datasets are combination of history, library, and jeha datasets.
         special = self.sa_session.query(model.JobExportHistoryArchive).filter_by(job=job).first()
         false_path = None
@@ -1965,8 +1958,6 @@ class JobWrapper(HasResourceParameters):
         results = []
         for da in job.output_datasets + job.output_library_datasets:
             da_false_path = dataset_path_rewriter.rewrite_dataset_path(da.dataset, 'output')
-            log.error("NORMAL da: %s" %(da))
-            log.error("NORMAL da.dataset %s -> da_false_path %s" %(da.dataset, da_false_path))
             mutable = da.dataset.dataset.external_filename is None
             dataset_path = DatasetPath(da.dataset.dataset.id, da.dataset.file_name, false_path=da_false_path, mutable=mutable)
             results.append((da.name, da.dataset, dataset_path))
@@ -1975,17 +1966,9 @@ class JobWrapper(HasResourceParameters):
         self.output_hdas_and_paths = {t[0]: t[1:] for t in results}
         if special:
             false_path = dataset_path_rewriter.rewrite_dataset_path(special.dataset, 'output')
-            log.error("SPECIAL special %s" %(special))
-            log.error("SPECIAL special.dataset %s -> false_path %s" %(special.dataset, false_path))
             dsp = DatasetPath(special.dataset.id, special.dataset.file_name, false_path)
             self.output_paths.append(dsp)
-            log.error("SPECIAL DIR %s"%str(dir(special)))
-            log.error("SPECIAL JOB %s " %(special.job))
-            log.error("SPECIAL NAME %s"%str(special.export_name))
-            log.error("SPECIAL ... %s"%str(special.__dict__))
-
-            self.output_hdas_and_paths[ "output_file" ] = [special.fda, dsp]
-        log.error( "self.output_hdas_and_paths %s"% str(self.output_hdas_and_paths) )
+            self.output_hdas_and_paths["output_file"] = [special.fda, dsp]
         return self.output_paths
 
     def get_output_file_id(self, file):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1559,6 +1559,17 @@ class JobExternalOutputMetadata(RepresentById):
             return self.library_dataset_dataset_association
         return None
 
+# Set up output dataset association for export history jobs. Because job
+# uses a Dataset rather than an HDA or LDA, it's necessary to set up a
+# fake dataset association that provides the needed attributes for
+# preparing a job.
+class FakeDatasetAssociation (object):
+    fake_dataset_association = True
+
+    def __init__(self, dataset=None):
+        self.dataset = dataset
+        self.file_name = dataset.file_name
+        self.metadata = dict()
 
 class JobExportHistoryArchive(RepresentById):
     def __init__(self, job=None, history=None, dataset=None, compressed=False,
@@ -1566,6 +1577,7 @@ class JobExportHistoryArchive(RepresentById):
         self.job = job
         self.history = history
         self.dataset = dataset
+        self.fda = FakeDatasetAssociation(dataset)
         self.compressed = compressed
         self.history_attrs_filename = history_attrs_filename
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1559,6 +1559,7 @@ class JobExternalOutputMetadata(RepresentById):
             return self.library_dataset_dataset_association
         return None
 
+
 # Set up output dataset association for export history jobs. Because job
 # uses a Dataset rather than an HDA or LDA, it's necessary to set up a
 # fake dataset association that provides the needed attributes for
@@ -1571,15 +1572,22 @@ class FakeDatasetAssociation (object):
         self.file_name = dataset.file_name
         self.metadata = dict()
 
+    def __eq__(self, other):
+        return isinstance(other, FakeDatasetAssociation) and self.dataset == other.dataset
+
+
 class JobExportHistoryArchive(RepresentById):
     def __init__(self, job=None, history=None, dataset=None, compressed=False,
                  history_attrs_filename=None):
         self.job = job
         self.history = history
         self.dataset = dataset
-        self.fda = FakeDatasetAssociation(dataset)
         self.compressed = compressed
         self.history_attrs_filename = history_attrs_filename
+
+    @property
+    def fda(self):
+        return FakeDatasetAssociation(self.dataset)
 
     @property
     def temp_directory(self):

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -4,7 +4,10 @@ import tempfile
 from collections import OrderedDict
 
 from galaxy.tools.actions import ToolAction
-from galaxy.tools.imp_exp import JobExportHistoryArchiveWrapper
+from galaxy.tools.imp_exp import (
+    JobExportHistoryArchiveWrapper,
+    JobImportHistoryArchiveWrapper
+)
 
 log = logging.getLogger(__name__)
 
@@ -47,6 +50,9 @@ class ImportHistoryToolAction(ToolAction):
         archive_dir = os.path.abspath(tempfile.mkdtemp())
         jiha = trans.app.model.JobImportHistoryArchive(job=job, archive_dir=archive_dir)
         trans.sa_session.add(jiha)
+
+        job_wrapper = JobImportHistoryArchiveWrapper(trans.app, job)
+        job_wrapper.setup_job(jiha, incoming['__ARCHIVE_SOURCE__'])
 
         #
         # Add parameters to job_parameter table.
@@ -121,7 +127,6 @@ class ExportHistoryToolAction(ToolAction):
         jeha = trans.app.model.JobExportHistoryArchive(job=job, history=history,
                                                        dataset=archive_dataset,
                                                        compressed=incoming['compress'])
-        log.error("JobExportHistoryArchive %s created with fda %s" %(jeha, jeha.fda))
         trans.sa_session.add(jeha)
 
         job_wrapper = JobExportHistoryArchiveWrapper(trans.app, job)

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -121,6 +121,7 @@ class ExportHistoryToolAction(ToolAction):
         jeha = trans.app.model.JobExportHistoryArchive(job=job, history=history,
                                                        dataset=archive_dataset,
                                                        compressed=incoming['compress'])
+        log.error("JobExportHistoryArchive %s created with fda %s" %(jeha, jeha.fda))
         trans.sa_session.add(jeha)
 
         job_wrapper = JobExportHistoryArchiveWrapper(trans.app, job)

--- a/lib/galaxy/tools/actions/history_imp_exp.py
+++ b/lib/galaxy/tools/actions/history_imp_exp.py
@@ -52,7 +52,7 @@ class ImportHistoryToolAction(ToolAction):
         trans.sa_session.add(jiha)
 
         job_wrapper = JobImportHistoryArchiveWrapper(trans.app, job)
-        job_wrapper.setup_job(jiha, incoming['__ARCHIVE_SOURCE__'])
+        job_wrapper.setup_job(jiha, incoming['__ARCHIVE_SOURCE__'], incoming["__ARCHIVE_TYPE__"])
 
         #
         # Add parameters to job_parameter table.

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -18,10 +18,7 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.model import tags
-from galaxy.util import (
-    commands,
-    unicodify
-)
+from galaxy.util import unicodify
 from galaxy.util.path import external_chown
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -378,7 +378,7 @@ def create_paramfile(trans, uploaded_datasets):
             # TODO: This will have to change when we start bundling inputs.
             # Also, in_place above causes the file to be left behind since the
             # user cannot remove it unless the parent directory is writable.
-            if link_data_only == 'copy_files':
+            if link_data_only == 'copy_files' and trans.user:
                 external_chown(uploaded_dataset.path,
                                trans.user.system_user_pwent(trans.app.config.real_system_username),
                                trans.app.config.external_chown_script, description="uploaded file")

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -83,23 +83,15 @@ class ToolEvaluator:
         inp_data, out_data, out_collections = job.io_dicts()
 
         if get_special:
-
-            # Set up output dataset association for export history jobs. Because job
-            # uses a Dataset rather than an HDA or LDA, it's necessary to set up a
-            # fake dataset association that provides the needed attributes for
-            # preparing a job.
-            class FakeDatasetAssociation :
-                fake_dataset_association = True
-
-                def __init__(self, dataset=None):
-                    self.dataset = dataset
-                    self.file_name = dataset.file_name
-                    self.metadata = dict()
-
+            log.error("ToolEvaluator.set_compute_environment get_special() %s"%(get_special))
             special = get_special()
+            log.error("ToolEvaluator.set_compute_environment special %s"%(special))
             if special:
-                out_data["output_file"] = FakeDatasetAssociation(dataset=special.dataset)
+                log.error("ToolEvaluator.set_compute_environment special.dataset(.filename) %s %s"%(special.dataset, special.dataset.file_name))
+                log.error("ToolEvaluator.set_compute_environment out_data before %s"%(out_data))
+                out_data["output_file"] = special.fda
 
+        log.error("ToolEvaluator.set_compute_environment out_data %s" %(out_data))
         # These can be passed on the command line if wanted as $__user_*__
         incoming.update(model.User.user_template_environment(job.history and job.history.user))
 

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -83,15 +83,10 @@ class ToolEvaluator:
         inp_data, out_data, out_collections = job.io_dicts()
 
         if get_special:
-            log.error("ToolEvaluator.set_compute_environment get_special() %s"%(get_special))
             special = get_special()
-            log.error("ToolEvaluator.set_compute_environment special %s"%(special))
             if special:
-                log.error("ToolEvaluator.set_compute_environment special.dataset(.filename) %s %s"%(special.dataset, special.dataset.file_name))
-                log.error("ToolEvaluator.set_compute_environment out_data before %s"%(out_data))
                 out_data["output_file"] = special.fda
 
-        log.error("ToolEvaluator.set_compute_environment out_data %s" %(out_data))
         # These can be passed on the command line if wanted as $__user_*__
         incoming.update(model.User.user_template_environment(job.history and job.history.user))
 

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -1,15 +1,32 @@
+import getpass
 import logging
 import os
+import shlex
 import shutil
+import subprocess
 import tempfile
 
 from galaxy import model
-from galaxy.model import store
+from galaxy.util import unicodify
 from galaxy.version import VERSION_MAJOR
 
 log = logging.getLogger(__name__)
 
 ATTRS_FILENAME_HISTORY = 'history_attrs.txt'
+
+
+def _chown(path, jeha, app, user):
+    try:
+        # get username from email/username
+        pwent = jeha.job.user.system_user_pwent(user)
+        cmd = shlex.split(app.config.external_chown_script)
+        cmd.extend([path, pwent[0], str(pwent[3])])
+        log.debug('Changing ownership of %s with: %s' % (path, ' '.join(cmd)))
+        p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        assert p.returncode == 0, stderr
+    except Exception as e:
+        log.warning('Changing ownership of uploaded file %s failed: %s', path, unicodify(e))
 
 
 class JobImportHistoryArchiveWrapper:
@@ -22,6 +39,13 @@ class JobImportHistoryArchiveWrapper:
         self.app = app
         self.job_id = job_id
         self.sa_session = self.app.model.context
+
+    def setup_job(self, jiha, archive_source):
+        log.error("JobImportHistoryArchiveWrapper setup_job()")
+
+        if self.app.config.external_chown_script is not None:
+            _chown(archive_source, jiha, self.app, self.app.config.real_system_username)
+            _chown(jiha.archive_dir, jiha, self.app, self.app.config.real_system_username)
 
     def cleanup_after_job(self):
         """ Set history, datasets, collections and jobs' attributes
@@ -40,15 +64,16 @@ class JobImportHistoryArchiveWrapper:
         new_history = None
         try:
             archive_dir = jiha.archive_dir
-            model_store = store.get_import_model_store_for_directory(archive_dir, app=self.app, user=user)
+            if self.app.config.external_chown_script is not None:
+                _chown(archive_dir, jiha, self.app, str(getpass.getuser()))
+
+            model_store = model.store.get_import_model_store_for_directory(archive_dir, app=self.app, user=user)
             job = jiha.job
             with model_store.target_history(default_history=job.history) as new_history:
 
                 jiha.history = new_history
                 self.sa_session.flush()
-
                 model_store.perform_import(new_history, job=job, new_history=True)
-
                 # Cleanup.
                 if os.path.exists(archive_dir):
                     shutil.rmtree(archive_dir)
@@ -87,21 +112,16 @@ class JobExportHistoryArchiveWrapper:
         # Use abspath because mkdtemp() does not, contrary to the documentation,
         # always return an absolute path.
         temp_output_dir = os.path.abspath(tempfile.mkdtemp())
-        jeha = self.sa_session.query(model.JobExportHistoryArchive).filter_by(job_id=self.job_id).first()
-	if jeha:
-            temp_output_dir = jeha.working_directory
-        else:
-            log.error("JobExportHistoryArchiveWrapper no such job")
-
-        log.error("JobExportHistoryArchiveWrapper temp_output_dir %s"%temp_output_dir)
 
         history = jeha.history
         history_attrs_filename = os.path.join(temp_output_dir, ATTRS_FILENAME_HISTORY)
         jeha.history_attrs_filename = history_attrs_filename
 
         # symlink files on export, on worker files will tarred up in a dereferenced manner.
-        with store.DirectoryModelExportStore(temp_output_dir, app=app, export_files="symlink") as export_store:
+        with model.store.DirectoryModelExportStore(temp_output_dir, app=app, export_files="symlink") as export_store:
             export_store.export_history(history, include_hidden=include_hidden, include_deleted=include_deleted)
+        if app.config.external_chown_script is not None:
+            _chown(temp_output_dir, jeha, app, app.config.real_system_username)
 
         #
         # Create and return command line for running tool.
@@ -115,9 +135,11 @@ class JobExportHistoryArchiveWrapper:
         """ Remove temporary directory and attribute files generated during setup for this job. """
         # Get jeha for job.
         jeha = self.sa_session.query(model.JobExportHistoryArchive).filter_by(job_id=self.job_id).first()
-        if jeha:
-            temp_dir = jeha.temp_directory
-            try:
-                shutil.rmtree(temp_dir)
-            except Exception as e:
-                log.debug('Error deleting directory containing attribute files ({}): {}'.format(temp_dir, e))
+        if not jeha:
+            return
+        _chown(jeha.temp_directory, jeha, self.app, str(getpass.getuser()))
+        temp_dir = jeha.temp_directory
+        try:
+            shutil.rmtree(temp_dir)
+        except Exception as e:
+            log.debug('Error deleting directory containing attribute files ({}): {}'.format(temp_dir, e))

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -87,6 +87,13 @@ class JobExportHistoryArchiveWrapper:
         # Use abspath because mkdtemp() does not, contrary to the documentation,
         # always return an absolute path.
         temp_output_dir = os.path.abspath(tempfile.mkdtemp())
+        jeha = self.sa_session.query(model.JobExportHistoryArchive).filter_by(job_id=self.job_id).first()
+	if jeha:
+            temp_output_dir = jeha.working_directory
+        else:
+            log.error("JobExportHistoryArchiveWrapper no such job")
+
+        log.error("JobExportHistoryArchiveWrapper temp_output_dir %s"%temp_output_dir)
 
         history = jeha.history
         history_attrs_filename = os.path.join(temp_output_dir, ATTRS_FILENAME_HISTORY)

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -24,9 +24,10 @@ class JobImportHistoryArchiveWrapper:
         self.job_id = job_id
         self.sa_session = self.app.model.context
 
-    def setup_job(self, jiha, archive_source):
-        external_chown(archive_source, jiha.job.user.system_user_pwent(self.app.config.real_system_username),
-                       self.app.config.external_chown_script, "history import archive")
+    def setup_job(self, jiha, archive_source, archive_type):
+        if archive_type != "url":
+            external_chown(archive_source, jiha.job.user.system_user_pwent(self.app.config.real_system_username),
+                           self.app.config.external_chown_script, "history import archive")
         external_chown(jiha.archive_dir, jiha.job.user.system_user_pwent(self.app.config.real_system_username),
                        self.app.config.external_chown_script, "history import archive directory")
 

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -25,6 +25,9 @@ def create_archive(export_directory, out_file, gzip=False):
     except Exception as e:
         print('Error creating history archive: %s' % unicodify(e), file=sys.stderr)
         return 1
+    finally:
+        if os.path.exists(export_directory):
+            shutil.rmtree(export_directory, ignore_errors=True)
 
 
 def main(argv=None):

--- a/lib/galaxy/tools/imp_exp/export_history.py
+++ b/lib/galaxy/tools/imp_exp/export_history.py
@@ -26,8 +26,7 @@ def create_archive(export_directory, out_file, gzip=False):
         print('Error creating history archive: %s' % unicodify(e), file=sys.stderr)
         return 1
     finally:
-        if os.path.exists(export_directory):
-            shutil.rmtree(export_directory, ignore_errors=True)
+        shutil.rmtree(export_directory, ignore_errors=True)
 
 
 def main(argv=None):

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -5,7 +5,6 @@ import errno
 import imp
 import logging
 import shlex
-import subprocess
 from functools import partial
 try:
     from grp import getgrgid
@@ -347,9 +346,14 @@ def external_chown(path, pwent, external_chown_script, description="file"):
     call the external chown script (if not None) to change
     the user and group of the given path, and additional description
     of the file/path for the log message can be given
+
+    return
+    - None if external_chown_script is None
+    - True in case of success
+    - False in case of failure
     """
     if external_chown_script is None:
-        return
+        return None
 
     try:
         cmd = shlex.split(external_chown_script)

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -355,11 +355,11 @@ def external_chown(path, pwent, external_chown_script, description="file"):
         cmd = shlex.split(external_chown_script)
         cmd.extend([path, pwent[0], str(pwent[3])])
         log.debug('Changing ownership of {} with: {}'.format(path, ' '.join(cmd)))
-        p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = p.communicate()
-        assert p.returncode == 0, stderr
-    except Exception as e:
+        galaxy.util.commands.execute(cmd)
+        return True
+    except galaxy.util.commands.CommandLineException as e:
         log.warning('Changing ownership of {} {} failed: {}'.format(description, path, galaxy.util.unicodify(e)))
+        return False
 
 
 def __listify(item):

--- a/lib/galaxy_test/api/_framework.py
+++ b/lib/galaxy_test/api/_framework.py
@@ -1,3 +1,5 @@
+from unittest import TestCase
+
 from galaxy_test.base.api import UsesApiTestCaseMixin
 from galaxy_test.base.testcase import FunctionalTestCase
 try:
@@ -8,7 +10,7 @@ except ImportError:
     GalaxyTestDriver = None
 
 
-class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin):
+class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin, TestCase):
     galaxy_driver_class = GalaxyTestDriver
 
     def setUp(self):

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -13,12 +13,25 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class HistoriesApiTestCase(ApiTestCase):
+class BaseHistories(object):
 
-    def setUp(self):
-        super().setUp()
-        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
-        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+    def _show(self, history_id):
+        return self._get("histories/%s" % history_id).json()
+
+    def _update(self, history_id, data):
+        update_url = self._api_url("histories/%s" % history_id, use_key=True)
+        put_response = put(update_url, json=data)
+        return put_response
+
+    def _create_history(self, name):
+        post_data = dict(name=name)
+        create_response = self._post("histories", data=post_data).json()
+        self._assert_has_keys(create_response, "name", "id")
+        self.assertEqual(create_response["name"], name)
+        return create_response
+
+
+class HistoriesApiTestCase(ApiTestCase, BaseHistories):
 
     def test_create_history(self):
         # Create a history.
@@ -176,6 +189,24 @@ class HistoriesApiTestCase(ApiTestCase):
         histories_url = self._api_url("histories")
         create_response = post(url=histories_url, data=post_data)
         self._assert_status_code_is(create_response, 403)
+
+    def test_create_tag(self):
+        post_data = dict(name="TestHistoryForTag")
+        history_id = self._post("histories", data=post_data).json()["id"]
+        tag_data = dict(value="awesometagvalue")
+        tag_url = "histories/%s/tags/awesometagname" % history_id
+        tag_create_response = self._post(tag_url, data=tag_data)
+        self._assert_status_code_is(tag_create_response, 200)
+
+    # TODO: (CE) test_create_from_copy
+
+
+class ImportExportHistoryTestCase(ApiTestCase, BaseHistories):
+
+    def setUp(self):
+        super(ImportExportHistoryTestCase, self).setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
     def test_import_export(self):
         history_name = "for_export_default"
@@ -385,28 +416,3 @@ class HistoriesApiTestCase(ApiTestCase):
 
         if elements_checker is not None:
             elements_checker(imported_collection_metadata["elements"])
-
-    def test_create_tag(self):
-        post_data = dict(name="TestHistoryForTag")
-        history_id = self._post("histories", data=post_data).json()["id"]
-        tag_data = dict(value="awesometagvalue")
-        tag_url = "histories/%s/tags/awesometagname" % history_id
-        tag_create_response = self._post(tag_url, data=tag_data)
-        self._assert_status_code_is(tag_create_response, 200)
-
-    def _show(self, history_id):
-        return self._get("histories/%s" % history_id).json()
-
-    def _update(self, history_id, data):
-        update_url = self._api_url("histories/%s" % history_id, use_key=True)
-        put_response = put(update_url, json=data)
-        return put_response
-
-    def _create_history(self, name):
-        post_data = dict(name=name)
-        create_response = self._post("histories", data=post_data).json()
-        self._assert_has_keys(create_response, "name", "id")
-        self.assertEqual(create_response["name"], name)
-        return create_response
-
-    # TODO: (CE) test_create_from_copy

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -1,6 +1,5 @@
 import os
 from contextlib import contextmanager
-from unittest import TestCase
 
 from six.moves.urllib.parse import urlencode
 
@@ -19,7 +18,6 @@ from .api_util import (
     TEST_USER,
 )
 from .interactor import TestCaseGalaxyInteractor as BaseInteractor
-from .testcase import FunctionalTestCase
 
 
 class UsesApiTestCaseMixin:
@@ -113,13 +111,6 @@ class UsesApiTestCaseMixin:
         return "1234567890123456"
 
     _assert_has_key = _assert_has_keys
-
-
-class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin, TestCase):
-
-    def setUp(self):
-        super().setUp()
-        self._setup_interactor()
 
 
 class ApiTestInteractor(BaseInteractor):

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -1,5 +1,6 @@
 import os
 from contextlib import contextmanager
+from unittest import TestCase
 
 from six.moves.urllib.parse import urlencode
 
@@ -111,6 +112,13 @@ class UsesApiTestCaseMixin:
         return "1234567890123456"
 
     _assert_has_key = _assert_has_keys
+
+
+class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self._setup_interactor()
 
 
 class ApiTestInteractor(BaseInteractor):

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -19,6 +19,7 @@ from .api_util import (
     TEST_USER,
 )
 from .interactor import TestCaseGalaxyInteractor as BaseInteractor
+from .testcase import FunctionalTestCase
 
 
 class UsesApiTestCaseMixin:

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -1,0 +1,14 @@
+from galaxy_test.api.test_histories import ImportExportHistoryTestCase
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+class ImportExportHistoryOutputsToWorkingDirTestCase(IntegrationTestCase, ImportExportHistoryTestCase):
+
+    framework_tool_and_types = True
+
+    def setUp(self):
+        super(ImportExportHistoryOutputsToWorkingDirTestCase, self).setUp()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config['outputs_to_working_directory'] = True

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -2,7 +2,7 @@ from galaxy_test.api.test_histories import ImportExportHistoryTestCase
 from galaxy_test.driver.integration_util import IntegrationTestCase
 
 
-class ImportExportHistoryOutputsToWorkingDirTestCase(IntegrationTestCase, ImportExportHistoryTestCase):
+class ImportExportHistoryOutputsToWorkingDirTestCase(ImportExportHistoryTestCase, IntegrationTestCase):
 
     framework_tool_and_types = True
 

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -172,6 +172,7 @@ class MockAppConfig(Bunch):
         self.root = root
         self.tool_cache_data_dir = os.path.join(root, 'tool_cache')
         self.delay_tool_initialization = True
+        self.external_chown_script = None
 
         self.config_file = None
 


### PR DESCRIPTION
Adds necessary calls to the `external_chown_script` for files and directories that need to be readable / writable by the user running the job. 

Essentially ready, but I guess some beautification could be nice (e.g., maybe marge the _chown function somehow with the chown of the job class) -- but I prefer to wait first for reviews.

@mvdbeek suggested that an integration test would be nice, but this seems out of reach for me.

Below in one of the comments I collected further questions / todos.

Note that I tested on import/export on usegalaxy.eu .. and it seemed to fail as well.