### PR TITLE
inputs configfile: test for filename and data_style attributes

### DIFF
--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -1,9 +1,9 @@
 <tool id="inputs_as_json" name="inputs_as_json" version="1.0.0">
     <command detect_errors="exit_code">
-        python $check_inputs $inputs $test_case
+        python $check_inputs inputs.json $test_case
     </command>
     <configfiles>
-        <inputs name="inputs" />
+        <inputs name="inputs" filename="inputs.json" />
         <!-- Can specify with fixed path in working directory instead:
         <inputs name="inputs" filename="input.json" />
         -->
@@ -21,6 +21,7 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
+    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -33,6 +34,7 @@ if test_case == "1":
     assert_equals(as_dict["section_example"]["section_text"], "section_default")
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
+    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -50,6 +52,7 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
+        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -85,6 +88,7 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -107,6 +111,7 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -21,7 +21,6 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
-    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -32,9 +31,9 @@ if test_case == "1":
     assert_equals(as_dict["repeat"][1]["r"], "FFFFFF")
     assert_equals(as_dict["cond"]["more_text"], "fdefault")
     assert_equals(as_dict["section_example"]["section_text"], "section_default")
+    assert "data_input" not in as_dict
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
-    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -45,6 +44,7 @@ elif test_case == "2":
     assert_equals(as_dict["cond"]["cond_test"], "second")
     assert_equals(as_dict["cond"]["more_text"], "sdefault")
     assert_equals(as_dict["section_example"]["section_text"], "section_default")
+    assert "data_input" not in as_dict
 
 with open("output", "w") as f:
     f.write("okay\n")
@@ -52,7 +52,6 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
-        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -63,6 +62,7 @@ with open("output", "w") as f:
             <option value="b_radio">B Radio</option>
             <option value="c_radio">C Radio</option>
         </param>
+        <param name="data_input" type="data" optional="true" />
         <repeat name="repeat" title="Repeat" min="1">
             <param name="r" type="color" />
         </repeat>
@@ -88,7 +88,6 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -111,10 +110,10 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />
+            <param name="data_input" value="simple_line.txt" />
             <!-- Testing null integers -->
             <!-- <param name="inttest" value="12456" /> -->
             <param name="r" value="000000" />

--- a/test/functional/tools/inputs_as_json_with_paths.xml
+++ b/test/functional/tools/inputs_as_json_with_paths.xml
@@ -21,6 +21,7 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
+    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -34,6 +35,7 @@ if test_case == "1":
     assert_equals(as_dict["data_input"], None)
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
+    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -53,6 +55,7 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
+        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -89,6 +92,7 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -111,6 +115,7 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />

--- a/test/functional/tools/inputs_as_json_with_paths.xml
+++ b/test/functional/tools/inputs_as_json_with_paths.xml
@@ -21,7 +21,6 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
-    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -35,7 +34,6 @@ if test_case == "1":
     assert_equals(as_dict["data_input"], None)
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
-    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -55,7 +53,6 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
-        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -92,7 +89,6 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -115,7 +111,6 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />


### PR DESCRIPTION
Shows a potential problem: with `filename` the file is created in the JOBDIR not JOBDIR/working.

Also I was expecting (or hoping) that also outputs are added to the json. 