### PR TITLE
sqlite sniffer: check table names for equality

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1403,10 +1403,7 @@ class SQlite(Binary):
             tables_query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
             result = c.execute(tables_query).fetchall()
             result = [_[0] for _ in result]
-            for table_name in table_names:
-                if table_name not in result:
-                    return False
-            return True
+            return set(result) == set(table_names)
         except Exception as e:
             log.warning('%s, sniff Exception: %s', self, e)
         return False

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1395,15 +1395,23 @@ class SQlite(Binary):
         except Exception:
             return False
 
-    def sniff_table_names(self, filename, table_names):
+    def sniff_table_names(self, filename, table_names, equality=False):
+        """
+        test if the tables defined in the SQLite DB (filename) are
+        a subset of given list of tables (tablenames). if equality
+        is true the test is for equality
+        """
         # All table names should be in the schema
         try:
             conn = sqlite.connect(filename)
             c = conn.cursor()
             tables_query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
             result = c.execute(tables_query).fetchall()
-            result = [_[0] for _ in result]
-            return set(result) == set(table_names)
+            result = (_[0] for _ in result)
+            if equality:
+                return set(result) == set(table_names)
+            else:
+                return set(result).issubset(set(table_names))
         except Exception as e:
             log.warning('%s, sniff Exception: %s', self, e)
         return False

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1409,9 +1409,9 @@ class SQlite(Binary):
             result = c.execute(tables_query).fetchall()
             result = (_[0] for _ in result)
             if equality:
-                return set(result) == set(table_names)
+                return set(table_names) == set(result)
             else:
-                return set(result).issubset(set(table_names))
+                return set(table_names).issubset(set(result))
         except Exception as e:
             log.warning('%s, sniff Exception: %s', self, e)
         return False

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1407,11 +1407,11 @@ class SQlite(Binary):
             c = conn.cursor()
             tables_query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
             result = c.execute(tables_query).fetchall()
-            result = (_[0] for _ in result)
+            result = set(_[0] for _ in result)
             if equality:
-                return set(table_names) == set(result)
+                return set(table_names) == result
             else:
-                return set(table_names).issubset(set(result))
+                return set(table_names).issubset(result)
         except Exception as e:
             log.warning('%s, sniff Exception: %s', self, e)
         return False


### PR DESCRIPTION
Not sure if the derived classes always give the full list of tables. If so a check for equality (instead for subset) this would be better. 

Unfortunately not all have tests.

Otherwise I would add a parameter that can control if the check should be done for equality