### PR TITLE
[19.05] Listify value for multiple SelectToolParameterWrapper

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -35,6 +35,7 @@ from galaxy.tools.wrappers import (
 )
 from galaxy.util import (
     find_instance_nested,
+    listify,
     unicodify,
 )
 from galaxy.util.bunch import Bunch
@@ -254,6 +255,8 @@ class ToolEvaluator(object):
                 )
                 input_values[input.name] = wrapper
             elif isinstance(input, SelectToolParameter):
+                if input.multiple:
+                    value = listify(value)
                 input_values[input.name] = SelectToolParameterWrapper(
                     input, value, other_values=param_dict, path_rewriter=self.unstructured_path_rewriter)
             else:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -974,7 +974,9 @@ def listify(item, do_strip=False):
     """
     if not item:
         return []
-    elif isinstance(item, list) or isinstance(item, tuple):
+    elif isinstance(item, list):
+        return item
+    elif isinstance(item, tuple):
         return list(item)
     elif isinstance(item, string_types) and item.count(','):
         if do_strip:


### PR DESCRIPTION
Fix error:

```
2019-12-05 19:03:43,286 ERROR [galaxy.jobs.runners] (2) Failure preparing job
Traceback (most recent call last):
  File "/tmp/tmpwRXIXJ/galaxy-dev/lib/galaxy/jobs/runners/__init__.py", line 230, in prepare_job
    job_wrapper.prepare()
  File "/tmp/tmpwRXIXJ/galaxy-dev/lib/galaxy/jobs/__init__.py", line 1066, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/tmp/tmpwRXIXJ/galaxy-dev/lib/galaxy/tools/evaluation.py", line 480, in build
    raise e
TypeError: argument of type 'SelectToolParameterWrapper' is not iterable
FAIL
```

when running `planemo test` on a tool which specify a multiple select param:

```xml
<param name="plots" type="select" multiple="true" ...>
    <option value="vln" selected="true">Violin and Scatter plots</option>
    <option value="feat" selected="true">Feature counts plots</option>
    ...
</param>
```

with a single value in the test:

```xml
<param name="plots" value="feat" />
```

and the command contains code like:

```
#if "vln" in $meta.plots:
```

Seen in Travis job:

https://travis-ci.org/galaxyproject/tools-iuc/jobs/621235187

for pull request:

https://github.com/galaxyproject/tools-iuc/pull/2625

Also:
- don't unnecessarily copy a list in `listify()` function