### PR TITLE
[20.01] Make set metadata exec after process more robust

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2460,7 +2460,7 @@ class SetMetadataTool(Tool):
                     external_metadata.load_metadata(dataset, name, sa_session, working_directory=working_directory)
                 except Exception:
                     metadata_set_successfully = False
-                    log.exception()
+                    log.exception("Exception occured while loading metadata results")
             if not metadata_set_successfully:
                 dataset._state = model.Dataset.states.FAILED_METADATA
                 self.sa_session.add(dataset)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2476,7 +2476,12 @@ class SetMetadataTool(Tool):
                 # Revert dataset.state to fall back to dataset.dataset.state
                 dataset._state = None
             # Need to reset the peek, which may rely on metadata
-            dataset.set_peek()
+            # TODO: move this into metadata setting, setting the peek requires dataset access,
+            # and large chunks of the dataset may be read here.
+            try:
+                dataset.set_peek()
+            except Exception:
+                log.exception()
             self.sa_session.add(dataset)
             self.sa_session.flush()
 


### PR DESCRIPTION
Should prevent accumulating thousands of events as in
https://sentry.galaxyproject.org/sentry/main/issues/501144/events/2975276/:
```
Unhandled exception calling fail_job:
FileNotFoundError: [Errno 2] No such file or directory: '/galaxy-repl/main/jobdir/026/946/26946617/metadata/metadata_temp_file_78vf9hm6'
  File "galaxy/jobs/runners/__init__.py", line 137, in run_next
    method(arg)
  File "galaxy/jobs/runners/__init__.py", line 475, in fail_job
    job_state.job_wrapper.fail(getattr(job_state, 'fail_message', 'Job failed'), exception=exception)
  File "galaxy/jobs/__init__.py", line 1293, in fail
    self.tool.job_failed(self, message, exception)
  File "galaxy/tools/__init__.py", line 2482, in job_failed
    return self.exec_after_process(job_wrapper.app, inp_data, {}, job_wrapper.get_param_dict(), job=job)
  File "galaxy/tools/__init__.py", line 2456, in exec_after_process
    external_metadata.load_metadata(dataset, name, sa_session, working_directory=working_directory)
  File "galaxy/metadata/__init__.py", line 212, in load_metadata
    self._load_metadata_from_path(dataset, metadata_output_path, working_directory, remote_metadata_directory)
  File "galaxy/metadata/__init__.py", line 89, in _load_metadata_from_path
    dataset.metadata.from_JSON_dict(metadata_output_path, path_rewriter=path_rewriter)
  File "galaxy/model/metadata.py", line 186, in from_JSON_dict
    value = param.from_external_value(external_value, dataset, **from_ext_kwds)
  File "galaxy/model/metadata.py", line 566, in from_external_value
    alt_name=os.path.basename(mf.file_name))
  File "galaxy/objectstore/__init__.py", line 566, in update_from_file
    return self._call_method('update_from_file', obj, ObjectNotFound, True, **kwargs)
  File "galaxy/objectstore/__init__.py", line 766, in _call_method
    return self.backends[object_store_id].__getattribute__(method)(obj, **kwargs)
  File "galaxy/objectstore/__init__.py", line 494, in update_from_file
    raise ex
  File "galaxy/objectstore/__init__.py", line 490, in update_from_file
    shutil.copy(file_name, path)
  File "python3.6/shutil.py", line 241, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
```