### PR TITLE
[19.09] Expunge tool shed repository objects, prevents ParentInstanceDetachedError

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -149,26 +149,20 @@ class ToolShedRepositoryCache(object):
         self.repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
 
     def rebuild(self):
-        session = self.app.install_model.context.current
-        self.repositories = session.query(self.app.install_model.ToolShedRepository).options(
-            defer(self.app.install_model.ToolShedRepository.metadata),
-            joinedload('tool_dependencies').subqueryload('tool_shed_repository').options(
-                defer(self.app.install_model.ToolShedRepository.metadata)
-            ),
-        ).all()
-        for r in self.repositories:
-            # We use sqlalchemy's expire_on_commit option for sessions,
-            # which means that attributes are fetched from the database
-            # after a commit occurs.
-            # The session used for establishing the cache however may have been closed,
-            # leading to ParentInstanceDetached errors.
-            # Expunging the repo prevents the refresh and should be
-            # safe since the cache will be rebuilt upon repository installations and uninstallations.
-            session.expunge(r)
-        repos_by_tuple = defaultdict(list)
-        for repository in self.repositories + self.local_repositories:
-            repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
-        self.repos_by_tuple = repos_by_tuple
+        try:
+            session = self.app.install_model.context.current.session_factory()
+            self.repositories = session.query(self.app.install_model.ToolShedRepository).options(
+                defer(self.app.install_model.ToolShedRepository.metadata),
+                joinedload('tool_dependencies').subqueryload('tool_shed_repository').options(
+                    defer(self.app.install_model.ToolShedRepository.metadata)
+                ),
+            ).all()
+            repos_by_tuple = defaultdict(list)
+            for repository in self.repositories + self.local_repositories:
+                repos_by_tuple[(repository.tool_shed, repository.owner, repository.name)].append(repository)
+            self.repos_by_tuple = repos_by_tuple
+        finally:
+            session.close()
 
     def get_installed_repository(self, tool_shed=None, name=None, owner=None, installed_changeset_revision=None, changeset_revision=None, repository_id=None):
         if repository_id:

--- a/test/unit/tools/conftest.py
+++ b/test/unit/tools/conftest.py
@@ -65,4 +65,13 @@ def create_repo(app, changeset, installed_changeset, config_filename=None):
     repository.deleted = False
     repository.uninstalled = False
     app.install_model.context.add(repository)
+    app.install_model.context.flush()
+    tool_dependency = tool_shed_install.ToolDependency(
+        name='Name',
+        version='100',
+        type='package',
+        status='ok',
+        tool_shed_repository_id=repository.id,
+    )
+    app.install_model.context.add(tool_dependency)
     return repository

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -67,6 +67,7 @@ def test_repo_cache_expunge(tool_shed_repository_cache, repos):
     # remove session, so access to expired attributes will raise exception
     tool_shed_repository_cache.app.install_model.session.remove()
     assert repo.changeset_revision == "1"
+    assert repo.tool_dependencies[0].name == 'Name'
     with pytest.raises(DetachedInstanceError):
         # Make sure this still raises DetachedInstanceError,
         # keeping this in memory would be expensive

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -54,3 +54,13 @@ def test_get_installed_repository(tool_shed_repository_cache, repos, tool_conf_r
         assert repo
     else:
         assert repo is None
+
+
+def test_repo_cache_expunge(tool_shed_repository_cache, repos):
+    tool_shed_repository_cache.rebuild()
+    assert len(tool_shed_repository_cache.repositories) == 10
+    repo = tool_shed_repository_cache.repositories[0]
+    repo.name = 'new name'
+    tool_shed_repository_cache.app.install_model.session.flush()
+    tool_shed_repository_cache.app.install_model.session.remove()
+    assert repo.changeset_revision == "1"

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -60,9 +60,11 @@ def test_get_installed_repository(tool_shed_repository_cache, repos, tool_conf_r
 def test_repo_cache_expunge(tool_shed_repository_cache, repos):
     tool_shed_repository_cache.rebuild()
     assert len(tool_shed_repository_cache.repositories) == 10
+    # Modify and commit a repo, will expire in memory attributes of orm objects (unless expunged)
     repo = tool_shed_repository_cache.repositories[0]
     repo.name = 'new name'
     tool_shed_repository_cache.app.install_model.session.flush()
+    # remove session, so access to expired attributes will raise exception
     tool_shed_repository_cache.app.install_model.session.remove()
     assert repo.changeset_revision == "1"
     with pytest.raises(DetachedInstanceError):

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.orm.exc import DetachedInstanceError
 
 from .conftest import create_repo
 
@@ -64,3 +65,7 @@ def test_repo_cache_expunge(tool_shed_repository_cache, repos):
     tool_shed_repository_cache.app.install_model.session.flush()
     tool_shed_repository_cache.app.install_model.session.remove()
     assert repo.changeset_revision == "1"
+    with pytest.raises(DetachedInstanceError):
+        # Make sure this still raises DetachedInstanceError,
+        # keeping this in memory would be expensive
+        repo.metadata

--- a/test/unit/tools/test_tool_shed_repository_cache.py
+++ b/test/unit/tools/test_tool_shed_repository_cache.py
@@ -60,11 +60,11 @@ def test_get_installed_repository(tool_shed_repository_cache, repos, tool_conf_r
 def test_repo_cache_expunge(tool_shed_repository_cache, repos):
     tool_shed_repository_cache.rebuild()
     assert len(tool_shed_repository_cache.repositories) == 10
-    # Modify and commit a repo, will expire in memory attributes of orm objects (unless expunged)
+    # Modify and commit a repo, will expire in memory attributes of orm objects (unless using a different session)
     repo = tool_shed_repository_cache.repositories[0]
     repo.name = 'new name'
     tool_shed_repository_cache.app.install_model.session.flush()
-    # remove session, so access to expired attributes will raise exception
+    # remove session, should demonstrate the separate session is in use
     tool_shed_repository_cache.app.install_model.session.remove()
     assert repo.changeset_revision == "1"
     assert repo.tool_dependencies[0].name == 'Name'


### PR DESCRIPTION
We use SQLAlchemy's `expire_on_commit` option for sessions, which means that attributes are fetched from the database after a commit occurs.
The session used for establishing the cache however may have been closed, leading to `ParentInstanceDetached` errors.
Expunging the repo prevents the refresh and should be safe since the cache will be rebuilt upon repository installations and uninstallations.

~~I still need to check how this plays together with the tool dependency relationship.~~
There is a test that confirms this works fine for the old-style tool dependency relationships as well.