### PR TITLE
[19.09] Add implementation of `parse_interactivetool` to `CwlToolSource` class

### DIFF
--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -100,6 +100,9 @@ class CwlToolSource(ToolSource):
     def parse_description(self):
         return self.tool_proxy.description()
 
+    def parse_interactivetool(self):
+        return []
+
     def parse_input_pages(self):
         page_source = CwlPageSource(self.tool_proxy)
         return PagesSource([page_source])


### PR DESCRIPTION
In https://github.com/galaxyproject/galaxy/pull/7494 and https://github.com/galaxyproject/galaxy/pull/8574 , the abstract `parse_interactivetool()` method was added to the `ToolSource` class without a corresponding implementation in its `CwlToolSource` subclass, leading to the following error:

```
In [4]: from galaxy.tool_util.parser.cwl import CwlToolSource
In [5]: cts = CwlToolSource('path')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-2f94370fb293> in <module>()
----> 1 cts = CwlToolSource('path')

TypeError: Can't instantiate abstract class CwlToolSource with abstract methods parse_interactivetool
```