### PR TITLE
[19.09] Always add shed_tool_config file to tool_configs

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1097,8 +1097,7 @@ class ConfiguresGalaxyMixin(object):
         from galaxy.managers.tools import DynamicToolManager
         self.dynamic_tools_manager = DynamicToolManager(self)
         self._toolbox_lock = threading.RLock()
-        # shed_tool_config_file has been set, add it to tool_configs
-        if self.config.shed_tool_config_file_set:
+        if self.config.shed_tool_config_file not in self.config.tool_configs:
             self.config.tool_configs.append(self.config.shed_tool_config_file)
         # The value of migrated_tools_config is the file reserved for containing only those tools that have been
         # eliminated from the distribution and moved to the tool shed. If migration checking is disabled, only add it if
@@ -1107,17 +1106,6 @@ class ConfiguresGalaxyMixin(object):
                 and self.config.migrated_tools_config not in self.config.tool_configs):
             self.config.tool_configs.append(self.config.migrated_tools_config)
         self.toolbox = tools.ToolBox(self.config.tool_configs, self.config.tool_path, self)
-        # If no shed-enabled tool config file has been loaded, we append a default shed_tool_conf.xml
-        if not self.config.shed_tool_config_file_set and not self.toolbox.dynamic_confs():
-            # This seems like the likely case for problems in older deployments
-            if self.config.tool_config_file_set:
-                log.warning(
-                    "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
-                    "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
-                    "config file", self.config.shed_tool_config_file
-                )
-            self.config.tool_configs.append(self.config.shed_tool_config_file)
-            self.toolbox._init_tools_from_config(self.config.shed_tool_config_file)
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(getattr(self.config, "file_path"))
         app_info = AppInfo(

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -255,6 +255,19 @@ class ToolBox(BaseGalaxyToolBox):
             app=app,
         )
 
+    def can_load_config_file(self, config_filename):
+        if config_filename == self.app.config.shed_tool_config_file and not self.app.config.shed_tool_config_file_set:
+            if self.dynamic_confs():
+                # Do not load or create a default shed_tool_config_file if another shed_tool_config file has already been loaded
+                return False
+        elif self.app.config.tool_config_file_set:
+            log.warning(
+                "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
+                "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
+                "config file", self.app.config.shed_tool_config_file
+            )
+        return True
+
     def has_reloaded(self, other_toolbox):
         return self._reload_count != other_toolbox._reload_count
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -127,6 +127,9 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
     def create_dynamic_tool(self, dynamic_tool):
         raise NotImplementedError()
 
+    def can_load_config_file(self, config_filename):
+        return True
+
     def _init_tools_from_configs(self, config_filenames):
         """ Read through all tool config files and initialize tools in each
         with init_tools_from_config below.
@@ -141,16 +144,8 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 config_filenames.remove(config_filename)
                 config_filenames.extend(directory_config_files)
         for config_filename in config_filenames:
-            if config_filename == self.app.config.shed_tool_config_file and not self.app.config.shed_tool_config_file_set:
-                if self.dynamic_confs():
-                    # Do not load or create a default shed_tool_config_file if another shed_tool_config file has already been loaded
-                    continue
-                elif self.app.config.tool_config_file_set:
-                    log.warning(
-                        "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
-                        "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
-                        "config file", self.app.config.shed_tool_config_file
-                    )
+            if not self.can_load_config_file(config_filename):
+                continue
             try:
                 self._init_tools_from_config(config_filename)
             except ParseError:

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -141,6 +141,16 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 config_filenames.remove(config_filename)
                 config_filenames.extend(directory_config_files)
         for config_filename in config_filenames:
+            if config_filename == self.app.config.shed_tool_config_file and not self.app.config.shed_tool_config_file_set:
+                if self.dynamic_confs():
+                    # Do not load or create a default shed_tool_config_file if another shed_tool_config file has already been loaded
+                    continue
+                elif self.app.config.tool_config_file_set:
+                    log.warning(
+                        "The default shed tool config file (%s) has been added to the tool_config_file option, if this is "
+                        "not the desired behavior, please set shed_tool_config_file to your primary shed-enabled tool "
+                        "config file", self.app.config.shed_tool_config_file
+                    )
             try:
                 self._init_tools_from_config(config_filename)
             except ParseError:

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -145,6 +145,8 @@ class MockAppConfig(Bunch):
         self.builds_file_path = os.path.join('tool-data', 'shared', 'ucsc', 'builds.txt.sample')
 
         self.migrated_tools_config = "/tmp/migrated_tools_conf.xml"
+        self.shed_tool_config_file = "config/shed_tool_conf.xml"
+        self.shed_tool_config_file_set = False
         self.preserve_python_environment = "always"
         self.enable_beta_gdpr = False
         self.legacy_eager_objectstore_initialization = True


### PR DESCRIPTION
This should fix https://github.com/galaxyproject/galaxy/issues/9356
The bug itself was due to not calling `toolbox._load_tool_panel()` (introduced in https://github.com/galaxyproject/galaxy/pull/8999) after injecting the default shed_tool_config_file into the toolbox, but implementation-wise it seems better to have this logic inside the toolbox.