### PR TITLE
add user.api_key in XML

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -571,16 +571,21 @@ class User(Dictifiable, RepresentById):
             user_id = '%d' % user.id
             user_email = str(user.email)
             user_name = str(user.username)
+            api_keys = [one_key.key for one_key in user.api_keys]
+            # get the more up to date (is the tab sorted by id?)
+            user_key = api_keys[0]
         else:
             user = None
             user_id = 'Anonymous'
             user_email = 'Anonymous'
             user_name = 'Anonymous'
+            user_key = 'Anonymous'
         environment = {}
         environment['__user__'] = user
         environment['__user_id__'] = environment['userId'] = user_id
         environment['__user_email__'] = environment['userEmail'] = user_email
         environment['__user_name__'] = user_name
+        environment['__user_key__'] = user_key
         return environment
 
     @staticmethod


### PR DESCRIPTION
This PR adds an new reserved variable $__user_key__ in Galaxy Tool XML file (https://docs.galaxyproject.org/en/latest/dev/schema.html#reserved-variables)

It's very convenient for us, regarding #8570

I will understand if this PR is not be merged if it is considered as a security concern.