### PR TITLE
[19.09] Fix output.file_path writing to read-only path on Docker

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -494,7 +494,7 @@ def default_exit_code_file(files_dir, id_tag):
 def collect_extra_files(object_store, dataset, job_working_directory):
     store_by = getattr(object_store, "store_by", "id")
     file_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
-    temp_file_path = os.path.join(job_working_directory, file_name)
+    temp_file_path = os.path.join(job_working_directory, "working", file_name)
     extra_dir = None
     try:
         # This skips creation of directories - object store

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -502,7 +502,7 @@ def collect_extra_files(object_store, dataset, job_working_directory):
         # not be created in the object store at all, which might be a
         # problem.
         for root, dirs, files in os.walk(temp_file_path):
-            extra_dir = root.replace(job_working_directory, '', 1).lstrip(os.path.sep)
+            extra_dir = root.replace(os.path.join(job_working_directory, "working"), '', 1).lstrip(os.path.sep)
             for f in files:
                 object_store.update_from_file(
                     dataset.dataset,

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -121,7 +121,7 @@ def set_metadata_portable():
             dataset.dataset.external_filename = dataset_filename_override
             store_by = metadata_params.get("object_store_store_by", "id")
             extra_files_dir_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
-            files_path = os.path.abspath(os.path.join(tool_job_working_directory, extra_files_dir_name))
+            files_path = os.path.abspath(os.path.join(tool_job_working_directory, "working", extra_files_dir_name))
             dataset.dataset.external_extra_files_path = files_path
             file_dict = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id)
             if 'ext' in file_dict:
@@ -179,7 +179,9 @@ def set_metadata_legacy():
         try:
             dataset = cPickle.load(open(filename_in, 'rb'))  # load DatasetInstance
             dataset.dataset.external_filename = dataset_filename_override
-            files_path = os.path.abspath(os.path.join(tool_job_working_directory, "dataset_%s_files" % (dataset.dataset.id)))
+            store_by = set_meta_kwds.get("object_store_store_by", "id")
+            extra_files_dir_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
+            files_path = os.path.abspath(os.path.join(tool_job_working_directory, "working", extra_files_dir_name))
             dataset.dataset.external_extra_files_path = files_path
             file_dict = tool_provided_metadata.get_dataset_meta(None, dataset.dataset.id)
             if 'ext' in file_dict:

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -358,7 +358,7 @@ class ToolEvaluator(object):
             # TODO: path munging for cluster/dataset server relocatability
             store_by = getattr(hda.dataset.object_store, "store_by", "id")
             file_name = "dataset_%s_files" % getattr(hda.dataset, store_by)
-            param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, file_name))
+            param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, "working", file_name))
         for out_name, output in self.tool.outputs.items():
             if out_name not in param_dict and output.filters:
                 # Assume the reason we lack this output is because a filter


### PR DESCRIPTION
Includes https://github.com/galaxyproject/galaxy/pull/9027 and should fix the failing tests