### PR TITLE
Fix API decorator order

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -86,8 +86,8 @@ class ConfigurationController(BaseAPIController):
         serialized = serializer.serialize_to_view(self.app.config, view=view, keys=keys, default_view=default_view)
         return serialized
 
-    @expose_api
     @require_admin
+    @expose_api
     def dynamic_tool_confs(self, trans):
         # WARNING: If this method is ever changed so as not to require admin privileges, update the nginx proxy
         # documentation, since this path is used as an authentication-by-proxy method for securing other paths on the
@@ -95,8 +95,8 @@ class ConfigurationController(BaseAPIController):
         confs = self.app.toolbox.dynamic_confs(include_migrated_tool_conf=True)
         return list(map(_tool_conf_to_dict, confs))
 
-    @expose_api
     @require_admin
+    @expose_api
     def decode_id(self, trans, encoded_id, **kwds):
         """Decode a given id."""
         decoded_id = None
@@ -107,8 +107,8 @@ class ConfigurationController(BaseAPIController):
             decoded_id = trans.security.decode_id(encoded_id)
         return {"decoded_id": decoded_id}
 
-    @expose_api
     @require_admin
+    @expose_api
     def tool_lineages(self, trans):
         rval = []
         for id, tool in self.app.toolbox.tools():
@@ -124,8 +124,8 @@ class ConfigurationController(BaseAPIController):
             rval.append(entry)
         return rval
 
-    @expose_api
     @require_admin
+    @expose_api
     def reload_toolbox(self, trans, **kwds):
         """
         PUT /api/configuration/toolbox

--- a/lib/galaxy/webapps/galaxy/api/display_applications.py
+++ b/lib/galaxy/webapps/galaxy/api/display_applications.py
@@ -32,8 +32,8 @@ class DisplayApplicationsController(BaseAPIController):
             })
         return response
 
-    @legacy_expose_api
     @require_admin
+    @legacy_expose_api
     def reload(self, trans, payload={}, **kwd):
         """
         POST /api/display_applications/reload

--- a/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
+++ b/lib/galaxy/webapps/galaxy/api/dynamic_tools.py
@@ -61,8 +61,8 @@ class DynamicToolsController(BaseAPIController):
         )
         return dynamic_tool.to_dict()
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def delete(self, trans, id, **kwd):
         """
         DELETE /api/dynamic_tools/{encoded_dynamic_tool_id|tool_uuid}

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 class GroupRolesAPIController(BaseAPIController):
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def index(self, trans, group_id, **kwd):
         """
         GET /api/groups/{encoded_group_id}/roles
@@ -41,8 +41,8 @@ class GroupRolesAPIController(BaseAPIController):
             trans.response.status = 500
         return rval
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def show(self, trans, id, group_id, **kwd):
         """
         GET /api/groups/{encoded_group_id}/roles/{encoded_role_id}
@@ -67,8 +67,8 @@ class GroupRolesAPIController(BaseAPIController):
             log.error(item + ": %s", unicodify(e))
         return item
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def update(self, trans, id, group_id, **kwd):
         """
         PUT /api/groups/{encoded_group_id}/roles/{encoded_role_id}
@@ -99,8 +99,8 @@ class GroupRolesAPIController(BaseAPIController):
             log.error(item + ": %s", unicodify(e))
         return item
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def delete(self, trans, id, group_id, **kwd):
         """
         DELETE /api/groups/{encoded_group_id}/roles/{encoded_role_id}

--- a/lib/galaxy/webapps/galaxy/api/group_users.py
+++ b/lib/galaxy/webapps/galaxy/api/group_users.py
@@ -12,8 +12,8 @@ log = logging.getLogger(__name__)
 
 class GroupUsersAPIController(BaseAPIController):
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def index(self, trans, group_id, **kwd):
         """
         GET /api/groups/{encoded_group_id}/users
