### PR TITLE
adding health check functionality, api endpoint and unit tests

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/healthcheck.py
+++ b/lib/galaxy/webapps/galaxy/api/healthcheck.py
@@ -22,13 +22,12 @@ class HealthCheckController(BaseAPIController):
         super(HealthCheckController, self).__init__(app)
 
     @staticmethod
-    def _handler_handler(handled, type):
+    def _handler_handler(handled, handler_type):
         if handled:
             return handled
         return [{
             "status": HealthCheckController.FAIL,
-            "notes": ["Error: no {} handlers found".format(type)]
-        }]
+            "notes": ["Error: no {} handlers found".format(handler_type)]}]
 
     @staticmethod
     def _create_status_and_notes(result, service_string=None):
@@ -44,9 +43,8 @@ class HealthCheckController(BaseAPIController):
                 not_passing += 1
                 service_notes.append(" - {}{} has status {}".format(
                     r["componentType"],
-                    ":"+str(r["componentId"]) if "componentId" in r else "",
-                    r["status"]
-                ))
+                    ":" + str(r["componentId"]) if "componentId" in r else "",
+                    r["status"]))
         if not_passing:
             status = HealthCheckController.WARN if not_passing < len(result) else HealthCheckController.FAIL
         _l = len(result)

--- a/lib/galaxy/webapps/galaxy/api/healthcheck.py
+++ b/lib/galaxy/webapps/galaxy/api/healthcheck.py
@@ -1,0 +1,149 @@
+import logging
+
+from galaxy.web import (
+    expose_api_anonymous_and_sessionless
+)
+from galaxy.webapps.base.controller import BaseAPIController
+
+log = logging.getLogger(__name__)
+
+
+class HealthCheckController(BaseAPIController):
+    """
+    controller for checking health
+    """
+
+    # status response strings
+    PASS = "pass"
+    FAIL = "fail"
+    WARN = "warn"
+
+    def __init__(self, app):
+        super(HealthCheckController, self).__init__(app)
+
+    @staticmethod
+    def _handler_handler(handled, type):
+        if handled:
+            return handled
+        return [{
+            "status": HealthCheckController.FAIL,
+            "notes": ["Error: no {} handlers found".format(type)]
+        }]
+
+    @staticmethod
+    def _create_status_and_notes(result, service_string=None):
+        if not result:
+            result_string = "No components found"
+            result_string = service_string + ": " + result_string
+            return HealthCheckController.FAIL, [result_string]
+        not_passing = 0
+        status = HealthCheckController.PASS
+        service_notes = []
+        for r in result:
+            if r["status"] != HealthCheckController.PASS:
+                not_passing += 1
+                service_notes.append(" - {}{} has status {}".format(
+                    r["componentType"],
+                    ":"+str(r["componentId"]) if "componentId" in r else "",
+                    r["status"]
+                ))
+        if not_passing:
+            status = HealthCheckController.WARN if not_passing < len(result) else HealthCheckController.FAIL
+        _l = len(result)
+        notes = ["{} of {} components pass health check".format(_l - not_passing, _l)]
+        notes.extend(service_notes)
+        if service_string:
+            notes[0] = service_string + ": " + notes[0]
+        return status, notes
+
+    @expose_api_anonymous_and_sessionless
+    def get(self, trans, **kwargs):
+        job_handler_result = self._get_job(trans)
+        job_status, job_notes = self._create_status_and_notes(job_handler_result, "Job")
+        worker_result = self._get_web(trans)
+        worker_status, worker_notes = self._create_status_and_notes(worker_result, "Web")
+
+        overall_status = HealthCheckController.PASS
+        notes = list(job_notes)
+        notes.extend(worker_notes)
+
+        job_handler_result = self._handler_handler(job_handler_result, "Job")
+        worker_result = self._handler_handler(worker_result, "Web")
+
+        # if tests are not all passing
+        if worker_status != HealthCheckController.PASS or job_status != HealthCheckController.PASS:
+            # FAIL condition: if both are bad
+            if worker_status == HealthCheckController.FAIL and job_status == HealthCheckController.FAIL:
+                overall_status = HealthCheckController.FAIL
+            # WARN condition: one at least passes
+            else:
+                overall_status = HealthCheckController.WARN
+        return {
+            "status": overall_status,
+            "notes": notes,
+            "checks": {
+                "Job": job_handler_result,
+                "Web": worker_result
+            }
+        }
+
+    @staticmethod
+    def _get_job(trans):
+        job_notes_template = "Job runner '{}' has status '{}'{}"  # {}s = componentType, status, cause
+        result = []
+        runner_dict = trans.app.job_manager.job_handler.dispatcher.job_runners
+        for key in runner_dict:
+            _entry = runner_dict[key]
+            subresult = {
+                "componentType": _entry.runner_name,
+                "status": HealthCheckController.PASS if _entry.nworkers > 0 else HealthCheckController.FAIL
+            }
+            if subresult["status"] != HealthCheckController.PASS:
+                cause = " - no workers found"
+                subresult["notes"] = job_notes_template.format(subresult["componentType"], subresult["status"], cause)
+            result.append(subresult)
+        return result
+
+    @expose_api_anonymous_and_sessionless
+    def get_job(self, trans, **kwargs):
+        job_info = self._get_job(trans)
+        job_status, job_notes = self._create_status_and_notes(job_info, "Job")
+        job_info = self._handler_handler(job_info, "Job")
+        return {
+            "status": job_status,
+            "notes": job_notes,
+            "checks": {"Job": job_info}
+        }
+
+    @staticmethod
+    def _get_web(trans):
+        workers = trans.app.application_stack.workers()
+        name = trans.app.application_stack.name
+        if not workers:
+            return []
+        result = []
+        for worker in workers:
+            subresult = {
+                "componentType": name + " worker",
+                "componentId": worker['id'],
+                "status": HealthCheckController.PASS
+            }
+            if worker['status'] not in ['busy', 'idle']:
+                subresult["status"] = HealthCheckController.FAIL
+                subresult["notes"] = "Web worker {} status is {}".format(worker['id'], worker['status'])
+            elif 'apps' not in worker.keys() or not worker['apps']:
+                subresult["status"] = HealthCheckController.FAIL
+                subresult["notes"] = "Web worker {} does not have a bound app".format(worker['id'])
+            result.append(subresult)
+        return result
+
+    @expose_api_anonymous_and_sessionless
+    def get_web(self, trans, **kwargs):
+        web_info = self._get_web(trans)
+        checked_status, checked_notes = self._create_status_and_notes(web_info, "Web")
+        web_info = self._handler_handler(web_info, "Web")
+        return {
+            "status": checked_status,
+            "notes": checked_notes,
+            "checks": {"Web": web_info}
+        }

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -346,6 +346,24 @@ def populate_api_routes(webapp, app):
                           action='get_custom_builds_metadata',
                           conditions=dict(method=["GET"]))
 
