### PR TITLE
Automatically use extended-base-image if necessary

### DIFF
--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -1,0 +1,27 @@
+name: Mulled Unit Tests
+on: [push, pull_request]
+jobs:
+
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [2.7, 3.7]
+    steps:
+    - name: Cache tox dir
+      uses: actions/cache@v1
+      id: cache-tox-mulled
+      with:
+        path: .tox/mulled
+        key: tox-mulled-${{ matrix.python-version }}
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install tox
+      run: pip install tox
+    - name: run tests
+      run: tox -e mulled

--- a/lib/galaxy/tool_util/deps/mulled/get_tests.py
+++ b/lib/galaxy/tool_util/deps/mulled/get_tests.py
@@ -10,7 +10,6 @@ import json
 import logging
 import tarfile
 from glob import glob
-from io import BytesIO
 
 import requests
 import yaml
@@ -21,7 +20,10 @@ except ImportError:
     Template = None
     UndefinedError = Exception
 
-from .util import split_container_name
+from .util import (
+    get_file_from_recipe_url,
+    split_container_name,
+)
 
 INSTALL_JINJA_EXCEPTION = "This mulled functionality required jinja2 but it is unavailable, install condatesting extras."
 
@@ -102,10 +104,8 @@ def get_test_from_anaconda(url):
     """
     Given the URL of an anaconda tarball, return tests
     """
-    r = requests.get(url)
-
     try:
