### PR TITLE
[20.01] Prevent caching of bootstrapped client data

### DIFF
--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -276,6 +276,10 @@ class JSAppLauncher(BaseUIController):
         return self._bootstrapped_client(trans, **kwd)
 
     def _bootstrapped_client(self, trans, app_name='analysis', **kwd):
+        # This includes contextualized user options in the bootstrapped data; we don't want to cache it.
+        trans.response.headers['Cache-Control'] = ['no-cache', 'no-store', 'must-revalidate']
+        trans.response.headers['Pragma'] = 'no-cache'
+        trans.response.headers['Expires'] = '0'
         js_options = self._get_js_options(trans)
         js_options['config'].update(self._get_extended_config(trans))
         return self.template(trans, app_name, options=js_options, **kwd)


### PR DESCRIPTION
Attempting to address the last bits of https://github.com/galaxyproject/galaxy/issues/7249

The javascript itself can/will still be cached, and that's the brunt of the data transmitted when filling out the app.  The majority of this particular response is the bootstrapped data related primarily to current user that we don't really want to cache.