### PR TITLE
#7975 Fix name variable used in job caching lookup table

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -84,7 +84,7 @@ class JobSearch(object):
         def populate_input_data_input_id(path, key, value):
             """Traverses expanded incoming using remap and collects input_ids and input_data."""
             if key == 'id':
-                path_key = get_path_key(path[:-2])
+                path_key = get_path_key(path[:-2]).split('|')[-1]
                 current_case = param_dump
                 for p in path:
                     current_case = current_case[p]


### PR DESCRIPTION
#7975: When trying to run a previously executed job, the caching step fails to find the previous job as the input parameters are different than the database entries.

- In jobs.py the `path_key` variable is used to hold the name of the input to search in the SQL query.
     - For certain tools this variable was being assigned a value that contains the full path of the input.
     - e.g. `library|input_2`
          -  Whereas within the database the input name is stored as `input_2`

* Fix in this commit makes it so that the `path_key` variable is set to be the input name that is consistent with the database entry by extracting the string that follows the last pipe character ' | '
* Tested using bwa, bowtie2, and shovill. Confirmed that the equivalent job was found and re-used.