### PR TITLE
assign discovered extension, dbkey and designation for assign_primary=true

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -379,8 +379,17 @@ def collect_primary_datasets(job_context, output, input_ext):
                 # Before I guess pop() would just have thrown an IndexError
                 raise Exception("Problem parsing metadata fields for file %s" % filename)
             designation = fields_match.designation
+            ext = fields_match.ext
+            if ext == "input":
+                ext = input_ext
+            dbkey = fields_match.dbkey
+            if dbkey == INPUT_DBKEY_TOKEN:
+                dbkey = job_context.input_dbkey
             if filename_index == 0 and extra_file_collector.assign_primary_output and output_index == 0:
                 new_outdata_name = fields_match.name or "{} ({})".format(outdata.name, designation)
+                outdata.change_datatype(ext)
+                outdata.dbkey = dbkey
+                outdata.designation = designation
                 outdata.dataset.external_filename = None  # resets filename_override
                 # Move data from temp location to dataset location
                 job_context.object_store.update_from_file(outdata.dataset, file_name=filename, create=True)
@@ -389,12 +398,6 @@ def collect_primary_datasets(job_context, output, input_ext):
             if name not in primary_datasets:
                 primary_datasets[name] = OrderedDict()
             visible = fields_match.visible
-            ext = fields_match.ext
-            if ext == "input":
-                ext = input_ext
-            dbkey = fields_match.dbkey
-            if dbkey == INPUT_DBKEY_TOKEN:
-                dbkey = job_context.input_dbkey
             # Create new primary dataset
             new_primary_name = fields_match.name or "{} ({})".format(outdata.name, designation)
             info = outdata.info

--- a/test/functional/tools/multi_output_assign_primary_ext_dbkey.xml
+++ b/test/functional/tools/multi_output_assign_primary_ext_dbkey.xml
@@ -1,0 +1,31 @@
+<tool id="multi_output_assign_primary" name="multi_output_assign_primary" version="0.1.0">
+  <command>
+    echo "1" > sample1.hg38.tsv;
+    echo "2" > sample2.hg19.csv;
+  </command>
+  <inputs>
+    <param name="num_param" type="integer" value="7" />
+    <param name="input" type="data" />
+  </inputs>
+  <outputs>
+	<data name="simple_dbkey_ext">
+       <discover_datasets pattern="^(?P&lt;designation&gt;sample.)\.(?P&lt;dbkey&gt;[^.]+)\.(?P&lt;ext&gt;[^.]+)$" visible="true" format="txt" assign_primary_output="true" />
+	</data>
+  </outputs>
+  <tests>
+    <test>
+      <param name="num_param" value="7" />
+      <param name="input" ftype="txt" value="simple_line.txt"/>
+      <output name="simple_dbkey_ext" ftype="tsv">
+        <metadata name="dbkey" value="hg38" />
+        <assert_contents>
+          <has_line line="1" />
+        </assert_contents>
+        <discovered_dataset designation="sample2" ftype="csv">
+          <metadata name="dbkey" value="hg19" />
+          <assert_contents><has_line line="2" /></assert_contents>
+        </discovered_dataset>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/multi_output_assign_primary_ext_dbkey.xml
+++ b/test/functional/tools/multi_output_assign_primary_ext_dbkey.xml
@@ -1,4 +1,4 @@
-<tool id="multi_output_assign_primary" name="multi_output_assign_primary" version="0.1.0">
+<tool id="multi_output_assign_primary_ext_dbkey" name="multi_output_assign_primary" version="0.1.0">
   <command>
     echo "1" > sample1.hg38.tsv;
     echo "2" > sample2.hg19.csv;
@@ -8,9 +8,9 @@
     <param name="input" type="data" />
   </inputs>
   <outputs>
-	<data name="simple_dbkey_ext">
+    <data name="simple_dbkey_ext">
        <discover_datasets pattern="^(?P&lt;designation&gt;sample.)\.(?P&lt;dbkey&gt;[^.]+)\.(?P&lt;ext&gt;[^.]+)$" visible="true" format="txt" assign_primary_output="true" />
-	</data>
+    </data>
   </outputs>
   <tests>
     <test>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -25,6 +25,7 @@
   <tool file="multi_output.xml" />
   <tool file="multi_output_configured.xml" />
   <tool file="multi_output_assign_primary.xml" />
+  <tool file="multi_output_assign_primary_ext_dbkey.xml" />
   <tool file="multi_output_recurse.xml" />
   <tool file="tool_provided_metadata_1.xml" />
   <tool file="tool_provided_metadata_2.xml" />

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -6,6 +6,7 @@ TEST_TOOL_IDS = [
     "multi_output",
     "multi_output_configured",
     "multi_output_assign_primary",
+    "multi_output_assign_primary_ext_dbkey",
     "multi_output_recurse",
     "tool_provided_metadata_1",
     "tool_provided_metadata_2",


### PR DESCRIPTION
I would find this really useful but I guess that this would also render the primary output useless for workflows, or?

- [ ] some if statements could be necessary to check if ext, designation, and dbkey were covered by pattern