### PR TITLE
WIP: Change type restriction of upload tool to all known types

### DIFF
--- a/tools/data_source/upload.xml
+++ b/tools/data_source/upload.xml
@@ -24,6 +24,7 @@
         <filter type="sort_by" column="0"/>
         <filter type="add_value" name="Auto-detect" value="auto" index="0"/>
       </options>
+      <validator type="expression"><![CDATA[ tool.app.datatypes_registry.includes(value) ]]></validator>
     </param>
     <param name="file_count" type="hidden" value="auto" />
     <upload_dataset name="files" title="Specify Files for Dataset" file_type_name="file_type" metadata_ref="files_metadata">


### PR DESCRIPTION
This is more of a bug report than a PR. I can't find documentation on how to access the datatypes registry and would appreciate a dev cleaning up the change.

Currently the upload tool does not allow files with a known type to be uploaded unless the datatype has `display_in_upload="True"` set in the datatypes_conf.xml