### PR TITLE
Handle stale element reference in new workflow bookmark test.

### DIFF
--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -12,6 +12,7 @@ from galaxy_test.base.workflow_fixtures import (
 )
 from .framework import (
     retry_assertion_during_transitions,
+    retry_during_transitions,
     selenium_test,
     SeleniumTestCase
 )
@@ -339,7 +340,7 @@ steps:
 
     @selenium_test
     def test_workflow_bookmarking(self):
-        @retry_assertion_during_transitions
+        @retry_during_transitions
         def assert_workflow_bookmarked_status(target_status):
             name_matches = [c.text == new_workflow_name for c in self.components.tool_panel.workflow_names.all()]
             status = any(name_matches)


### PR DESCRIPTION
Should address this exception reported by @dannon: 

```
...
  File "/galaxy/lib/galaxy_test/selenium/test_workflow_editor.py", line 344, in assert_workflow_bookmarked_status
    name_matches = [c.text == new_workflow_name for c in self.components.tool_panel.workflow_names.all()]
  File "/galaxy/lib/galaxy_test/selenium/test_workflow_editor.py", line 344, in <listcomp>
    name_matches = [c.text == new_workflow_name for c in self.components.tool_panel.workflow_names.all()]
  File "/galaxy_venv3/lib/python3.5/site-packages/selenium/webdriver/remote/webelement.py", line 76, in text
    return self._execute(Command.GET_ELEMENT_TEXT)['value']
...
selenium.common.exceptions.StaleElementReferenceException: Message: stale element reference: element is not attached to the page document
```