### PR TITLE
[20.01] Run integration tests on github, fix various bugs (interactive tools, kubernetes, test framework)

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,48 @@
+name: Integration
+on: [push, pull_request]
+env:
+  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+jobs:
+
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.7, 2.7]
+        subset: ['upload_datatype', 'extended_metadata', 'kubernetes', 'not (upload_datatype or extended_metadata or kubernetes)']
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+    - name: Setup Minikube
+      if: matrix.subset == 'kubernetes'
+      id: minikube
+      uses: CodingNagger/minikube-setup-action@v1.0.2
+    - name: Launch Minikube
+      if: matrix.subset == 'kubernetes'
+      run: eval ${{ steps.minikube.outputs.launcher }}
+    - name: Check pods
+      if: matrix.subset == 'kubernetes'
+      run: |
+        kubectl get pods
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache venv dir
+      uses: actions/cache@v1
+      id: cache-venv-galaxy
+      with:
+        path: .venv
+        key: cache-venv-galaxy-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+    - name: Run tests
+      run: './run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7, 2.7]
+        python-version: [3.7]
         subset: ['upload_datatype', 'extended_metadata', 'kubernetes', 'not (upload_datatype or extended_metadata or kubernetes)']
     services:
       postgres:

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -194,7 +194,7 @@ class ConditionalDependencies(object):
 
 def optional(config_file=None):
     if not config_file:
-        config_file = find_config_file(['galaxy', 'universe_wsgi'])
+        config_file = find_config_file(['galaxy', 'universe_wsgi'], include_samples=True)
     if not config_file:
         print("galaxy.dependencies.optional: no config file found", file=sys.stderr)
         return []

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -11,7 +11,10 @@ import pkg_resources
 import yaml
 
 from galaxy.containers import parse_containers_config
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    which,
+)
 from galaxy.util.properties import (
     find_config_file,
     load_app_properties
@@ -145,7 +148,7 @@ class ConditionalDependencies(object):
         return "galaxy.jobs.runners.pbs:PBSJobRunner" in self.job_runners
 
     def check_pykube(self):
-        return "galaxy.jobs.runners.kubernetes:KubernetesJobRunner" in self.job_runners
+        return "galaxy.jobs.runners.kubernetes:KubernetesJobRunner" in self.job_runners or which('kubectl')
 
     def check_chronos_python(self):
         return "galaxy.jobs.runners.chronos:ChronosJobRunner" in self.job_runners

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -112,7 +112,7 @@ oslo.log==3.45.0
 oslo.serialization==2.29.2
 oslo.utils==3.42.0
 packaging==19.2
-paramiko==2.7.0
+paramiko==2.7.1
 parsley==1.3
 paste==3.2.3
 pastedeploy==2.0.1

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2111,7 +2111,7 @@ class JobWrapper(HasResourceParameters):
                 "connection_configuration": container.connection_configuration,
             }, f)
 
-        return "(python '%s'/lib/galaxy_ext/container_monitor/monitor.py &) " % exec_dir
+        return "(python '%s'/lib/galaxy_ext/container_monitor/monitor.py &); sleep 1 " % exec_dir
 
     @property
     def user(self):

--- a/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
+++ b/lib/galaxy/jobs/runners/util/cli/shell/rsh.py
@@ -6,7 +6,8 @@ from pulsar.managers.util.retry import RetryActionExecutor
 
 from galaxy.util import (
     smart_str,
-    unicodify
+    string_as_bool,
+    unicodify,
 )
 from galaxy.util.bunch import Bunch
 from .local import LocalShell
@@ -43,7 +44,7 @@ class SecureShell(RemoteShell):
     SSH_NEW_KEY_STRING = 'Are you sure you want to continue connecting'
 
     def __init__(self, rsh='ssh', rcp='scp', private_key=None, port=None, strict_host_key_checking=True, **kwargs):
-        strict_host_key_checking = "yes" if strict_host_key_checking else "no"
+        strict_host_key_checking = "yes" if string_as_bool(strict_host_key_checking) else "no"
         options = ["-o", "StrictHostKeyChecking=%s" % strict_host_key_checking]
         options.extend(["-o", "ConnectTimeout=60"])
         if private_key:

