### PR TITLE
[20.01] Fix runtime error in ToolConfWatcher

### DIFF
--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -98,7 +98,7 @@ class ToolConfWatcher(object):
 
     def check(self):
         """Check for changes in self.paths or self.cache and call the event handler."""
-        hashes = {key: None for key in list(self.paths.keys())}
+        hashes = {}
         while self._active and not self.exit.isSet():
             do_reload = False
             with self._lock:

--- a/lib/galaxy/tools/toolbox/watcher.py
+++ b/lib/galaxy/tools/toolbox/watcher.py
@@ -98,7 +98,7 @@ class ToolConfWatcher(object):
 
     def check(self):
         """Check for changes in self.paths or self.cache and call the event handler."""
-        hashes = {key: None for key in self.paths.keys()}
+        hashes = {key: None for key in list(self.paths.keys())}
         while self._active and not self.exit.isSet():
             do_reload = False
             with self._lock:


### PR DESCRIPTION
Should prevent
```
Traceback (most recent call last):
  File "PY3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "PY3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "lib/galaxy/tools/toolbox/watcher.py", line 101, in check
    hashes = {key: None for key in self.paths.keys()}
  File "lib/galaxy/tools/toolbox/watcher.py", line 101, in <dictcomp>
    hashes = {key: None for key in self.paths.keys()}
RuntimeError: dictionary changed size during iteration
```
We do something similar already in https://github.com/mvdbeek/galaxy/blob/6af20e1b0cac5a3abdcab3be901b4d0a761b9067/lib/galaxy/tools/toolbox/watcher.py#L105

reported by @selten on gitter