### PR TITLE
Create temporary files for cgi.FieldsStorage with delete=False

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -335,11 +335,11 @@ def _make_file(self, binary=None):
     # but for performance reasons it's way better to use Paste's tempfile than to
     # create a new one and copy.
     if six.PY2:
-        return tempfile.NamedTemporaryFile()
+        return tempfile.NamedTemporaryFile(delete=False)
     if self._binary_file or self.length >= 0:
-        return tempfile.NamedTemporaryFile("wb+")
+        return tempfile.NamedTemporaryFile("wb+", delete=False)
     else:
-        return tempfile.NamedTemporaryFile("w+", encoding=self.encoding, newline='\n')
+        return tempfile.NamedTemporaryFile("w+", encoding=self.encoding, newline='\n', delete=False)
 
 
 def _read_lines(self):

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -319,9 +319,6 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
             if archive_source:
                 archive_type = payload.get("archive_type", "url")
             elif hasattr(archive_file, "file"):
-                # archive_file.file is a TemporaryFile and will be deleted once it is closed.
-                # We prevent this by setting `delete` to `False`.
-                archive_file.file.delete = False
                 archive_source = payload["archive_file"].file.name
                 archive_type = "file"
             else:


### PR DESCRIPTION
Not doing this leads to files being deleted too early on upload.
@davidchristiany noticed that this was breaking history imports
when using uwsgi.