--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -270,7 +270,7 @@ class InteractiveToolManager(object):
         entry_point = trans.sa_session.query(model.InteractiveToolEntryPoint).get(entry_point_id)
         if self.app.interactivetool_manager.can_access_entry_point(trans, entry_point):
             if entry_point.active:
-                return self.target_if_active(entry_point)
+                return self.target_if_active(trans, entry_point)
             elif entry_point.deleted:
                 raise exceptions.MessageException('InteractiveTool has ended. You will have to start a new one.')
             else:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -180,7 +180,7 @@ def mull_targets(
     if DEST_BASE_IMAGE:
         dest_base_image = DEST_BASE_IMAGE
     else:
-        dest_base_image = DEFAULT_EXTENDED_BASE_IMAGE if not any_target_requires_extended_base(targets) else DEST_BASE_IMAGE
+        dest_base_image = DEFAULT_EXTENDED_BASE_IMAGE if any_target_requires_extended_base(targets) else DEST_BASE_IMAGE
 
     targets = list(targets)
     if involucro_context is None:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -271,7 +271,7 @@ def xml_to_string(elem, pretty=False):
     except TypeError as e:
         # we assume this is a comment
         if hasattr(elem, 'text'):
-            return "<!-- %s -->\n" % elem.text
+            return u"<!-- %s -->\n" % elem.text
         else:
             raise e
     if xml_str and pretty:

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -22,7 +22,7 @@ def parse_ports(container_name, connection_configuration):
                                         preexec_fn=os.setpgrp)
             if exit_code == 0:
                 stdout_file.seek(0)
-                ports_raw = stdout_file.read()
+                ports_raw = stdout_file.read().decode('utf-8')
                 return ports_raw
 
 

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -31,7 +31,7 @@ def skip_if_jenkins(cls):
 def skip_unless_executable(executable):
     if which(executable):
         return _identity
-    return skip("PATH doesn't contain executable %s" % executable)
+    return pytest.mark.skip("PATH doesn't contain executable %s" % executable)
 
 
 def skip_unless_docker():
@@ -50,7 +50,7 @@ def skip_unless_fixed_port():
     if os.environ.get("GALAXY_TEST_PORT_RANDOM") != "1":
         return _identity
 
-    return skip("GALAXY_TEST_PORT must be set for this test.")
+    return pytest.mark.skip("GALAXY_TEST_PORT must be set for this test.")
 
 
 class IntegrationInstance(UsesApiTestCaseMixin):

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -47,7 +47,7 @@ def k8s_config_path():
 
 
 def skip_unless_fixed_port():
-    if os.environ.get("GALAXY_TEST_PORT"):
+    if os.environ.get("GALAXY_TEST_PORT_RANDOM") != "1":
         return _identity
 
     return skip("GALAXY_TEST_PORT must be set for this test.")

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -602,6 +602,7 @@ if [ -z "$skip_common_startup" ]; then
             export GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
     fi
     ./scripts/common_startup.sh $skip_venv $no_create_venv $no_replace_pip $replace_pip $skip_client_build --dev-wheels || exit 1
+    unset GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION
 fi
 
 . ./scripts/common_startup_functions.sh

--- a/scripts/interactivetools/key_type_token_mapping.py
+++ b/scripts/interactivetools/key_type_token_mapping.py
@@ -6,7 +6,7 @@ from time import time
 import uwsgi
 
 
-realtime_db_file = uwsgi.opt["interactivetools_map"]
+realtime_db_file = uwsgi.opt["interactivetools_map"].decode('utf-8')
 db_conn = sqlite3.connect(realtime_db_file)
 
 DATABASE_TABLE_NAME = 'gxitproxy'
@@ -51,6 +51,14 @@ class CacheList():
 key_type_token_mapped_cache = CacheList()
 
 
