### PR TITLE
Ensure visible overflow on navbar container

### DIFF
--- a/client/galaxy/scripts/viz/trackster/tracks.js
+++ b/client/galaxy/scripts/viz/trackster/tracks.js
@@ -1002,7 +1002,7 @@ var TracksterView = Backbone.View.extend({
 
         // We break out of the parent container with nav (and potentially other
         // things?) so we need to override any overflow settings here.
-        parent_element.css("overflow", "visible");
+        parent_element.attr("style", "overflow: visible !important");
         // Navigation at top
         this.nav_container = $("<div/>")
             .addClass("trackster-nav-container")


### PR DESCRIPTION
This ensures that the genome navigation can be pushed into the title element. Fixes #9205

Alternatively, it would be possible to change the base CSS [here](https://github.com/galaxyproject/galaxy/blob/47613021c6dbe4bd4a95f1c9c10ae6dbe37e14d5/client/galaxy/style/scss/base.scss#L240) so that `.unified-panel-body` does not extend `.overflow-auto`, which applies the `!important` flag. However, that might have unintended consequences in other places.