### PR TITLE
Separate automated schema loading from config options

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -26,7 +26,7 @@ from beaker.util import parse_cache_config_options
 from six import string_types
 from six.moves import configparser
 
-from galaxy.config.schema import AppSchema
+from galaxy.config.loader import ConfigurationLoader
 from galaxy.containers import parse_containers_config
 from galaxy.exceptions import ConfigurationError
 from galaxy.model import mapping
@@ -211,134 +211,21 @@ class BaseAppConfiguration(object):
 class GalaxyAppConfiguration(BaseAppConfiguration):
     deprecated_options = ('database_file', 'track_jobs_in_database')
     default_config_file_name = 'galaxy.yml'
-    # {key: config option, value: deprecated directory name}
-    # If value == first dir in a user path that resolves to key, it will be stripped from the path
-    deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
 
     def __init__(self, **kwargs):
-        self._load_schema()  # Load schema from schema definition file
-        self._load_config_from_schema()  # Load default propery values from schema
-        self._validate_schema_paths()  # check that paths can be resolved
-        self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
-        self._create_attributes_from_raw_config()  # Create attributes for LOADED properties
-
         self.config_dict = kwargs
         self.root = find_root(kwargs)
-        self._set_config_base(kwargs)  # must be called prior to _resolve_paths()
-
-        self._resolve_paths(kwargs)  # Overwrite attributes (not _raw_config) w/resolved paths
+        self._set_config_base(kwargs)  # Must be called prior to resolving paths
+        self._load_schema(kwargs)  # Load configuration from schema file + kwargs
         self._process_config(kwargs)  # Finish processing configuration
 
-    def _load_schema(self):
-        self.schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
-        self.appschema = self.schema.app_schema
-
-    def _load_config_from_schema(self):
-        self._raw_config = {}  # keeps track of startup values (kwargs or schema default)
-        self.reloadable_options = set()  # config options we can reload at runtime
-        self._paths_to_resolve = {}  # {config option: referenced config option}
-        for key, data in self.appschema.items():
-            self._raw_config[key] = data.get('default')
-            if data.get('reloadable'):
-                self.reloadable_options.add(key)
-            if data.get('path_resolves_to'):
-                self._paths_to_resolve[key] = data.get('path_resolves_to')
-
-    def _validate_schema_paths(self):
-
-        def check_exists(option, key):
-            if not option:
-                message = "Invalid schema: property '{}' listed as path resolution target " \
-                    "for '{}' does not exist".format(resolves_to, key)
-                raise_error(message)
-
-        def check_type_is_str(option, key):
-            if option.get('type') != 'str':
-                message = "Invalid schema: property '{}' should have type 'str'".format(key)
-                raise_error(message)
-
-        def check_is_dag():
-            visited = set()
-            for key in self._paths_to_resolve:
-                visited.clear()
-                while key:
-                    visited.add(key)
-                    key = self.appschema[key].get('path_resolves_to')
-                    if key and key in visited:
-                        raise_error('Invalid schema: cycle detected')
-
-        def raise_error(message):
-            log.error(message)
-            raise ConfigurationError(message)
-
-        for key, resolves_to in self._paths_to_resolve.items():
-            parent = self.appschema.get(resolves_to)
-            check_exists(parent, key)
-            check_type_is_str(parent, key)
-            check_type_is_str(self.appschema[key], key)
-        check_is_dag()  # must be called last: walks entire graph
-
-    def _update_raw_config_from_kwargs(self, kwargs):
-
-        def convert_datatype(key, value):
-            datatype = self.appschema[key].get('type')
-            # check for `not None` explicitly (value can be falsy)
-            if value is not None and datatype in type_converters:
-                return type_converters[datatype](value)
-            return value
-
-        def strip_deprecated_dir(key, value):
-            resolves_to = self.appschema[key].get('path_resolves_to')
-            if resolves_to:  # value is a path that will be resolved
-                first_dir = value.split(os.sep)[0]  # get first directory component
-                if first_dir == self.deprecated_dirs[resolves_to]:  # first_dir is deprecated for this option
-                    ignore = first_dir + os.sep
-                    log.warning(
-                        "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
-                        "to suppress this warning: %s", key, resolves_to, ignore, value
-                    )
-                    return value[len(ignore):]
-            return value
-
-        type_converters = {'bool': string_as_bool, 'int': int, 'float': float, 'str': str}
-
-        for key, value in kwargs.items():
-            if key in self.appschema:
-                value = convert_datatype(key, value)
-                if value:
-                    value = strip_deprecated_dir(key, value)
-                self._raw_config[key] = value
-
-    def _create_attributes_from_raw_config(self):
-        for key, value in self._raw_config.items():
-            if not hasattr(self, key):
-                setattr(self, key, value)
-            else:
-                log.debug("Attribute '%s' is set and cannot be overwritten with value '%s'" % (key, value))
-
-    def _resolve_paths(self, kwargs):
-
-        def resolve(key):
-            if key in _cache:  # resolve each path only once
-                return _cache[key]
-
-            path = getattr(self, key)  # path prior to being resolved
-            parent = self.appschema[key].get('path_resolves_to')
-            if not parent:  # base case: nothing else needs resolving
-                return path
-            parent_path = resolve(parent)  # recursively resolve parent path
-            if path is not None:
-                path = os.path.join(parent_path, path)  # resolve path
-            else:
-                path = parent_path  # or use parent path
-
-            setattr(self, key, path)  # update property
-            _cache[key] = path  # cache it!
-            return path
-
-        _cache = {}
-        for key in self._paths_to_resolve:
-            resolve(key)
+    def _load_schema(self, kwargs):
+        loader = ConfigurationLoader()
+        loader.load(self, kwargs)
+        self.schema = loader.schema
+        self.appschema = loader.appschema
+        self._raw_config = loader._raw_config
+        self.reloadable_options = loader.reloadable_options
 
     def _process_config(self, kwargs):
         # Resolve paths of other config files

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -311,9 +311,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
     def _create_attributes_from_raw_config(self):
         for key, value in self._raw_config.items():
