### PR TITLE
[WIP] Export CWL-abstract workflow representation

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -993,8 +993,8 @@ class WorkflowContentsManager(UsesAnnotations):
             tag_str = stored.make_tag_string_list()
         # Pack workflow data into a dictionary and return
         data = {}
-        data['class'] = 'Workflow'  # Placeholder for identifying galaxy workflow
-        data['cwlVersion'] = "v1.3"
+        data['class'] = 'Workflow'
+        data['cwlVersion'] = "v1.2.0-dev1"
         if annotation_str != '':
             data['doc'] = workflow.name + ': ' + annotation_str
         else:
@@ -1002,9 +1002,9 @@ class WorkflowContentsManager(UsesAnnotations):
         # how can I make use of tags in the cwl-abstract?
         #data['tags'] = tag_str
         data['steps'] = {}
-        global_input_dicts={}
-        workflow_outputs_dicts={}  #global outputs
-        input_index=0
+        global_input_dicts = {}
+        workflow_outputs_dicts = {}  #global outputs
+        input_index = 0
         for step in workflow.steps:
             # Load from database representation
             module = module_factory.from_workflow_step(trans, step)
@@ -1016,7 +1016,6 @@ class WorkflowContentsManager(UsesAnnotations):
             # Export differences for backward compatibility
             tool_state = module.get_export_state()
             input_dicts = {}
-
             # Step info
             step_dict={'out': []}
             step_run_dict = {
@@ -1032,7 +1031,6 @@ class WorkflowContentsManager(UsesAnnotations):
                         'changeset_revision': module.tool.changeset_revision,
                         'tool_shed': module.tool.tool_shed
                     }
-
                 tool_representation = None
                 dynamic_tool = step.dynamic_tool
                 if dynamic_tool:
@@ -1044,19 +1042,17 @@ class WorkflowContentsManager(UsesAnnotations):
 
             ## how to handle subworkflows?
             step_state = module.state.inputs or {}
-
-
             if module.type != 'data_input':
-                step_run_dict['doc']=module.get_name()
-                step_inputs={}
-                inp_connections=step.input_connections
-                connection_num=1
+                step_run_dict['doc'] = module.get_name()
+                step_inputs = {}
+                inp_connections = step.input_connections
+                connection_num = 1
                 for conn in inp_connections:
                     # the combination of input_step.uuid and input_name should be unique
                     # the combination of output_step.uuid and output_name should be unique
-                    input_id=str(conn.input_step.uuid) + '_' + conn.input_name
-                    source_id=str(conn.output_step.uuid) + '/'+ conn.output_name
-                    connection_num+=1
+                    input_id = str(conn.input_step.uuid) + '_' + conn.input_name
+                    source_id = str(conn.output_step.uuid) + '/'+ conn.output_name
+                    connection_num += 1
                     label = conn.input_name
                     #the input is not connected to a previous tool (data_input is not considered a step)
                     if conn.output_step.type == 'data_input':
@@ -1067,53 +1063,52 @@ class WorkflowContentsManager(UsesAnnotations):
                                 'type' : 'File',
                                 'name': label
                                 }
-                        source_id=str(conn.output_step.uuid) + '_'+ conn.output_name   # the data_input id is used to identify the file
+                        source_id = str(conn.output_step.uuid) + '_'+ conn.output_name   # the data_input id is used to identify the file
                         if source_id not in global_input_dicts:
-                            global_input_dicts[source_id]=input_dict
-                    step_inputs[conn.input_name]=source_id
-                    input_dicts[conn.input_name]={"name": label, "description": "Input file(s) for tool %s" % module.get_name()}
+                            global_input_dicts[source_id] = input_dict
+                    step_inputs[conn.input_name] = source_id
+                    ## case when input is not connected from a previous step. Assume it is a value and not a File?
+                    input_dicts[conn.input_name] = {"name": label, "description": "Input value for tool %s" % module.get_name(), "type": "Any"}
                 for name, val in step_state.items():
                     input_type = type(val)
                     if input_type != ConnectedValue and module.type != 'data_input':
                         if name not in step_inputs:  #not a connected value
-                            source_id= str(step.uuid) + '_' + str(name) #global_input_id
+                            source_id = str(step.uuid) + '_' + str(name) #global_input_id
                             if input_type == RuntimeValue:
-                                input_dicts[name]={"name": name, "description": "runtime parameter for tool %s" % module.get_name()}
+                                input_dicts[name] = {"name": name, "description": "runtime parameter for tool %s" % module.get_name()}
                             else:
