### PR TITLE
[20.01] Mount job_working_directory/configs rw

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -19,7 +19,7 @@ YIELD_CAPTURED_CODE = 'sh -c "exit $return_code"'
 SETUP_GALAXY_FOR_METADATA = """
 [ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True
 """
-PREPARE_DIRS = """mkdir -p working outputs
+PREPARE_DIRS = """mkdir -p working outputs configs
 if [ -d _working ]; then
     rm -rf working/ outputs/ configs/; cp -R _working working; cp -R _outputs outputs; cp -R _configs configs
 else

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -21,9 +21,9 @@ SETUP_GALAXY_FOR_METADATA = """
 """
 PREPARE_DIRS = """mkdir -p working outputs
 if [ -d _working ]; then
-    rm -rf working/ outputs/; cp -R _working working; cp -R _outputs outputs
+    rm -rf working/ outputs/ configs/; cp -R _working working; cp -R _outputs outputs; cp -R _configs configs
 else
-    cp -R working _working; cp -R outputs _outputs
+    cp -R working _working; cp -R outputs _outputs; cp -R configs _configs
 fi
 cd working"""
 

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -426,9 +426,16 @@ class BaseJobRunner(object):
 
         tool = job_wrapper.tool
         guest_ports = [ep.get('port') for ep in getattr(job_wrapper, 'interactivetools', [])]
-        tool_id = tool.id
-        tool_version = tool.version
-        tool_info = ToolInfo(tool.containers, tool.requirements, tool.requires_galaxy_python_environment, tool.docker_env_pass_through, guest_ports=guest_ports, tool_id=tool_id, tool_version=tool_version)
+        tool_info = ToolInfo(
+            tool.containers,
+            tool.requirements,
+            tool.requires_galaxy_python_environment,
+            tool.docker_env_pass_through,
+            guest_ports=guest_ports,
+            tool_id=tool.id,
+            tool_version=tool.version,
+            profile=tool.profile,
+        )
         job_info = JobInfo(
             working_directory=compute_working_directory,
             tool_directory=compute_tool_directory,

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -179,7 +179,9 @@ class HasDockerLikeVolumes(object):
             if self.job_info.tool_directory:
                 defaults += ",$tool_directory:default_ro"
             if self.job_info.job_directory:
-                defaults += ",$job_directory:default_ro,$job_directory/outputs:rw,$job_directory/configs"
+                defaults += ",$job_directory:default_ro,$job_directory/outputs:rw"
+                if self.tool_info.profile <= 19.09:
+                    defaults += ",$job_directory/configs:rw"
             if self.job_info.tmp_directory is not None:
                 defaults += ",$tmp_directory:rw"
             if self.job_info.home_directory is not None:

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -179,7 +179,7 @@ class HasDockerLikeVolumes(object):
             if self.job_info.tool_directory:
                 defaults += ",$tool_directory:default_ro"
             if self.job_info.job_directory:
-                defaults += ",$job_directory:default_ro,$job_directory/outputs:rw"
+                defaults += ",$job_directory:default_ro,$job_directory/outputs:rw,$job_directory/configs"
             if self.job_info.tmp_directory is not None:
                 defaults += ",$tmp_directory:rw"
             if self.job_info.home_directory is not None:

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -36,7 +36,7 @@ class ToolInfo(object):
     # variables they can consume (e.g. JVM options, license keys, etc..)
     # and add these to env_path_through
 
-    def __init__(self, container_descriptions=None, requirements=None, requires_galaxy_python_environment=False, env_pass_through=["GALAXY_SLOTS"], guest_ports=None, tool_id=None, tool_version=None):
+    def __init__(self, container_descriptions=None, requirements=None, requires_galaxy_python_environment=False, env_pass_through=["GALAXY_SLOTS"], guest_ports=None, tool_id=None, tool_version=None, profile=-1):
         if container_descriptions is None:
             container_descriptions = []
         if requirements is None:
@@ -48,6 +48,7 @@ class ToolInfo(object):
         self.guest_ports = guest_ports
         self.tool_id = tool_id
         self.tool_version = tool_version
+        self.profile = profile
 
 
 class JobInfo(object):


### PR DESCRIPTION
Many tools have this pattern where they move the config file somewhere,
which doesn't work if it is mounted read-only.