### PR TITLE
[19.09] Move migrated_tools_conf > mutable_config_dir (#9376)

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -280,7 +280,8 @@
     Tool config maintained by tool migration scripts.  If you use the
     migration scripts to install tools that have been migrated to the
     tool shed upon a new release, they will be added to this tool
-    config file.
+    config file.  The value of this option will be resolved with
+    respect to <mutable_config_dir>.
 :Default: ``config/migrated_tools_conf.xml``
 :Type: str
 
@@ -294,7 +295,8 @@
     panel config files integrated into a single file that defines the
     tool panel layout.  This file can be changed by the Galaxy
     administrator to alter the layout of the tool panel.  If not
-    present, Galaxy will create it.
+    present, Galaxy will create it.  The value of this option will be
+    resolved with respect to <mutable_config_dir>.
 :Default: ``integrated_tool_panel.xml``
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -838,7 +838,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             job_resource_params_file=[self._in_config_dir('job_resource_params_conf.xml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
-            migrated_tools_config=[self._in_config_dir('migrated_tools_conf.xml')],
+            migrated_tools_config=[self._in_mutable_config_dir('migrated_tools_conf.xml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
             object_store_config_file=[self._in_config_dir('object_store_conf.xml')],
             oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.xml')],

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -224,14 +224,16 @@ galaxy:
   # Tool config maintained by tool migration scripts.  If you use the
   # migration scripts to install tools that have been migrated to the
   # tool shed upon a new release, they will be added to this tool config
-  # file.
+  # file.  The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
   #migrated_tools_config: config/migrated_tools_conf.xml
 
   # File that contains the XML section and tool tags from all tool panel
   # config files integrated into a single file that defines the tool
   # panel layout.  This file can be changed by the Galaxy administrator
   # to alter the layout of the tool panel.  If not present, Galaxy will
-  # create it.
+  # create it.  The value of this option will be resolved with respect
+  # to <mutable_config_dir>.
   #integrated_tool_panel_config: integrated_tool_panel.xml
 
   # Default path to the directory containing the tools defined in

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -231,6 +231,8 @@ mapping:
           scripts to install tools that have been migrated to the tool shed upon a new
           release, they will be added to this tool config file.
 
+          The value of this option will be resolved with respect to <mutable_config_dir>.
+
       integrated_tool_panel_config:
         type: str
         default: integrated_tool_panel.xml
@@ -240,6 +242,8 @@ mapping:
           files integrated into a single file that defines the tool panel layout.  This
           file can be changed by the Galaxy administrator to alter the layout of the
           tool panel.  If not present, Galaxy will create it.
+
+          The value of this option will be resolved with respect to <mutable_config_dir>.
 
       tool_path:
         type: str


### PR DESCRIPTION
Backport #9376

1. Keep it consistent with ansible-galaxy.

2. Correct description of integrated_tool_panel_config.