### PR TITLE
[20.01] Allow remote jobs to configure Interactive Tool entry points.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -699,10 +699,17 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # indicate if this was not set explicitly, so dependending on the context a better default
         # can be used (request url in a web thread, Docker parent in IE stuff, etc.)
         self.galaxy_infrastructure_url_set = kwargs.get('galaxy_infrastructure_url') is not None
-
         if "HOST_IP" in self.galaxy_infrastructure_url:
             self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
                 'HOST_IP': socket.gethostbyname(socket.gethostname())
+            })
+        if "UWSGI_PORT" in self.galaxy_infrastructure_url:
+            import uwsgi
+            http = unicodify(uwsgi.opt['http'])
+            host, port = http.split(":", 1)
+            assert port, "galaxy_infrastructure_url depends on dynamic PORT determination but port unknown"
+            self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
+                'UWSGI_PORT': port
             })
 
     @property

--- a/lib/galaxy/job_execution/ports/__init__.py
+++ b/lib/galaxy/job_execution/ports/__init__.py
@@ -1,0 +1,3 @@
+from .view import JobPortsView
+
+__all__ = ('JobPortsView', )

--- a/lib/galaxy/job_execution/ports/view.py
+++ b/lib/galaxy/job_execution/ports/view.py
@@ -36,7 +36,7 @@ class JobPortsView(object):
         # Verify job is active. Don't update the contents of complete jobs.
         sa_session = self._app.model.context.current
         job = sa_session.query(model.Job).get(job_id)
-        if job.finished:
+        if not job.running:
             error_message = "Attempting to read or modify the files of a job that has already completed."
             raise exceptions.ItemAccessibilityException(error_message)
         return job

--- a/lib/galaxy/job_execution/ports/view.py
+++ b/lib/galaxy/job_execution/ports/view.py
@@ -1,0 +1,46 @@
+import logging
+
+from galaxy import (
+    exceptions,
+    model,
+    util
+)
+
+log = logging.getLogger(__name__)
+
+
+class JobPortsView(object):
+
+    def __init__(self, app):
+        self._app = app
+
+    def register_container_information(self, job_id, **kwd):
+        job = self.__authorize_job_access(job_id, **kwd)
+        container_runtime = kwd.get("container_runtime")
+        log.info(kwd)
+        self._app.interactivetool_manager.configure_entry_points(job, container_runtime)
+        return {"message": "ok"}
+
+    # Copy/paste from JobFilesView - TODO: de-duplicate.
+    def __authorize_job_access(self, encoded_job_id, **kwargs):
+        key = "job_key"
+        if key not in kwargs:
+            error_message = "Job files action requires a valid '%s'." % key
+            raise exceptions.ObjectAttributeMissingException(error_message)
+
+        job_id = self._security.decode_id(encoded_job_id)
+        job_key = self._security.encode_id(job_id, kind="jobs_files")
+        if not util.safe_str_cmp(kwargs["job_key"], job_key):
+            raise exceptions.ItemAccessibilityException("Invalid job_key supplied.")
+
+        # Verify job is active. Don't update the contents of complete jobs.
+        sa_session = self._app.model.context.current
+        job = sa_session.query(model.Job).get(job_id)
+        if job.finished:
+            error_message = "Attempting to read or modify the files of a job that has already completed."
+            raise exceptions.ItemAccessibilityException(error_message)
+        return job
+
+    @property
+    def _security(self):
+        return self._app.security

--- a/lib/galaxy/job_execution/setup.py
+++ b/lib/galaxy/job_execution/setup.py
@@ -1,0 +1,11 @@
+"""Utilities to help job and tool code setup jobs."""
+import os
+
+from galaxy.util import safe_makedirs
+
+
+def ensure_configs_directory(work_dir):
+    configs_dir = os.path.join(work_dir, "configs")
+    if not os.path.exists(configs_dir):
+        safe_makedirs(configs_dir)
+    return configs_dir

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -35,6 +35,7 @@ from galaxy.job_execution.datasets import (
     TaskPathRewriter
 )
 from galaxy.job_execution.output_collect import collect_extra_files
+from galaxy.job_execution.setup import ensure_configs_directory
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.jobs.mapper import JobMappingException, JobRunnerMapper
 from galaxy.jobs.runners import BaseJobRunner, JobState
@@ -2096,12 +2097,9 @@ class JobWrapper(HasResourceParameters):
         if not container or not self.tool.produces_entry_points:
             return None
 
-        from os.path import abspath
-        from os import getcwd
-        exec_dir = kwds.get('exec_dir', abspath(getcwd()))
+        exec_dir = kwds.get('exec_dir', os.path.abspath(os.getcwd()))
         work_dir = self.working_directory
