### PR TITLE
Rename function, params in ConfigSerializer

### DIFF
--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -33,71 +33,72 @@ class ConfigSerializer(base.ModelSerializer):
         def _defaults_to(default):
             return lambda item, key, **context: getattr(item, key, default)
 
-        def _required_attribute(item, key, **context):
-            assert hasattr(item, key)
-            return getattr(item, key)
+        def _use_config(config, key, **context):
+            """Let config object determine the value for key"""
+            assert hasattr(config, key)
+            return getattr(config, key)
 
         self.serializers = {
             # TODO: this is available from user data, remove
             'is_admin_user'                     : lambda *a, **c: False,
-            'brand'                             : _required_attribute,
-            'display_galaxy_brand'              : _required_attribute,
+            'brand'                             : _use_config,
+            'display_galaxy_brand'              : _use_config,
             # TODO: this doesn't seem right
             'logo_url'                          : lambda item, key, **context: self.url_for(item.get(key, '/')),
             'logo_src'                          : lambda item, key, **context: self.url_for('/static/favicon.png'),
-            'terms_url'                         : _required_attribute,
-            'myexperiment_target_url'           : _required_attribute,
-            'wiki_url'                          : _required_attribute,
-            'search_url'                        : _required_attribute,
+            'terms_url'                         : _use_config,
+            'myexperiment_target_url'           : _use_config,
+            'wiki_url'                          : _use_config,
+            'search_url'                        : _use_config,
             'mailing_lists'                     : _defaults_to(self.app.config.mailing_lists_url),
-            'screencasts_url'                   : _required_attribute,
-            'genomespace_ui_url'                : _required_attribute,
-            'citation_url'                      : _required_attribute,
-            'support_url'                       : _required_attribute,
-            'helpsite_url'                      : _required_attribute,
+            'screencasts_url'                   : _use_config,
+            'genomespace_ui_url'                : _use_config,
+            'citation_url'                      : _use_config,
+            'support_url'                       : _use_config,
+            'helpsite_url'                      : _use_config,
             'lims_doc_url'                      : _defaults_to("https://usegalaxy.org/u/rkchak/p/sts"),
-            'default_locale'                    : _required_attribute,
-            'enable_openid'                     : _required_attribute,
-            'enable_communication_server'       : _required_attribute,
-            'communication_server_port'         : _required_attribute,
-            'communication_server_host'         : _required_attribute,
-            'persistent_communication_rooms'    : _required_attribute,
-            'allow_user_impersonation'          : _required_attribute,
+            'default_locale'                    : _use_config,
+            'enable_openid'                     : _use_config,
+            'enable_communication_server'       : _use_config,
+            'communication_server_port'         : _use_config,
+            'communication_server_host'         : _use_config,
+            'persistent_communication_rooms'    : _use_config,
+            'allow_user_impersonation'          : _use_config,
             'allow_user_creation'               : _defaults_to(False),  # schema default is True
             'use_remote_user'                   : _defaults_to(None),  # schema default is False; or config.single_user
-            'enable_oidc'                       : _required_attribute,
-            'oidc'                              : _required_attribute,
-            'enable_quotas'                     : _required_attribute,
-            'remote_user_logout_href'           : _required_attribute,
-            'datatypes_disable_auto'            : _required_attribute,
+            'enable_oidc'                       : _use_config,
+            'oidc'                              : _use_config,
+            'enable_quotas'                     : _use_config,
+            'remote_user_logout_href'           : _use_config,
+            'datatypes_disable_auto'            : _use_config,
             'allow_user_dataset_purge'          : _defaults_to(False),  # schema default is True
-            'ga_code'                           : _required_attribute,
-            'enable_unique_workflow_defaults'   : _required_attribute,
-            'enable_beta_markdown_export'       : _required_attribute,
+            'ga_code'                           : _use_config,
+            'enable_unique_workflow_defaults'   : _use_config,
+            'enable_beta_markdown_export'       : _use_config,
             'has_user_tool_filters'             : _defaults_to(False),
             # TODO: is there no 'correct' way to get an api url? controller='api', action='tools' is a hack
             # at any rate: the following works with path_prefix but is still brittle
             # TODO: change this to (more generic) upload_path and incorporate config.nginx_upload_path into building it
             'nginx_upload_path'                 : lambda item, key, **context: getattr(item, key, False),
-            'chunk_upload_size'                 : _required_attribute,
-            'ftp_upload_site'                   : _required_attribute,
+            'chunk_upload_size'                 : _use_config,
+            'ftp_upload_site'                   : _use_config,
             'version_major'                     : _defaults_to(None),
-            'require_login'                     : _required_attribute,
-            'inactivity_box_content'            : _required_attribute,
-            'visualizations_visible'            : _required_attribute,
-            'interactivetools_enable'           : _required_attribute,
-            'message_box_content'               : _required_attribute,
-            'message_box_visible'               : _required_attribute,
-            'message_box_class'                 : _required_attribute,
+            'require_login'                     : _use_config,
+            'inactivity_box_content'            : _use_config,
+            'visualizations_visible'            : _use_config,
+            'interactivetools_enable'           : _use_config,
+            'message_box_content'               : _use_config,
+            'message_box_visible'               : _use_config,
+            'message_box_class'                 : _use_config,
             'server_startttime'                 : lambda item, key, **context: server_starttime,
             'mailing_join_addr'                 : _defaults_to('galaxy-announce-join@bx.psu.edu'),  # should this be the schema default?
             'server_mail_configured'            : lambda item, key, **context: bool(getattr(item, 'smtp_server')),
-            'registration_warning_message'      : _required_attribute,
-            'welcome_url'                       : _required_attribute,
+            'registration_warning_message'      : _use_config,
+            'welcome_url'                       : _use_config,
             'show_welcome_with_login'           : _defaults_to(True),  # schema default is False
-            'cookie_domain'                     : _required_attribute,
+            'cookie_domain'                     : _use_config,
             'python'                            : _defaults_to((sys.version_info.major, sys.version_info.minor)),
-            'select_type_workflow_threshold'    : _required_attribute,
+            'select_type_workflow_threshold'    : _use_config,
         }
 
 

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -31,7 +31,7 @@ class ConfigSerializer(base.ModelSerializer):
     def add_serializers(self):
 
         def _defaults_to(default):