@@ -41,8 +41,8 @@ class GroupUsersAPIController(BaseAPIController):
             trans.response.status = 500
         return rval
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def show(self, trans, id, group_id, **kwd):
         """
         GET /api/groups/{encoded_group_id}/users/{encoded_user_id}
@@ -67,8 +67,8 @@ class GroupUsersAPIController(BaseAPIController):
             log.error(item + ": %s", unicodify(e))
         return item
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def update(self, trans, id, group_id, **kwd):
         """
         PUT /api/groups/{encoded_group_id}/users/{encoded_user_id}
@@ -99,8 +99,8 @@ class GroupUsersAPIController(BaseAPIController):
             log.error(item + ": %s", unicodify(e))
         return item
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def delete(self, trans, id, group_id, **kwd):
         """
         DELETE /api/groups/{encoded_group_id}/users/{encoded_user_id}

--- a/lib/galaxy/webapps/galaxy/api/groups.py
+++ b/lib/galaxy/webapps/galaxy/api/groups.py
@@ -13,8 +13,8 @@ log = logging.getLogger(__name__)
 
 class GroupAPIController(BaseAPIController):
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def index(self, trans, **kwd):
         """
         GET /api/groups
@@ -71,8 +71,8 @@ class GroupAPIController(BaseAPIController):
         item['url'] = url_for('group', id=encoded_id)
         return [item]
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def show(self, trans, id, **kwd):
         """
         GET /api/groups/{encoded_group_id}
@@ -97,8 +97,8 @@ class GroupAPIController(BaseAPIController):
         item['roles_url'] = url_for('group_roles', group_id=group_id)
         return item
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def update(self, trans, id, payload, **kwd):
         """
         PUT /api/groups/{encoded_group_id}

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -26,8 +26,8 @@ log = logging.getLogger(__name__)
 
 
 class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaParamParser):
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def index(self, trans, deleted='False', **kwd):
         """
         GET /api/quotas
@@ -50,8 +50,8 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             rval.append(item)
         return rval
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def show(self, trans, id, deleted='False', **kwd):
         """
         GET /api/quotas/{encoded_quota_id}
@@ -61,8 +61,8 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         quota = self.get_quota(trans, id, deleted=util.string_as_bool(deleted))
         return quota.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'total_disk_usage': float})
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/quotas
@@ -82,8 +82,8 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         item['message'] = message
         return item
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def update(self, trans, id, payload, **kwd):
         """
         PUT /api/quotas/{encoded_quota_id}
@@ -120,8 +120,8 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             messages.append(message)
         return '; '.join(messages)
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def delete(self, trans, id, **kwd):
         """
         DELETE /api/quotas/{encoded_quota_id}
@@ -142,8 +142,8 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
             raise HTTPBadRequest(detail=util.unicodify(e))
         return message
 
-    @web.legacy_expose_api
     @web.require_admin
+    @web.legacy_expose_api
     def undelete(self, trans, id, **kwd):
         """
         POST /api/quotas/deleted/{encoded_quota_id}/undelete

--- a/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_dependencies.py
@@ -19,24 +19,24 @@ class ToolDependenciesAPIController(BaseAPIController):
         super(ToolDependenciesAPIController, self).__init__(app)
         self._view = views.DependencyResolversView(app)
 
-    @expose_api
     @require_admin
+    @expose_api
     def index(self, trans, **kwd):
         """
         GET /api/dependency_resolvers
         """
         return self._view.index()
 
-    @expose_api
     @require_admin
+    @expose_api
     def show(self, trans, id):
         """
         GET /api/dependency_resolvers/<id>
         """
         return self._view.show(id)
 
-    @expose_api
     @require_admin
+    @expose_api
     def update(self, trans):
         """
         PUT /api/dependency_resolvers
@@ -45,8 +45,8 @@ class ToolDependenciesAPIController(BaseAPIController):
         """
         return self._view.reload()
 
-    @expose_api
     @require_admin
+    @expose_api
     def resolver_dependency(self, trans, id, **kwds):
         """
         GET /api/dependency_resolvers/{index}/dependency
@@ -71,8 +71,8 @@ class ToolDependenciesAPIController(BaseAPIController):
         """
         return self._view.resolver_dependency(id, **kwds)
 
-    @expose_api
     @require_admin
+    @expose_api
     def install_dependency(self, trans, id=None, **kwds):
         """
         POST /api/dependency_resolvers/{index}/dependency
