### PR TITLE
Don't break generated reStructuredText and YAML on hyphens

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -282,9 +282,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable / disable checking if any tools defined in the above non-
-    shed tool_config_files (i.e., tool_conf.xml) have been migrated
-    from the Galaxy code distribution to the Tool Shed. This
+    Enable / disable checking if any tools defined in the above
+    non-shed tool_config_files (i.e., tool_conf.xml) have been
+    migrated from the Galaxy code distribution to the Tool Shed. This
     functionality is largely untested in modern Galaxy releases and
     has serious issues such as #7273 and the possibility of slowing
     down Galaxy startup, so the default and recommended value is
@@ -409,8 +409,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    conda channels to enable by default (https://conda.io/docs/user-
-    guide/tasks/manage-channels.html)
+    conda channels to enable by default
+    (https://conda.io/docs/user-guide/tasks/manage-channels.html)
 :Default: ``iuc,conda-forge,bioconda,defaults``
 :Type: str
 
@@ -880,8 +880,8 @@
     definition files. Galaxy ships with several basic interface tours
     enabled, though a different directory with custom tours can be
     specified here. The path is relative to the Galaxy root dir.  To
-    use an absolute path begin the path with '/'.  This is a comma-
-    separated list.
+    use an absolute path begin the path with '/'.  This is a
+    comma-separated list.
 :Default: ``config/plugins/tours``
 :Type: str
 
@@ -894,8 +894,8 @@
     Webhooks directory: where to store webhooks - plugins to extend
     the Galaxy UI. By default none will be loaded.  Set to
     config/plugins/webhooks/demo to load Galaxy's demo webhooks.  To
-    use an absolute path begin the path with '/'.  This is a comma-
-    separated list. Add test/functional/webhooks to this list to
+    use an absolute path begin the path with '/'.  This is a
+    comma-separated list. Add test/functional/webhooks to this list to
     include the demo webhooks used to test the webhook framework.
 :Default: ``config/plugins/webhooks``
 :Type: str
@@ -1170,8 +1170,8 @@
     Email address to use in the 'From' field when sending emails for
     account activations, workflow step notifications and password
     resets. We recommend using string in the following format: Galaxy
-    Project <galaxy-no-reply@example.com> If not configured, '<galaxy-
-    no-reply@HOSTNAME>' will be used.
+    Project <galaxy-no-reply@example.com> If not configured,
+    '<galaxy-no-reply@HOSTNAME>' will be used.
 :Default: ``None``
 :Type: str
 
@@ -1322,10 +1322,10 @@
     Set this to false to disable the old-style display applications
     that are hardcoded into datatype classes. This may be desirable
     due to using the new-style, XML-defined, display applications that
-    have been defined for many of the datatypes that have the old-
-    style. There is also a potential security concern with the old-
-    style applications, where a malicious party could provide a link
-    that appears to reference the Galaxy server, but contains a
+    have been defined for many of the datatypes that have the
+    old-style. There is also a potential security concern with the
+    old-style applications, where a malicious party could provide a
+    link that appears to reference the Galaxy server, but contains a
     redirect to a third-party server, tricking a Galaxy user to access
     said site.
 :Default: ``true``
@@ -1731,10 +1731,10 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    The same download handling can be done by nginx using X-Accel-
-    Redirect.  This should be set to the path defined in the nginx
-    config as an internal redirect with access to Galaxy's data files
-    (see documentation linked above).
+    The same download handling can be done by nginx using
+    X-Accel-Redirect.  This should be set to the path defined in the
+    nginx config as an internal redirect with access to Galaxy's data
+    files (see documentation linked above).
 :Default: ``None``
 :Type: str
 
@@ -1854,8 +1854,9 @@
 
 :Description:
     As of 16.04 Galaxy supports multiple proxy types. The original
-    NodeJS implementation, alongside a new Golang single-binary-no-
-    dependencies version. Valid values are (node, golang)
+    NodeJS implementation, alongside a new Golang
+    single-binary-no-dependencies version. Valid values are (node,
+    golang)
 :Default: ``node``
 :Type: str
 
@@ -1924,8 +1925,8 @@
     Additionally, when the dynamic proxy is proxied by an upstream
     server, you'll want to specify a prefixed URL so both Galaxy and
     the proxy reside under the same path that your cookies are under.
-    This will result in a url like https://FQDN/galaxy-
-    prefix/gie_proxy for proxying
+    This will result in a url like
+    https://FQDN/galaxy-prefix/gie_proxy for proxying
 :Default: ``gie_proxy``
 :Type: str
 
@@ -2369,8 +2370,8 @@
 :Description:
     Add an option to the library upload form which allows authorized
     non-administrators to upload a directory of files.  The configured
-    directory must contain sub-directories named the same as the non-
-    admin user's Galaxy login ( email ).  The non-admin user is
+    directory must contain sub-directories named the same as the
+    non-admin user's Galaxy login ( email ).  The non-admin user is
     restricted to uploading files or sub-directories of files
     contained in their directory.
 :Default: ``None``
@@ -2591,12 +2592,13 @@
 
 :Description:
     Set tool test data directory. The test framework sets this value
-    to 'test-data,https://github.com/galaxyproject/galaxy-test-
-    data.git' which will cause Galaxy to clone down extra test data on
-    the fly for certain tools distributed with Galaxy but this is
-    likely not appropriate for production systems. Instead one can
-    simply clone that repository directly and specify a path here
-    instead of a Git HTTP repository.
+    to
+    'test-data,https://github.com/galaxyproject/galaxy-test-data.git'
+    which will cause Galaxy to clone down extra test data on the fly
+    for certain tools distributed with Galaxy but this is likely not
+    appropriate for production systems. Instead one can simply clone
+    that repository directly and specify a path here instead of a Git
+    HTTP repository.
 :Default: ``test-data``
 :Type: str
 
@@ -2785,8 +2787,8 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    When using LDAP for authentication, allow administrators to pre-
-    populate users using an additional form on 'Create new user'
+    When using LDAP for authentication, allow administrators to
+    pre-populate users using an additional form on 'Create new user'
 :Default: ``false``
 :Type: bool
 
@@ -3535,9 +3537,9 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) this script is used to run the
-    job script Galaxy generates for a tool execution.
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+    this script is used to run the job script Galaxy generates for a
+    tool execution.
     Example value 'sudo -E scripts/drmaa_external_runner.py
     --assign_all_groups'
 :Default: ``None``
