### PR TITLE
Make callbacks for tour and config watchers a control task

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -868,7 +868,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 Configuration = GalaxyAppConfiguration
 
 
-def reload_config_options(current_config, path=None):
+def reload_config_options(current_config):
     """ Reload modified reloadable config options """
     modified_config = read_properties_from_file(current_config.config_file)
     for option in current_config.reloadable_options:

--- a/lib/galaxy/config_watchers.py
+++ b/lib/galaxy/config_watchers.py
@@ -1,7 +1,5 @@
-from functools import partial
 from os.path import dirname
 
-from galaxy.config import reload_config_options
 from galaxy.queue_worker import job_rule_modules
 from galaxy.tools.toolbox.watcher import (
     get_tool_conf_watcher,
@@ -81,11 +79,11 @@ class ConfigWatchers(object):
         if self.app.config.config_file:
             self.core_config_watcher.watch_file(
                 self.app.config.config_file,
-                callback=partial(reload_config_options, self.app.config)
+                callback=lambda path: self.app.queue_worker.send_control_task('reload_core_config')
             )
             self.tour_watcher.watch_directory(
                 self.app.config.tour_config_dir,
-                callback=lambda path: self.app.tour_registry.reload_tour(path)
+                callback=lambda path: self.app.queue_worker.send_control_task('reload_tour', kwargs={'path': path})
             )
         self.active = True
 

--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -29,6 +29,7 @@ from six.moves import reload_module
 
 import galaxy.queues
 from galaxy import util
+from galaxy.config import reload_config_options
 
 logging.getLogger('kombu').setLevel(logging.WARNING)
 log = logging.getLogger(__name__)
@@ -262,6 +263,16 @@ def reload_job_rules(app, **kwargs):
     log.debug("Job rules reloaded %s", reload_timer)
 
 
+def reload_core_config(app, **kwargs):
+    reload_config_options(app.config)
+
+
+def reload_tour(app, **kwargs):
+    path = kwargs.get('path')
+    app.tour_registry.reload_tour(path)
+    log.debug('Tour reloaded')
+
+
 def __job_rule_module_names(app):
     rules_module_names = set(['galaxy.jobs.rules'])
     if app.job_config.dynamic_params is not None:
@@ -310,6 +321,8 @@ control_message_to_task = {
     'recalculate_user_disk_usage': recalculate_user_disk_usage,
     'rebuild_toolbox_search_index': rebuild_toolbox_search_index,
     'reconfigure_watcher': reconfigure_watcher,
+    'reload_tour': reload_tour,
+    'reload_core_config': reload_core_config,
 }
 
 


### PR DESCRIPTION
Re:
https://github.com/mvdbeek/galaxy/commit/e3f3af91830c1c998134fcf0b9ceb1ad09739a2c#r36356830

@mvdbeek is this correct? Should this be backported to 19.09?