### PR TITLE
[20.01] Fix hid comparison failing with hdas without hid

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1881,34 +1881,27 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
         return galaxy.util.nice_size(self.disk_size)
 
     @property
+    def active_dataset_and_roles_query(self):
+        db_session = object_session(self)
+        return (db_session.query(HistoryDatasetAssociation)
+            .filter(HistoryDatasetAssociation.table.c.history_id == self.id)
+            .filter(not_(HistoryDatasetAssociation.deleted))
+            .order_by(HistoryDatasetAssociation.table.c.hid.asc())
+            .options(joinedload("dataset"),
+                     joinedload("dataset.actions"),
+                     joinedload("dataset.actions.role"),
+                     joinedload("tags")))
+
+    @property
     def active_datasets_and_roles(self):
         if not hasattr(self, '_active_datasets_and_roles'):
-            db_session = object_session(self)
-            query = (db_session.query(HistoryDatasetAssociation)
-                .filter(HistoryDatasetAssociation.table.c.history_id == self.id)
-                .filter(not_(HistoryDatasetAssociation.deleted))
-                .order_by(HistoryDatasetAssociation.table.c.hid.asc())
-                .options(joinedload("dataset"),
-                         joinedload("dataset.actions"),
-                         joinedload("dataset.actions.role"),
-                         joinedload("tags")))
-            self._active_datasets_and_roles = query.all()
+            self._active_datasets_and_roles = self.active_dataset_and_roles_query.all()
         return self._active_datasets_and_roles
 
     @property
     def active_visible_datasets_and_roles(self):
         if not hasattr(self, '_active_visible_datasets_and_roles'):
-            db_session = object_session(self)
-            query = (db_session.query(HistoryDatasetAssociation)
-                .filter(HistoryDatasetAssociation.table.c.history_id == self.id)
-                .filter(not_(HistoryDatasetAssociation.deleted))
-                .filter(HistoryDatasetAssociation.visible)
-                .order_by(HistoryDatasetAssociation.table.c.hid.asc())
-                .options(joinedload("dataset"),
-                         joinedload("dataset.actions"),
-                         joinedload("dataset.actions.role"),
-                         joinedload("tags")))
-            self._active_visible_datasets_and_roles = query.all()
+            self._active_visible_datasets_and_roles = self.active_dataset_and_roles_query.filter(HistoryDatasetAssociation.visible).all()
         return self._active_visible_datasets_and_roles
 
     @property

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1947,7 +1947,7 @@ class DataToolParameter(BaseDataToolParameter):
         def append(list, hda, name, src, keep=False, subcollection_type=None):
             value = {
                 'id'   : trans.security.encode_id(hda.id),
-                'hid'  : hda.hid,
+                'hid'  : hda.hid if hda.hid is not None else -1,
                 'name' : name,
                 'tags' : [t.user_tname if not t.value else "%s:%s" % (t.user_tname, t.value) for t in hda.tags],
                 'src'  : src,


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/sentry/main/issues/501183/:
```
TypeError: '<' not supported between instances of 'int' and 'NoneType'
  File "galaxy/tools/__init__.py", line 2095, in populate_model
    tool_dict = input.to_dict(request_context, other_values=other_values)
  File "galaxy/tools/parameters/basic.py", line 2000, in to_dict
    d['options']['hda'] = sorted(d['options']['hda'], key=lambda k: k['hid'], reverse=True)
TypeError: '<' not supported between instances of 'int' and 'NoneType'
  File "galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/tools.py", line 124, in build
    return tool.to_json(trans, kwd.get('inputs', kwd))
  File "galaxy/tools/__init__.py", line 2032, in to_json
    self.populate_model(request_context, self.inputs, state_inputs, tool_model['inputs'])
  File "galaxy/tools/__init__.py", line 2104, in populate_model
    tool_dict = input.to_dict(request_context)
  File "galaxy/tools/parameters/basic.py", line 2000, in to_dict
    d['options']['hda'] = sorted(d['options']['hda'], key=lambda k: k['hid'], reverse=True)
```

HDAs really should have a `hid`, but custom len files built by the custom
API endpoint don't actually get added to any history. On our old prod server
we also have a couple of datasets that are in error state and have no
hid. I'm not sure how they could ever get into `hda_list`, but this is
clearly better than failing.

This is also kind of a python 3 issue, comparing None to an integer works on python 2.