### PR TITLE
[19.05] Fix comparison if parameter is optional and value is not provided

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -86,7 +86,12 @@ class InputValueWrapper(ToolParameterValueWrapper):
             'float': float,
             'boolean': bool,
         }
-        return cast.get(self.input.type, str)(self)
+        try:
+            return cast.get(self.input.type, str)(self)
+        except ValueError:
+            if self.input.optional:
+                return str(self)
+            raise
 
     def __eq__(self, other):
         if self.input.type == 'boolean' and isinstance(other, string_types):

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -120,6 +120,13 @@ def test_input_value_wrapper_comparison(tool):
 
 
 @with_mock_tool
+def test_input_value_wrapper_comparison_optional(tool):
+    parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" min="0" optional="true"/>'))
+    wrapper = InputValueWrapper(parameter, "")
+    assert wrapper == ""
+
+
+@with_mock_tool
 def test_input_value_wrapper_input_value_wrapper_comparison(tool):
     wrapper = valuewrapper(tool, 5, "integer")
     assert str(wrapper) == valuewrapper(tool, "5", "text")


### PR DESCRIPTION
Fixes in qiime_filter_otus_from_otu_table:
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/template.py", line 67, in fill_template
    return unicodify(t)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/__init__.py", line 1045, in unicodify
    msg = "Value '%s' could not be coerced to Unicode" % value
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.7/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1575109637_700104_46530.py", line 110, in respond
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 97, in __ne__
    return not self == other
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 94, in __eq__
    return self._get_cast_value() == other
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 89, in _get_cast_value
    return cast.get(self.input.type, str)(self)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 122, in __int__
    return int(float(self))
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 125, in __float__
    return float(str(self))
ValueError: could not convert string to float:
```