-        configs_dir = os.path.join(work_dir, "configs")
-        util.safe_makedirs(configs_dir)
+        configs_dir = ensure_configs_directory(work_dir)
         container_config = os.path.join(configs_dir, "container_config.json")
         self.extra_filenames.append(container_config)
 

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1072,6 +1072,7 @@ class JobWrapper(HasResourceParameters):
 
         tool_evaluator = self._get_tool_evaluator(job)
         compute_environment = compute_environment or self.default_compute_environment(job)
+        self.galaxy_url = compute_environment.galaxy_url
         tool_evaluator.set_compute_environment(compute_environment, get_special=get_special)
 
         self.sa_session.flush()
@@ -2099,22 +2100,33 @@ class JobWrapper(HasResourceParameters):
         from os import getcwd
         exec_dir = kwds.get('exec_dir', abspath(getcwd()))
         work_dir = self.working_directory
-        container_config = os.path.join(work_dir, "container_config.json")
+        configs_dir = os.path.join(work_dir, "configs")
+        util.safe_makedirs(configs_dir)
+        container_config = os.path.join(configs_dir, "container_config.json")
+        self.extra_filenames.append(container_config)
 
-        # TODO: implement callback via URL callback for configuring ports instead
-        #       of fs polling.
-        # if self.app.config.galaxy_infrastructure_url_set:
-        #    # TODO: settable from job destination...
-        #    infrastructure_url = self.app.config.galaxy_infrastructure_url
-        # else:
-        #    infrastructure_url = "host.docker.internal"
+        # What should be done with the result... 'file' or 'callback'
+        result = self.get_destination_configuration("container_monitor_result", "file")
+        galaxy_url = self.galaxy_url()
+        container_config_dict = {
+            "container_name": container.container_name,
+            "container_type": container.container_type,
+            "connection_configuration": container.connection_configuration,
+        }
+        if result == "callback":
+            job_id = self.job_id
+            encoded_job_id = self.app.security.encode_id(job_id)
+            job_key = self.app.security.encode_id(job_id, kind="jobs_files")
+            endpoint_base = "%s/api/jobs/%s/ports?job_key=%s"
+            callback_url = endpoint_base % (
+                galaxy_url,
+                encoded_job_id,
+                job_key
+            )
+            container_config_dict["callback_url"] = callback_url
 
         with open(container_config, "w") as f:
-            json.dump({
-                "container_name": container.container_name,
-                "container_type": container.container_type,
-                "connection_configuration": container.connection_configuration,
-            }, f)
+            json.dump(container_config_dict, f)
 
         return "(python '%s'/lib/galaxy_ext/container_monitor/monitor.py &); sleep 1 " % exec_dir
 
@@ -2297,7 +2309,8 @@ class TaskWrapper(JobWrapper):
 
         self.sa_session.flush()
 
-        self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
+        self.command_line, extra_filenames, self.environment_variables = tool_evaluator.build()
+        self.extra_filenames.extend(extra_filenames)
 
         # Ensure galaxy_lib_dir is set in case there are any later chdirs
         self.galaxy_lib_dir

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -104,6 +104,9 @@ PULSAR_PARAM_SPECS = dict(
         map=specs.to_str_or_none,
         default=None,
     ),
