### PR TITLE
Allow mixed store_by objectstore configurations.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -773,7 +773,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             markdown_export_css=[self._in_config_dir('markdown_export.css')],
             markdown_export_css_pages=[self._in_config_dir('markdown_export_pages.css')],
             markdown_export_css_invocation_reports=[self._in_config_dir('markdown_export_invocation_reports.css')],
-            file_path=[self._in_data_dir('files'), self._in_data_dir('objects')],
+            # self.file_path set to self._in_data_dir('objects') by schema
+            file_path=[self._in_data_dir('files'), self.file_path],
         )
         listify_defaults = {
             'tool_data_table_config_path': [

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -403,8 +403,7 @@ class Data(object):
             return smart_str(data)
         if filename and filename != "index":
             # For files in extra_files_path
-            store_by = data.dataset.object_store.store_by
-            extra_dir = 'dataset_%s_files' % getattr(data.dataset, store_by)
+            extra_dir = data.dataset.extra_files_path_name
             file_path = trans.app.object_store.get_filename(data.dataset, extra_dir=extra_dir, alt_name=filename)
             if os.path.exists(file_path):
                 if os.path.isdir(file_path):

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -593,8 +593,7 @@ def default_exit_code_file(files_dir, id_tag):
 
 
 def collect_extra_files(object_store, dataset, job_working_directory):
-    store_by = getattr(object_store, "store_by", "id")
-    file_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
+    file_name = dataset.dataset.extra_files_path_name_from(object_store)
     temp_file_path = os.path.join(job_working_directory, "working", file_name)
     extra_dir = None
     try:

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -144,9 +144,11 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
 
             _initialize_metadata_inputs(dataset, _metadata_path, tmp_dir, kwds, real_metadata_object=real_metadata_object)
 
+            store_by = galaxy.model.Dataset.object_store.store_by  # TODO: per dataset
             outputs[name] = {
                 "filename_override": _get_filename_override(output_fnames, dataset.file_name),
                 "validate": validate_outputs,
+                "object_store_store_by": store_by,
                 'id': dataset.id,
             }
 
@@ -158,7 +160,6 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
             "datatypes_config": datatypes_config,
             "max_metadata_value_size": max_metadata_value_size,
             "outputs": outputs,
-            "object_store_store_by": galaxy.model.Dataset.object_store.store_by,
         }
 
         if self.write_object_store_conf:

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -144,11 +144,10 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
 
             _initialize_metadata_inputs(dataset, _metadata_path, tmp_dir, kwds, real_metadata_object=real_metadata_object)
 
-            store_by = galaxy.model.Dataset.object_store.store_by  # TODO: per dataset
             outputs[name] = {
                 "filename_override": _get_filename_override(output_fnames, dataset.file_name),
                 "validate": validate_outputs,
-                "object_store_store_by": store_by,
+                "object_store_store_by": dataset.dataset.store_by,
                 'id': dataset.id,
             }
 

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -190,12 +190,14 @@ def set_metadata_portable():
         filename_results_code = os.path.join("metadata/metadata_results_%s" % output_name)
         override_metadata = os.path.join("metadata/metadata_override_%s" % output_name)
         dataset_filename_override = output_dict["filename_override"]
+        # pre-20.05 this was a per job parameter and not a per dataset parameter, drop in 21.XX
+        legacy_object_store_store_by = metadata_params.get("object_store_store_by", "id")
 
         # Same block as below...
         set_meta_kwds = stringify_dictionary_keys(json.load(open(filename_kwds)))  # load kwds; need to ensure our keywords are not unicode
         try:
             dataset.dataset.external_filename = dataset_filename_override
-            store_by = metadata_params.get("object_store_store_by", "id")
+            store_by = output_dict.get("object_store_store_by", legacy_object_store_store_by)
             extra_files_dir_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
             files_path = os.path.abspath(os.path.join(tool_job_working_directory, "working", extra_files_dir_name))
             dataset.dataset.external_extra_files_path = files_path
@@ -337,7 +339,7 @@ def set_metadata_legacy():
         try:
             dataset = cPickle.load(open(filename_in, 'rb'))  # load DatasetInstance
             dataset.dataset.external_filename = dataset_filename_override
-            store_by = set_meta_kwds.get("object_store_store_by", "id")
+            store_by = "id"
             extra_files_dir_name = "dataset_%s_files" % getattr(dataset.dataset, store_by)
             files_path = os.path.abspath(os.path.join(tool_job_working_directory, "working", extra_files_dir_name))
             dataset.dataset.external_extra_files_path = files_path

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2254,10 +2254,17 @@ class Dataset(StorableObject, RepresentById):
     def extra_files_path_exists(self):
         return self.object_store.exists(self, extra_dir=self._extra_files_rel_path, dir_only=True)
 
+    def extra_files_path_name_from(self, object_store):
+        store_by = getattr(object_store, "store_by", "id")
+        return "dataset_%s_files" % getattr(self, store_by)
+
+    @property
+    def extra_files_path_name(self):
+        return self.extra_files_path_name_from(self.object_store)
+
     @property
     def _extra_files_rel_path(self):
-        store_by = getattr(self.object_store, "store_by", "id")
-        return self._extra_files_path or "dataset_%s_files" % getattr(self, store_by)
+        return self._extra_files_path or self.extra_files_path_name
 
     def _calculate_size(self):
         if self.external_filename:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -327,8 +327,7 @@ class ModelImportStore(object):
                         # Import additional files if present. Histories exported previously might not have this attribute set.
                         dataset_extra_files_path = dataset_attrs.get('extra_files_path', None)
                         if dataset_extra_files_path:
-                            store_by = self.object_store.store_by
-                            dir_name = 'dataset_%s_files' % getattr(dataset_instance.dataset, store_by)
+                            dir_name = dataset_instance.dataset.extra_files_path_name
                             dataset_extra_files_path = os.path.join(self.archive_dir, dataset_extra_files_path)
                             for root, dirs, files in safe_walk(dataset_extra_files_path):
                                 extra_dir = os.path.join(dir_name, root.replace(dataset_extra_files_path, '', 1).lstrip(os.path.sep))

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -98,8 +98,6 @@ class ObjectStore(object):
         self.running = True
         self.config = config
         self.check_old_style = config.object_store_check_old_style
-        self.store_by = config_dict.get("store_by", None) or getattr(config, "object_store_store_by", "id")
-        assert self.store_by in ["id", "uuid"]
         extra_dirs = {}
         extra_dirs['job_work'] = config.jobs_directory
         extra_dirs['temp'] = config.new_file_path
@@ -212,6 +210,13 @@ class ObjectStore(object):
         """Return the percentage indicating how full the store is."""
         raise NotImplementedError()
 
+    def get_store_by(self, obj):
+        """Return how object is stored (by 'uuid', 'id', or None if not yet saved).
+
+        Certain Galaxy remote data features aren't available if objects are stored by 'id'.
+        """
+        raise NotImplementedError()
+
     @classmethod
     def parse_xml(clazz, config_xml):
         """Parse an XML description of a configuration for this object store.
@@ -233,7 +238,6 @@ class ObjectStore(object):
         return {
             'config': config_to_dict(self.config),
             'extra_dirs': extra_dirs,
-            'store_by': self.store_by,
             'type': self.store_type,
         }
 
@@ -246,7 +250,39 @@ class ObjectStore(object):
             return obj.id
 
 
-class DiskObjectStore(ObjectStore):
+class ConcreteObjectStore(ObjectStore):
+    """Subclass of ObjectStore for stores that don't delegate (non-nested).
+
+    Currently only adds store_by functionality. Which doesn't make
+    sense for the delegating object stores.
+    """
+
+    def __init__(self, config, config_dict={}, **kwargs):
+        """
+        :type config: object
+        :param config: An object, most likely populated from
+            `galaxy/config.ini`, having the following attributes:
+
+            * object_store_check_old_style (only used by the
+              :class:`DiskObjectStore` subclass)
+            * jobs_directory -- Each job is given a unique empty directory
+              as its current working directory. This option defines in what
+              parent directory those directories will be created.
+            * new_file_path -- Used to set the 'temp' extra_dir.
+        """
+        super(ConcreteObjectStore, self).__init__(config=config, config_dict=config_dict, **kwargs)
+        self.store_by = config_dict.get("store_by", None) or getattr(config, "object_store_store_by", "id")
+
+    def to_dict(self):
+        rval = super(ConcreteObjectStore, self).to_dict()
+        rval["store_by"] = self.store_by
+        return rval
+
+    def get_store_by(self, obj):
+        return self.store_by
+
+
+class DiskObjectStore(ConcreteObjectStore):
     """
     Standard Galaxy object store.
 
@@ -288,6 +324,9 @@ class DiskObjectStore(ObjectStore):
         extra_dirs = []
         config_dict = {}
         if config_xml is not None:
+            store_by = config_xml.attrib.get('store_by', None)
+            if store_by is not None:
+                config_dict['store_by'] = store_by
             for e in config_xml:
                 if e.tag == 'files_dir':
                     config_dict["files_dir"] = e.get('path')
@@ -569,6 +608,9 @@ class NestedObjectStore(ObjectStore):
         """For the first backend that has this `obj`, get its URL."""
         return self._call_method('get_object_url', obj, None, False, **kwargs)
 
+    def get_store_by(self, obj):
+        return self._call_method('get_store_by', obj, None, False)
+
     def _repr_object_for_exception(self, obj):
         try:
             # there are a few objects in python that don't have __class__
@@ -632,7 +674,10 @@ class DistributedObjectStore(NestedObjectStore):
             extra_dirs = backend_def.get("extra_dirs", [])
             maxpctfull = backend_def.get("max_percent_full", 0)
             weight = backend_def["weight"]
+            store_by = backend_def.get("store_by")
             disk_config_dict = dict(files_dir=file_path, extra_dirs=extra_dirs)
+            if store_by is not None:
+                disk_config_dict['store_by'] = store_by
             self.backends[backened_id] = DiskObjectStore(config, disk_config_dict)
             self.max_percent_full[backened_id] = maxpctfull
             log.debug("Loaded disk backend '%s' with weight %s and file_path: %s" % (backened_id, weight, file_path))
@@ -670,7 +715,7 @@ class DistributedObjectStore(NestedObjectStore):
             weight = int(elem.get('weight', 1))
             maxpctfull = float(elem.get('maxpctfull', 0))
             elem_type = elem.get('type', 'disk')
-
+            store_by = elem.get('store_by', None)
             if elem_type:
                 path = None
                 extra_dirs = []
@@ -689,6 +734,8 @@ class DistributedObjectStore(NestedObjectStore):
                     'extra_dirs': extra_dirs,
                     'type': elem_type,
                 }
