### PR TITLE
[20.01] Fix unselected select parameter comparison to empty string

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -79,6 +79,8 @@ class InputValueWrapper(ToolParameterValueWrapper):
         # For backward compatibility, allow `$wrapper != ""` for optional non-text param
         if self.input.optional and self.value is None:
             if isinstance(other, string_types):
+                if other == '':
+                    return ''
                 return str(self)
             else:
                 return None
@@ -170,6 +172,9 @@ class SelectToolParameterWrapper(ToolParameterValueWrapper):
 
     def __eq__(self, other):
         if isinstance(other, string_types):
+            if other == '' and self.value in (None, []):
+                # Allow $wrapper == '' for select (self.value is None) and multiple select (self.value is []) params
+                return True
             return str(self) == other
         else:
             return super(SelectToolParameterWrapper, self) == other

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -45,6 +45,10 @@ def test_select_wrapper_simple_options(tool):
     assert wrapper.name == "blah"
     assert str(wrapper) == "x"
     assert wrapper.value_label == "I am X"
+    wrapper = SelectToolParameterWrapper(parameter, None)
+    assert str(wrapper) == "None"
+    assert wrapper == ""
+    assert wrapper == "None"
 
 
 @with_mock_tool
@@ -64,6 +68,8 @@ def test_select_wrapper_multiple_options(tool):
     assert "x" in wrapper
     wrapper = SelectToolParameterWrapper(parameter, [])
     assert str(wrapper) == "None"
+    assert wrapper == ""
+    assert wrapper == "None"
     assert "x" not in wrapper
 
 


### PR DESCRIPTION
`$wrapper == ""` and `$wrapper == "None"` had been valid ways
to check for unselected / optional select parameters.
This restores the `$wrapper == ""` form as used by gffcompare
https://github.com/galaxyproject/tools-iuc/blob/master/tools/gffcompare/gffcompare.xml#L41