### PR TITLE
migrated_tools_conf should be in mutable_config_dir

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -303,7 +303,7 @@
     tool shed upon a new release, they will be added to this tool
     config file.
     The value of this option will be resolved with respect to
-    <config_dir>.
+    <mutable_config_dir>.
 :Default: ``migrated_tools_conf.xml``
 :Type: str
 
@@ -318,6 +318,8 @@
     tool panel layout.  This file can be changed by the Galaxy
     administrator to alter the layout of the tool panel.  If not
     present, Galaxy will create it.
+    The value of this option will be resolved with respect to
+    <mutable_config_dir>.
 :Default: ``integrated_tool_panel.xml``
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -757,7 +757,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             job_resource_params_file=[self._in_config_dir('job_resource_params_conf.xml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
-            migrated_tools_config=[self._in_config_dir('migrated_tools_conf.xml')],
+            migrated_tools_config=[self._in_mutable_config_dir('migrated_tools_conf.xml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
             object_store_config_file=[self._in_config_dir('object_store_conf.xml')],
             oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.xml')],

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -249,7 +249,7 @@ galaxy:
   # tool shed upon a new release, they will be added to this tool config
   # file.
   # The value of this option will be resolved with respect to
-  # <config_dir>.
+  # <mutable_config_dir>.
   #migrated_tools_config: migrated_tools_conf.xml
 
   # File that contains the XML section and tool tags from all tool panel
@@ -257,6 +257,8 @@ galaxy:
   # panel layout.  This file can be changed by the Galaxy administrator
   # to alter the layout of the tool panel.  If not present, Galaxy will
   # create it.
+  # The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
   #integrated_tool_panel_config: integrated_tool_panel.xml
 
   # Default path to the directory containing the tools defined in

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -245,7 +245,7 @@ mapping:
           scripts to install tools that have been migrated to the tool shed upon a new
           release, they will be added to this tool config file.
 
-          The value of this option will be resolved with respect to <config_dir>.
+          The value of this option will be resolved with respect to <mutable_config_dir>.
 
       integrated_tool_panel_config:
         type: str
@@ -256,6 +256,8 @@ mapping:
           files integrated into a single file that defines the tool panel layout.  This
           file can be changed by the Galaxy administrator to alter the layout of the
           tool panel.  If not present, Galaxy will create it.
+
+          The value of this option will be resolved with respect to <mutable_config_dir>.
 
       tool_path:
         type: str


### PR DESCRIPTION
This used to be in `config_dir` by default, but should be in `mutable_confiig_dir`.

1. Keep it consistent with ansible-galaxy. (as per discussion with @natefoo)
2. Also, correct description of integrated_tool_panel_config (unrelated minor fix)

Context: 
* current ansible-galaxy: https://github.com/galaxyproject/ansible-galaxy/blob/master/defaults/main.yml#L192
* galaxy's `config/__init__.py` as it used to be prior to #8610: https://github.com/galaxyproject/galaxy/pull/8674/commits/be5aafd34b1f400704ef863684c9b742e1ca7427#diff-46f86ea0d82b84642e4218279ef61442L209
