### PR TITLE
[20.01] backport 9268: Fix target_str_to_targets

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -403,8 +403,8 @@ def target_str_to_targets(targets_raw):
         if "=" in target_str:
             package_name, version = target_str.split("=", 1)
             build = None
-            if "--" in version:
-                version, build = version.split('--')
+            if "=" in version:
+                version, build = version.split('=')
             target = build_target(package_name, version, build)
         else:
             target = build_target(target_str)


### PR DESCRIPTION
This was meant to go to 20.01 in https://github.com/galaxyproject/galaxy/pull/9268 already, but I selected the wrong target branch.

This function is used to parse out Conda targets. The build part here is
wrong, a package build is specified like this:
`<package_name>=<version>=build`. This fixed building images as in https://github.com/BioContainers/multi-package-containers/pull/953