### PR TITLE
[WIP] Model Store Workflow Invocation Import/Export

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5696,6 +5696,11 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             inputs.append(input_dataset_collection_assoc)
         return inputs
 
+    def serialize(self, id_encoder, serialization_options):
+        invocation_attrs = dict_for(self)
+        serialization_options.attach_identifier(id_encoder, self, invocation_attrs)
+        return invocation_attrs
+
     def to_dict(self, view='collection', value_mapper=None, step_details=False, legacy_job_state=False):
         rval = super().to_dict(view=view, value_mapper=value_mapper)
         if view == 'element':

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from enum import Enum
 from json import (
     dump,
     dumps,
@@ -37,14 +38,32 @@ ATTRS_FILENAME_LIBRARIES = 'libraries_attrs.txt'
 GALAXY_EXPORT_VERSION = "2"
 
 
-class ImportOptions:
+class ImportDiscardedDataType(Enum):
+    # Don't allow discarded 'okay' datasets on import, datasets will be marked deleted.
+    FORBID = 'forbid'
+    # Allow datasets to be imported as experimental DISCARDED datasets that are not deleted if file data unavailable.
+    ALLOW = 'allow'
+    # Import all datasets as discarded regardless of whether file data is available in the store.
+    FORCE = 'force'
 
-    def __init__(self, allow_edit=False, allow_library_creation=False, allow_dataset_object_edit=None):
+
+DEFAULT_DISCARDED_DATA_TYPE = ImportDiscardedDataType.FORBID
+
+
+class ImportOptions:
+    allow_edit: bool
+    allow_library_creation: bool
+    allow_dataset_object_edit: bool
+    discarded_data: ImportDiscardedDataType
+
+    def __init__(self, allow_edit=False, allow_library_creation=False, allow_dataset_object_edit=None, discarded_data=DEFAULT_DISCARDED_DATA_TYPE):
         self.allow_edit = allow_edit
         self.allow_library_creation = allow_library_creation
         if allow_dataset_object_edit is None:
-            allow_dataset_object_edit = allow_edit
-        self.allow_dataset_object_edit = allow_dataset_object_edit
+            self.allow_dataset_object_edit = allow_edit
+        else:
+            self.allow_dataset_object_edit = allow_dataset_object_edit
+        self.discarded_data = discarded_data
 
 
 class SessionlessContext:
@@ -323,12 +342,14 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         if not in_directory(temp_dataset_file_name, self.archive_dir):
                             raise MalformedContents(f"Invalid dataset path: {temp_dataset_file_name}")
 
-                    if not file_name or not os.path.exists(temp_dataset_file_name):
+                    discarded_data = self.import_options.discarded_data
+                    if not file_name or not os.path.exists(temp_dataset_file_name) or discarded_data is ImportDiscardedDataType.FORCE:
                         dataset_instance.state = dataset_instance.states.DISCARDED
-                        dataset_instance.deleted = True
-                        dataset_instance.purged = True
-                        dataset_instance.dataset.deleted = True
-                        dataset_instance.dataset.purged = True
+                        deleted = discarded_data == ImportDiscardedDataType.FORBID
+                        dataset_instance.deleted = deleted
+                        dataset_instance.purged = deleted
+                        dataset_instance.dataset.deleted = deleted
+                        dataset_instance.dataset.purged = deleted
                     else:
                         dataset_instance.state = dataset_attrs.get('state', dataset_instance.states.OK)
                         self.object_store.update_from_file(dataset_instance.dataset, file_name=temp_dataset_file_name, create=True)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -703,7 +703,7 @@ def populate_api_routes(webapp, app):
             conditions=conditions,
         )
 
-    connect_invocation_endpoint('show', '', action='show_invocation')
+    connect_invocation_endpoint('show', r'{.format:[\w\.]+}', action='show_invocation')
     connect_invocation_endpoint('show_report', '/report', action='show_invocation_report')
     connect_invocation_endpoint('show_report_pdf', '/report.pdf', action='show_invocation_report_pdf')
     connect_invocation_endpoint('biocompute/download', '/biocompute/download', action='download_invocation_bco')

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -4205,6 +4205,23 @@ input:
 
         assert invocation_tool_step_response.json()["job_id"] == job_id
 
