### PR TITLE
Make failing to load tools from a tool_dir non-fatal.

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -828,19 +828,19 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 return None
 
         tool_loaded = False
-        try:
-            for name in os.listdir(directory):
-                if name.startswith(('.', '_')):
-                    # Very unlikely that we want to load tools from a hidden or private folder
-                    continue
-                child_path = os.path.join(directory, name)
-                if os.path.isdir(child_path) and recursive:
-                    self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
-                elif self._looks_like_a_tool(child_path):
-                    quick_load(child_path, async_load=False)
-                    tool_loaded = True
-        except Exception:
-            log.exception("Failed to read tool directory %s.", directory)
+        if not os.path.isdir(directory):
+            log.error("Failed to read tool directory %s.", directory)
+            return
+        for name in os.listdir(directory):
+            if name.startswith(('.', '_')):
+                # Very unlikely that we want to load tools from a hidden or private folder
+                continue
+            child_path = os.path.join(directory, name)
+            if os.path.isdir(child_path) and recursive:
+                self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
+            elif self._looks_like_a_tool(child_path):
+                quick_load(child_path, async_load=False)
+                tool_loaded = True
         if (tool_loaded or force_watch) and self._tool_watcher:
             self._tool_watcher.watch_directory(directory, quick_load)
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -828,16 +828,19 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 return None
 
         tool_loaded = False
-        for name in os.listdir(directory):
-            if name.startswith('.' or '_'):
-                # Very unlikely that we want to load tools from a hidden or private folder
-                continue
-            child_path = os.path.join(directory, name)
-            if os.path.isdir(child_path) and recursive:
-                self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
-            elif self._looks_like_a_tool(child_path):
-                quick_load(child_path, async_load=False)
-                tool_loaded = True
+        try:
+            for name in os.listdir(directory):
+                if name.startswith('.' or '_'):
+                    # Very unlikely that we want to load tools from a hidden or private folder
+                    continue
+                child_path = os.path.join(directory, name)
+                if os.path.isdir(child_path) and recursive:
+                    self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
+                elif self._looks_like_a_tool(child_path):
+                    quick_load(child_path, async_load=False)
+                    tool_loaded = True
+        except Exception:
+            log.exception("Failed to read tool directory %s.", directory)
         if (tool_loaded or force_watch) and self._tool_watcher:
             self._tool_watcher.watch_directory(directory, quick_load)
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -830,7 +830,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         tool_loaded = False
         try:
             for name in os.listdir(directory):
-                if name.startswith('.' or '_'):
+                if name.startswith(('.', '_')):
                     # Very unlikely that we want to load tools from a hidden or private folder
                     continue
                 child_path = os.path.join(directory, name)


### PR DESCRIPTION
Previously, having e.g. a missing directory prevented the remainder of the `tool_conf.xml` file from being read.

```
<tool_dir dir="/path/no/exist/tools" />
```