### PR TITLE
Move schema loading/validating code out of config

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -177,7 +177,7 @@ class BaseAppConfiguration(object):
         # Override in subclasses
         raise Exception('Not implemented')
 
-    def _deprecated_dirs():
+    def _deprecated_dirs(self):
         # Override in subclasses (optional)
         # {KEY: config option, VALUE: deprecated directory name}
         # If VALUE == first directory in a user path that resolves to KEY, it will be stripped from the path

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -212,11 +212,14 @@ class BaseAppConfiguration(object):
                 self._raw_config[key] = value
 
     def _create_attributes_from_raw_config(self):
+        # `base_configs` are a special case: these attributes have been created and will be ignored
+        # by the code below. Trying to overwrite any other existing attributes will raise an error.
+        base_configs = {'config_dir', 'data_dir', 'managed_config_dir'}
         for key, value in self._raw_config.items():
             if not hasattr(self, key):
                 setattr(self, key, value)
-            else:
-                log.debug("Attribute '%s' is set and cannot be overwritten with value '%s'" % (key, value))
+            elif key not in base_configs:
+                raise ConfigurationError("Attempting to override existing attribute '%s'" % key)
 
     def _resolve_paths(self):
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -268,9 +268,10 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
     def _create_attributes_from_raw_config(self):
         for key, value in self._raw_config.items():
-            if hasattr(self, key):
-                raise ConfigurationError("Attempting to override existing attribute '%s'" % key)
-            setattr(self, key, value)
+            if not hasattr(self, key):
+                setattr(self, key, value)
+            else:
+                log.debug("Attribute '%s' is set and cannot be overwritten with value '%s'" % (key, value))
 
     def _resolve_paths(self, paths_to_resolve):
 

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -30,12 +30,12 @@ if __name__ == '__main__':
 from galaxy.config import GALAXY_CONFIG_SCHEMA_PATH
 from galaxy.config.schema import (
     AppSchema,
+    OPTION_DEFAULTS,
     Schema,
 )
 from galaxy.util import safe_makedirs
 from galaxy.util.properties import nice_config_parser
 from galaxy.util.yaml_util import (
-    OPTION_DEFAULTS,
     ordered_dump,
     ordered_load,
 )

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -38,13 +38,14 @@ class AppSchema(Schema):
         self.description = self.raw_schema.get("desc", None)
         app_schema = self.raw_schema['mapping'][app_name]['mapping']
         self._preprocess(app_schema)
-        super().__init__(app_schema)
+        super(AppSchema, self).__init__(app_schema)
 
     def _read_schema(self, path):
         with open(path, "r") as f:
             return ordered_load(f)
 
     def _preprocess(self, app_schema):
+        """Populate schema collections used for app configuration."""
         self._defaults = {}  # {config option: default value or null}
         self._reloadable_options = set()  # config options we can reload at runtime
         self._paths_to_resolve = {}  # {config option: referenced config option}
@@ -68,8 +69,9 @@ class AppSchema(Schema):
         return self._reloadable_options
 
     def validate_path_resolution_graph(self):
-        # This method is for tests only: we SHOULD validate the schema's path resolution graph
-        # as part of automated testing; but we should NOT validate it at runtime.
+        """This method is for tests only: we SHOULD validate the schema's path resolution graph
+           as part of automated testing; but we should NOT validate it at runtime.
+        """
         def check_exists(option, key):
             if not option:
                 message = "Invalid schema: property '{}' listed as path resolution target " \

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -1,8 +1,12 @@
+import logging
+
+from galaxy.exceptions import ConfigurationError
 from galaxy.util.yaml_util import (
     OPTION_DEFAULTS,
     ordered_load,
 )
 
