### PR TITLE
Allow setting container path for docker_volumes

### DIFF
--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -103,6 +103,8 @@ def preprocess_volumes(volumes_raw_str, container_type):
     ['/a/b:rw']
     >>> preprocess_volumes("/a/b:ro,/a/b/c:rw", DOCKER_CONTAINER_TYPE)
     ['/a/b:ro', '/a/b/c:rw']
+    >>> preprocess_volumes("/a/b:/a:ro,/a/b/c:/a/b:rw", DOCKER_CONTAINER_TYPE)
+    ['/a/b:/a:ro', '/a/b/c:/a/b:rw']
     >>> preprocess_volumes("/a/b:default_ro,/a/b/c:rw", DOCKER_CONTAINER_TYPE)
     ['/a/b:ro', '/a/b/c:rw']
     >>> preprocess_volumes("/a/b:default_ro,/a/b/c:rw", SINGULARITY_CONTAINER_TYPE)
@@ -115,8 +117,12 @@ def preprocess_volumes(volumes_raw_str, container_type):
 
     for volume_raw_str in volumes_raw_strs:
         volume_parts = volume_raw_str.split(":")
-        if len(volume_parts) > 2:
+        if len(volume_parts) > 3:
             raise Exception("Unparsable volumes string in configuration [%s]" % volumes_raw_str)
+        if len(volume_parts) == 3:
+            volume_parts = ["%s:%s" % (volume_parts[0], volume_parts[1]), volume_parts[2]]
+        if len(volume_parts) == 2 and volume_parts[1] not in ("rw", "ro", "default_ro"):
+            volume_parts = ["%s:%s" % (volume_parts[0], volume_parts[1]), "rw"]
         if len(volume_parts) == 1:
             volume_parts.append("rw")
         volumes.append(volume_parts)


### PR DESCRIPTION
I'm working on getting InteractiveTools to run on my docker-compose setup on Mac. The problem I faced was that I had to mount GALAXY_ROOT from a different path at the host, while keeping it consistent inside the container. Trying `<param id="docker_volumes">/Users/../export/galaxy:/galaxy:rw</param>` resulted in the error: `Unparsable volumes string in configuration`, which to me seemed not quite right. 
The function `preprocess_volumes` only allowed to set the host path (HOST:MODE) and therefore forced to use it inside the container, which in some cases might be problematic. With this change it is also possible to set the container path (HOST:CONTAINER:MODE), as described in https://docs.docker.com/storage/bind-mounts/