-            if hasattr(self, key):
-                raise ConfigurationError("Attempting to override existing attribute '%s'" % key)
-            setattr(self, key, value)
+            if not hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                log.debug("Attribute '%s' is set and cannot be overwritten with value '%s'" % (key, value))
 
     def _resolve_paths(self, kwargs):
 

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -30,12 +30,12 @@ if __name__ == '__main__':
 from galaxy.config import GALAXY_CONFIG_SCHEMA_PATH
 from galaxy.config.schema import (
     AppSchema,
+    OPTION_DEFAULTS,
     Schema,
 )
 from galaxy.util import safe_makedirs
 from galaxy.util.properties import nice_config_parser
 from galaxy.util.yaml_util import (
-    OPTION_DEFAULTS,
     ordered_dump,
     ordered_load,
 )

--- a/lib/galaxy/config/loader.py
+++ b/lib/galaxy/config/loader.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 from galaxy.config.schema import AppSchema
 from galaxy.exceptions import ConfigurationError

--- a/lib/galaxy/config/loader.py
+++ b/lib/galaxy/config/loader.py
@@ -4,9 +4,6 @@ import os
 from galaxy.exceptions import ConfigurationError
 from galaxy.util import string_as_bool
 
-GALAXY_APP_NAME = 'galaxy'
-GALAXY_CONFIG_SCHEMA_PATH = 'lib/galaxy/webapps/galaxy/config_schema.yml'
-
 log = logging.getLogger(__name__)
 
 

--- a/lib/galaxy/config/loader.py
+++ b/lib/galaxy/config/loader.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-from galaxy.config.schema import AppSchema
 from galaxy.exceptions import ConfigurationError
 from galaxy.util import string_as_bool
 
@@ -12,28 +11,21 @@ log = logging.getLogger(__name__)
 
 
 class ConfigurationLoader():
-    # {key: config option, value: deprecated directory name}
-    # If value == first dir in a user path that resolves to key, it will be stripped from the path
-    deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
 
     def load(self, appconfig, kwargs):
-        self._load_schema()  # Load schema from schema definition file
+        self._appschema = appconfig.appschema
         self._load_config_from_schema()  # Load default propery values from schema
         self._validate_schema_paths()  # check that paths can be resolved
