### PR TITLE
[19.09] Add requirements to interval_to_bed_converter.xml

### DIFF
--- a/lib/galaxy/datatypes/converters/interval_to_bed_converter.xml
+++ b/lib/galaxy/datatypes/converters/interval_to_bed_converter.xml
@@ -1,5 +1,9 @@
 <tool id="CONVERTER_interval_to_bed_0" name="Convert Genomic Intervals To BED" version="1.0.0">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
+    <requirements>
+        <requirement type="package" version="2.7">python</requirement>
+        <requirement type="package" version="0.8.6">bx-python</requirement>
+    </requirements>
     <command>python '$__tool_directory__/interval_to_bed_converter.py' '$output1' '$input1' ${input1.metadata.chromCol} ${input1.metadata.startCol} ${input1.metadata.endCol} ${input1.metadata.strandCol} ${input1.metadata.nameCol}</command>
     <inputs>
         <param format="interval" name="input1" type="data" label="Choose intervals"/>


### PR DESCRIPTION
Otherwise execution can hang indefinitely (should also figure out why ...) when running the converter containerized.