### PR TITLE
Default format 2 workflows to be downloaded as YAML.

### DIFF
--- a/lib/galaxy/web/__init__.py
+++ b/lib/galaxy/web/__init__.py
@@ -13,6 +13,7 @@ from .framework.decorators import (
     expose_api_raw,
     expose_api_raw_anonymous,
     expose_api_raw_anonymous_and_sessionless,
+    format_return_as_json,
     json,
     json_pretty,
     legacy_expose_api,
@@ -23,7 +24,7 @@ from .framework.decorators import (
     require_login,
 )
 
-__all__ = ('url_for', 'error', 'expose', 'json', 'json_pretty',
+__all__ = ('url_for', 'error', 'expose', 'format_return_as_json', 'json', 'json_pretty',
            'require_admin', 'require_login', 'legacy_expose_api', 'legacy_expose_api_anonymous',
            'legacy_expose_api_raw', 'legacy_expose_api_raw_anonymous', 'expose_api',
            'expose_api_anonymous', 'expose_api_raw',

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -55,7 +55,7 @@ def json(func, pretty=False):
         else:
             trans.response.set_content_type(JSON_CONTENT_TYPE)
         rval = func(self, trans, *args, **kwargs)
-        return _format_return_as_json(rval, jsonp_callback, pretty=(pretty or trans.debug))
+        return format_return_as_json(rval, jsonp_callback, pretty=(pretty or trans.debug))
 
     if not hasattr(func, '_orig'):
         call_and_format._orig = func
@@ -156,7 +156,7 @@ def legacy_expose_api(func, to_json=True, user_required=True):
         try:
             rval = func(self, trans, *args, **kwargs)
             if to_json:
-                rval = _format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
+                rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
             return rval
         except paste.httpexceptions.HTTPException:
             raise  # handled
@@ -281,7 +281,7 @@ def expose_api(func, to_json=True, user_required=True, user_or_session_required=
         try:
             rval = func(self, trans, *args, **kwargs)
             if to_json:
-                rval = _format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
+                rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
             return rval
         except MessageException as e:
             traceback_string = format_exc()
@@ -307,7 +307,7 @@ def expose_api(func, to_json=True, user_required=True, user_or_session_required=
     return decorator
 
 
-def _format_return_as_json(rval, jsonp_callback=None, pretty=False):
+def format_return_as_json(rval, jsonp_callback=None, pretty=False):
     """
     Formats a return value as JSON or JSONP if `jsonp_callback` is present.
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -515,6 +515,11 @@ test_data:
             if step['type'] == "tool":
                 self._assert_has_keys(step, "post_job_actions")
 
+    def test_export_format2(self):
+        uploaded_workflow_id = self.workflow_populator.simple_workflow("test_for_export_format2")
+        downloaded_workflow = self._download_workflow(uploaded_workflow_id, style="format2")
+        assert downloaded_workflow["class"] == "GalaxyWorkflow"
+
     def test_export_editor(self):
         uploaded_workflow_id = self.workflow_populator.simple_workflow("test_for_export")
         downloaded_workflow = self._download_workflow(uploaded_workflow_id, style="editor")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -20,6 +20,7 @@ from gxformat2 import (
     convert_and_import_workflow,
     ImporterGalaxyInterface,
 )
+from gxformat2._yaml import ordered_load
 from pkg_resources import resource_string
 from six import StringIO
 
@@ -849,7 +850,10 @@ class BaseWorkflowPopulator(object):
             params["style"] = style
         response = self._get("workflows/%s/download" % workflow_id, data=params)
         api_asserts.assert_status_code_is(response, 200)
-        return response.json()
+        if style != "format2":
+            return response.json()
+        else:
+            return ordered_load(response.text)
 
     def update_workflow(self, workflow_id, workflow_object):
         data = dict(


### PR DESCRIPTION
Exporting them as JSON or YAML wrapped in json (existing options) proved to be repeatedly confusing at the Elixir Biohackathon 2019. Next step toward making these the default export I think.