### PR TITLE
Check return value of quick_load

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -839,7 +839,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             if os.path.isdir(child_path) and recursive:
                 self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
             elif self._looks_like_a_tool(child_path):
-                tool_loaded = quick_load(child_path, async_load=False)
+                tool_id = quick_load(child_path, async_load=False)
+                tool_loaded = bool(tool_id)
         if (tool_loaded or force_watch) and self._tool_watcher:
             self._tool_watcher.watch_directory(directory, quick_load)
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -839,8 +839,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             if os.path.isdir(child_path) and recursive:
                 self.__watch_directory(child_path, elems, integrated_elems, load_panel_dict, recursive)
             elif self._looks_like_a_tool(child_path):
-                quick_load(child_path, async_load=False)
-                tool_loaded = True
+                tool_loaded = quick_load(child_path, async_load=False)
         if (tool_loaded or force_watch) and self._tool_watcher:
             self._tool_watcher.watch_directory(directory, quick_load)
 


### PR DESCRIPTION
Addresses comment by @nsoranzo in previous commit:
https://github.com/galaxyproject/galaxy/pull/9106#discussion_r358028297

Assumption: neither `0` nor the empty string will ever be valid tool IDs or indicators of a successful tool load. 