+def args_as_unicode(func):
+    def wrap_args(*args):
+        args = (arg.decode('utf-8') if isinstance(arg, bytes) else arg for arg in args)
+        return func(*args)
+    return wrap_args
+
+
+@args_as_unicode
 def key_type_token_mapper_cached(key, key_type, token, route_extra, url, ttl):
     global key_type_token_mapped_cache
     cache_key = (key, key_type, token)
@@ -58,11 +66,12 @@ def key_type_token_mapper_cached(key, key_type, token, route_extra, url, ttl):
     if entry is None:
         entry = key_type_token_mapper(key, key_type, token, route_extra, url)
         if entry is not None:
-            # Should we cache empt/not authorized entries, perhaps for shorter time?
+            # Should we cache empty/not authorized entries, perhaps for shorter time?
             key_type_token_mapped_cache.add_entry(cache_key, entry, ttl=float(ttl))
     return entry
 
 
+@args_as_unicode
 def key_type_token_mapper(key, key_type, token, route_extra, url):
     global db_conn
     # print 'key %s key_type %s token %s route_extra %s url %s\n' % (key, key_type, token, route_extra, url)

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -12,7 +12,7 @@ from galaxy_test.driver import integration_util
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
 
 
-RemoteConnection = collections.namedtuple('remote_connection', ['hostname', 'username', 'password', 'port', 'private_key', 'public_key'])
+RemoteConnection = collections.namedtuple('remote_connection', ['hostname', 'username', 'port', 'private_key', 'public_key'])
 
 
 @integration_util.skip_unless_docker()
@@ -36,7 +36,8 @@ def start_ssh_docker(container_name, jobs_directory, port=10022, image='agaveapi
                           'nofile=2048:2048',
                           image]
     subprocess.check_call(START_SLURM_DOCKER)
-    return RemoteConnection('localhost', 'testuser', 'testuser', port, ssh_keys.private_key_file, ssh_keys.public_key_file)
+    subprocess.check_call(['docker', 'exec', container_name, 'usermod', '-u', str(os.getuid()), 'testuser'])
+    return RemoteConnection('localhost', 'testuser', port, ssh_keys.private_key_file, ssh_keys.public_key_file)
 
 
 def stop_ssh_docker(container_name, remote_connection):

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -3,6 +3,7 @@ import collections
 import os
 import string
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -37,7 +38,8 @@ def start_ssh_docker(container_name, jobs_directory, port=10022, image='agaveapi
                           'nofile=2048:2048',
                           image]
     subprocess.check_call(START_SLURM_DOCKER)
