### PR TITLE
[19.09] Swap 'danger' to 'info' for the registration bonus message 

### DIFF
--- a/client/galaxy/scripts/components/login/Register.vue
+++ b/client/galaxy/scripts/components/login/Register.vue
@@ -2,7 +2,7 @@
     <div class="container">
         <div class="row justify-content-md-center">
             <div class="col" :class="{ 'col-lg-6': !isAdmin }">
-                <b-alert :show="showRegistrationWarning" variant="danger">
+                <b-alert :show="showRegistrationWarning" variant="info">
                     {{ registration_warning_message }}
                 </b-alert>
                 <b-alert :show="messageShow" :variant="messageVariant" v-html="messageText" />


### PR DESCRIPTION
I already added this in https://github.com/galaxyproject/galaxy/pull/8994, but it should be applied to 19.09 as well.