### PR TITLE
[20.01] Automatically resolve and add static-safe mappings for client-based images

### DIFF
--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -23,7 +23,7 @@ ALIASES = {
     'module': ('mount',),   # mount is not actually an alias for module, but we don't want to set module if mount is set
 }
 DEFAULT_ARGS = {
-    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'static-safe', 'die-on-term', 'hook-master-start', 'enable-threads', 'umask'),
+    '_all_': ('pythonpath', 'threads', 'buffer-size', 'http', 'static-map', 'die-on-term', 'hook-master-start', 'enable-threads', 'umask'),
     'galaxy': ('py-call-osafterfork',),
     'reports': (),
     'tool_shed': ('cron',),

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -94,7 +94,6 @@ def _get_uwsgi_args(cliargs, kwargs):
         'static-map': ('/static/style={here}/static/style/blue'.format(here=os.getcwd()),
                        '/static={here}/static'.format(here=os.getcwd()),
                        '/favicon.ico={here}/static/favicon.ico'.format(here=os.getcwd())),
-        'static-safe': ('{here}/client/galaxy/images'.format(here=os.getcwd())),
         'die-on-term': True,
         'enable-threads': True,
         'hook-master-start': ('unix_signal:2 gracefully_kill_them_all',

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -121,6 +121,8 @@ def _get_uwsgi_args(cliargs, kwargs):
         if hmr_server.lower() in ['1', 'true', 'default']:
             hmr_server = "http:127.0.0.1:8081"
         __add_arg(args, 'route', '^/static/scripts/bundled/ {hmr_server}'.format(hmr_server=hmr_server))
+    # We always want to append client/galaxy/images as static-safe.
+    __add_arg(args, 'static-safe', '{here}/client/galaxy/images'.format(here=os.getcwd()))
 
     for arg in DEFAULT_ARGS['_all_'] + DEFAULT_ARGS[cliargs.app]:
         if not __arg_set(arg, uwsgi_kwargs):


### PR DESCRIPTION
This is safe, and we might as well just automate/force it here, since multiple deployments have seen issues with it so far.  Deployers can always add additional static-safe paths, of course, for external plugins or the like but this ensures galaxy internal static files are resolvable.