+log = logging.getLogger(__name__)
 
 UNKNOWN_OPTION = {
     "type": "str",
@@ -33,8 +37,68 @@ class AppSchema(Schema):
         self.raw_schema = self._read_schema(schema_path)
         self.description = self.raw_schema.get("desc", None)
         app_schema = self.raw_schema['mapping'][app_name]['mapping']
-        super(AppSchema, self).__init__(app_schema)
+        self._preprocess(app_schema)
+        super().__init__(app_schema)
 
     def _read_schema(self, path):
         with open(path, "r") as f:
             return ordered_load(f)
+
+    def _preprocess(self, app_schema):
+        self._defaults = {}  # {config option: default value or null}
+        self._reloadable_options = set()  # config options we can reload at runtime
+        self._paths_to_resolve = {}  # {config option: referenced config option}
+        for key, data in app_schema.items():
+            self._defaults[key] = data.get('default')
+            if data.get('reloadable'):
+                self._reloadable_options.add(key)
+            if data.get('path_resolves_to'):
+                self._paths_to_resolve[key] = data.get('path_resolves_to')
+
+    @property
+    def defaults(self):
+        return self._defaults
+
+    @property
+    def paths_to_resolve(self):
+        return self._paths_to_resolve
+
+    @property
+    def reloadable_options(self):
+        return self._reloadable_options
+
+    def validate_path_resolution_graph(self):
+        # This method is for tests only: we SHOULD validate the schema's path resolution graph
+        # as part of automated testing; but we should NOT validate it at runtime.
+        def check_exists(option, key):
+            if not option:
+                message = "Invalid schema: property '{}' listed as path resolution target " \
+                    "for '{}' does not exist".format(resolves_to, key)
+                raise_error(message)
+
+        def check_type_is_str(option, key):
+            if option.get('type') != 'str':
+                message = "Invalid schema: property '{}' should have type 'str'".format(key)
+                raise_error(message)
+
+        def check_is_dag():
+            visited = set()
+            for key in self.paths_to_resolve:
+                visited.clear()
+                while key:
+                    visited.add(key)
+                    key = self.app_schema[key].get('path_resolves_to')
+                    if key and key in visited:
+                        raise_error('Invalid schema: cycle detected')
+
+        def raise_error(message):
+            log.error(message)
+            raise ConfigurationError(message)
+
+        for key, resolves_to in self.paths_to_resolve.items():
+            print(key)
+            parent = self.app_schema.get(resolves_to)
+            check_exists(parent, key)
+            check_type_is_str(parent, key)
+            check_type_is_str(self.app_schema[key], key)
+        check_is_dag()  # must be called last: walks entire graph

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -1,12 +1,16 @@
 import logging
 
 from galaxy.exceptions import ConfigurationError
-from galaxy.util.yaml_util import (
-    OPTION_DEFAULTS,
-    ordered_load,
-)
+from galaxy.util.yaml_util import ordered_load
 
 log = logging.getLogger(__name__)
+
+OPTION_DEFAULTS = {
+    "type": "str",
+    "unknown_option": False,
+    "default": None,
+    "desc": None,
+}
 
 UNKNOWN_OPTION = {
     "type": "str",

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -1217,7 +1217,7 @@ class BaseGalaxyToolBox(AbstractToolBox):
             return
         app_config_dict = self.app.config.config_dict
         conf_file = app_config_dict.get("dependency_resolvers_config_file")
-        default_tool_dependency_dir = os.path.join(self.app.config.data_dir, self.app.config.appschema['tool_dependency_dir'].get('default'))
+        default_tool_dependency_dir = os.path.join(self.app.config.data_dir, self.app.config.schema.defaults['tool_dependency_dir'])
         self.dependency_manager = build_dependency_manager(app_config_dict=app_config_dict, conf_file=conf_file,
                                                            default_tool_dependency_dir=default_tool_dependency_dir)
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -1217,9 +1217,10 @@ class BaseGalaxyToolBox(AbstractToolBox):
             return
         app_config_dict = self.app.config.config_dict
         conf_file = app_config_dict.get("dependency_resolvers_config_file")
-        default_tool_dependency_dir = os.path.join(self.app.config.data_dir, self.app.config.schema.defaults['tool_dependency_dir'])
-        self.dependency_manager = build_dependency_manager(app_config_dict=app_config_dict, conf_file=conf_file,
-                                                           default_tool_dependency_dir=default_tool_dependency_dir)
+        default_tool_dependency_dir = os.path.join(
+            self.app.config.data_dir, self.app.config.schema.app_schema['tool_dependency_dir'].get('default'))
+        self.dependency_manager = build_dependency_manager(
+            app_config_dict=app_config_dict, conf_file=conf_file, default_tool_dependency_dir=default_tool_dependency_dir)
 
     def reload_dependency_manager(self):
         self._init_dependency_manager()

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -1218,7 +1218,7 @@ class BaseGalaxyToolBox(AbstractToolBox):
         app_config_dict = self.app.config.config_dict
         conf_file = app_config_dict.get("dependency_resolvers_config_file")
         default_tool_dependency_dir = os.path.join(
-            self.app.config.data_dir, self.app.config.schema.app_schema['tool_dependency_dir'].get('default'))
+            self.app.config.data_dir, self.app.config.schema.defaults['tool_dependency_dir'])
         self.dependency_manager = build_dependency_manager(
             app_config_dict=app_config_dict, conf_file=conf_file, default_tool_dependency_dir=default_tool_dependency_dir)
 

--- a/lib/galaxy/util/yaml_util.py
+++ b/lib/galaxy/util/yaml_util.py
@@ -10,13 +10,6 @@ from yaml.constructor import ConstructorError
 
 log = logging.getLogger(__name__)
 
-OPTION_DEFAULTS = {
-    "type": "str",
-    "unknown_option": False,
-    "default": None,
-    "desc": None,
-}
-
 
 class OrderedLoader(yaml.SafeLoader):
     # This class was pulled out of ordered_load() for the sake of

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -38,17 +38,17 @@ class ConfigurationError(Exception):
 class ToolShedAppConfiguration(BaseAppConfiguration):
     default_config_file_name = 'tool_shed.yml'
 
-    def _load_schema():
+    def _load_schema(self):
         return AppSchema(TOOLSHED_CONFIG_SCHEMA_PATH, TOOLSHED_APP_NAME)
 
     def _update_raw_config_from_kwargs(self, kwargs):
-        pass  # Intentionally does nothing. Remove to enable.
+        pass  # Intentionally does nothing. To enable, remove + call base __init__().
 
     def _create_attributes_from_raw_config(self):
-        pass  # Intentionally does nothing. Remove to enable.
+        pass  # Intentionally does nothing. To enable, remove + call base __init__().
 
     def _resolve_paths(self, paths_to_resolve):
-        pass  # Intentionally does nothing. Remove to enable.
+        pass  # Intentionally does nothing. To enable, remove + call base __init__().
 
     def __init__(self, **kwargs):
         self.config_dict = kwargs

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 from six.moves import configparser
 
 from galaxy.config import BaseAppConfiguration
+from galaxy.config.schema import AppSchema
 from galaxy.util import string_as_bool
 from galaxy.version import VERSION, VERSION_MAJOR
 from galaxy.web.formatting import expand_pretty_datetime_format
@@ -18,6 +19,9 @@ log = logging.getLogger(__name__)
 
 ts_webapp_path = os.path.abspath(os.path.dirname(__file__))
 templates_path = os.path.join(ts_webapp_path, "templates")
+
+TOOLSHED_APP_NAME = 'tool_shed'
+TOOLSHED_CONFIG_SCHEMA_PATH = 'lib/tool_shed/webapp/config_schema.yml'
 
 
 def resolve_path(path, root):
@@ -33,6 +37,18 @@ class ConfigurationError(Exception):
 
 class ToolShedAppConfiguration(BaseAppConfiguration):
     default_config_file_name = 'tool_shed.yml'
+
+    def _load_schema():
+        return AppSchema(TOOLSHED_CONFIG_SCHEMA_PATH, TOOLSHED_APP_NAME)
+
+    def _update_raw_config_from_kwargs(self, kwargs):
+        pass  # Intentionally does nothing. Remove to enable.
+
+    def _create_attributes_from_raw_config(self):
+        pass  # Intentionally does nothing. Remove to enable.
+
+    def _resolve_paths(self, paths_to_resolve):
+        pass  # Intentionally does nothing. Remove to enable.
 
     def __init__(self, **kwargs):
         self.config_dict = kwargs

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -253,7 +253,7 @@ def get_config_data():
 
     create_driver()  # create + setup DRIVER
     parent_dirs = load_parent_dirs()  # called after DRIVER is setup
-    items = ((k, v) for k, v in DRIVER.app.config.appschema.items() if k not in DO_NOT_TEST)
+    items = ((k, v) for k, v in DRIVER.app.config.schema.app_schema.items() if k not in DO_NOT_TEST)
     for key, data in items:
         expected_value = get_expected(key, data, parent_dirs)
         loaded_value = getattr(DRIVER.app.config, key)

--- a/test/integration/test_config_schema.py
+++ b/test/integration/test_config_schema.py
@@ -1,0 +1,9 @@
+from galaxy_test.driver import integration_util
+
+
+class ConfigSchemaTestCase(integration_util.IntegrationTestCase):
+
+    def test_schema_path_resolution_graph(self):
+        # Run schema's validation method; throws error if schema invalid
+        schema = self._app.config.schema
+        schema.validate_path_resolution_graph()

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -2,60 +2,26 @@ import pytest
 
 from galaxy.config import GalaxyAppConfiguration
 from galaxy.config.schema import AppSchema
-from galaxy.util.yaml_util import (
-    ordered_load,
-    OrderedLoader,
-)
 
 
-MOCK_YAML = '''
-    type: map
-    desc: mocked schema
-    mapping:
-      mockgalaxy:
-        type: map
-        mapping:
-          property1:
-            default: a
-            type: str
-          property2:
-            default: 1
-            type: int
-            reloadable: true
-          property3:
-            default: 1.0
-            type: float
-            reloadable: true
-          property4:
-            default: true
-            type: bool
-          property5:
-            something_else: b
-            type: invalid
-          property6:
-            something_else: b
-    '''
+MOCK_SCHEMA = {
+    'property1': {'default': 'a', 'type': 'str'},  # str
+    'property2': {'default': 1, 'type': 'int'},  # int
+    'property3': {'default': 1.0, 'type': 'float'},  # float
+    'property4': {'default': True, 'type': 'bool'},  # bool
+    'property5': {'something_else': 'b', 'type': 'invalid'},
+    'property6': {'something_else': 'b'},  # no type
+}
+
+
+def get_schema(app_mapping):
+    return {'mapping': {'galaxy': {'mapping': app_mapping}}}
 
 
 @pytest.fixture
 def mock_init(monkeypatch):
-
-    def mock_read_schema(self, path):
-        return ordered_load(MOCK_YAML)
-
-    def mock_init(self, stream):
-        super(OrderedLoader, self).__init__(stream)
-
-    def mock_load_schema(self):
-        return AppSchema('no path', 'mockgalaxy')
-
-    def mock_process_config(self, kwargs):
-        pass
-
-    monkeypatch.setattr(AppSchema, '_read_schema', mock_read_schema)
-    monkeypatch.setattr(OrderedLoader, '__init__', mock_init)
-    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
-    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+    monkeypatch.setattr(AppSchema, '_read_schema', lambda a, b: get_schema(MOCK_SCHEMA))
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
 
 
 def test_load_config_from_schema(mock_init):

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -46,14 +46,14 @@ def test_deprecated_prefixes_set_correctly(monkeypatch):
     monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
 
     config = GalaxyAppConfiguration()
-    assert config._deprecated_dirs() == {'config_dir': 'config', 'data_dir': 'database'}
+    assert config.deprecated_dirs == {'config_dir': 'config', 'data_dir': 'database'}
 
 
 @pytest.fixture
 def mock_init(monkeypatch):
     monkeypatch.setattr(AppSchema, '_read_schema', lambda a, b: get_schema(MOCK_SCHEMA))
     monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
-    monkeypatch.setattr(GalaxyAppConfiguration, '_deprecated_dirs', lambda a: MOCK_DEPRECATED_DIRS)
+    monkeypatch.setattr(GalaxyAppConfiguration, 'deprecated_dirs', MOCK_DEPRECATED_DIRS)
 
 
 def test_mock_schema_is_loaded(mock_init):

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -46,14 +46,14 @@ def test_deprecated_prefixes_set_correctly(monkeypatch):
     monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
 
     config = GalaxyAppConfiguration()
-    assert config.deprecated_dirs == {'config_dir': 'config', 'data_dir': 'database'}
+    assert config._deprecated_dirs() == {'config_dir': 'config', 'data_dir': 'database'}
 
 
 @pytest.fixture
 def mock_init(monkeypatch):
     monkeypatch.setattr(AppSchema, '_read_schema', lambda a, b: get_schema(MOCK_SCHEMA))
     monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
-    monkeypatch.setattr(GalaxyAppConfiguration, 'deprecated_dirs', MOCK_DEPRECATED_DIRS)
+    monkeypatch.setattr(GalaxyAppConfiguration, '_deprecated_dirs', lambda a: MOCK_DEPRECATED_DIRS)
 
 
 def test_mock_schema_is_loaded(mock_init):

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -1,6 +1,7 @@
 import pytest
 
 from galaxy.config import GalaxyAppConfiguration
+from galaxy.config.schema import AppSchema
 
 
 MOCK_DEPRECATED_DIRS = {
@@ -35,34 +36,23 @@ MOCK_SCHEMA = {
 }
 
 
+def get_schema(app_mapping):
+    return {'mapping': {'galaxy': {'mapping': app_mapping}}}
+
+
 def test_deprecated_prefixes_set_correctly(monkeypatch):
     # Before we mock them, check that correct values are assigned
-    def mock_load_schema(self):
-        self.appschema = {}
-
-    def mock_process_config(self, kwargs):
-        pass
-
-    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
-    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+    monkeypatch.setattr(AppSchema, '_read_schema', lambda a, b: get_schema(MOCK_SCHEMA))
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
 
     config = GalaxyAppConfiguration()
-    expected_deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
-
-    assert config.deprecated_dirs == expected_deprecated_dirs
+    assert config.deprecated_dirs == {'config_dir': 'config', 'data_dir': 'database'}
 
 
 @pytest.fixture
 def mock_init(monkeypatch):
-
-    def mock_load_schema(self):
-        self.appschema = MOCK_SCHEMA
-
-    def mock_process_config(self, kwargs):
-        pass  # because we're done before this is called
-
-    monkeypatch.setattr(GalaxyAppConfiguration, '_load_schema', mock_load_schema)
-    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', mock_process_config)
+    monkeypatch.setattr(AppSchema, '_read_schema', lambda a, b: get_schema(MOCK_SCHEMA))
+    monkeypatch.setattr(GalaxyAppConfiguration, '_process_config', lambda a, b: None)
     monkeypatch.setattr(GalaxyAppConfiguration, 'deprecated_dirs', MOCK_DEPRECATED_DIRS)
 
 

--- a/test/unit/config/test_reload_config.py
+++ b/test/unit/config/test_reload_config.py
@@ -6,9 +6,13 @@ R1, R2, N1, N2 = 'reloadable1', 'reloadable2', 'nonrelodable1', 'nonreloadable2'
 
 
 class MockGalaxyAppConfiguration():
+
+    class MockSchema():
+        reloadable_options = {R1, R2}
+
     def __init__(self, properties):
         self.config_file = None
-        self.reloadable_options = {R1, R2}
+        self.schema = self.MockSchema
         self._raw_config = {}
         for key, value in properties.items():
             setattr(self, key, value)

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -564,7 +564,7 @@ class SimplifiedToolBox(ToolBox):
         app.tool_cache = ToolCache() if not hasattr(app, 'tool_cache') else app.tool_cache
         app.job_config.get_tool_resource_parameters = lambda tool_id: None
         app.config.update_integrated_tool_panel = True
-        app.config.appschema = {
+        app.config.schema.app_schema = {
             'tool_dependency_dir': {
                 'default': 'dependencies',
             }

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -564,11 +564,7 @@ class SimplifiedToolBox(ToolBox):
         app.tool_cache = ToolCache() if not hasattr(app, 'tool_cache') else app.tool_cache
         app.job_config.get_tool_resource_parameters = lambda tool_id: None
         app.config.update_integrated_tool_panel = True
-        app.config.schema.app_schema = {
-            'tool_dependency_dir': {
-                'default': 'dependencies',
-            }
-        }
+        app.config.schema.defaults = {'tool_dependency_dir': 'dependencies'}
         config_files = test_case.config_files
         tool_root_dir = test_case.test_directory
         super(SimplifiedToolBox, self).__init__(

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -111,6 +111,9 @@ class MockLock(object):
 
 class MockAppConfig(Bunch):
 
+    class MockSchema(Bunch):
+        pass
+
     def __init__(self, root=None, **kwargs):
         Bunch.__init__(self, **kwargs)
         if not root:
@@ -118,6 +121,7 @@ class MockAppConfig(Bunch):
             self._remove_root = True
         else:
             self._remove_root = False
+        self.schema = self.MockSchema()
         self.security = idencoding.IdEncodingHelper(id_secret='6e46ed6483a833c100e68cc3f1d0dd76')
         self.database_connection = kwargs.get('database_connection', "sqlite:///:memory:")
         self.use_remote_user = kwargs.get('use_remote_user', False)


### PR DESCRIPTION
This replaces #9307. 

Motivation: `config/__init__.py` is doing too much. Last year's modifications to the config system, while simplifying configuration loading, have done the opposite to the configuration module's code, and especially to the `GalaxyAppConfiguration` class. This is an attempt to address this problem by separating 2 different responsibilities of the `GalaxyAppConfiguration` class: (1) automatically loading and processing all config properties from the schema; and (2) setting individual config properties and handling special cases. My first attempt (#9307) was to delegate the former to a ConfigurationLoader module and use it for any further schema processing, while using GalaxyAppConfiguration for setting individual config properties (as it did before).

However, concerns were raised during the code review: (a) the schema loader object was manipulating the internal structure of the config object; and (b) such tight coupling of 2 objects suggested the separation may have been not necessary (https://github.com/galaxyproject/galaxy/pull/9307#pullrequestreview-356385467). 

This, I think, is a better approach. Instead of delegating everything to a new "builder" object, I've split up the stuff that IMO does not belong in `GalaxyAppConfiguration` into 2 parts: (a) schema-related; and (b) configuration-related. All schema-related functionality has been moved to the schema object: loading collections of schema data + validating that data are now the schema object's responsibilities. All the configuration-related stuff that deals with all attributes + their processing, and does *not* include setting individual, galaxy-specific properties, has been moved up to the base config class.

I've updated the tests; I've also simplified the mocking in the unit tests in `test/unit/config`. 

I expect this will simplify the config code and make modifications easier. Also, as a side benefit, we can now eliminate much redundant code from TS's config (e.g., #9379, if needed).

Ping @nsoranzo, @bgruening.  

(EDIT: more details in config messages.)