@@ -3550,9 +3552,9 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) this script is used to kill
-    such jobs by Galaxy (e.g. if the user cancels the job).
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+    this script is used to kill such jobs by Galaxy (e.g. if the user
+    cancels the job).
     Example value 'sudo -E scripts/drmaa_external_killer.py'
 :Default: ``None``
 :Type: str
@@ -3564,10 +3566,9 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) this script is used transfer
-    permissions back and forth between the Galaxy user and the user
-    that is running the job.
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+    this script is used transfer permissions back and forth between
+    the Galaxy user and the user that is running the job.
     Example value 'sudo -E scripts/external_chown_script.py'
 :Default: ``None``
 :Type: str
@@ -3579,16 +3580,15 @@
 
 :Description:
     When running DRMAA jobs as the Galaxy user
-    (https://docs.galaxyproject.org/en/master/admin/cluster.html
-    #submitting-jobs-as-the-real-user) Galaxy can extract the user
-    name from the email address (actually the local-part before the @)
-    or the username which are both stored in the Galaxy data base. The
-    latter option is particularly useful for installations that get
-    the authentication from LDAP. Also, Galaxy can accept the name of
-    a common system user (eg. galaxy_worker) who can run every job
-    being submitted. This user should not be the same user running the
-    galaxy system. Possible values are user_email (default), username
-    or <common_system_user>
+    (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+    Galaxy can extract the user name from the email address (actually
+    the local-part before the @) or the username which are both stored
+    in the Galaxy data base. The latter option is particularly useful
+    for installations that get the authentication from LDAP. Also,
+    Galaxy can accept the name of a common system user (eg.
+    galaxy_worker) who can run every job being submitted. This user
+    should not be the same user running the galaxy system. Possible
+    values are user_email (default), username or <common_system_user>
 :Default: ``user_email``
 :Type: str
 
@@ -3697,9 +3697,9 @@
 ~~~~~~~~~~~~~~~~
 
 :Description:
-    Define toolbox filters (https://galaxyproject.org/user-defined-
-    toolbox-filters/) that admins may use to restrict the tools to
-    display.
+    Define toolbox filters
+    (https://galaxyproject.org/user-defined-toolbox-filters/) that
+    admins may use to restrict the tools to display.
 :Default: ``None``
 :Type: str
 
@@ -3709,9 +3709,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Define toolbox filters (https://galaxyproject.org/user-defined-
-    toolbox-filters/) that admins may use to restrict the tool labels
-    to display.
+    Define toolbox filters
+    (https://galaxyproject.org/user-defined-toolbox-filters/) that
+    admins may use to restrict the tool labels to display.
 :Default: ``None``
 :Type: str
 
@@ -3721,9 +3721,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Define toolbox filters (https://galaxyproject.org/user-defined-
-    toolbox-filters/) that admins may use to restrict the tool
-    sections to display.
+    Define toolbox filters
+    (https://galaxyproject.org/user-defined-toolbox-filters/) that
+    admins may use to restrict the tool sections to display.
 :Default: ``None``
 :Type: str
 
@@ -3733,9 +3733,9 @@
 ~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Define toolbox filters (https://galaxyproject.org/user-defined-
-    toolbox-filters/) that users may use to restrict the tools to
-    display.
+    Define toolbox filters
+    (https://galaxyproject.org/user-defined-toolbox-filters/) that
+    users may use to restrict the tools to display.
 :Default: ``examples:restrict_upload_to_admins, examples:restrict_encode``
 :Type: str
 
@@ -3745,9 +3745,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Define toolbox filters (https://galaxyproject.org/user-defined-
-    toolbox-filters/) that users may use to restrict the tool sections
-    to display.
+    Define toolbox filters
+    (https://galaxyproject.org/user-defined-toolbox-filters/) that
+    users may use to restrict the tool sections to display.
 :Default: ``examples:restrict_text``
 :Type: str
 
@@ -3757,9 +3757,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Define toolbox filters (https://galaxyproject.org/user-defined-
-    toolbox-filters/) that users may use to restrict the tool labels
-    to display.
+    Define toolbox filters
+    (https://galaxyproject.org/user-defined-toolbox-filters/) that
+    users may use to restrict the tool labels to display.
 :Default: ``examples:restrict_upload_to_admins, examples:restrict_encode``
 :Type: str
 
@@ -3770,8 +3770,9 @@
 
 :Description:
     The base module(s) that are searched for modules for toolbox
-    filtering (https://galaxyproject.org/user-defined-toolbox-
-    filters/) functions.
+    filtering
+    (https://galaxyproject.org/user-defined-toolbox-filters/)
+    functions.
 :Default: ``galaxy.tools.filters,galaxy.tools.toolbox.filters``
 :Type: str
 

--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -4,8 +4,8 @@
 
 :Description:
     Verbosity of console log messages.  Acceptable values can be found
-    here: https://docs.python.org/2/library/logging.html#logging-
-    levels
+    here:
+    https://docs.python.org/2/library/logging.html#logging-levels
 :Default: ``DEBUG``
 :Type: str
 

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -48,8 +48,8 @@ EXTRA_SERVER_MESSAGE = "Additional server section after [%s] encountered [%s], w
 MISSING_FILTER_TYPE_MESSAGE = "Missing filter type for section [%s], it will be ignored."
 UNHANDLED_FILTER_TYPE_MESSAGE = "Unhandled filter type encountered [%s] for section [%s]."
 NO_APP_MAIN_MESSAGE = "No app:main section found, using application defaults throughout."
-YAML_COMMENT_WRAPPER = TextWrapper(initial_indent="# ", subsequent_indent="# ", break_long_words=False)
-RST_DESCRIPTION_WRAPPER = TextWrapper(initial_indent="    ", subsequent_indent="    ", break_long_words=False)
+YAML_COMMENT_WRAPPER = TextWrapper(initial_indent="# ", subsequent_indent="# ", break_long_words=False, break_on_hyphens=False)
+RST_DESCRIPTION_WRAPPER = TextWrapper(initial_indent="    ", subsequent_indent="    ", break_long_words=False, break_on_hyphens=False)
 UWSGI_SCHEMA_PATH = "lib/galaxy/webapps/uwsgi_schema.yml"
 
 App = namedtuple(
@@ -684,16 +684,16 @@ def _build_sample_yaml(args, app_desc):
 
 
 def _write_to_file(args, f, path):
-    dry_run = args.dry_run
     if hasattr(f, "getvalue"):
         contents = f.getvalue()
     else:
         contents = f
-    contents_indented = "\n".join([" |%s" % l for l in contents.splitlines()])
-    print("Writing the file contents:\n%s\nto %s" % (contents_indented, path))
-    if dry_run:
+    if args.dry_run:
+        contents_indented = "\n".join([" |%s" % l for l in contents.splitlines()])
+        print("Overwriting %s with the following contents:\n%s" % (path, contents_indented))
         print("... skipping because --dry-run is enabled.")
     else:
+        print("Overwriting %s" % path)
         safe_makedirs(os.path.dirname(path))
         with open(path, "w") as to_f:
             to_f.write(contents)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -30,8 +30,8 @@ uwsgi:
   buffer-size: 16384
 
   # Number of web server (worker) processes to fork after the
-  # application has loaded. If this is set to greater than 1, thunder-
-  # lock likely should be enabled below.
+  # application has loaded. If this is set to greater than 1,
+  # thunder-lock likely should be enabled below.
   processes: 1
 
   # Number of threads for each web server process.
@@ -70,8 +70,8 @@ uwsgi:
   # URL prefix. Cannot be used together with 'module:' above.
   #mount: /galaxy=galaxy.webapps.galaxy.buildapp:uwsgi_app()
 
-  # Make uWSGI rewrite PATH_INFO and SCRIPT_NAME according to mount-
-  # points. Set this to true if a URL prefix is used.
+  # Make uWSGI rewrite PATH_INFO and SCRIPT_NAME according to
+  # mount-points. Set this to true if a URL prefix is used.
   manage-script-name: false
 
   # It is usually a good idea to set this to ``true`` if processes is
@@ -217,9 +217,9 @@ galaxy:
   # Tool config file for tools installed from the Galaxy Tool Shed. Must
   # be writable by Galaxy and generally should not be edited by hand. In
   # older Galaxy releases, this file was part of the tool_config_file
-  # option. It is still possible to specify this file (and other shed-
-  # enabled tool config files) in tool_config_file, but in the standard
-  # case of a single shed-enabled tool config, this option is
+  # option. It is still possible to specify this file (and other
+  # shed-enabled tool config files) in tool_config_file, but in the
+  # standard case of a single shed-enabled tool config, this option is
   # preferable. This file will be created automatically upon tool
   # installation, whereas Galaxy will fail to start if any files in
   # tool_config_file cannot be read.
@@ -290,8 +290,8 @@ galaxy:
   # Pass debug flag to conda commands.
   #conda_debug: false
 
-  # conda channels to enable by default (https://conda.io/docs/user-
-  # guide/tasks/manage-channels.html)
+  # conda channels to enable by default
+  # (https://conda.io/docs/user-guide/tasks/manage-channels.html)
   #conda_ensure_channels: iuc,conda-forge,bioconda,defaults
 
   # Use locally-built conda packages.
@@ -505,8 +505,8 @@ galaxy:
 
   # Visualizations config directory: where to look for individual
   # visualization plugins.  The path is relative to the Galaxy root dir.
-  # To use an absolute path begin the path with '/'.  This is a comma-
-  # separated list.
+  # To use an absolute path begin the path with '/'.  This is a
+  # comma-separated list.
   #visualization_plugins_directory: config/plugins/visualizations
 
   # Interactive environment plugins root directory: where to look for
@@ -651,8 +651,8 @@ galaxy:
   # Email address to use in the 'From' field when sending emails for
   # account activations, workflow step notifications and password
   # resets. We recommend using string in the following format: Galaxy
-  # Project <galaxy-no-reply@example.com> If not configured, '<galaxy-
-  # no-reply@HOSTNAME>' will be used.
+  # Project <galaxy-no-reply@example.com> If not configured,
+  # '<galaxy-no-reply@HOSTNAME>' will be used.
   #email_from: null
 
   # URL of the support resource for the galaxy instance.  Used in
@@ -890,10 +890,10 @@ galaxy:
   # upstream.
   #apache_xsendfile: false
 
-  # The same download handling can be done by nginx using X-Accel-
-  # Redirect.  This should be set to the path defined in the nginx
-  # config as an internal redirect with access to Galaxy's data files
-  # (see documentation linked above).
+  # The same download handling can be done by nginx using
+  # X-Accel-Redirect.  This should be set to the path defined in the
+  # nginx config as an internal redirect with access to Galaxy's data
+  # files (see documentation linked above).
   #nginx_x_accel_redirect_base: null
 
   # If using compression in the upstream proxy server, use this option
@@ -907,8 +907,8 @@ galaxy:
   # prevent a class of attack called clickjacking
   # (https://www.owasp.org/index.php/Clickjacking).  If you configure a
   # proxy in front of Galaxy - please ensure this header remains intact
-  # to protect your users.  Uncomment and leave empty to not set the `X
-  # -Frame-Options` header.
+  # to protect your users.  Uncomment and leave empty to not set the
+  # `X-Frame-Options` header.
   #x_frame_options: SAMEORIGIN
 
   # nginx can also handle file uploads (user-to-Galaxy) via
@@ -950,8 +950,9 @@ galaxy:
   #dynamic_proxy_manage: true
 
   # As of 16.04 Galaxy supports multiple proxy types. The original
-  # NodeJS implementation, alongside a new Golang single-binary-no-
-  # dependencies version. Valid values are (node, golang)
+  # NodeJS implementation, alongside a new Golang
+  # single-binary-no-dependencies version. Valid values are (node,
+  # golang)
   #dynamic_proxy: node
 
   # The NodeJS dynamic proxy can use an SQLite database or a JSON file
@@ -1069,9 +1070,9 @@ galaxy:
 
   # Return a Access-Control-Allow-Origin response header that matches
   # the Origin header of the request if that Origin hostname matches one
-  # of the strings or regular expressions listed here. This is a comma-
-  # separated list of hostname strings or regular expressions beginning
-  # and ending with /. E.g.
+  # of the strings or regular expressions listed here. This is a
+  # comma-separated list of hostname strings or regular expressions
+  # beginning and ending with /. E.g.
   # mysite.com,google.com,usegalaxy.org,/^[\w\.]*example\.com/ See:
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
   #allowed_origin_hostnames: null
@@ -1106,8 +1107,9 @@ galaxy:
   # responsible for preparing/submitting and collecting/finishing jobs,
   # and which can cause job errors if not shut down cleanly. If using
   # supervisord, consider also increasing the value of `stopwaitsecs`.
-  # If using job handler mules, consider also setting the `mule-reload-
-  # mercy` uWSGI option. See the Galaxy Admin Documentation for more.
+  # If using job handler mules, consider also setting the
+  # `mule-reload-mercy` uWSGI option. See the Galaxy Admin Documentation
+  # for more.
   #monitor_thread_join_timeout: 30
 
   # Write thread status periodically to 'heartbeat.log',  (careful, uses
@@ -1176,8 +1178,8 @@ galaxy:
 
   # Add an option to the library upload form which allows authorized
   # non-administrators to upload a directory of files.  The configured
-  # directory must contain sub-directories named the same as the non-
-  # admin user's Galaxy login ( email ).  The non-admin user is
+  # directory must contain sub-directories named the same as the
+  # non-admin user's Galaxy login ( email ).  The non-admin user is
   # restricted to uploading files or sub-directories of files contained
   # in their directory.
   #user_library_import_dir: null
@@ -1366,8 +1368,8 @@ galaxy:
   # debugging).
   #allow_user_impersonation: false
 
-  # When using LDAP for authentication, allow administrators to pre-
-  # populate users using an additional form on 'Create new user'
+  # When using LDAP for authentication, allow administrators to
+  # pre-populate users using an additional form on 'Create new user'
   #show_user_prepopulate_form: false
 
   # Allow users to remove their datasets from disk immediately
@@ -1408,8 +1410,8 @@ galaxy:
   # space, to prevent users making requests to services which the
   # administrator did not intend to expose. Previously, you could
   # request any network service that Galaxy might have had access to,
-  # even if the user could not normally access it. It should be a comma-
-  # separated list of IP addresses or IP address/mask, e.g.
+  # even if the user could not normally access it. It should be a
+  # comma-separated list of IP addresses or IP address/mask, e.g.
   # 10.10.10.10,10.0.1.0/24,fd00::/8
   #fetch_url_whitelist: null
 
@@ -1728,39 +1730,37 @@ galaxy:
   #cleanup_job: always
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) this script is used to run the
-  # job script Galaxy generates for a tool execution.
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # this script is used to run the job script Galaxy generates for a
+  # tool execution.
   # Example value 'sudo -E scripts/drmaa_external_runner.py
   # --assign_all_groups'
   #drmaa_external_runjob_script: null
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) this script is used to kill such
-  # jobs by Galaxy (e.g. if the user cancels the job).
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # this script is used to kill such jobs by Galaxy (e.g. if the user
+  # cancels the job).
   # Example value 'sudo -E scripts/drmaa_external_killer.py'
   #drmaa_external_killjob_script: null
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) this script is used transfer
-  # permissions back and forth between the Galaxy user and the user that
-  # is running the job.
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # this script is used transfer permissions back and forth between the
+  # Galaxy user and the user that is running the job.
   # Example value 'sudo -E scripts/external_chown_script.py'
   #external_chown_script: null
 
   # When running DRMAA jobs as the Galaxy user
-  # (https://docs.galaxyproject.org/en/master/admin/cluster.html
-  # #submitting-jobs-as-the-real-user) Galaxy can extract the user name
-  # from the email address (actually the local-part before the @) or the
-  # username which are both stored in the Galaxy data base. The latter
-  # option is particularly useful for installations that get the
-  # authentication from LDAP. Also, Galaxy can accept the name of a
-  # common system user (eg. galaxy_worker) who can run every job being
-  # submitted. This user should not be the same user running the galaxy
-  # system. Possible values are user_email (default), username or
-  # <common_system_user>
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # Galaxy can extract the user name from the email address (actually
+  # the local-part before the @) or the username which are both stored
+  # in the Galaxy data base. The latter option is particularly useful
+  # for installations that get the authentication from LDAP. Also,
+  # Galaxy can accept the name of a common system user (eg.
+  # galaxy_worker) who can run every job being submitted. This user
+  # should not be the same user running the galaxy system. Possible
+  # values are user_email (default), username or <common_system_user>
   #real_system_username: user_email
 
   # File to source to set up the environment when running jobs.  By
@@ -1819,34 +1819,34 @@ galaxy:
   # if running many handlers.
   #cache_user_job_count: false
 
-  # Define toolbox filters (https://galaxyproject.org/user-defined-
-  # toolbox-filters/) that admins may use to restrict the tools to
-  # display.
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that
+  # admins may use to restrict the tools to display.
   #tool_filters: null
 
-  # Define toolbox filters (https://galaxyproject.org/user-defined-
-  # toolbox-filters/) that admins may use to restrict the tool labels to
-  # display.
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that
+  # admins may use to restrict the tool labels to display.
   #tool_label_filters: null
 
-  # Define toolbox filters (https://galaxyproject.org/user-defined-
-  # toolbox-filters/) that admins may use to restrict the tool sections
-  # to display.
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that
+  # admins may use to restrict the tool sections to display.
   #tool_section_filters: null
 
-  # Define toolbox filters (https://galaxyproject.org/user-defined-
-  # toolbox-filters/) that users may use to restrict the tools to
-  # display.
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
+  # may use to restrict the tools to display.
   #user_tool_filters: examples:restrict_upload_to_admins, examples:restrict_encode
 
-  # Define toolbox filters (https://galaxyproject.org/user-defined-
-  # toolbox-filters/) that users may use to restrict the tool sections
-  # to display.
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
+  # may use to restrict the tool sections to display.
   #user_tool_section_filters: examples:restrict_text
 
-  # Define toolbox filters (https://galaxyproject.org/user-defined-
-  # toolbox-filters/) that users may use to restrict the tool labels to
-  # display.
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
+  # may use to restrict the tool labels to display.
   #user_tool_label_filters: examples:restrict_upload_to_admins, examples:restrict_encode
 
   # The base module(s) that are searched for modules for toolbox

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -12,8 +12,8 @@ uwsgi:
   buffer-size: 16384
 
   # Number of web server (worker) processes to fork after the
-  # application has loaded. If this is set to greater than 1, thunder-
-  # lock likely should be enabled below.
+  # application has loaded. If this is set to greater than 1,
+  # thunder-lock likely should be enabled below.
   processes: 1
 
   # Number of threads for each web server process.
@@ -52,8 +52,8 @@ uwsgi:
   # URL prefix. Cannot be used together with 'module:' above.
   #mount: /galaxy=galaxy.webapps.galaxy.buildapp:uwsgi_app()
 
-  # Make uWSGI rewrite PATH_INFO and SCRIPT_NAME according to mount-
-  # points. Set this to true if a URL prefix is used.
+  # Make uWSGI rewrite PATH_INFO and SCRIPT_NAME according to
+  # mount-points. Set this to true if a URL prefix is used.
   manage-script-name: false
 
   # It is usually a good idea to set this to ``true`` if processes is

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -12,8 +12,8 @@ uwsgi:
   buffer-size: 16384
 
   # Number of web server (worker) processes to fork after the
-  # application has loaded. If this is set to greater than 1, thunder-
-  # lock likely should be enabled below.
+  # application has loaded. If this is set to greater than 1,
+  # thunder-lock likely should be enabled below.
   processes: 1
 
   # Number of threads for each web server process.
@@ -52,8 +52,8 @@ uwsgi:
   # URL prefix. Cannot be used together with 'module:' above.
   #mount: /galaxy=galaxy.webapps.galaxy.buildapp:uwsgi_app()
 
-  # Make uWSGI rewrite PATH_INFO and SCRIPT_NAME according to mount-
-  # points. Set this to true if a URL prefix is used.
+  # Make uWSGI rewrite PATH_INFO and SCRIPT_NAME according to
+  # mount-points. Set this to true if a URL prefix is used.
   manage-script-name: false
 
   # It is usually a good idea to set this to ``true`` if processes is
@@ -78,8 +78,8 @@ uwsgi:
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true
 
-  # Task for rebuilding Toolshed search indexes using the uWSGI cron-
-  # like interface.
+  # Task for rebuilding Toolshed search indexes using the uWSGI
+  # cron-like interface.
   cron: 0 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed
 
 tool_shed:
@@ -181,8 +181,8 @@ tool_shed:
   # User authentication can be delegated to an upstream proxy server
   # (usually Apache).  The upstream proxy should set a REMOTE_USER
   # header in the request. Enabling remote user disables regular logins.
-  # For more information, see: https://galaxyproject.org/admin/config
-  # /apache-external-user-auth/
+  # For more information, see:
+  # https://galaxyproject.org/admin/config/apache-external-user-auth/
   #use_remote_user: false
 
   # If use_remote_user is enabled, anyone who can log in to the Galaxy
@@ -318,10 +318,10 @@ tool_shed:
   # upstream.
   #apache_xsendfile: false
 
-  # The same download handling can be done by nginx using X-Accel-
-  # Redirect.  This should be set to the path defined in the nginx
-  # config as an internal redirect with access to Galaxy's data files
-  # (see documentation linked above).
+  # The same download handling can be done by nginx using
+  # X-Accel-Redirect.  This should be set to the path defined in the
+  # nginx config as an internal redirect with access to Galaxy's data
+  # files (see documentation linked above).
   #nginx_x_accel_redirect_base: null
 
   # This value overrides the action set on the file upload form, e.g.


### PR DESCRIPTION
Also print YAML contents only when running `lib/galaxy/config/config_manage.py` with `--dry-run` option.