### PR TITLE
[PROCEDURES] Add Sergey Golitsynskiy to committers group

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -51,6 +51,7 @@ Members
 - Dave Clements (@tnabtaf)
 - Nate Coraor (@natefoo)
 - Jeremy Goecks (@jgoecks)
+- Sergey Golitsynskiy (@ic4f)
 - Björn Grüning (@bgruening)
 - Aysam Guerler (@guerler)
 - Jennifer Hillman Jackson (@jennaj)


### PR DESCRIPTION
Sergey Golitsynskiy has been a very active contributor to the Galaxy
code base and ecosystem (ansible-galaxy, sequence-utils, iuc) during the
last year. His contributions are of high quality and contain appropriate
tests and documentation and it is a pleasure to review Sergey's
contributions.

I propose that we add Sergey (@ic4f) to the Galaxy committers group so that we
can benefit from his experience and skills.

@galaxyproject/core please vote