### PR TITLE
[20.01] Fix lint warning string formatting

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -47,7 +47,7 @@ def lint_output(tool_xml, lint_ctx):
                 format_set = True
 
         if not format_set:
-            lint_ctx.warn("Tool %s output %name doesn't define an output format." % (output.tag, output.attrib.get("name", "with missing name")))
+            lint_ctx.warn("Tool %s output %s doesn't define an output format." % (output.tag, output.attrib.get("name", "with missing name")))
 
     lint_ctx.info("%d outputs found.", num_outputs)
 


### PR DESCRIPTION
Introduced in
https://github.com/galaxyproject/galaxy/commit/c4fabf05e11c033006834fd0bf0d9077c0156134,
causes:
```
ValueError: unsupported format character 'n' (0x6e) at index 16
```