### PR TITLE
Add a test for a tool with `from_working_dir`, `outputs_to_working_directory` and `pulsar`

### DIFF
--- a/test/integration/test_pulsar_embedded_copy_working.py
+++ b/test/integration/test_pulsar_embedded_copy_working.py
@@ -21,4 +21,4 @@ class EmbeddedCopyWorkingPulsarIntegrationInstance(integration_util.IntegrationI
 
 instance = integration_util.integration_module_instance(EmbeddedCopyWorkingPulsarIntegrationInstance)
 
-test_tools = integration_util.integration_tool_runner(["output_format"])
+test_tools = integration_util.integration_tool_runner(["output_format", "output_filter"])


### PR DESCRIPTION
The combination of:
  * from_work_dir in tools
  * outputs_to_working_directory
  * pulsar

seems to cause problem in our setup. Let's see if the test fails here.