### PR TITLE
[20.01] Fix reports disk usage query for python 3

### DIFF
--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -179,8 +179,8 @@ class Users(BaseUIController, ReportQueryBuilder):
         user_cutoff = int(kwd.get('user_cutoff', 60))
         # disk_usage isn't indexed
         all_users = trans.sa_session.query(galaxy.model.User).all()
-        sortAttrGetter = operator.attrgetter(str(sort_id))
-        users = sorted(all_users, key=lambda x: sortAttrGetter(x) or 0, reverse=_order)
+        sort_attrgetter = operator.attrgetter(str(sort_id))
+        users = sorted(all_users, key=lambda x: sort_attrgetter(x) or 0, reverse=_order)
         if user_cutoff:
             users = users[:user_cutoff]
         return trans.fill_template('/webapps/reports/users_user_disk_usage.mako',

--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -178,7 +178,9 @@ class Users(BaseUIController, ReportQueryBuilder):
 
         user_cutoff = int(kwd.get('user_cutoff', 60))
         # disk_usage isn't indexed
-        users = sorted(trans.sa_session.query(galaxy.model.User).all(), key=operator.attrgetter(str(sort_id)), reverse=_order)
+        all_users = trans.sa_session.query(galaxy.model.User).all()
+        sortAttrGetter = operator.attrgetter(str(sort_id))
+        users = sorted(all_users, key=lambda x: sortAttrGetter(x) or 0, reverse=_order)
         if user_cutoff:
             users = users[:user_cutoff]
         return trans.fill_template('/webapps/reports/users_user_disk_usage.mako',


### PR DESCRIPTION
closes #9313 

Another approach would be to set up the raw disk usage using `@property` (which would do similar and return `0` instead of `None`), but I didn't want to be that invasive for a stable PR.