### PR TITLE
[20.01] Extended base annotation fixes

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -526,7 +526,11 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
     try:
         res = commands.execute(search_cmd)
         res = unicodify(res)
-        hits = json.loads(res).get(conda_target.package, [])
+        # Use python's stable list sorting to sort by date,
+        # then build_number, then version. The top of the list
+        # then is the newest version with the newest build and
+        # the latest update time.
+        hits = json.loads(res).get(conda_target.package, [])[::-1]
         hits = sorted(hits, key=lambda hit: hit['build_number'], reverse=True)
         hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
     except CommandLineException:

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -153,8 +153,11 @@ def base_image_for_targets(targets, conda_context=None):
     hits = get_conda_hits_for_targets(targets, conda_context or CondaInDockerContext())
     for hit in hits:
         try:
-            meta_content = unicodify(get_file_from_recipe_url(hit['url']).extractfile('info/about.json').read())
+            tarball = get_file_from_recipe_url(hit['url'])
+            meta_content = unicodify(tarball.extractfile('info/about.json').read())
             if json.loads(meta_content).get('extra', {}).get('container', {}).get('extended-base', False):
+                return DEFAULT_EXTENDED_BASE_IMAGE
+            elif yaml.safe_load(unicodify(tarball.extractfile('info/recipe/meta.yaml').read())).get('extra', {}).get('container', {}).get('extended-base', False):
                 return DEFAULT_EXTENDED_BASE_IMAGE
         except Exception:
             log.warning("Could not load metadata.yaml for '%s', version '%s'", hit['name'], hit['version'], exc_info=True)

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -9,11 +9,12 @@ from galaxy.tool_util.deps.mulled.mulled_build import (
 from ..util import external_dependency_management
 
 
-@pytest.mark.parametrize("target,base_image", [
-    ('maker', DEFAULT_EXTENDED_BASE_IMAGE),
-    ('samtools', DEFAULT_BASE_IMAGE)
+@pytest.mark.parametrize("target,version,base_image", [
+    ('maker', None, DEFAULT_EXTENDED_BASE_IMAGE),
+    ('qiime', '1.9.1', DEFAULT_EXTENDED_BASE_IMAGE),
+    ('samtools', None, DEFAULT_BASE_IMAGE),
 ])
 @external_dependency_management
-def test_base_image_for_targets(target, base_image):
-    target = build_target(target)
+def test_base_image_for_targets(target, version, base_image):
+    target = build_target(target, version=version)
     assert base_image_for_targets([target]) == base_image


### PR DESCRIPTION
Sort best package by upload time (lowest priority) in addition to version and build number.

This is necessary for getting the extended-base annotation for qiime 1.9.1,
which does not contain the annotation in
linux-64/qiime-1.9.1-np110py27_1.tar.bz2 while in the newer
linux-64/qiime-1.9.1-np112py27_1.tar.bz2 it is present. This depends of course
on `conda search` returning packages sorted by upload time and is a little
brittle. It does seem better than always picking the oldest upload time as we
do without this change.  Also looks in meta.yaml for extended base annotation,
since sometimes this isn't present in info/about.json.