### PR TITLE
[19.01] Update bleach to 3.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,6 @@ jobs:
     steps:
       - *restore_repo_cache
       - *install_tox
-      - run: sudo apt-get update
-      # For uwsgi
-      - run: sudo apt-get install -y libpython3.5-dev
       - run: tox -e py35-first_startup
   validate_test_tools:
     docker:

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -23,7 +23,7 @@ bcrypt==3.1.4
 bdbag==1.4.1
 beaker==1.10.0
 bioblend==0.11.0
-bleach==3.0.2
+bleach==3.1.1
 boltons==18.0.1
 boto3==1.7.84
 boto==2.49.0


### PR DESCRIPTION
due to security fixes explained in

https://github.com/mozilla/bleach/blob/master/CHANGES