### PR TITLE
[19.09] Fix jobs stuck in preparing state when dynamic rules raise arbitrary exceptions

### DIFF
--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -15,6 +15,7 @@ DYNAMIC_DESTINATION_ID = "dynamic_legacy_from_url"
 
 ERROR_MESSAGE_NO_RULE_FUNCTION = "Galaxy misconfigured - cannot find dynamic rule function name for destination %s."
 ERROR_MESSAGE_RULE_FUNCTION_NOT_FOUND = "Galaxy misconfigured - no rule function named %s found in dynamic rule modules."
+ERROR_MESSAGE_RULE_EXCEPTION = "Galaxy misconfigured - encountered an unhandled exception while caching dynamic rule."
 
 
 class JobMappingException(Exception):
@@ -225,8 +226,11 @@ class JobRunnerMapper(object):
         return job_destination
 
     def __cache_job_destination(self, params, raw_job_destination=None):
-        self.cached_job_destination = self.__determine_job_destination(
-            params, raw_job_destination=raw_job_destination)
+        try:
+            self.cached_job_destination = self.__determine_job_destination(params, raw_job_destination=raw_job_destination)
+        except Exception:
+            log.exception("Caught unhandled exception while attempting to cache job destination:")
+            raise JobMappingException(ERROR_MESSAGE_RULE_EXCEPTION)
         return self.cached_job_destination
 
     def get_job_destination(self, params):

--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -228,6 +228,8 @@ class JobRunnerMapper(object):
     def __cache_job_destination(self, params, raw_job_destination=None):
         try:
             self.cached_job_destination = self.__determine_job_destination(params, raw_job_destination=raw_job_destination)
+        except (JobMappingException, JobNotReadyException):
+            raise
         except Exception:
             log.exception("Caught unhandled exception while attempting to cache job destination:")
             raise JobMappingException(ERROR_MESSAGE_RULE_EXCEPTION)

--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -15,7 +15,11 @@ DYNAMIC_DESTINATION_ID = "dynamic_legacy_from_url"
 
 ERROR_MESSAGE_NO_RULE_FUNCTION = "Galaxy misconfigured - cannot find dynamic rule function name for destination %s."
 ERROR_MESSAGE_RULE_FUNCTION_NOT_FOUND = "Galaxy misconfigured - no rule function named %s found in dynamic rule modules."
-ERROR_MESSAGE_RULE_EXCEPTION = "Galaxy misconfigured - encountered an unhandled exception while caching dynamic rule."
+ERROR_MESSAGE_RULE_EXCEPTION = "Encountered an unhandled exception while caching job destination dynamic rule."
+
+
+class JobMappingConfigurationException(Exception):
+    pass
 
 
 class JobMappingException(Exception):
@@ -158,12 +162,12 @@ class JobRunnerMapper(object):
                 rule_modules, expand_function_name)
             if not expand_function:
                 message = ERROR_MESSAGE_RULE_FUNCTION_NOT_FOUND % expand_function_name
-                raise Exception(message)
+                raise JobMappingConfigurationException(message)
         else:
             expand_function = self.__find_function_by_tool_id(rule_modules)
             if not expand_function:
                 message = ERROR_MESSAGE_NO_RULE_FUNCTION % destination
-                raise Exception(message)
+                raise JobMappingConfigurationException(message)
         return expand_function
 
     def __get_rule_modules_or_defaults(self, rules_module_name):
@@ -193,7 +197,7 @@ class JobRunnerMapper(object):
         elif expand_type in STOCK_RULES:
             expand_function = STOCK_RULES[expand_type]
         else:
-            raise Exception("Unhandled dynamic job runner type specified - %s" % expand_type)
+            raise JobMappingConfigurationException("Unhandled dynamic job runner type specified - %s" % expand_type)
 
         return self.__handle_rule(expand_function, destination)
 
@@ -228,7 +232,7 @@ class JobRunnerMapper(object):
     def __cache_job_destination(self, params, raw_job_destination=None):
         try:
             self.cached_job_destination = self.__determine_job_destination(params, raw_job_destination=raw_job_destination)
