### PR TITLE
[19.05] Restore returning "None" when casting unselected multiselect param to str

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -903,7 +903,7 @@ class SelectToolParameter(ToolParameter):
             return value
 
     def to_param_dict_string(self, value, other_values={}):
-        if value is None:
+        if value in (None, []):
             return "None"
         if isinstance(value, list):
             if not self.multiple:

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -42,9 +42,29 @@ def test_select_wrapper_simple_options(tool):
     </param>''')
     parameter = SelectToolParameter(tool, xml)
     wrapper = SelectToolParameterWrapper(parameter, "x")
-    assert str(wrapper) == "x"
     assert wrapper.name == "blah"
+    assert str(wrapper) == "x"
     assert wrapper.value_label == "I am X"
+
+
+@with_mock_tool
+def test_select_wrapper_multiple_options(tool):
+    xml = XML('''<param name="blah" type="select" multiple="true">
+        <option value="x">I am X</option>
+        <option value="y" selected="true">I am Y</option>
+        <option value="z">I am Z</option>
+    </param>''')
+    parameter = SelectToolParameter(tool, xml)
+    wrapper = SelectToolParameterWrapper(parameter, ["x"])
+    assert wrapper.name == "blah"
+    assert str(wrapper) == "x"
+    assert "x" in wrapper
+    wrapper = SelectToolParameterWrapper(parameter, ["x", "z"])
+    assert str(wrapper) == "x,z"
+    assert "x" in wrapper
+    wrapper = SelectToolParameterWrapper(parameter, [])
+    assert str(wrapper) == "None"
+    assert "x" not in wrapper
 
 
 @with_mock_tool


### PR DESCRIPTION
Broken in commit 7d3b9c53bbabd4f780f8d051717d8d9c0008267d .

Before the above-mentioned commit, when a `<param name="blah" type="select" multiple="true"/>` was left unselected, its value was `None`, casted to string as `"None"`.
Tool authors would check if the user has selected a value with something like:

```
#if str($blah) != 'None':
```

After the above-mentioned commit, the value of the unselected param is `[]`, casted to string as `""`, which breaks tools using the check above.
This restores the previous behaviour.

Seen in pull request:

https://github.com/galaxyproject/tools-iuc/pull/2691