+    pulsar_app_config=dict(
+        default=None,
+    ),
     manager=dict(
         map=specs.to_str_or_none,
         default=None,
@@ -203,7 +206,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
         self._init_monitor_thread()
 
     def __init_client_manager(self):
-        pulsar_conf = self.runner_params.get('app', None)
+        pulsar_conf = self.runner_params.get('pulsar_app_config', None)
         pulsar_conf_file = None
         if pulsar_conf is None:
             pulsar_conf_file = self.runner_params.get('pulsar_config', None)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -727,6 +727,10 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         self.state_history.append(JobStateHistory(self))
 
     @property
+    def running(self):
+        return self.state == Job.states.RUNNING
+
+    @property
     def finished(self):
         states = self.states
         return self.state in [

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -7,6 +7,7 @@ import tempfile
 from six import string_types
 
 from galaxy import model
+from galaxy.job_execution.setup import ensure_configs_directory
 from galaxy.model.none_like import NoneDataset
 from galaxy.tools import global_tool_errors
 from galaxy.tools.parameters import (
@@ -521,9 +522,7 @@ class ToolEvaluator(object):
         for name, filename, content in self.tool.config_files:
             config_text, is_template = self.__build_config_file_text(content)
             # If a particular filename was forced by the config use it
-            directory = os.path.join(self.local_working_directory, "configs")
-            if not os.path.exists(directory):
-                os.makedirs(directory)
+            directory = ensure_configs_directory(self.local_working_directory)
             if filename is not None:
                 # Explicit filename was requested, needs to be placed in tool working directory
                 directory = os.path.join(self.local_working_directory, "working")

--- a/lib/galaxy/webapps/galaxy/api/job_ports.py
+++ b/lib/galaxy/webapps/galaxy/api/job_ports.py
@@ -1,0 +1,43 @@
+""" API for asynchronous job running mechanisms can use to fetch or put files
+related to running and queued jobs.
+"""
+from galaxy.job_execution.ports import JobPortsView
+from galaxy.web import expose_api_anonymous_and_sessionless
+from galaxy.webapps.base.controller import BaseAPIController
+
+
+class JobPortsAPIController(BaseAPIController):
+    """ This job files controller allows remote job running mechanisms to
+    modify the current state of ports for queued and running jobs.
+    It is certainly not meant to represent part of Galaxy's stable, user
+    facing API.
+
+    See the JobFiles API for information about per-job API keys.
+    """
+
+    def __init__(self, app):
+        self._job_ports_view = JobPortsView(app)
+
+    @expose_api_anonymous_and_sessionless
+    def create(self, trans, job_id, payload, **kwargs):
+        """
+        create( self, trans, job_id, payload, **kwargs )
+        * POST /api/jobs/{job_id}/ports
+            Populate port information for interactive tools.
+
+        :type   job_id: str
+        :param  job_id: encoded id string of the job
+        :type   payload:    dict
+        :param  payload:    dictionary structure containing::
+            'job_key'           = Key authenticating
+            'container_runtime' = Path to file to create.
+
+        ..note:
+            This API method is intended only for consumption by job runners,
+            not end users.
+
+        :rtype:     dict
+        :returns:   an okay message
+        """
+        payload.update(kwargs)
+        return self._job_ports_view.register_container_information(job_id, **payload)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -951,6 +951,12 @@ def populate_api_routes(webapp, app):
                            name_prefix="job_",
                            path_prefix='/api/jobs/{job_id}',
                            parent_resources=dict(member_name="job", collection_name="jobs"))
+    webapp.mapper.resource('port',
+                           'ports',
+                           controller="job_ports",
+                           name_prefix="job_",
+                           path_prefix='/api/jobs/{job_id}',
+                           parent_resources=dict(member_name="job", collection_name="jobs"))
 
     _add_item_extended_metadata_controller(webapp,
                                            name_prefix="history_dataset_",

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -46,12 +46,12 @@ def main():
                 except Exception:
                     # doesn't work on OS X
                     host_ip = None
+                ports = docker_util.parse_port_text(ports_raw)
+                if host_ip is not None:
+                    for key in ports:
+                        if ports[key]['host'] == '0.0.0.0':
+                            ports[key]['host'] = host_ip
                 with open("container_runtime.json", "w") as f:
-                    ports = docker_util.parse_port_text(ports_raw)
-                    if host_ip is not None:
-                        for key in ports:
-                            if ports[key]['host'] == '0.0.0.0':
-                                ports[key]['host'] = host_ip
                     json.dump(ports, f)
                 break
             else:

--- a/lib/galaxy_ext/container_monitor/monitor.py
+++ b/lib/galaxy_ext/container_monitor/monitor.py
@@ -29,7 +29,11 @@ def parse_ports(container_name, connection_configuration):
 
 
 def main():
-    with open("../configs/container_config.json", "r") as f:
+    if not os.path.exists("configs"):
+        # on Pulsar and in tool working directory instead of job directory
+        os.chdir("..")
+
+    with open("configs/container_config.json", "r") as f:
         container_config = json.load(f)
 
     container_type = container_config["container_type"]

--- a/test/integration/embedded_pulsar_docker_job_conf.yml
+++ b/test/integration/embedded_pulsar_docker_job_conf.yml
@@ -3,6 +3,10 @@ runners:
     load: galaxy.jobs.runners.local:LocalJobRunner
   pulsar_embed:
     load: galaxy.jobs.runners.pulsar:PulsarEmbeddedJobRunner
+    pulsar_app_config:  # this doesn't start in uwsgi without disabling - filelock problem
+      tool_dependency_dir: none
+      conda_auto_init: false
+      conda_auto_install: false
 
 execution:
   default: pulsar_embed
@@ -14,6 +18,7 @@ execution:
       docker_enabled: true
       docker_sudo: false
       docker_required: true
+      container_monitor_result: callback
 
 tools:
 - id: upload1

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -9,56 +9,27 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     wait_on,
 )
-from .test_containerized_jobs import ContainerizedIntegrationTestCase
+from .test_containerized_jobs import (
+    ContainerizedIntegrationTestCase,
+    disable_dependency_resolution,
+)
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+EMBEDDED_PULSAR_JOB_CONFIG_FILE_DOCKER = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_docker_job_conf.yml")
 
 
-class InteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
-
+class BaseInteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
     framework_tool_and_types = True
     container_type = "docker"
     require_uwsgi = True
     enable_realtime_mapping = True
 
     def setUp(self):
-        super(InteractiveToolsIntegrationTestCase, self).setUp()
+        super(BaseInteractiveToolsIntegrationTestCase, self).setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.history_id = self.dataset_populator.new_history()
 
-    def test_simple_execution(self):
-        response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, self.history_id, assert_ok=True)
-        assert "jobs" in response_dict, response_dict
-        jobs = response_dict["jobs"]
-        assert isinstance(jobs, list)
-        assert len(jobs) == 1
-        job0 = jobs[0]
-        entry_points = self.wait_on_entry_points_active(job0["id"])
-        assert len(entry_points) == 1
-        entry_point0 = entry_points[0]
-        target = self.entry_point_target(entry_point0["id"])
-        content = self.wait_on_proxied_content(target)
-        assert content == "moo cow\n", content
-
-    def test_multi_server_realtime_tool(self):
-        response_dict = self.dataset_populator.run_tool("interactivetool_two_entry_points", {}, self.history_id, assert_ok=True)
-        assert "jobs" in response_dict, response_dict
-        jobs = response_dict["jobs"]
-        assert isinstance(jobs, list)
-        assert len(jobs) == 1
-        job0 = jobs[0]
-        entry_points = self.wait_on_entry_points_active(job0["id"], expected_num=2)
-        entry_point0 = entry_points[0]
-        entry_point1 = entry_points[1]
-        target0 = self.entry_point_target(entry_point0["id"])
-        target1 = self.entry_point_target(entry_point1["id"])
-        assert target0 != target1
-        content0 = self.wait_on_proxied_content(target0)
-        assert content0 == "moo cow\n", content0
-
-        content1 = self.wait_on_proxied_content(target1)
-        assert content1 == "moo cow\n", content1
-
+    # Move helpers to populators.py
     def wait_on_proxied_content(self, target):
         def get_hosted_content():
             try:
@@ -100,3 +71,52 @@ class InteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
         entry_points_response = self._get("entry_points?job_id=%s" % job_id)
         api_asserts.assert_status_code_is(entry_points_response, 200)
         return entry_points_response.json()
+
+
+class RunsInterativeToolTests(object):
+
+    def test_simple_execution(self):
+        response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, self.history_id, assert_ok=True)
+        assert "jobs" in response_dict, response_dict
+        jobs = response_dict["jobs"]
+        assert isinstance(jobs, list)
+        assert len(jobs) == 1
+        job0 = jobs[0]
+        entry_points = self.wait_on_entry_points_active(job0["id"])
+        assert len(entry_points) == 1
+        entry_point0 = entry_points[0]
+        target = self.entry_point_target(entry_point0["id"])
+        content = self.wait_on_proxied_content(target)
+        assert content == "moo cow\n", content
+
+    def test_multi_server_realtime_tool(self):
+        response_dict = self.dataset_populator.run_tool("interactivetool_two_entry_points", {}, self.history_id, assert_ok=True)
+        assert "jobs" in response_dict, response_dict
+        jobs = response_dict["jobs"]
+        assert isinstance(jobs, list)
+        assert len(jobs) == 1
+        job0 = jobs[0]
+        entry_points = self.wait_on_entry_points_active(job0["id"], expected_num=2)
+        entry_point0 = entry_points[0]
+        entry_point1 = entry_points[1]
+        target0 = self.entry_point_target(entry_point0["id"])
+        target1 = self.entry_point_target(entry_point1["id"])
+        assert target0 != target1
+        content0 = self.wait_on_proxied_content(target0)
+        assert content0 == "moo cow\n", content0
+
+        content1 = self.wait_on_proxied_content(target1)
+        assert content1 == "moo cow\n", content1
+
+
+class InteractiveToolsIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
+    pass
+
+
+class InteractiveToolsPulsarIntegrationTestCase(BaseInteractiveToolsIntegrationTestCase, RunsInterativeToolTests):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE_DOCKER
+        config["galaxy_infrastructure_url"] = 'http://localhost:$UWSGI_PORT'
+        disable_dependency_resolution(config)


### PR DESCRIPTION
Allow remote container port monitoring for ITs.

Tested with Pulsar but not sure there is anything Pulsar specific about the implementation - simply set container_monitor_result on the job destination to 'callback' (instead of implicit default of 'file'). This causes the monitor.py script to hit a new job_ports API (that mirrors job_files API) and uses the same security mechanism (per-job keys that are only active while the job is active).

PR contains fixes for embedded Pulsar configuration handling, embedded Pulsar under uwsgi, and the introduction of new feature that allows dynamic expansion of ``$UWSGI_PORT`` inside of galaxy_infrastructure_url.

Builds on open PR https://github.com/galaxyproject/galaxy/pull/8846.  Uses infrastructure URL abstraction for tools setup in https://github.com/galaxyproject/galaxy/pull/8897. 

xref original interactive tools PR (https://github.com/galaxyproject/galaxy/pull/7494).
