### PR TITLE
[20.01] Mount tool_data_path (ro) when running containerized tools

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1029,6 +1029,8 @@ class ConfiguresGalaxyMixin(object):
         app_info = AppInfo(
             galaxy_root_dir=galaxy_root_dir,
             default_file_path=file_path,
+            tool_data_path=self.config.tool_data_path,
+            shed_tool_data_path=self.config.shed_tool_data_path,
             outputs_to_working_directory=self.config.outputs_to_working_directory,
             container_image_cache_path=self.config.container_image_cache_path,
             library_import_dir=self.config.library_import_dir,

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -186,6 +186,8 @@ class HasDockerLikeVolumes(object):
         add_var("galaxy_root", self.app_info.galaxy_root_dir)
         add_var("default_file_path", self.app_info.default_file_path)
         add_var("library_import_dir", self.app_info.library_import_dir)
+        add_var('tool_data_path', self.app_info.tool_data_path)
+        add_var('shed_tool_data_path', self.app_info.shed_tool_data_path)
 
         if self.job_info.job_directory and self.job_info.job_directory_type == "pulsar":
             # We have a Pulsar job directory, so everything needed (excluding index
@@ -215,6 +217,10 @@ class HasDockerLikeVolumes(object):
 
         if self.app_info.library_import_dir:
             defaults += ",$library_import_dir:default_ro"
+        if self.app_info.tool_data_path:
+            defaults += ",$tool_data_path:default_ro"
+        if self.app_info.shed_tool_data_path:
+            defaults += ",$shed_tool_data_path:default_ro"
 
         # Define $defaults that can easily be extended with external library and
         # index data without deployer worrying about above details.

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -9,6 +9,8 @@ class AppInfo(object):
         self,
         galaxy_root_dir=None,
         default_file_path=None,
+        tool_data_path=None,
+        shed_tool_data_path=None,
         outputs_to_working_directory=False,
         container_image_cache_path=None,
         library_import_dir=None,
@@ -20,6 +22,8 @@ class AppInfo(object):
     ):
         self.galaxy_root_dir = galaxy_root_dir
         self.default_file_path = default_file_path
+        self.tool_data_path = tool_data_path
+        self.shed_tool_data_path = shed_tool_data_path
         # TODO: Vary default value for docker_volumes based on this...
         self.outputs_to_working_directory = outputs_to_working_directory
         self.container_image_cache_path = container_image_cache_path


### PR DESCRIPTION
This affects instances that store reference data outside of the galaxy
root.