### PR TITLE
Missing env in AskOmics IT

### DIFF
--- a/tools/interactive/interactivetool_askomics.xml
+++ b/tools/interactive/interactivetool_askomics.xml
@@ -16,6 +16,7 @@
         <environment_variable name="USER_LAST_NAME">Galaxy</environment_variable>
         <environment_variable name="USER_USERNAME">${__user_name__}</environment_variable>
         <environment_variable name="USER_EMAIL">${__user_email__}</environment_variable>
+        <environment_variable name="USER_APIKEY">${__user_name__}</environment_variable>
         <!-- Galaxy info -->
         <environment_variable name="GALAXY_URL">$__galaxy_url__</environment_variable>
         <environment_variable name="GALAXY_API_KEY" inject="api_key" />

--- a/tools/interactive/interactivetool_askomics.xml
+++ b/tools/interactive/interactivetool_askomics.xml
@@ -1,7 +1,7 @@
 <tool id="interactive_tool_askomics" tool_type="interactive" name="AskOmics" version="1.0">
     <description>a visual SPARQL query builder</description>
     <requirements>
-        <container type="docker">askomics/flaskomics-with-dependencies:3.2.0</container>
+        <container type="docker">askomics/flaskomics-with-dependencies:3.2.1</container>
     </requirements>
     <entry_points>
         <entry_point name="AskOmics instance on $infile.display_name" requires_domain="True">


### PR DESCRIPTION
Hi everyone,

This PR fix the missing env described in #8517 

This env is needed to log a user into the AskOmics instance using his username as an askomics apikey.

I also upgrade the docker image to the latest version

ping @abretaud 

