### PR TITLE
[19.09] Fix iteritems use in build_from_current_history.mako

### DIFF
--- a/templates/webapps/galaxy/workflow/build_from_current_history.mako
+++ b/templates/webapps/galaxy/workflow/build_from_current_history.mako
@@ -103,7 +103,7 @@ into a workflow will be shown in gray.</p>
         <th style="width: 47.5%">${_('History items created')}</th>
     </tr>
 
-%for job, datasets in jobs.iteritems():
+%for job, datasets in jobs.items():
 
     <%
     cls = "toolForm"


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/9265

I guess this used to be our custom OrderedDict implementation that defined iteritems.