### PR TITLE
Attempt to configure new Galaxies to storing files by UUID by default.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -773,7 +773,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             markdown_export_css=[self._in_config_dir('markdown_export.css')],
             markdown_export_css_pages=[self._in_config_dir('markdown_export_pages.css')],
             markdown_export_css_invocation_reports=[self._in_config_dir('markdown_export_invocation_reports.css')],
-            file_path=[self._in_data_dir('files'), self._in_data_dir('objects')],
+            # self.file_path set to self._in_data_dir('objects') by schema
+            file_path=[self._in_data_dir('files'), self.file_path],
         )
         listify_defaults = {
             'tool_data_table_config_path': [

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -181,7 +181,7 @@ mapping:
 
       file_path:
         type: str
-        default: files
+        default: objects
         path_resolves_to: data_dir
         required: false
         desc: |
@@ -802,11 +802,12 @@ mapping:
 
       object_store_store_by:
         type: str
-        default: id
         required: false
         desc: |
           What Dataset attribute is used to reference files in an ObjectStore implementation,
-          default is 'id' but can also be set to 'uuid' for more de-centralized usage.
+          this can be 'uuid' or 'id'. The default will depend on how the object store is configured,
+          starting with 20.05 Galaxy will try to default to 'uuid' if it can be sure this
+          is a new Galaxy instance - but the default will be 'id' in many cases.
 
       smtp_server:
         type: str


### PR DESCRIPTION
Extended metadata has been merged #8930. Time to circle back and make it more robust. One of the hardening goals is simplified configuration - so ideally I think Galaxy should store objects by UUID by default so it can then in turn use extended metadata by default.