### PR TITLE
[19.09] Use newer psycopg2 conditional requirement for wheels on 3.7

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -1,5 +1,5 @@
 # These dependencies are only required when certain config options are set
-psycopg2-binary==2.7.4
+psycopg2-binary==2.8.4
 weberror==0.10.3
 mysqlclient
 fluent-logger


### PR DESCRIPTION
There are no python 3.7 wheels available for 2.7.4: https://pypi.org/project/psycopg2-binary/2.7.4/#files
This breaks python 3.7 setups without build requirements, seen in https://github.com/mvdbeek/planemo/runs/336607791