### PR TITLE
[20.01] Throw error if authnz attempts to create new user with existing email

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -88,7 +88,7 @@ class CustosAuthnz(IdentityProvider):
         # Create or update custos_authnz_token record
         custos_authnz_token = self._get_custos_authnz_token(trans.sa_session, user_id, self.config['provider'])
         if custos_authnz_token is None:
-            user = self._get_current_user(trans)
+            user = trans.user
             if not user:
                 user = self._create_user(trans.sa_session, username, email)
             custos_authnz_token = CustosAuthnzToken(user=user,
@@ -155,9 +155,6 @@ class CustosAuthnz(IdentityProvider):
     def _get_custos_authnz_token(self, sa_session, user_id, provider):
         return sa_session.query(CustosAuthnzToken).filter_by(
             external_user_id=user_id, provider=provider).one_or_none()
-
-    def _get_current_user(self, trans):
-        return trans.user if trans.user else None
 
     def _create_user(self, sa_session, username, email):
         user = User(email=email, username=username)

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -157,7 +157,7 @@ class CustosAuthnz(IdentityProvider):
             external_user_id=user_id, provider=provider).one_or_none()
 
     def _create_user(self, sa_session, username, email):
-        if sa_session.query(User).filter(User.table.c.email == email).first():
+        if sa_session.query(User).filter_by(email == email).first():
             raise Exception("User with this email '%s' already exists." % email)
         user = User(email=email, username=username)
         user.set_random_password()

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -157,6 +157,8 @@ class CustosAuthnz(IdentityProvider):
             external_user_id=user_id, provider=provider).one_or_none()
 
     def _create_user(self, sa_session, username, email):
+        if sa_session.query(User).filter(User.table.c.email == email).first():
+            raise Exception("User with this email '%s' already exists." % email)
         user = User(email=email, username=username)
         user.set_random_password()
         sa_session.add(user)

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -95,11 +95,8 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         user = self.model_class(email=email)
         user.set_password_cleartext(password)
         user.username = username
-        if self.app.config.user_activation_on:
-            user.active = False
-        else:
-            # Activation is off, every new user is active by default.
-            user.active = True
+        # Activation is off, every new user is active by default.
+        user.active = not self.app.config.user_activation_on
         self.session().add(user)
         try:
             self.session().flush()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5690,6 +5690,8 @@ class UserAuthnzToken(UserMixin, RepresentById):
     def create_user(cls, *args, **kwargs):
         model = cls.user_model()
         instance = model(*args, **kwargs)
+        if cls.get_users_by_email(instance.email).first():
+            raise Exception("User with this email '%s' already exists." % instance.email)
         instance.set_random_password()
         cls.sa_session.add(instance)
         cls.sa_session.flush()


### PR DESCRIPTION
It seems that the authnz process does create users with already existing emails. This PR adds check flags to prevent this from happening. This PR requires a follow-up in order to understand why the authnz module does attempt to create a new user for an already existing user.