### PR TITLE
Eliminate extensions=['input_collection'] hack.

### DIFF
--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -312,7 +312,7 @@ var BaseInputTerminal = Terminal.extend({
                 if (
                     firstOutput.isCollection ||
                     firstOutput.isMappedOver() ||
-                    firstOutput.datatypes.indexOf("input_collection") > 0
+                    firstOutput.datatypes.indexOf("input") > 0
                 ) {
                     return true;
                 } else {
@@ -359,7 +359,6 @@ var BaseInputTerminal = Terminal.extend({
                 if (
                     other_datatype == "input" ||
                     other_datatype == "_sniff_" ||
-                    other_datatype == "input_collection" ||
                     window.workflow_globals.app.isSubType(cat_outputs[other_datatype_i], thisDatatype)
                 ) {
                     return new ConnectionAcceptable(true, null);

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -47,7 +47,7 @@ const DataOutputView = Backbone.View.extend({
         let label = output.label || output.name;
         const node = this.nodeView.node;
 
-        const isInput = output.extensions.indexOf("input") >= 0 || output.extensions.indexOf("input_collection") >= 0;
+        const isInput = output.extensions.indexOf("input") >= 0;
         if (!isInput) {
             label = `${label} (${output.force_datatype || output.extensions.join(", ")})`;
         }

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -646,7 +646,7 @@ class InputDataCollectionModule(InputModule):
         return [
             dict(
                 name='output',
-                extensions=['input_collection'],
+                extensions=['input'],
                 collection=True,
                 collection_type=self.state.inputs.get('collection_type', self.default_collection_type)
             )


### PR DESCRIPTION
The existing hack of extensions=['input'] is bad enough and should work fine for collections. Not sure what past-John was thinking by adding this.

Part of work on #9086 but I want to see the tests in isolation and doesn't really depend on that work anyway. 