### PR TITLE
[19.09] Ensure that users have a private role before login

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -102,12 +102,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             # TODO:?? flush needed for permissions below? If not, make optional
         except exc.IntegrityError as db_err:
             raise exceptions.Conflict(str(db_err))
-        # can throw an sqlalx.IntegrityError if username not unique
-        self.app.security_agent.create_private_user_role(user)
-        # We set default user permissions, before we log in and set the default history permissions
-        if hasattr(self.app.config, "new_user_dataset_access_role_default_private"):
-            permissions = self.app.config.new_user_dataset_access_role_default_private
-            self.app.security_agent.user_set_default_permissions(user, default_access_private=permissions)
+        self.app.security_agent.create_user_role(user, self.app)
         return user
 
     def delete(self, user, flush=True):

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -658,7 +658,7 @@ class GalaxyRBACAgent(RBACAgent):
 
     def create_user_role(self, user, app):
         # Create private user role if necessary
-        if app.security_agent.get_private_user_role(user):
+        if not app.security_agent.get_private_user_role(user):
             app.security_agent.create_private_user_role(user)
         # Create default user permissions if necessary
         if not user.default_permissions:

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -656,6 +656,18 @@ class GalaxyRBACAgent(RBACAgent):
         self.sa_session.flush()
         return assoc
 
+    def create_user_role(self, user, app):
+        # Create private user role if necessary
+        if self.app.security_agent.get_private_user_role(user):
+            self.app.security_agent.create_private_user_role(user)
+        # Create default user permissions if necessary
+        if not user.default_permissions:
+            if hasattr(self.app.config, "new_user_dataset_access_role_default_private"):
+                permissions = self.app.config.new_user_dataset_access_role_default_private
+                self.app.security_agent.user_set_default_permissions(user, default_access_private=permissions)
+            else:
+                self.app.security_agent.user_set_default_permissions(user, history=True, dataset=True)
+
     def create_private_user_role(self, user):
         # Create private role
         role = self.model.Role(name=user.email, description='Private Role for ' + user.email, type=self.model.Role.types.PRIVATE)

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -658,15 +658,15 @@ class GalaxyRBACAgent(RBACAgent):
 
     def create_user_role(self, user, app):
         # Create private user role if necessary
-        if self.app.security_agent.get_private_user_role(user):
-            self.app.security_agent.create_private_user_role(user)
+        if app.security_agent.get_private_user_role(user):
+            app.security_agent.create_private_user_role(user)
         # Create default user permissions if necessary
         if not user.default_permissions:
-            if hasattr(self.app.config, "new_user_dataset_access_role_default_private"):
-                permissions = self.app.config.new_user_dataset_access_role_default_private
-                self.app.security_agent.user_set_default_permissions(user, default_access_private=permissions)
+            if hasattr(app.config, "new_user_dataset_access_role_default_private"):
+                permissions = app.config.new_user_dataset_access_role_default_private
+                app.security_agent.user_set_default_permissions(user, default_access_private=permissions)
             else:
-                self.app.security_agent.user_set_default_permissions(user, history=True, dataset=True)
+                app.security_agent.user_set_default_permissions(user, history=True, dataset=True)
 
     def create_private_user_role(self, user):
         # Create private role

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -658,15 +658,15 @@ class GalaxyRBACAgent(RBACAgent):
 
     def create_user_role(self, user, app):
         # Create private user role if necessary
-        if not app.security_agent.get_private_user_role(user):
-            app.security_agent.create_private_user_role(user)
+        if not self.get_private_user_role(user):
+            self.create_private_user_role(user)
         # Create default user permissions if necessary
         if not user.default_permissions:
             if hasattr(app.config, "new_user_dataset_access_role_default_private"):
                 permissions = app.config.new_user_dataset_access_role_default_private
-                app.security_agent.user_set_default_permissions(user, default_access_private=permissions)
+                self.user_set_default_permissions(user, default_access_private=permissions)
             else:
-                app.security_agent.user_set_default_permissions(user, history=True, dataset=True)
+                self.user_set_default_permissions(user, history=True, dataset=True)
 
     def create_private_user_role(self, user):
         # Create private role

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -712,6 +712,9 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
            - add the disk usage of the current session to the user's total disk usage
         """
         self.user_checks(user)
+        # Make sure that user has a private role
+        if not self.app.security_agent.get_private_user_role(user):
+            self.app.security_agent.create_private_user_role(user)
         # Set the previous session
         prev_galaxy_session = self.galaxy_session
         prev_galaxy_session.is_valid = False

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -712,9 +712,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
            - add the disk usage of the current session to the user's total disk usage
         """
         self.user_checks(user)
-        # Make sure that user has a private role
-        if not self.app.security_agent.get_private_user_role(user):
-            self.app.security_agent.create_private_user_role(user)
+        self.app.security_agent.create_user_role(user, self.app)
         # Set the previous session
         prev_galaxy_session = self.galaxy_session
         prev_galaxy_session.is_valid = False


### PR DESCRIPTION
Fixes #9165.

The underlying problem is that the OIDC login does not create user roles or sets default permissions for a newly created user as done by the regular user registration: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/managers/users.py#L110.

In the case of the remote user helper this is done manually: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/web/framework/webapp.py#L594.