### PR TITLE
Refactor Workflow Run Form Toward Vue (part 2)

### DIFF
--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.test.js
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.test.js
@@ -1,0 +1,52 @@
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { __RewireAPI__ as rewire } from "./WorkflowRun";
+import WorkflowRun from "./WorkflowRun.vue";
+import { mount, createLocalVue } from "@vue/test-utils";
+
+import sampleRunData1 from "./testdata/run1.json";
+
+const run1WorkflowId = "ebab00128497f9d7";
+
+describe("WorkflowRun.vue", () => {
+    let axiosMock;
+    let wrapper;
+    let localVue;
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        rewire.__Rewire__("getAppRoot", () => "/");
+
+        const propsData = { workflowId: run1WorkflowId };
+        localVue = createLocalVue();
+        axiosMock.onGet(`/api/workflows/${run1WorkflowId}/download?style=run`).reply(200, sampleRunData1);
+        wrapper = mount(WorkflowRun, {
+            propsData: propsData,
+            localVue
+        });
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    it("loads run data from API and parses it into a WorkflowRunModel object", async () => {
+        expect(wrapper.vm.loading).to.equal(true);
+        expect(wrapper.vm.error).to.equal(null);
+        expect(wrapper.vm.model).to.equal(null);
+        await localVue.nextTick();
+        await localVue.nextTick();
+        await localVue.nextTick();
+        await localVue.nextTick();
+        expect(wrapper.vm.error).to.equal(null);
+        expect(wrapper.vm.loading).to.equal(false);
+        const model = wrapper.vm.model;
+        expect(model).to.not.equal(null);
+        expect(model.workflowId).to.equal(run1WorkflowId);
+        expect(model.name).to.equal("Cool Test Workflow");
+        expect(model.historyId).to.equal("8f7a155755f10e73");
+        expect(model.hasUpgradeMessages).to.equal(false);
+        expect(model.hasStepVersionChanges).to.equal(false);
+        expect(model.wpInputs.wf_param.label).to.equal("wf_param");
+    });
+});

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.test.js
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.test.js
@@ -22,7 +22,7 @@ describe("WorkflowRun.vue", () => {
         axiosMock.onGet(`/api/workflows/${run1WorkflowId}/download?style=run`).reply(200, sampleRunData1);
         wrapper = mount(WorkflowRun, {
             propsData: propsData,
-            localVue
+            localVue,
         });
     });
 

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -36,7 +36,7 @@
                 </wait-button>
             </div>
             <workflow-run-form
-                ref="run-form"
+                ref="runform"
                 :model="model"
                 :setRunButtonStatus="setRunButtonStatus"
                 @submissionSuccess="handleInvocations"
