### PR TITLE
[20.01] Add base_image column to mulled-build-files

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -175,9 +175,11 @@ def mull_targets(
     repository_template=DEFAULT_REPOSITORY_TEMPLATE, dry_run=False,
     conda_version=None, verbose=False, binds=DEFAULT_BINDS, rebuild=True,
     oauth_token=None, hash_func="v2", singularity=False,
-    singularity_image_dir="singularity_import",
+    singularity_image_dir="singularity_import", base_image=None,
 ):
-    if DEST_BASE_IMAGE:
+    if base_image:
+        dest_base_image = base_image
+    elif DEST_BASE_IMAGE:
         dest_base_image = DEST_BASE_IMAGE
     else:
         dest_base_image = DEFAULT_EXTENDED_BASE_IMAGE if any_target_requires_extended_base(targets) else DEST_BASE_IMAGE

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_files.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_files.py
@@ -25,6 +25,8 @@ from .mulled_build import (
     mull_targets,
     target_str_to_targets,
 )
+KNOWN_FIELDS = ["targets", "image_build", "name_override", "base_image"]
+FALLBACK_LINE_TUPLE = collections.namedtuple("_Line", " ".join(KNOWN_FIELDS))
 
 
 def main(argv=None):
@@ -35,12 +37,13 @@ def main(argv=None):
     parser.add_argument('files', metavar="FILES", default=".",
                         help="Path to directory (or single file) of TSV files describing composite recipes.")
     args = parser.parse_args()
-    for (targets, image_build, name_override) in generate_targets(args.files):
+    for target in generate_targets(args.files):
         try:
             ret = mull_targets(
-                targets,
-                image_build=image_build,
-                name_override=name_override,
+                target.targets,
+                image_build=target.image_build,
+                name_override=target.name_override,
+                base_image=target.base_image,
                 **args_to_mull_targets_kwds(args)
             )
         except BuildExistsException:
@@ -58,30 +61,36 @@ def generate_targets(target_source):
         target_source_files = [target_source]
 
     for target_source_file in target_source_files:
+        # If no headers are defined we use the 4 default fields in the order
+        # that has been used in galaxy-tool-util / galaxy-lib < 20.01
+        line_tuple = FALLBACK_LINE_TUPLE
         with open(target_source_file, "r") as f:
             for line in f.readlines():
                 if line:
                     line = line.strip()
-
-                if not line or line.startswith("#"):
-                    continue
-
-                yield line_to_targets(line)
-
-
-def line_to_targets(line_str):
-    line = _parse_line(line_str)
-    return (target_str_to_targets(line.targets), line.image_build, line.name_override)
+                    if line.startswith('#'):
+                        # headers can define a different column order
+                        line_tuple = tuple_from_header(line)
+                    else:
+                        yield line_to_targets(line, line_tuple)
 
 
-_Line = collections.namedtuple("_Line", ["targets", "image_build", "name_override"])
+def tuple_from_header(header):
+    fields = header[1:].split('\t')
+    for field in fields:
+        assert field in KNOWN_FIELDS, "'%s' is not one of %s" % (field, KNOWN_FIELDS)
+    return collections.namedtuple("_Line", "%s" % " ".join(fields))
 
 
-def _parse_line(line_str):
+def line_to_targets(line_str, line_tuple):
+    """Parse a line so that some columns can remain unspecified."""
     line_parts = line_str.split("\t")
-    assert len(line_parts) < 3, "Too many fields in line [%s], expect at most 3 - targets, image build number, and name override." % line_str
-    line_parts += [None] * (3 - len(line_parts))
-    return _Line(*line_parts)
+    n_fields = len(line_tuple._fields)
+    targets_column = line_tuple._fields.index('targets')
+    assert len(line_parts) <= n_fields, "Too many fields in line [%s], expect at most %s - targets, image build number, and name override." % (line_str, n_fields)
+    line_parts += [None] * (n_fields - len(line_parts))
+    line_parts[targets_column] = target_str_to_targets(line_parts[targets_column])
+    return line_tuple(*line_parts)
 
 
 __all__ = ("main", )

--- a/test/unit/tool_util/mulled/test_mulled_build_files.py
+++ b/test/unit/tool_util/mulled/test_mulled_build_files.py
@@ -1,0 +1,64 @@
+import tempfile
+
+import pytest
+import yaml
+
+from galaxy.tool_util.deps.mulled.mulled_build import target_str_to_targets
+from galaxy.tool_util.deps.mulled.mulled_build_files import (
+    FALLBACK_LINE_TUPLE,
+    generate_targets,
+)
+
+
+TESTCASES = yaml.safe_load(r"""
+- test_legacy_files_package_only:
+    content: samtools
+    equals:
+      base_image: null
+      image_build: null
+      name_override: null
+      targets: samtools
+- test_legacy_files_package_image_build:
+    content: "samtools\t10"
+    equals:
+      base_image: null
+      image_build: '10'
+      name_override: null
+      targets: samtools
+- test_legacy_files_package_image_build_name_override:
+    content: "samtools\t10\timage_name"
+    equals:
+      base_image: null
+      image_build: '10'
+      name_override: image_name
+      targets: samtools
+- test_files_package_image_build_name_override_base_image_with_header:
+    content: "#targets\timage_build\tname_override\tbase_image\nsamtools\t10\timage_name\textended_image"
+    equals:
+      base_image: extended_image
+      image_build: '10'
+      name_override: image_name
+      targets: samtools
+- test_files_package_image_build_name_override_base_image_with_header_reordered:
+    content: "#base_image\ttargets\timage_build\tname_override\nextended_image\tsamtools\t10\timage_name"
+    equals:
+      base_image: extended_image
+      image_build: '10'
+      name_override: image_name
+      targets: samtools
+""")
+TEST_IDS = [next(iter(k.keys())) for k in TESTCASES]
+
+
+@pytest.mark.parametrize('content, equals', [(d[k]['content'], d[k]['equals']) for k, d in zip(TEST_IDS, TESTCASES)], ids=TEST_IDS)
+def test_generate_targets(content, equals):
+    equals['targets'] = target_str_to_targets(equals['targets'])
+    equals = FALLBACK_LINE_TUPLE(**equals)
+    with tempfile.NamedTemporaryFile(mode='w') as tmpfile:
+        tmpfile.write(content)
+        tmpfile.flush()
+        generated_target = next(generate_targets(tmpfile.name))
+    assert generated_target.targets == equals.targets
+    assert generated_target.image_build == equals.image_build
+    assert generated_target.name_override == equals.name_override
+    assert generated_target.base_image == equals.base_image


### PR DESCRIPTION
This will continue to work for single column files or files that make use of the second and third column already (build_number and name_override).
I don't think we should be using name_override, but given the library nature and not knowing if anyone except for biocontainers/multi-package-containers uses this I chose to keep backwards compatibility.

This does add support for meaningful column headers, so we can write something like
```
\#base_image	targets	build_number
extended	package	10
```
and not include name_override.

xref https://github.com/BioContainers/multi-package-containers/issues/940