### PR TITLE
Remove more duplication from TS, galaxy config

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -320,6 +320,15 @@ class CommonConfigurationMixin(object):
         """Determine if the provided user is listed in `admin_users`."""
         return user is not None and user.email in self.admin_users_list
 
+    @property
+    def sentry_dsn_public(self):
+        """
+        Sentry URL with private key removed for use in client side scripts,
+        sentry server will need to be configured to accept events
+        """
+        if self.sentry_dsn:
+            return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
+
 
 class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     deprecated_options = ('database_file', 'track_jobs_in_database')
@@ -727,17 +736,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
                 'UWSGI_PORT': port
             })
-
-    @property
-    def sentry_dsn_public(self):
-        """
-        Sentry URL with private key removed for use in client side scripts,
-        sentry server will need to be configured to accept events
-        """
-        if self.sentry_dsn:
-            return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
-        else:
-            return None
 
     def parse_config_file_options(self, kwargs):
         """Backwards compatibility for config files moved to the config/ dir."""

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -329,6 +329,17 @@ class CommonConfigurationMixin(object):
         if self.sentry_dsn:
             return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
 
+    def get_bool(self, key, default):  
+        # Warning: the value of self.config_dict['foo'] may be different from self.foo
+        if key in self.config_dict:
+            return string_as_bool(self.config_dict[key])
+        else:
+            return default
+
+    def get(self, key, default=None):
+        # Warning: the value of self.config_dict['foo'] may be different from self.foo
+        return self.config_dict.get(key, default)
+
 
 class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     deprecated_options = ('database_file', 'track_jobs_in_database')
@@ -795,15 +806,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         except IOError:
             if explicit:
                 log.warning("Sanitize log file explicitly specified as '%s' but does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
-
-    def get(self, key, default=None):
-        return self.config_dict.get(key, default)
-
-    def get_bool(self, key, default):
-        if key in self.config_dict:
-            return string_as_bool(self.config_dict[key])
-        else:
-            return default
 
     def ensure_tempdir(self):
         self._ensure_directory(self.new_file_path)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -329,7 +329,7 @@ class CommonConfigurationMixin(object):
         if self.sentry_dsn:
             return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
 
-    def get_bool(self, key, default):  
+    def get_bool(self, key, default):
         # Warning: the value of self.config_dict['foo'] may be different from self.foo
         if key in self.config_dict:
             return string_as_bool(self.config_dict[key])

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -250,7 +250,7 @@ class BaseAppConfiguration(object):
             resolve(key)
 
     def _in_root_dir(self, path):
-        return os.path.join(self.root, path)
+        return self._in_dir(self.root, path)
 
     def _in_managed_config_dir(self, path):
         return self._in_dir(self.managed_config_dir, path)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -528,13 +528,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
         self.object_store_cache_path = self.resolve_path(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
         if self.object_store_store_by is None:
-            if not self.file_path_set:
-                if self.file_path.endswith('objects'):
-                    self.object_store_store_by = 'uuid'
-                else:
-                    self.object_store_store_by = 'id'
-            else:
-                self.object_store_store_by = 'id'
+            self.object_store_store_by = 'id'
+            if not self.file_path_set and self.file_path.endswith('objects'):
+                self.object_store_store_by = 'uuid'
         assert self.object_store_store_by in ['id', 'uuid'], "Invalid value for object_store_store_by [%s]" % self.object_store_store_by
         # Handle AWS-specific config options for backward compatibility
         if kwargs.get('aws_access_key') is not None:

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -301,7 +301,27 @@ class BaseAppConfiguration(object):
             setattr(self, var, [os.path.join(self.root, x) for x in paths])
 
 
-class GalaxyAppConfiguration(BaseAppConfiguration):
+class CommonConfigurationMixin(object):
+    """Shared configuration settings code for Galaxy and ToolShed."""
+
+    @property
+    def admin_users(self):
+        return self._admin_users
+
+    @admin_users.setter
+    def admin_users(self, value):
+        self._admin_users = value
+        if value:
+            self.admin_users_list = [u.strip() for u in value.split(',') if u]
+        else:  # provide empty list for convenience (check membership, etc.)
+            self.admin_users_list = []
+
+    def is_admin_user(self, user):
+        """Determine if the provided user is listed in `admin_users`."""
+        return user is not None and user.email in self.admin_users_list
+
+
+class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     deprecated_options = ('database_file', 'track_jobs_in_database')
     default_config_file_name = 'galaxy.yml'
     deprecated_dirs = {'config_dir': 'config', 'data_dir': 'database'}
@@ -709,18 +729,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             })
 
     @property