-        tarball = tarfile.open(mode="r:bz2", fileobj=BytesIO(r.content))
+        tarball = get_file_from_recipe_url(url)
     except tarfile.ReadError:
         return None
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -31,6 +31,7 @@ from .util import (
     build_target,
     conda_build_target_str,
     create_repository,
+    get_file_from_recipe_url,
     PrintProgress,
     quay_repository,
     v1_image_name,
@@ -252,6 +253,21 @@ def mull_targets(
 def context_from_args(args):
     verbose = "2" if not args.verbose else "3"
     return InvolucroContext(involucro_bin=args.involucro_path, verbose=verbose)
+
+
+class CondaInDockerContext(object):
+
+    @property
+    def conda_exec(self):
+        conda_image = CONDA_IMAGE or 'continuumio/miniconda3:latest'
+        return docker_command_list('run', [conda_image, 'conda'])
+
+    @property
+    def _override_channels_args(self):
+        override_channels_args = ['--override-channels']
+        for channel in DEFAULT_CHANNELS:
+            override_channels_args.extend(["--channel", channel])
+        return override_channels_args
 
 
 class InvolucroContext(installable.InstallableContext):

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -5,8 +5,10 @@ import collections
 import hashlib
 import logging
 import sys
+import tarfile
 import threading
 import time
+from io import BytesIO
 
 import packaging.version
 import requests
@@ -118,7 +120,7 @@ def version_sorted(elements):
     return sorted(elements, key=packaging.version.parse, reverse=True)
 
 
-Target = collections.namedtuple("Target", ["package_name", "version", "build"])
+Target = collections.namedtuple("Target", ["package_name", "version", "build", "package"])
 
 
 def build_target(package_name, version=None, build=None, tag=None):
@@ -128,7 +130,7 @@ def build_target(package_name, version=None, build=None, tag=None):
         assert build is None
         version, build = split_tag(tag)
 
-    return Target(package_name, version, build)
+    return Target(package_name, version, build, package_name)
 
 
 def conda_build_target_str(target):
@@ -250,6 +252,12 @@ def v2_image_name(targets, image_build=None, name_override=None):
         if version_hash_str or build_suffix:
             suffix = ":%s%s" % (version_hash_str, build_suffix)
         return "mulled-v2-%s%s" % (package_hash.hexdigest(), suffix)
+
+
+def get_file_from_recipe_url(url):
+    """Downloads file at url and returns tarball"""
+    r = requests.get(url)
+    return tarfile.open(mode="r:bz2", fileobj=BytesIO(r.content))
 
 
 def split_container_name(name):

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -1,6 +1,6 @@
 from galaxy.tool_util.deps.mulled.get_tests import deep_test_search, find_anaconda_versions, get_alternative_versions, get_anaconda_url, get_commands_from_yaml, get_run_test, get_test_from_anaconda, hashed_test_search, main_test_search, open_recipe_file, prepend_anaconda_url
 from galaxy.util import smart_str
-from ..test_conda_resolution import external_dependency_management
+from ..util import external_dependency_management
 
 TEST_RECIPE = r"""
 {% set name = "eagle" %}

--- a/test/unit/tool_util/mulled/test_get_tests.py
+++ b/test/unit/tool_util/mulled/test_get_tests.py
@@ -85,7 +85,7 @@ def test_main_test_search():
 @external_dependency_management
 def test_hashed_test_search():
     tests = hashed_test_search('mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0')
-    assert tests['commands'] == ['bamtools --help']
+    assert tests['commands'] == ['bamtools --help', 'samtools --help']
     assert tests['container'] == 'mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0'
     assert tests['import_lang'] == 'python -c'
     assert tests['imports'] == []

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,10 +1,13 @@
 import pytest
+
 from galaxy.tool_util.deps.mulled.mulled_build import (
     any_target_requires_extended_base,
     build_target,
 )
+from ..util import external_dependency_management
 
 
+@external_dependency_management
 @pytest.mark.parametrize("target,requires_extended", [
     ('maker', True),
     ('samtools', False)

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -7,11 +7,11 @@ from galaxy.tool_util.deps.mulled.mulled_build import (
 from ..util import external_dependency_management
 
 
-@external_dependency_management
 @pytest.mark.parametrize("target,requires_extended", [
     ('maker', True),
     ('samtools', False)
 ])
+@external_dependency_management
 def test_any_target_requires_extended_base(target, requires_extended):
     target = build_target(target)
     assert any_target_requires_extended_base([target]) == requires_extended

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,0 +1,14 @@
+import pytest
+from galaxy.tool_util.deps.mulled.mulled_build import (
+    any_target_requires_extended_base,
+    build_target,
+)
+
+
+@pytest.mark.parametrize("target,requires_extended", [
+    ('maker', True),
+    ('samtools', False)
+])
+def test_any_target_requires_extended_base(target, requires_extended):
+    target = build_target(target)
+    assert any_target_requires_extended_base([target]) == requires_extended

--- a/test/unit/tool_util/mulled/test_mulled_list.py
+++ b/test/unit/tool_util/mulled/test_mulled_list.py
@@ -2,7 +2,7 @@ import shutil
 import tempfile
 
 from galaxy.tool_util.deps.mulled.mulled_list import get_missing_containers, get_missing_envs, get_singularity_containers
-from ..test_conda_resolution import external_dependency_management
+from ..util import external_dependency_management
 
 # def test_get_quay_containers():
 #     lst = get_quay_containers()

--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -1,7 +1,7 @@
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_search import CondaSearch, get_package_hash, GitHubSearch, QuaySearch, run_command, singularity_search
-from ..test_conda_resolution import external_dependency_management
+from ..util import external_dependency_management
 
 
 @external_dependency_management

--- a/test/unit/tool_util/mulled/test_mulled_update_singularity_containers.py
+++ b/test/unit/tool_util/mulled/test_mulled_update_singularity_containers.py
@@ -6,7 +6,7 @@ import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_update_singularity_containers import docker_to_singularity, get_list_from_file, singularity_container_test
 from galaxy.util import which
-from ..test_conda_resolution import external_dependency_management
+from ..util import external_dependency_management
 
 
 @external_dependency_management

--- a/test/unit/tool_util/test_conda_resolution.py
+++ b/test/unit/tool_util/test_conda_resolution.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import unittest
 from tempfile import mkdtemp
 
 from galaxy.tool_util.deps import (
@@ -9,16 +8,7 @@ from galaxy.tool_util.deps import (
 )
 from galaxy.tool_util.deps.requirements import ToolRequirement
 from galaxy.tool_util.deps.resolvers.conda import CondaDependencyResolver
-
-
-def skip_unless_environ(var):
-    if var in os.environ:
-        return lambda func: func
-    template = "Environment variable %s not found, dependent test skipped."
-    return unittest.skip(template % var)
-
-
-external_dependency_management = skip_unless_environ("GALAXY_TEST_INCLUDE_SLOW")
+from .util import external_dependency_management
 
 
 @external_dependency_management
@@ -40,7 +30,7 @@ def test_conda_resolution():
         shutil.rmtree(base_path)
 
 
-@skip_unless_environ("GALAXY_TEST_INCLUDE_SLOW")
+@external_dependency_management
 def test_against_conda_prefix_regression():
     """Test that would fail if https://github.com/rtfd/readthedocs.org/issues/1902 regressed."""
 

--- a/test/unit/tool_util/util.py
+++ b/test/unit/tool_util/util.py
@@ -1,5 +1,16 @@
+import unittest
 from contextlib import contextmanager
 from os import environ
+
+
+def skip_unless_environ(var):
+    if var in environ:
+        return lambda func: func
+    template = "Environment variable %s not found, dependent test skipped."
+    return unittest.skip(template % var)
+
+
+external_dependency_management = skip_unless_environ("GALAXY_TEST_INCLUDE_SLOW")
 
 
 @contextmanager

--- a/test/unit/tool_util/util.py
+++ b/test/unit/tool_util/util.py
@@ -1,16 +1,12 @@
-import unittest
 from contextlib import contextmanager
 from os import environ
 
+import pytest
 
-def skip_unless_environ(var):
-    if var in environ:
-        return lambda func: func
-    template = "Environment variable %s not found, dependent test skipped."
-    return unittest.skip(template % var)
-
-
-external_dependency_management = skip_unless_environ("GALAXY_TEST_INCLUDE_SLOW")
+external_dependency_management = pytest.mark.skipif(
+    not environ.get('GALAXY_TEST_INCLUDE_SLOW'),
+    reason="GALAXY_TEST_INCLUDE_SLOW not set"
+)
 
 
 @contextmanager

--- a/tox.ini
+++ b/tox.ini
@@ -15,10 +15,14 @@ setenv =
     py{35,36,37}-first_startup: GALAXY_VIRTUAL_ENV=.venv3
     unit: GALAXY_VIRTUAL_ENV={envdir}
     unit: GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1
+    mulled: GALAXY_TEST_INCLUDE_SLOW=1
 deps =
     lint,lint_docstring,lint_docstring_include_list: -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
     unit: mock
     unit: mock-ssh-server
+
+[testenv:mulled]
+commands =  bash run_tests.sh --skip-venv -u test/unit/tool_util/mulled
 
 [testenv:check_py3_compatibility]
 commands = bash .ci/check_py3_compatibility.sh


### PR DESCRIPTION
Any explicitly set destination image will still be honored. I think this is the minimal change we can do without replacing the involucro based container building.
Also fixes version comparison in `best_search_result` and adds a github workflow that only tests the mulled utilities.

This could be complimentary to https://github.com/galaxyproject/galaxy/pull/9088 and allow us to containerize more tools. This doesn't fix missing environment variables normally set by conda activate.