### PR TITLE
Add a datatype subclass for CAT (Contig Annotation Tool)

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -450,6 +450,7 @@
     <datatype extension="xlsx" type="galaxy.datatypes.binary:Xlsx" display_in_upload="true"/>
     <datatype extension="btwisted" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="cai" type="galaxy.datatypes.data:Text" subclass="true"/>
+    <datatype extension="cat_db" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="charge" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="checktrans" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="chips" type="galaxy.datatypes.data:Text" subclass="true"/>


### PR DESCRIPTION
This datatype will be assigned when the cat_prepare tool creates a "database"  in a user history.  The other CAT tools may select that database form the history.