+                if store_by is not None:
+                    backend_dict['store_by'] = store_by
                 backends.append(backend_dict)
 
         return config_dict

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -28,8 +28,8 @@ from galaxy.util import (
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
 from ..objectstore import (
+    ConcreteObjectStore,
     convert_bytes,
-    ObjectStore
 )
 
 NO_BLOBSERVICE_ERROR_MESSAGE = ("ObjectStore configured, but no azure.storage.blob dependency available."
@@ -81,7 +81,7 @@ def parse_config_xml(config_xml):
         raise
 
 
-class AzureBlobObjectStore(ObjectStore):
+class AzureBlobObjectStore(ConcreteObjectStore):
     """
     Object store that stores objects as blobs in an Azure Blob Container. A local
     cache exists that is used as an intermediate location for files between

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -20,7 +20,7 @@ from galaxy.util import (
 )
 from galaxy.util.sleeper import Sleeper
 from .s3 import parse_config_xml
-from ..objectstore import convert_bytes, ObjectStore
+from ..objectstore import ConcreteObjectStore, convert_bytes
 try:
     from cloudbridge.factory import CloudProviderFactory, ProviderList
     from cloudbridge.interfaces.exceptions import InvalidNameException
@@ -60,7 +60,7 @@ class CloudConfigMixin(object):
         }
 
 
-class Cloud(ObjectStore, CloudConfigMixin):
+class Cloud(ConcreteObjectStore, CloudConfigMixin):
     """
     Object store that stores objects as items in an cloud storage. A local
     cache exists that is used as an intermediate location for files between

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -26,7 +26,7 @@ from galaxy.util import (
     umask_fix_perms,
 )
 from galaxy.util.path import safe_relpath
-from ..objectstore import ObjectStore
+from ..objectstore import ConcreteObjectStore
 
 NO_KAMAKI_ERROR_MESSAGE = (
     "ObjectStore configured, but no kamaki.clients dependency available."
@@ -79,7 +79,7 @@ def parse_config_xml(config_xml):
     return r
 
 
-class PithosObjectStore(ObjectStore):
+class PithosObjectStore(ConcreteObjectStore):
     """
     Object store that stores objects as items in a Pithos+ container.
     Cache is ignored for the time being.

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -29,7 +29,7 @@ from galaxy.util import (
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
 from .s3_multipart_upload import multipart_upload
-from ..objectstore import convert_bytes, ObjectStore
+from ..objectstore import ConcreteObjectStore, convert_bytes
 
 NO_BOTO_ERROR_MESSAGE = ("S3/Swift object store configured, but no boto dependency available."
                          "Please install and properly configure boto or modify object store configuration.")
@@ -129,7 +129,7 @@ class CloudConfigMixin(object):
         }
 
 
-class S3ObjectStore(ObjectStore, CloudConfigMixin):
+class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
     """
     Object store that stores objects as items in an AWS S3 bucket. A local
     cache exists that is used as an intermediate location for files between

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -349,8 +349,7 @@ class ToolEvaluator(object):
             # TODO: move compute path logic into compute environment, move setting files_path
             # logic into DatasetFilenameWrapper. Currently this sits in the middle and glues
             # stuff together inconsistently with the way the rest of path rewriting works.
-            store_by = getattr(hda.dataset.object_store, "store_by", "id")
-            file_name = "dataset_%s_files" % getattr(hda.dataset, store_by)
+            file_name = hda.dataset.extra_files_path_name
             param_dict[name].files_path = os.path.abspath(os.path.join(job_working_directory, "working", file_name))
         for out_name, output in self.tool.outputs.items():
             if out_name not in param_dict and output.filters:

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -398,12 +398,10 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         rval = ''
         try:
             hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
-
             if raw:
                 if filename and filename != 'index':
                     object_store = trans.app.object_store
-                    store_by = getattr(object_store, "store_by", "id")
-                    dir_name = 'dataset_%s_files' % getattr(hda.dataset, store_by)
+                    dir_name = hda.dataset.extra_files_path_name
                     file_path = object_store.get_filename(hda.dataset,
                                                           extra_dir=dir_name,
                                                           alt_name=filename)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -181,7 +181,7 @@ mapping:
 
       file_path:
         type: str
-        default: files
+        default: objects
         path_resolves_to: data_dir
         required: false
         desc: |
@@ -802,11 +802,12 @@ mapping:
 
       object_store_store_by:
         type: str
-        default: id
         required: false
         desc: |
           What Dataset attribute is used to reference files in an ObjectStore implementation,
-          default is 'id' but can also be set to 'uuid' for more de-centralized usage.
+          this can be 'uuid' or 'id'. The default will depend on how the object store is configured,
+          starting with 20.05 Galaxy will try to default to 'uuid' if it can be sure this
+          is a new Galaxy instance - but the default will be 'id' in many cases.
 
       smtp_server:
         type: str

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -30,3 +30,7 @@ class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
     def setUp(self):
         super(BaseObjectStoreIntegrationTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+
+def files_count(directory):
+    return sum(len(files) for _, _, files in os.walk(directory))

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -1,0 +1,32 @@
+import os
+import re
+
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+)
+from galaxy_test.driver import integration_util
+
+
+class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def _configure_object_store(cls, template, config):
+        temp_directory = cls._test_driver.mkdtemp()
+        cls.object_stores_parent = temp_directory
+        config_path = os.path.join(temp_directory, "object_store_conf.xml")
+        xml = template.safe_substitute({"temp_directory": temp_directory})
+        with open(config_path, "w") as f:
+            f.write(xml)
+        config["object_store_config_file"] = config_path
+        for path in re.findall(r'files_dir path="([^"]*)"', xml):
+            assert path.startswith(temp_directory)
+            dir_name = os.path.basename(path)
+            os.path.join(temp_directory, dir_name)
+            os.makedirs(path)
+            setattr(cls, "%s_path" % dir_name, path)
+
+    def setUp(self):
+        super(BaseObjectStoreIntegrationTestCase, self).setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/objectstore/test_jobs.py
+++ b/test/integration/objectstore/test_jobs.py
@@ -3,7 +3,7 @@
 import os
 import string
 
-from ._base import BaseObjectStoreIntegrationTestCase
+from ._base import BaseObjectStoreIntegrationTestCase, files_count
 
 DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0"?>
 <object_store type="hierarchical">
@@ -75,9 +75,9 @@ class ObjectStoreJobsIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
         `secondary/files3`, assuming it will not fail persisting
         data in `primary` backend.
         """
-        files_1_count = _files_count(self.files1_path)
-        files_2_count = _files_count(self.files2_path)
-        files_3_count = _files_count(self.files3_path)
+        files_1_count = files_count(self.files1_path)
+        files_2_count = files_count(self.files2_path)
+        files_3_count = files_count(self.files3_path)
 
         # Ensure no files written to the secondary/inactive hierarchical disk store.
         assert files_3_count == 0
@@ -106,10 +106,6 @@ class ObjectStoreJobsIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
 
         for expected_content in range(1, 10):
             assert str(expected_content) in contents
-
-
-def _files_count(directory):
-    return sum(len(files) for _, _, files in os.walk(directory))
 
 
 def _get_datasets_files_in_path(directory):

--- a/test/integration/objectstore/test_jobs.py
+++ b/test/integration/objectstore/test_jobs.py
@@ -3,10 +3,7 @@
 import os
 import string
 
-from galaxy_test.base.populators import (
-    DatasetPopulator,
-)
-from galaxy_test.driver import integration_util
+from ._base import BaseObjectStoreIntegrationTestCase
 
 DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0"?>
 <object_store type="hierarchical">
@@ -37,26 +34,14 @@ DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0
 TEST_INPUT_FILES_CONTENT = "1 2 3"
 
 
-class ObjectStoreJobsIntegrationTestCase(integration_util.IntegrationTestCase):
-
-    framework_tool_and_types = True
+class ObjectStoreJobsIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        temp_directory = cls._test_driver.mkdtemp()
-        cls.object_stores_parent = temp_directory
-        for disk_store_file_name in ["files1", "files2", "files3"]:
-            disk_store_path = os.path.join(temp_directory, disk_store_file_name)
-            os.makedirs(disk_store_path)
-            setattr(cls, "%s_path" % disk_store_file_name, disk_store_path)
-        config_path = os.path.join(temp_directory, "object_store_conf.xml")
-        with open(config_path, "w") as f:
-            f.write(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE.safe_substitute({"temp_directory": temp_directory}))
-        config["object_store_config_file"] = config_path
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
 
     def setUp(self):
         super(ObjectStoreJobsIntegrationTestCase, self).setUp()
-        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         with self.dataset_populator.test_history() as history_id:
             hda1 = self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_FILES_CONTENT)
             create_10_inputs = {

--- a/test/integration/objectstore/test_mixed_store_by.py
+++ b/test/integration/objectstore/test_mixed_store_by.py
@@ -1,0 +1,71 @@
+"""Integration tests for mixing store_by."""
+
+import os
+import re
+import string
+
+from galaxy.util import is_uuid
+from ._base import BaseObjectStoreIntegrationTestCase, files_count
+
+DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0"?>
+<object_store type="distributed" id="primary" order="0">
+    <backends>
+        <backend id="files1" type="disk" weight="1" store_by="uuid">
+            <files_dir path="${temp_directory}/files1"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+        </backend>
+        <backend id="files2" type="disk" weight="1" store_by="id">
+            <files_dir path="${temp_directory}/files2"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp2"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory2"/>
+        </backend>
+    </backends>
+</object_store>
+""")
+
+TEST_INPUT_FILES_CONTENT = "1 2 3"
+
+
+class MixedStoreByObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        """Test each object store configures files correctly.
+        """
+        i = 0
+        with self.dataset_populator.test_history() as history_id:
+            # Loop breaks once each object store has at least once file of each type.
+            while True:
+                hda = self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True)
+                content = self.dataset_populator.get_history_dataset_content(history_id, hda["id"])
+                assert content.strip() == TEST_INPUT_FILES_CONTENT
+                files1_count = files_count(self.files1_path)
+                files2_count = files_count(self.files2_path)
+                if files1_count and files2_count:
+                    break
+                i += 1
+                if i > 50:
+                    raise Exception("Problem with logic of test, randomly each object store should have at least one file by now")
+
+            def strip_to_id(x):
+                return re.match(r'dataset_(.*)\.dat', os.path.basename(x)).group(1)
+
+            files1_paths = [strip_to_id(p) for p in _get_datasets_files_in_path(self.files1_path)]
+            files2_paths = [strip_to_id(p) for p in _get_datasets_files_in_path(self.files2_path)]
+            for files1_path in files1_paths:
+                assert is_uuid(files1_path)
+            for files2_path in files2_paths:
+                assert files2_path.isdigit()
+
+
+def _get_datasets_files_in_path(directory):
+    files = []
+    for path, _, filename in os.walk(directory):
+        for f in filename:
+            if f.endswith(".dat"):
+                files.append(os.path.join(path, f))
+    return files

--- a/test/integration/objectstore/test_selection.py
+++ b/test/integration/objectstore/test_selection.py
@@ -3,7 +3,7 @@
 import os
 import string
 
-from ._base import BaseObjectStoreIntegrationTestCase
+from ._base import BaseObjectStoreIntegrationTestCase, files_count
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "selection_job_conf.xml")
@@ -46,16 +46,16 @@ class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         config["job_resource_params_file"] = JOB_RESOURCE_PARAMETERS_CONFIG_FILE
 
     def _object_store_counts(self):
