### PR TITLE
Simplified Workflow Run Form

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -44,9 +44,22 @@
                 <workflow-run-form
                     ref="runform"
                     :model="model"
+                    v-if="!simpleForm"
                     :set-run-button-status="setRunButtonStatus"
                     @submissionSuccess="handleInvocations"
                 />
+                <div v-else>
+                    <workflow-run-form-simple
+                        ref="runform"
+                        :model="model"
+                        :set-run-button-status="setRunButtonStatus"
+                        :target-history="simpleFormTargetHistory"
+                        :use-job-cache="simpleFormUseJobCache"
+                        @submissionSuccess="handleInvocations"
+                    />
+                    <!-- Options to default one way or the other, disable if admins want, etc.. -->
+                    <a href="#" @click="showAdvanced">Expand to full workflow form.</a>
+                </div>
             </div>
         </span>
     </span>
@@ -58,6 +71,7 @@ import WaitButton from "components/WaitButton";
 import LoadingSpan from "components/LoadingSpan";
 import WorkflowRunSuccess from "./WorkflowRunSuccess";
 import WorkflowRunForm from "./WorkflowRunForm";
+import WorkflowRunFormSimple from "./WorkflowRunFormSimple";
 import { WorkflowRunModel } from "./model.js";
 import { errorMessageAsString } from "utils/simple-error";
 
