### PR TITLE
Clean up old 'blue' style path, update documentation and samples

### DIFF
--- a/doc/source/admin/apache.md
+++ b/doc/source/admin/apache.md
@@ -150,7 +150,6 @@ SSLStaplingCache        shmcb:/var/run/ocsp(128000)
 
     # serve framework static content
     RewriteEngine On
-    RewriteRule ^/static/style/(.*) ${galaxy_root}/static/style/blue/$1 [L]
     RewriteRule ^/static/(.*) ${galaxy_root}/static/$1 [L]
     RewriteRule ^/favicon.ico ${galaxy_root}/static/favicon.ico [L]
     RewriteRule ^/robots.txt ${galaxy_root}/static/robots.txt [L]
@@ -216,7 +215,6 @@ previous section:
         # serve framework static content
         RewriteEngine On
         RewriteRule ^/galaxy/$ /galaxy [R,L]
-        RewriteRule ^/galaxy/static/style/(.*) ${galaxy_root}/static/style/blue/$1 [L]
         RewriteRule ^/galaxy/static/(.*) ${galaxy_root}/static/$1 [L]
         RewriteRule ^/galaxy/favicon.ico ${galaxy_root}/static/favicon.ico [L]
     RewriteRule ^/galaxy/robots.txt ${galaxy_root}/static/robots.txt [L]

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -226,7 +226,7 @@
     Where dataset files are stored. It must be accessible at the same
     path on any cluster nodes that will run Galaxy jobs, unless using
     Pulsar.
-:Default: ``files``
+:Default: ``objects``
 :Type: str
 
 
@@ -1078,9 +1078,12 @@
 
 :Description:
     What Dataset attribute is used to reference files in an
-    ObjectStore implementation, default is 'id' but can also be set to
-    'uuid' for more de-centralized usage.
-:Default: ``id``
+    ObjectStore implementation, this can be 'uuid' or 'id'. The
+    default will depend on how the object store is configured,
+    starting with 20.05 Galaxy will try to default to 'uuid' if it can
+    be sure this is a new Galaxy instance - but the default will be
+    'id' in many cases.
+:Default: ``None``
 :Type: str
 
 

--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -117,7 +117,7 @@ http {
         server_name _;
 
         # use a variable for convenience
-		set $galaxy_root /srv/galaxy/server;
+        set $galaxy_root /srv/galaxy/server;
 
         # Enable HSTS
         add_header Strict-Transport-Security "max-age=15552000; includeSubdomains";
@@ -129,24 +129,24 @@ http {
             include uwsgi_params;
         }
 
-		# serve framework static content
-		location /static {
-			alias $galaxy_root/static;
-			expires 24h;
-		}
-		location /robots.txt {
-			alias $galaxy_root/static/robots.txt;
-			expires 24h;
-		}
-		location /favicon.ico {
-			alias $galaxy_root/static/favicon.ico;
-			expires 24h;
-		}
+        # serve framework static content
+        location /static {
+            alias $galaxy_root/static;
+            expires 24h;
+        }
+        location /robots.txt {
+            alias $galaxy_root/static/robots.txt;
+            expires 24h;
+        }
+        location /favicon.ico {
+            alias $galaxy_root/static/favicon.ico;
+            expires 24h;
+        }
 
         # serve visualization and interactive environment plugin static content
-		location ~ ^/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
+        location ~ ^/plugins/(?<plug_type>.+?)/(?<vis_name>.+?)/static/(?<static_file>.*?)$ {
             alias $galaxy_root/config/plugins/$plug_type/$vis_name/static/$static_file;
-			expires 24;
+            expires 24;
         }
     }
 }
