### PR TITLE
[19.05] Fix optional unset integer and float params

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -83,7 +83,7 @@ class InputValueWrapper(ToolParameterValueWrapper):
         if self.input.type == 'boolean' and isinstance(other, string_types):
             return str(self)
         # For backward compatibility, allow `$wrapper != ""` for optional non-text param
-        if self.input.optional and self.value is None and isinstance(other, string_types):
+        if self.input.optional and self.value is None and self.input.type != 'boolean':
             return str(self)
         cast = {
             'text': str,

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -108,15 +108,19 @@ def test_raw_object_wrapper():
     assert not false_wrapper
 
 
-def valuewrapper(tool, value, paramtype):
+def valuewrapper(tool, value, paramtype, optional=False):
     if paramtype == "integer":
-        parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" value="10" min="0" />'))
+        optional = 'optional="true"' if optional else 'value="10"'
+        parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" %s min="0" />' % optional))
     elif paramtype == "text":
-        parameter = TextToolParameter(tool, XML('<param name="blah" type="text" value="foo"/>'))
+        optional = 'optional="true"' if optional else 'value="foo"'
+        parameter = TextToolParameter(tool, XML('<param name="blah" type="text" %s/>' % optional))
     elif paramtype == "float":
-        parameter = FloatToolParameter(tool, XML('<param name="blah" type="float" value="10.0"/>'))
+        optional = 'optional="true"' if optional else 'value="10.0"'
+        parameter = FloatToolParameter(tool, XML('<param name="blah" type="float" %s/>' % optional))
     elif paramtype == "boolean":
-        parameter = BooleanToolParameter(tool, XML('<param name="blah" type="boolean" truevalue="truevalue" falsevalue="falsevalue"/>'))
+        optional = 'optional="true"' if optional else 'value=""'
+        parameter = BooleanToolParameter(tool, XML('<param name="blah" type="boolean" truevalue="truevalue" falsevalue="falsevalue" %s/>' % optional))
     return InputValueWrapper(parameter, value)
 
 
@@ -143,19 +147,23 @@ def test_input_value_wrapper_comparison(tool):
 
 @with_mock_tool
 def test_input_value_wrapper_comparison_optional(tool):
-    parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" min="0" optional="true"/>'))
-    wrapper = InputValueWrapper(parameter, None)
+    wrapper = valuewrapper(tool, None, 'integer', optional=True)
     assert not wrapper
     with pytest.raises(ValueError):
         int(wrapper)
     assert str(wrapper) == ""
     assert wrapper == ""  # for backward-compatibility
-    parameter = IntegerToolParameter(tool, XML('<param name="blah" type="integer" min="0" optional="true"/>'))
-    wrapper = InputValueWrapper(parameter, 0)
+    wrapper = valuewrapper(tool, 0, 'integer', optional=True)
     assert wrapper == 0
     assert int(wrapper) == 0
     assert str(wrapper)
     assert wrapper != ""  # for backward-compatibility, the correct way to check if an optional integer param is not empty is to use str(wrapper)
+    wrapper = valuewrapper(tool, None, 'integer', optional=True)
+    assert wrapper != 1
+    assert str(wrapper) == ""
+    wrapper = valuewrapper(tool, None, "boolean")
+    assert bool(wrapper) is False, wrapper
+    assert str(wrapper) == 'falsevalue'
 
 
 @with_mock_tool


### PR DESCRIPTION
Neither of them can be cast to int/float respectively.
Fixes test 3 in bowtie2, which errors with:
```
2019-12-19 17:11:34,022 ERROR [galaxy.jobs.runners] (12) Failure preparing job
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/__init__.py", line 1039, in unicodify
    value = text_type(value)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.6/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1576771894_0091798_17143.py", line 680, in respond
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 94, in __ne__
    return not self == other
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 91, in __eq__
    return self._get_cast_value(other) == other
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 88, in _get_cast_value
    return cast.get(self.input.type, str)(self)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 117, in __int__
    return int(float(self))
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 120, in __float__
    return float(str(self))
ValueError: could not convert string to float:
```

Fixes https://github.com/galaxyproject/galaxy/issues/9148