### PR TITLE
Fix first_startup Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ install:
   - pip install tox
   - |
     if [ "$TOX_ENV" == "py27-first_startup" ]; then
-        sh scripts/common_startup.sh
-        wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0127.sqlite
-        mv db_gx_rev_0127.sqlite database/universe.sqlite
-        sh manage_db.sh upgrade
+        # Use this job to test the latest migrations
+        wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0141.sqlite
+        mv db_gx_rev_0141.sqlite database/universe.sqlite
     elif [ "$TOX_ENV" == "py35-first_startup" ]; then
+        # There is now a pre-installed python3 on osx Travis workers, but use this job to test using a conda environment
         MINICONDA_URL="https://repo.anaconda.com/miniconda"
         MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
         curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: generic
 
 env:
   - TOX_ENV=py27-first_startup
-  - TOX_ENV=py35-first_startup
+  - TOX_ENV=py37-first_startup
 
 install:
   - set -e
@@ -14,14 +14,13 @@ install:
         # Use this job to test the latest migrations
         wget -q https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0141.sqlite
         mv db_gx_rev_0141.sqlite database/universe.sqlite
-    elif [ "$TOX_ENV" == "py35-first_startup" ]; then
+    elif [ "$TOX_ENV" == "py37-first_startup" ]; then
         # There is now a pre-installed python3 on osx Travis workers, but use this job to test using a conda environment
         MINICONDA_URL="https://repo.anaconda.com/miniconda"
         MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
         curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
         bash $MINICONDA_FILE -b
-        ~/miniconda3/bin/conda create --yes --override-channels --channel conda-forge --channel defaults --name _galaxy_ 'python=3.5' 'pip>=9' 'virtualenv>=16'
-        . ~/miniconda3/bin/activate _galaxy_
+        . ~/miniconda3/bin/activate
     fi
 
 script: tox -e $TOX_ENV

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -128,11 +128,7 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
             fi
             virtualenv "$GALAXY_VIRTUAL_ENV"
         else
-            # If .venv does not exist, and there is no conda available, attempt to create it.
-            # Ensure Python is a supported version before creating .venv
-            echo "Creating Python virtual environment for Galaxy: $GALAXY_VIRTUAL_ENV"
-            echo "To avoid this, use the --no-create-venv flag or set \$GALAXY_VIRTUAL_ENV to an"
-            echo "existing environment before starting Galaxy."
+            # If $GALAXY_VIRTUAL_ENV does not exist, and there is no conda available, attempt to create it.
             if [ -z "$GALAXY_PYTHON" ]; then
                 if command -v python3 >/dev/null; then
                     GALAXY_PYTHON=python3
@@ -140,7 +136,12 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
                     GALAXY_PYTHON=python
                 fi
             fi
+            # Ensure Python is a supported version before creating $GALAXY_VIRTUAL_ENV
             "$GALAXY_PYTHON" ./scripts/check_python.py || exit 1
+            echo "Creating Python virtual environment for Galaxy: $GALAXY_VIRTUAL_ENV"
+            echo "using Python: $GALAXY_PYTHON"
+            echo "To avoid this, use the --no-create-venv flag or set \$GALAXY_VIRTUAL_ENV to an"
+            echo "existing environment before starting Galaxy."
             if command -v virtualenv >/dev/null; then
                 virtualenv -p "$GALAXY_PYTHON" "$GALAXY_VIRTUAL_ENV"
             else
@@ -186,7 +187,7 @@ fi
 : ${PYPI_INDEX_URL:="https://pypi.python.org/simple"}
 : ${GALAXY_DEV_REQUIREMENTS:="./lib/galaxy/dependencies/dev-requirements.txt"}
 if [ $REPLACE_PIP -eq 1 ]; then
-    pip install 'pip>=8.1'
+    python -m pip install 'pip>=8.1'
 fi
 
 requirement_args="-r requirements.txt"

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ whitelist_externals = bash
 passenv = CI CONDA_EXE
 setenv =
     first_startup: GALAXY_PYTHON=python
+    first_startup: GALAXY_CONFIG_DATABASE_AUTO_MIGRATE=true
     py{35,36,37}-first_startup: GALAXY_VIRTUAL_ENV=.venv3
     unit: GALAXY_VIRTUAL_ENV={envdir}
     unit: GALAXY_ENABLE_BETA_COMPRESSED_GENBANK_SNIFFING=1


### PR DESCRIPTION
- Fix py27-first_startup Travis job to actually use Python 2
  `scripts/common_startup.sh` now prefers python3 when creating Galaxy's virtual environment, so it needs to be run when inside the tox virtualenv, where `GALAXY_PYTHON` is defined.
- Let Galaxy create the `_galaxy_` conda env