### PR TITLE
[20.01] Add static-safe mapping to config management

### DIFF
--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -101,6 +101,12 @@ UWSGI_OPTIONS = OrderedDict([
         'default': '/favicon.ico=static/favicon.ico',
         'type': 'str',
     }),
+    ('static-safe', {
+        'key': 'static-safe',
+        'desc': """Allow serving images out of `client`.  Most modern Galaxy interfaces bundle all of this, but some older pages still serve these via symlink, requiring this rule.""",
+        'default': 'client/galaxy/images',
+        'type': 'str',
+    }),
     ('master', {
         'desc': """Enable the master process manager. Disabled by default for maximum compatibility with CTRL+C, but should be enabled for use with --daemon and/or production deployments.""",
         'default': False,

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -50,6 +50,11 @@ uwsgi:
   # Mapping to serve the favicon.
   static-map: /favicon.ico=static/favicon.ico
 
+  # Allow serving images out of `client`.  Most modern Galaxy interfaces
+  # bundle all of this, but some older pages still serve these via
+  # symlink, requiring this rule.
+  static-safe: client/galaxy/images
+
   # Enable the master process manager. Disabled by default for maximum
   # compatibility with CTRL+C, but should be enabled for use with
   # --daemon and/or production deployments.

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -32,6 +32,11 @@ uwsgi:
   # Mapping to serve the favicon.
   static-map: /favicon.ico=static/favicon.ico
 
+  # Allow serving images out of `client`.  Most modern Galaxy interfaces
+  # bundle all of this, but some older pages still serve these via
+  # symlink, requiring this rule.
+  static-safe: client/galaxy/images
+
   # Enable the master process manager. Disabled by default for maximum
   # compatibility with CTRL+C, but should be enabled for use with
   # --daemon and/or production deployments.

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -32,6 +32,11 @@ uwsgi:
   # Mapping to serve the favicon.
   static-map: /favicon.ico=static/favicon.ico
 
+  # Allow serving images out of `client`.  Most modern Galaxy interfaces
+  # bundle all of this, but some older pages still serve these via
+  # symlink, requiring this rule.
+  static-safe: client/galaxy/images
+
   # Enable the master process manager. Disabled by default for maximum
   # compatibility with CTRL+C, but should be enabled for use with
   # --daemon and/or production deployments.

--- a/lib/galaxy/config/script.py
+++ b/lib/galaxy/config/script.py
@@ -37,6 +37,7 @@ DEFAULT_DB_CONN = 'sqlite:///./database/universe.sqlite?isolation_level=IMMEDIAT
 SAMPLES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), 'sample'))
 GALAXY_CONFIG_TEMPLATE_FILE = os.path.join(SAMPLES_PATH, 'galaxy.yml.sample')
 STATIC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, 'web', 'framework', 'static'))
+CLIENT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, 'client'))
 
 MSG_CONFIG_SUMMARY = """
 For help on configuring Galaxy, consult the documentation at: \n {}
@@ -55,6 +56,7 @@ GALAXY_CONFIG_SUBSTITUTIONS = {
     '  static-map: /static/style=static/style/blue': '  static-map: /static=${static_path}/style/blue',
     '  static-map: /static=static': '  static-map: /static=${static_path}',
     '  static-map: /favicon.ico=static/favicon.ico': '  static-map: /static=${static_path}/favicon.ico',
+    '  static-safe: client/galaxy/images': '  ${client_path}/galaxy/images',
     '  virtualenv: .venv': '  #venv: .venv   # not used when running installed',
     '  pythonpath: lib': '  #pythonpath: lib  # not used  when running installed',
     '  #config_dir: false': '  config_dir: ${config_dir}',
@@ -147,6 +149,7 @@ def _handle_galaxy_yml(args, config_dir, data_dir):
         uwsgi_transport=uwsgi_transport,
         config_dir=config_dir,
         data_dir=data_dir,
+        client_dir=CLIENT_PATH,
         static_path=STATIC_PATH,
         database_connection=args.db_conn,
     )


### PR DESCRIPTION
Was previously only defined in uwsgi default args which not everything uses.

This closes the loop on the last point of https://github.com/galaxyproject/galaxy/issues/9080

xref: https://github.com/galaxyproject/galaxy-helm/pull/87