-        files_default_count = _files_count(self.files_default_path)
-        files_static_count = _files_count(self.files_static_path)
-        files_dynamic_count = _files_count(self.files_dynamic_path)
+        files_default_count = files_count(self.files_default_path)
+        files_static_count = files_count(self.files_static_path)
+        files_dynamic_count = files_count(self.files_dynamic_path)
         return files_default_count, files_static_count, files_dynamic_count
 
     def _assert_file_counts(self, default, static, dynamic_ebs, dynamic_s3):
-        files_default_count = _files_count(self.files_default_path)
-        files_static_count = _files_count(self.files_static_path)
-        files_dynamic_ebs_count = _files_count(self.files_dynamic_ebs_path)
-        files_dynamic_s3_count = _files_count(self.files_dynamic_s3_path)
+        files_default_count = files_count(self.files_default_path)
+        files_static_count = files_count(self.files_static_path)
+        files_dynamic_ebs_count = files_count(self.files_dynamic_ebs_path)
+        files_dynamic_s3_count = files_count(self.files_dynamic_s3_path)
         assert default == files_default_count
         assert static == files_static_count
         assert dynamic_ebs == files_dynamic_ebs_count
@@ -103,7 +103,3 @@ class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase
             }
             _run_tool("create_10", create_10_inputs)
             self._assert_file_counts(1, 2, 10, 10)
