### PR TITLE
implement selenium test User->Preferences->Manage information

### DIFF
--- a/client/galaxy/scripts/components/User/UserPreferences.vue
+++ b/client/galaxy/scripts/components/User/UserPreferences.vue
@@ -5,16 +5,16 @@
             {{ message }}
         </b-alert>
         <p>
-            You are logged in as <strong>{{ email }}</strong
+            You are logged in as <strong id="user-preferences-current-email">{{ email }}</strong
             >.
         </p>
         <b-row class="ml-3 mb-1" v-for="(link, index) in activeLinks" :key="index">
             <i :class="['pref-icon pt-1 fa fa-lg', link.icon]" />
             <div class="pref-content pr-1">
-                <a v-if="link.onclick" @click="link.onclick" href="javascript:void(0)"
+                <a :id="link.id" v-if="link.onclick" @click="link.onclick" href="javascript:void(0)"
                     ><b>{{ link.title }}</b></a
                 >
-                <a v-else :href="`${baseUrl}/${link.action}`"
+                <a :id="link.id" v-else :href="`${baseUrl}/${link.action}`"
                     ><b>{{ link.title }}</b></a
                 >
                 <div class="form-text text-muted">

--- a/client/galaxy/scripts/components/User/UserPreferencesModel.js
+++ b/client/galaxy/scripts/components/User/UserPreferencesModel.js
@@ -7,6 +7,7 @@ export const getUserPreferencesModel = () => {
     return {
         information: {
             title: _l("Manage Information"),
+            id: "edit-preferences-information",
             description: "Edit your email, addresses and custom parameters or change your public name.",
             url: `api/users/${Galaxy.user.id}/information/inputs`,
             icon: "fa-user",
@@ -15,6 +16,7 @@ export const getUserPreferencesModel = () => {
         },
         password: {
             title: _l("Change Password"),
+            id: "edit-preferences-password",
             description: _l("Allows you to change your login credentials."),
             icon: "fa-unlock-alt",
             url: `api/users/${Galaxy.user.id}/password/inputs`,
@@ -24,6 +26,7 @@ export const getUserPreferencesModel = () => {
         },
         communication: {
             title: _l("Change Communication Settings"),
+            id: "edit-preferences-communication",
             description: _l("Enable or disable the communication feature to chat with other users."),
             url: `api/users/${Galaxy.user.id}/communication/inputs`,
             icon: "fa-comments-o",
@@ -32,6 +35,7 @@ export const getUserPreferencesModel = () => {
         },
         permissions: {
             title: _l("Set Dataset Permissions for new Histories"),
+            id: "edit-preferences-permissions",
             description:
                 "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored.",
             url: `api/users/${Galaxy.user.id}/permissions/inputs`,
@@ -41,11 +45,13 @@ export const getUserPreferencesModel = () => {
         },
         make_data_private: {
             title: _l("Make all Data Private"),
+            id: "edit-preferences-make-data-private",
             description: _l("Click here to make all data private."),
             icon: "fa-lock"
         },
         api_key: {
             title: _l("Manage API Key"),
+            id: "edit-preferences-api-key",
             description: _l("Access your current API key or create a new one."),
             url: `api/users/${Galaxy.user.id}/api_key/inputs`,
             icon: "fa-key",
@@ -53,6 +59,7 @@ export const getUserPreferencesModel = () => {
             submit_icon: "fa-check"
         },
         cloud_auth: {
+            id: "edit-preferences-cloud-auth",
             title: _l("Manage Cloud Authorization"),
             description: _l("Add or modify the configuration that grants Galaxy to access your cloud-based resources."),
             icon: "fa-cloud",
@@ -61,6 +68,7 @@ export const getUserPreferencesModel = () => {
         },
         toolbox_filters: {
             title: _l("Manage Toolbox Filters"),
+            id: "edit-preferences-toolbox-filters",
             description: _l("Customize your Toolbox by displaying or omitting sets of Tools."),
             url: `api/users/${Galaxy.user.id}/toolbox_filters/inputs`,
             icon: "fa-filter",
@@ -75,6 +83,7 @@ export const getUserPreferencesModel = () => {
         },
         logout: {
             title: _l("Sign Out"),
+            id: "edit-preferences-custom-builds",
             description: _l("Click here to sign out of all sessions."),
             icon: "fa-sign-out",
             shouldRender: !!Galaxy.session_csrf_token

--- a/client/galaxy/scripts/mvc/form/form-input.js
+++ b/client/galaxy/scripts/mvc/form/form-input.js
@@ -177,6 +177,7 @@ export default Backbone.View.extend({
             this.$title_text.show().text(this.model.get("label"));
             this.$collapsible.hide();
         }
+        this.$field.attr("data-label", this.model.get("label"));
     },
 
     _template: function() {

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -60,12 +60,28 @@ masthead:
     # user menu
     logout: 'Logout'
     custom_builds: 'Custom Builds'
+    preferences: 'Preferences'
     histories: 'Histories'
     pages: 'Pages'
 
     # Shared data
     libraries: 'Data Libraries'
     published_histories: 'Histories'
+
+preferences:
+  selectors:
+    manage_information: '#edit-preferences-information'
+    current_email: "#user-preferences-current-email"
+
+change_user_email:
+  selectors:
+    submit: '#submit'
+
+change_user_address:
+  selectors:
+    address_button:
+      type: xpath
+      selector: '//span[contains(text(), "Insert Address")]'
 
 history_panel:
   menu:

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -107,13 +107,5 @@ class ManageInformationTestCase(SeleniumTestCase):
         element.clear()
         element.send_keys(new_input_text)
 
-    # Since ids are not permanent we need to search with xpath
     def get_address_input_field(self, address_form, input_field_label):
-        # . in the beginning = search only within current element
-        # span[.="variable"] find a span where text equals a variable
-        # //ancestor::div[@class = 'ui-form-title']" get an ancestor of found element with 'ui-form-title' classname
-        parent_element = address_form.find_element_by_xpath(
-            ".//span[.='" + input_field_label + "']//ancestor::div[@class = 'ui-form-title']")
-        # we cannot get to the desired parent directly (@class='ui-form-element section-row'),
-        # because then it will match the entire form. Thus, we need to use '..' to get one element up and get input tag
-        return parent_element.find_element_by_xpath('./..').find_element_by_tag_name('input')
+        return address_form.find_element_by_css_selector("[data-label='" + input_field_label + "'] > input")

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -1,0 +1,119 @@
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class ManageInformationTestCase(SeleniumTestCase):
+
+    @selenium_test
+    def test_change_email(self):
+        def assert_email(email_to_check):
+            self.assertTrue(email_to_check == self.driver.find_element_by_id("user-preferences-current-email").text)
+
+        email = self._get_random_email()
+        self.register(email)
+        self.navigate_to_user_preferences()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # rendered email should be equal
+        assert_email(email)
+
+        self.components.preferences.manage_information.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        new_email = self._get_random_email()
+        # new email should be different from initially registered
+        self.assertTrue(email != new_email)
+        email_input_field = self.driver.find_element_by_css_selector("[tour_id='email'] input")
+
+        self.clear_input_field_and_write(email_input_field, new_email)
+        self.components.change_user_email.submit.wait_for_and_click()
+
+        # UX_RENDER time sometimes is not enough
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        # email should be changed
+        assert_email(new_email)
+
+    @selenium_test
+    def test_public_name(self):
+        def get_name_input_field():
+            return self.driver.find_element_by_css_selector("[tour_id='username'] input")
+
+        def assert_public_name(expected_name):
+            self.assertTrue(expected_name == get_name_input_field().get_attribute('value'))
+
+        public_name = "user-public-name"
+        self.register(username=public_name)
+        self.navigate_to_manage_information()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # make sure that public name is the same as registered
+        assert_public_name(public_name)
+        new_public_name = "new-public-name"
+        # change public name
+        self.clear_input_field_and_write(get_name_input_field(), new_public_name)
+        self.components.change_user_email.submit.wait_for_and_click()
+
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        self.navigate_to_manage_information()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        # public name field should render new public name
+        assert_public_name(new_public_name)
+
+    @selenium_test
+    def test_user_address(self):
+        def get_address_form():
+            return self.driver.find_element_by_css_selector("div.ui-portlet-section > div.portlet-content")
+
+        self.register(self._get_random_email())
+        self.navigate_to_manage_information()
+        self.components.change_user_address.address_button.wait_for_and_click()
+
+        address_field_labels = ["Short address description", "Name", "Institution", "Address", "City",
+                                "State/Province/Region", "Postal Code", "Country", "Phone"]
+
+        address_fields = {}
+        # fill address fields with random data
+        for input_field_label in address_field_labels:
+            input_value = self._get_random_name(prefix=input_field_label)
+            address_fields[input_field_label] = input_value
+            input_field = self.get_address_input_field(get_address_form(), input_field_label)
+            self.clear_input_field_and_write(input_field, input_value)
+        # save new address
+        self.components.change_user_email.submit.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+
+        self.navigate_to_manage_information()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # check if address was saved correctly
+        for input_field_label in address_fields.keys():
+            input_field = self.get_address_input_field(get_address_form(), input_field_label)
+            self.assertTrue(input_field.get_attribute('value') == address_fields[input_field_label])
+
+    def navigate_to_user_preferences(self):
+        self.home()
+        self.click_masthead_user()
+        self.components.masthead.preferences.wait_for_and_click()
+
+    def navigate_to_manage_information(self):
+        self.navigate_to_user_preferences()
+        self.components.preferences.manage_information.wait_for_and_click()
+
+    def clear_input_field_and_write(self, element, new_input_text):
+        element.clear()
+        element.send_keys(new_input_text)
+
+    # Since ids are not permanent we need to search with xpath
+    def get_address_input_field(self, address_form, input_field_label):
+        # . in the beginning = search only within current element
+        # span[.="variable"] find a span where text equals a variable
+        # //ancestor::div[@class = 'ui-form-title']" get an ancestor of found element with 'ui-form-title' classname
+        parent_element = address_form.find_element_by_xpath(
+            ".//span[.='" + input_field_label + "']//ancestor::div[@class = 'ui-form-title']")
+        # we cannot get to the desired parent directly (@class='ui-form-element section-row'),
+        # because then it will match the entire form. Thus, we need to use '..' to get one element up and get input tag
+        return parent_element.find_element_by_xpath('./..').find_element_by_tag_name('input')


### PR DESCRIPTION
Expanding Selenium tests coverage according to https://github.com/galaxyproject/galaxy/issues/3241

Test capabilities under ```{http://{galaxy}/user/information```
- test changing user email
- test public name
- test user address (a tricky one, will appreciate a comment on it, see ```test_personal_information.py:get_address_input_field()``` )