### PR TITLE
add option select_type_workflow_threshold (rebase)

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-parameters.js
+++ b/client/galaxy/scripts/mvc/form/form-parameters.js
@@ -95,14 +95,12 @@ export default Backbone.Model.extend({
         // check select_type_workflow_threshold option
         const Galaxy = getGalaxyInstance();
         var searchable = true;
-        if ( input_def.flavor == "workflow") {
+        if (input_def.flavor == "workflow") {
             if (Galaxy.config.select_type_workflow_threshold == -1) {
                 searchable = false;
-            }
-            else if (Galaxy.config.select_type_workflow_threshold == 0) {
+            } else if (Galaxy.config.select_type_workflow_threshold == 0) {
                 searchable = true;
-            }
-            else if (Galaxy.config.select_type_workflow_threshold < input_def.options.length) {
+            } else if (Galaxy.config.select_type_workflow_threshold < input_def.options.length) {
                 searchable = false;
             }
         }

--- a/client/galaxy/scripts/mvc/form/form-parameters.js
+++ b/client/galaxy/scripts/mvc/form/form-parameters.js
@@ -91,6 +91,21 @@ export default Backbone.Model.extend({
             radiobutton: Ui.RadioButton
         };
         var SelectClass = classes[input_def.display] || Ui.Select;
+        // use Select2 fields or regular select fields in workflow launch form?
+        // check select_type_workflow_threshold option
+        const Galaxy = getGalaxyInstance();
+        var searchable = true;
+        if ( input_def.flavor == "workflow") {
+            if (Galaxy.config.select_type_workflow_threshold == -1) {
+                searchable = false;
+            }
+            else if (Galaxy.config.select_type_workflow_threshold == 0) {
+                searchable = true;
+            }
+            else if (Galaxy.config.select_type_workflow_threshold < input_def.options.length) {
+                searchable = false;
+            }
+        }
         return new Ui.TextSelect({
             id: `field-${input_def.id}`,
             data: input_def.data,
@@ -102,7 +117,7 @@ export default Backbone.Model.extend({
             optional: input_def.optional,
             onchange: input_def.onchange,
             individual: input_def.individual,
-            searchable: input_def.flavor !== "workflow",
+            searchable: searchable,
             textable: input_def.textable,
             SelectClass: SelectClass
         });

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3829,4 +3829,20 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``select_type_workflow_threshold``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Due to performance considerations (select2 fields are pretty
+    'expensive' in terms of memory usage) Galaxy uses the regular
+    select fields for non-dataset selectors in the workflow run form.
+    use 0 in order to always use select2 fields, use -1 (default) in
+    order to always use the regular select fields, use any other
+    positive number as threshold (above threshold: regular select
+    fields will be used)
+:Default: ``-1``
+:Type: int
+
+
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1878,3 +1878,11 @@ galaxy:
   # unique session cookie shared by all subdomains.
   #cookie_domain: null
 
+  # Due to performance considerations (select2 fields are pretty
+  # 'expensive' in terms of memory usage) Galaxy uses the regular select
+  # fields for non-dataset selectors in the workflow run form. use 0 in
+  # order to always use select2 fields, use -1 (default) in order to
+  # always use the regular select fields, use any other positive number
+  # as threshold (above threshold: regular select fields will be used)
+  #select_type_workflow_threshold: -1
+

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -95,6 +95,7 @@ class ConfigSerializer(base.ModelSerializer):
             'show_welcome_with_login'           : _defaults_to(True),  # schema default is False
             'cookie_domain'                     : _required_attribute,
             'python'                            : _defaults_to((sys.version_info.major, sys.version_info.minor)),
+            'select_type_workflow_threshold'    : _required_attribute,
         }
 
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2861,3 +2861,14 @@ mapping:
           to the other.
           This root domain will be written in the unique session cookie shared
           by all subdomains.
+
+      select_type_workflow_threshold:
+        type: int
+        default: -1
+        required: false
+        desc: |
+          Due to performance considerations (select2 fields are pretty 'expensive' in terms of memory usage)
+          Galaxy uses the regular select fields for non-dataset selectors in the workflow run form.
+          use 0 in order to always use select2 fields,
+          use -1 (default) in order to always use the regular select fields,
+          use any other positive number as threshold (above threshold: regular select fields will be used)


### PR DESCRIPTION
Rebase of #8816, cleaner diff in Github now.

I'm a bit uneasy about this - it doesn't feel like something that should be configurable - but that said I understand why we don't and why we want to.

The simplified workflow run interface sketched out in http://bit.ly/simplified-workflow-ui - would cause dozens of fewer select boxes to render per large workflow - so maybe that would mitigate this problem somewhat.