-    def admin_users(self):
-        return self._admin_users
-
-    @admin_users.setter
-    def admin_users(self, value):
-        self._admin_users = value
-        if value:
-            self.admin_users_list = [u.strip() for u in value.split(',') if u]
-        else:  # provide empty list for convenience (check membership, etc.)
-            self.admin_users_list = []
-
-    @property
     def sentry_dsn_public(self):
         """
         Sentry URL with private key removed for use in client side scripts,
@@ -835,15 +843,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         for key in self.config_dict.keys():
             if key in self.deprecated_options:
                 log.warning("Config option '%s' is deprecated and will be removed in a future release.  Please consult the latest version of the sample configuration file." % key)
-
-    def is_admin_user(self, user):
-        """
-        Determine if the provided user is listed in `admin_users`.
-
-        NOTE: This is temporary, admin users will likely be specified in the
-              database in the future.
-        """
-        return user is not None and user.email in self.admin_users_list
 
     @staticmethod
     def _parse_allowed_origin_hostnames(kwargs):

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -327,7 +327,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # Database related configuration
         self.check_migrate_databases = kwargs.get('check_migrate_databases', True)
         if not self.database_connection:  # Provide default if not supplied by user
-            db_path = os.path.join(self.data_dir, 'universe.sqlite')
+            db_path = self._in_data_dir('universe.sqlite')
             self.database_connection = 'sqlite:///%s?isolation_level=IMMEDIATE' % db_path
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get('database_create_tables', 'True'))
@@ -343,8 +343,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             tempfile.tempdir = self.new_file_path
         self.shared_home_dir = kwargs.get("shared_home_dir")
         self.cookie_path = kwargs.get("cookie_path")
-        self.tool_path = os.path.join(self.root, self.tool_path)
-        self.tool_data_path = os.path.join(self.root, self.tool_data_path)
+        self.tool_path = self._in_root_dir(self.tool_path)
+        self.tool_data_path = self._in_root_dir(self.tool_data_path)
         if not running_from_source and kwargs.get("tool_data_path") is None:
             self.tool_data_path = self._in_data_dir(self.schema.defaults['tool_data_path'])
         self.builds_file_path = os.path.join(self.tool_data_path, self.builds_file_path)
@@ -356,7 +356,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.integrated_tool_panel_config = self._in_managed_config_dir(self.integrated_tool_panel_config)
         integrated_tool_panel_tracking_directory = kwargs.get('integrated_tool_panel_tracking_directory')
         if integrated_tool_panel_tracking_directory:
-            self.integrated_tool_panel_tracking_directory = os.path.join(self.root, integrated_tool_panel_tracking_directory)
+            self.integrated_tool_panel_tracking_directory = self._in_root_dir(integrated_tool_panel_tracking_directory)
         else:
             self.integrated_tool_panel_tracking_directory = None
         self.toolbox_filter_base_modules = listify(self.toolbox_filter_base_modules)
@@ -372,7 +372,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.password_expiration_period = timedelta(days=int(self.password_expiration_period))
 
         if self.shed_tool_data_path:
-            self.shed_tool_data_path = os.path.join(self.root, self.shed_tool_data_path)
+            self.shed_tool_data_path = self._in_root_dir(self.shed_tool_data_path)
         else:
             self.shed_tool_data_path = self.tool_data_path
 
@@ -407,21 +407,21 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             for ip in kwargs.get("fetch_url_whitelist", "").split(',')
             if len(ip.strip()) > 0
         ]
-        self.template_path = os.path.join(self.root, kwargs.get("template_path", "templates"))
+        self.template_path = self._in_root_dir(kwargs.get("template_path", "templates"))
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
         self.cluster_files_directory = self._in_root_dir(self.cluster_files_directory)
 
         # Fall back to legacy job_working_directory config variable if set.
-        self.jobs_directory = os.path.join(self.data_dir, kwargs.get("jobs_directory", self.job_working_directory))
+        self.jobs_directory = self._in_data_dir(kwargs.get("jobs_directory", self.job_working_directory))
         if self.preserve_python_environment not in ["legacy_only", "legacy_and_local", "always"]:
             log.warning("preserve_python_environment set to unknown value [%s], defaulting to legacy_only")
             self.preserve_python_environment = "legacy_only"
         self.nodejs_path = kwargs.get("nodejs_path")
         # Older default container cache path, I don't think anyone is using it anymore and it wasn't documented - we
         # should probably drop the backward compatiblity to save the path check.
-        self.container_image_cache_path = os.path.join(self.data_dir, kwargs.get("container_image_cache_path", "container_images"))
+        self.container_image_cache_path = self._in_data_dir(kwargs.get("container_image_cache_path", "container_images"))
         if not os.path.exists(self.container_image_cache_path):
-            self.container_image_cache_path = self._in_root_dir(kwargs.get("container_image_cache_path", os.path.join(self.data_dir, "container_cache")))
+            self.container_image_cache_path = self._in_root_dir(kwargs.get("container_image_cache_path", self._in_data_dir("container_cache")))
         self.output_size_limit = int(kwargs.get('output_size_limit', 0))
         # activation_email was used until release_15.03
         activation_email = kwargs.get('activation_email')
@@ -430,7 +430,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         #  Get the disposable email domains blacklist file and its contents
         self.blacklist_content = None
         if self.blacklist_file:
-            self.blacklist_file = os.path.join(self.root, self.blacklist_file)
+            self.blacklist_file = self._in_root_dir(self.blacklist_file)
             try:
                 with open(self.blacklist_file) as f:
                     self.blacklist_content = [line.rstrip() for line in f]
@@ -469,7 +469,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
 
         _sanitize_whitelist_path = self._in_managed_config_dir(self.sanitize_whitelist_file)
         if not os.path.isfile(_sanitize_whitelist_path):  # then check old default location
-            deprecated = os.path.join(self.root, 'config/sanitize_whitelist.txt')
+            deprecated = self._in_root_dir('config/sanitize_whitelist.txt')
             if os.path.isfile(deprecated):
                 log.warning("The path '%s' for the 'sanitize_whitelist_file' config option is "
                     "deprecated and will be no longer checked in a future release. Please consult "
@@ -497,29 +497,26 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # not needed on production systems but useful if running many functional tests.
         self.index_tool_help = string_as_bool(kwargs.get("index_tool_help", True))
         self.tool_labels_boost = kwargs.get("tool_labels_boost", 1)
-        default_tool_test_data_directories = os.environ.get("GALAXY_TEST_FILE_DIR", os.path.join(self.root, "test-data"))
+        default_tool_test_data_directories = os.environ.get("GALAXY_TEST_FILE_DIR", self._in_root_dir("test-data"))
         self.tool_test_data_directories = kwargs.get("tool_test_data_directories", default_tool_test_data_directories)
         # Deployers may either specify a complete list of mapping files or get the default for free and just
         # specify a local mapping file to adapt and extend the default one.
         if "conda_mapping_files" not in kwargs:
-            conda_mapping_files = [
-                self.local_conda_mapping_file,
-                os.path.join(self.root, "lib", "galaxy", "tool_util", "deps", "resolvers", "default_conda_mapping.yml"),
-            ]
+            _default_mapping = self._in_root_dir(os.path.join("lib", "galaxy", "tool_util", "deps", "resolvers", "default_conda_mapping.yml"))
             # dependency resolution options are consumed via config_dict - so don't populate
             # self, populate config_dict
-            self.config_dict["conda_mapping_files"] = conda_mapping_files
+            self.config_dict["conda_mapping_files"] = [self.local_conda_mapping_file, _default_mapping]
 
         if self.containers_resolvers_config_file:
-            self.containers_resolvers_config_file = os.path.join(self.config_dir, self.containers_resolvers_config_file)
+            self.containers_resolvers_config_file = self._in_config_dir(self.containers_resolvers_config_file)
 
         # tool_dependency_dir can be "none" (in old configs). If so, set it to None
         if self.tool_dependency_dir and self.tool_dependency_dir.lower() == 'none':
             self.tool_dependency_dir = None
         if self.involucro_path is None:
             target_dir = self.tool_dependency_dir or self.schema.defaults['tool_dependency_dir']
-            self.involucro_path = os.path.join(self.data_dir, target_dir, "involucro")
-        self.involucro_path = os.path.join(self.root, self.involucro_path)
+            self.involucro_path = self._in_data_dir(os.path.join(target_dir, "involucro"))
+        self.involucro_path = self._in_root_dir(self.involucro_path)
         if self.mulled_channels:
             self.mulled_channels = [c.strip() for c in self.mulled_channels.split(',')]
 
@@ -533,7 +530,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self.nginx_upload_store = os.path.abspath(self.nginx_upload_store)
         self.object_store = kwargs.get('object_store', 'disk')
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
-        self.object_store_cache_path = self._in_root_dir(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
+        self.object_store_cache_path = self._in_root_dir(kwargs.get("object_store_cache_path", self._in_data_dir("object_store_cache")))
         if self.object_store_store_by is None:
             self.object_store_store_by = 'id'
             if not self.file_path_set and self.file_path.endswith('objects'):
@@ -557,7 +554,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.object_store_cache_size = float(kwargs.get('object_store_cache_size', -1))
         self.distributed_object_store_config_file = kwargs.get('distributed_object_store_config_file')
         if self.distributed_object_store_config_file is not None:
-            self.distributed_object_store_config_file = os.path.join(self.root, self.distributed_object_store_config_file)
+            self.distributed_object_store_config_file = self._in_root_dir(self.distributed_object_store_config_file)
         self.irods_root_collection_path = kwargs.get('irods_root_collection_path')
         self.irods_default_resource = kwargs.get('irods_default_resource')
         # Heartbeat log file name override
@@ -603,7 +600,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         elif 'database_connection' in kwargs:
             self.amqp_internal_connection = "sqlalchemy+" + self.database_connection
         else:
-            self.amqp_internal_connection = "sqlalchemy+sqlite:///%s?isolation_level=IMMEDIATE" % os.path.join(self.data_dir, "control.sqlite")
+            self.amqp_internal_connection = "sqlalchemy+sqlite:///%s?isolation_level=IMMEDIATE" % self._in_data_dir("control.sqlite")
         self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
         try:
             with open(self.user_preferences_extra_conf_path, 'r') as stream:
@@ -632,7 +629,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.manage_dynamic_proxy = self.dynamic_proxy_manage  # Set to false if being launched externally
 
         # InteractiveTools propagator mapping file
-        self.interactivetools_map = self._in_root_dir(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
+        self.interactivetools_map = self._in_root_dir(kwargs.get("interactivetools_map", self._in_data_dir("interactivetools_map.sqlite")))
         self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
         self.interactivetool_proxy_host = kwargs.get("interactivetool_proxy_host", None)
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -325,7 +325,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get('database_create_tables', 'True'))
         self.database_encoding = kwargs.get('database_encoding')  # Create new databases with this encoding
-        self.database_log_query_counts = string_as_bool(kwargs.get("database_log_query_counts", 'False'))
         self.thread_local_log = None
         if self.enable_per_request_sql_debugging:
             self.thread_local_log = threading.local()
@@ -340,7 +339,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.tool_path = os.path.join(self.root, self.tool_path)
         self.tool_data_path = os.path.join(self.root, self.tool_data_path)
         if not running_from_source and kwargs.get("tool_data_path") is None:
-            self.tool_data_path = os.path.join(self.data_dir, "tool-data")
+            self.tool_data_path = self._in_data_dir(self.schema.defaults['tool_data_path'])
         self.builds_file_path = os.path.join(self.tool_data_path, self.builds_file_path)
         self.len_file_path = os.path.join(self.tool_data_path, self.len_file_path)
         # Galaxy OIDC settings.
@@ -528,17 +527,15 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.object_store = kwargs.get('object_store', 'disk')
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
         self.object_store_cache_path = self.resolve_path(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
-        object_store_store_by = kwargs.get('object_store_store_by', None)
-        if object_store_store_by is None:
+        if self.object_store_store_by is None:
             if not self.file_path_set:
                 if self.file_path.endswith('objects'):
-                    object_store_store_by = 'uuid'
+                    self.object_store_store_by = 'uuid'
                 else:
-                    object_store_store_by = 'id'
+                    self.object_store_store_by = 'id'
             else:
-                object_store_store_by = 'id'
-        assert object_store_store_by in ['id', 'uuid'], "Invalid value for object_store_store_by [%s]" % object_store_store_by
-        self.object_store_store_by = object_store_store_by
+                self.object_store_store_by = 'id'
+        assert self.object_store_store_by in ['id', 'uuid'], "Invalid value for object_store_store_by [%s]" % self.object_store_store_by
         # Handle AWS-specific config options for backward compatibility
         if kwargs.get('aws_access_key') is not None:
             self.os_access_key = kwargs.get('aws_access_key')
@@ -620,7 +617,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # This is for testing new library browsing capabilities.
         self.new_lib_browse = string_as_bool(kwargs.get('new_lib_browse', False))
         # Logging configuration with logging.config.configDict:
-        self.logging = kwargs.get('logging')
         # Statistics and profiling with statsd
         self.statsd_host = kwargs.get('statsd_host', '')
 

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -95,7 +95,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.cloud_controller_instance = False
         self.server_name = ''
         # Where the tool shed hgweb.config file is stored - the default is the Galaxy installation directory.
-        self.hgweb_config_dir = self._in_root_dir(self.hgweb_config_dir)
+        self.hgweb_config_dir = self._in_root_dir(self.hgweb_config_dir) or self.root
         # Proxy features
         self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
         self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script', None)

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -51,10 +51,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         pass  # Intentionally does nothing. To enable, remove + call base __init__().
 
     def __init__(self, **kwargs):
-        self.config_dict = kwargs
-        self.root = kwargs.get('root_dir', '.')
-
-        self._set_config_base(kwargs)
+        super(ToolShedAppConfiguration, self).__init__(**kwargs)
 
         # Resolve paths of other config files
         self.parse_config_file_options(kwargs)
@@ -66,34 +63,16 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.version_major = VERSION_MAJOR
         self.version = VERSION
         # Database related configuration
-        self.database_connection = kwargs.get("database_connection", False)
         self.database_connection = kwargs.get("database_connection",
                                               "sqlite:///%s?isolation_level=IMMEDIATE" % resolve_path("community.sqlite", self.data_dir))
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
-        # Repository and Tool search API
-        self.toolshed_search_on = string_as_bool(kwargs.get("toolshed_search_on", True))
-        self.whoosh_index_dir = kwargs.get("whoosh_index_dir", 'database/toolshed_whoosh_indexes')
-        self.repo_name_boost = kwargs.get("repo_name_boost", 0.9)
-        self.repo_description_boost = kwargs.get("repo_description_boost", 0.6)
-        self.repo_long_description_boost = kwargs.get("repo_long_description_boost", 0.5)
-        self.repo_homepage_url_boost = kwargs.get("repo_homepage_url_boost", 0.3)
-        self.repo_remote_repository_url_boost = kwargs.get("repo_remote_repository_url_boost", 0.2)
-        self.repo_owner_username_boost = kwargs.get("repo_owner_username_boost", 0.3)
-        self.tool_name_boost = kwargs.get("tool_name_boost", 1.2)
-        self.tool_description_boost = kwargs.get("tool_description_boost", 0.6)
-        self.tool_help_boost = kwargs.get("tool_help_boost", 0.4)
-        self.tool_repo_owner_username = kwargs.get("tool_repo_owner_username", 0.3)
-        # Analytics
-        self.ga_code = kwargs.get("ga_code", None)
-        self.session_duration = int(kwargs.get('session_duration', 0))
         # Where dataset files are stored
-        self.file_path = resolve_path(kwargs.get("file_path", "database/community_files"), self.root)
-        self.new_file_path = resolve_path(kwargs.get("new_file_path", "database/tmp"), self.root)
+        self.file_path = resolve_path(self.file_path, self.root)
+        self.new_file_path = resolve_path(self.new_file_path, self.root)
         self.cookie_path = kwargs.get("cookie_path", None)
         self.cookie_domain = kwargs.get("cookie_domain", None)
         self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
-        self.id_secret = kwargs.get("id_secret", "changethisinproductiontoo")
         # Tool stuff
         self.tool_path = resolve_path(kwargs.get("tool_path", "tools"), self.root)
         self.tool_secret = kwargs.get("tool_secret", "")
@@ -105,11 +84,8 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.ftp_upload_dir = kwargs.get('ftp_upload_dir', None)
         self.update_integrated_tool_panel = False
         # Galaxy flavor Docker Image
-        self.enable_galaxy_flavor_docker_image = string_as_bool(kwargs.get("enable_galaxy_flavor_docker_image", "False"))
-        self.use_remote_user = string_as_bool(kwargs.get("use_remote_user", "False"))
         self.user_activation_on = None
         self.registration_warning_message = kwargs.get('registration_warning_message', None)
-        self.terms_url = kwargs.get('terms_url', None)
         self.blacklist_location = kwargs.get('blacklist_file', None)
         self.blacklist_content = None
         self.whitelist_location = kwargs.get('whitelist_file', None)
@@ -118,41 +94,26 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.remote_user_header = kwargs.get("remote_user_header", 'HTTP_REMOTE_USER')
         self.remote_user_logout_href = kwargs.get("remote_user_logout_href", None)
         self.remote_user_secret = kwargs.get("remote_user_secret", None)
-        self.require_login = string_as_bool(kwargs.get("require_login", "False"))
-        self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
-        self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
         self.template_path = templates_path
         self.template_cache_path = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates/community"), self.root)
-        self.admin_users = kwargs.get("admin_users", "")
         self.admin_users_list = [u.strip() for u in self.admin_users.split(',') if u]
-        self.mailing_join_addr = kwargs.get('mailing_join_addr', "galaxy-announce-join@bx.psu.edu")
         self.error_email_to = kwargs.get('error_email_to', None)
         self.smtp_server = kwargs.get('smtp_server', None)
-        self.smtp_username = kwargs.get('smtp_username', None)
-        self.smtp_password = kwargs.get('smtp_password', None)
         self.smtp_ssl = kwargs.get('smtp_ssl', None)
         self.email_from = kwargs.get('email_from', None)
         self.nginx_upload_path = kwargs.get('nginx_upload_path', False)
         self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
-        self.brand = kwargs.get('brand', None)
-        self.pretty_datetime_format = expand_pretty_datetime_format(kwargs.get('pretty_datetime_format', '$locale (UTC)'))
+        self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
         # Configuration for the message box directly below the masthead.
-        self.message_box_visible = string_as_bool(kwargs.get('message_box_visible', False))
-        self.message_box_content = kwargs.get('message_box_content', None)
-        self.message_box_class = kwargs.get('message_box_class', 'info')
-        self.support_url = kwargs.get('support_url', 'https://galaxyproject.org/support')
         self.wiki_url = kwargs.get('wiki_url', 'https://galaxyproject.org/')
         self.blog_url = kwargs.get('blog_url', None)
         self.screencasts_url = kwargs.get('screencasts_url', None)
         self.log_events = False
         self.cloud_controller_instance = False
         self.server_name = ''
-        # Error logging with sentry
-        self.sentry_dsn = kwargs.get('sentry_dsn', None)
         # Where the tool shed hgweb.config file is stored - the default is the Galaxy installation directory.
-        self.hgweb_config_dir = resolve_path(kwargs.get('hgweb_config_dir', ''), self.root)
+        self.hgweb_config_dir = resolve_path(self.hgweb_config_dir, self.root)
         # Proxy features
-        self.apache_xsendfile = kwargs.get('apache_xsendfile', False)
         self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
         self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script', None)
         # Parse global_conf and save the parser

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -8,7 +8,11 @@ from datetime import timedelta
 
 from six.moves import configparser
 
-from galaxy.config import BaseAppConfiguration, CommonConfigurationMixin
+from galaxy.config import (
+    BaseAppConfiguration,
+    CommonConfigurationMixin,
+    get_database_engine_options,
+)
 from galaxy.config.schema import AppSchema
 from galaxy.util import string_as_bool
 from galaxy.version import VERSION, VERSION_MAJOR
@@ -161,31 +165,3 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
 
 
 Configuration = ToolShedAppConfiguration
-
-
-def get_database_engine_options(kwargs):
-    """
-    Allow options for the SQLAlchemy database engine to be passed by using
-    the prefix "database_engine_option".
-    """
-    conversions = {
-        'convert_unicode': string_as_bool,
-        'pool_timeout': int,
-        'echo': string_as_bool,
-        'echo_pool': string_as_bool,
-        'pool_recycle': int,
-        'pool_size': int,
-        'max_overflow': int,
-        'pool_threadlocal': string_as_bool,
-        'server_side_cursors': string_as_bool
-    }
-    prefix = "database_engine_option_"
-    prefix_len = len(prefix)
-    rval = {}
-    for key, value in kwargs.items():
-        if key.startswith(prefix):
-            key = key[prefix_len:]
-            if key in conversions:
-                value = conversions[key](value)
-            rval[key] = value
-    return rval

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -4,7 +4,6 @@ Universe configuration builder.
 import logging
 import logging.config
 import os
-import re
 from datetime import timedelta
 
 from six.moves import configparser
@@ -125,19 +124,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     @property
     def shed_tool_data_path(self):
         return self.tool_data_path
-
-    @property
-    def sentry_dsn_public(self):
-        """
-        Sentry URL with private key removed for use in client side scripts,
-        sentry server will need to be configured to accept events
-        """
-        # TODO refactor this to a common place between toolshed/galaxy config, along
-        # with other duplicated methods.
-        if self.sentry_dsn:
-            return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
-        else:
-            return None
 
     def parse_config_file_options(self, kwargs):
         defaults = dict(

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -139,7 +139,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
 
     def check(self):
         # Check that required directories exist.
-        paths_to_check = [self.root, self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]
+        paths_to_check = [self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]
         for path in paths_to_check:
             if path not in [None, False] and not os.path.isdir(path):
                 try:

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -41,15 +41,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
     def _load_schema(self):
         return AppSchema(TOOLSHED_CONFIG_SCHEMA_PATH, TOOLSHED_APP_NAME)
 
-    def _update_raw_config_from_kwargs(self, kwargs):
-        pass  # Intentionally does nothing. To enable, remove + call base __init__().
-
-    def _create_attributes_from_raw_config(self):
-        pass  # Intentionally does nothing. To enable, remove + call base __init__().
-
-    def _resolve_paths(self, paths_to_resolve):
-        pass  # Intentionally does nothing. To enable, remove + call base __init__().
-
     def __init__(self, **kwargs):
         super(ToolShedAppConfiguration, self).__init__(**kwargs)
 

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 
 from six.moves import configparser
 
-from galaxy.config import BaseAppConfiguration
+from galaxy.config import BaseAppConfiguration, CommonConfigurationMixin
 from galaxy.config.schema import AppSchema
 from galaxy.util import string_as_bool
 from galaxy.version import VERSION, VERSION_MAJOR
@@ -28,7 +28,7 @@ class ConfigurationError(Exception):
     pass
 
 
-class ToolShedAppConfiguration(BaseAppConfiguration):
+class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     default_config_file_name = 'tool_shed.yml'
 
     def _load_schema(self):
@@ -80,7 +80,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.remote_user_secret = kwargs.get("remote_user_secret", None)
         self.template_path = templates_path
         self.template_cache_path = self._in_root_dir(kwargs.get("template_cache_path", "database/compiled_templates/community"))
-        self.admin_users_list = [u.strip() for u in self.admin_users.split(',') if u]
         self.error_email_to = kwargs.get('error_email_to', None)
         self.smtp_server = kwargs.get('smtp_server', None)
         self.smtp_ssl = kwargs.get('smtp_ssl', None)
@@ -182,13 +181,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         # Check that required files exist.
         if not os.path.isfile(self.datatypes_config):
             raise ConfigurationError("File not found: %s" % self.datatypes_config)
-
-    def is_admin_user(self, user):
-        """
-        Determine if the provided user is listed in `admin_users`.
-        """
-        admin_users = self.get("admin_users", "").split(",")
-        return user is not None and user.email in admin_users
 
 
 Configuration = ToolShedAppConfiguration

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -137,15 +137,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         # Backwards compatibility for names used in too many places to fix
         self.datatypes_config = self.datatypes_config_file
 
-    def get(self, key, default=None):
-        return self.config_dict.get(key, default)
-
-    def get_bool(self, key, default):
-        if key in self.config_dict:
-            return string_as_bool(self.config_dict[key])
-        else:
-            return default
-
     def check(self):
         # Check that required directories exist.
         paths_to_check = [self.root, self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]


### PR DESCRIPTION
The TS part of this is based on #9371 where part of config processing was moved from GalaxyAppConfiguration into BaseAppConfiguration. Since that base class is the parent of ToolShedAppConfiguration, much of TS config code becomes redundant. In particular, TS config now uses the same schema defaults/kwargs loading process as galaxy's config.
The galaxy config changes are minor cleanup.

Related to issue #8493.

EDIT: the following description is from a follow-up PR, but now that a few commits have been moved around, it really belongs in this PR:
Main theme: factor out common configuration settings into a mixin class. Much of TS's config code is duplication of code in Galaxy's main config object (there's even a TODO in the code: https://github.com/galaxyproject/galaxy/blob/dev/lib/tool_shed/webapp/config.py#L191 )

Argument for not moving common code into BaseAppConfiguration:

* `BaseAppConfiguration` contains code that is used by the configuration code of both apps, Galaxy and TS - i.e., base config paths, schema loading, etc.
* `CommonConfigurationMixin` will contain code that happens to be present in both
Galaxy and TS, but deals with individual configuration properties.

I didn't move all common code into the mixin: there are many settings that are the same for both Galaxy and TS; however, factoring out individual lines, that are identical, would make the configuration of both apps much less readable. I think it's more important to have the individual config steps in one place (i.e., one method) for each app, even if some properties happen to have the same values.

The rest is mostly minor cleanup.



