### PR TITLE
[WIP] xml parser: input elements get attributes also from sub tags

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -761,9 +761,8 @@ def __parse_param_elem(param_elem, i=0):
     attrib = dict(param_elem.attrib)
     if 'values' in attrib:
         value = attrib['values'].split(',')
-    elif 'value' in attrib:
-        value = attrib['value']
-    else:
+    value = xml_text(param_elem, 'value')
+    if value == '':
         value = None
     children_elem = param_elem
     if children_elem is not None:
@@ -1048,7 +1047,12 @@ class XmlInputSource(InputSource):
         return self.input_elem
 
     def get(self, key, value=None):
-        return self.input_elem.get(key, value)
+        v = xml_text(self.input_elem, key)
+        if v == '':
+            return value
+        else:
+            return v
+        #return self.input_elem.get(key, value)
 
     def get_bool(self, key, default):
         return string_as_bool(self.get(key, default))
@@ -1076,7 +1080,7 @@ class XmlInputSource(InputSource):
         static_options = list()
         elem = self.input_elem
         for index, option in enumerate(elem.findall("option")):
-            value = option.get("value")
+            value = xml_text(option, "value")
             selected = string_as_bool(option.get("selected", False))
             static_options.append((option.text or value, value, selected))
         return static_options

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -828,6 +828,11 @@ be present in ``test`` definition.</xs:documentation>
       <xs:element name="section" type="TestSection" />
       <xs:element name="output" type="TestOutput" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="output_collection" type="TestOutputCollection"/>
+      <xs:element name="value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Documentation for help</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="assert_command" type="TestAssertions">
         <xs:annotation>
           <xs:documentation xml:lang="en">Describe assertions about the job's
@@ -2647,6 +2652,11 @@ allow access to Python code to generate options for a select list. See
       <xs:element name="options" type="ParamOptions"/>
       <xs:element name="validator" type="Validator" />
       <xs:element name="sanitizer" type="Sanitizer"/>
+      <xs:element name="value" type="xs:string">
+        <xs:annotation>
+          <xs:documentation xml:lang="en">Documentation for help</xs:documentation>
+        </xs:annotation>
+      </xs:element>
       <xs:element name="help" type="xs:string">
         <xs:annotation>
           <xs:documentation xml:lang="en">Documentation for help</xs:documentation>


### PR DESCRIPTION
As previously discussed on gitter it is sometimes helpful to specify attributes as subtags. In particular because this allows to use CDATA. This already worked for the attributes `label` and `help`. 

This adds `value` to this list. 

The xml parser can now do this for each attribute, but the xsd limits the functionality to the attributes mentioned above.