### PR TITLE
Fix incorrect reference to app

### DIFF
--- a/lib/galaxy/model/tool_shed_install/__init__.py
+++ b/lib/galaxy/model/tool_shed_install/__init__.py
@@ -137,7 +137,7 @@ class ToolShedRepository(object):
                 self.shed_config_filename = shed_tool_conf_dict['config_filename']
                 return shed_tool_conf_dict
         # Very last resort, get default shed_tool_config file for this instance
-        shed_tool_conf_dict = self.app.toolbox.default_shed_tool_conf_dict()
+        shed_tool_conf_dict = app.toolbox.default_shed_tool_conf_dict()
         self.shed_config_filename = shed_tool_conf_dict['config_filename']
         return shed_tool_conf_dict
 


### PR DESCRIPTION
Saw the following stack trace when trying to uninstall the plasmidspades tool. Fix seems simple but not sure what a good test for this might be.
```pytb
galaxy.web.framework.decorators ERROR 2019-12-21 20:56:27,778 [p:69,w:1,m:0] [uWSGIWorker1Core1] Uncaught exception in exposed API method:
Traceback (most recent call last):
File "/galaxy/server/lib/galaxy/web/framework/decorators.py", line 282, in decorator
rval = func(self, trans, *args, **kwargs)
File "/galaxy/server/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py", line 656, in uninstall_repository
errors = irm.uninstall_repository(repository=repository, remove_from_disk=kwd.get('remove_from_disk', True))
File "/galaxy/server/lib/tool_shed/galaxy_install/installed_repository_manager.py", line 761, in uninstall_repository
suc.get_tool_panel_config_tool_path_install_dir(app=self.app, repository=repository)
File "/galaxy/server/lib/tool_shed/util/shed_util_common.py", line 408, in get_tool_panel_config_tool_path_install_dir
shed_config_dict = repository.get_shed_config_dict(app)
File "/galaxy/server/lib/galaxy/model/tool_shed_install/__init__.py", line 99, in get_shed_config_dict
return self.guess_shed_config(app)
File "/galaxy/server/lib/galaxy/model/tool_shed_install/__init__.py", line 140, in guess_shed_config
shed_tool_conf_dict = self.app.toolbox.default_shed_tool_conf_dict()
AttributeError: 'ToolShedRepository' object has no attribute 'app'
```