### PR TITLE
[20.01] Use RenamedTemporaryFile for safer integrated_tool_panel_file writing

### DIFF
--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -1,11 +1,11 @@
 import os
 import shutil
 import string
-import tempfile
 import time
 import traceback
 from xml.sax.saxutils import escape
 
+from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 from .panel import (
     panel_item_types,
     ToolPanelElements
@@ -51,14 +51,15 @@ class ManagesIntegratedToolPanelMixin(object):
         Write the current in-memory version of the integrated_tool_panel.xml file to disk.  Since Galaxy administrators
         use this file to manage the tool panel, we'll not use xml_to_string() since it doesn't write XML quite right.
         """
+        destination = os.path.abspath(self._integrated_tool_panel_config)
         tracking_directory = self._integrated_tool_panel_tracking_directory
-        if not tracking_directory:
-            fd, filename = tempfile.mkstemp()
-        else:
+        if tracking_directory:
             if not os.path.exists(tracking_directory):
                 os.makedirs(tracking_directory)
             name = "integrated_tool_panel_%.10f.xml" % time.time()
             filename = os.path.join(tracking_directory, name)
+        else:
+            filename = destination
         template = string.Template("""<?xml version="1.0"?>
 <toolbox>
     <!--
@@ -101,14 +102,13 @@ $INTEGRATED_TOOL_PANEL
         tool_panel_description = '\n    '.join([l for l in INTEGRATED_TOOL_PANEL_DESCRIPTION.split("\n") if l])
         tp_string = template.substitute(INTEGRATED_TOOL_PANEL_DESCRIPTION=tool_panel_description,
                                         INTEGRATED_TOOL_PANEL='\n'.join(integrated_tool_panel))
-        with open(filename, "w") as integrated_tool_panel_file:
+        with RenamedTemporaryFile(filename, mode='w') as integrated_tool_panel_file:
             integrated_tool_panel_file.write(tp_string)
-        destination = os.path.abspath(self._integrated_tool_panel_config)
         if tracking_directory:
             open(filename + ".stack", "w").write(''.join(traceback.format_stack()))
             shutil.copy(filename, filename + ".copy")
             filename = filename + ".copy"
-        shutil.move(filename, destination)
+            shutil.move(filename, destination)
         try:
             os.chmod(destination, 0o644)
         except OSError:

--- a/lib/galaxy/tools/toolbox/integrated_panel.py
+++ b/lib/galaxy/tools/toolbox/integrated_panel.py
@@ -102,13 +102,13 @@ $INTEGRATED_TOOL_PANEL
         tool_panel_description = '\n    '.join([l for l in INTEGRATED_TOOL_PANEL_DESCRIPTION.split("\n") if l])
         tp_string = template.substitute(INTEGRATED_TOOL_PANEL_DESCRIPTION=tool_panel_description,
                                         INTEGRATED_TOOL_PANEL='\n'.join(integrated_tool_panel))
-        with RenamedTemporaryFile(filename, mode='w') as integrated_tool_panel_file:
-            integrated_tool_panel_file.write(tp_string)
+        with RenamedTemporaryFile(filename, mode='w') as f:
+            f.write(tp_string)
         if tracking_directory:
-            open(filename + ".stack", "w").write(''.join(traceback.format_stack()))
+            with open(filename + ".stack", "w") as f:
+                f.write(''.join(traceback.format_stack()))
             shutil.copy(filename, filename + ".copy")
-            filename = filename + ".copy"
-            shutil.move(filename, destination)
+            shutil.move(filename + ".copy", destination)
         try:
             os.chmod(destination, 0o644)
         except OSError:


### PR DESCRIPTION
If not using the largely undocumented and debug-y `integrated_tool_panel_tracking_directory`
we should use RenamedTemporaryFile which creates a temp file in the
directory where `integrated_tool_panel_file` lives, and upon succesful
write rename the file to `integrated_tool_panel_file`.
We use this in other places in the code and it seems to work well
when multiple threads are potentially modifying the target file.