### PR TITLE
Fix tool image loading (was broken due to failing repo dir resolution)

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -937,8 +937,8 @@ class Tool(Dictifiable):
             if tool_dir.parts[-1] == self.repository_name:
                 return str(tool_dir)
             for parent in tool_dir.parents:
-                if parent.parts[-1] == self.repository_name:
-                    return str(parent)
+                if parent.stem == self.repository_name:
+                    return str(tool_dir)
             else:
                 log.error("Problem finding repository dir for tool [%s]" % self.id)
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1,6 +1,7 @@
 """
 Classes encapsulating galaxy tools and tool configuration.
 """
+import itertools
 import json
 import logging
 import os
@@ -934,11 +935,9 @@ class Tool(Dictifiable):
 
         if getattr(self, 'tool_shed', None):
             tool_dir = Path(self.tool_dir)
-            if tool_dir.parts[-1] == self.repository_name:
-                return str(tool_dir)
-            for parent in tool_dir.parents:
-                if parent.stem == self.repository_name:
-                    return str(tool_dir)
+            for repo_dir in itertools.chain([tool_dir], tool_dir.parents):
+                if repo_dir.stem == self.repository_name:
+                    return str(repo_dir)
             else:
                 log.error("Problem finding repository dir for tool [%s]" % self.id)
 


### PR DESCRIPTION
Popped up in https://github.com/galaxyproject/galaxy/commit/5f4df5eb932dbb91f66e010624925928c10fac69.  I think this more correctly keeps the previous behavior, while also not throwing it into an infinite loop.

@bgruening reported this, can be tested with a tool like https://usegalaxy.eu/shed_tool_static/toolshed.g2.bx.psu.edu/bgruening/deeptools_plot_enrichment/deeptools_plot_enrichment/3.0.2.0/plotEnrichment_output.png