### PR TITLE
[20.01] Fix wrong map use in many places

### DIFF
--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -66,11 +66,12 @@ def get_keys_from_dict(dl, keys_list):
     """
     This function builds a list using the keys from nest dictionaries
     """
+    assert isinstance(keys_list, list)
     if isinstance(dl, dict):
-        keys_list += dl.keys()
-        map(lambda x: get_keys_from_dict(x, keys_list), dl.values())
+        keys_list += list(dl.keys())
+        list(map(lambda x: get_keys_from_dict(x, keys_list), dl.values()))
     elif isinstance(dl, list):
-        map(lambda x: get_keys_from_dict(x, keys_list), dl)
+        list(map(lambda x: get_keys_from_dict(x, keys_list), dl))
 
 
 class RuleValidator(object):

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -152,7 +152,7 @@ class SharableModelManager(base.ModelManager, secured.OwnableManagerMixin, secur
         # precondition: user has been validated
         # allow user to be a list and call recursivly
         if isinstance(user, list):
-            return map(lambda user: self.share_with(item, user, flush=False), user)
+            return list(map(lambda user: self.share_with(item, user, flush=False), user))
         # get or create
         existing = self.get_share_assocs(item, user=user)
         if existing:
@@ -181,7 +181,7 @@ class SharableModelManager(base.ModelManager, secured.OwnableManagerMixin, secur
         Delete a user share (or list of shares) from the database.
         """
         if isinstance(user, list):
-            return map(lambda user: self.unshare_with(item, user, flush=False), user)
+            return list(map(lambda user: self.unshare_with(item, user, flush=False), user))
         # Look for and delete sharing relation for user.
         user_share_assoc = self.get_share_assocs(item, user=user)[0]
         self.session().delete(user_share_assoc)

--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -99,7 +99,7 @@ class DependenciesDescription(object):
         requirements_dicts = as_dict.get('requirements', [])
         requirements = ToolRequirements.from_list(requirements_dicts)
         installed_tool_dependencies_dicts = as_dict.get('installed_tool_dependencies', [])
-        installed_tool_dependencies = map(DependenciesDescription._toolshed_install_dependency_from_dict, installed_tool_dependencies_dicts)
+        installed_tool_dependencies = list(map(DependenciesDescription._toolshed_install_dependency_from_dict, installed_tool_dependencies_dicts))
         return DependenciesDescription(
             requirements=requirements,
             installed_tool_dependencies=installed_tool_dependencies

--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -103,7 +103,7 @@ class MappableDependencyResolver(object):
         except (OSError, IOError) as exc:
             if exc.errno != errno.ENOENT:
                 raise
-        return map(RequirementMapping.from_dict, raw_mapping)
+        return list(map(RequirementMapping.from_dict, raw_mapping))
 
     def _expand_mappings(self, requirement):
         for mapping in self._mappings:

--- a/lib/galaxy/tool_util/parser/cwl.py
+++ b/lib/galaxy/tool_util/parser/cwl.py
@@ -163,7 +163,7 @@ class CwlPageSource(PageSource):
 
     def __init__(self, tool_proxy):
         cwl_instances = tool_proxy.input_instances()
-        self._input_list = map(self._to_input_source, cwl_instances)
+        self._input_list = list(map(self._to_input_source, cwl_instances))
 
     def _to_input_source(self, input_instance):
         as_dict = input_instance.to_dict()

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -399,7 +399,7 @@ class TestCollectionDef(object):
             "model_class": "TestCollectionDef",
             "attributes": self.attrib,
             "collection_type": self.collection_type,
-            "elements": map(element_to_dict, self.elements or []),
+            "elements": list(map(element_to_dict, self.elements or [])),
             "name": self.name,
         }
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1088,7 +1088,7 @@ class ToolTestDescription(object):
         return {
             "inputs": inputs_dict,
             "outputs": self.outputs,
-            "output_collections": map(lambda o: o.to_dict(), self.output_collections),
+            "output_collections": list(map(lambda o: o.to_dict(), self.output_collections)),
             "num_outputs": self.num_outputs,
             "command_line": self.command_line,
             "command_version": self.command_version,

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2636,7 +2636,7 @@ class DatabaseOperationTool(Tool):
                 if not input_dataset_collection.collection.populated:
                     raise ToolInputsNotReadyException("An input collection is not populated.")
 
-            map(check_dataset_instance, input_dataset_collection.dataset_instances)
+            list(map(check_dataset_instance, input_dataset_collection.dataset_instances))
 
     def _add_datasets_to_history(self, history, elements, datasets_visible=False):
         datasets = []

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -936,7 +936,7 @@ class SelectToolParameter(ToolParameter):
         # FIXME: Currently only translating values back to labels if they
         #        are not dynamic
         if self.is_dynamic:
-            rval = map(str, value)
+            rval = [str(_) for _ in value]
         else:
             options = list(self.static_options)
             rval = []

--- a/lib/galaxy/util/object_wrapper.py
+++ b/lib/galaxy/util/object_wrapper.py
@@ -144,7 +144,7 @@ def wrap_with_safe_string(value, no_wrap_classes=None):
             return safe_class(value, safe_string_wrapper_function=__do_wrap)
         for this_type in __WRAP_SEQUENCES__ + __WRAP_SETS__:
             if isinstance(value, this_type):
-                return this_type(map(__do_wrap, value))
+                return this_type(list(map(__do_wrap, value)))
         for this_type in __WRAP_MAPPINGS__:
             if isinstance(value, this_type):
                 # Wrap both key and value

--- a/lib/galaxy/webapps/reports/controllers/jobs.py
+++ b/lib/galaxy/webapps/reports/controllers/jobs.py
@@ -164,11 +164,11 @@ class SpecifiedDateListGrid(grids.Grid):
             # We are either filtering on a date like YYYY-MM-DD or on a month like YYYY-MM,
             # so we need to figure out which type of date we have
             if column_filter.count('-') == 2:  # We are filtering on a date like YYYY-MM-DD
-                year, month, day = map(int, column_filter.split("-"))
+                year, month, day = list(map(int, column_filter.split("-")))
                 start_date = date(year, month, day)
                 end_date = start_date + timedelta(days=1)
             if column_filter.count('-') == 1:  # We are filtering on a month like YYYY-MM
-                year, month = map(int, column_filter.split("-"))
+                year, month = list(map(int, column_filter.split("-")))
                 start_date = date(year, month, 1)
                 end_date = start_date + timedelta(days=calendar.monthrange(year, month)[1])
 
@@ -371,7 +371,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
         specified_date = kwd.get('specified_date', datetime.utcnow().strftime("%Y-%m-%d"))
         specified_month = specified_date[:7]
 
-        year, month = map(int, specified_month.split("-"))
+        year, month = list(map(int, specified_month.split("-")))
         start_date = date(year, month, 1)
         end_date = start_date + timedelta(days=calendar.monthrange(year, month)[1])
         month_label = start_date.strftime("%B")
@@ -472,7 +472,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
         # If specified_date is not received, we'll default to the current month
         specified_date = kwd.get('specified_date', datetime.utcnow().strftime("%Y-%m-%d"))
         specified_month = specified_date[:7]
-        year, month = map(int, specified_month.split("-"))
+        year, month = list(map(int, specified_month.split("-")))
         start_date = date(year, month, 1)
         end_date = start_date + timedelta(days=calendar.monthrange(year, month)[1])
         month_label = start_date.strftime("%B")

--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -61,7 +61,7 @@ class Users(BaseUIController, ReportQueryBuilder):
         # If specified_date is not received, we'll default to the current month
         specified_date = kwd.get('specified_date', datetime.utcnow().strftime("%Y-%m-%d"))
         specified_month = specified_date[:7]
-        year, month = map(int, specified_month.split("-"))
+        year, month = list(map(int, specified_month.split("-")))
         start_date = date(year, month, 1)
         end_date = start_date + timedelta(days=calendar.monthrange(year, month)[1])
         month_label = start_date.strftime("%B")
@@ -91,7 +91,7 @@ class Users(BaseUIController, ReportQueryBuilder):
         message = escape(util.restore_text(kwd.get('message', '')))
         # If specified_date is not received, we'll default to the current month
         specified_date = kwd.get('specified_date', datetime.utcnow().strftime("%Y-%m-%d"))
-        year, month, day = map(int, specified_date.split("-"))
+        year, month, day = list(map(int, specified_date.split("-")))
         start_date = date(year, month, day)
         end_date = start_date + timedelta(days=1)
         day_of_month = start_date.strftime("%d")

--- a/lib/galaxy/webapps/reports/controllers/workflows.py
+++ b/lib/galaxy/webapps/reports/controllers/workflows.py
@@ -64,14 +64,14 @@ class SpecifiedDateListGrid(grids.Grid):
             # so we need to figure out which type of date we have
             if column_filter.count('-') == 2:
                 # We are filtering on a date like YYYY-MM-DD
-                year, month, day = map(int, column_filter.split("-"))
+                year, month, day = list(map(int, column_filter.split("-")))
                 start_date = date(year, month, day)
                 end_date = start_date + timedelta(days=1)
                 return query.filter(and_(self.model_class.table.c.create_time >= start_date,
                                          self.model_class.table.c.create_time < end_date))
             if column_filter.count('-') == 1:
                 # We are filtering on a month like YYYY-MM
-                year, month = map(int, column_filter.split("-"))
+                year, month = list(map(int, column_filter.split("-")))
                 start_date = date(year, month, 1)
                 end_date = start_date + timedelta(days=calendar.monthrange(year, month)[1])
                 return query.filter(and_(self.model_class.table.c.create_time >= start_date,


### PR DESCRIPTION
Map objects can't be serialized to JSON, so they can't be sent out as API responses, they can only be iterated over once, they can't be unpacked like lists or tuples, and just calling `map()` doesn't evaluate whatever function is mapped.

Some of these look pretty serious, and overall I think we should use them less often because often it is not immediately clear if using map is safe. List comprehensions or generators are often a better choice.