@@ -303,24 +303,24 @@ user galaxy;
 
 http {
 
-	#...
+    #...
 
     server {
 
-		#...
+        #...
 
         # handle file uploads via the upload module
-		location /_upload {
-			upload_store /srv/galaxy/upload_store;
-			upload_store_access user:rw group:rw;
-			upload_pass_form_field "";
-			upload_set_form_field "__${upload_field_name}__is_composite" "true";
-			upload_set_form_field "__${upload_field_name}__keys" "name path";
-			upload_set_form_field "${upload_field_name}_name" "$upload_file_name";
-			upload_set_form_field "${upload_field_name}_path" "$upload_tmp_path";
-			upload_pass_args on;
-			upload_pass /_upload_done;
-		}
+        location /_upload {
+            upload_store /srv/galaxy/upload_store;
+            upload_store_access user:rw group:rw;
+            upload_pass_form_field "";
+            upload_set_form_field "__${upload_field_name}__is_composite" "true";
+            upload_set_form_field "__${upload_field_name}__keys" "name path";
+            upload_set_form_field "${upload_field_name}_name" "$upload_file_name";
+            upload_set_form_field "${upload_field_name}_path" "$upload_tmp_path";
+            upload_pass_args on;
+            upload_pass /_upload_done;
+        }
 
         # once upload is complete, redirect to the proper galaxy path
         location /_upload_done {

--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -199,7 +199,7 @@ previous section:
             }
 
             # serve framework static content
-            location /static {
+            location /galaxy/static {
                 alias $galaxy_root/static;
                 expires 24h;
             }

--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -130,10 +130,6 @@ http {
         }
 
 		# serve framework static content
-		location /static/style {
-			alias $galaxy_root/static/style/blue;
-			expires 24h;
-		}
 		location /static {
 			alias $galaxy_root/static;
 			expires 24h;
@@ -203,8 +199,8 @@ previous section:
             }
 
             # serve framework static content
-            location /galaxy/static/style {
-                alias $galaxy_root/static/style/blue;
+            location /static {
+                alias $galaxy_root/static;
                 expires 24h;
             }
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -355,7 +355,6 @@ uWSGI can be configured to serve HTTP and/or HTTPS directly:
   # listening options
   http: :8080
   https: :8443,server.crt,server.key
-  static-map: /static/style=static/style/blue
   static-map: /static=static
 ```
 
@@ -370,7 +369,6 @@ user and drop privileges to the Galaxy user with a configuration such as:
   https: =1
   uid: galaxy
   gid: galaxy
-  static-map: /static/style=static/style/blue
   static-map: /static=static
 ```
 

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -88,17 +88,11 @@ UWSGI_OPTIONS = OrderedDict([
     }),
     ('static-map.1', {
         'key': 'static-map',
-        'desc': """Mapping to serve style content.""",
-        'default': '/static/style=static/style/blue',
-        'type': 'str',
-    }),
-    ('static-map.2', {
-        'key': 'static-map',
-        'desc': """Mapping to serve the remainder of the static content.""",
+        'desc': """Mapping to serve static content.""",
         'default': '/static=static',
         'type': 'str',
     }),
-    ('static-map.3', {
+    ('static-map.2', {
         'key': 'static-map',
         'desc': """Mapping to serve the favicon.""",
         'default': '/favicon.ico=static/favicon.ico',

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -41,10 +41,7 @@ uwsgi:
   # routing requests.
   offload-threads: 2
 
-  # Mapping to serve style content.
-  static-map: /static/style=static/style/blue
-
-  # Mapping to serve the remainder of the static content.
+  # Mapping to serve static content.
   static-map: /static=static
 
   # Mapping to serve the favicon.
@@ -211,7 +208,7 @@ galaxy:
   # Where dataset files are stored. It must be accessible at the same
   # path on any cluster nodes that will run Galaxy jobs, unless using
   # Pulsar.
-  #file_path: files
+  #file_path: objects
 
   # Where temporary files are stored. It must be accessible at the same
   # path on any cluster nodes that will run Galaxy jobs, unless using
@@ -620,9 +617,11 @@ galaxy:
   #object_store_config_file: object_store_conf.xml
 
   # What Dataset attribute is used to reference files in an ObjectStore
-  # implementation, default is 'id' but can also be set to 'uuid' for
-  # more de-centralized usage.
-  #object_store_store_by: id
+  # implementation, this can be 'uuid' or 'id'. The default will depend
+  # on how the object store is configured, starting with 20.05 Galaxy
+  # will try to default to 'uuid' if it can be sure this is a new Galaxy
+  # instance - but the default will be 'id' in many cases.
+  #object_store_store_by: null
 
   # Galaxy sends mail for various things: subscribing users to the
   # mailing list if they request it, password resets, reporting dataset

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -23,10 +23,7 @@ uwsgi:
   # routing requests.
   offload-threads: 2
 
-  # Mapping to serve style content.
-  static-map: /static/style=static/style/blue
-
-  # Mapping to serve the remainder of the static content.
+  # Mapping to serve static content.
   static-map: /static=static
 
   # Mapping to serve the favicon.

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -23,10 +23,7 @@ uwsgi:
   # routing requests.
   offload-threads: 2
 
-  # Mapping to serve style content.
-  static-map: /static/style=static/style/blue
-
-  # Mapping to serve the remainder of the static content.
+  # Mapping to serve static content.
   static-map: /static=static
 
   # Mapping to serve the favicon.
@@ -313,7 +310,7 @@ tool_shed:
   #static_scripts_dir: static/scripts/
 
   # Serving static files (needed if running standalone)
-  #static_style_dir: static/style/blue
+  #static_style_dir: static/style
 
   # Enables GDPR Compliance mode. This makes several changes to the way
   # Galaxy logs and exposes data externally such as removing

--- a/lib/galaxy/config/script.py
+++ b/lib/galaxy/config/script.py
@@ -53,7 +53,6 @@ Start Galaxy by running the command from directory [{}]:
 # configs differently.
 GALAXY_CONFIG_SUBSTITUTIONS = {
     '  http: 127.0.0.1:8080': '  ${uwsgi_transport}: ${host}:${port}',
-    '  static-map: /static/style=static/style/blue': '  static-map: /static=${static_path}/style/blue',
     '  static-map: /static=static': '  static-map: /static=${static_path}',
     '  static-map: /favicon.ico=static/favicon.ico': '  static-map: /static=${static_path}/favicon.ico',
     '  static-safe: client/galaxy/images': '  ${client_path}/galaxy/images',

--- a/lib/galaxy/web/framework/webapp.py
+++ b/lib/galaxy/web/framework/webapp.py
@@ -1013,7 +1013,6 @@ def build_url_map(app, global_conf, local_conf):
     urlmap["/static"] = Static(conf.get("static_dir", default_url_path("static/")), cache_time)
     urlmap["/images"] = Static(conf.get("static_images_dir", default_url_path("static/images")), cache_time)
     urlmap["/static/scripts"] = Static(conf.get("static_scripts_dir", default_url_path("static/scripts/")), cache_time)
-    urlmap["/static/style"] = Static(conf.get("static_style_dir", default_url_path("static/style/blue")), cache_time)
     urlmap["/static/welcome.html"] = Static(conf.get("static_welcome_html", default_url_path("static/welcome.html")), cache_time)
     urlmap["/favicon.ico"] = Static(conf.get("static_favicon_dir", default_url_path("static/favicon.ico")), cache_time)
     urlmap["/robots.txt"] = Static(conf.get("static_robots_txt", default_url_path("static/robots.txt")), cache_time)

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -459,7 +459,7 @@ def _get_static_settings():
         static_images_dir=os.path.join(static_dir, 'images', ''),
         static_favicon_dir=os.path.join(static_dir, 'favicon.ico'),
         static_scripts_dir=os.path.join(static_dir, 'scripts', ''),
-        static_style_dir=os.path.join(static_dir, 'style', 'blue'),
+        static_style_dir=os.path.join(static_dir, 'style'),
         static_robots_txt=os.path.join(static_dir, 'robots.txt'),
     )
 

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -425,7 +425,7 @@ mapping:
 
       static_style_dir:
         type: str
-        default: static/style/blue
+        default: static/style
         required: false
         desc: |
           Serving static files (needed if running standalone)

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -91,8 +91,7 @@ def _get_uwsgi_args(cliargs, kwargs):
         'threads': '4',
         'buffer-size': '16384',  # https://github.com/galaxyproject/galaxy/issues/1530
         'http': 'localhost:{port}'.format(port=DEFAULT_PORTS[cliargs.app]),
-        'static-map': ('/static/style={here}/static/style/blue'.format(here=os.getcwd()),
-                       '/static={here}/static'.format(here=os.getcwd()),
+        'static-map': ('/static={here}/static'.format(here=os.getcwd()),
                        '/favicon.ico={here}/static/favicon.ico'.format(here=os.getcwd())),
         'static-safe': ('{here}/client/galaxy/images'.format(here=os.getcwd())),
         'die-on-term': True,

--- a/test/unit/config/config_manage/embedded/config/galaxy.yml
+++ b/test/unit/config/config_manage/embedded/config/galaxy.yml
@@ -4,7 +4,6 @@ uwsgi:
   processes: 1
   threads: 4
   offload-threads: 2
-  static-map: /static/style=static/style/blue
   static-map: /static=static
   static-map: /favicon.ico=static/favicon.ico
   master: false

--- a/test/unit/config/config_manage/simple/config/galaxy.yml
+++ b/test/unit/config/config_manage/simple/config/galaxy.yml
@@ -4,7 +4,6 @@ uwsgi:
   processes: 1
   threads: 4
   offload-threads: 2
-  static-map: /static/style=static/style/blue
   static-map: /static=static
   static-map: /favicon.ico=static/favicon.ico
   master: false


### PR DESCRIPTION
to refer to plain old 'static' now.

Includes a config rebuild (necessary for the changes here) that picked up a few extra bits that look like they got left out of a previous PR?