### PR TITLE
[19.05] Fix importing a directory from user_library_import_dir

### DIFF
--- a/lib/galaxy/actions/library.py
+++ b/lib/galaxy/actions/library.py
@@ -45,8 +45,8 @@ def validate_server_directory_upload(trans, server_dir):
     unsafe = None
     if safe_relpath(server_dir):
         username = trans.user.username if trans.app.config.user_library_import_check_permissions else None
-        if import_dir_desc == 'user_library_import_dir' and safe_contains(import_dir, full_dir, whitelist=trans.app.config.user_library_import_symlink_whitelist, username=username):
-            for unsafe in unsafe_walk(full_dir, whitelist=[import_dir] + trans.app.config.user_library_import_symlink_whitelist):
+        if import_dir_desc == 'user_library_import_dir' and safe_contains(import_dir, full_dir, whitelist=trans.app.config.user_library_import_symlink_whitelist):
+            for unsafe in unsafe_walk(full_dir, whitelist=[import_dir] + trans.app.config.user_library_import_symlink_whitelist, username=username):
                 log.error('User attempted to import a path that resolves to a path outside of their import dir: %s -> %s', unsafe, os.path.realpath(unsafe))
     else:
         log.error('User attempted to import a directory path that resolves to a path outside of their import dir: %s -> %s', server_dir, os.path.realpath(full_dir))


### PR DESCRIPTION
Fix the following traceback:

```
Traceback (most recent call last):
  File "/galaxy/lib/galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/galaxy/lib/galaxy/webapps/galaxy/api/library_contents.py", line 250, in create
    status, output = self._upload_library_dataset(trans, library_id, real_folder_id, **payload)
  File "/galaxy/lib/galaxy/webapps/galaxy/api/library_contents.py", line 337, in _upload_library_dataset
    **kwd)
  File "/galaxy/lib/galaxy/actions/library.py", line 91, in _upload_dataset
    full_dir, import_dir_desc = validate_server_directory_upload(trans, server_dir)
  File "/galaxy/lib/galaxy/actions/library.py", line 48, in validate_server_directory_upload
    if import_dir_desc == 'user_library_import_dir' and safe_contains(import_dir, full_dir, whitelist=trans.app.config.user_library_import_symlink_whitelist, username=username):
TypeError: safe_contains() got an unexpected keyword argument 'username'
```

Also add a test case to reproduce the fixed issue, which was introduced in commit f4442ffc807285a96fa049f9a7e961b5e945bbff .

Reported by @jhl667 .