### PR TITLE
[19.05] Fix input parameter comparisons

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -79,10 +79,7 @@ class InputValueWrapper(ToolParameterValueWrapper):
         self.value = value
         self._other_values = other_values
 
-    def __eq__(self, other):
-        return self.get_cast_value() == other
-
-    def get_cast_value(self):
+    def _get_cast_value(self):
         cast = {
             'text': str,
             'integer': int,
@@ -90,6 +87,9 @@ class InputValueWrapper(ToolParameterValueWrapper):
             'boolean': bool,
         }
         return cast.get(self.input.type, str)(self)
+
+    def __eq__(self, other):
+        return self._get_cast_value() == other
 
     def __ne__(self, other):
         return not self == other
@@ -112,7 +112,7 @@ class InputValueWrapper(ToolParameterValueWrapper):
         return getattr(self.value, key)
 
     def __gt__(self, other):
-        return self.get_cast_value() > other
+        return self._get_cast_value() > other
 
     def __int__(self):
         return int(float(self))

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -80,14 +80,12 @@ class InputValueWrapper(ToolParameterValueWrapper):
         self._other_values = other_values
 
     def __eq__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, string_types) or (isinstance(other, InputValueWrapper) and other.input.type == 'text'):
             return str(self) == other
-        elif isinstance(other, int):
-            return int(self) == other
-        elif isinstance(other, float):
+        elif isinstance(other, (int, float)) or (isinstance(other, InputValueWrapper) and other.input.type in ('float', 'integer')):
             return float(self) == other
         else:
-            return super(InputValueWrapper, self) == other
+            return self.value == other
 
     def __ne__(self, other):
         return not self == other
@@ -110,14 +108,12 @@ class InputValueWrapper(ToolParameterValueWrapper):
         return getattr(self.value, key)
 
     def __gt__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, string_types) or (isinstance(other, InputValueWrapper) and other.input.type == 'text'):
             return str(self) > other
-        elif isinstance(other, int):
-            return int(self) > other
-        elif isinstance(other, float):
+        elif isinstance(other, (int, float)) or (isinstance(other, InputValueWrapper) and other.input.type in ('float', 'integer')):
             return float(self) > other
         else:
-            super(InputValueWrapper, self).__gt__(other)
+            return self.value > other
 
     def __int__(self):
         return int(float(self))

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -80,12 +80,16 @@ class InputValueWrapper(ToolParameterValueWrapper):
         self._other_values = other_values
 
     def __eq__(self, other):
-        if isinstance(other, string_types) or (isinstance(other, InputValueWrapper) and other.input.type == 'text'):
-            return str(self) == other
-        elif isinstance(other, (int, float)) or (isinstance(other, InputValueWrapper) and other.input.type in ('float', 'integer')):
-            return float(self) == other
-        else:
-            return self.value == other
+        return self.get_cast_value() == other
+
+    def get_cast_value(self):
+        cast = {
+            'text': str,
+            'integer': int,
+            'float': float,
+            'boolean': bool,
+        }
+        return cast.get(self.input.type, str)(self)
 
     def __ne__(self, other):
         return not self == other
@@ -108,12 +112,7 @@ class InputValueWrapper(ToolParameterValueWrapper):
         return getattr(self.value, key)
 
     def __gt__(self, other):
