### PR TITLE
[20.01] Fix extended base for singularity and add base_image_for_targets

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -149,16 +149,16 @@ def get_conda_hits_for_targets(targets, conda_context):
     return [r for r in search_results if r]
 
 
-def any_target_requires_extended_base(targets, conda_context=None):
+def base_image_for_targets(targets, conda_context=None):
     hits = get_conda_hits_for_targets(targets, conda_context or CondaInDockerContext())
     for hit in hits:
         try:
             meta_content = unicodify(get_file_from_recipe_url(hit['url']).extractfile('info/about.json').read())
             if json.loads(meta_content).get('extra', {}).get('container', {}).get('extended-base', False):
-                return True
+                return DEFAULT_EXTENDED_BASE_IMAGE
         except Exception:
             log.warning("Could not load metadata.yaml for '%s', version '%s'", hit['name'], hit['version'], exc_info=True)
-    return False
+    return DEFAULT_BASE_IMAGE
 
 
 class BuildExistsException(Exception):
@@ -183,7 +183,7 @@ def mull_targets(
     elif DEST_BASE_IMAGE:
         dest_base_image = DEST_BASE_IMAGE
     else:
-        dest_base_image = DEFAULT_EXTENDED_BASE_IMAGE if any_target_requires_extended_base(targets) else DEST_BASE_IMAGE
+        dest_base_image = base_image_for_targets(targets)
 
     targets = list(targets)
     if involucro_context is None:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -48,6 +48,7 @@ from ..conda_compat import MetaData
 log = logging.getLogger(__name__)
 
 DIRNAME = os.path.dirname(__file__)
+DEFAULT_BASE_IMAGE = "bgruening/busybox-bash:0.1"
 DEFAULT_EXTENDED_BASE_IMAGE = "bioconda/extended-base-image:latest"
 DEFAULT_CHANNELS = ["conda-forge", "bioconda"]
 DEFAULT_REPOSITORY_TEMPLATE = "quay.io/${namespace}/${image}"
@@ -59,7 +60,7 @@ DEST_BASE_IMAGE = os.environ.get('DEST_BASE_IMAGE', None)
 CONDA_IMAGE = os.environ.get('CONDA_IMAGE', None)
 
 SINGULARITY_TEMPLATE = """Bootstrap: docker
-From: bgruening/busybox-bash:0.1
+From: %(base_image)s
 
 %%setup
 
@@ -271,7 +272,7 @@ def mull_targets(
             if not os.path.exists(singularity_image_dir):
                 safe_makedirs(singularity_image_dir)
             with open(os.path.join(singularity_image_dir, 'Singularity.def'), 'w+') as sin_def:
-                fill_template = SINGULARITY_TEMPLATE % {'container_test': test}
+                fill_template = SINGULARITY_TEMPLATE % {'container_test': test, 'base_image': dest_base_image or DEFAULT_BASE_IMAGE}
                 sin_def.write(fill_template)
         with PrintProgress():
             ret = involucro_context.exec_command(involucro_args)

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -1,17 +1,19 @@
 import pytest
 
 from galaxy.tool_util.deps.mulled.mulled_build import (
-    any_target_requires_extended_base,
+    base_image_for_targets,
     build_target,
+    DEFAULT_BASE_IMAGE,
+    DEFAULT_EXTENDED_BASE_IMAGE,
 )
 from ..util import external_dependency_management
 
 
-@pytest.mark.parametrize("target,requires_extended", [
-    ('maker', True),
-    ('samtools', False)
+@pytest.mark.parametrize("target,base_image", [
+    ('maker', DEFAULT_EXTENDED_BASE_IMAGE),
+    ('samtools', DEFAULT_BASE_IMAGE)
 ])
 @external_dependency_management
-def test_any_target_requires_extended_base(target, requires_extended):
+def test_base_image_for_targets(target, base_image):
     target = build_target(target)
-    assert any_target_requires_extended_base([target]) == requires_extended
+    assert base_image_for_targets([target]) == base_image


### PR DESCRIPTION
This is easier to use in planemo (we don't need to figure out which
image to use based on the return value of
any_target_requires_extended_base) and leaves open the possibility for
custom base image annotation in conda recipes or other places.