### PR TITLE
[19.09] Add build_sites_config_file option to config_schema

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -732,6 +732,17 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``build_sites_config_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    File that defines the builds (dbkeys) available at sites used by
+    display applications and the URL to those sites.
+:Default: ``config/build_sites.yml.sample``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~
 ``builds_file_path``
 ~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -441,6 +441,10 @@ galaxy:
   # scenarios than the watchdog default.
   #watch_tool_data_dir: 'false'
 
+  # File that defines the builds (dbkeys) available at sites used by
+  # display applications and the URL to those sites.
+  #build_sites_config_file: config/build_sites.yml.sample
+
   # File containing old-style genome builds
   #builds_file_path: tool-data/shared/ucsc/builds.txt
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -553,6 +553,14 @@ mapping:
           will use a less efficient monitoring scheme that may work in wider range of scenarios than
           the watchdog default.
 
+      build_sites_config_file:
+        type: str
+        default: config/build_sites.yml.sample
+        required: false
+        desc: |
+          File that defines the builds (dbkeys) available at sites used by display applications
+          and the URL to those sites.
+
       builds_file_path:
         type: str
         default: tool-data/shared/ucsc/builds.txt


### PR DESCRIPTION
We need this for the default value. Without the defaults
many external display applications won't load.