### PR TITLE
Do not test config_dir default value

### DIFF
--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -158,6 +158,7 @@ DO_NOT_TEST = [
     'chunk_upload_size',  # broken: default overridden
     'cleanup_job',  # broken: default overridden
     'conda_auto_init',  # broken: default overridden
+    'config_dir',  # value overridden for testing
     'data_dir',  # value overridden for testing
     'data_manager_config_file',  # broken: remove 'config/' prefix from schema
     'database_connection',  # untestable; refactor config/__init__ to test


### PR DESCRIPTION
This default value should not be tested as part of this test case. (test passes on jenkins, but breaks when tested locally). (why did I add it in the first place, when my own comment in the file says 'do not test'...)