@@ -95,7 +95,7 @@ export default {
     },
     methods: {
         execute() {
-            this.$refs["run-form"].execute();
+            this.$refs.runform.execute();
         },
         setRunButtonStatus(enabled, waitText, percentage) {
             this.runButtonEnabled = enabled;

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -1,47 +1,54 @@
 <template>
     <span>
-        <b-alert variant="error" show v-if="error">
+        <b-alert variant="danger" show v-if="error">
             {{ error }}
         </b-alert>
-        <b-alert v-if="loading" variant="info" show>
-            <loading-span message="Loading workflow run data" />
-        </b-alert>
-        <workflow-run-success v-else-if="invocations != null" :invocations="invocations" :workflowName="workflowName" />
-        <div v-else class="ui-form-composite">
-            <div class="ui-form-composite-messages mb-4">
-                <b-alert v-if="hasUpgradeMessages" variant="warning" show>
-                    Some tools in this workflow may have changed since it was last saved or some errors were found. The
-                    workflow may still run, but any new options will have default values. Please review the messages
-                    below to make a decision about whether the changes will affect your analysis.
-                </b-alert>
-                <b-alert v-if="hasStepVersionChanges" variant="warning" show>
-                    Some tools are being executed with different versions compared to those available when this workflow
-                    was last saved because the other versions are not or no longer available on this Galaxy instance. To
-                    upgrade your workflow and dismiss this message simply edit the workflow and re-save it.
-                </b-alert>
-            </div>
-            <!-- h4 as a class here looks odd but it was in the Backbone -->
-            <div class="ui-form-composite-header h4">
-                <b>Workflow: {{ workflowName }}</b>
-                <wait-button
-                    title="Run Workflow"
-                    id="run-workflow"
-                    variant="primary"
-                    :disabled="!runButtonEnabled"
-                    :waiting="!runButtonEnabled"
-                    :waitText="runButtonWaitText"
-                    :percentage="runButtonPercentage"
-                    @click="execute"
-                >
-                </wait-button>
-            </div>
-            <workflow-run-form
-                ref="runform"
-                :model="model"
-                :setRunButtonStatus="setRunButtonStatus"
-                @submissionSuccess="handleInvocations"
+        <span v-else>
+            <b-alert v-if="loading" variant="info" show>
+                <loading-span message="Loading workflow run data" />
+            </b-alert>
+            <workflow-run-success
+                v-else-if="invocations != null"
+                :invocations="invocations"
+                :workflowName="workflowName"
             />
-        </div>
+            <div v-else class="ui-form-composite">
+                <div class="ui-form-composite-messages mb-4">
+                    <b-alert v-if="hasUpgradeMessages" variant="warning" show>
+                        Some tools in this workflow may have changed since it was last saved or some errors were found.
+                        The workflow may still run, but any new options will have default values. Please review the
+                        messages below to make a decision about whether the changes will affect your analysis.
+                    </b-alert>
+                    <b-alert v-if="hasStepVersionChanges" variant="warning" show>
+                        Some tools are being executed with different versions compared to those available when this
+                        workflow was last saved because the other versions are not or no longer available on this Galaxy
+                        instance. To upgrade your workflow and dismiss this message simply edit the workflow and re-save
+                        it.
+                    </b-alert>
+                </div>
+                <!-- h4 as a class here looks odd but it was in the Backbone -->
+                <div class="ui-form-composite-header h4">
+                    <b>Workflow: {{ workflowName }}</b>
+                    <wait-button
+                        title="Run Workflow"
+                        id="run-workflow"
+                        variant="primary"
+                        :disabled="!runButtonEnabled"
+                        :waiting="!runButtonEnabled"
+                        :waitText="runButtonWaitText"
+                        :percentage="runButtonPercentage"
+                        @click="execute"
+                    >
+                    </wait-button>
+                </div>
+                <workflow-run-form
+                    ref="runform"
+                    :model="model"
+                    :setRunButtonStatus="setRunButtonStatus"
+                    @submissionSuccess="handleInvocations"
+                />
+            </div>
+        </span>
     </span>
 </template>
 

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -68,7 +68,7 @@ export default {
     },
     data() {
         return {
-            error: false,
+            error: null,
             loading: true,
             hasUpgradeMessages: false,
             hasStepVersionChanges: false,

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -37,7 +37,7 @@
             </div>
             <workflow-run-form
                 ref="run-form"
-                :runData="runData"
+                :model="model"
                 :setRunButtonStatus="setRunButtonStatus"
                 @submissionSuccess="handleInvocations"
             />
@@ -52,6 +52,7 @@ import WaitButton from "components/WaitButton";
 import LoadingSpan from "components/LoadingSpan";
 import WorkflowRunSuccess from "./WorkflowRunSuccess";
 import WorkflowRunForm from "./WorkflowRunForm";
+import { WorkflowRunModel } from "./model.js";
 import { getAppRoot } from "onload";
 import { errorMessageAsString } from "utils/simple-error";
 
@@ -77,7 +78,7 @@ export default {
             runButtonWaitText: "",
             runButtonPercentage: -1,
             invocations: null,
-            runData: null,
+            model: null,
         };
     },
     created() {
@@ -86,10 +87,11 @@ export default {
             .get(url)
             .then((response) => {
                 const runData = response.data;
-                this.runData = runData;
-                this.hasUpgradeMessages = runData.has_upgrade_messages;
-                this.hasStepVersionChanges = runData.step_version_changes && runData.step_version_changes.length > 0;
-                this.workflowName = runData.name;
+                const model = new WorkflowRunModel(runData);
+                this.model = model;
+                this.hasUpgradeMessages = model.hasUpgradeMessages;
+                this.hasStepVersionChanges = model.hasStepVersionChanges;
+                this.workflowName = this.model.name;
                 this.loading = false;
             })
             .catch((response) => {

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRun.vue
@@ -46,14 +46,12 @@
 </template>
 
 <script>
-import axios from "axios";
-
+import { getRunData } from "./services.js";
 import WaitButton from "components/WaitButton";
 import LoadingSpan from "components/LoadingSpan";
 import WorkflowRunSuccess from "./WorkflowRunSuccess";
 import WorkflowRunForm from "./WorkflowRunForm";
 import { WorkflowRunModel } from "./model.js";
-import { getAppRoot } from "onload";
 import { errorMessageAsString } from "utils/simple-error";
 
 export default {
@@ -82,11 +80,8 @@ export default {
         };
     },
     created() {
-        const url = `${getAppRoot()}api/workflows/${this.workflowId}/download?style=run`;
-        axios
-            .get(url)
-            .then((response) => {
-                const runData = response.data;
+        getRunData(this.workflowId)
+            .then((runData) => {
                 const model = new WorkflowRunModel(runData);
                 this.model = model;
                 this.hasUpgradeMessages = model.hasUpgradeMessages;

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRunForm.vue
@@ -7,7 +7,7 @@ import ToolFormComposite from "mvc/tool/tool-form-composite";
 
 export default {
     props: {
-        runData: {
+        model: {
             type: Object,
             required: true,
         },
@@ -26,10 +26,11 @@ export default {
             const el = this.$refs["form"];
             const formProps = {
                 el,
+                model: this.model,
                 setRunButtonStatus: this.setRunButtonStatus,
                 handleInvocations: this.handleInvocations,
             };
-            this.runForm = new ToolFormComposite.View(Object.assign({}, this.runData, formProps));
+            this.runForm = new ToolFormComposite.View(formProps);
         });
     },
     methods: {

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRunForm.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRunForm.vue
@@ -1,0 +1,44 @@
+<template>
+    <div ref="form"></div>
+</template>
+
+<script>
+import ToolFormComposite from "mvc/tool/tool-form-composite";
+
+export default {
+    props: {
+        runData: {
+            type: Object,
+            required: true,
+        },
+        setRunButtonStatus: {
+            type: Function,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            runForm: null,
+        };
+    },
+    mounted() {
+        this.$nextTick(() => {
+            const el = this.$refs["form"];
+            const formProps = {
+                el,
+                setRunButtonStatus: this.setRunButtonStatus,
+                handleInvocations: this.handleInvocations,
+            };
+            this.runForm = new ToolFormComposite.View(Object.assign({}, this.runData, formProps));
+        });
+    },
+    methods: {
+        execute() {
+            this.runForm.execute();
+        },
+        handleInvocations(invocations) {
+            this.$emit("submissionSuccess", invocations);
+        },
+    },
+};
+</script>

--- a/client/galaxy/scripts/components/Workflow/Run/index.js
+++ b/client/galaxy/scripts/components/Workflow/Run/index.js
@@ -1,0 +1,6 @@
+export { default as WorkflowRun } from "./WorkflowRun";
+
+// Utilities used outside this component directory by tool-form-composite.
+export { isDataStep } from "./model";
+
+export { invokeWorkflow } from "./services";

--- a/client/galaxy/scripts/components/Workflow/Run/model.js
+++ b/client/galaxy/scripts/components/Workflow/Run/model.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 import _ from "underscore";
 
 import FormData from "mvc/form/form-data";
-import WorkflowIcons from "mvc/workflow/workflow-icons";
+import WorkflowIcons from "components/Workflow/icons";
 import Utils from "utils/utils";
 
 export class WorkflowRunModel {

--- a/client/galaxy/scripts/components/Workflow/Run/model.js
+++ b/client/galaxy/scripts/components/Workflow/Run/model.js
@@ -1,0 +1,196 @@
+import $ from "jquery";
+import _ from "underscore";
+
+import FormData from "mvc/form/form-data";
+import WorkflowIcons from "mvc/workflow/workflow-icons";
+import Utils from "utils/utils";
+
+export class WorkflowRunModel {
+    constructor(runData) {
+        this.runData = runData;
+        this.name = runData.name;
+        this.workflowResourceParameters = runData.workflow_resource_parameters;
+        this.historyId = runData.history_id;
+        this.workflowId = runData.id;
+
+        this.hasUpgradeMessages = runData.has_upgrade_messages;
+        this.hasStepVersionChanges = runData.step_version_changes && runData.step_version_changes.length > 0;
+
+        this.steps = [];
+        this.links = [];
+        this.parms = [];
+        this.wpInputs = {};
+
+        _.each(runData.steps, (step, i) => {
+            var icon = WorkflowIcons[step.step_type];
+            var title = `${parseInt(i + 1)}: ${step.step_label || step.step_name}`;
+            if (step.annotation) {
+                title += ` - ${step.annotation}`;
+            }
+            if (step.step_version) {
+                title += ` (Galaxy Version ${step.step_version})`;
+            }
+
+            step = Utils.merge(
+                {
+                    index: i,
+                    fixed_title: _.escape(title),
+                    icon: icon || "",
+                    help: null,
+                    citations: null,
+                    collapsible: true,
+                    collapsed: i > 0 && !isDataStep(step),
+                    sustain_version: true,
+                    sustain_repeats: true,
+                    sustain_conditionals: true,
+                    narrow: true,
+                    text_enable: "Edit",
+                    text_disable: "Undo",
+                    cls_enable: "fa fa-edit",
+                    cls_disable: "fa fa-undo",
+                    errors: step.messages,
+                    initial_errors: true,
+                    cls: "ui-portlet-section",
+                    hide_operations: true,
+                    needs_refresh: false,
+                    always_refresh: step.step_type != "tool",
+                },
+                step
+            );
+
+            this.steps[i] = step;
+            this.links[i] = [];
+            this.parms[i] = {};
+        });
+
+        // build linear index of step input pairs
+        _.each(this.steps, (step, i) => {
+            FormData.visitInputs(step.inputs, (input, name) => {
+                this.parms[i][name] = input;
+            });
+        });
+
+        // iterate through data input modules and collect linked sub steps
+        _.each(this.steps, (step, i) => {
+            _.each(step.output_connections, (output_connection) => {
+                _.each(this.steps, (sub_step, j) => {
+                    if (sub_step.step_index === output_connection.input_step_index) {
+                        this.links[i].push(sub_step);
+                    }
+                });
+            });
+        });
+
+        // convert all connected data inputs to hidden fields with proper labels,
+        // and track the linked source step
+        _.each(this.steps, (step, i) => {
+            _.each(this.steps, (sub_step, j) => {
+                var connections_by_name = {};
+                _.each(step.output_connections, (connection) => {
+                    if (sub_step.step_index === connection.input_step_index) {
+                        connections_by_name[connection.input_name] = connection;
+                    }
+                });
+                _.each(this.parms[j], (input, name) => {
+                    var connection = connections_by_name[name];
+                    if (connection) {
+                        input.type = "hidden";
+                        input.help = input.step_linked ? `${input.help}, ` : "";
+                        input.help += `Output dataset '${connection.output_name}' from step ${parseInt(i) + 1}`;
+                        input.step_linked = input.step_linked || [];
+                        input.step_linked.push({ index: step.index, step_type: step.step_type });
+                    }
+                });
+            });
+        });
+
+        // identify and configure workflow parameters
+        var wp_count = 0;
+
+        const _ensureWorkflowParameter = (wp_name) => {
+            return (this.wpInputs[wp_name] = this.wpInputs[wp_name] || {
+                label: wp_name,
+                name: wp_name,
+                type: "text",
+                color: `hsl( ${++wp_count * 100}, 70%, 30% )`,
+                style: "ui-form-wp-source",
+                links: [],
+            });
+        };
+
+        function _handleWorkflowParameter(value, callback) {
+            var re = /\$\{(.+?)\}/g;
+            var match;
+            while ((match = re.exec(String(value)))) {
+                var wp_name = match[1];
+                callback(_ensureWorkflowParameter(wp_name));
+            }
+        }
+
+        _.each(this.steps, (step, i) => {
+            _.each(this.parms[i], (input, name) => {
+                _handleWorkflowParameter(input.value, (wp_input) => {
+                    wp_input.links.push(step);
+                    input.wp_linked = true;
+                    input.type = "text";
+                    input.backdrop = true;
+                    input.style = "ui-form-wp-target";
+                });
+            });
+            _.each(step.replacement_parameters, (wp_name) => {
+                _ensureWorkflowParameter(wp_name);
+            });
+        });
+
+        // select fields are shown for dynamic fields if all putative data inputs are available,
+        // or if an explicit reference is specified as data_ref and available
+        _.each(this.steps, (step, i) => {
+            if (step.step_type == "tool") {
+                var data_resolved = true;
+                FormData.visitInputs(step.inputs, (input, name, context) => {
+                    var is_runtime_value = input.value && input.value.__class__ == "RuntimeValue";
+                    var is_data_input = ["data", "data_collection"].indexOf(input.type) != -1;
+                    var data_ref = context[input.data_ref];
+                    if (input.step_linked && !isDataStep(input.step_linked)) {
+                        data_resolved = false;
+                    }
+                    if (input.options && ((input.options.length == 0 && !data_resolved) || input.wp_linked)) {
+                        input.is_workflow = true;
+                    }
+                    if (data_ref) {
+                        input.is_workflow =
+                            (data_ref.step_linked && !isDataStep(data_ref.step_linked)) || input.wp_linked;
+                    }
+                    if (
+                        is_data_input ||
+                        (input.value && input.value.__class__ == "RuntimeValue" && !input.step_linked)
+                    ) {
+                        step.collapsed = false;
+                    }
+                    if (is_runtime_value) {
+                        input.value = null;
+                    }
+                    input.flavor = "workflow";
+                    if (!is_runtime_value && !is_data_input && input.type !== "hidden" && !input.wp_linked) {
+                        if (input.optional || (!Utils.isEmpty(input.value) && input.value !== "")) {
+                            input.collapsible_value = input.value;
+                            input.collapsible_preview = true;
+                        }
+                    }
+                });
+            }
+        });
+    }
+}
+
+/** Is data input module/step */
+export function isDataStep(steps) {
+    var lst = $.isArray(steps) ? steps : [steps];
+    for (var i = 0; i < lst.length; i++) {
+        var step = lst[i];
+        if (!step || !step.step_type || !step.step_type.startsWith("data")) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/client/galaxy/scripts/components/Workflow/Run/services.js
+++ b/client/galaxy/scripts/components/Workflow/Run/services.js
@@ -1,0 +1,22 @@
+/**
+ * Service layer for interaction for the workflow run API.
+ */
+import { getAppRoot } from "onload/loadConfig";
+import axios from "axios";
+import { rethrowSimple } from "utils/simple-error";
+
+/**
+ * Download the workflow using the 'run' style (see workflow manager on backend
+ * for implementation). This contains the data needed to render the UI for workflows.
+ *
+ * @param {String} workflowId - (Stored?) Workflow ID to fetch data for.
+ */
+export async function getRunData(workflowId) {
+    const url = `${getAppRoot()}api/workflows/${workflowId}/download?style=run`;
+    try {
+        const response = await axios.get(url);
+        return response.data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}

--- a/client/galaxy/scripts/components/Workflow/Run/services.js
+++ b/client/galaxy/scripts/components/Workflow/Run/services.js
@@ -20,3 +20,14 @@ export async function getRunData(workflowId) {
         rethrowSimple(e);
     }
 }
+
+/**
+ * Invoke the specified workflow using the supplied data.
+ *
+ * @param {String} workflowId - (Stored?) Workflow ID to fetch data for.
+ */
+export async function invokeWorkflow(workflowId, invocationData) {
+    const url = `${getAppRoot()}api/workflows/${workflowId}/invocations`;
+    const response = await axios.post(url, invocationData);
+    return response.data;
+}

--- a/client/galaxy/scripts/components/Workflow/Run/testdata/run1.json
+++ b/client/galaxy/scripts/components/Workflow/Run/testdata/run1.json
@@ -1,0 +1,756 @@
+{
+  "name": "Cool Test Workflow",
+  "history_id": "8f7a155755f10e73",
+  "step_version_changes": [],
+  "version": 9,
+  "steps": [
+    {
+      "inputs": [
+        {
+          "multiple": false,
+          "help": "",
+          "optional": false,
+          "argument": null,
+          "value": null,
+          "label": "",
+          "is_dynamic": false,
+          "extensions": [
+            "data"
+          ],
+          "model_class": "DataCollectionToolParameter",
+          "hidden": false,
+          "refresh_on_change": true,
+          "type": "data_collection",
+          "options": {
+            "hdca": [],
+            "hda": []
+          },
+          "name": "input"
+        }
+      ],
+      "step_index": 0,
+      "replacement_parameters": [],
+      "step_type": "data_collection_input",
+      "output_connections": [
+        {
+          "input_step_index": 2,
+          "input_name": "inputs",
+          "output_step_index": 0,
+          "output_name": "output"
+        },
+        {
+          "input_step_index": 1,
+          "input_name": "inputs_0|input",
+          "output_step_index": 0,
+          "output_name": "output"
+        }
+      ],
+      "step_name": "Input dataset collection",
+      "step_label": null,
+      "step_version": null
+    },
+    {
+      "help": "<p>This tool takes two lists and creates a single unified list.</p>\n<p class=\"infomark\">This tool will create new history datasets for your collection but your quota usage will not increase.</p>\n",
+      "labels": [],
+      "panel_section_id": "collection_operations",
+      "sharable_url": null,
+      "id": "__MERGE_COLLECTION__",
+      "step_label": "",
+      "job_remap": false,
+      "errors": {},
+      "requirements": [],
+      "job_id": null,
+      "citations": false,
+      "post_job_actions": [],
+      "form_style": "regular",
+      "output_connections": [],
+      "step_index": 1,
+      "version": "1.0.0",
+      "state_inputs": {
+        "inputs": "[{\"__index__\": 0, \"input\": {\"__class__\": \"ConnectedValue\"}}, {\"__index__\": 1, \"input\": {\"__class__\": \"RuntimeValue\"}}]",
+        "advanced": "{\"conflict\": {\"__current_case__\": 3, \"duplicate_options\": \"keep_first\"}}"
+      },
+      "step_version": "1.0.0",
+      "inputs": [
+        {
+          "inputs": [
+            {
+              "multiple": false,
+              "help": "",
+              "optional": false,
+              "argument": null,
+              "value": null,
+              "label": "Input Collection",
+              "is_dynamic": false,
+              "extensions": [
+                "data"
+              ],
+              "model_class": "DataCollectionToolParameter",
+              "hidden": false,
+              "refresh_on_change": true,
+              "type": "data_collection",
+              "options": {
+                "hdca": [],
+                "hda": []
+              },
+              "name": "input"
+            }
+          ],
+          "help": null,
+          "title": "Input Collections",
+          "default": 2,
+          "max": "__Infinity__",
+          "cache": {
+            "0": [
+              {
+                "default_value": null,
+                "multiple": false,
+                "help": "",
+                "text_value": "Not available.",
+                "optional": false,
+                "argument": null,
+                "value": {
+                  "__class__": "ConnectedValue"
+                },
+                "label": "Input Collection",
+                "is_dynamic": false,
+                "extensions": [
+                  "data"
+                ],
+                "model_class": "DataCollectionToolParameter",
+                "hidden": false,
+                "refresh_on_change": true,
+                "type": "data_collection",
+                "options": {
+                  "hdca": [],
+                  "hda": []
+                },
+                "name": "input"
+              }
+            ],
+            "1": [
+              {
+                "default_value": null,
+                "multiple": false,
+                "help": "",
+                "text_value": "Not available.",
+                "optional": false,
+                "argument": null,
+                "value": {
+                  "__class__": "RuntimeValue"
+                },
+                "label": "Input Collection",
+                "is_dynamic": false,
+                "extensions": [
+                  "data"
+                ],
+                "model_class": "DataCollectionToolParameter",
+                "hidden": false,
+                "refresh_on_change": true,
+                "type": "data_collection",
+                "options": {
+                  "hdca": [],
+                  "hda": []
+                },
+                "name": "input"
+              }
+            ]
+          },
+          "min": 2,
+          "model_class": "Repeat",
+          "type": "repeat",
+          "name": "inputs"
+        },
+        {
+          "inputs": [
+            {
+              "test_param": {
+                "multiple": false,
+                "help": "Collection elements must have unique element identifiers, when appending how should unique identifiers be assured.",
+                "display": null,
+                "text_value": "Keep first instance",
+                "argument": null,
+                "value": "keep_first",
+                "label": "How should conflicts (or potential conflicts) be handled?",
+                "is_dynamic": false,
+                "optional": false,
+                "textable": true,
+                "model_class": "SelectToolParameter",
+                "hidden": false,
+                "refresh_on_change": true,
+                "type": "select",
+                "options": [
+                  [
+                    "Append suffix to conflicted element identifers",
+                    "suffix_conflict",
+                    false
+                  ],
+                  [
+                    "Append suffix to conflicted element identifers after first one encountered",
+                    "suffix_conflict_rest",
+                    false
+                  ],
+                  [
+                    "Append suffix to every element identifer",
+                    "suffix_every",
+                    false
+                  ],
+                  [
+                    "Keep first instance",
+                    "keep_first",
+                    true
+                  ],
+                  [
+                    "Keep last instance",
+                    "keep_last",
+                    false
+                  ],
+                  [
+                    "Fail collection creation",
+                    "fail",
+                    false
+                  ]
+                ],
+                "name": "duplicate_options"
+              },
+              "model_class": "Conditional",
+              "cases": [
+                {
+                  "model_class": "ConditionalWhen",
+                  "value": "suffix_conflict",
+                  "inputs": [
+                    {
+                      "default_value": "_#",
+                      "help": "Describe the suffix pattern to use when joing element name and data copy number. For instance, the default is '_#', which will produce _1 as the first suffix used.",
+                      "area": false,
+                      "datalist": [],
+                      "text_value": "_#",
+                      "argument": null,
+                      "value": "_#",
+                      "label": "Use the follow suffix pattern:",
+                      "is_dynamic": false,
+                      "optional": false,
+                      "model_class": "TextToolParameter",
+                      "hidden": false,
+                      "refresh_on_change": false,
+                      "type": "text",
+                      "name": "suffix_pattern"
+                    }
+                  ]
+                },
+                {
+                  "model_class": "ConditionalWhen",
+                  "value": "suffix_conflict_rest",
+                  "inputs": [
+                    {
+                      "default_value": "_#",
+                      "help": "Describe the suffix pattern to use when joing element name and data copy number. For instance, the default is '_#', which will produce _1 as the first suffix used.",
+                      "area": false,
+                      "datalist": [],
+                      "text_value": "_#",
+                      "argument": null,
+                      "value": "_#",
+                      "label": "Use the follow suffix pattern:",
+                      "is_dynamic": false,
+                      "optional": false,
+                      "model_class": "TextToolParameter",
+                      "hidden": false,
+                      "refresh_on_change": false,
+                      "type": "text",
+                      "name": "suffix_pattern"
+                    }
+                  ]
+                },
+                {
+                  "model_class": "ConditionalWhen",
+                  "value": "suffix_every",
+                  "inputs": [
+                    {
+                      "default_value": "_#",
+                      "help": "Describe the suffix pattern to use when joing element name and data copy number. For instance, the default is '_#', which will produce _1 as the first suffix used.",
+                      "area": false,
+                      "datalist": [],
+                      "text_value": "_#",
+                      "argument": null,
+                      "value": "_#",
+                      "label": "Use the follow suffix pattern:",
+                      "is_dynamic": false,
+                      "optional": false,
+                      "model_class": "TextToolParameter",
+                      "hidden": false,
+                      "refresh_on_change": false,
+                      "type": "text",
+                      "name": "suffix_pattern"
+                    }
+                  ]
+                },
+                {
+                  "model_class": "ConditionalWhen",
+                  "value": "keep_first",
+                  "inputs": []
+                },
+                {
+                  "model_class": "ConditionalWhen",
+                  "value": "keep_last",
+                  "inputs": []
+                },
+                {
+                  "model_class": "ConditionalWhen",
+                  "value": "fail",
+                  "inputs": []
+                }
+              ],
+              "type": "conditional",
+              "name": "conflict"
+            }
+          ],
+          "help": null,
+          "title": "Advanced Options",
+          "expanded": false,
+          "model_class": "Section",
+          "type": "section",
+          "name": "advanced"
+        }
+      ],
+      "xrefs": [],
+      "description": "into single list of datasets",
+      "warnings": "",
+      "replacement_parameters": [],
+      "history_id": "8f7a155755f10e73",
+      "panel_section_name": "Collection Operations",
+      "edam_topics": [],
+      "tool_errors": null,
+      "enctype": "application/x-www-form-urlencoded",
+      "name": "Merge Collections",
+      "versions": [
+        "1.0.0"
+      ],
+      "message": "",
+      "step_type": "tool",
+      "edam_operations": [],
+      "method": "post",
+      "step_name": "Merge Collections",
+      "action": "/tool_runner/index",
+      "model_class": "MergeCollectionTool",
+      "display": true
+    },
+    {
+      "help": "<p class=\"warningmark\"><strong>WARNING:</strong> Be careful not to concatenate datasets of different kinds (e.g., sequences with intervals). This tool does not check if the datasets being concatenated are in the same format.</p>\n<hr class=\"docutils\" />\n<p><strong>What it does</strong></p>\n<p>Concatenates datasets</p>\n<hr class=\"docutils\" />\n<p><strong>Example</strong></p>\n<p>Concatenating Dataset:</p>\n<pre class=\"literal-block\">\nchrX  151087187  151087355  A  0  -\nchrX  151572400  151572481  B  0  +\n</pre>\n<p>with Dataset1:</p>\n<pre class=\"literal-block\">\nchr1  151242630  151242955  X  0  +\nchr1  151271715  151271999  Y  0  +\nchr1  151278832  151279227  Z  0  -\n</pre>\n<p>and with Dataset2:</p>\n<pre class=\"literal-block\">\nchr2  100000030  200000955  P  0  +\nchr2  100000015  200000999  Q  0  +\n</pre>\n<p>will result in the following:</p>\n<pre class=\"literal-block\">\nchrX  151087187  151087355  A  0  -\nchrX  151572400  151572481  B  0  +\nchr1  151242630  151242955  X  0  +\nchr1  151271715  151271999  Y  0  +\nchr1  151278832  151279227  Z  0  -\nchr2  100000030  200000955  P  0  +\nchr2  100000015  200000999  Q  0  +\n</pre>\n<hr class=\"docutils\" />\n<p><strong>Citation</strong></p>\n<p>If you use this tool in Galaxy, please cite:</p>\n<p>Bjoern A. Gruening (2014), <a class=\"reference external\" href=\"https://github.com/bgruening/galaxytools\">Galaxy wrapper</a></p>\n<p>Assaf Gordon (gordon &lt;at&gt; cshl dot edu)</p>\n",
+      "labels": [],
+      "panel_section_id": "text_manipulation",
+      "sharable_url": "https://toolshed.g2.bx.psu.edu/view/bgruening/text_processing",
+      "message": "",
+      "id": "toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/tp_cat/0.1.0",
+      "tool_shed_repository": {
+        "owner": "bgruening",
+        "changeset_revision": "0a8c6b61f0f4",
+        "name": "text_processing",
+        "tool_shed": "toolshed.g2.bx.psu.edu"
+      },
+      "step_label": "",
+      "panel_section_name": "Text Manipulation",
+      "errors": {},
+      "requirements": [
+        {
+          "version": "8.25",
+          "name": "coreutils"
+        }
+      ],
+      "job_id": null,
+      "post_job_actions": [],
+      "form_style": "regular",
+      "citations": false,
+      "step_index": 2,
+      "version": "0.1.0",
+      "state_inputs": {
+        "inputs": "{\"__class__\": \"ConnectedValue\"}",
+        "queries": "[{\"__index__\": 0, \"inputs2\": {\"values\": [{\"id\": 48563346, \"src\": \"hda\"}]}}]"
+      },
+      "step_version": "0.1.0",
+      "inputs": [
+        {
+          "default_value": {
+            "values": [
+              {
+                "src": "hda",
+                "id": "bbd44e69cb8906b50467c46e02ff909c"
+              }
+            ]
+          },
+          "max": null,
+          "multiple": true,
+          "help": "",
+          "min": null,
+          "text_value": "Not available.",
+          "optional": false,
+          "argument": null,
+          "value": {
+            "__class__": "ConnectedValue"
+          },
+          "label": "Datasets to concatenate",
+          "is_dynamic": false,
+          "extensions": [
+            "txt"
+          ],
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "model_class": "DataToolParameter",
+          "hidden": false,
+          "refresh_on_change": true,
+          "type": "data",
+          "options": {
+            "hdca": [],
+            "hda": [
+              {
+                "src": "hda",
+                "name": "SRR5363633_1.fastq.gz (as fqtoc)",
+                "tags": [],
+                "keep": false,
+                "hid": 1,
+                "id": "bbd44e69cb8906b50467c46e02ff909c"
+              }
+            ]
+          },
+          "name": "inputs"
+        },
+        {
+          "inputs": [
+            {
+              "multiple": true,
+              "help": "",
+              "min": null,
+              "max": null,
+              "optional": false,
+              "argument": null,
+              "value": {
+                "values": [
+                  {
+                    "src": "hda",
+                    "id": "bbd44e69cb8906b50467c46e02ff909c"
+                  }
+                ]
+              },
+              "label": "Select",
+              "is_dynamic": false,
+              "extensions": [
+                "txt"
+              ],
+              "edam": {
+                "edam_data": [
+                  "data_0006"
+                ],
+                "edam_formats": [
+                  "format_2330"
+                ]
+              },
+              "model_class": "DataToolParameter",
+              "hidden": false,
+              "refresh_on_change": true,
+              "type": "data",
+              "options": {
+                "hdca": [],
+                "hda": [
+                  {
+                    "src": "hda",
+                    "name": "SRR5363633_1.fastq.gz (as fqtoc)",
+                    "tags": [],
+                    "keep": false,
+                    "hid": 1,
+                    "id": "bbd44e69cb8906b50467c46e02ff909c"
+                  }
+                ]
+              },
+              "name": "inputs2"
+            }
+          ],
+          "help": null,
+          "title": "Dataset",
+          "default": 0,
+          "max": "__Infinity__",
+          "cache": {
+            "0": [
+              {
+                "default_value": {
+                  "values": [
+                    {
+                      "src": "hda",
+                      "id": "bbd44e69cb8906b50467c46e02ff909c"
+                    }
+                  ]
+                },
+                "max": null,
+                "multiple": true,
+                "help": "",
+                "min": null,
+                "text_value": "No dataset.",
+                "optional": false,
+                "argument": null,
+                "value": {
+                  "values": [
+                    {
+                      "src": "hda",
+                      "id": "bbd44e69cb8906b50467c46e02ff909c"
+                    }
+                  ]
+                },
+                "label": "Select",
+                "is_dynamic": false,
+                "extensions": [
+                  "txt"
+                ],
+                "edam": {
+                  "edam_data": [
+                    "data_0006"
+                  ],
+                  "edam_formats": [
+                    "format_2330"
+                  ]
+                },
+                "model_class": "DataToolParameter",
+                "hidden": false,
+                "refresh_on_change": true,
+                "type": "data",
+                "options": {
+                  "hdca": [],
+                  "hda": [
+                    {
+                      "src": "hda",
+                      "name": "SRR5363633_1.fastq.gz (as fqtoc)",
+                      "tags": [],
+                      "keep": false,
+                      "hid": 1,
+                      "id": "bbd44e69cb8906b50467c46e02ff909c"
+                    }
+                  ]
+                },
+                "name": "inputs2"
+              }
+            ]
+          },
+          "min": 0,
+          "model_class": "Repeat",
+          "type": "repeat",
+          "name": "queries"
+        }
+      ],
+      "xrefs": [],
+      "description": "tail-to-head (cat)",
+      "warnings": "",
+      "replacement_parameters": [],
+      "history_id": "8f7a155755f10e73",
+      "job_remap": false,
+      "edam_topics": [],
+      "output_connections": [
+        {
+          "input_step_index": 3,
+          "input_name": "input",
+          "output_step_index": 2,
+          "output_name": "out_file1"
+        }
+      ],
+      "tool_errors": null,
+      "enctype": "application/x-www-form-urlencoded",
+      "name": "Concatenate datasets",
+      "versions": [
+        "0.1.0"
+      ],
+      "step_type": "tool",
+      "edam_operations": [],
+      "method": "post",
+      "step_name": "Concatenate datasets",
+      "action": "/tool_runner/index",
+      "model_class": "Tool",
+      "display": true
+    },
+    {
+      "help": "<p><strong>What it does</strong></p>\n<p>This tool selects N random lines from a file, with no repeats, and preserving ordering.</p>\n<hr class=\"docutils\" />\n<p><strong>Example</strong></p>\n<p>Input File:</p>\n<pre class=\"literal-block\">\nchr7  56632  56652   D17003_CTCF_R6  310  +\nchr7  56736  56756   D17003_CTCF_R7  354  +\nchr7  56761  56781   D17003_CTCF_R4  220  +\nchr7  56772  56792   D17003_CTCF_R7  372  +\nchr7  56775  56795   D17003_CTCF_R4  207  +\n</pre>\n<p>Selecting 2 random lines might return this:</p>\n<pre class=\"literal-block\">\nchr7  56736  56756   D17003_CTCF_R7  354  +\nchr7  56775  56795   D17003_CTCF_R4  207  +\n</pre>\n",
+      "labels": [],
+      "panel_section_id": "text_manipulation",
+      "sharable_url": null,
+      "id": "random_lines1",
+      "step_label": "",
+      "job_remap": false,
+      "errors": {},
+      "requirements": [],
+      "job_id": null,
+      "citations": false,
+      "post_job_actions": [],
+      "form_style": "regular",
+      "output_connections": [],
+      "step_index": 3,
+      "version": "2.0.2",
+      "state_inputs": {
+        "input": "{\"__class__\": \"ConnectedValue\"}",
+        "seed_source": "{\"__current_case__\": 1, \"seed\": \"${wf_param}\", \"seed_source_selector\": \"set_seed\"}",
+        "num_lines": "{\"__class__\": \"RuntimeValue\"}"
+      },
+      "step_version": "2.0.2",
+      "inputs": [
+        {
+          "default_value": "1",
+          "help": "lines",
+          "area": false,
+          "datalist": [],
+          "max": null,
+          "min": null,
+          "argument": null,
+          "value": {
+            "__class__": "RuntimeValue"
+          },
+          "label": "Randomly select",
+          "is_dynamic": false,
+          "optional": false,
+          "text_value": "Not available.",
+          "model_class": "IntegerToolParameter",
+          "hidden": false,
+          "refresh_on_change": false,
+          "type": "integer",
+          "name": "num_lines"
+        },
+        {
+          "default_value": {
+            "values": [
+              {
+                "src": "hda",
+                "id": "bbd44e69cb8906b50467c46e02ff909c"
+              }
+            ]
+          },
+          "multiple": false,
+          "help": "",
+          "text_value": "Not available.",
+          "optional": false,
+          "argument": null,
+          "value": {
+            "__class__": "ConnectedValue"
+          },
+          "label": "from",
+          "is_dynamic": false,
+          "extensions": [
+            "txt"
+          ],
+          "edam": {
+            "edam_data": [
+              "data_0006"
+            ],
+            "edam_formats": [
+              "format_2330"
+            ]
+          },
+          "model_class": "DataToolParameter",
+          "hidden": false,
+          "refresh_on_change": true,
+          "type": "data",
+          "options": {
+            "hdca": [],
+            "hda": [
+              {
+                "src": "hda",
+                "name": "SRR5363633_1.fastq.gz (as fqtoc)",
+                "tags": [],
+                "keep": false,
+                "hid": 1,
+                "id": "bbd44e69cb8906b50467c46e02ff909c"
+              }
+            ]
+          },
+          "name": "input"
+        },
+        {
+          "test_param": {
+            "multiple": false,
+            "help": "",
+            "display": null,
+            "text_value": "Set seed",
+            "argument": null,
+            "value": "set_seed",
+            "label": "Set a random seed",
+            "is_dynamic": false,
+            "optional": false,
+            "textable": true,
+            "model_class": "SelectToolParameter",
+            "hidden": false,
+            "refresh_on_change": true,
+            "type": "select",
+            "options": [
+              [
+                "Don't set seed",
+                "no_seed",
+                true
+              ],
+              [
+                "Set seed",
+                "set_seed",
+                false
+              ]
+            ],
+            "name": "seed_source_selector"
+          },
+          "model_class": "Conditional",
+          "cases": [
+            {
+              "model_class": "ConditionalWhen",
+              "value": "no_seed",
+              "inputs": []
+            },
+            {
+              "model_class": "ConditionalWhen",
+              "value": "set_seed",
+              "inputs": [
+                {
+                  "default_value": "",
+                  "help": "",
+                  "area": false,
+                  "datalist": [],
+                  "text_value": "${wf_param}",
+                  "argument": null,
+                  "value": "${wf_param}",
+                  "label": "Random seed",
+                  "is_dynamic": false,
+                  "optional": false,
+                  "model_class": "TextToolParameter",
+                  "hidden": false,
+                  "refresh_on_change": false,
+                  "type": "text",
+                  "name": "seed"
+                }
+              ]
+            }
+          ],
+          "type": "conditional",
+          "name": "seed_source"
+        }
+      ],
+      "xrefs": [],
+      "description": "from a file",
+      "warnings": "",
+      "replacement_parameters": [],
+      "history_id": "8f7a155755f10e73",
+      "panel_section_name": "Text Manipulation",
+      "edam_topics": [],
+      "tool_errors": null,
+      "enctype": "application/x-www-form-urlencoded",
+      "name": "Select random lines",
+      "versions": [
+        "2.0.2"
+      ],
+      "message": "",
+      "step_type": "tool",
+      "edam_operations": [],
+      "method": "post",
+      "step_name": "Select random lines",
+      "action": "/tool_runner/index",
+      "model_class": "Tool",
+      "display": true
+    }
+  ],
+  "has_upgrade_messages": false,
+  "id": "ebab00128497f9d7",
+  "workflow_resource_parameters": null
+}

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -8,20 +8,17 @@ import _l from "utils/localization";
 import Utils from "utils/utils";
 import Deferred from "utils/deferred";
 import Form from "mvc/form/form-view";
-import FormData from "mvc/form/form-data";
+import { isDataStep } from "components/Workflow/Run/model";
+
 import ToolFormBase from "mvc/tool/tool-form-base";
 import Modal from "mvc/ui/ui-modal";
-import WorkflowIcons from "components/Workflow/icons";
 
 var View = Backbone.View.extend({
     initialize: function (options) {
         const Galaxy = getGalaxyInstance();
         this.modal = Galaxy.modal || new Modal.View();
-        this.model = (options && options.model) || new Backbone.Model(options);
+        this.runWorkflowModel = options.model;
         this.deferred = new Deferred();
-        if (options && options.active_tab) {
-            this.active_tab = options.active_tab;
-        }
         this.setRunButtonStatus = options.setRunButtonStatus;
         this.handleInvocations = options.handleInvocations;
         this.setElement(options.el);
@@ -31,169 +28,11 @@ var View = Backbone.View.extend({
 
     /** Configures form/step options for each workflow step */
     _configure: function () {
-        const Galaxy = getGalaxyInstance();
         this.forms = [];
-        this.steps = [];
-        this.links = [];
-        this.parms = [];
-        _.each(this.model.get("steps"), (step, i) => {
-            Galaxy.emit.debug("tool-form-composite::initialize()", `${i} : Preparing workflow step.`);
-            var icon = WorkflowIcons[step.step_type];
-            var title = `${parseInt(i + 1)}: ${step.step_label || step.step_name}`;
-            if (step.annotation) {
-                title += ` - ${step.annotation}`;
-            }
-            if (step.step_version) {
-                title += ` (Galaxy Version ${step.step_version})`;
-            }
-            step = Utils.merge(
-                {
-                    index: i,
-                    fixed_title: _.escape(title),
-                    icon: icon || "",
-                    help: null,
-                    citations: null,
-                    collapsible: true,
-                    collapsed: i > 0 && !this._isDataStep(step),
-                    sustain_version: true,
-                    sustain_repeats: true,
-                    sustain_conditionals: true,
-                    narrow: true,
-                    text_enable: "Edit",
-                    text_disable: "Undo",
-                    cls_enable: "fa fa-edit",
-                    cls_disable: "fa fa-undo",
-                    errors: step.messages,
-                    initial_errors: true,
-                    cls: "ui-portlet-section",
-                    hide_operations: true,
-                    needs_refresh: false,
-                    always_refresh: step.step_type != "tool",
-                },
-                step
-            );
-            this.steps[i] = step;
-            this.links[i] = [];
-            this.parms[i] = {};
-        });
-
-        // build linear index of step input pairs
-        _.each(this.steps, (step, i) => {
-            FormData.visitInputs(step.inputs, (input, name) => {
-                this.parms[i][name] = input;
-            });
-        });
-
-        // iterate through data input modules and collect linked sub steps
-        _.each(this.steps, (step, i) => {
-            _.each(step.output_connections, (output_connection) => {
-                _.each(this.steps, (sub_step, j) => {
-                    if (sub_step.step_index === output_connection.input_step_index) {
-                        this.links[i].push(sub_step);
-                    }
-                });
-            });
-        });
-
-        // convert all connected data inputs to hidden fields with proper labels,
-        // and track the linked source step
-        _.each(this.steps, (step, i) => {
-            _.each(this.steps, (sub_step, j) => {
-                var connections_by_name = {};
-                _.each(step.output_connections, (connection) => {
-                    if (sub_step.step_index === connection.input_step_index) {
-                        connections_by_name[connection.input_name] = connection;
-                    }
-                });
-                _.each(this.parms[j], (input, name) => {
-                    var connection = connections_by_name[name];
-                    if (connection) {
-                        input.type = "hidden";
-                        input.help = input.step_linked ? `${input.help}, ` : "";
-                        input.help += `Output dataset '${connection.output_name}' from step ${parseInt(i) + 1}`;
-                        input.step_linked = input.step_linked || [];
-                        input.step_linked.push({ index: step.index, step_type: step.step_type });
-                    }
-                });
-            });
-        });
-
-        // identify and configure workflow parameters
-        var wp_count = 0;
-        this.wp_inputs = {};
-
-        const _ensureWorkflowParameter = (wp_name) => {
-            return (this.wp_inputs[wp_name] = this.wp_inputs[wp_name] || {
-                label: wp_name,
-                name: wp_name,
-                type: "text",
-                color: `hsl( ${++wp_count * 100}, 70%, 30% )`,
-                style: "ui-form-wp-source",
-                links: [],
-            });
-        };
-
-        function _handleWorkflowParameter(value, callback) {
-            var re = /\$\{(.+?)\}/g;
-            var match;
-            while ((match = re.exec(String(value)))) {
-                var wp_name = match[1];
-                callback(_ensureWorkflowParameter(wp_name));
-            }
-        }
-        _.each(this.steps, (step, i) => {
-            _.each(this.parms[i], (input, name) => {
-                _handleWorkflowParameter(input.value, (wp_input) => {
-                    wp_input.links.push(step);
-                    input.wp_linked = true;
-                    input.type = "text";
-                    input.backdrop = true;
-                    input.style = "ui-form-wp-target";
-                });
-            });
-            _.each(step.replacement_parameters, (wp_name) => {
-                _ensureWorkflowParameter(wp_name);
-            });
-        });
-
-        // select fields are shown for dynamic fields if all putative data inputs are available,
-        // or if an explicit reference is specified as data_ref and available
-        _.each(this.steps, (step, i) => {
-            if (step.step_type == "tool") {
-                var data_resolved = true;
-                FormData.visitInputs(step.inputs, (input, name, context) => {
-                    var is_runtime_value = input.value && input.value.__class__ == "RuntimeValue";
-                    var is_data_input = ["data", "data_collection"].indexOf(input.type) != -1;
-                    var data_ref = context[input.data_ref];
-                    if (input.step_linked && !this._isDataStep(input.step_linked)) {
-                        data_resolved = false;
-                    }
-                    if (input.options && ((input.options.length == 0 && !data_resolved) || input.wp_linked)) {
-                        input.is_workflow = true;
-                    }
-                    if (data_ref) {
-                        input.is_workflow =
-                            (data_ref.step_linked && !this._isDataStep(data_ref.step_linked)) || input.wp_linked;
-                    }
-                    if (
-                        is_data_input ||
-                        (input.value && input.value.__class__ == "RuntimeValue" && !input.step_linked)
-                    ) {
-                        step.collapsed = false;
-                    }
-                    if (is_runtime_value) {
-                        input.value = null;
-                    }
-                    input.flavor = "workflow";
-                    if (!is_runtime_value && !is_data_input && input.type !== "hidden" && !input.wp_linked) {
-                        if (input.optional || (!Utils.isEmpty(input.value) && input.value !== "")) {
-                            input.collapsible_value = input.value;
-                            input.collapsible_preview = true;
-                        }
-                    }
-                });
-            }
-        });
+        this.steps = this.runWorkflowModel.steps;
+        this.links = this.runWorkflowModel.links;
+        this.parms = this.runWorkflowModel.parms;
+        this.wp_inputs = this.runWorkflowModel.wpInputs;
     },
 
     render: function () {
@@ -251,7 +90,7 @@ var View = Backbone.View.extend({
                                     name: "name",
                                     label: "History name",
                                     type: "text",
-                                    value: this.model.get("name"),
+                                    value: this.runWorkflowModel.name,
                                 },
                             ],
                         },
@@ -265,11 +104,11 @@ var View = Backbone.View.extend({
     /** Render Workflow Options */
     _renderResourceParameters: function () {
         this.workflow_resource_parameters_form = null;
-        if (!_.isEmpty(this.model.get("workflow_resource_parameters"))) {
+        if (!_.isEmpty(this.runWorkflowModel.workflowResourceParameters)) {
             this.workflow_resource_parameters_form = new Form({
                 cls: "ui-portlet-section",
                 title: "<b>Workflow Resource Options</b>",
-                inputs: this.model.get("workflow_resource_parameters"),
+                inputs: this.runWorkflowModel.workflowResourceParameters,
             });
             this._append(this.$el, this.workflow_resource_parameters_form.$el);
         }
@@ -421,7 +260,7 @@ var View = Backbone.View.extend({
                         if (input.step_linked) {
                             new_value = { values: [] };
                             _.each(input.step_linked, (source_step) => {
-                                if (this._isDataStep(source_step)) {
+                                if (isDataStep(source_step)) {
                                     var value = this.forms[source_step.index].data.create().input;
                                     if (value) {
                                         _.each(value.values, (v) => {
@@ -477,7 +316,7 @@ var View = Backbone.View.extend({
         var history_form_data = this.history_form.data.create();
         var job_def = {
             new_history_name: history_form_data["new_history|name"] ? history_form_data["new_history|name"] : null,
-            history_id: !history_form_data["new_history|name"] ? this.model.get("history_id") : null,
+            history_id: !history_form_data["new_history|name"] ? this.runWorkflowModel.historyId : null,
             resource_params: this.workflow_resource_parameters_form
                 ? this.workflow_resource_parameters_form.data.create()
                 : {},
@@ -506,7 +345,7 @@ var View = Backbone.View.extend({
                 var input_id = form.data.match(job_input_id);
                 var input_def = form.input_list[input_id];
                 if (!input_def.step_linked) {
-                    if (this._isDataStep(step)) {
+                    if (isDataStep(step)) {
                         validated = input_value && input_value.values && input_value.values.length > 0;
                         if (!validated && input_def.optional) {
                             validated = true;
@@ -536,7 +375,7 @@ var View = Backbone.View.extend({
             Galaxy.emit.debug("tool-form-composite::submit()", "Validation complete.", job_def);
             Utils.request({
                 type: "POST",
-                url: `${getAppRoot()}api/workflows/${this.model.id}/invocations`,
+                url: `${getAppRoot()}api/workflows/${this.runWorkflowModel.workflowId}/invocations`,
                 data: job_def,
                 success: (response) => {
                     Galaxy.emit.debug("tool-form-composite::submit", "Submission successful.", response);
@@ -593,18 +432,6 @@ var View = Backbone.View.extend({
                 form.portlet[enabled ? "enable" : "disable"]();
             }
         });
-    },
-
-    /** Is data input module/step */
-    _isDataStep: function (steps) {
-        var lst = $.isArray(steps) ? steps : [steps];
-        for (var i = 0; i < lst.length; i++) {
-            var step = lst[i];
-            if (!step || !step.step_type || !step.step_type.startsWith("data")) {
-                return false;
-            }
-        }
-        return true;
     },
 
     submissionErrorModal: function (job_def, response) {


### PR DESCRIPTION
Builds on #9138. New commits include:

- Breaking out the actual form (below the run landing header) into its own component so we can substitute an alternative component for #9111. 
- Breaks a bunch of workflow run request parsing logic out of the backbone view an into a plain old JS object that I'm calling a model for a lack of a better term. This should allow the logic to be shared more easily between this form and the simplified one for #9111. 
- Introduces a test case that mocks out the run request logic with a real request from usegalaxy.org and ensures Vue delegates the request properly and the "model" parses it correctly.
- Implement service layer for workflow runs - per advice of @guerler.
