### PR TITLE
Refactor Workflow Run Form Toward Vue (part 1)

### DIFF
--- a/client/galaxy/scripts/components/WaitButton.vue
+++ b/client/galaxy/scripts/components/WaitButton.vue
@@ -1,11 +1,6 @@
 /** Button variant with waiting and progress tracking. */
 <template>
-    <button
-        class="ui-button-default"
-        v-bind:class="[waiting ? 'disabled' : '', variantClass]"
-        type="button"
-        v-on:click="$emit('click')"
-    >
+    <button class="ui-button-default" v-bind:class="buttonClass" type="button" v-on:click="$emit('click')">
         <i class="icon fa" v-bind:class="iconClass"> </i>
         <span class="title"> {{ currentText }} </span>
         <div class="progress" v-if="percentage != -1">
@@ -46,8 +41,12 @@ export default {
         progressWidth() {
             return `${this.percentage}%`;
         },
-        variantClass() {
-            return `btn btn-${this.variant}`;
+        buttonClass() {
+            if (this.waiting) {
+                return "disabled";
+            } else {
+                return `btn btn-${this.variant}`;
+            }
         },
         iconClass() {
             if (this.waiting) {

--- a/client/galaxy/scripts/components/WaitButton.vue
+++ b/client/galaxy/scripts/components/WaitButton.vue
@@ -1,0 +1,68 @@
+/** Button variant with waiting and progress tracking. */
+<template>
+    <button
+        class="ui-button-default"
+        v-bind:class="[waiting ? 'disabled' : '', variantClass]"
+        type="button"
+        v-on:click="$emit('click')"
+    >
+        <i class="icon fa" v-bind:class="iconClass"> </i>
+        <span class="title"> {{ currentText }} </span>
+        <div class="progress" v-if="percentage != -1">
+            <div class="progress-bar" v-bind:style="{ width: progressWidth }"></div>
+        </div>
+    </button>
+</template>
+
+<script>
+export default {
+    props: {
+        title: {
+            type: String,
+            default: ""
+        },
+        icon: {
+            type: String,
+            deafult: ""
+        },
+        percentage: {
+            type: Number,
+            default: -1
+        },
+        waiting: {
+            type: Boolean,
+            default: false
+        },
+        waitText: {
+            type: String,
+            default: "Sending..."
+        },
+        variant: {
+            type: String,
+            default: "info"
+        }
+    },
+    computed: {
+        progressWidth() {
+            return `${this.percentage}%`;
+        },
+        variantClass() {
+            return `btn btn-${this.variant}`;
+        },
+        iconClass() {
+            if (this.waiting) {
+                return "fa-spinner fa-spin mr-1";
+            } else {
+                return this.icon + " mr-1";
+            }
+        },
+        currentText() {
+            if (this.waiting) {
+                return this.waitText;
+            } else {
+                return this.title;
+            }
+        }
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -6,6 +6,7 @@
         <b-alert v-if="loading" variant="info" show>
             <loading-span message="Loading workflow run data" />
         </b-alert>
+        <workflow-run-success v-else-if="invocations != null" :invocations="invocations" :workflowName="workflowName" />
         <div v-else>
             <div ref="run" class="ui-form-composite">
                 <div class="ui-form-composite-messages mb-4" ref="messages">
@@ -48,6 +49,7 @@ import axios from "axios";
 
 import WaitButton from "components/WaitButton";
 import LoadingSpan from "components/LoadingSpan";
+import WorkflowRunSuccess from "./WorkflowRunSuccess";
 import { getAppRoot } from "onload";
 import ToolFormComposite from "mvc/tool/tool-form-composite";
 import { errorMessageAsString } from "utils/simple-error";
@@ -55,7 +57,8 @@ import { errorMessageAsString } from "utils/simple-error";
 export default {
     components: {
         LoadingSpan,
-        WaitButton
+        WaitButton,
+        WorkflowRunSuccess
     },
     props: {
         workflowId: { type: String }
@@ -70,7 +73,8 @@ export default {
             runForm: null,
             runButtonEnabled: true,
             runButtonWaitText: "",
-            runButtonPercentage: -1
+            runButtonPercentage: -1,
+            invocations: null
         };
     },
     created() {
@@ -85,7 +89,11 @@ export default {
                 this.loading = false;
                 this.$nextTick(() => {
                     const el = this.$refs["run"];
-                    const formProps = { el, setRunButtonStatus: this.setRunButtonStatus };
+                    const formProps = {
+                        el,
+                        setRunButtonStatus: this.setRunButtonStatus,
+                        handleInvocations: this.handleInvocations
+                    };
                     this.runForm = new ToolFormComposite.View(_.extend(runData, formProps));
                 });
             })
@@ -101,6 +109,9 @@ export default {
             this.runButtonEnabled = enabled;
             this.runButtonWaitText = waitText;
             this.runButtonPercentage = percentage;
+        },
+        handleInvocations(invocations) {
+            this.invocations = invocations;
         }
     },
 };

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -9,7 +9,7 @@
         <workflow-run-success v-else-if="invocations != null" :invocations="invocations" :workflowName="workflowName" />
         <div v-else>
             <div ref="run" class="ui-form-composite">
-                <div class="ui-form-composite-messages mb-4" ref="messages">
+                <div class="ui-form-composite-messages mb-4">
                     <b-alert v-if="hasUpgradeMessages" variant="warning" show>
                         Some tools in this workflow may have changed since it was last saved or some errors were found.
                         The workflow may still run, but any new options will have default values. Please review the
@@ -23,7 +23,7 @@
                     </b-alert>
                 </div>
                 <!-- h4 as a class here looks odd but it was in the Backbone -->
-                <div class="ui-form-composite-header h4" ref="header">
+                <div class="ui-form-composite-header h4">
                     <b>Workflow: {{ workflowName }}</b>
                     <wait-button
                         title="Run Workflow"
@@ -37,7 +37,7 @@
                     >
                     </wait-button>
                 </div>
-                <div class="ui-form-composite-steps" ref="steps"></div>
+                <div class="ui-form-composite-form" ref="form"></div>
             </div>
         </div>
     </div>
@@ -88,7 +88,7 @@ export default {
                 this.workflowName = runData.name;
                 this.loading = false;
                 this.$nextTick(() => {
-                    const el = this.$refs["run"];
+                    const el = this.$refs["form"];
                     const formProps = {
                         el,
                         setRunButtonStatus: this.setRunButtonStatus,

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -7,7 +7,11 @@
             <loading-span message="Loading workflow run data" />
         </b-alert>
         <div v-else>
-            <div class="workflow-run-form" ref="workflow-run-form" />
+            <div ref="run" class="ui-form-composite">
+                <div class="ui-form-composite-messages mb-4" ref="messages"></div>
+                <div class="ui-form-composite-header" ref="header"></div>
+                <div class="ui-form-composite-steps" ref="steps"></div>
+            </div>
         </div>
     </div>
 </template>
@@ -40,9 +44,8 @@ export default {
             .then(response => {
                 this.loading = false;
                 this.$nextTick(() => {
-                    const formEl = this.$refs["workflow-run-form"];
-                    console.log(this.$refs);
-                    const view = new ToolFormComposite.View(_.extend(response.data, { el: formEl }));
+                    const el = this.$refs["run"];
+                    const view = new ToolFormComposite.View(_.extend(response.data, { el }));
                 });
             })
             .catch(response => {

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -44,7 +44,6 @@
 </template>
 
 <script>
-import _ from "underscore";
 import axios from "axios";
 
 import WaitButton from "components/WaitButton";
@@ -94,7 +93,7 @@ export default {
                         setRunButtonStatus: this.setRunButtonStatus,
                         handleInvocations: this.handleInvocations
                     };
-                    this.runForm = new ToolFormComposite.View(_.extend(runData, formProps));
+                    this.runForm = new ToolFormComposite.View(Object.assign({}, runData, formProps));
                 });
             })
             .catch(response => {

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <span>
         <b-alert variant="error" show v-if="error">
             {{ error }}
         </b-alert>
@@ -7,40 +7,38 @@
             <loading-span message="Loading workflow run data" />
         </b-alert>
         <workflow-run-success v-else-if="invocations != null" :invocations="invocations" :workflowName="workflowName" />
-        <div v-else>
-            <div ref="run" class="ui-form-composite">
-                <div class="ui-form-composite-messages mb-4">
-                    <b-alert v-if="hasUpgradeMessages" variant="warning" show>
-                        Some tools in this workflow may have changed since it was last saved or some errors were found.
-                        The workflow may still run, but any new options will have default values. Please review the
-                        messages below to make a decision about whether the changes will affect your analysis.
-                    </b-alert>
-                    <b-alert v-if="hasStepVersionChanges" variant="warning" show>
-                        Some tools are being executed with different versions compared to those available when this
-                        workflow was last saved because the other versions are not or no longer available on this Galaxy
-                        instance. To upgrade your workflow and dismiss this message simply edit the workflow and re-save
-                        it.
-                    </b-alert>
-                </div>
-                <!-- h4 as a class here looks odd but it was in the Backbone -->
-                <div class="ui-form-composite-header h4">
-                    <b>Workflow: {{ workflowName }}</b>
-                    <wait-button
-                        title="Run Workflow"
-                        id="run-workflow"
-                        variant="primary"
-                        :disabled="!runButtonEnabled"
-                        :waiting="!runButtonEnabled"
-                        :waitText="runButtonWaitText"
-                        :percentage="runButtonPercentage"
-                        @click="execute"
-                    >
-                    </wait-button>
-                </div>
-                <div class="ui-form-composite-form" ref="form"></div>
+        <div v-else ref="run" class="ui-form-composite">
+            <div class="ui-form-composite-messages mb-4">
+                <b-alert v-if="hasUpgradeMessages" variant="warning" show>
+                    Some tools in this workflow may have changed since it was last saved or some errors were found. The
+                    workflow may still run, but any new options will have default values. Please review the messages
+                    below to make a decision about whether the changes will affect your analysis.
+                </b-alert>
+                <b-alert v-if="hasStepVersionChanges" variant="warning" show>
+                    Some tools are being executed with different versions compared to those available when this workflow
+                    was last saved because the other versions are not or no longer available on this Galaxy instance. To
+                    upgrade your workflow and dismiss this message simply edit the workflow and re-save it.
+                </b-alert>
             </div>
+            <!-- h4 as a class here looks odd but it was in the Backbone -->
+            <div class="ui-form-composite-header h4">
+                <b>Workflow: {{ workflowName }}</b>
+                <wait-button
+                    title="Run Workflow"
+                    id="run-workflow"
+                    variant="primary"
+                    icon="fa-check"
+                    :disabled="!runButtonEnabled"
+                    :waiting="!runButtonEnabled"
+                    :waitText="runButtonWaitText"
+                    :percentage="runButtonPercentage"
+                    @click="execute"
+                >
+                </wait-button>
+            </div>
+            <div class="ui-form-composite-form" ref="form"></div>
         </div>
-    </div>
+    </span>
 </template>
 
 <script>

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -113,6 +113,6 @@ export default {
         handleInvocations(invocations) {
             this.invocations = invocations;
         }
-    },
+    }
 };
 </script>

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -1,0 +1,53 @@
+<template>
+    <div>
+        <b-alert variant="error" show v-if="error">
+            {{ error }}
+        </b-alert>
+        <b-alert v-if="loading" variant="info" show>
+            <loading-span message="Loading workflow run data" />
+        </b-alert>
+        <div v-else>
+            <div class="workflow-run-form" ref="workflow-run-form" />
+        </div>
+    </div>
+</template>
+
+<script>
+import axios from "axios";
+
+import LoadingSpan from "components/LoadingSpan";
+import { getAppRoot } from "onload";
+import ToolFormComposite from "mvc/tool/tool-form-composite";
+import { errorMessageAsString } from "utils/simple-error";
+
+export default {
+    components: {
+        LoadingSpan
+    },
+    props: {
+        workflowId: { type: String }
+    },
+    data() {
+        return {
+            error: false,
+            loading: true
+        };
+    },
+    created() {
+        const url = `${getAppRoot()}api/workflows/${this.workflowId}/download?style=run`;
+        axios
+            .get(url)
+            .then(response => {
+                this.loading = false;
+                this.$nextTick(() => {
+                    const formEl = this.$refs["workflow-run-form"];
+                    console.log(this.$refs);
+                    const view = new ToolFormComposite.View(_.extend(response.data, { el: formEl }));
+                });
+            })
+            .catch(response => {
+                this.error = errorMessageAsString(response);
+            });
+    }
+};
+</script>

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -8,7 +8,19 @@
         </b-alert>
         <div v-else>
             <div ref="run" class="ui-form-composite">
-                <div class="ui-form-composite-messages mb-4" ref="messages"></div>
+                <div class="ui-form-composite-messages mb-4" ref="messages">
+                    <b-alert v-if="hasUpgradeMessages" variant="warning" show>
+                        Some tools in this workflow may have changed since it was last saved or some errors were found.
+                        The workflow may still run, but any new options will have default values. Please review the
+                        messages below to make a decision about whether the changes will affect your analysis.
+                    </b-alert>
+                    <b-alert v-if="hasStepVersionChanges" variant="warning" show>
+                        Some tools are being executed with different versions compared to those available when this
+                        workflow was last saved because the other versions are not or no longer available on this Galaxy
+                        instance. To upgrade your workflow and dismiss this message simply edit the workflow and re-save
+                        it.
+                    </b-alert>
+                </div>
                 <div class="ui-form-composite-header" ref="header"></div>
                 <div class="ui-form-composite-steps" ref="steps"></div>
             </div>
@@ -17,6 +29,7 @@
 </template>
 
 <script>
+import _ from "underscore";
 import axios from "axios";
 
 import LoadingSpan from "components/LoadingSpan";
@@ -34,7 +47,9 @@ export default {
     data() {
         return {
             error: false,
-            loading: true
+            loading: true,
+            hasUpgradeMessages: false,
+            hasStepVersionChanges: false
         };
     },
     created() {
@@ -42,10 +57,13 @@ export default {
         axios
             .get(url)
             .then(response => {
+                const runData = response.data;
+                this.hasUpgradeMessages = runData.has_upgrade_messages;
+                this.hasStepVersionChanges = runData.step_version_changes && runData.step_version_changes.length > 0;
                 this.loading = false;
                 this.$nextTick(() => {
                     const el = this.$refs["run"];
-                    const view = new ToolFormComposite.View(_.extend(response.data, { el }));
+                    new ToolFormComposite.View(_.extend(runData, { el }));
                 });
             })
             .catch(response => {

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -18,11 +18,7 @@
                 this has not already happened automatically.
             </p>
         </div>
-        <workflow-invocation-state
-            v-for="invocation in invocations"
-            v-bind:key="invocation.id"
-            :invocationId="invocation.id"
-        >
+        <workflow-invocation-state v-for="invocation in invocations" :key="invocation.id" :invocationId="invocation.id">
         </workflow-invocation-state>
         <div id="webhook-view"></div>
     </div>

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -1,0 +1,110 @@
+<template>
+    <div>
+        <div class="donemessagelarge">
+            <p>
+                Successfully invoked workflow <b>{{ workflowName }}</b
+                ><em v-if="multipleInvocations"> - {{ timesExecuted }} times</em>.
+            </p>
+            <p v-if="multipleInvocations">
+                This workflow will generate results in multiple histories. You can observe progress in the
+                <a :href="historyTarget">history multi-view</a>.
+            </p>
+            <p v-else-if="wasNewHistoryTarget">
+                This workflow will generate results in a new history.
+                <a :href="historyTarget">Switch to that history now</a>.
+            </p>
+            <p v-else>
+                You can check the status of queued jobs and view the resulting data by refreshing the History pane, if
+                this has not already happened automatically.
+            </p>
+        </div>
+        <workflow-invocation-state
+            v-for="invocation in invocations"
+            v-bind:key="invocation.id"
+            :invocationId="invocation.id"
+        >
+        </workflow-invocation-state>
+        <div id="webhook-view"></div>
+    </div>
+</template>
+
+<script>
+import { WorkflowInvocationState } from "components/WorkflowInvocationState";
+import Webhooks from "mvc/webhooks";
+import { getAppRoot } from "onload/loadConfig";
+import { getGalaxyInstance } from "app";
+
+export default {
+    components: {
+        WorkflowInvocationState
+    },
+    props: {
+        workflowName: {
+            type: String,
+            required: true
+        },
+        invocations: {
+            type: Array,
+            required: true
+        }
+    },
+    data() {
+        return {
+            refreshHistoryTimeout: null
+        };
+    },
+    computed: {
+        timesExecuted() {
+            return this.invocations.length;
+        },
+        multipleInvocations() {
+            return this.timesExecuted > 1;
+        },
+        historyTarget() {
+            if (this.multipleInvocations) {
+                return `${getAppRoot()}history/view_multiple`;
+            } else {
+                return `${getAppRoot()}history/switch_to_history?hist_id=${this.invocations[0].history_id}`;
+            }
+        },
+        wasNewHistoryTarget() {
+            if (this.invocations.length < 1) {
+                return false;
+            }
+            const Galaxy = getGalaxyInstance();
+            return (
+                (this.invocations[0].history_id &&
+                    Galaxy.currHistoryPanel &&
+                    Galaxy.currHistoryPanel.model.id != this.invocations[0].history_id) ||
+                false
+            );
+        }
+    },
+    methods: {
+        _refreshHistory() {
+            const Galaxy = getGalaxyInstance();
+            var history = Galaxy && Galaxy.currHistoryPanel && Galaxy.currHistoryPanel.model;
+            if (this.refreshHistoryTimeout) {
+                window.clearTimeout(this.refreshHistoryTimeout);
+            }
+            if (history) {
+                history.refresh().success(() => {
+                    if (history.numOfUnfinishedShownContents() === 0) {
+                        this.refreshHistoryTimeout = window.setTimeout(() => {
+                            this._refreshHistory();
+                        }, history.UPDATE_DELAY);
+                    }
+                });
+            }
+        }
+    },
+    mounted() {
+        new Webhooks.WebhookView({
+            type: "workflow",
+            toolId: null,
+            toolVersion: null
+        });
+        this._refreshHistory();
+    }
+};
+</script>

--- a/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
+++ b/client/galaxy/scripts/entry/analysis/AnalysisRouter.js
@@ -31,13 +31,11 @@ import WorkflowList from "components/Workflow/WorkflowList.vue";
 import HistoryImport from "components/HistoryImport.vue";
 import HistoryView from "components/HistoryView.vue";
 import WorkflowInvocationReport from "components/WorkflowInvocationReport.vue";
+import WorkflowRun from "components/Workflow/Run/WorkflowRun.vue";
 import RecentInvocations from "components/User/RecentInvocations.vue";
 import HistoryList from "mvc/history/history-list";
 import PluginList from "components/PluginList.vue";
-import ToolFormComposite from "mvc/tool/tool-form-composite";
 import QueryStringParsing from "utils/query-string-parsing";
-import Utils from "utils/utils";
-import Ui from "mvc/ui/ui-misc";
 import DatasetError from "mvc/dataset/dataset-error";
 import DatasetEditAttributes from "mvc/dataset/dataset-edit-attributes";
 import Citations from "components/Citations.vue";
@@ -94,9 +92,12 @@ export const getAnalysisRouter = Galaxy =>
             return (Galaxy.user && Galaxy.user.id) || this.require_login.indexOf(name) == -1;
         },
 
-        _display_vue_helper: function(component, propsData = {}) {
+        _display_vue_helper: function(component, propsData = {}, active_tab = null) {
             const instance = Vue.extend(component);
             const container = document.createElement("div");
+            if (active_tab) {
+                container.active_tab = active_tab;
+            }
             this.page.display(container);
             new instance({ store, propsData }).$mount(container);
         },
@@ -406,21 +407,7 @@ export const getAnalysisRouter = Galaxy =>
 
         /** load workflow by its url in run mode */
         _loadWorkflow: function() {
-            Utils.get({
-                url: `${getAppRoot()}api/workflows/${Utils.getQueryString("id")}/download?style=run`,
-                success: response => {
-                    this.page.display(new ToolFormComposite.View(_.extend(response, { active_tab: "workflow" })));
-                },
-                error: response => {
-                    const error_msg = response.err_msg || "Error occurred while loading the resource.";
-                    const options = {
-                        message: error_msg,
-                        status: "danger",
-                        persistent: true,
-                        active_tab: "workflow"
-                    };
-                    this.page.display(new Ui.Message(options));
-                }
-            });
+            const workflowId = QueryStringParsing.get("id");
+            this._display_vue_helper(WorkflowRun, { workflowId: workflowId }, "workflow");
         }
     });

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -25,14 +25,11 @@ var View = Backbone.View.extend({
         if (options && options.active_tab) {
             this.active_tab = options.active_tab;
         }
-        this.setElement(
-            $("<div/>")
-                .addClass("ui-form-composite")
-                .append((this.$message = $("<div/>").addClass("mb-4")))
-                .append((this.$header = $("<div/>")))
-                .append((this.$steps = $("<div/>")))
-        );
-        $("body").append(this.$el);
+        const $el = $(options.el);
+        $el.addClass("ui-form-composite")
+            .append((this.$message = $("<div/>").addClass("mb-4")))
+            .append((this.$header = $("<div/>")))
+            .append((this.$steps = $("<div/>")));
         this._configure();
         this.render();
     },

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -25,11 +25,12 @@ var View = Backbone.View.extend({
         if (options && options.active_tab) {
             this.active_tab = options.active_tab;
         }
-        const $el = $(options.el);
-        $el.addClass("ui-form-composite")
-            .append((this.$message = $("<div/>").addClass("mb-4")))
-            .append((this.$header = $("<div/>")))
-            .append((this.$steps = $("<div/>")));
+        // refactor message, header, and 'run' response handling out into WorkflowRun
+        // so only steps needs to be passed in as the target element.
+        this.setElement(options.el);
+        this.$message = this.$el.find(".ui-form-composite-messages");
+        this.$header = this.$el.find(".ui-form-composite-header");
+        this.$steps = this.$el.find(".ui-form-composite-steps");
         this._configure();
         this.render();
     },

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -25,10 +25,9 @@ var View = Backbone.View.extend({
         if (options && options.active_tab) {
             this.active_tab = options.active_tab;
         }
-        // refactor message, header, and 'run' response handling out into WorkflowRun
+        // TODO: refactor header, and 'run' response handling out into WorkflowRun
         // so only steps needs to be passed in as the target element.
         this.setElement(options.el);
-        this.$message = this.$el.find(".ui-form-composite-messages");
         this.$header = this.$el.find(".ui-form-composite-header");
         this.$steps = this.$el.find(".ui-form-composite-steps");
         this._configure();
@@ -207,7 +206,6 @@ var View = Backbone.View.extend({
         var self = this;
         this.deferred.reset();
         this._renderHeader();
-        this._renderMessage();
         this._renderParameters();
         this._renderHistory();
         this._renderUseCachedJob();
@@ -234,34 +232,6 @@ var View = Backbone.View.extend({
             .empty()
             .append(`<b>Workflow: ${this.model.get("name")}<b>`)
             .append(this.execute_btn.$el);
-    },
-
-    /** Render message */
-    _renderMessage: function() {
-        this.$message.empty();
-        if (this.model.get("has_upgrade_messages")) {
-            this.$message.append(
-                new Ui.Message({
-                    message:
-                        "Some tools in this workflow may have changed since it was last saved or some errors were found. The workflow may still run, but any new options will have default values. Please review the messages below to make a decision about whether the changes will affect your analysis.",
-                    status: "warning",
-                    persistent: true,
-                    fade: false
-                }).$el
-            );
-        }
-        var step_version_changes = this.model.get("step_version_changes");
-        if (step_version_changes && step_version_changes.length > 0) {
-            this.$message.append(
-                new Ui.Message({
-                    message:
-                        "Some tools are being executed with different versions compared to those available when this workflow was last saved because the other versions are not or no longer available on this Galaxy instance. To upgrade your workflow and dismiss this message simply edit the workflow and re-save it.",
-                    status: "warning",
-                    persistent: true,
-                    fade: false
-                }).$el
-            );
-        }
     },
 
     /** Render workflow parameters */

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -24,10 +24,7 @@ var View = Backbone.View.extend({
         }
         this.setRunButtonStatus = options.setRunButtonStatus;
         this.handleInvocations = options.handleInvocations;
-        // TODO: refactor 'run' response handling out into WorkflowRun
-        // so only steps needs to be passed in as the target element.
         this.setElement(options.el);
-        this.$steps = this.$el.find(".ui-form-composite-steps");
         this._configure();
         this.render();
     },
@@ -229,7 +226,7 @@ var View = Backbone.View.extend({
                     });
                 }
             });
-            this._append(this.$steps.empty(), this.wp_form.$el);
+            this._append(this.$el.empty(), this.wp_form.$el);
         }
     },
 
@@ -265,7 +262,7 @@ var View = Backbone.View.extend({
                 }
             ]
         });
-        this._append(this.$steps, this.history_form.$el);
+        this._append(this.$el, this.history_form.$el);
     },
 
     /** Render Workflow Options */
@@ -277,7 +274,7 @@ var View = Backbone.View.extend({
                 title: "<b>Workflow Resource Options</b>",
                 inputs: this.model.get("workflow_resource_parameters")
             });
-            this._append(this.$steps, this.workflow_resource_parameters_form.$el);
+            this._append(this.$el, this.workflow_resource_parameters_form.$el);
         }
     },
 
@@ -311,7 +308,7 @@ var View = Backbone.View.extend({
                     }
                 ]
             });
-            this._append(this.$steps, this.job_options_form.$el);
+            this._append(this.$el, this.job_options_form.$el);
         }
     },
 
@@ -321,7 +318,7 @@ var View = Backbone.View.extend({
         var self = this;
         var form = null;
         this.deferred.execute(promise => {
-            self.$steps.addClass("ui-steps");
+            self.$el.addClass("ui-steps");
             if (step.step_type == "tool") {
                 step.postchange = function(process, form) {
                     var current_state = {
@@ -404,7 +401,7 @@ var View = Backbone.View.extend({
                 }
             }
             self.forms[step.index] = form;
-            self._append(self.$steps, form.$el);
+            self._append(self.$el, form.$el);
             if (step.needs_refresh) {
                 self._refreshStep(step);
             }

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -556,10 +556,7 @@ var View = Backbone.View.extend({
                     if ($.isArray(response) && response.length > 0) {
                         this.handleInvocations(response);
                     } else {
-                        // Probably handle this up a layer in
-                        this.$el.append(
-                            this._templateError(response, "Invalid success response. No invocations found.")
-                        );
+                        this.submissionErrorModal(job_def, response);
                     }
                 },
                 error: function(response) {
@@ -580,15 +577,7 @@ var View = Backbone.View.extend({
                         }
                     }
                     if (!input_found) {
-                        self.modal.show({
-                            title: _l("Workflow submission failed"),
-                            body: self._templateError(job_def, response && response.err_msg),
-                            buttons: {
-                                Close: function() {
-                                    self.modal.hide();
-                                }
-                            }
-                        });
+                        this.submissionErrorModal(job_def, response);
                     }
                 },
                 complete: function() {
@@ -629,6 +618,18 @@ var View = Backbone.View.extend({
             }
         }
         return true;
+    },
+
+    submissionErrorModal: function(job_def, response) {
+        this.modal.show({
+            title: _l("Workflow submission failed"),
+            body: this._templateError(job_def, response && response.err_msg),
+            buttons: {
+                Close: () => {
+                    this.modal.hide();
+                }
+            }
+        });
     },
 
     /** Templates */


### PR DESCRIPTION
Move the workflow run landing, header, alert messages, and success handling into Vue from AnalysisRouter.js and tool-form-composite.js.

Somethings are cleaner:

- Invocation status Vue components are embedded directly as intended and not need external mounting from scanning tags in the DOM.
- The whole success page looks a lot cleaner in Vue than embedded in Backbone templates with pieced together conditional log and stuff via string concatenation. 
- Analysis router mounting looks a lot more like other parts of the app.

Some things are a bit messy now:

- Had to introduce a new component with a progress bar in a button to match what we had for backbone. 
- The interaction between this button in Vue and the step rendering logic in Backbone is messy (passing through a callback that takes three parameters). 

The messiness is unfortunate - but there will always be some messiness when bridging Vue and non-Vue code and I think on the whole this is a step in the right direction. 