@@ -67,9 +81,22 @@ export default {
         WaitButton,
         WorkflowRunSuccess,
         WorkflowRunForm,
+        WorkflowRunFormSimple,
     },
     props: {
         workflowId: { type: String },
+        preferSimpleForm: {
+            type: Boolean,
+            default: false,
+        },
+        simpleFormTargetHistory: {
+            type: String,
+            default: "current",
+        },
+        simpleFormUseJobCache: {
+            type: Boolean,
+            default: false,
+        },
     },
     data() {
         return {
@@ -83,6 +110,7 @@ export default {
             runButtonWaitText: "",
             runButtonPercentage: -1,
             invocations: null,
+            simpleForm: null,
             model: null,
         };
     },
@@ -90,6 +118,34 @@ export default {
         getRunData(this.workflowId)
             .then((runData) => {
                 const model = new WorkflowRunModel(runData);
+                let simpleForm = this.preferSimpleForm;
+                if (simpleForm) {
+                    // These only work with PJA - the API doesn't evaluate them at
+                    // all outside that context currently. The main workflow form renders
+                    // these dynamically and takes care of all the validation and setup details
+                    // on the frontend. If these are implemented on the backend at some
+                    // point this restriction can be lifted.
+                    if (model.hasReplacementParametersInToolForm) {
+                        console.log("cannot render simple workflow form - has ${} values in tool steps");
+                        simpleForm = false;
+                    }
+                    // If there are required parameters in a tool form (a disconnected runtime
+                    // input), we have to render the tool form steps and cannot use the
+                    // simplified tool form.
+                    if (model.hasOpenToolSteps) {
+                        console.log(
+                            "cannot render simple workflow form - one or more tools have disconnected runtime inputs"
+                        );
+                        simpleForm = false;
+                    }
+                    // Just render the whole form for resource request parameters (kind of
+                    // niche - I'm not sure anyone is using these currently anyway).
+                    if (model.hasWorkflowResourceParameters) {
+                        console.log(`Cannot render simple workflow form - workflow resource parameters are configured`);
+                        simpleForm = false;
+                    }
+                }
+                this.simpleForm = simpleForm;
                 this.model = model;
                 this.hasUpgradeMessages = model.hasUpgradeMessages;
                 this.hasStepVersionChanges = model.hasStepVersionChanges;
@@ -97,6 +153,7 @@ export default {
                 this.loading = false;
             })
             .catch((response) => {
+                console.log(response);
                 this.error = errorMessageAsString(response);
             });
     },
@@ -111,6 +168,9 @@ export default {
         },
         handleInvocations(invocations) {
             this.invocations = invocations;
+        },
+        showAdvanced() {
+            this.simpleForm = false;
         },
     },
 };

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -1,0 +1,114 @@
+<template>
+    <div ref="form"></div>
+</template>
+
+<script>
+import Form from "mvc/form/form-view";
+import { invokeWorkflow } from "./services";
+
+export default {
+    props: {
+        model: {
+            type: Object,
+            required: true,
+        },
+        setRunButtonStatus: {
+            type: Function,
+            required: true,
+        },
+        targetHistory: {
+            type: String,
+            default: "current",
+        },
+        useJobCache: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    data() {
+        return {
+            form: null,
+            inputTypes: {},
+        };
+    },
+    computed: {},
+    created() {
+        this.form = new Form(this.formDefinition());
+        this.$nextTick(() => {
+            const el = this.$refs["form"];
+            el.appendChild(this.form.$el[0]);
+        });
+    },
+    methods: {
+        formDefinition() {
+            const inputs = [];
+
+            // Add workflow parameters.
+            Object.values(this.model.wpInputs).forEach((input) => {
+                const inputCopy = Object.assign({}, input);
+                // do we want to keep the color if we're not showing steps?
+                inputCopy.color = undefined;
+                inputs.push(inputCopy);
+                this.inputTypes[inputCopy.name] = "replacement_parameter";
+            });
+
+            // Add actual input modules.
+            this.model.steps.forEach((step, i) => {
+                const is_input =
+                    ["data_input", "data_collection_input", "parameter_input"].indexOf(step.step_type) != -1;
+                if (!is_input) {
+                    return;
+                }
+
+                const stepName = new String(step.step_index);
+                const stepLabel = step.step_label || new String(step.step_index + 1);
+                const help = step.annotation;
+                const longFormInput = step.inputs[0];
+                const stepAsInput = Object.assign({}, longFormInput, { name: stepName, help: help, label: stepLabel });
+                // disable collection mapping...
+                stepAsInput.flavor = "module";
+                inputs.push(stepAsInput);
+                this.inputTypes[stepName] = step.step_type;
+            });
+
+            const def = {
+                inputs: inputs,
+            };
+            return def;
+        },
+        execute() {
+            const replacementParams = {};
+            const inputs = {};
+            const formData = this.form.data.create();
+            for (const inputName in formData) {
+                const value = formData[inputName];
+                const inputType = this.inputTypes[inputName];
+                if (inputType == "replacement_parameter") {
+                    replacementParams[inputName] = value;
+                } else if (inputType == "data_input" || inputType == "data_collection_input") {
+                    inputs[inputName] = value;
+                }
+            }
+            const data = {
+                replacement_dict: replacementParams,
+                inputs: inputs,
+                inputs_by: "step_index",
+                batch: true,
+                use_cached_job: this.useJobCache,
+            };
+            if (this.targetHistory == "current") {
+                data.history_id = this.model.historyId;
+            } else {
+                data.new_history_name = this.model.name;
+            }
+            invokeWorkflow(this.model.workflowId, data)
+                .then((invocations) => {
+                    this.$emit("submissionSuccess", invocations);
+                })
+                .catch((error) => {
+                    console.log(error);
+                });
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/Run/model.js
+++ b/client/src/components/Workflow/Run/model.js
@@ -10,16 +10,19 @@ export class WorkflowRunModel {
         this.runData = runData;
         this.name = runData.name;
         this.workflowResourceParameters = runData.workflow_resource_parameters;
+        this.hasWorkflowResourceParameters = !_.isEmpty(this.workflowResourceParameters);
         this.historyId = runData.history_id;
         this.workflowId = runData.id;
 
         this.hasUpgradeMessages = runData.has_upgrade_messages;
-        this.hasStepVersionChanges = runData.step_version_changes && runData.step_version_changes.length > 0;
+        this.hasStepVersionChanges = !_.isEmpty(runData.step_version_changes);
 
         this.steps = [];
         this.links = [];
         this.parms = [];
         this.wpInputs = {};
+        let hasOpenToolSteps = false;
+        let hasReplacementParametersInToolForm = false;
 
         _.each(runData.steps, (step, i) => {
             var icon = WorkflowIcons[step.step_type];
@@ -130,6 +133,7 @@ export class WorkflowRunModel {
         _.each(this.steps, (step, i) => {
             _.each(this.parms[i], (input, name) => {
                 _handleWorkflowParameter(input.value, (wp_input) => {
+                    hasReplacementParametersInToolForm = true;
                     wp_input.links.push(step);
                     input.wp_linked = true;
                     input.type = "text";
@@ -166,6 +170,7 @@ export class WorkflowRunModel {
                         (input.value && input.value.__class__ == "RuntimeValue" && !input.step_linked)
                     ) {
                         step.collapsed = false;
+                        hasOpenToolSteps = true;
                     }
                     if (is_runtime_value) {
                         input.value = null;
@@ -180,6 +185,8 @@ export class WorkflowRunModel {
                 });
             }
         });
+        this.hasOpenToolSteps = hasOpenToolSteps;
+        this.hasReplacementParametersInToolForm = hasReplacementParametersInToolForm;
     }
 }
 

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -386,6 +386,20 @@ export const getAnalysisRouter = (Galaxy) =>
         /** load workflow by its url in run mode */
         _loadWorkflow: function () {
             const workflowId = QueryStringParsing.get("id");
-            this._display_vue_helper(WorkflowRun, { workflowId: workflowId }, "workflow");
+            const Galaxy = getGalaxyInstance();
+            let preferSimpleForm = Galaxy.config.simplified_workflow_run_ui == "prefer";
+            const preferSimpleFormOverride = QueryStringParsing.get("simplified_workflow_run_ui");
+            if (preferSimpleFormOverride == "prefer") {
+                preferSimpleForm = true;
+            }
+            const simpleFormTargetHistory = Galaxy.config.simplified_workflow_run_ui_target_history;
+            const simpleFormUseJobCache = Galaxy.config.simplified_workflow_run_ui_job_cache == "on";
+            const props = {
+                workflowId,
+                preferSimpleForm,
+                simpleFormTargetHistory,
+                simpleFormUseJobCache,
+            };
+            this._display_vue_helper(WorkflowRun, props, "workflow");
         },
     });

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -79,6 +79,9 @@ class ConfigSerializer(base.ModelSerializer):
             'ga_code'                           : _use_config,
             'enable_unique_workflow_defaults'   : _use_config,
             'enable_beta_markdown_export'       : _use_config,
+            'simplified_workflow_run_ui'        : _use_config,
+            'simplified_workflow_run_ui_target_history': _use_config,
+            'simplified_workflow_run_ui_job_cache': _use_config,
             'has_user_tool_filters'             : _defaults_to(False),
             # TODO: is there no 'correct' way to get an api url? controller='api', action='tools' is a hack
             # at any rate: the following works with path_prefix but is still brittle

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -1,7 +1,7 @@
 import copy
 import itertools
 import logging
-from collections import OrderedDict
+from collections import namedtuple, OrderedDict
 
 from galaxy import (
     exceptions,
@@ -14,61 +14,123 @@ from . import visit_input_values
 
 log = logging.getLogger(__name__)
 
+WorkflowParameterExpansion = namedtuple('WorkflowParameterExpansion', ['param_combinations', 'param_keys', 'input_combinations'])
 
-def expand_workflow_inputs(inputs):
+
+class ParamKey(object):
+
+    def __init__(self, step_id, key):
+        self.step_id = step_id
+        self.key = key
+
+
+class InputKey(object):
+
+    def __init__(self, input_id):
+        self.input_id = input_id
+
+
+def expand_workflow_inputs(param_inputs, inputs=None):
     """
     Expands incoming encoded multiple payloads, into the set of all individual payload combinations
-    >>> params, param_keys = expand_workflow_inputs({'1': {'input': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}})
-    >>> print(["%s" % (p['1']['input']['hid']) for p in params])
+    >>> expansion = expand_workflow_inputs({'1': {'input': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}})
+    >>> print(["%s" % (p['1']['input']['hid']) for p in expansion.param_combinations])
     ['1', '2']
-    >>> params, param_keys = expand_workflow_inputs({'1': {'input': {'batch': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}})
-    >>> print(["%s" % (p['1']['input']['hid']) for p in params])
+    >>> expansion = expand_workflow_inputs({'1': {'input': {'batch': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}})
+    >>> print(["%s" % (p['1']['input']['hid']) for p in expansion.param_combinations])
     ['1', '2']
-    >>> params, param_keys = expand_workflow_inputs({'1': {'input': {'batch': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}, '2': {'input': {'batch': True, 'values': [{'hid': '3'}, {'hid': '4'}] }}})
-    >>> print(["%s%s" % (p['1']['input']['hid'], p['2']['input']['hid']) for p in params])
+    >>> expansion = expand_workflow_inputs({'1': {'input': {'batch': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}, '2': {'input': {'batch': True, 'values': [{'hid': '3'}, {'hid': '4'}] }}})
+    >>> print(["%s%s" % (p['1']['input']['hid'], p['2']['input']['hid']) for p in expansion.param_combinations])
     ['13', '24']
-    >>> params, param_keys = expand_workflow_inputs({'1': {'input': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}, '2': {'input': {'batch': True, 'values': [{'hid': '3'}, {'hid': '4'}, {'hid': '5'}] }}})
-    >>> print(["%s%s" % (p['1']['input']['hid'], p['2']['input']['hid']) for p in params])
+    >>> expansion = expand_workflow_inputs({'1': {'input': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}, '2': {'input': {'batch': True, 'values': [{'hid': '3'}, {'hid': '4'}, {'hid': '5'}] }}})
+    >>> print(["%s%s" % (p['1']['input']['hid'], p['2']['input']['hid']) for p in expansion.param_combinations])
     ['13', '23', '14', '24', '15', '25']
-    >>> params, param_keys = expand_workflow_inputs({'1': {'input': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}, '2': {'input': {'batch': True, 'product': True, 'values': [{'hid': '3'}, {'hid': '4'}, {'hid': '5'}] }}, '3': {'input': {'batch': True, 'product': True, 'values': [{'hid': '6'}, {'hid': '7'}, {'hid': '8'}] }}})
-    >>> print(["%s%s%s" % (p['1']['input']['hid'], p['2']['input']['hid'], p['3']['input']['hid']) for p in params])
+    >>> expansion = expand_workflow_inputs({'1': {'input': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }}, '2': {'input': {'batch': True, 'product': True, 'values': [{'hid': '3'}, {'hid': '4'}, {'hid': '5'}] }}, '3': {'input': {'batch': True, 'product': True, 'values': [{'hid': '6'}, {'hid': '7'}, {'hid': '8'}] }}})
+    >>> print(["%s%s%s" % (p['1']['input']['hid'], p['2']['input']['hid'], p['3']['input']['hid']) for p in expansion.param_combinations])
     ['136', '137', '138', '146', '147', '148', '156', '157', '158', '236', '237', '238', '246', '247', '248', '256', '257', '258']
+    >>> expansion = expand_workflow_inputs(None, inputs={'myinput': {'batch': True, 'product': True, 'values': [{'hid': '1'}, {'hid': '2'}] }})
+    >>> print(["%s" % (p['myinput']['hid']) for p in expansion.input_combinations])
+    ['1', '2']
     """
+    param_inputs = param_inputs or {}
+    inputs = inputs or {}
+
     linked_n = None
     linked = []
     product = []
     linked_keys = []
     product_keys = []
-    for step_id, step in sorted(inputs.items()):
+
+    def is_batch(value):
+        return isinstance(value, dict) and 'batch' in value and value['batch'] is True and 'values' in value and isinstance(value['values'], list)
+
+    for step_id, step in sorted(param_inputs.items()):
         for key, value in sorted(step.items()):
-            if isinstance(value, dict) and 'batch' in value and value['batch'] is True and 'values' in value and isinstance(value['values'], list):
+            if is_batch(value):
                 nval = len(value['values'])
                 if 'product' in value and value['product'] is True:
                     product.append(value['values'])
-                    product_keys.append((step_id, key))
+                    product_keys.append(ParamKey(step_id, key))
                 else:
                     if linked_n is None:
                         linked_n = nval
                     elif linked_n != nval or nval == 0:
                         raise exceptions.RequestParameterInvalidException('Failed to match linked batch selections. Please select equal number of data files.')
                     linked.append(value['values'])
-                    linked_keys.append((step_id, key))
-    params = []
+                    linked_keys.append(ParamKey(step_id, key))
+
+    # Force it to a list to allow modification...
+    input_items = list(inputs.items())
+    for input_id, value in input_items:
+        if is_batch(value):
+            nval = len(value['values'])
+            if 'product' in value and value['product'] is True:
+                product.append(value['values'])
+                product_keys.append(InputKey(input_id))
+            else:
+                if linked_n is None:
+                    linked_n = nval
+                elif linked_n != nval or nval == 0:
+                    raise exceptions.RequestParameterInvalidException('Failed to match linked batch selections. Please select equal number of data files.')
+                linked.append(value['values'])
+                linked_keys.append(InputKey(input_id))
+        elif isinstance(value, dict) and 'batch' in value:
+            # remove batch wrapper and render simplified input form rest of workflow
+            # code expects
+            inputs[input_id] = value['values'][0]
+
+    param_combinations = []
+    input_combinations = []
     params_keys = []
     linked = linked or [[None]]
     product = product or [[None]]
-    linked_keys = linked_keys or [(None, None)]
-    product_keys = product_keys or [(None, None)]
+    linked_keys = linked_keys or [None]
+    product_keys = product_keys or [None]
     for linked_values, product_values in itertools.product(zip(*linked), itertools.product(*product)):
-        new_params = copy.deepcopy(inputs)
+        new_params = copy.deepcopy(param_inputs)
+        new_inputs = copy.deepcopy(inputs)
         new_keys = []
-        for (step_id, key), value in list(zip(linked_keys, linked_values)) + list(zip(product_keys, product_values)):
-            if step_id is not None:
-                new_params[step_id][key] = value
-                new_keys.append(str(value['hid']))
+        for input_key, value in list(zip(linked_keys, linked_values)) + list(zip(product_keys, product_values)):
+            if input_key:
+                if isinstance(input_key, ParamKey):
+                    step_id = input_key.step_id
+                    key = input_key.key
+                    assert step_id is not None
+                    new_params[step_id][key] = value
+                    if 'hid' in value:
+                        new_keys.append(str(value['hid']))
+                else:
+                    input_id = input_key.input_id
+                    assert input_id is not None
+                    new_inputs[input_id] = value
+                    if 'hid' in value:
+                        new_keys.append(str(value['hid']))
+
         params_keys.append(new_keys)
-        params.append(new_params)
-    return params, params_keys
+        param_combinations.append(new_params)
+        input_combinations.append(new_inputs)
+
+    return WorkflowParameterExpansion(param_combinations, params_keys, input_combinations)
 
 
 def process_key(incoming_key, incoming_value, d):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2436,6 +2436,38 @@ mapping:
           When false, the most recently added compatible item in the history will
           be used for each "Set at Runtime" input, independent of others in the workflow.
 
+      simplified_workflow_run_ui:
+        type: str
+        default: 'prefer'
+        enum: ['off', 'prefer']
+        required: false
+        desc: |
+          If set to 'off' by default, always use the traditional workflow form that renders
+          all steps in the GUI and serializes the tool state of all steps during
+          invocation. Set to 'prefer' to default to a simplified workflow UI that
+          only renders the inputs if possible (the workflow must have no disconnected
+          runtime inputs and not replacement parameters within tool steps). In the
+          future 'force' may be added an option for Galaskio-style servers that should
+          only render simplified workflows.
+
+      simplified_workflow_run_ui_target_history:
+        type: str
+        default: 'current'
+        enum: ['current', 'new']
+        required: false
+        desc: |
+          When the simplified workflow run form is rendered, should the invocation outputs
+          be sent to the 'current' history or a 'new' history.
+
+      simplified_workflow_run_ui_job_cache:
+        type: str
+        default: 'off'
+        enum: ['on', 'off']
+        required: false
+        desc: |
+          When the simplified workflow run form is rendered, should the invocation use job
+          caching. This isn't a boolean so an option for 'show-selection' can be added later.
+
       myexperiment_target_url:
         type: str
         default: www.myexperiment.org:80

--- a/lib/galaxy_test/base/data/test_workflow_batch.ga
+++ b/lib/galaxy_test/base/data/test_workflow_batch.ga
@@ -15,7 +15,7 @@
                     "name": "Input Dataset"
                 }
             ], 
-            "label": null, 
+            "label": "coolinput",
             "name": "Input dataset", 
             "outputs": [], 
             "position": {

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -254,6 +254,7 @@ def setup_galaxy_config(
         logging=LOGGING_CONFIG_DEFAULT,
         monitor_thread_join_timeout=5,
         object_store_store_by="uuid",
+        simplified_workflow_run_ui="off",
     )
     if not use_shared_connection_for_amqp:
         config["amqp_internal_connection"] = "sqlalchemy+sqlite:///%s?isolation_level=IMMEDIATE" % os.path.join(tmpdir, "control.sqlite")

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -198,6 +198,7 @@
   <tool file="for_workflows/count_list.xml" />
   <tool file="for_workflows/count_multi_file.xml" />
   <tool file="for_workflows/create_input_collection.xml" />
+  <tool file="for_workflows/randomlines.xml" />
 
   <section id="filter" name="For Tours">
     <tool file="for_tours/filtering.xml" />

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -195,6 +195,7 @@ DO_NOT_TEST = [
     'object_store_store_by',  # broken: default overridden
     'pretty_datetime_format',  # untestable; refactor config/__init__ to test
     'retry_metadata_internally',  # broken: default overridden
+    'simplified_workflow_run_ui',  # set to off in testing
     'statsd_host',  # broken: default overridden with empty string
     'template_cache_path',  # may or may not be able to test; may be broken
     'tool_config_file',  # default not used; may or may not be testable


### PR DESCRIPTION
Builds on refactoring the workflow run form landing and orchestration into Vue (#9147).

Implements #9111 - part of https://github.com/orgs/galaxyproject/projects/47 and outlined in http://bit.ly/simplified-workflow-ui.

## What is in the PR:

- Add new Galaxy configuration option - ``simplified_workflow_run_ui`` set to ``off`` by default.
- If instead the admin has set this parameter to ``prefer``, on the workflow run page scan the workflow run request and if three conditions are met show a simplified tool form. These conditions are:
  - No workflow "resource parameters" - pretty niche, not documented, I don't think anyone outside of Canada is using them and even them I'm not sure if they ever got to production.
  - No "open" tools (i.e. tools with disconnected runtime inputs).
  - No "replacement parameters" defined outside PJAs. I'm calling #{} inside PJA and ${} inside tool steps both "replacement parameters" because the user populates them the same way in the GUI. The API only handles them inside the context of the PJA - it seems the GUI is responsible for replacing them at runtime in the traditional form.
- The simplified workflow form:
   - Drops tool and subworkflow steps from rendering all together and instead just renders the inputs. These are not rendered as separate "steps" or forms - but as just different inputs the same clean, simple form (more the like tool GUI). Labels (or step indexes as a fallback) are used at the input name, step annotations are used as the input help text.
   - Simplify the workflow request made by the client - send only replacement parameters and inputs - do not serialize tool state for each module. I think this makes what we are tracking more structured and should be more performant as well. Prevents storing HDA IDs in unstructured JSON blobs in the database as well.
   - Drops history target option to simplify the UI - ``simplified_workflow_run_ui_target_history`` can be set to either 'current' (default) or 'new' to adjust this parameter Galaxy-wide for the simplified form.
   - Drops job caching option to simplify the UI - ``simplified_workflow_run_ui_job_cache`` can be set to 'off' (default) or 'on' to change this parameter Galaxy-wide for the simplified form.
   - Drops resource parameters - we've already verified there are none for simplified workflows.

What is in the PR:

## Screenshots

Original Form:

<img width="539" alt="Screen Shot 2019-12-19 at 4 11 11 PM" src="https://user-images.githubusercontent.com/216771/71209873-9f2b7000-227a-11ea-90e6-52fbaf01a855.png">

Simplified Form:


<img width="551" alt="Screen Shot 2019-12-19 at 4 10 59 PM" src="https://user-images.githubusercontent.com/216771/71209877-a3f02400-227a-11ea-87cb-dcfc0e279828.png">

Clicking to open advanced form from simplified one:

![inaction](https://user-images.githubusercontent.com/216771/71210531-15c86d80-227b-11ea-9531-ade25678d46c.gif)
