### PR TITLE
Lint config 'use_interactive' as a dropped config option.

### DIFF
--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -272,6 +272,7 @@ class _RenameAction(_OptionAction):
 
 OPTION_ACTIONS = {
     'use_beaker_session': _DeprecatedAndDroppedAction(),
+    'use_interactive': _DeprecatedAndDroppedAction(),
     'session_type': _DeprecatedAndDroppedAction(),
     'session_data_dir': _DeprecatedAndDroppedAction(),
     'session_key': _DeprecatedAndDroppedAction(),


### PR DESCRIPTION
Just noticed https://github.com/galaxyproject/galaxy/pull/8877 because of Gitter which looks great, but it should probably mark this option as dropped when linting configurations.