-    subprocess.check_call(['docker', 'exec', container_name, 'usermod', '-u', str(os.getuid()), 'testuser'])
+    if sys.platform != 'darwin':
+        subprocess.check_call(['docker', 'exec', container_name, 'usermod', '-u', str(os.getuid()), 'testuser'])
     return RemoteConnection('localhost', 'testuser', port, ssh_keys.private_key_file, ssh_keys.public_key_file)
 
 

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -58,6 +58,7 @@ def cli_job_config(remote_connection, shell_plugin='ParamikoShell', job_plugin='
             <param id="shell_private_key">$private_key</param>
             <param id="shell_hostname">$hostname</param>
             <param id="shell_port">$port</param>
+            <param id="shell_strict_host_key_checking">False</param>
             <param id="embed_metadata_in_job">False</param>
             <env id="SOME_ENV_VAR">42</env>
         </destination>

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -28,6 +28,7 @@ def start_ssh_docker(container_name, jobs_directory, port=10022, image='agaveapi
                           '--name',
                           container_name,
                           '--rm',
+                          '--privileged',  # for torque
                           '-v',
                           "{jobs_directory}:{jobs_directory}".format(jobs_directory=jobs_directory),
                           "-v",

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -96,7 +96,7 @@ class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
         super(BaseCliIntegrationTestCase, cls).tearDownClass()
 
     @classmethod
-    def handle_galaxy_config_kwds(cls, config, ):
+    def handle_galaxy_config_kwds(cls, config):
         config["jobs_directory"] = cls.jobs_directory
         config["file_path"] = cls.jobs_directory
         config["job_config_file"] = cli_job_config(remote_connection=cls.remote_connection,

--- a/test/integration/test_cli_runners.py
+++ b/test/integration/test_cli_runners.py
@@ -12,11 +12,9 @@ from galaxy_test.base.ssh_util import generate_ssh_keys
 from galaxy_test.driver import integration_util
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
 
-
 RemoteConnection = collections.namedtuple('remote_connection', ['hostname', 'username', 'port', 'private_key', 'public_key'])
 
 
-@integration_util.skip_unless_docker()
 def start_ssh_docker(container_name, jobs_directory, port=10022, image='agaveapi/slurm'):
     ssh_keys = generate_ssh_keys()
     START_SLURM_DOCKER = ['docker',
@@ -77,6 +75,7 @@ def cli_job_config(remote_connection, shell_plugin='ParamikoShell', job_plugin='
     return job_conf.name
 
 
+@integration_util.skip_unless_docker()
 class BaseCliIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
 
     @classmethod

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -37,6 +37,11 @@ class ContainerizedIntegrationTestCase(integration_util.IntegrationTestCase):
         skip_if_container_type_unavailable(cls)
         super(ContainerizedIntegrationTestCase, cls).setUpClass()
 
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = DOCKERIZED_JOB_CONFIG_FILE
+        disable_dependency_resolution(config)
+
 
 def disable_dependency_resolution(config):
     # Disable tool dependency resolution.

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -62,7 +62,6 @@ class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, Ru
     job_config_file = DOCKERIZED_JOB_CONFIG_FILE
     build_mulled_resolver = 'build_mulled'
     container_type = 'docker'
-    default_container_home_dir = '/'
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -106,7 +105,7 @@ class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, Ru
         assert job_env.pwd.endswith("/working")
         # Should we change env_pass_through to just always include TMP and HOME for docker?
         # I'm not sure, if yes this would change.
-        assert job_env.home == self.default_container_home_dir, job_env.home
+        assert not job_env.home.endswith('/home')
 
     def test_build_mulled(self):
         if not which('docker'):
@@ -175,5 +174,3 @@ class SingularityJobsIntegrationTestCase(DockerizedJobsIntegrationTestCase):
     job_config_file = SINGULARITY_JOB_CONFIG_FILE
     build_mulled_resolver = 'build_mulled_singularity'
     container_type = 'singularity'
-    # singularity passes $HOME by default
-    default_container_home_dir = os.environ.get('HOME', '/')

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -47,8 +47,7 @@ class InteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
         assert isinstance(jobs, list)
         assert len(jobs) == 1
         job0 = jobs[0]
-        entry_points = self.wait_on_entry_points_active(job0["id"])
-        assert len(entry_points) == 2
+        entry_points = self.wait_on_entry_points_active(job0["id"], expected_num=2)
         entry_point0 = entry_points[0]
         entry_point1 = entry_points[1]
         target0 = self.entry_point_target(entry_point0["id"])
@@ -59,19 +58,18 @@ class InteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
 
         content1 = self.wait_on_proxied_content(target1)
         assert content1 == "moo cow\n", content1
-        assert False
 
     def wait_on_proxied_content(self, target):
         def get_hosted_content():
             try:
                 scheme, rest = target.split("://", 1)
-                prefix, host_and_port = rest.split(".realtime.")
-                print(rest)
+                prefix, host_and_port = rest.split(".interactivetool.")
                 faked_host = rest
                 if "/" in rest:
                     faked_host = rest.split("/", 1)[0]
-                response = requests.get("%s://%s" % (scheme, host_and_port), timeout=1, headers={"Host": faked_host})
-                return response.content
+                url = "%s://%s" % (scheme, host_and_port)
+                response = requests.get(url, timeout=1, headers={"Host": faked_host})
+                return response.text
             except Exception as e:
                 print(e)
                 return None

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -184,7 +184,10 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         config_dir = self.config_dir
         path = os.path.join(config_dir, "galaxy.yml")
         self._test_driver.temp_directories.extend([config_dir])
+        config = self._raw_config
+        # Update config dict with database_connection, which might be set through env variables
+        config['database_connection'] = self._app.config.database_connection
         with open(path, "w") as f:
-            yaml.dump({"galaxy": self._raw_config}, f)
+            yaml.dump({"galaxy": config}, f)
 
         return path

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -178,7 +178,12 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         clean_env = {
             "PATH": os.environ.get("PATH", None),
         }  # Don't let testing environment variables interfere with config.
-        return unicodify(subprocess.check_output(cmd, cwd=cwd, env=clean_env))
+        try:
+            return unicodify(subprocess.check_output(cmd, cwd=cwd, env=clean_env))
+        except Exception as e:
+            if isinstance(e, subprocess.CalledProcessError):
+                raise Exception("%s\nOutput was:\n%s" % (unicodify(e), e.output))
+            raise
 
     def write_config_file(self):
         config_dir = self.config_dir

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -116,7 +116,6 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         output = self._scripts_check_output(script, ["-c", config_file])
         assert "Complete" in output
 
-    @integration_util.skip_if_jenkins
     def test_grt_export(self):
         script = "grt/export.py"
         self._scripts_check_argparse_help(script)
@@ -134,7 +133,7 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
         json_file = os.path.join(self.config_dir, json_files[0])
         with open(json_file, "r") as f:
             export = json.load(f)
-        assert export["version"] == 2
+        assert export["version"] == 3
 
     def test_admin_cleanup_datasets(self):
         self._scripts_check_argparse_help("cleanup_datasets/admin_cleanup_datasets.py")

--- a/test/unit/test_remote_shell.py
+++ b/test/unit/test_remote_shell.py
@@ -23,6 +23,7 @@ class TestCliInterface(unittest.TestCase):
         cls.username = 'testuser'
         cls.shell_params = {'username': cls.username,
                             'private_key': cls.ssh_keys.private_key_file,
+                            'strict_host_key_checking': False,
                             'hostname': 'localhost'}
         cls.cli_interface = CliInterface()
 

--- a/test/unit/tools/test_watcher.py
+++ b/test/unit/tools/test_watcher.py
@@ -16,15 +16,17 @@ def test_watcher():
     with __test_directory() as t:
         tool_path = path.join(t, "test.xml")
         toolbox = Toolbox()
-        open(tool_path, "w").write("a")
+        with open(tool_path, "w") as f:
+            f.write("a")
         tool_watcher = watcher.get_tool_watcher(toolbox, bunch.Bunch(
             watch_tools=True
         ))
         tool_watcher.start()
-        time.sleep(1)
         tool_watcher.watch_file(tool_path, "cool_tool")
+        time.sleep(2)
         assert not toolbox.was_reloaded("cool_tool")
-        open(tool_path, "w").write("b")
+        with open(tool_path, "w") as f:
+            f.write("b")
         wait_for_reload(lambda: toolbox.was_reloaded("cool_tool"))
         tool_watcher.shutdown()
         assert tool_watcher.observer is None
@@ -41,10 +43,12 @@ def test_tool_conf_watcher():
 
     with __test_directory() as t:
         tool_conf_path = path.join(t, "test_conf.xml")
-        open(tool_conf_path, "w").write("a")
+        with open(tool_conf_path, "w", 1) as t:
+            t.write("a")
         conf_watcher.watch_file(tool_conf_path)
-        time.sleep(1)
-        open(tool_conf_path, "w").write("b")
+        time.sleep(2)
+        with open(tool_conf_path, 'wb', 0) as t:
+            t.write(b"b")
         wait_for_reload(lambda: callback.called)
         conf_watcher.shutdown()
         assert conf_watcher.thread is None


### PR DESCRIPTION
We didn't run any of the tests that need docker on Jenkins (since the tests already run in docker).
This fixes:
  - Interactive tools on python 3
  - ssh/paramiko based tests and host key policy (they only worked on OSX)
  - Updates mulled_build API tests for new API
  - Fixes any_target_requires_extended_base logic
  - Many testing framework fixes

The only integration tests we still skip is test_kubernetes_staging.py ... for this we would need a means to spin up a local checkout of Galaxy in k8s. I'm hoping we can do this with galaxy-k8s in the future.