-            return lambda item, key, **context: getattr(item, key, default)
+            return lambda config, key, **context: getattr(config, key, default)
 
         def _use_config(config, key, **context):
             """Let config object determine the value for key"""
@@ -44,8 +44,8 @@ class ConfigSerializer(base.ModelSerializer):
             'brand'                             : _use_config,
             'display_galaxy_brand'              : _use_config,
             # TODO: this doesn't seem right
-            'logo_url'                          : lambda item, key, **context: self.url_for(item.get(key, '/')),
-            'logo_src'                          : lambda item, key, **context: self.url_for('/static/favicon.png'),
+            'logo_url'                          : lambda config, key, **context: self.url_for(config.get(key, '/')),
+            'logo_src'                          : lambda config, key, **context: self.url_for('/static/favicon.png'),
             'terms_url'                         : _use_config,
             'myexperiment_target_url'           : _use_config,
             'wiki_url'                          : _use_config,
@@ -79,7 +79,7 @@ class ConfigSerializer(base.ModelSerializer):
             # TODO: is there no 'correct' way to get an api url? controller='api', action='tools' is a hack
             # at any rate: the following works with path_prefix but is still brittle
             # TODO: change this to (more generic) upload_path and incorporate config.nginx_upload_path into building it
-            'nginx_upload_path'                 : lambda item, key, **context: getattr(item, key, False),
+            'nginx_upload_path'                 : lambda config, key, **context: getattr(config, key, False),
             'chunk_upload_size'                 : _use_config,
             'ftp_upload_site'                   : _use_config,
             'version_major'                     : _defaults_to(None),
@@ -90,9 +90,9 @@ class ConfigSerializer(base.ModelSerializer):
             'message_box_content'               : _use_config,
             'message_box_visible'               : _use_config,
             'message_box_class'                 : _use_config,
-            'server_startttime'                 : lambda item, key, **context: server_starttime,
+            'server_startttime'                 : lambda config, key, **context: server_starttime,
             'mailing_join_addr'                 : _defaults_to('galaxy-announce-join@bx.psu.edu'),  # should this be the schema default?
-            'server_mail_configured'            : lambda item, key, **context: bool(getattr(item, 'smtp_server')),
+            'server_mail_configured'            : lambda config, key, **context: bool(getattr(config, 'smtp_server')),
             'registration_warning_message'      : _use_config,
             'welcome_url'                       : _use_config,
             'show_welcome_with_login'           : _defaults_to(True),  # schema default is False
@@ -109,7 +109,7 @@ class AdminConfigSerializer(ConfigSerializer):
         super(AdminConfigSerializer, self).add_serializers()
 
         def _defaults_to(default):
-            return lambda item, key, **context: getattr(item, key, default)
+            return lambda config, key, **context: getattr(config, key, default)
 
         self.serializers.update({
             # TODO: this is available from user serialization: remove


### PR DESCRIPTION
Two cosmetic changes:
1) `_required_attribute` >> `_use_config` 
The previous name appeared to be confusing (on several occasions). I think the new one is a better way to say "let the config object determine what the value should be" (which currently is the schema default unless overwritten by user configs, or hardcoded in `config/__init.py__`, or `None`). So, now it's `_defaults_to(foo)` or `_use_config` or a lambda expression. 

2) `item` >> `config`. I think it's easier to understand that way; and in ConfigSerializer, the item is always the config object.
