### PR TITLE
Refactor more of jobs admin component toward API.

### DIFF
--- a/client/galaxy/scripts/components/admin/Jobs.vue
+++ b/client/galaxy/scripts/components/admin/Jobs.vue
@@ -226,15 +226,7 @@ export default {
     },
     watch: {
         jobLock(newVal) {
-            axios
-                .get(`${getAppRoot()}admin/jobs_control?job_lock=${this.jobLock}`)
-                .then(response => {
-                    this.jobLock = response.data.job_lock;
-                    this.jobLockDisplay = response.data.job_lock;
-                })
-                .catch(error => {
-                    console.error(error);
-                });
+            this.handleJobLock(axios.put(`${getAppRoot()}api/job_lock`, { active: this.jobLock }));
         },
         selectedStopJobIds(newVal) {
             if (newVal.length === 0) {
@@ -250,6 +242,19 @@ export default {
         }
     },
     methods: {
+        initJobLock() {
+            this.handleJobLock(axios.get(`${getAppRoot()}api/job_lock`));
+        },
+        handleJobLock(axiosPromise) {
+            axiosPromise
+                .then(response => {
+                    this.jobLock = response.data.active;
+                    this.jobLockDisplay = response.data.active;
+                })
+                .catch(error => {
+                    console.error(error);
+                });
+        },
         update() {
             this.busy = true;
             let params = [];
@@ -263,8 +268,6 @@ export default {
                     this.cutoffDisplay = response.data.cutoff;
                     this.message = response.data.message;
                     this.status = response.data.status;
-                    this.jobLock = response.data.job_lock;
-                    this.jobLockDisplay = response.data.job_lock;
                     this.loading = false;
                     this.busy = false;
                 })
@@ -360,6 +363,7 @@ export default {
         }
     },
     created() {
+        this.initJobLock();
         this.update();
     }
 };

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -65,6 +65,15 @@ class JobManager(object):
         trans.sa_session.refresh(job)
         return job
 
+    def stop(self, job, message=None):
+        if not job.finished:
+            job.mark_deleted(self.app.config.track_jobs_in_database)
+            self.app.model.context.current.flush()
+            self.app.job_manager.stop(job, message=message)
+            return True
+        else:
+            return False
+
 
 class JobSearch(object):
     """Search for jobs using tool inputs or other jobs"""

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -16,6 +16,7 @@ from galaxy.managers.jobs import JobManager, JobSearch
 from galaxy.web import (
     expose_api,
     expose_api_anonymous,
+    require_admin,
 )
 from galaxy.webapps.base.controller import (
     BaseAPIController,
@@ -567,3 +568,23 @@ class JobController(BaseAPIController, UsesVisualizationMixin):
         )
 
         return {'messages': messages}
+
+    @require_admin
+    @expose_api
+    def show_job_lock(self, trans, **kwd):
+        """
+        * GET /api/job_lock
+            return boolean indicating if job lock active.
+        """
+        return {"active": self.app.job_manager.job_lock}
+
+    @require_admin
+    @expose_api
+    def update_job_lock(self, trans, payload, **kwd):
+        """
+        * PUT /api/job_lock
+            return boolean indicating if job lock active.
+        """
+        job_lock = payload.get("active")
+        self.app.queue_worker.send_control_task('admin_job_lock', kwargs={'job_lock': job_lock}, get_response=True)
+        return {"active": self.app.job_manager.job_lock}

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -237,15 +237,13 @@ class JobController(BaseAPIController, UsesVisualizationMixin):
 
         :type   id: string
         :param  id: Encoded job id
+        :type   message: string
+        :param  message: Stop message.
         """
+        payload = kwd.get("payload") or {}
         job = self.__get_job(trans, id)
-        if not job.finished:
-            job.mark_deleted(self.app.config.track_jobs_in_database)
-            trans.sa_session.flush()
-            self.app.job_manager.stop(job)
-            return True
-        else:
-            return False
+        message = payload.get("message", None)
+        return self.job_manager.stop(job, message=message)
 
     @expose_api
     def resume(self, trans, id, **kwd):

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -928,6 +928,8 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('common_problems', '/api/jobs/{id}/common_problems', controller='jobs', action='common_problems', conditions=dict(method=['GET']))
     # Job metrics and parameters by job id or dataset id (for slightly different accessibility checking)
     webapp.mapper.connect('metrics', '/api/jobs/{job_id}/metrics', controller='jobs', action='metrics', conditions=dict(method=['GET']))
+    webapp.mapper.connect('show_job_lock', '/api/job_lock', controller='jobs', action='show_job_lock', conditions=dict(method=['GET']))
+    webapp.mapper.connect('update_job_lock', '/api/job_lock', controller='jobs', action='update_job_lock', conditions=dict(method=['PUT']))
     webapp.mapper.connect('dataset_metrics', '/api/datasets/{dataset_id}/metrics', controller='jobs', action='metrics', conditions=dict(method=['GET']))
     webapp.mapper.connect('parameters_display', '/api/jobs/{job_id}/parameters_display', controller='jobs', action='parameters_display', conditions=dict(method=['GET']))
     webapp.mapper.connect('dataset_parameters_display', '/api/datasets/{dataset_id}/parameters_display', controller='jobs', action='parameters_display', conditions=dict(method=['GET']))

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1520,20 +1520,9 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
     @web.expose
     @web.json
     @web.require_admin
-    def jobs_control(self, trans, job_lock=None, **kwd):
-        if job_lock is not None:
-            job_lock = True if job_lock == 'true' else False
-            trans.app.queue_worker.send_control_task('admin_job_lock', kwargs={'job_lock': job_lock}, get_response=True)
-        job_lock = trans.app.job_manager.job_lock
-        return {'job_lock': job_lock}
-
-    @web.expose
-    @web.json
-    @web.require_admin
     def jobs_list(self, trans, cutoff=180, **kwd):
         message = kwd.get('message', '')
         status = kwd.get('status', 'info')
-        job_lock = trans.app.job_manager.job_lock
         cutoff_time = datetime.utcnow() - timedelta(seconds=int(cutoff))
         jobs = trans.sa_session.query(trans.app.model.Job) \
                                .filter(and_(trans.app.model.Job.table.c.update_time < cutoff_time,
@@ -1576,8 +1565,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 'recent_jobs': prepare_jobs_list(recent_jobs),
                 'cutoff': cutoff,
                 'message': message,
-                'status': status,
-                'job_lock': job_lock}
+                'status': status}
 
     @web.expose
     @web.require_admin

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -3,7 +3,6 @@ import logging
 import os
 from collections import OrderedDict
 from datetime import datetime, timedelta
-from string import punctuation as PUNCTUATION
 
 import six
 from sqlalchemy import and_, false, or_
@@ -1531,36 +1530,9 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
     @web.expose
     @web.json
     @web.require_admin
-    def jobs_list(self, trans, stop=[], stop_msg=None, cutoff=180, **kwd):
-        deleted = []
+    def jobs_list(self, trans, cutoff=180, **kwd):
         message = kwd.get('message', '')
         status = kwd.get('status', 'info')
-        job_ids = util.listify(stop)
-        if job_ids and stop_msg in [None, '']:
-            message = 'Please enter an error message to display to the user describing why the job was terminated'
-            return self.message_exception(trans, message)
-        elif job_ids:
-            if stop_msg[-1] not in PUNCTUATION:
-                stop_msg += '.'
-            for job_id in job_ids:
-                error_msg = "This job was stopped by an administrator: %s  <a href='%s' target='_blank'>Contact support</a> for additional help." \
-                    % (stop_msg, self.app.config.get("support_url", "https://galaxyproject.org/support/"))
-                if trans.app.config.track_jobs_in_database:
-                    job = trans.sa_session.query(trans.app.model.Job).get(job_id)
-                    job.job_stderr = error_msg
-                    job.set_state(trans.app.model.Job.states.DELETED_NEW)
-                    trans.sa_session.add(job)
-                else:
-                    trans.app.job_manager.stop(job, message=error_msg)
-                deleted.append(str(job_id))
-        if deleted:
-            message = 'Queued job'
-            if len(deleted) > 1:
-                message += 's'
-            message += ' for deletion: '
-            message += ', '.join(deleted)
-            status = 'done'
-            trans.sa_session.flush()
         job_lock = trans.app.job_manager.job_lock
         cutoff_time = datetime.utcnow() - timedelta(seconds=int(cutoff))
         jobs = trans.sa_session.query(trans.app.model.Job) \
@@ -1589,6 +1561,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                         'id': job.id,
                         'info_url': "{}?jobid={}".format(web.url_for(controller="admin", action="job_info"), job.id)
                     },
+                    'id': trans.security.encode_id(job.id),
                     'user': job.history.user.email if job.history and job.history.user else 'anonymous',
                     'update_time': job.update_time.isoformat(),
                     'tool_id': job.tool_id,


### PR DESCRIPTION
Continuing thread started with #8943 - trying to unwind the admin/jobs controller endpoint - so the Jobs.vue component can use a proper API. Now uses real API calls for stopping jobs and for interacting with the job lock.
