### PR TITLE
[WIP] Manage Tools List

### DIFF
--- a/client/galaxy/scripts/components/admin/AdminServices.js
+++ b/client/galaxy/scripts/components/admin/AdminServices.js
@@ -110,3 +110,14 @@ export async function resolveContainersWithInstall(toolIds, params_) {
         rethrowSimple(e);
     }
 }
+
+export async function getTools() {
+    const params = {"in_panel": "false"};
+    const url = `${getAppRoot()}api/tools`;
+    try {
+        const response = await axios.get(url, { params: params });
+        return response.data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}

--- a/client/galaxy/scripts/components/admin/Dependencies/ContainerResolutionDetails.vue
+++ b/client/galaxy/scripts/components/admin/Dependencies/ContainerResolutionDetails.vue
@@ -1,6 +1,6 @@
 <template>
     <b-card>
-        <div class="row">
+        <div class="row" v-if="includeToolContext">
             <div class="col">
                 <span v-if="singleTool || resolution.tool_ids.length == 1">Tool</span>
                 <span v-else>Tools</span>
@@ -66,6 +66,10 @@ export default {
         resolution: {
             type: Object,
             required: true
+        },
+        includeToolContext: {
+            type: Boolean,
+            default: true
         }
     },
     computed: {

--- a/client/galaxy/scripts/components/admin/Dependencies/ResolutionDetails.vue
+++ b/client/galaxy/scripts/components/admin/Dependencies/ResolutionDetails.vue
@@ -1,9 +1,9 @@
 <template>
     <div v-if="isContainerResolution">
-        <container-resolution-details :resolution="containerResolution" />
+        <container-resolution-details :resolution="containerResolution" :includeToolContext="includeToolContext" />
     </div>
     <b-card v-else>
-        <div class="row">
+        <div class="row" v-if="includeToolContext">
             <div class="col">
                 <span v-if="singleTool || resolution.tool_ids.length == 1">Tool</span>
                 <span v-else>Tools</span>
@@ -100,6 +100,10 @@ export default {
         resolution: {
             type: Object,
             required: true
+        },
+        includeToolContext: {
+            type: Boolean,
+            default: true
         }
     },
     computed: {

--- a/client/galaxy/scripts/components/admin/ToolDetails.vue
+++ b/client/galaxy/scripts/components/admin/ToolDetails.vue
@@ -1,0 +1,77 @@
+<template>
+    <b-card>
+        Tool Details for Tool {{ toolId }} at version {{ toolVersion }}.
+        <div v-if="repo">
+            <b>Installation Repository Details:</b>
+            <repository-details :repo="repo" />
+        </div>
+        <div v-else>
+            <b>Not a Tool Shed installed tool.</b>
+        </div>
+        <div v-if="containerResolution">
+            <b>Container Resolution Details:</b>
+            <container-resolution-details :resolution="containerResolution" :includeToolContext="false" />
+        </div>
+        <div v-if="dependencyResolution">
+            <b>Dependency Resolution Details:</b>
+            <resolution-details :resolution="dependencyResolution" :includeToolContext="false" />
+        </div>
+    </b-card>
+</template>
+
+<script>
+import RepositoryDetails from "components/Toolshed/InstalledList/Details";
+import ContainerResolutionDetails from "./Dependencies/ContainerResolutionDetails";
+import ResolutionDetails from "./Dependencies/ResolutionDetails";
+import { getToolboxDependencies, getContainerResolutionToolbox } from "./AdminServices";
+
+export default {
+    components: { RepositoryDetails, ContainerResolutionDetails, ResolutionDetails },
+    props: {
+        toolId: {
+            type: String,
+            required: true
+        },
+        toolVersion: {
+            type: String,
+            required: true
+        },
+        repo: {
+            type: Object,
+            default: null
+        }
+    },
+    data() {
+        return {
+            dependencyResolution: null,
+            containerResolution: null
+        };
+    },
+    created()  {
+        // TODO: handle tool_version...
+        const dependencyResolutionParams = { "tool_ids": [this.toolId], "index_by": "tools" };
+        getToolboxDependencies( dependencyResolutionParams )
+                .then(resolutions => {
+                    if( resolutions && resolutions.length > 0 ) {
+                        this.dependencyResolution = resolutions[0];
+                    }
+                })
+                .catch(this.handleError);
+        const containerResolutionParams = { "tool_ids": [this.toolId] };        
+        getContainerResolutionToolbox( containerResolutionParams )
+                .then(resolutions => {
+                    if( resolutions && resolutions.length > 0 ) {
+                        this.containerResolution = resolutions[0];
+                    }
+                })
+                .catch(this.handleError);
+    },
+    computed: {
+    },
+    methods: {
+        handleError(e) {
+            console.error(e);
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/admin/Tools.vue
+++ b/client/galaxy/scripts/components/admin/Tools.vue
@@ -3,13 +3,21 @@
         <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
         <div v-else>
             <loading-span v-if="loading" :message="loadingMessage" />
-            <b-table id="manage-tools-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
-                <template v-slot:cell(tool_id)="data">
-                    {{ data.item.tool.id }}
-                </template>
-                <template v-slot:cell(tool_version)="data">
-                    {{ data.item.tool.version }}
-                </template>
+            <!-- search header borrowed from WorkflowList.vue -->
+            <b-row class="mb-3">
+                <b-col cols="6">
+                    <b-input
+                        id="tool-search"
+                        class="m-1"
+                        name="query"
+                        placeholder="Search Tool IDs"
+                        autocomplete="off"
+                        type="text"
+                        v-model="filter"
+                    />
+                </b-col>
+            </b-row>
+            <b-table id="manage-tools-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails" :filter="filter">
                 <template v-slot:cell(link)="data">
                     <b-button
                         v-b-tooltip.hover.bottom
@@ -45,8 +53,9 @@ export default {
             loading: true,
             loadingMessage: 'Loading available Galaxy tools...',
             error: null,
-            fields: [{ key: "tool_id", label: "ID" }, { key: "tool_version", label: "Version" }, { key: "link", label: "" }],
-            tools: []
+            fields: [{ key: "tool_id", label: "ID", sortable: true }, { key: "tool_version", label: "Version", sortable: true }, { key: "link", label: "" }],
+            tools: [],
+            filter: ""
         };
     },
     created() {
@@ -64,13 +73,14 @@ export default {
                     repo.owner = tool.tool_shed_repository.owner;
                     repo.name = tool.tool_shed_repository.name;
                 }
-                return { tool: tool, repo: repo, selected: false, _showDetails: false };
+                return { tool: tool, tool_id: tool.id, tool_version: tool.version, repo: repo, selected: false, _showDetails: false };
             });
         },
     },
     methods: {
         load() {
             this.loading = true;
+            this.filter = "";
             getTools()
                 .then(tools => {
                     this.tools = tools;

--- a/client/galaxy/scripts/components/admin/Tools.vue
+++ b/client/galaxy/scripts/components/admin/Tools.vue
@@ -1,0 +1,95 @@
+<template>
+    <div>
+        <div v-if="error" class="alert alert-danger" show>{{ error }}</div>
+        <div v-else>
+            <loading-span v-if="loading" :message="loadingMessage" />
+            <b-table id="manage-tools-table" striped :fields="fields" :items="items" @row-clicked="showRowDetails">
+                <template v-slot:cell(tool_id)="data">
+                    {{ data.item.tool.id }}
+                </template>
+                <template v-slot:cell(tool_version)="data">
+                    {{ data.item.tool.version }}
+                </template>
+                <template v-slot:cell(link)="data">
+                    <b-button
+                        v-b-tooltip.hover.bottom
+                        title="Run Tools"
+                        class="btn-sm fa fa-link"
+                        :href="toolLink(data)"
+                    />
+                </template>
+                <template slot="row-details" slot-scope="row">
+                    <tool-details :toolId="row.item.tool.id" :toolVersion="row.item.tool.version" :repo="row.item.repo" />
+                </template>
+            </b-table>
+        </div>
+    </div>
+</template>
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import LoadingSpan from "components/LoadingSpan";
+import { getTools } from "./AdminServices.js";
+import ToolDetails from "./ToolDetails.vue";
+import { getAppRoot } from "onload/loadConfig";
+
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        LoadingSpan,
+        ToolDetails
+    },
+    data() {
+        return {
+            loading: true,
+            loadingMessage: 'Loading available Galaxy tools...',
+            error: null,
+            fields: [{ key: "tool_id", label: "ID" }, { key: "tool_version", label: "Version" }, { key: "link", label: "" }],
+            tools: []
+        };
+    },
+    created() {
+        this.load();
+    },
+    computed: {
+        items: function() {
+            return this.tools.map(tool => {
+                let repo = null;
+                if ( tool.tool_shed_repository ) {
+                    repo = {};
+                    // TODO: relax tool_shed_url on the server side - shouldn't need to know http vs. https and
+                    // shouldn't depend on last /.
+                    repo.tool_shed_url = "https://" + tool.tool_shed_repository.tool_shed + "/";
+                    repo.owner = tool.tool_shed_repository.owner;
+                    repo.name = tool.tool_shed_repository.name;
+                }
+                return { tool: tool, repo: repo, selected: false, _showDetails: false };
+            });
+        },
+    },
+    methods: {
+        load() {
+            this.loading = true;
+            getTools()
+                .then(tools => {
+                    this.tools = tools;
+                    this.loading = false;
+                })
+                .catch(this.handleError);
+        },
+        showRowDetails(row, index, e) {
+            if (e.target.nodeName != "A") {
+                row._showDetails = !row._showDetails;
+            }
+        },
+        toolLink(row) {
+            // why doesn't ${getAppRoot()}${link} work?
+            return `${row.item.tool.link}`;
+        },
+        handleError(e) {
+            this.error = e;
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/entry/admin/AdminRouter.js
+++ b/client/galaxy/scripts/entry/admin/AdminRouter.js
@@ -10,6 +10,7 @@ import DataTypes from "components/admin/DataTypes.vue";
 import Jobs from "components/admin/Jobs.vue";
 import ActiveInvocations from "components/admin/ActiveInvocations.vue";
 import Landing from "components/admin/Dependencies/Landing.vue";
+import Tools from "components/admin/Tools.vue";
 import DataManagerView from "components/admin/DataManager/DataManagerView.vue";
 import DataManagerRouter from "components/admin/DataManager/DataManagerRouter.vue";
 import Register from "components/login/Register.vue";
@@ -42,6 +43,7 @@ export const getAdminRouter = (Galaxy, options) => {
             "(/)admin/jobs": "show_jobs",
             "(/)admin/invocations": "show_invocations",
             "(/)admin/toolbox_dependencies": "show_toolbox_dependencies",
+            "(/)admin/tools": "show_tools",
             "(/)admin/data_manager*path": "show_data_manager",
             "(/)admin(/)reset_metadata": "show_reset_metadata",
             "*notFound": "not_found"
@@ -135,6 +137,10 @@ export const getAdminRouter = (Galaxy, options) => {
 
         show_toolbox_dependencies: function() {
             this._display_vue_helper(Landing);
+        },
+
+        show_tools: function() {
+            this._display_vue_helper(Tools);
         },
 
         show_error_stack: function() {

--- a/client/galaxy/scripts/entry/panels/admin-panel.js
+++ b/client/galaxy/scripts/entry/panels/admin-panel.js
@@ -94,6 +94,12 @@ const AdminPanel = Backbone.View.extend({
                 title: _l("Tool Management"),
                 items: [
                     {
+                        title: _l("Manage"),
+                        url: "admin/tools",
+                        target: "__use_router__",
+                        id: "admin-link-manage-tools"
+                    },
+                    {
                         title: _l("Install and Uninstall"),
                         url: "admin/toolshed",
                         target: "__use_router__",

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -105,6 +105,7 @@ def app_factory(global_conf, load_app_kwds={}, **kwargs):
     webapp.add_client_route('/admin/jobs', 'admin')
     webapp.add_client_route('/admin/invocations', 'admin')
     webapp.add_client_route('/admin/toolbox_dependencies', 'admin')
+    webapp.add_client_route('/admin/tools', 'admin')
     webapp.add_client_route('/admin/data_manager{path_info:.*}', 'admin')
     webapp.add_client_route('/admin/error_stack', 'admin')
     webapp.add_client_route('/admin/users', 'admin')


### PR DESCRIPTION
Still early but work stemming from experiments when working on #8741.

Bring container, dependency, and repository information together in one place for a given tool. Other sections provide contain, dependency, or repository centric information - information in this view is presented in a tool centric way. It serve as a good place to summarize recent job failures, run tool tests as the admin, etc..

I see other views as good for summarizing data across a lot of tools or working with new tools during install - this will hopefully be the landing point for debugging issues with tools.

Builds nicely on existing components - real demonstration of Vue coolness. 
