### PR TITLE
[19.09] Don't watch tool files through watchdog

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -867,8 +867,6 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         if not tool.id.startswith("__"):
             # do not monitor special tools written to tmp directory - no reason
             # to monitor such a large directory.
-            if self._tool_watcher:
-                self._tool_watcher.watch_file(tool.config_file, tool.id)
             if self._tool_config_watcher:
                 [self._tool_config_watcher.watch_file(macro_path) for macro_path in tool._macro_paths]
 


### PR DESCRIPTION
These will be watched more efficiently through the ToolConfigWatcher.
Watching all tool files (which watches their directories) can lead to enormous CPU usage when many tools are installed. Explicitly indicated tool directories (with `<tool_dir dir="dump_dir"/>`) will still be watched through watchdog.

If I activate `watch_tools` (this should only be done in dev anyway) I couldn't get any watchdog events to appear. Forcing  watchdog to use the PollingObserver then led to 100% CPU load. Not sure this is related to https://github.com/galaxyproject/galaxy/issues/9085, but it haven't seen [this traceback](https://github.com/galaxyproject/galaxy/issues/9085#issuecomment-564070010) anymore 