### PR TITLE
[20.01] Fix: Added support for specifying k8s job pod priority class

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -45,6 +45,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_use_service_account=dict(map=bool, default=False),
             k8s_persistent_volume_claims=dict(map=str),
             k8s_namespace=dict(map=str, default="default"),
+            k8s_pod_priority_class=dict(map=str, default=None),
             k8s_galaxy_instance_id=dict(map=str),
             k8s_timeout_seconds_job_deletion=dict(map=int, valid=lambda x: int > 0, default=30),
             k8s_job_api_version=dict(map=str, default=DEFAULT_JOB_API_VERSION),
@@ -239,7 +240,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             "spec": {
                 "volumes": self.runner_params['k8s_mountable_volumes'],
                 "restartPolicy": self.__get_k8s_restart_policy(ajs.job_wrapper),
-                "containers": self.__get_k8s_containers(ajs)
+                "containers": self.__get_k8s_containers(ajs),
+                "priorityClassName": self.runner_params['k8s_pod_priority_class']
             }
         }
         # TODO include other relevant elements that people might want to use from


### PR DESCRIPTION
So that jobs don't evict the Galaxy pod when resources are scarce.