-        if isinstance(other, string_types) or (isinstance(other, InputValueWrapper) and other.input.type == 'text'):
-            return str(self) > other
-        elif isinstance(other, (int, float)) or (isinstance(other, InputValueWrapper) and other.input.type in ('float', 'integer')):
-            return float(self) > other
-        else:
-            return self.value > other
+        return self.get_cast_value() > other
 
     def __int__(self):
         return int(float(self))

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -6,8 +6,10 @@ from galaxy.datatypes.metadata import MetadataSpecCollection
 from galaxy.jobs.datasets import DatasetPath
 from galaxy.tools.parameters.basic import (
     DrillDownSelectToolParameter,
+    FloatToolParameter,
     IntegerToolParameter,
-    SelectToolParameter
+    SelectToolParameter,
+    TextToolParameter,
 )
 from galaxy.tools.wrappers import (
     DatasetFilenameWrapper,
@@ -83,10 +85,19 @@ def test_raw_object_wrapper():
     assert not false_wrapper
 
 
+def valuewrapper(tool, value, paramtype):
+    if paramtype == "integer":
+        parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" value="10" min="0" />'))
+    elif paramtype == "text":
+        parameter = TextToolParameter(tool, XML('<param name="blah" type="text" value="10"/>'))
+    elif paramtype == "float":
+        parameter = FloatToolParameter(tool, XML('<param name="bla" type="float" value="10"/>'))
+    return InputValueWrapper(parameter, str(value))
+
+
 @with_mock_tool
-def test_input_value_wrapper(tool):
-    parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" value="10" min="0" />'))
-    wrapper = InputValueWrapper(parameter, "5")
+def test_input_value_wrapper_comparison(tool):
+    wrapper = valuewrapper(tool, 5, "integer")
     assert str(wrapper) == "5"
     assert int(wrapper) == 5
     assert wrapper == "5"
@@ -94,6 +105,20 @@ def test_input_value_wrapper(tool):
     assert wrapper == 5.0
     assert wrapper > 2
     assert wrapper < 10
+    assert wrapper <= 5.1
+
+
+@with_mock_tool
+def test_input_value_wrapper_input_value_wrapper_comparison(tool):
+    wrapper = valuewrapper(tool, 5, "integer")
+    assert str(wrapper) == valuewrapper(tool, "5", "text")
+    assert int(wrapper) == valuewrapper(tool, "5", "integer")
+    assert wrapper == valuewrapper(tool, "5", "text")
+    assert wrapper == valuewrapper(tool, "5", "integer")
+    assert wrapper == valuewrapper(tool, "5", "float")
+    assert wrapper > valuewrapper(tool, "2", "integer")
+    assert wrapper < valuewrapper(tool, "10", "integer")
+    assert wrapper <= valuewrapper(tool, "5.1", "float")
 
 
 def test_dataset_wrapper():

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -105,7 +105,7 @@ def test_input_value_wrapper_comparison(tool):
     assert wrapper == 5.0
     assert wrapper > 2
     assert wrapper < 10
-    assert wrapper <= 5.1
+    assert wrapper < 5.1
 
 
 @with_mock_tool
@@ -118,7 +118,7 @@ def test_input_value_wrapper_input_value_wrapper_comparison(tool):
     assert wrapper == valuewrapper(tool, "5", "float")
     assert wrapper > valuewrapper(tool, "2", "integer")
     assert wrapper < valuewrapper(tool, "10", "integer")
-    assert wrapper <= valuewrapper(tool, "5.1", "float")
+    assert wrapper < valuewrapper(tool, "5.1", "float")
 
 
 def test_dataset_wrapper():

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -100,7 +100,7 @@ def test_input_value_wrapper_comparison(tool):
     wrapper = valuewrapper(tool, 5, "integer")
     assert str(wrapper) == "5"
     assert int(wrapper) == 5
-    assert wrapper == "5"
+    assert wrapper != "5"
     assert wrapper == 5
     assert wrapper == 5.0
     assert wrapper > 2
@@ -113,7 +113,7 @@ def test_input_value_wrapper_input_value_wrapper_comparison(tool):
     wrapper = valuewrapper(tool, 5, "integer")
     assert str(wrapper) == valuewrapper(tool, "5", "text")
     assert int(wrapper) == valuewrapper(tool, "5", "integer")
-    assert wrapper == valuewrapper(tool, "5", "text")
+    assert wrapper != valuewrapper(tool, "5", "text")
     assert wrapper == valuewrapper(tool, "5", "integer")
     assert wrapper == valuewrapper(tool, "5", "float")
     assert wrapper > valuewrapper(tool, "2", "integer")


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/tools-iuc/pull/2702#issuecomment-559718768
Broken in https://github.com/galaxyproject/galaxy/pull/7826

The implementation of `__gt__` and `__eq__` is simpler now. One possible breaking change is that a TextToolParameter with value "5" is not equal to a literal 5 anymore. I doubt anyone relied on this behavior.