### PR TITLE
[20.01] Backwards compatible build number parsing

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -405,6 +405,8 @@ def target_str_to_targets(targets_raw):
             build = None
             if "=" in version:
                 version, build = version.split('=')
+            elif "--" in version:
+                version, build = version.split('--')
             target = build_target(package_name, version, build)
         else:
             target = build_target(target_str)

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -168,11 +168,11 @@ def _simple_image_name(targets, image_build=None):
     target = targets[0]
     suffix = ""
     if target.version is not None:
-        if image_build is not None:
+        build = target.build
+        if build is None and image_build is not None and image_build != "0":
+            # Special case image_build == "0", which has been built without a suffix
             print("WARNING: Hard-coding image build instead of using Conda build - this is not recommended.")
             build = image_build
-        else:
-            build = target.build
         suffix += ":%s" % target.version
         if build is not None:
             suffix += "--%s" % build
@@ -227,6 +227,15 @@ def v2_image_name(targets, image_build=None, name_override=None):
     >>> single_targets = [build_target("samtools", version="1.3.1")]
     >>> v2_image_name(single_targets)
     'samtools:1.3.1'
+    >>> single_targets = [build_target("samtools", version="1.3.1", build="py_1")]
+    >>> v2_image_name(single_targets)
+    'samtools:1.3.1--py_1'
+    >>> single_targets = [build_target("samtools", version="1.3.1")]
+    >>> v2_image_name(single_targets, image_build="0")
+    'samtools:1.3.1'
+    >>> single_targets = [build_target("samtools", version="1.3.1", build="py_1")]
+    >>> v2_image_name(single_targets, image_build="0")
+    'samtools:1.3.1--py_1'
     >>> multi_targets = [build_target("samtools", version="1.3.1"), build_target("bwa", version="0.7.13")]
     >>> v2_image_name(multi_targets)
     'mulled-v2-fe8faa35dbf6dc65a0f7f5d4ea12e31a79f73e40:4d0535c94ef45be8459f429561f0894c3fe0ebcf'


### PR DESCRIPTION
- Restore parsing build numbers separated with `--`. I changed this in #9268
but the alternative `--` is also in use at https://github.com/BioContainers/multi-package-containers/blob/master/combinations/hash.tsv#L14

- Don't include build number 0 for single images and have conda build take precedence over image_build
for single target images. If overriding the build suffix is really necessary one can use the `name_override` column.

With those 2 commits I can get https://github.com/BioContainers/multi-package-containers/pull/966/files to pass without building any new images