### PR TITLE
[19.09] Admin job info display fix

### DIFF
--- a/client/galaxy/scripts/components/admin/Jobs.vue
+++ b/client/galaxy/scripts/components/admin/Jobs.vue
@@ -166,8 +166,8 @@
                 <!-- Enable cell formatting for the command line column -->
                 <span slot="html" slot-scope="data" v-html="data.value" />
                 <template slot="job_info" slot-scope="data">
-                    <b-link :href="data.value['info_url']" target="galaxy_main">
-                        {{ data.value["id"] }}
+                    <b-link :href="data.value.info_url" v-on:click.prevent="clickJobInfo(data.value.id)">
+                        {{ data.value.id }}
                     </b-link>
                 </template>
                 <template slot="row-details" slot-scope="row">


### PR DESCRIPTION
Noticed this when I tested https://github.com/galaxyproject/galaxy/pull/9104

I missed a spot where jobs display when changing how this was handled before in https://github.com/galaxyproject/galaxy/pull/9097