### PR TITLE
Automatically redirect to OIDC provider when only auth option

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -18,7 +18,7 @@ function logoutClick() {
         if (galaxy.user) {
             galaxy.user.clearSessionStorage();
         }
-        window.top.location.href = `${galaxy.root}login`;
+        window.top.location.href = galaxy.root;
     });
 }
 

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -17,6 +17,7 @@ from galaxy import (
     managers,
     web
 )
+from galaxy.auth.util import get_authenticators
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util import (
     FILENAME_VALID_CHARS,
@@ -83,6 +84,17 @@ class RootController(controller.JSAppLauncher, UsesAnnotations):
         """
         User login path for client-side.
         """
+        # directly redirect to oidc provider if 1) enable_oidc is True, 2)
+        # there is only one oidc provider, 3) auth_conf.xml has no authenticators
+        if (trans.app.config.enable_oidc and
+                len(trans.app.config.oidc) == 1 and
+                len(trans.app.auth_manager.authenticators) == 0):
+
+            provider = trans.app.config.oidc[0]
+            success, message, redirect_uri = trans.app.authnz_manager.authenticate(provider, trans)
+            if success:
+                return trans.response.send_redirect(redirect_uri)
+
         return self.template(trans, 'login',
                              redirect=redirect,
                              # an installation may have it's own welcome_url - show it here if they've set that

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -17,7 +17,6 @@ from galaxy import (
     managers,
     web
 )
-from galaxy.auth.util import get_authenticators
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.util import (
     FILENAME_VALID_CHARS,


### PR DESCRIPTION
When Galaxy is configured to only use a single OIDC provider for authentication, it is desirable for /login to automatically redirect to that provider's login page instead of requiring the user to select that provider on the Galaxy login page.

This PR changes /login to automatically do this redirection when:

1. enable_oidc is true
2. there is only one OIDC provider in oidc_backends_config.xml
3. there are no other authenticators as defined in auth_config.xml

With this automatic redirection, a problem can occur on logout if the user is still logged into the identity provider. Since the Galaxy logout page redirects to the login page, if the user tries to logout of Galaxy but is still logged into the identity provider the user will end up logged into Galaxy again. The steps are:
* user logs out at /user/logout (menu.js)
* /user/logout -> /login
* /login -> idp login page
* user is still logged in, so idp login page -> Galaxy home page and user is logged in

Hence, the logout logic has been changed to redirect to the home page instead of the login page.
