### PR TITLE
[16.04] Explicitly include PyPI as an ``--extra-index-url`` to pip

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -130,17 +130,18 @@ if [ $SET_VENV -eq 1 ]; then
 fi
 
 : ${GALAXY_WHEELS_INDEX_URL:="https://wheels.galaxyproject.org/simple"}
+: ${PYPI_INDEX_URL:="https://pypi.python.org/simple"}
 if [ $REPLACE_PIP -eq 1 ]; then
     pip install 'pip>=8.1'
 fi
 
 if [ $FETCH_WHEELS -eq 1 ]; then
-    pip install -r requirements.txt --index-url ${GALAXY_WHEELS_INDEX_URL}
+    pip install -r requirements.txt --index-url ${GALAXY_WHEELS_INDEX_URL} --extra-index-url "${PYPI_INDEX_URL}"
     GALAXY_CONDITIONAL_DEPENDENCIES=`PYTHONPATH=lib python -c "import galaxy.dependencies; print '\n'.join(galaxy.dependencies.optional('$GALAXY_CONFIG_FILE'))"`
     [ -z "$GALAXY_CONDITIONAL_DEPENDENCIES" ] || echo "$GALAXY_CONDITIONAL_DEPENDENCIES" | pip install -r /dev/stdin --index-url ${GALAXY_WHEELS_INDEX_URL}
 fi
 
 if [ $FETCH_WHEELS -eq 1 -a $DEV_WHEELS -eq 1 ]; then
     dev_requirements='./lib/galaxy/dependencies/dev-requirements.txt'
-    [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url ${GALAXY_WHEELS_INDEX_URL}
+    [ -f $dev_requirements ] && pip install -r $dev_requirements --index-url ${GALAXY_WHEELS_INDEX_URL} --extra-index-url "${PYPI_INDEX_URL}"
 fi


### PR DESCRIPTION
Backport combining commits 244fc834cd4dd3980cc3edb755d22ca5a9372421 and 09fdac513d59ca6dad440616a53daa97751ff905 . This is now needed because wheels.galaxyproject.org is not a full-fledged pypiserver any more but just an S3 bucket served via a CDN.