### PR TITLE
[WIP] Fix 'outputs' in .ga files.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -39,7 +39,6 @@ from galaxy.web import url_for
 from galaxy.workflow.modules import (
     is_tool_module_type,
     module_factory,
-    ToolModule,
     WorkflowModuleInjector
 )
 from galaxy.workflow.resources import get_resource_mapper_function

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -915,7 +915,7 @@ class WorkflowContentsManager(UsesAnnotations):
             for output in module.get_all_outputs():
                 # for backward compatibility set 'type' to first extension for data outputs. This isn't
                 # used on re-import so backward compatibility isn't super important but in case someone
-                # is using this. 'extensions is obviously much more correct.
+                # is using this. 'extensions' is obviously much more correct.
                 # So call what other API endpoints call 'type' - 'output_type' instead to do this.
                 output['output_type'] = output.pop('type')  # (e.g. data, collection, float)
                 extensions = output.get('extensions')

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -912,9 +912,16 @@ class WorkflowContentsManager(UsesAnnotations):
 
             # All step outputs
             step_dict['outputs'] = []
-            if type(module) is ToolModule:
-                for output in module.get_data_outputs():
-                    step_dict['outputs'].append({'name': output['name'], 'type': output['extensions'][0]})
+            for output in module.get_all_outputs():
+                # for backward compatibility set 'type' to first extension for data outputs. This isn't
+                # used on re-import so backward compatibility isn't super important but in case someone
+                # is using this. 'extensions is obviously much more correct.
+                # So call what other API endpoints call 'type' - 'output_type' instead to do this.
+                output['output_type'] = output.pop('type')  # (e.g. data, collection, float)
+                extensions = output.get('extensions')
+                if extensions and len(extensions) > 0:
+                    output['type'] = extensions[0]  # (e.g. fasta, fastqsanger, input)
+                step_dict['outputs'].append(output)
 
             step_in = {}
             for step_input in step.inputs:


### PR DESCRIPTION
Didn't handle collections, parameter outputs, subworkflows, tools that produce outputs with variable datatypes, etc.. 

This field is not used on re-import luckily - but if corrected it can be used to translate to a better format 2 file and can be used for external validation. 