@@ -98,8 +98,8 @@ class ToolDependenciesAPIController(BaseAPIController):
         self._view.install_dependency(id, **kwds)
         return self._view.manager_dependency(**kwds)
 
-    @expose_api
     @require_admin
+    @expose_api
     def manager_dependency(self, trans, **kwds):
         """
         GET /api/dependency_resolvers/dependency
@@ -125,8 +125,8 @@ class ToolDependenciesAPIController(BaseAPIController):
         """
         return self._view.manager_dependency(**kwds)
 
-    @expose_api
     @require_admin
+    @expose_api
     def resolver_requirements(self, trans, id, **kwds):
         """
         GET /api/dependency_resolvers/{index}/requirements
@@ -144,8 +144,8 @@ class ToolDependenciesAPIController(BaseAPIController):
         """
         return self._view.resolver_requirements(id)
 
-    @expose_api
     @require_admin
+    @expose_api
     def manager_requirements(self, trans, **kwds):
         """
         GET /api/dependency_resolvers/requirements
@@ -163,8 +163,8 @@ class ToolDependenciesAPIController(BaseAPIController):
         """
         return self._view.manager_requirements()
 
-    @expose_api
     @require_admin
+    @expose_api
     def clean(self, trans, id=None, **kwds):
         """
         POST /api/dependency_resolvers/{index}/clean

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -23,7 +23,11 @@ from galaxy.tool_shed.util.repository_util import (
 )
 from galaxy.tool_shed.util.shed_util_common import have_shed_tool_conf_for_install
 from galaxy.tool_shed.util.tool_util import generate_message_for_invalid_tools
-from galaxy.web import expose_api, require_admin, url_for
+from galaxy.web import (
+    expose_api,
+    require_admin,
+    url_for
+)
 from galaxy.webapps.base.controller import BaseAPIController
 
 
@@ -90,8 +94,8 @@ class ToolShedRepositoriesController(BaseAPIController):
             tool_shed_repository_dicts.append(tool_shed_repository_dict)
         return tool_shed_repository_dicts
 
-    @expose_api
     @require_admin
+    @expose_api
     def install_repository_revision(self, trans, payload, **kwd):
         """
         POST /api/tool_shed_repositories/install_repository_revision
@@ -145,8 +149,8 @@ class ToolShedRepositoriesController(BaseAPIController):
         message = "No repositories were installed, possibly because the selected repository has already been installed."
         return dict(status="ok", message=message)
 
-    @expose_api
     @require_admin
+    @expose_api
     def install_repository_revisions(self, trans, payload, **kwd):
         """
         POST /api/tool_shed_repositories/install_repository_revisions
@@ -225,8 +229,8 @@ class ToolShedRepositoriesController(BaseAPIController):
                 all_installed_tool_shed_repositories.extend(installed_tool_shed_repositories)
         return all_installed_tool_shed_repositories
 
-    @expose_api
     @require_admin
+    @expose_api
     def uninstall_repository(self, trans, id=None, **kwd):
         """
         DELETE /api/tool_shed_repositories/id
@@ -287,8 +291,8 @@ class ToolShedRepositoriesController(BaseAPIController):
 
         return tool_shed_url, name, owner, changeset_revision
 
-    @expose_api
     @require_admin
