### PR TITLE
[20.01] Add require_login bypass for entire authnz controller.

### DIFF
--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -563,6 +563,10 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
                         return
                 except IndexError:
                     pass
+            authnz_controller_base = url_for(controller='authnz', action='index')
+            if self.request.path.startswith(authnz_controller_base):
+                #  All authnz requests pass through
+                return
             # redirect to root if the path is not in the list above
             if self.request.path not in allowed_paths:
                 login_url = url_for(controller='root', action='login', redirect=self.request.path)


### PR DESCRIPTION
Without this, when require_login is set you can't use authnz-based login.