+    @skip_without_tool("cat1")
+    def test_invocation_usage_targz(self):
+        workflow_id, invocation = self._run_workflow_once_get_invocation("test_invocation_targz")
+        invocation_id = invocation["id"]
+        url = f"invocations/{invocation_id}.tar.gz"
+        invocation_response = self._get(url)
+        self._assert_status_code_is(invocation_response, 200)
+
+        invocation_id = invocation["id"]
+        url = f"invocations/{invocation_id}.bag.zip"
+        invocation_response = self._get(url)
+        self._assert_status_code_is(invocation_response, 200)
+
+        url = f"invocations/{invocation_id}.bag.ofdonuts"
+        invocation_response = self._get(url)
+        self._assert_status_code_is(invocation_response, 400)
+
     def test_invocation_with_collection_mapping(self):
         workflow_id, invocation_id = self._run_mapping_workflow()
 

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -700,15 +700,7 @@ class MappingTests(BaseModelTestCase):
             password="password"
         )
 
-        def workflow_from_steps(steps):
-            stored_workflow = model.StoredWorkflow()
-            stored_workflow.user = user
-            workflow = model.Workflow()
-            workflow.steps = steps
-            workflow.stored_workflow = stored_workflow
-            return workflow
-
-        child_workflow = workflow_from_steps([])
+        child_workflow = _workflow_from_steps(user, [])
         self.persist(child_workflow)
 
         workflow_step_1 = model.WorkflowStep()
@@ -724,7 +716,7 @@ class MappingTests(BaseModelTestCase):
         workflow_step_2.get_or_add_input("moo")
         workflow_step_1.add_connection("foo", "cow", workflow_step_2)
 
-        workflow = workflow_from_steps([workflow_step_1, workflow_step_2])
+        workflow = _workflow_from_steps(user, [workflow_step_1, workflow_step_2])
         self.persist(workflow)
         workflow_id = workflow.id
 
@@ -735,13 +727,11 @@ class MappingTests(BaseModelTestCase):
         self.persist(annotation)
 
         assert workflow_step_1.id is not None
-        h1 = model.History(name="WorkflowHistory1", user=user)
+        workflow_invocation = _invocation_for_workflow(user, workflow)
 
         invocation_uuid = uuid.uuid1()
 
-        workflow_invocation = model.WorkflowInvocation()
         workflow_invocation.uuid = invocation_uuid
-        workflow_invocation.history = h1
 
         workflow_invocation_step1 = model.WorkflowInvocationStep()
         workflow_invocation_step1.workflow_invocation = workflow_invocation
@@ -754,8 +744,7 @@ class MappingTests(BaseModelTestCase):
         workflow_invocation_step2.workflow_invocation = workflow_invocation
         workflow_invocation_step2.workflow_step = workflow_step_2
 
-        workflow_invocation.workflow = workflow
-
+        h1 = workflow_invocation.history
         d1 = self.new_hda(h1, name="1")
         workflow_request_dataset = model.WorkflowRequestToInputDatasetAssociation()
         workflow_request_dataset.workflow_invocation = workflow_invocation
@@ -932,6 +921,23 @@ class PostgresMappingTests(MappingTests):
         postgres_url = base + dbname
         create_database(postgres_url)
         return postgres_url
+
+
+def _invocation_for_workflow(user, workflow):
+    h1 = galaxy.model.History(name="WorkflowHistory1", user=user)
+    workflow_invocation = galaxy.model.WorkflowInvocation()
+    workflow_invocation.workflow = workflow
+    workflow_invocation.history = h1
+    return workflow_invocation
+
+
+def _workflow_from_steps(user, steps):
+    stored_workflow = galaxy.model.StoredWorkflow()
+    stored_workflow.user = user
+    workflow = galaxy.model.Workflow()
+    workflow.steps = steps
+    workflow.stored_workflow = stored_workflow
+    return workflow
 
 
 class MockObjectStore:

--- a/test/unit/test_routes.py
+++ b/test/unit/test_routes.py
@@ -94,6 +94,13 @@ def test_galaxy_routes():
     )
 
     test_webapp.assert_maps(
+        "/api/invocations/0123abcdedf.tar.gz",
+        controller="workflows",
+        action="show_invocation",
+        format="tar.gz",
+    )
+
+    test_webapp.assert_maps(
         "/api/dependency_resolvers/dependency",
         controller="tool_dependencies",
         action="manager_dependency"


### PR DESCRIPTION
Early days here still... builds a bit on #9023 (mostly just for a clean diff).

Adds an API endpoint for a version that doesn't include files - this should be quick enough to handle in a web thread. A version that would include files like history export should probably mirror that and I'm not quite sure what the future of history import/export APIs look like. @mvdbeek thinks the jobs should just output the results to a history to simplify a lot of the plumbing and the UI.

Will land up supporting a Galaxy native format that sort of mirrors history exports, as well as bagit packaging.

It is probably a bug that history import/export doesn't include invocation information - this will hopefully fix that issue. Really meant a stepping stone for https://github.com/galaxyproject/galaxy/issues/3088 / https://github.com/galaxyproject/galaxy/issues/2491.