-        self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
+        self._update_raw_config_from_kwargs(appconfig.deprecated_dirs, kwargs)  # Overwrite default values passed as kwargs
         self._create_attributes_from_raw_config(appconfig)  # Create attributes for LOADED properties
-        self._resolve_paths(appconfig, kwargs)  # Overwrite attributes (not _raw_config) w/resolved paths
-
-    def _load_schema(self):
-        self.schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
-        self.appschema = self.schema.app_schema
+        self._resolve_paths(appconfig, kwargs)  # Overwrite attributes (not raw_config) w/resolved paths
 
     def _load_config_from_schema(self):
-        self._raw_config = {}  # keeps track of startup values (kwargs or schema default)
+        self.raw_config = {}  # keeps track of startup values (kwargs or schema default)
         self.reloadable_options = set()  # config options we can reload at runtime
         self._paths_to_resolve = {}  # {config option: referenced config option}
-        for key, data in self.appschema.items():
-            self._raw_config[key] = data.get('default')
+        for key, data in self._appschema.items():
+            self.raw_config[key] = data.get('default')
             if data.get('reloadable'):
                 self.reloadable_options.add(key)
             if data.get('path_resolves_to'):
@@ -58,7 +50,7 @@ class ConfigurationLoader():
                 visited.clear()
                 while key:
                     visited.add(key)
-                    key = self.appschema[key].get('path_resolves_to')
+                    key = self._appschema[key].get('path_resolves_to')
                     if key and key in visited:
                         raise_error('Invalid schema: cycle detected')
 
@@ -67,26 +59,26 @@ class ConfigurationLoader():
             raise ConfigurationError(message)
 
         for key, resolves_to in self._paths_to_resolve.items():
-            parent = self.appschema.get(resolves_to)
+            parent = self._appschema.get(resolves_to)
             check_exists(parent, key)
             check_type_is_str(parent, key)
-            check_type_is_str(self.appschema[key], key)
+            check_type_is_str(self._appschema[key], key)
         check_is_dag()  # must be called last: walks entire graph
 
-    def _update_raw_config_from_kwargs(self, kwargs):
+    def _update_raw_config_from_kwargs(self, deprecated_dirs, kwargs):
 
         def convert_datatype(key, value):
-            datatype = self.appschema[key].get('type')
+            datatype = self._appschema[key].get('type')
             # check for `not None` explicitly (value can be falsy)
             if value is not None and datatype in type_converters:
                 return type_converters[datatype](value)
             return value
 
         def strip_deprecated_dir(key, value):
-            resolves_to = self.appschema[key].get('path_resolves_to')
+            resolves_to = self._appschema[key].get('path_resolves_to')
             if resolves_to:  # value is a path that will be resolved
                 first_dir = value.split(os.sep)[0]  # get first directory component
