### PR TITLE
[19.09] Fix name and version for export of a previous workflow version

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -482,7 +482,7 @@ class WorkflowContentsManager(UsesAnnotations):
             wf_dict = self._workflow_to_dict_export(trans, stored, workflow=workflow)
         else:
             raise exceptions.RequestParameterInvalidException('Unknown workflow style [%s]' % style)
-        if version:
+        if version is not None:
             wf_dict['version'] = version
         else:
             wf_dict['version'] = len(stored.workflows) - 1
@@ -979,6 +979,7 @@ class WorkflowContentsManager(UsesAnnotations):
         encode = self.app.security.encode_id
         sa_session = self.app.model.context
         item = stored.to_dict(view='element', value_mapper={'id': encode})
+        item['name'] = workflow.name
         item['url'] = url_for('workflow', id=item['id'])
         item['owner'] = stored.user.username
         inputs = {}


### PR DESCRIPTION
The API call to retrieve an old version of a workflow:

```
GET /api/workflows/<workflow_id>?version=<N>
```

was returning always the latest workflow name, while the name of a previous workflow version could have an important meaning for the user.
Also, when retrieving version 0, the returned dictionary contained the latest version number instead of 0.