### PR TITLE
[20.01] Fix deletion of outputs and working before job

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1113,6 +1113,7 @@ class JobWrapper(HasResourceParameters):
             # The tool execution is given a working directory beneath the
             # "job" working directory.
             safe_makedirs(self.tool_working_directory)
+            safe_makedirs(os.path.join(working_directory, 'outputs'))
             log.debug('(%s) Working directory for job is: %s',
                       self.job_id, self.working_directory)
         except ObjectInvalid:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1787,8 +1787,9 @@ class JobWrapper(HasResourceParameters):
                 for fname in self.extra_filenames:
                     try:
                         os.remove(fname)
-                    except FileNotFoundError:
-                        pass
+                    except EnvironmentError as e:
+                        if e.errno != errno.ENOENT:
+                            raise
                 self.external_output_metadata.cleanup_external_metadata(self.sa_session)
             galaxy.tools.imp_exp.JobExportHistoryArchiveWrapper(self.app, self.job_id).cleanup_after_job()
             galaxy.tools.imp_exp.JobImportHistoryArchiveWrapper(self.app, self.job_id).cleanup_after_job()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1785,7 +1785,10 @@ class JobWrapper(HasResourceParameters):
         try:
             if delete_files:
                 for fname in self.extra_filenames:
-                    os.remove(fname)
+                    try:
+                        os.remove(fname)
+                    except FileNotFoundError:
+                        pass
                 self.external_output_metadata.cleanup_external_metadata(self.sa_session)
             galaxy.tools.imp_exp.JobExportHistoryArchiveWrapper(self.app, self.job_id).cleanup_after_job()
             galaxy.tools.imp_exp.JobImportHistoryArchiveWrapper(self.app, self.job_id).cleanup_after_job()

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -99,15 +99,13 @@ def build_command(
         # usually working will already exist, but it will not for task
         # split jobs.
 
-        # Remove the working directory incase this is for instance a SLURM re-submission.
+        # Remove all non-readonly files in the workfing directory incase this is a re-submission.
         # xref https://github.com/galaxyproject/galaxy/issues/3289
-        commands_builder.prepend_command("""# Delete working/ and outputs/ only if job was resubmitted
+        commands_builder.prepend_command("""
 if [ -f .job_started ]; then
-    rm -rf working outputs; mkdir -p working outputs
+    find working outputs -perm /0222  -delete 2> /dev/null || true
 fi
-touch .job_started
-cd working
-""", sep='')
+mkdir -p working outputs; touch .job_started; cd working""")
 
     container_monitor_command = job_wrapper.container_monitor_command(container)
     if container_monitor_command:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -19,6 +19,13 @@ YIELD_CAPTURED_CODE = 'sh -c "exit $return_code"'
 SETUP_GALAXY_FOR_METADATA = """
 [ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True
 """
+PREPARE_DIRS = """mkdir -p working outputs
+if [ -f .job_started ]; then
+    rm -rf working/ outputs/; cp -R _working working; cp -R _outputs outputs
+else
+    cp -R working _working; cp -R outputs _outputs
+fi
+touch .job_started; cd working"""
 
 
 def build_command(
@@ -99,15 +106,9 @@ def build_command(
         # usually working will already exist, but it will not for task
         # split jobs.
 
-        # Copy working/ and output/ before job submission so that these can be restored on resubmission
+        # Copy working and outputs before job submission so that these can be restored on resubmission
         # xref https://github.com/galaxyproject/galaxy/issues/3289
-        commands_builder.prepend_command("""mkdir -p working outputs
-if [ -f .job_started ]; then
-    rm -rf working/ outputs/; cp -R _working working; cp -R _outputs outputs
-else
-    cp -R working _working; cp -R outputs _outputs
-fi
-touch .job_started; cd working""")
+        commands_builder.prepend_command(PREPARE_DIRS)
 
     container_monitor_command = job_wrapper.container_monitor_command(container)
     if container_monitor_command:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -101,7 +101,13 @@ def build_command(
 
         # Remove the working directory incase this is for instance a SLURM re-submission.
         # xref https://github.com/galaxyproject/galaxy/issues/3289
-        commands_builder.prepend_command("rm -rf working outputs; mkdir -p working outputs; cd working")
+        commands_builder.prepend_command("""# Delete working/ and outputs/ only if job was resubmitted
+if [ -f .job_started ]; then
+    rm -rf working outputs; mkdir -p working outputs
+fi
+touch .job_started
+cd working
+""", sep='')
 
     container_monitor_command = job_wrapper.container_monitor_command(container)
     if container_monitor_command:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -99,13 +99,15 @@ def build_command(
         # usually working will already exist, but it will not for task
         # split jobs.
 
-        # Remove all non-readonly files in the workfing directory incase this is a re-submission.
+        # Copy working/ and output/ before job submission so that these can be restored on resubmission
         # xref https://github.com/galaxyproject/galaxy/issues/3289
-        commands_builder.prepend_command("""
+        commands_builder.prepend_command("""mkdir -p working outputs
 if [ -f .job_started ]; then
-    find working outputs -perm /0222  -delete 2> /dev/null || true
+    rm -rf working/ outputs/; cp -R _working working; cp -R _outputs outputs
+else
+    cp -R working _working; cp -R outputs _outputs
 fi
-mkdir -p working outputs; touch .job_started; cd working""")
+touch .job_started; cd working""")
 
     container_monitor_command = job_wrapper.container_monitor_command(container)
     if container_monitor_command:

--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -20,12 +20,12 @@ SETUP_GALAXY_FOR_METADATA = """
 [ "$GALAXY_VIRTUAL_ENV" = "None" ] && GALAXY_VIRTUAL_ENV="$_GALAXY_VIRTUAL_ENV"; _galaxy_setup_environment True
 """
 PREPARE_DIRS = """mkdir -p working outputs
-if [ -f .job_started ]; then
+if [ -d _working ]; then
     rm -rf working/ outputs/; cp -R _working working; cp -R _outputs outputs
 else
     cp -R working _working; cp -R outputs _outputs
 fi
-touch .job_started; cd working"""
+cd working"""
 
 
 def build_command(

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4812,6 +4812,11 @@ This file is then used in the ``command`` block of the tool as follows:
 the path to the file created with this directive.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="filename" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Path relative to the working directory of the tool for the configfile created in response to this directive.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2269,9 +2269,8 @@ class OutputParameterJSONTool(Tool):
             json_params['output_data'].append(data_dict)
             if json_filename is None:
                 json_filename = file_name
-        out = open(json_filename, 'w')
-        out.write(json.dumps(json_params))
-        out.close()
+        with open(json_filename, 'w') as out:
+            out.write(json.dumps(json_params))
 
 
 class ExpressionTool(Tool):

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -584,14 +584,13 @@ class ToolEvaluator(object):
         if self.tool.profile < 16.04 and command and "$param_file" in command:
             fd, param_filename = tempfile.mkstemp(dir=directory)
             os.close(fd)
-            f = open(param_filename, "w")
-            for key, value in param_dict.items():
-                # parameters can be strings or lists of strings, coerce to list
-                if not isinstance(value, list):
-                    value = [value]
-                for elem in value:
-                    f.write('%s=%s\n' % (key, elem))
-            f.close()
+            with open(param_filename, "w") as f:
+                for key, value in param_dict.items():
+                    # parameters can be strings or lists of strings, coerce to list
+                    if not isinstance(value, list):
+                        value = [value]
+                    for elem in value:
+                        f.write('%s=%s\n' % (key, elem))
             self.__register_extra_file('param_file', param_filename)
             return param_filename
         else:

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -525,6 +525,8 @@ class ToolEvaluator(object):
             if not os.path.exists(directory):
                 os.makedirs(directory)
             if filename is not None:
+                # Explicit filename was requested, needs to be placed in tool working directory
+                directory = os.path.join(self.local_working_directory, "working")
                 config_filename = os.path.join(directory, filename)
             else:
                 fd, config_filename = tempfile.mkstemp(dir=directory)

--- a/test/functional/tools/exit_code_oom.xml
+++ b/test/functional/tools/exit_code_oom.xml
@@ -1,7 +1,7 @@
-<tool id="exit_code_oom" name="exit_code_oom">
+<tool id="exit_code_oom" name="exit_code_oom" version="0.1.1" profile="16.04">
     <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
-        echo 'Hello' > '$out_file1';
+        mv hi.txt '$out_file1';
         echo "\$GALAXY_MEMORY_MB";
         : \${GALAXY_MEMORY_MB:=20};
         echo "\$GALAXY_MEMORY_MB";
@@ -12,6 +12,10 @@
             exit 0;
         fi
     ]]></command>
+    <configfiles>
+        <!-- also tests that configfiles are placed in working dir and that this works on resubmission as well -->
+        <configfile filename="hi.txt">Hello</configfile>
+    </configfiles>
     <inputs>
         <param name="input" type="integer" label="Dummy" value="6" />
     </inputs>

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -1,9 +1,9 @@
 <tool id="inputs_as_json" name="inputs_as_json" version="1.0.0">
     <command detect_errors="exit_code">
-        python $check_inputs $inputs $test_case
+        python $check_inputs inputs.json $test_case
     </command>
     <configfiles>
-        <inputs name="inputs" />
+        <inputs name="inputs" filename="inputs.json" />
         <!-- Can specify with fixed path in working directory instead:
         <inputs name="inputs" filename="input.json" />
         -->
@@ -21,6 +21,7 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
+    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -33,6 +34,7 @@ if test_case == "1":
     assert_equals(as_dict["section_example"]["section_text"], "section_default")
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
+    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -50,6 +52,7 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
+        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -85,6 +88,7 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -107,6 +111,7 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />

--- a/test/functional/tools/inputs_as_json.xml
+++ b/test/functional/tools/inputs_as_json.xml
@@ -21,7 +21,6 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
-    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -32,9 +31,9 @@ if test_case == "1":
     assert_equals(as_dict["repeat"][1]["r"], "FFFFFF")
     assert_equals(as_dict["cond"]["more_text"], "fdefault")
     assert_equals(as_dict["section_example"]["section_text"], "section_default")
+    assert "data_input" not in as_dict
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
-    assert "file_test" not in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -45,6 +44,7 @@ elif test_case == "2":
     assert_equals(as_dict["cond"]["cond_test"], "second")
     assert_equals(as_dict["cond"]["more_text"], "sdefault")
     assert_equals(as_dict["section_example"]["section_text"], "section_default")
+    assert "data_input" not in as_dict
 
 with open("output", "w") as f:
     f.write("okay\n")
@@ -52,7 +52,6 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
-        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -63,6 +62,7 @@ with open("output", "w") as f:
             <option value="b_radio">B Radio</option>
             <option value="c_radio">C Radio</option>
         </param>
+        <param name="data_input" type="data" optional="true" />
         <repeat name="repeat" title="Repeat" min="1">
             <param name="r" type="color" />
         </repeat>
@@ -88,7 +88,6 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -111,10 +110,10 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />
+            <param name="data_input" value="simple_line.txt" />
             <!-- Testing null integers -->
             <!-- <param name="inttest" value="12456" /> -->
             <param name="r" value="000000" />

--- a/test/functional/tools/inputs_as_json_with_paths.xml
+++ b/test/functional/tools/inputs_as_json_with_paths.xml
@@ -21,6 +21,7 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
+    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -34,6 +35,7 @@ if test_case == "1":
     assert_equals(as_dict["data_input"], None)
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
+    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -53,6 +55,7 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
+        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -89,6 +92,7 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -111,6 +115,7 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
+            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />

--- a/test/functional/tools/inputs_as_json_with_paths.xml
+++ b/test/functional/tools/inputs_as_json_with_paths.xml
@@ -21,7 +21,6 @@ def assert_equals(x, y):
 
 if test_case == "1":
     assert_equals(as_dict["test_case"], 1)
-    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "foo")
     assert_equals(as_dict["booltest"], True)
     assert_equals(as_dict["booltest2"], True)
@@ -35,7 +34,6 @@ if test_case == "1":
     assert_equals(as_dict["data_input"], None)
 elif test_case == "2":
     assert_equals(as_dict["test_case"], 2)
-    assert "file_test" in as_dict
     assert_equals(as_dict["text_test"], "bar")
     assert_equals(as_dict["booltest"], False)
     assert_equals(as_dict["booltest2"], False)
@@ -55,7 +53,6 @@ with open("output", "w") as f:
     </configfiles>
     <inputs>
         <param name="test_case" type="integer" value="0" />
-        <param name="file_test" type="data" format="txt" />
         <param name="text_test" type="text" />
         <param name="booltest" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
         <param name="booltest2" truevalue="booltrue" falsevalue="boolfalse" checked="false" type="boolean" />
@@ -92,7 +89,6 @@ with open("output", "w") as f:
     <tests>
         <test>
             <param name="test_case" value="1" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="foo" />
             <param name="booltest" value="true" />
             <param name="booltest2" value="booltrue" />
@@ -115,7 +111,6 @@ with open("output", "w") as f:
         </test>
         <test>
             <param name="test_case" value="2" />
-            <param name="file_test" value="simple_lines_both.txt" ftype="txt" />
             <param name="text_test" value="bar" />
             <param name="booltest" value="false" />
             <param name="booltest2" value="boolfalse" />

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -4,7 +4,11 @@ from os import getcwd
 from tempfile import mkdtemp
 from unittest import TestCase
 
-from galaxy.jobs.command_factory import build_command, SETUP_GALAXY_FOR_METADATA
+from galaxy.jobs.command_factory import (
+    build_command,
+    PREPARE_DIRS,
+    SETUP_GALAXY_FOR_METADATA,
+)
 from galaxy.util.bunch import Bunch
 
 MOCK_COMMAND_LINE = "/opt/galaxy/tools/bowtie /mnt/galaxyData/files/000/input000.dat"
@@ -157,7 +161,7 @@ class TestCommandFactory(TestCase):
 
 
 def _surround_command(command):
-    return '''rm -rf working outputs; mkdir -p working outputs; cd working; %s; sh -c "exit $return_code"''' % command
+    return '''%s; %s; sh -c "exit $return_code"''' % (PREPARE_DIRS, command)
 
 
 class MockJobWrapper(object):


### PR DESCRIPTION
Both directories may contain important files for a job, so deleting these directories may be inappropriate.
We originally implemented this for https://github.com/galaxyproject/galaxy/issues/3289

I noticed this with data managers (and potentially other OutputParameterJSONTool tools) that populate datasets in the `outputs/` directory if using `outputs_to_working_directory`. These used to be pre-populated in the job working directory, but with https://github.com/galaxyproject/galaxy/commit/ad573b215802aaaa9d09e1d2e3e2974e79295dfe they are moved to `outputs`/ (which is good), but which gets deleted during job setup.

The approach here is to copy the `working` and `outputs` directories to `_working` and `_outputs` before running the actual jobs, and if re-running the job deleting `working` and `outputs` and copying the backups back into place.
This seems to be the most robust way to make sure that resubmission by the DRM will start with proper configfiles and pre-populated outputs. The cost should be minimal as most of the time these are empty
directories.
This would also help with #9236 (comment)