-                if first_dir == self.deprecated_dirs[resolves_to]:  # first_dir is deprecated for this option
+                if first_dir == deprecated_dirs[resolves_to]:  # first_dir is deprecated for this option
                     ignore = first_dir + os.sep
                     log.warning(
                         "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
@@ -98,14 +90,14 @@ class ConfigurationLoader():
         type_converters = {'bool': string_as_bool, 'int': int, 'float': float, 'str': str}
 
         for key, value in kwargs.items():
-            if key in self.appschema:
+            if key in self._appschema:
                 value = convert_datatype(key, value)
                 if value:
                     value = strip_deprecated_dir(key, value)
-                self._raw_config[key] = value
+                self.raw_config[key] = value
 
     def _create_attributes_from_raw_config(self, appconfig):
-        for key, value in self._raw_config.items():
+        for key, value in self.raw_config.items():
             if not hasattr(appconfig, key):
                 setattr(appconfig, key, value)
             else:
@@ -118,7 +110,7 @@ class ConfigurationLoader():
                 return _cache[key]
 
             path = getattr(appconfig, key)  # path prior to being resolved
-            parent = self.appschema[key].get('path_resolves_to')
+            parent = self._appschema[key].get('path_resolves_to')
             if not parent:  # base case: nothing else needs resolving
                 return path
             parent_path = resolve(parent)  # recursively resolve parent path

--- a/lib/galaxy/config/loader.py
+++ b/lib/galaxy/config/loader.py
@@ -1,0 +1,136 @@
+import os
+import logging
+
+from galaxy.config.schema import AppSchema
+from galaxy.exceptions import ConfigurationError
+from galaxy.util import string_as_bool
+
+GALAXY_APP_NAME = 'galaxy'
+GALAXY_CONFIG_SCHEMA_PATH = 'lib/galaxy/webapps/galaxy/config_schema.yml'
+
+log = logging.getLogger(__name__)
+
+
+class ConfigurationLoader():
+    # {key: config option, value: deprecated directory name}
+    # If value == first dir in a user path that resolves to key, it will be stripped from the path
+    deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
+
+    def load(self, appconfig, kwargs):
+        self._load_schema()  # Load schema from schema definition file
+        self._load_config_from_schema()  # Load default propery values from schema
+        self._validate_schema_paths()  # check that paths can be resolved
+        self._update_raw_config_from_kwargs(kwargs)  # Overwrite default values passed as kwargs
+        self._create_attributes_from_raw_config(appconfig)  # Create attributes for LOADED properties
+        self._resolve_paths(appconfig, kwargs)  # Overwrite attributes (not _raw_config) w/resolved paths
+
+    def _load_schema(self):
+        self.schema = AppSchema(GALAXY_CONFIG_SCHEMA_PATH, GALAXY_APP_NAME)
+        self.appschema = self.schema.app_schema
+
+    def _load_config_from_schema(self):
+        self._raw_config = {}  # keeps track of startup values (kwargs or schema default)
+        self.reloadable_options = set()  # config options we can reload at runtime
+        self._paths_to_resolve = {}  # {config option: referenced config option}
+        for key, data in self.appschema.items():
+            self._raw_config[key] = data.get('default')
+            if data.get('reloadable'):
+                self.reloadable_options.add(key)
+            if data.get('path_resolves_to'):
+                self._paths_to_resolve[key] = data.get('path_resolves_to')
+
+    def _validate_schema_paths(self):
+
+        def check_exists(option, key):
+            if not option:
+                message = "Invalid schema: property '{}' listed as path resolution target " \
+                    "for '{}' does not exist".format(resolves_to, key)
+                raise_error(message)
+
+        def check_type_is_str(option, key):
+            if option.get('type') != 'str':
+                message = "Invalid schema: property '{}' should have type 'str'".format(key)
+                raise_error(message)
+
+        def check_is_dag():
+            visited = set()
+            for key in self._paths_to_resolve:
+                visited.clear()
+                while key:
+                    visited.add(key)
+                    key = self.appschema[key].get('path_resolves_to')
+                    if key and key in visited:
+                        raise_error('Invalid schema: cycle detected')
+
+        def raise_error(message):
+            log.error(message)
+            raise ConfigurationError(message)
+
+        for key, resolves_to in self._paths_to_resolve.items():
+            parent = self.appschema.get(resolves_to)
+            check_exists(parent, key)
+            check_type_is_str(parent, key)
+            check_type_is_str(self.appschema[key], key)
+        check_is_dag()  # must be called last: walks entire graph
+
+    def _update_raw_config_from_kwargs(self, kwargs):
+
+        def convert_datatype(key, value):
+            datatype = self.appschema[key].get('type')
+            # check for `not None` explicitly (value can be falsy)
+            if value is not None and datatype in type_converters:
+                return type_converters[datatype](value)
+            return value
+
+        def strip_deprecated_dir(key, value):
+            resolves_to = self.appschema[key].get('path_resolves_to')
+            if resolves_to:  # value is a path that will be resolved
+                first_dir = value.split(os.sep)[0]  # get first directory component
+                if first_dir == self.deprecated_dirs[resolves_to]:  # first_dir is deprecated for this option
+                    ignore = first_dir + os.sep
+                    log.warning(
+                        "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
+                        "to suppress this warning: %s", key, resolves_to, ignore, value
+                    )
+                    return value[len(ignore):]
+            return value
+
+        type_converters = {'bool': string_as_bool, 'int': int, 'float': float, 'str': str}
+
+        for key, value in kwargs.items():
+            if key in self.appschema:
+                value = convert_datatype(key, value)
+                if value:
+                    value = strip_deprecated_dir(key, value)
+                self._raw_config[key] = value
+
+    def _create_attributes_from_raw_config(self, appconfig):
+        for key, value in self._raw_config.items():
+            if not hasattr(appconfig, key):
+                setattr(appconfig, key, value)
+            else:
+                log.debug("Attribute '%s' is set and cannot be overwritten with value '%s'" % (key, value))
+
+    def _resolve_paths(self, appconfig, kwargs):
+
+        def resolve(key):
+            if key in _cache:  # resolve each path only once
+                return _cache[key]
+
+            path = getattr(appconfig, key)  # path prior to being resolved
+            parent = self.appschema[key].get('path_resolves_to')
+            if not parent:  # base case: nothing else needs resolving
+                return path
+            parent_path = resolve(parent)  # recursively resolve parent path
+            if path is not None:
+                path = os.path.join(parent_path, path)  # resolve path
+            else:
+                path = parent_path  # or use parent path
+
+            setattr(appconfig, key, path)  # update property
+            _cache[key] = path  # cache it!
+            return path
+
+        _cache = {}
+        for key in self._paths_to_resolve:
+            resolve(key)

--- a/lib/galaxy/config/loader.py
+++ b/lib/galaxy/config/loader.py
@@ -10,7 +10,7 @@ GALAXY_CONFIG_SCHEMA_PATH = 'lib/galaxy/webapps/galaxy/config_schema.yml'
 log = logging.getLogger(__name__)
 
 
-class ConfigurationLoader():
+class ConfigurationLoader(object):
 
     def load(self, appconfig, kwargs):
         self._appschema = appconfig.appschema

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -1,8 +1,11 @@
-from galaxy.util.yaml_util import (
-    OPTION_DEFAULTS,
-    ordered_load,
-)
+from galaxy.util.yaml_util import ordered_load
 
+OPTION_DEFAULTS = {
+    "type": "str",
+    "unknown_option": False,
+    "default": None,
+    "desc": None,
+}
 
 UNKNOWN_OPTION = {
     "type": "str",

--- a/lib/galaxy/util/yaml_util.py
+++ b/lib/galaxy/util/yaml_util.py
@@ -10,13 +10,6 @@ from yaml.constructor import ConstructorError
 
 log = logging.getLogger(__name__)
 
-OPTION_DEFAULTS = {
-    "type": "str",
-    "unknown_option": False,
-    "default": None,
-    "desc": None,
-}
-
 
 class OrderedLoader(yaml.SafeLoader):
     # This class was pulled out of ordered_load() for the sake of

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -43,7 +43,7 @@ def test_load_config_from_schema(mock_init):
     assert type(config.raw_config['property4']) is bool
 
 
-def test_updateraw_config_from_kwargs(mock_init):
+def test_update_raw_config_from_kwargs(mock_init):
     config = GalaxyAppConfiguration(property2=2, property3=2.0, another_key=66)
 
     assert len(config.raw_config) == 6   # no change: another_key NOT added
@@ -60,7 +60,7 @@ def test_updateraw_config_from_kwargs(mock_init):
     assert type(config.raw_config['property4']) is bool
 
 
-def test_updateraw_config_from_string_kwargs(mock_init):
+def test_update_raw_config_from_string_kwargs(mock_init):
     # kwargs may be passed as strings: property data types should not be affected
     config = GalaxyAppConfiguration(property1='b', property2='2', property3='2.0', property4='false')
 
@@ -76,7 +76,7 @@ def test_updateraw_config_from_string_kwargs(mock_init):
     assert type(config.raw_config['property4']) is bool
 
 
-def test_updateraw_config_from_kwargs_with_none(mock_init):
+def test_update_raw_config_from_kwargs_with_none(mock_init):
     # should be able to set to null regardless of property's datatype
     config = GalaxyAppConfiguration(
         property1=None, property2=None, property3=None, property4=None, property5=None, property6=None,
@@ -90,7 +90,7 @@ def test_updateraw_config_from_kwargs_with_none(mock_init):
     assert config.raw_config['property6'] is None
 
 
-def test_updateraw_config_from_kwargs_falsy_not_none(mock_init):
+def test_update_raw_config_from_kwargs_falsy_not_none(mock_init):
     # if kwargs supplies a falsy value, it should not evaluate to null
     # (ensures code is 'if value is not None' vs. 'if value')
     config = GalaxyAppConfiguration(property1=0)

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -29,71 +29,71 @@ def mock_init(monkeypatch):
 def test_load_config_from_schema(mock_init):
     config = GalaxyAppConfiguration()
 
-    assert len(config._raw_config) == 6
-    assert config._raw_config['property1'] == 'a'
-    assert config._raw_config['property2'] == 1
-    assert config._raw_config['property3'] == 1.0
-    assert config._raw_config['property4'] is True
-    assert config._raw_config['property5'] is None
-    assert config._raw_config['property6'] is None
+    assert len(config.raw_config) == 6
+    assert config.raw_config['property1'] == 'a'
+    assert config.raw_config['property2'] == 1
+    assert config.raw_config['property3'] == 1.0
+    assert config.raw_config['property4'] is True
+    assert config.raw_config['property5'] is None
+    assert config.raw_config['property6'] is None
 
-    assert type(config._raw_config['property1']) is str
-    assert type(config._raw_config['property2']) is int
-    assert type(config._raw_config['property3']) is float
-    assert type(config._raw_config['property4']) is bool
+    assert type(config.raw_config['property1']) is str
+    assert type(config.raw_config['property2']) is int
+    assert type(config.raw_config['property3']) is float
+    assert type(config.raw_config['property4']) is bool
 
 
-def test_update_raw_config_from_kwargs(mock_init):
+def test_updateraw_config_from_kwargs(mock_init):
     config = GalaxyAppConfiguration(property2=2, property3=2.0, another_key=66)
 
-    assert len(config._raw_config) == 6   # no change: another_key NOT added
-    assert config._raw_config['property1'] == 'a'  # no change
-    assert config._raw_config['property2'] == 2  # updated
-    assert config._raw_config['property3'] == 2.0  # updated
-    assert config._raw_config['property4'] is True  # no change
-    assert config._raw_config['property5'] is None  # no change
-    assert config._raw_config['property6'] is None  # no change
+    assert len(config.raw_config) == 6   # no change: another_key NOT added
+    assert config.raw_config['property1'] == 'a'  # no change
+    assert config.raw_config['property2'] == 2  # updated
+    assert config.raw_config['property3'] == 2.0  # updated
+    assert config.raw_config['property4'] is True  # no change
+    assert config.raw_config['property5'] is None  # no change
+    assert config.raw_config['property6'] is None  # no change
 
-    assert type(config._raw_config['property1']) is str
-    assert type(config._raw_config['property2']) is int
-    assert type(config._raw_config['property3']) is float
-    assert type(config._raw_config['property4']) is bool
+    assert type(config.raw_config['property1']) is str
+    assert type(config.raw_config['property2']) is int
+    assert type(config.raw_config['property3']) is float
+    assert type(config.raw_config['property4']) is bool
 
 
-def test_update_raw_config_from_string_kwargs(mock_init):
+def test_updateraw_config_from_string_kwargs(mock_init):
     # kwargs may be passed as strings: property data types should not be affected
     config = GalaxyAppConfiguration(property1='b', property2='2', property3='2.0', property4='false')
 
-    assert len(config._raw_config) == 6  # no change
-    assert config._raw_config['property1'] == 'b'  # updated
-    assert config._raw_config['property2'] == 2  # updated
-    assert config._raw_config['property3'] == 2.0  # updated
-    assert config._raw_config['property4'] is False  # updated
+    assert len(config.raw_config) == 6  # no change
+    assert config.raw_config['property1'] == 'b'  # updated
+    assert config.raw_config['property2'] == 2  # updated
+    assert config.raw_config['property3'] == 2.0  # updated
+    assert config.raw_config['property4'] is False  # updated
 
-    assert type(config._raw_config['property1']) is str
-    assert type(config._raw_config['property2']) is int
-    assert type(config._raw_config['property3']) is float
-    assert type(config._raw_config['property4']) is bool
+    assert type(config.raw_config['property1']) is str
+    assert type(config.raw_config['property2']) is int
+    assert type(config.raw_config['property3']) is float
+    assert type(config.raw_config['property4']) is bool
 
 
-def test_update_raw_config_from_kwargs_with_none(mock_init):
+def test_updateraw_config_from_kwargs_with_none(mock_init):
     # should be able to set to null regardless of property's datatype
     config = GalaxyAppConfiguration(
         property1=None, property2=None, property3=None, property4=None, property5=None, property6=None,
     )
 
-    assert config._raw_config['property1'] is None
-    assert config._raw_config['property2'] is None
-    assert config._raw_config['property3'] is None
-    assert config._raw_config['property4'] is None
-    assert config._raw_config['property5'] is None
-    assert config._raw_config['property6'] is None
+    assert config.raw_config['property1'] is None
+    assert config.raw_config['property2'] is None
+    assert config.raw_config['property3'] is None
+    assert config.raw_config['property4'] is None
+    assert config.raw_config['property5'] is None
+    assert config.raw_config['property6'] is None
 
 
-def test_update_raw_config_from_kwargs_falsy_not_none(mock_init):
+def test_updateraw_config_from_kwargs_falsy_not_none(mock_init):
     # if kwargs supplies a falsy value, it should not evaluate to null
     # (ensures code is 'if value is not None' vs. 'if value')
     config = GalaxyAppConfiguration(property1=0)
 
-    assert config._raw_config['property1'] == '0'  # updated
-    assert type(config._raw_config['property1']) is str  # and converted to str
+    assert config.raw_config['property1'] == '0'  # updated
+    assert type(config.raw_config['property1']) is str  # and converted to str

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -69,12 +69,12 @@ def mock_init(monkeypatch):
 def test_mock_schema_is_loaded(mock_init):
     # Check that mock is loaded as expected
     config = GalaxyAppConfiguration()
-    assert len(config._raw_config) == 5
-    assert config._raw_config['my_config_dir'] == 'my-config'
-    assert config._raw_config['my_data_dir'] == 'my-data'
-    assert config._raw_config['path1'] == 'my-config-files'
-    assert config._raw_config['path2'] == 'my-data-files'
-    assert config._raw_config['path3'] == 'my-other-files'
+    assert len(config.raw_config) == 5
+    assert config.raw_config['my_config_dir'] == 'my-config'
+    assert config.raw_config['my_data_dir'] == 'my-data'
+    assert config.raw_config['path1'] == 'my-config-files'
+    assert config.raw_config['path2'] == 'my-data-files'
+    assert config.raw_config['path3'] == 'my-other-files'
 
 
 def test_no_kwargs(mock_init):

--- a/test/unit/config/test_reload_config.py
+++ b/test/unit/config/test_reload_config.py
@@ -9,10 +9,10 @@ class MockGalaxyAppConfiguration():
     def __init__(self, properties):
         self.config_file = None
         self.reloadable_options = {R1, R2}
-        self._raw_config = {}
+        self.raw_config = {}
         for key, value in properties.items():
             setattr(self, key, value)
-            self._raw_config[key] = value
+            self.raw_config[key] = value
 
     def update_reloadable_property(self, key, value):
         setattr(self, key, value)
@@ -47,7 +47,7 @@ def test_overwrite_reloadable_attribute(monkeypatch):
     # GalaxyAppConfiguration, do something like this: `foo = resove_path(foo, bar)`. Now the value of `foo`
     # is not what was initially loaded, and if `foo` is reloadable, it will be reset to its default as soon
     # as the config file is modified. To prevent this, we compare the values read from the modified file
-    # to the `_raw_config` dict. This test ensures this works correctly.
+    # to the `raw_config` dict. This test ensures this works correctly.
     appconfig = MockGalaxyAppConfiguration({R1: 1, R2: 2, N1: 3})
 
     def mock_read_properties_from_file(values):


### PR DESCRIPTION
Update: this is ready for review.

Delegate loading+processing configuration from schema to separate module. 

`config/__init__.py` is doing too much. This is an attempt to separate 2 different responsibilities: (1) automatically loading and processing all config properties from the schema; and (2) setting individual config properties and handling special cases. The former is delegated to a `ConfigurationLoader` module. The idea is to use this loader module for any further automated schema processing, whereas `GalaxyAppConfiguration` is to be used for processing individual config properties (as it did before).

Last year's modifications to the config system, while simplifying configuration loading, have done the opposite to the configuration module's code. This modification is an attempt to address this problem.

(Edit: more detailed rationale in commit messages)






