### PR TITLE
fix special characters in citation field

### DIFF
--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -47,7 +47,7 @@ class DoiCache(object):
         doi_url = "https://doi.org/" + doi
         headers = {'Accept': 'text/bibliography; style=bibtex, application/x-bibtex'}
         req = requests.get(doi_url, headers=headers)
-        return req.text
+        return req.content.decode("utf-8")
 
     def get_bibtex(self, doi):
         createfunc = functools.partial(self._raw_get_bibtex, doi)

--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -47,7 +47,8 @@ class DoiCache(object):
         doi_url = "https://doi.org/" + doi
         headers = {'Accept': 'text/bibliography; style=bibtex, application/x-bibtex'}
         req = requests.get(doi_url, headers=headers)
-        return req.content.decode("utf-8")
+        req.encoding = req.apparent_encoding
+        return req.text
 
     def get_bibtex(self, doi):
         createfunc = functools.partial(self._raw_get_bibtex, doi)

--- a/lib/galaxy/managers/citations.py
+++ b/lib/galaxy/managers/citations.py
@@ -45,7 +45,7 @@ class DoiCache(object):
 
     def _raw_get_bibtex(self, doi):
         doi_url = "https://doi.org/" + doi
-        headers = {'Accept': 'text/bibliography; style=bibtex, application/x-bibtex'}
+        headers = {'Accept': 'application/x-bibtex'}
         req = requests.get(doi_url, headers=headers)
         req.encoding = req.apparent_encoding
         return req.text


### PR DESCRIPTION
Fix for https://github.com/galaxyproject/galaxy/issues/9369
A lot of python dark magic in here. To make it work, please delete cache in ```{galaxy}/database/citations/*```