### PR TITLE
[20.01] Fix mailto hrefs in menus

### DIFF
--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -501,7 +501,7 @@ const Tab = Backbone.View.extend({
 
     /** Url formatting */
     _formatUrl: function(url) {
-        return typeof url == "string" && url.indexOf("//") === -1 && url.charAt(0) != "/" ? getAppRoot() + url : url;
+        return typeof url == "string" && url.indexOf("mailto:")=== -1 && url.indexOf("//") === -1 && url.charAt(0) != "/" ? getAppRoot() + url : url;
     },
 
     /** body tempate */

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -501,7 +501,12 @@ const Tab = Backbone.View.extend({
 
     /** Url formatting */
     _formatUrl: function(url) {
-        return typeof url == "string" && url.indexOf("mailto:")=== -1 && url.indexOf("//") === -1 && url.charAt(0) != "/" ? getAppRoot() + url : url;
+        return typeof url == "string" &&
+            url.indexOf("mailto:") === -1 &&
+            url.indexOf("//") === -1 &&
+            url.charAt(0) != "/"
+            ? getAppRoot() + url
+            : url;
     },
 
     /** body tempate */


### PR DESCRIPTION
Without this, Galaxy makes a link like `http://mygalaxydomain.com/mailto:blah` when, for example, you set the 'support' menu entry to a mailto address.