### PR TITLE
[20.01] Make linters more robust on python 3

### DIFF
--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -23,7 +23,7 @@ lint_tool_types = ["*"]
 
 def lint_general(tool_source, lint_ctx):
     """Check tool version, name, and id."""
-    version = tool_source.parse_version()
+    version = tool_source.parse_version() or ''
     parsed_version = packaging.version.parse(version)
     if not version:
         lint_ctx.error(ERROR_VERSION_MSG)

--- a/lib/galaxy/tool_util/loader_directory.py
+++ b/lib/galaxy/tool_util/loader_directory.py
@@ -171,7 +171,10 @@ def looks_like_xml(path, regex=TOOL_REGEX):
         return False
 
     with open(path, "r") as f:
-        start_contents = f.read(5 * 1024)
+        try:
+            start_contents = f.read(5 * 1024)
+        except UnicodeDecodeError:
+            return False
         if regex.search(start_contents):
             return True
 

--- a/lib/galaxy/tool_util/loader_directory.py
+++ b/lib/galaxy/tool_util/loader_directory.py
@@ -1,6 +1,7 @@
 """Utilities for loading and reasoning about unparsed tools in directories."""
 import fnmatch
 import glob
+import io
 import logging
 import os
 import re
@@ -170,7 +171,7 @@ def looks_like_xml(path, regex=TOOL_REGEX):
        checkers.is_zip(full_path)):
         return False
 
-    with open(path, "r") as f:
+    with io.open(path, "r", encoding='utf-8') as f:
         try:
             start_contents = f.read(5 * 1024)
         except UnicodeDecodeError:


### PR DESCRIPTION
Fixes
```
  File "..\planemo\venv\lib\site-packages\galaxy\tool_util\loader_directory.py", line 174, in looks_like_xml
    start_contents = f.read(5 * 1024)
  File "..\planemo\venv\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1713: character maps to <undefined>
```
reported by @VJalili 

Still weird that this is cp1252 though.