### PR TITLE
[20.01] Fix: Added support for specifying k8s job affinity and tolerations

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -8,6 +8,8 @@ import os
 import re
 from time import sleep
 
+import yaml
+
 from galaxy import model
 from galaxy.jobs.runners import (
     AsynchronousJobRunner,
@@ -46,6 +48,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_persistent_volume_claims=dict(map=str),
             k8s_namespace=dict(map=str, default="default"),
             k8s_pod_priority_class=dict(map=str, default=None),
+            k8s_affinity=dict(map=str, default=None),
+            k8s_tolerations=dict(map=str, default=None),
             k8s_galaxy_instance_id=dict(map=str),
             k8s_timeout_seconds_job_deletion=dict(map=int, valid=lambda x: int > 0, default=30),
             k8s_job_api_version=dict(map=str, default=DEFAULT_JOB_API_VERSION),
@@ -241,7 +245,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 "volumes": self.runner_params['k8s_mountable_volumes'],
                 "restartPolicy": self.__get_k8s_restart_policy(ajs.job_wrapper),
                 "containers": self.__get_k8s_containers(ajs),
-                "priorityClassName": self.runner_params['k8s_pod_priority_class']
+                "priorityClassName": self.runner_params['k8s_pod_priority_class'],
+                "tolerations": yaml.safe_load(self.runner_params['k8s_tolerations'] or "[]"),
+                "affinity": yaml.safe_load(self.runner_params['k8s_affinity'] or "{}")
             }
         }
         # TODO include other relevant elements that people might want to use from


### PR DESCRIPTION
This patch allows job placement to be controlled on k8s, as without it, jobs can sometimes overwhelm the head node.