-        except (JobMappingException, JobNotReadyException):
+        except (JobMappingConfigurationException, JobMappingException, JobNotReadyException):
             raise
         except Exception:
             log.exception("Caught unhandled exception while attempting to cache job destination:")

--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -235,6 +235,8 @@ class JobRunnerMapper(object):
         except (JobMappingConfigurationException, JobMappingException, JobNotReadyException):
             raise
         except Exception:
+            # Other exceptions should not bubble up to the job wrapper since they can occur during the fail() method,
+            # causing jobs to become permanently stuck in a non-terminal state.
             log.exception("Caught unhandled exception while attempting to cache job destination:")
             raise JobMappingException(ERROR_MESSAGE_RULE_EXCEPTION)
         return self.cached_job_destination


### PR DESCRIPTION
Related to #7786 but exceptions raised by dynamic rules and not caught in the rule (and re-raised as a `JobMappingException`) were bubbling up and therefore not being caught by that fix. This resulted in an infinite loop of attempting to prepare, then fail (and failing to fail) such jobs.

E.g., while preparing to run:

```pytb
galaxy.jobs.handler ERROR 2020-01-09 09:46:26,355 Failed to generate job destination
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/handler.py", line 534, in __verify_job_ready
    job_destination = job_wrapper.job_destination
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/__init__.py", line 992, in job_destination
    return self.job_runner_mapper.get_job_destination(self.params)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 239, in get_job_destination
    return self.__cache_job_destination(params)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 229, in __cache_job_destination
    params, raw_job_destination=raw_job_destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 217, in __determine_job_destination
    job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 197, in __handle_dynamic_job_destination
    return self.__handle_rule(expand_function, destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 200, in __handle_rule
    job_destination = self.__invoke_expand_function(rule_function, destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 116, in __invoke_expand_function
    return expand_function(**actual_args)
  File "/srv/galaxy/main/dynamic_rules/usegalaxy/jobs/rules/nvc_dynamic_memory.py", line 37, in dynamic_nvc_dynamic_memory
    array_bytes = guess_array_memory_usage( bam_readers, dtype, use_strand=use_strand )
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/pyBamTools/util/__init__.py", line 94, in guess_array_memory_usage
    if dtypes[i] is not None:
IndexError: list index out of range
```

While attempting to fail due to that exception:

```pytb
galaxy.jobs.handler ERROR 2020-01-09 09:46:28,861 failure running job 26245024
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/handler.py", line 375, in __handle_waiting_jobs
    job_state = self.__check_job_state(job)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/handler.py", line 513, in __check_job_state
    state, job_destination = self.__verify_job_ready(job, job_wrapper)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/handler.py", line 548, in __verify_job_ready
    job_wrapper.fail(failure_message)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/__init__.py", line 1202, in fail
    self.job_destination
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/__init__.py", line 992, in job_destination
    return self.job_runner_mapper.get_job_destination(self.params)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 239, in get_job_destination
    return self.__cache_job_destination(params)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 229, in __cache_job_destination
    params, raw_job_destination=raw_job_destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 217, in __determine_job_destination
    job_destination = self.__handle_dynamic_job_destination(raw_job_destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 197, in __handle_dynamic_job_destination
    return self.__handle_rule(expand_function, destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 200, in __handle_rule
    job_destination = self.__invoke_expand_function(rule_function, destination)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/mapper.py", line 116, in __invoke_expand_function
    return expand_function(**actual_args)
  File "/srv/galaxy/main/dynamic_rules/usegalaxy/jobs/rules/nvc_dynamic_memory.py", line 37, in dynamic_nvc_dynamic_memory
    array_bytes = guess_array_memory_usage( bam_readers, dtype, use_strand=use_strand )
  File "/cvmfs/main.galaxyproject.org/venv/lib/python2.7/site-packages/pyBamTools/util/__init__.py", line 94, in guess_array_memory_usage
    if dtypes[i] is not None:
IndexError: list index out of range
```