### PR TITLE
Track non-history content outputs.

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1134,6 +1134,15 @@ model.WorkflowInvocationOutputDatasetCollectionAssociation.table = Table(
     Column("workflow_output_id", Integer, ForeignKey("workflow_output.id", name='fk_wiodca_woi')),
 )
 
+model.WorkflowInvocationOutputValue.table = Table(
+    "workflow_invocation_output_value", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
+    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id"), index=True),
+    Column("value", JSONType),
+)
+
 model.WorkflowInvocationStepOutputDatasetAssociation.table = Table(
     "workflow_invocation_step_output_dataset_association", metadata,
     Column("id", Integer, primary_key=True),
@@ -2599,6 +2608,14 @@ simple_mapping(
     workflow_invocation=relation(model.WorkflowInvocation, backref="output_dataset_collections"),
     workflow_step=relation(model.WorkflowStep),
     dataset_collection=relation(model.HistoryDatasetCollectionAssociation),
+    workflow_output=relation(model.WorkflowOutput),
+)
+
+
+simple_mapping(
+    model.WorkflowInvocationOutputValue,
+    workflow_invocation=relation(model.WorkflowInvocation, backref="output_values"),
+    workflow_step=relation(model.WorkflowStep),
     workflow_output=relation(model.WorkflowOutput),
 )
 

--- a/lib/galaxy/model/migrate/versions/0161_add_workflow_invocation_output_table.py
+++ b/lib/galaxy/model/migrate/versions/0161_add_workflow_invocation_output_table.py
@@ -1,0 +1,43 @@
+"""
+Migration script to add a new workflow_invocation_output_parameter table to track output parameters.
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table
+
+from galaxy.model.custom_types import JSONType
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+workflow_invocation_output_parameter_table = Table(
+    "workflow_invocation_output_value", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
+    Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
+    Column("workflow_output_id", Integer, ForeignKey("workflow_output.id"), index=True),
+    Column("value", JSONType),
+)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        workflow_invocation_output_parameter_table.create()
+    except Exception:
+        log.exception("Creating workflow_invocation_output_parameter table failed")
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        workflow_invocation_output_parameter_table.drop()
+    except Exception:
+        log.exception("Dropping workflow_invocation_output_parameter table failed")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1426,11 +1426,14 @@ input1:
 class: GalaxyWorkflow
 inputs:
   input1: data
+  text_input: text
 outputs:
   wf_output_1:
     outputSource: input1
+  wf_output_param:
+    outputSource: text_input
 steps: []
-""", test_data={"input1": "hello world"}, history_id=history_id)
+""", test_data={"input1": "hello world", "text_input": {"value": "A text variable", "type": "raw"}}, history_id=history_id)
             workflow_id = summary.workflow_id
             invocation_id = summary.invocation_id
             invocation_response = self._get("workflows/%s/invocations/%s" % (workflow_id, invocation_id))
@@ -1439,6 +1442,9 @@ steps: []
             self._assert_has_keys(invocation , "id", "outputs", "output_collections")
             assert len(invocation["output_collections"]) == 0
             assert len(invocation["outputs"]) == 1
+            assert len(invocation["output_values"]) == 1
+            assert "wf_output_param" in invocation["output_values"]
+            assert invocation["output_values"]["wf_output_param"] == "A text variable", invocation["output_values"]
             output_content = self.dataset_populator.get_history_dataset_content(history_id, content_id=invocation["outputs"]["wf_output_1"]["id"])
             assert output_content == "hello world\n"
 


### PR DESCRIPTION
Messed up cherry-pick of 5220723a7e142050073da631e2c12402afc06205 so authorship isn't really reflected properly.