+    @expose_api
     def check_for_updates(self, trans, **kwd):
         '''
         GET /api/tool_shed_repositories/check_for_updates
@@ -300,8 +304,8 @@ class ToolShedRepositoriesController(BaseAPIController):
         message, status = check_for_updates(self.app, trans.install_model, repository_id)
         return {'status': status, 'message': message}
 
-    @expose_api
     @require_admin
+    @expose_api
     def reset_metadata_on_selected_installed_repositories(self, trans, **kwd):
         repository_ids = util.listify(kwd.get("repository_ids"))
         if repository_ids:

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -123,8 +123,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         tool = self._get_tool(id, tool_version=tool_version, user=trans.user)
         return tool.to_json(trans, kwd.get('inputs', kwd))
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def test_data_path(self, trans, id, **kwd):
         """
         GET /api/tools/{tool_id}/test_data_path?tool_version={tool_version}
@@ -212,8 +212,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         result = [t.to_dict() for t in tool.tests]
         return safe_dumps(result, default=json_encodeify)
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def reload(self, trans, id, **kwd):
         """
         GET /api/tools/{tool_id}/reload
@@ -225,8 +225,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
             raise exceptions.MessageException(message)
         return {'message': message}
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def all_requirements(self, trans, **kwds):
         """
         GET /api/tools/all_requirements
@@ -235,8 +235,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
 
         return trans.app.toolbox.all_requirements
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def requirements(self, trans, id, **kwds):
         """
         GET /api/tools/{tool_id}/requirements
@@ -246,8 +246,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         tool = self._get_tool(id, user=trans.user)
         return tool.tool_requirements_status
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def install_dependencies(self, trans, id, **kwds):
         """
         POST /api/tools/{tool_id}/dependencies
@@ -272,8 +272,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         # _view.install_dependencies should return a dict with stdout, stderr and success status
         return tool.tool_requirements_status
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def uninstall_dependencies(self, trans, id, **kwds):
         """
         DELETE /api/tools/{tool_id}/dependencies
@@ -289,8 +289,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         # TODO: rework resolver install system to log and report what has been done.
         return tool.tool_requirements_status
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def build_dependency_cache(self, trans, id, **kwds):
         """
         POST /api/tools/{tool_id}/build_dependency_cache
@@ -304,8 +304,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         # TODO: Should also have a more meaningful return.
         return tool.tool_requirements_status
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def diagnostics(self, trans, id, **kwd):
         """
         GET /api/tools/{tool_id}/diagnostics
@@ -407,8 +407,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         tool = self._get_tool(id, user=trans.user)
         return tool.xrefs
 
-    @web.legacy_expose_api_raw
     @web.require_admin
+    @web.legacy_expose_api_raw
     def download(self, trans, id, **kwds):
         tool_tarball = trans.app.toolbox.package_tool(trans, id)
         trans.response.set_content_type('application/x-gzip')
@@ -446,8 +446,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         create_payload.update(files_payload)
         return self._create(trans, create_payload, **kwd)
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def error_stack(self, trans, **kwd):
         """
         GET /api/tools/error_stack

--- a/lib/galaxy/webapps/galaxy/api/toolshed.py
+++ b/lib/galaxy/webapps/galaxy/api/toolshed.py
@@ -25,8 +25,8 @@ class ToolShedController(BaseAPIController):
             tool_sheds.append(dict(name=name, url=quote(url, '')))
         return tool_sheds
 
-    @expose_api
     @require_admin
+    @expose_api
     def request(self, trans, **params):
         """
         GET /api/tool_shed/request

--- a/lib/galaxy/webapps/galaxy/api/tours.py
+++ b/lib/galaxy/webapps/galaxy/api/tours.py
@@ -38,8 +38,8 @@ class ToursController(BaseAPIController):
         """
         return self.app.tour_registry.tour_contents(tour_id)
 
-    @legacy_expose_api
     @require_admin
+    @legacy_expose_api
     def update_tour(self, trans, tour_id, **kwd):
         """
         This simply reloads tours right now.  It's a quick hack.

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -229,8 +229,8 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
         self.user_deserializer.deserialize(user_to_update, payload, user=current_user, trans=trans)
         return self.user_serializer.serialize_to_view(user_to_update, view='detailed')
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def delete(self, trans, id, **kwd):
         """
         DELETE /api/users/{id}
@@ -251,8 +251,8 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, CreatesApiKeysMixin, B
             self.user_manager.delete(user)
         return self.user_serializer.serialize_to_view(user, view='detailed')
 
-    @expose_api
     @web.require_admin
+    @expose_api
     def undelete(self, trans, id, **kwd):
         """
         POST /api/users/deleted/{id}/undelete


### PR DESCRIPTION
in order to get a simple error message instead of an HTML error page when accessing API methods protected by the `@require_admin` decorator.