### PR TITLE
[20.01] Python3: unicodify the output of ``subprocess.check_output()``

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -128,8 +128,8 @@ def get_affected_packages(args):
     recipes_dir = args.recipes_dir
     hours = args.diff_hours
     cmd = ['git', 'log', '--diff-filter=ACMRTUXB', '--name-only', '--pretty=""', '--since="%s hours ago"' % hours]
-    changed_files = subprocess.check_output(cmd, cwd=recipes_dir).strip().split('\n')
-    pkg_list = set([x for x in changed_files if x.startswith('recipes/') and x.endswith('meta.yaml')])
+    changed_files = unicodify(subprocess.check_output(cmd, cwd=recipes_dir)).splitlines()
+    pkg_list = {x for x in changed_files if x.startswith('recipes/') and x.endswith('meta.yaml')}
     for pkg in pkg_list:
         if pkg and os.path.exists(os.path.join(recipes_dir, pkg)):
             yield (get_pkg_name(args, pkg), get_tests(args, pkg))

--- a/lib/galaxy/webapps/reports/controllers/system.py
+++ b/lib/galaxy/webapps/reports/controllers/system.py
@@ -8,6 +8,7 @@ from sqlalchemy import and_, desc, false, null, true
 from sqlalchemy.orm import eagerload
 
 from galaxy import model, util
+from galaxy.util import unicodify
 from galaxy.webapps.base.controller import BaseUIController, web
 
 log = logging.getLogger(__name__)
@@ -151,9 +152,9 @@ class System(BaseUIController):
     def get_disk_usage(self, file_path):
         is_sym_link = os.path.islink(file_path)
         file_system = disk_size = disk_used = disk_avail = disk_cap_pct = mount = None
-        df_output = subprocess.check_output(['df', '-h', file_path])
+        df_output = unicodify(subprocess.check_output(['df', '-h', file_path]))
 
-        for df_line in df_output:
+        for df_line in df_output.splitlines():
             df_line = df_line.strip()
             if df_line:
                 df_line = df_line.lower()

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -32,7 +32,7 @@ def add_changeset(repo_path, path_to_filename_in_archive):
     except Exception as e:
         error_message = "Error adding '%s' to repository: %s" % (path_to_filename_in_archive, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += "\nOutput was:\n%s" % e.output
+            error_message += "\nOutput was:\n%s" % unicodify(e.output)
         raise Exception(error_message)
 
 

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -11,6 +11,7 @@ import time
 
 import pytest
 
+from galaxy.util import unicodify
 from galaxy_test.base.populators import skip_without_tool
 from galaxy_test.driver import integration_util
 from .test_containerized_jobs import MulledJobTestCases
@@ -235,7 +236,8 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
                 time.sleep(1)
                 max_tries -= 1
 
-            status = json.loads(subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json']))
+            output = unicodify(subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json']))
+            status = json.loads(output)
             assert status['status']['active'] == 1
 
             delete_response = self.dataset_populator.cancel_job(job_dict["id"])
@@ -246,7 +248,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
             # The default job config removes jobs, didn't find a better way to check that the job doesn't exist anymore
             with pytest.raises(subprocess.CalledProcessError) as excinfo:
                 subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json'], stderr=subprocess.STDOUT)
-            assert "not found" in excinfo.value.output.decode()
+            assert "not found" in unicodify(excinfo.value.output)
 
     @skip_without_tool('job_properties')
     def test_exit_code_127(self):
@@ -297,7 +299,8 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         job_dict = running_response["jobs"][0]
         job = self.galaxy_interactor.get("jobs/%s" % job_dict['id'], admin=True).json()
         external_id = job['external_id']
-        status = json.loads(subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json']))
+        output = unicodify(subprocess.check_output(['kubectl', 'get', 'job', external_id, '-o', 'json']))
+        status = json.loads(output)
         assert 'active' not in status['status']
 
     @skip_without_tool('create_2')

--- a/test/integration/test_scripts.py
+++ b/test/integration/test_scripts.py
@@ -182,7 +182,7 @@ class ScriptsIntegrationTestCase(integration_util.IntegrationTestCase):
             return unicodify(subprocess.check_output(cmd, cwd=cwd, env=clean_env))
         except Exception as e:
             if isinstance(e, subprocess.CalledProcessError):
-                raise Exception("%s\nOutput was:\n%s" % (unicodify(e), e.output))
+                raise Exception("%s\nOutput was:\n%s" % (unicodify(e), unicodify(e.output)))
             raise
 
     def write_config_file(self):

--- a/test/unit/tool_util/mulled/test_mulled_update_singularity_containers.py
+++ b/test/unit/tool_util/mulled/test_mulled_update_singularity_containers.py
@@ -9,7 +9,6 @@ from galaxy.util import which
 from ..util import external_dependency_management
 
 
-@external_dependency_management
 def test_get_list_from_file():
     test_dir = tempfile.mkdtemp()
     try:
@@ -25,8 +24,7 @@ def test_get_list_from_file():
 @pytest.mark.skipif(not which('singularity'), reason="requires singularity but singularity not on PATH")
 def test_docker_to_singularity(tmp_path):
     tmp_dir = str(tmp_path)
-    errors = docker_to_singularity('abundancebin:1.0.1--0', 'singularity', tmp_dir, no_sudo=True)
-    assert errors is None
+    docker_to_singularity('abundancebin:1.0.1--0', 'singularity', tmp_dir, no_sudo=True)
     assert tmp_path.joinpath('abundancebin:1.0.1--0').exists()
 
 

--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -117,7 +117,7 @@ def main():
     try:
         subprocess.check_output(command_line, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
-        stop_err("Sorting input dataset resulted in error: %s: %s" % (e.returncode, e.output))
+        stop_err("Sorting input dataset resulted in error: %s: %s" % (e.returncode, e.output.decode()))
 
     def is_new_item(line):
         try:


### PR DESCRIPTION
By default it's a bytestring.

Also:
- don't use `shell=True`
- add a `splitlines()` forgotten in commit 670897ec5ca2284c7fad453c3d595defe3cca280
- raise exception instead of returning `error_info` in `docker_to_singularity()`
- use a random temp dir in `singularity_container_test()`

Fix second bug reported in https://github.com/galaxyproject/galaxy/issues/9313 .