### PR TITLE
Remove a dead symlink

### DIFF
--- a/static/toolshed/src
+++ b/static/toolshed/src
@@ -1,1 +1,0 @@
-../../client/toolshed/scripts/


### PR DESCRIPTION
Just removing a symlink which seems to be dead starting with 19.09 (unless it is supposed to be created later?)
As it is dead, it triggers an error in https://github.com/galaxyproject/ansible-galaxy-extras/blob/master/templates/export_user_files.py.j2#L73