### PR TITLE
Do not strip tab characters from data_column reference and clarify documentation for use_header_names

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2563,8 +2563,10 @@ Set to ``false`` to not force user to select an option in the list.</xs:document
             <xs:documentation xml:lang="en">Used only if the ``type`` attribute
 value is ``data_column``, if ``true`` Galaxy assumes first row of ``data_ref``
 is a header and builds the select list with these values rather than the more
-generic ``c1`` ... ``cN``.
-</xs:documentation>
+generic ``c1`` ... ``cN`` (i.e. it will be ``c1: head1`` ... ``cN: headN``).
+Note that the content of the Cheetah variable is still
+the column index.
+            </xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="display" type="DisplayType">
@@ -4830,7 +4832,7 @@ write out a JSON representation of the tool parameters.
 
 *Example*
 
-The following will create a cheetah variable that can be evaluated as ``$inputs`` that
+The following will create a Cheetah variable that can be evaluated as ``$inputs`` that
 will contain the tool parameter inputs.
 
 ```xml

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2561,7 +2561,7 @@ Set to ``false`` to not force user to select an option in the list.</xs:document
         <xs:attribute name="use_header_names" type="PermissiveBoolean">
           <xs:annotation>
             <xs:documentation xml:lang="en">Used only if the ``type`` attribute
-value is ``data_column``, if ``true`` Galaxy assumes first row of ``data_ref``
+value is ``data_column``. If ``true``, Galaxy assumes the first row of ``data_ref``
 is a header and builds the select list with these values rather than the more
 generic ``c1`` ... ``cN`` (i.e. it will be ``c1: head1`` ... ``cN: headN``).
 Note that the content of the Cheetah variable is still

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1271,7 +1271,7 @@ class ColumnListParameter(SelectToolParameter):
             try:
                 with open(dataset.get_file_name(), 'r') as f:
                     head = f.readline()
-                cnames = head.rstrip().split('\t')
+                cnames = head.rstrip("\n\r ").split('\t')
                 column_list = [('%d' % (i + 1), 'c%d: %s' % (i + 1, x)) for i, x in enumerate(cnames)]
                 if self.numerical:  # If numerical was requested, filter columns based on metadata
                     if hasattr(dataset, 'metadata') and hasattr(dataset.metadata, 'column_types'):

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -1,10 +1,13 @@
 <tool id="column_param" name="Column Param">
-  <command>
+  <command><![CDATA[
+    echo "col $col" &&
+    echo "col_names $col_names" &&
     cut -f '$col' '$input1' > '$output1'
-  </command>
+  ]]></command>
   <inputs>
     <param type="data" format="tabular" name="input1" label="Input 1" />
     <param name="col" type="data_column" data_ref="input1" label="Column to Use" />
+    <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
   </inputs>
   <outputs>
     <data name="output1" format="tabular" />
@@ -13,8 +16,11 @@
     <test>
       <param name="input1" value="2.tabular" />
       <param name="col" value="2" />
+      <param name="col_names" value="2" />
       <output name="output1">
         <assert_contents>
+          <has_line line="col 2" />
+          <has_line line="col_names 2" />
           <has_line line="68" />
         </assert_contents>
       </output>

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -1,8 +1,8 @@
 <tool id="column_param" name="Column Param">
   <command><![CDATA[
-    echo "col $col" >> '$output1' &&
-    echo "col_names $col_names" >> '$output1' &&
-	cut -f '$col' '$input1' >> '$output1'
+    cut -f '$col' '$input1' >> '$output1'
+    echo "col $col" >> '$output2' &&
+    echo "col_names $col_names" >> '$output2' &&
   ]]></command>
   <inputs>
     <param type="data" format="tabular" name="input1" label="Input 1" />
@@ -11,6 +11,7 @@
   </inputs>
   <outputs>
     <data name="output1" format="tabular" />
+    <data name="output2" format="tabular" />
   </outputs>
   <tests>
     <test>
@@ -19,9 +20,13 @@
       <param name="col_names" value="2" />
       <output name="output1">
         <assert_contents>
+          <has_line line="68" />
+        </assert_contents>
+      </output>
+      <output name="output2">
+        <assert_contents>
           <has_line line="col 2" />
           <has_line line="col_names 2" />
-          <has_line line="68" />
         </assert_contents>
       </output>
     </test>

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -1,8 +1,8 @@
 <tool id="column_param" name="Column Param">
   <command><![CDATA[
-    echo "col $col" &&
-    echo "col_names $col_names" &&
-    cut -f '$col' '$input1' > '$output1'
+    echo "col $col" >> '$output1' &&
+    echo "col_names $col_names" >> '$output1' &&
+	cut -f '$col' '$input1' >> '$output1'
   ]]></command>
   <inputs>
     <param type="data" format="tabular" name="input1" label="Input 1" />

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -1,8 +1,8 @@
 <tool id="column_param" name="Column Param">
   <command><![CDATA[
-    cut -f '$col' '$input1' >> '$output1'
-    echo "col $col" >> '$output2' &&
-    echo "col_names $col_names" >> '$output2' &&
+cut -f '$col' '$input1' > '$output1' &&
+echo "col $col" > '$output2' &&
+echo "col_names $col_names" >> '$output2'
   ]]></command>
   <inputs>
     <param type="data" format="tabular" name="input1" label="Input 1" />

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -11,7 +11,7 @@ echo "col_names $col_names" >> '$output2'
   </inputs>
   <outputs>
     <data name="output1" format="tabular" />
-    <data name="output2" format="tabular" />
+    <data name="output2" format="txt" />
   </outputs>
   <tests>
     <test>


### PR DESCRIPTION
- add a test (also as example)
- clarify in the docs
- bugfix empty columns must not be stripped