### PR TITLE
Skip ``test_config_option[build_sites_config_file]``

### DIFF
--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -1,13 +1,3 @@
-import os
-from collections import namedtuple
-from datetime import timedelta
-
-import pytest
-
-from galaxy.util import listify
-from galaxy_test.driver.driver_util import GalaxyTestDriver
-
-
 """
 This tests: (1) automatic creation of configuration properties; and
 (2) assignment of default values that are specified in the schema and, in
@@ -35,9 +25,16 @@ Configuration options NOT tested:
 - job_config (no obvious testable defaults)
 """
 
+import os
+from collections import namedtuple
+from datetime import timedelta
 
-OptionData = namedtuple('OptionData', 'key, expected, loaded')
+import pytest
 
+from galaxy.util import listify
+from galaxy_test.driver.driver_util import GalaxyTestDriver
+
+OptionData = namedtuple('OptionData', ('key', 'expected', 'loaded'))
 
 # Configuration properties that are paths should be absolute paths, by default resolved w.r.t root.
 PATH_CONFIG_PROPERTIES = [
@@ -155,6 +152,7 @@ DO_NOT_TEST = [
     'allow_user_deletion',  # broken: default overridden
     'amqp_internal_connection',  # may or may not be testable; refactor config/
     'api_allow_run_as',  # may or may not be testable: test value assigned
+    'build_sites_config_file',  # broken: remove 'config/' prefix from schema
     'chunk_upload_size',  # broken: default overridden
     'cleanup_job',  # broken: default overridden
     'conda_auto_init',  # broken: default overridden
@@ -204,7 +202,7 @@ DO_NOT_TEST = [
     'user_tool_label_filters',  # broken: default overridden
     'user_tool_section_filters',  # broken: default overridden
     'webhooks_dir',  # broken; also remove 'config/' prefix from schema
-    'workflow_resource_params_mapper',  # broken
+    'workflow_resource_params_mapper',  # broken: remove 'config/' prefix from schema
 ]
 
 


### PR DESCRIPTION
Fix:

```
_________________ test_config_option[build_sites_config_file] __________________

data = OptionData(key='build_sites_config_file', expected='config/build_sites.yml.sample', loaded='/home/runner/work/galaxy/galaxy root/lib/galaxy/config/sample/build_sites.yml')
driver = <galaxy_test.driver.driver_util.GalaxyTestDriver object at 0x7f0accbf93d0>

    @pytest.mark.parametrize('data', get_config_data(), ids=get_key)
    def test_config_option(data, driver):
>       assert data.expected == data.loaded
E       AssertionError: assert 'config/build...es.yml.sample' == '/home/runner/...ild_sites.yml'
E         - config/build_sites.yml.sample
E         + /home/runner/work/galaxy/galaxy root/lib/galaxy/config/sample/build_sites.yml
```

from https://github.com/galaxyproject/galaxy/pull/9353/checks?check_run_id=438827128