### PR TITLE
"Normalize" more custom functions in admin jobs index.

### DIFF
--- a/client/galaxy/scripts/components/admin/JobDetails.vue
+++ b/client/galaxy/scripts/components/admin/JobDetails.vue
@@ -1,0 +1,39 @@
+<template>
+    <b-card>
+        <h5>Command Line</h5>
+        <pre class="text-white bg-dark"><code class="break-word">{{ commandLine }}</code></pre>
+        <h5>Job Parameters</h5>
+        <job-parameters :jobId="jobId" :includeTitle="false" />
+        <h5>Job Metrics</h5>
+        <job-metrics :jobId="jobId" :includeTitle="false" />
+    </b-card>
+</template>
+
+<script>
+import { JobMetrics } from "components/JobMetrics";
+import { JobParameters } from "components/JobParameters";
+
+export default {
+    components: {
+        JobMetrics,
+        JobParameters
+    },
+    props: {
+        commandLine: {
+            type: String,
+            required: true
+        },
+        jobId: {
+            type: String,
+            required: true
+        }
+    }
+};
+</script>
+
+<style scoped>
+.break-word {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+</style>

--- a/client/galaxy/scripts/components/admin/Jobs.vue
+++ b/client/galaxy/scripts/components/admin/Jobs.vue
@@ -68,9 +68,6 @@
                                 </b-input-group-append>
                             </b-input-group>
                         </b-form-group>
-                        <b-button :pressed.sync="showCommandLine" variant="outline-secondary">
-                            {{ showCommandLine ? "Hide" : "Show" }} Command Line
-                        </b-button>
                     </b-col>
                     <b-col>
                         <b-card v-if="jobsItemsComputed.length" header="Stop Selected Jobs">
@@ -213,7 +210,6 @@ export default {
                 { key: "job_runner_name", label: "Job Runner" },
                 { key: "job_runner_external_id", label: "PID/Cluster ID", sortable: true }
             ],
-            showCommandLine: false,
             cutoff: 180,
             cutoffDisplay: 180,
             jobLock: false,
@@ -327,12 +323,6 @@ export default {
         },
         computeFields(fields) {
             const f = Array.from(fields).slice(0);
-            if (this.showCommandLine) {
-                f.splice(6, 0, {
-                    key: "command_line",
-                    tdClass: ["text-white", "bg-dark", "break-word"]
-                });
-            }
             return f;
         },
         toggleAll(checked) {

--- a/client/galaxy/scripts/components/admin/Jobs.vue
+++ b/client/galaxy/scripts/components/admin/Jobs.vue
@@ -132,12 +132,7 @@
                     </b-link>
                 </template>
                 <template v-slot:row-details="row">
-                    <b-card>
-                        <h5>Command Line</h5>
-                        <pre
-                            class="text-white bg-dark"
-                        ><code class="break-word">{{ row.item.command_line }}</code></pre>
-                    </b-card>
+                    <job-details :commandLine="row.item.command_line" :jobId="row.item.jobId" />
                 </template>
             </b-table>
             <b-alert v-if="!recentJobsItemsComputed.length" variant="secondary" show>
@@ -167,12 +162,7 @@
                     <utc-date :date="data.value" mode="elapsed" />
                 </template>
                 <template v-slot:row-details="row">
-                    <b-card>
-                        <h5>Command Line</h5>
-                        <pre
-                            class="text-white bg-dark"
-                        ><code class="break-word">{{ row.item.command_line }}</code></pre>
-                    </b-card>
+                    <job-details :commandLine="row.item.command_line" :jobId="row.item.id" />
                 </template>
             </b-table>
             <b-modal ref="job-info-modal" scrollable hide-header ok-only @hidden="resetModalContents">
@@ -188,6 +178,7 @@
 import { getAppRoot } from "onload/loadConfig";
 import UtcDate from "components/UtcDate";
 import axios from "axios";
+import JobDetails from "./JobDetails";
 
 function cancelJob(jobId, message) {
     const url = `${getAppRoot()}api/jobs/${jobId}`;
@@ -195,7 +186,7 @@ function cancelJob(jobId, message) {
 }
 
 export default {
-    components: { UtcDate },
+    components: { UtcDate, JobDetails },
     data() {
         return {
             jobsItems: [],
@@ -206,7 +197,6 @@ export default {
                 { key: "user" },
                 { key: "tool_id", label: "Tool", tdClass: ["break-word"] },
                 { key: "state" },
-                { key: "input_dataset", label: "Inputs" },
                 { key: "job_runner_name", label: "Job Runner" },
                 { key: "job_runner_external_id", label: "PID/Cluster ID", sortable: true }
             ],

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1541,11 +1541,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         def prepare_jobs_list(jobs):
             res = []
             for job in jobs:
-                inputs = ""
-                try:
-                    inputs = ", ".join(['{} {}'.format(da.dataset.id, da.dataset.state) for da in job.input_datasets])
-                except Exception:
-                    inputs = 'Unable to determine inputs'
                 res.append({
                     'job_info': {
                         'id': job.id,
@@ -1555,7 +1550,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                     'update_time': job.update_time.isoformat(),
                     'tool_id': job.tool_id,
                     'state': job.state,
-                    'input_dataset': inputs,
                     'command_line': job.command_line,
                     'job_runner_name': job.job_runner_name,
                     'job_runner_external_id': job.job_runner_external_id

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -1549,7 +1549,6 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
                 res.append({
                     'job_info': {
                         'id': job.id,
-                        'info_url': "{}?jobid={}".format(web.url_for(controller="admin", action="job_info"), job.id)
                     },
                     'id': trans.security.encode_id(job.id),
                     'user': job.history.user.email if job.history and job.history.user else 'anonymous',


### PR DESCRIPTION
Continuing thread of #8943,  #9093... trying to standardize the jobs index Vue component for re-use.

- Eliminate info_url from API web controller response - wasn't used and isn't available in regular jobs API calls that I'd like to get to.
- Eliminate showing the command-line as a row of the table - it is redundant with the expanded row details which are already there, was ugly when embedded in the row, and simplifies the form nicely to get rid of.
- Eliminate "inputs" from the web controller response - it isn't available in the regular API and I replaced the inputs handling with reuse of the JobParameters Vue component. We get this for free from the job id, it renders a lot richer information about the parameters, input names, etc... and things are hyperlinked so inputs can be navigated to.
- Add JobMetrics - since we have a component to do that for free that looks a lot like the JobParameters component. 

Before:

<img width="1438" alt="Screen Shot 2019-12-21 at 12 19 28 PM" src="https://user-images.githubusercontent.com/216771/71311283-2e0bca00-23ec-11ea-9f53-7f69dbca48ec.png">


After:

<img width="1443" alt="Screen Shot 2019-12-21 at 12 17 11 PM" src="https://user-images.githubusercontent.com/216771/71311239-eab15b80-23eb-11ea-9ad1-dff55c23b780.png">

I think the couple more clicks to certain pieces of information is worth it to get us closer to a re-usable component built on the standard APIs especially given the richer information we are now able to present (full tool parameters with links and handling non-dataset inputs as well as job metrics). If people feel strongly about fast index-level access to input states or something though - I can try to rework the traditional APIs to expose this efficiently but my initial thought is that it is not worth the effort.