+    webapp.mapper.connect('healthcheck',
+                          '/api/healthcheck/',
+                          controller='healthcheck',
+                          action='get',
+                          conditions=dict(method=["GET"]))
+
+    webapp.mapper.connect('healthcheck_web',
+                          '/api/healthcheck/web',
+                          controller='healthcheck',
+                          action='get_web',
+                          conditions=dict(method=["GET"]))
+
+    webapp.mapper.connect('healthcheck_job',
+                          '/api/healthcheck/job',
+                          controller='healthcheck',
+                          action='get_job',
+                          conditions=dict(method=["GET"]))
+
     # =======================
     # ====== TOOLS API ======
     # =======================

--- a/test/unit/test_healthcheck.py
+++ b/test/unit/test_healthcheck.py
@@ -1,5 +1,6 @@
-from galaxy.webapps.galaxy.api.healthcheck import HealthCheckController
 import json
+
+from galaxy.webapps.galaxy.api.healthcheck import HealthCheckController
 
 
 PASS = HealthCheckController.PASS

--- a/test/unit/test_healthcheck.py
+++ b/test/unit/test_healthcheck.py
@@ -1,0 +1,399 @@
+from galaxy.webapps.galaxy.api.healthcheck import HealthCheckController
+import json
+
+
+PASS = HealthCheckController.PASS
+FAIL = HealthCheckController.FAIL
+WARN = HealthCheckController.WARN
+
+
+# helper class to create an object with attribute-style access from a dictionary
+class AttributeNester:
+    def __init__(self, input_dict):
+        for key, val in input_dict.items():
+            if isinstance(val, dict):
+                val = AttributeNester(val)
+            setattr(self, key, val)
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+
+# helper function to make a mock transaction object to simulate Galaxy states
+def transmaker(worker_function, runners_dict):
+    trans = AttributeNester({
+        "app": {
+            "application_stack": {
+                "name": "MockWebWorker",
+                "workers": worker_function},
+            "job_manager": {
+                "job_handler": {
+                    "dispatcher": {
+                        "job_runners": None}}}},
+        "error_message": "",
+        "anonymous": "",
+        "request": {
+            "body": ""},
+        "response": {
+            "headers": {
+                "Cache-Control": "placeholder string"},
+            "set_content_type": lambda arg, **kwargs: None,
+            "status": "good?"
+        },
+        "debug": "",
+        "status_code": 200
+    })
+    trans.app.job_manager.job_handler.dispatcher.job_runners = runners_dict
+    return trans
+
+
+# create base health check controller
+hcc = HealthCheckController(AttributeNester(
+    {
+        "model": {
+            "context": "contextless",
+            "User": "MockUserModel"
+        }
+    }))
+
+
+# general web worker mock-up
+def _mock_workers(worker_count=3, status="idle", app=None):
+    worker_template = {
+        "id": 0,
+        "status": status,
+        "apps": app
+    }
+    result = []
+    for w in range(worker_count):
+        subresult = dict(worker_template)
+        subresult["id"] = w
+        result.append(subresult)
+    return result
+
+
+# general job runner mock-up
+def _mock_job_runners(runner_count, nworkers):
+    result = {}
+    for r in range(runner_count):
+        subresult = {
+            "runner_name": "MockJobRunner",
+            "nworkers": nworkers}
+        result["MockJobRunner {}".format(r)] = AttributeNester(subresult)
+    return result
+
+
+# create mock healthy transaction object components
+def _healthy_workers():
+    return _mock_workers(3, "idle", ({"id": 0}))
+
+
+def _healthy_job_runners():
+    return _mock_job_runners(2, 2)
+
+
+# create mock unhealthy transaction object components
+def _unhealthy_workers_noapp():
+    return _mock_workers(1, "idle", ())
+
+
+def _unhealthy_workers_no_handlers():
+    return []
+
+
+def _unhealthy_workers_allfails():
+    return _mock_workers(3, "fail", ({"id": 0}))
+
+
+def _unhealthy_job_runners_noworkers():
+    return _mock_job_runners(2, 0)
+
+
+def _unhealthy_job_runners_norunner():
+    return {}
+
+
+def _half_healthy_job_runner():
+    r = {}
+    good_half = _mock_job_runners(1, 1)
+    bad_half = _mock_job_runners(1, 0)
+    values = list(bad_half.values()) + list(good_half.values())
+    for n in range(len(values)):
+        r["MockJobRunner {}".format(n)] = values[n]
+    return r
+
+
+def _half_healthy_web_workers():
+    good_half = _mock_workers(1, "idle", ({"id": 0}))
+    bad_half = _mock_workers(1, "neither idle nor busy", ({"id": 0}))
+    return good_half + bad_half
+
+
+def expected_webfail_checks(worker_number=0):
+    return {
+        'componentType': 'MockWebWorker worker',
+        'status': FAIL,
+        'notes': 'Web worker {} does not have a bound app'.format(worker_number),
+        'componentId': 0}
+
+
+expected_healthy_job_check_result = [
+    {"componentType": "MockJobRunner", "status": PASS},
+    {"componentType": "MockJobRunner", "status": PASS}]
+expected_healthy_web_check_result = [
+    {"componentType": "MockWebWorker worker", "status": PASS, "componentId": 0},
+    {"componentType": "MockWebWorker worker", "status": PASS, "componentId": 1},
+    {"componentType": "MockWebWorker worker", "status": PASS, "componentId": 2}]
+
+expected_jobfail_notes = [
+    'Job: 0 of 2 components pass health check',
+    ' - MockJobRunner has status {}'.format(FAIL),
+    ' - MockJobRunner has status {}'.format(FAIL)]
+expected_jobfail_checks_notes = "Job runner 'MockJobRunner' has status '{}' - no workers found".format(FAIL)
+
+expected_webfail_notes = [
+    'Web: 0 of 1 components pass health check',
+    ' - MockWebWorker worker:0 has status {}'.format(FAIL)]
+
+expected_partial_job_notes = [
+    'Job: 1 of 2 components pass health check',
+    ' - MockJobRunner has status fail']
+expected_partial_web_notes = ['Web: 3 of 3 components pass health check']
+
+
+# test case: everything's good
+def test_healthy_instance():
+    healthy_trans = transmaker(_healthy_workers, _healthy_job_runners())
+    expected_result = {
+        "status": PASS,
+        "notes": ["Job: 2 of 2 components pass health check", "Web: 3 of 3 components pass health check"],
+        "checks": {
+            "Web": expected_healthy_web_check_result,
+            "Job": expected_healthy_job_check_result}}
+    actual_result = json.loads(hcc.get(healthy_trans))
+    assert expected_result == actual_result
+
+
+# sub-test-case: web handler is good
+def test_healthy_web():
+    healthy_trans = transmaker(_healthy_workers, _healthy_job_runners())
+    expected_result = {
+        "status": PASS,
+        "notes": ["Web: 3 of 3 components pass health check"],
+        "checks": {
+            "Web": expected_healthy_web_check_result}}
+    actual_result = json.loads(hcc.get_web(healthy_trans))
+    assert expected_result == actual_result
+
+
+# sub-test-case: job runner is good
+def test_healthy_job():
+    healthy_trans = transmaker(_healthy_workers, _healthy_job_runners())
+    expected_result = {
+        "status": PASS,
+        "notes": ["Job: 2 of 2 components pass health check"],
+        "checks": {
+            "Job": expected_healthy_job_check_result}}
+    assert expected_result == json.loads(hcc.get_job(healthy_trans))
+
+
+# run failure tests
+#   NOTES:
+# job runners fail by having no job runners or by being totally absent
+# web runners fail by not being idle or busy, or by having no bound apps
+
+# test case: job handler has no workers, web handler has no bound app
+def test_failing_instance_noapp_noworker():
+    failing_trans_job_workerless_web_appless = transmaker(_unhealthy_workers_noapp, _unhealthy_job_runners_noworkers())
+    expected_result = {
+        'status': FAIL,
+        'notes': expected_jobfail_notes + expected_webfail_notes,
+        'checks': {
+            'Web': [expected_webfail_checks(0)],
+            'Job': [
+                {'componentType': 'MockJobRunner',
+                 'status': FAIL,
+                 'notes': expected_jobfail_checks_notes},
+                {'componentType': 'MockJobRunner',
+                 'status': FAIL,
+                 'notes': expected_jobfail_checks_notes}]}}
+
+    actual_result = json.loads(hcc.get(failing_trans_job_workerless_web_appless))
+    assert expected_result == actual_result
+
+
+# sub-test-case: job check with no workers
+def test_failing_instance_noworker_job():
+    failing_trans_job_workerless_web_appless = transmaker(_unhealthy_workers_noapp, _unhealthy_job_runners_noworkers())
+    expected_result = {
+        'status': FAIL,
+        'notes': expected_jobfail_notes,
+        'checks': {
+            'Job': [
+                {'componentType': 'MockJobRunner',
+                 'status': FAIL,
+                 'notes': expected_jobfail_checks_notes},
+                {'componentType': 'MockJobRunner',
+                 'status': FAIL,
+                 'notes': expected_jobfail_checks_notes}]}}
+    actual_result = json.loads(hcc.get_job(failing_trans_job_workerless_web_appless))
+    assert expected_result == actual_result
+
+
+# sub-test-case: web check with no bound app
+def test_failing_instance_noapp_web():
+    failing_trans_job_workerless_web_appless = transmaker(_unhealthy_workers_noapp, _unhealthy_job_runners_noworkers())
+    expected_result = {
+        'status': FAIL,
+        'notes': expected_webfail_notes,
+        'checks': {
+            'Web': [
+                {'componentType': 'MockWebWorker worker',
+                 'status': FAIL,
+                 'notes': 'Web worker 0 does not have a bound app',
+                 'componentId': 0}]}}
+    actual_result = json.loads(hcc.get_web(failing_trans_job_workerless_web_appless))
+    assert expected_result == actual_result
+
+
+# test case: no job handlers, no web handlers
+def test_failing_instance_no_handlers():
+    failing_trans_no_handlers = transmaker(_unhealthy_workers_no_handlers, _unhealthy_job_runners_norunner())
+    expected_result = {
+        'status': FAIL,
+        'notes': [
+            'Job: No components found',
+            'Web: No components found'],
+        'checks': {
+            'Job': [
+                {'status': FAIL, 'notes': ['Error: no Job handlers found']}],
+            'Web': [
+                {'status': FAIL, 'notes': ['Error: no Web handlers found']}]}}
+    actual_result = json.loads(hcc.get(failing_trans_no_handlers))
+    assert expected_result == actual_result
+
+
+# sub-test-case: job check with no handlers
+def test_failing_instance_no_handlers_job():
+    failing_trans_no_handlers = transmaker(_unhealthy_workers_no_handlers, _unhealthy_job_runners_norunner())
+    expected_result = {
+        'status': FAIL,
+        'notes': ['Job: No components found'],
+        'checks': {'Job': [
+            {'status': FAIL,
+             'notes': ['Error: no Job handlers found']}]}}
+    actual_result = json.loads(hcc.get_job(failing_trans_no_handlers))
+    assert expected_result == actual_result
+
+
+# sub-test-case: web check with no handlers
+def test_failing_instance_no_handlers_web():
+    failing_trans_no_handlers = transmaker(_unhealthy_workers_no_handlers, _unhealthy_job_runners_norunner())
+    expected_result = {
+        'status': FAIL,
+        'notes': ['Web: No components found'],
+        'checks': {'Web': [
+            {'status': FAIL,
+             'notes': ['Error: no Web handlers found']}]}}
+    actual_result = json.loads(hcc.get_web(failing_trans_no_handlers))
+    assert expected_result == actual_result
+
+
+# test case: partial success in job, success in web
+def test_partial_job_instance():
+    warning_trans_iffy_jobs = transmaker(_healthy_workers, _half_healthy_job_runner())
+    expected_result = {
+        'status': WARN,
+        'notes': expected_partial_job_notes + expected_partial_web_notes,
+        'checks': {
+            'Web': expected_healthy_web_check_result,
+            'Job': [
+                {'componentType': 'MockJobRunner',
+                 'status': 'fail',
+                 'notes': "Job runner 'MockJobRunner' has status 'fail' - no workers found"},
+                {'componentType': 'MockJobRunner',
+                 'status': 'pass'}]}}
+    actual_result = json.loads(hcc.get(warning_trans_iffy_jobs))
+    assert expected_result == actual_result
+
+
+# sub-test-case: job handler group that is only half-healthy
+def test_partial_job_instance_job():
+    warning_trans_iffy_jobs = transmaker(_healthy_workers, _half_healthy_job_runner())
+    expected_result = {
+        'status': 'warn',
+        'notes': expected_partial_job_notes,
+        'checks': {
+            'Job': [
+                {'componentType': 'MockJobRunner',
+                 'status': 'fail',
+                 'notes': "Job runner 'MockJobRunner' has status 'fail' - no workers found"},
+                {'componentType': 'MockJobRunner', 'status': 'pass'}]}}
+    actual_result = json.loads(hcc.get_job(warning_trans_iffy_jobs))
+    assert expected_result == actual_result
+
+
+# test case: success in job, partial success in web
+def test_partial_web_instance():
+    warning_trans_iffy_web = transmaker(_half_healthy_web_workers, _healthy_job_runners())
+    expected_result = {
+        'status': 'warn',
+        'notes': [
+            'Job: 2 of 2 components pass health check',
+            'Web: 1 of 2 components pass health check',
+            ' - MockWebWorker worker:0 has status fail'],
+        'checks': {
+            'Web': [
+                {'componentType': 'MockWebWorker worker', 'status': 'pass', 'componentId': 0},
+                {'componentType': 'MockWebWorker worker', 'status': 'fail',
+                 'notes': 'Web worker 0 status is neither idle nor busy', 'componentId': 0}],
+            'Job': [
+                {'componentType': 'MockJobRunner', 'status': 'pass'},
+                {'componentType': 'MockJobRunner', 'status': 'pass'}]}}
+    actual_result = json.loads(hcc.get(warning_trans_iffy_web))
+    assert expected_result == actual_result
+
+
+# sub-test-case: web worker that is only half-healthy
+def test_partial_web_instance_web():
+    warning_trans_iffy_web = transmaker(_half_healthy_web_workers, _healthy_job_runners())
+    expected_result = {
+        'status': 'warn',
+        'notes': [
+            'Web: 1 of 2 components pass health check',
+            ' - MockWebWorker worker:0 has status fail'],
+        'checks': {
+            'Web': [
+                {'componentType': 'MockWebWorker worker',
+                 'status': 'pass', 'componentId': 0},
+                {'componentType': 'MockWebWorker worker',
+                 'status': 'fail',
+                 'notes': 'Web worker 0 status is neither idle nor busy',
+                 'componentId': 0}]}}
+    actual_result = json.loads(hcc.get_web(warning_trans_iffy_web))
+    assert expected_result == actual_result
+
+
+# test case: both web and job handlers are half-healthy
+def test_partial_web_and_job_instance():
+    warning_trans_iffy_both = transmaker(_half_healthy_web_workers, _half_healthy_job_runner())
+    expected_result = {
+        'status': 'warn',
+        'notes': [
+            'Job: 1 of 2 components pass health check',
+            ' - MockJobRunner has status fail',
+            'Web: 1 of 2 components pass health check',
+            ' - MockWebWorker worker:0 has status fail'],
+        'checks': {
+            'Web': [
+                {'componentType': 'MockWebWorker worker',
+                 'status': 'pass', 'componentId': 0},
+                {'componentType': 'MockWebWorker worker', 'status': 'fail',
+                 'notes': 'Web worker 0 status is neither idle nor busy',
+                 'componentId': 0}],
+            'Job': [
+                {'componentType': 'MockJobRunner', 'status': 'fail',
+                 'notes': "Job runner 'MockJobRunner' has status 'fail' - no workers found"},
+                {'componentType': 'MockJobRunner', 'status': 'pass'}]}}
+    actual_result = json.loads(hcc.get(warning_trans_iffy_both))
+    assert expected_result == actual_result


### PR DESCRIPTION
**Why the changes should be made**:
Health checks are generally useful, and on the Galaxy/Kubernetes to-do list. More info in #9180 

**Description of the implementation of the changes**:
a sessionless, anonymous API endpoint was added (`api/healthcheck`) with sub-endpoints (`api/healthcheck/job, api/healthcheck/web`) to test general health, and also specifically web / job handlers/runners, to map to the job/web pod separation of responsibilities in the current Galaxy/K8s helm chart. see issue #9180 for more details.

**How to test the changes**:
- generally:
```
<host>/api/healthcheck
<host>/api/healthcheck/job
<host>/api/healthcheck/web
```
- unit tests:
`sh run_tests.sh -unit test/unit/test_healthcheck.py --verbose_errors`

There are probably better ways to go about this, but perhaps a working implementation will lead to some discussion on that matter. 

Please let me know if there are any questions, or what I can do to improve the quality of this submission. Thanks for reading!