-                                step_inputs_dict={"name": name, "default":val,"description": "runtime parameter for tool %s" % module.get_name()}
-                                input_dicts[name]=step_inputs_dict
-                                global_input_dicts[source_id]=step_inputs_dict
-                            step_inputs[name]=source_id  # connect operation input name with source
+                                step_inputs_dict = {"name": name, "default":val,"description": "runtime parameter for tool %s" % module.get_name()}
+                                input_dicts[name] = step_inputs_dict
+                                global_input_dicts[source_id] = step_inputs_dict
+                            step_inputs[name] = source_id  # connect operation input name with source
 
-                step_dict['in']=step_inputs
+                step_dict['in'] = step_inputs
                 step_run_dict['inputs'] = input_dicts
-
-
             # Global wf outputs and step wf output list
             for workflow_output in step.unique_workflow_outputs:
                 # do not list the User's inputs as wf outputs
                 if module.type != 'data_input':
                     workflow_output_dict = dict(
-                        label=workflow_output.label,
-                        name=workflow_output.output_name,
-                        output_source=str(step.uuid) + '/' + workflow_output.output_name
+                        label = workflow_output.label,
+                        name = workflow_output.output_name,
+                        outputSource = str(step.uuid) + '/' + workflow_output.output_name,
+                        type = "Any"
                     )
-                    workflow_outputs_dicts[str(workflow_output.uuid)]=workflow_output_dict
+                    workflow_outputs_dicts[str(workflow_output.uuid)] = workflow_output_dict
                     step_dict['out'].append(workflow_output.output_name)
 
             # All step outputs
             step_outputs_dict = {}
             if type(module) is ToolModule:
                 for output in module.get_data_outputs():
-                    step_outputs_dict[output['name']]= {'type': output['extensions'][0]}  #can add something in the doc?
-
-            step_run_dict['outputs']=step_outputs_dict
+                    step_outputs_dict[output['name']] = {'type': output['extensions'][0]}  #can add something in the doc?
+            step_run_dict['outputs'] = step_outputs_dict
             if module.type != 'data_input':
-                step_dict['run']=step_run_dict
+                step_dict['run'] = step_run_dict
                 data['steps'][str(step.uuid)] = step_dict
         # add the global input and outputs to the return value
-        data['outputs']=workflow_outputs_dicts
-        data['inputs']=global_input_dicts
+        data['outputs'] = workflow_outputs_dicts
+        data['inputs'] = global_input_dicts
         return data
 
     def _workflow_to_dict_instance(self, stored, workflow, legacy=True):

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -5,10 +5,10 @@ from __future__ import absolute_import
 
 import io
 import json
-import yaml
 import logging
 import os
 
+import yaml
 import requests
 from gxformat2._yaml import ordered_dump
 from markupsafe import escape

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import io
 import json
+import yaml
 import logging
 import os
 
@@ -479,6 +480,10 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
 
         if style == "format2" and download_format != 'json-download':
             return ordered_dump(ret_dict)
+        elif style == "cwl_abstract":
+            noalias_dumper = yaml.dumper.SafeDumper
+            noalias_dumper.ignore_aliases = lambda self, data: True
+            return yaml.dump(ret_dict, default_flow_style=False, Dumper=noalias_dumper)
         else:
             return format_return_as_json(ret_dict, pretty=True)
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -571,6 +571,11 @@ test_data:
         downloaded_workflow = self._download_workflow(uploaded_workflow_id, style="format2")
         assert downloaded_workflow["class"] == "GalaxyWorkflow"
 
+    def test_export_cwl_abstract(self):
+        uploaded_workflow_id = self.workflow_populator.simple_workflow("test_for_export_format2")  #should i use a different test wf
+        downloaded_workflow = self._download_workflow(uploaded_workflow_id, style="cwl_abstract")
+        assert downloaded_workflow["class"] == "Workflow"
+
     def test_export_editor(self):
         uploaded_workflow_id = self.workflow_populator.simple_workflow("test_for_export")
         downloaded_workflow = self._download_workflow(uploaded_workflow_id, style="editor")


### PR DESCRIPTION
This is a first step towards exporting a Galaxy workflow as an [RO-crate](https://researchobject.github.io/ro-crate/) object.
Besides the required metadata, the [workflow RO-Crate profile](https://www.researchobject.org/ro-crate/profiles.html#workflow-ro-crate-profile) recommends to accompany the native workflow definition with an [abstract CWL description](https://www.commonwl.org/v1.2/Workflow.html#Operation).

This PR is heavily dependant on the implementation of the Abstract Operation in CWL (https://github.com/common-workflow-language/cwl-v1.2/pull/3) .





