### PR TITLE
[19.09] Python3: don't check for has_key attribute

### DIFF
--- a/lib/galaxy/auth/providers/ldap_ad.py
+++ b/lib/galaxy/auth/providers/ldap_ad.py
@@ -7,7 +7,10 @@ Created on 15/07/2014
 import logging
 
 from galaxy.exceptions import ConfigurationError
-from galaxy.util import string_as_bool
+from galaxy.util import (
+    string_as_bool,
+    unicodify,
+)
 from ..providers import AuthProvider
 
 try:
@@ -82,9 +85,10 @@ class LDAP(AuthProvider):
 
     def check_config(self, username, email, options):
         ok = True
-        failure_mode = False  # reject but continue
         if options.get('continue-on-failure', 'False') == 'False':
             failure_mode = None  # reject and do not continue
+        else:
+            failure_mode = False  # reject but continue
 
         if string_as_bool(options.get('login-use-username', False)):
             if not username:
@@ -103,7 +107,11 @@ class LDAP(AuthProvider):
             raise ConfigurationError("If 'auto-assign-roles-to-groups-only' is True, auto-create-roles and "
                                      "auto-create-groups have to be True as well.")
 
-        self.role_search_attribute = options.get(self.role_search_option, None)
+        self.role_search_attribute = options.get(self.role_search_option)
+        if self.auto_create_roles_or_groups and self.role_search_attribute is None:
+            raise ConfigurationError("If 'auto-create-roles' or 'auto-create-groups' is True, a '%s' attribute has to"
+                                     " be provided." % self.role_search_option)
+
         return ok, failure_mode
 
     def ldap_search(self, email, username, options):
@@ -113,10 +121,6 @@ class LDAP(AuthProvider):
 
         if not config_ok:
             return failure_mode, None
-
-        if self.auto_create_roles_or_groups and self.role_search_attribute is None:
-            raise ConfigurationError("If 'auto-create-roles' or 'auto-create-groups' is True, a '%s' attribute has to"
-                                     " be provided." % self.role_search_option)
 
         params = {'email': email, 'username': username}
 
@@ -149,8 +153,7 @@ class LDAP(AuthProvider):
                     l.simple_bind_s()
 
                 # setup search
-                attributes = [_.strip().format(**params)
-                              for _ in options['search-fields'].split(',')]
+                attributes = {_.strip().format(**params) for _ in options['search-fields'].split(',')}
                 suser = l.search_ext_s(_get_subs(options, 'search-base', params),
                     ldap.SCOPE_SUBTREE,
                     _get_subs(options, 'search-filter', params), attributes,
@@ -161,17 +164,16 @@ class LDAP(AuthProvider):
                     log.warning('LDAP authenticate: search returned no results')
                     return (failure_mode, None)
                 dn, attrs = suser[0]
-                log.debug(("LDAP authenticate: dn is %s" % dn))
-                log.debug(("LDAP authenticate: search attributes are %s" % attrs))
-                if hasattr(attrs, 'has_key'):
-                    for attr in attributes:
-                        if self.role_search_attribute and attr == self.role_search_attribute[1:-1]:  # strip brackets
-                            # keep role names as list
-                            params[self.role_search_option] = attrs[attr]
-                        elif attr in attrs:
-                            params[attr] = str(attrs[attr][0])
-                        else:
-                            params[attr] = ""
+                log.debug("LDAP authenticate: dn is %s", dn)
+                log.debug("LDAP authenticate: search attributes are %s", attrs)
+                for attr in attributes:
+                    if self.role_search_attribute and attr == self.role_search_attribute[1:-1]:  # strip curly brackets
+                        # keep role names as list
+                        params[self.role_search_option] = [unicodify(_) for _ in attrs[attr]]
+                    elif attr in attrs:
+                        params[attr] = unicodify(attrs[attr][0])
+                    else:
+                        params[attr] = ""
 
                 if self.auto_create_roles_or_groups and self.role_search_option not in params:
                     raise ConfigurationError("Missing or mismatching LDAP parameters for %s. Make sure the %s is "


### PR DESCRIPTION
Also partially backport commit f892231b8b5f99d90903097076e47552c051f1bf .
Fix https://github.com/galaxyproject/galaxy/issues/9178 .