-
-
-def _files_count(directory):
-    return sum(len(files) for _, _, files in os.walk(directory))

--- a/test/integration/objectstore/test_selection.py
+++ b/test/integration/objectstore/test_selection.py
@@ -3,10 +3,7 @@
 import os
 import string
 
-from galaxy_test.base.populators import (
-    DatasetPopulator,
-)
-from galaxy_test.driver import integration_util
+from ._base import BaseObjectStoreIntegrationTestCase
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "selection_job_conf.xml")
@@ -40,28 +37,13 @@ DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0
 """)
 
 
-class ObjectStoreJobsIntegrationTestCase(integration_util.IntegrationTestCase):
-
-    framework_tool_and_types = True
+class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        temp_directory = cls._test_driver.mkdtemp()
-        cls.object_stores_parent = temp_directory
-        for disk_store_file_name in ["files_default", "files_static", "files_dynamic_ebs", "files_dynamic_s3"]:
-            disk_store_path = os.path.join(temp_directory, disk_store_file_name)
-            os.makedirs(disk_store_path)
-            setattr(cls, "%s_path" % disk_store_file_name, disk_store_path)
-        config_path = os.path.join(temp_directory, "object_store_conf.xml")
-        with open(config_path, "w") as f:
-            f.write(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE.safe_substitute({"temp_directory": temp_directory}))
-        config["object_store_config_file"] = config_path
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
         config["job_config_file"] = JOB_CONFIG_FILE
         config["job_resource_params_file"] = JOB_RESOURCE_PARAMETERS_CONFIG_FILE
-
-    def setUp(self):
-        super(ObjectStoreJobsIntegrationTestCase, self).setUp()
-        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
     def _object_store_counts(self):
         files_default_count = _files_count(self.files_default_path)

--- a/test/unit/test_galaxy_mapping.py
+++ b/test/unit/test_galaxy_mapping.py
@@ -603,6 +603,9 @@ class MockObjectStore(object):
     def get_filename(self, *args, **kwds):
         return "dataest_14.dat"
 
+    def get_store_by(self, *args, **kwds):
+        return 'id'
+
 
 def get_suite():
     suite = unittest.TestSuite()

--- a/test/unit/test_objectstore.py
+++ b/test/unit/test_objectstore.py
@@ -200,6 +200,23 @@ def test_disk_store_alt_name_abspath():
             pass
 
 
+MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
+<object_store type="hierarchical">
+    <backends>
+        <backend id="files1" type="disk" weight="1" order="0" store_by="id">
+            <files_dir path="${temp_directory}/files1"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+        </backend>
+        <backend id="files2" type="disk" weight="1" order="1" store_by="uuid">
+            <files_dir path="${temp_directory}/files2"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp2"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory2"/>
+        </backend>
+    </backends>
+</object_store>
+"""
+
 HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
 <object_store type="hierarchical">
     <backends>
@@ -216,7 +233,6 @@ HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
     </backends>
 </object_store>
 """
-
 
 HIERARCHICAL_TEST_CONFIG_YAML = """
 type: hierarchical
@@ -269,6 +285,13 @@ def test_hierarchical_store():
             as_dict = object_store.to_dict()
             _assert_has_keys(as_dict, ["backends", "extra_dirs", "type"])
             _assert_key_has_value(as_dict, "type", "hierarchical")
+
+
+def test_mixed_store_by():
+    with TestConfig(MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
+        as_dict = object_store.to_dict()
+        assert as_dict["backends"][0]["store_by"] == "id"
+        assert as_dict["backends"][1]["store_by"] == "uuid"
 
 
 DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>


### PR DESCRIPTION
Allow a single Galaxy instance to store data both ways (both by UUID and by ID) - this should allow evolving toward remote extended metadata for existing big instances (main, EU, etc..). 

xref 
- https://github.com/galaxyproject/galaxy/pull/7154 (original PR adding storing by UUID)
- https://github.com/galaxyproject/galaxy/pull/7650 (followup PR fixing a bunch of edgier stuff)