### PR TITLE
Add admin functionality to histories API

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -146,11 +146,16 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         filters = []
         # support the old default of not-returning/filtering-out deleted histories
         filters += self._get_deleted_filter(deleted, filter_params)
-        # check if user is admin and optional parameter 'all' is True
+        # check if user is admin and get optional parameter 'all' 
         admin = trans.user_is_admin
         all_histories = util.string_as_bool(kwd.get('all', False))
-        if not (admin and all_histories):
-            # users are limited to requesting only their own histories (here)
+        # if parameter 'all' is true, throw exception is not admin
+        # else add current user filter to query (default behaviour)
+        if all_histories:
+            if not admin:
+                message = "Only admins can query all histories"
+                raise exceptions.AdminRequiredException(message)
+        else:
             filters += [self.app.model.History.user == current_user]
         # and any sent in from the query string
         filters += self.filters.parse_filters(filter_params)

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -77,6 +77,8 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
                     controls which set of properties to return
             keys:   comma separated strings, unused by default
                     keys/names of individual properties to return
+            all:    boolean, defaults to 'false', admin-only
+                    returns all histories, not just current user's
 
         If neither keys or views are sent, the default view (set of keys) is returned.
         If both a view and keys are sent, the key list and the view's keys are
@@ -144,8 +146,12 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         filters = []
         # support the old default of not-returning/filtering-out deleted histories
         filters += self._get_deleted_filter(deleted, filter_params)
-        # users are limited to requesting only their own histories (here)
-        filters += [self.app.model.History.user == current_user]
+        # check if user is admin and optional parameter 'all' is True
+        admin = trans.user_is_admin
+        all_histories = util.string_as_bool(kwd.get('all', False))
+        if not (admin and all_histories):
+            # users are limited to requesting only their own histories (here)
+            filters += [self.app.model.History.user == current_user]
         # and any sent in from the query string
         filters += self.filters.parse_filters(filter_params)
 

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -146,13 +146,12 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         filters = []
         # support the old default of not-returning/filtering-out deleted histories
         filters += self._get_deleted_filter(deleted, filter_params)
-        # check if user is admin and get optional parameter 'all'
-        admin = trans.user_is_admin
+        # get optional parameter 'all'
         all_histories = util.string_as_bool(kwd.get('all', False))
         # if parameter 'all' is true, throw exception if not admin
         # else add current user filter to query (default behaviour)
         if all_histories:
-            if not admin:
+            if not trans.user_is_admin:
                 message = "Only admins can query all histories"
                 raise exceptions.AdminRequiredException(message)
         else:

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -146,7 +146,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         filters = []
         # support the old default of not-returning/filtering-out deleted histories
         filters += self._get_deleted_filter(deleted, filter_params)
-        # check if user is admin and get optional parameter 'all' 
+        # check if user is admin and get optional parameter 'all'
         admin = trans.user_is_admin
         all_histories = util.string_as_bool(kwd.get('all', False))
         # if parameter 'all' is true, throw exception if not admin

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -149,7 +149,7 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         # check if user is admin and get optional parameter 'all' 
         admin = trans.user_is_admin
         all_histories = util.string_as_bool(kwd.get('all', False))
-        # if parameter 'all' is true, throw exception is not admin
+        # if parameter 'all' is true, throw exception if not admin
         # else add current user filter to query (default behaviour)
         if all_histories:
             if not admin:


### PR DESCRIPTION
Added the ability for Admins to query all histories using the API.

This was implemented as part of a new tool for managing users for Galaxy Australia, and generating stats/graphs for reporting measures.