### PR TITLE
Fix sending email error on python-3.7

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1484,7 +1484,6 @@ def send_mail(frm, to, subject, body, config, html=None):
         s = smtplib.SMTP_SSL(config.smtp_server)
     else:
         s = smtplib.SMTP(config.smtp_server)
-    s.connect(config.smtp_server)
     if not smtp_ssl:
         try:
             s.starttls()

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1481,9 +1481,9 @@ def send_mail(frm, to, subject, body, config, html=None):
 
     smtp_ssl = asbool(getattr(config, 'smtp_ssl', False))
     if smtp_ssl:
-        s = smtplib.SMTP_SSL()
+        s = smtplib.SMTP_SSL(config.smtp_server)
     else:
-        s = smtplib.SMTP()
+        s = smtplib.SMTP(config.smtp_server)
     s.connect(config.smtp_server)
     if not smtp_ssl:
         try:


### PR DESCRIPTION
Fix sending email error( `ValueError: server_hostname cannot be an empty string or start with a leading dot.`) in python-3.7.