### PR TITLE
[19.09] Add bam_native alias of unsorted.bam

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -41,6 +41,7 @@
       <converter file="to_coordinate_sorted_bam.xml" target_datatype="bam"/>
       <converter file="to_qname_sorted_bam.xml" target_datatype="qname_sorted.bam"/>
     </datatype>
+    <datatype extension="bam_native" type="galaxy.datatypes.binary:BamNative" mimetype="application/octet-stream" subclass="true"/>
     <datatype extension="probam" type="galaxy.datatypes.binary:ProBam" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="cram" type="galaxy.datatypes.binary:CRAM" mimetype="application/octet-stream" display_in_upload="true" description="CRAM is a file format for highly efficient and tunable reference-based compression of alignment data." description_url="http://www.ebi.ac.uk/ena/software/cram-usage">
       <converter file="cram_to_bam_converter.xml" target_datatype="bam"/>


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/sentry/main/issues/307648/events/?cursor=1579818609000%3A2%3A0:
```
Datatype class not found for extension 'bam_native'
```
Probably an old version of bowtie2 that uses this datatype.