### PR TITLE
disable activation of galaxy venv for jobs

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -19,10 +19,10 @@ _galaxy_setup_environment() {
     # These don't get cleaned on a re-run but may in the future.
     [ -z "$_GALAXY_JOB_TMP_DIR" -a ! -f "$_GALAXY_JOB_TMP_DIR" ] || mkdir -p "$_GALAXY_JOB_TMP_DIR"
     [ -z "$_GALAXY_JOB_HOME_DIR" -a ! -f "$_GALAXY_JOB_HOME_DIR" ] || mkdir -p "$_GALAXY_JOB_HOME_DIR"
-    if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
-         -a "`command -v python`" != "$GALAXY_VIRTUAL_ENV/bin/python" ]; then
-        . "$GALAXY_VIRTUAL_ENV/bin/activate"
-    fi
+#     if [ "$GALAXY_VIRTUAL_ENV" != "None" -a -f "$GALAXY_VIRTUAL_ENV/bin/activate" \
+#          -a "`command -v python`" != "$GALAXY_VIRTUAL_ENV/bin/python" ]; then
+#         . "$GALAXY_VIRTUAL_ENV/bin/activate"
+#     fi
 }
 
 $integrity_injection


### PR DESCRIPTION
So far only a test .. I don't understand what this is good for. So lets disable this and check what fails.