### PR TITLE
Add delta_frac for sim_size to specify relative file size differences

### DIFF
--- a/lib/galaxy/tool_util/parser/util.py
+++ b/lib/galaxy/tool_util/parser/util.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
-DEFAULT_DELTA = "10000"
+DEFAULT_DELTA = 10000
+DEFAULT_DELTA_FRAC = None
 
 
 def is_dict(item):

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -9,7 +9,10 @@ from math import isinf
 import packaging.version
 
 from galaxy.tool_util.deps import requirements
-from galaxy.tool_util.parser.util import DEFAULT_DELTA
+from galaxy.tool_util.parser.util import (
+    DEFAULT_DELTA,
+    DEFAULT_DELTA_FRAC
+)
 from galaxy.util import string_as_bool, xml_text, xml_to_string
 from .interface import (
     InputSource,
@@ -614,6 +617,7 @@ def __parse_test_attributes(output_elem, attrib, parse_elements=False, parse_dis
     attributes['lines_diff'] = int(attrib.pop('lines_diff', '0'))
     # Allow a file size to vary if sim_size compare
     attributes['delta'] = int(attrib.pop('delta', DEFAULT_DELTA))
+    attributes['delta_frac'] = float(attrib['delta_frac']) if 'delta_frac' in attrib else DEFAULT_DELTA_FRAC
     attributes['sort'] = string_as_bool(attrib.pop('sort', False))
     attributes['decompress'] = string_as_bool(attrib.pop('decompress', False))
     extra_files = []

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -3,7 +3,10 @@ from collections import OrderedDict
 import packaging.version
 
 from galaxy.tool_util.deps import requirements
-from galaxy.tool_util.parser.util import DEFAULT_DELTA
+from galaxy.tool_util.parser.util import (
+    DEFAULT_DELTA,
+    DEFAULT_DELTA_FRAC
+)
 from .interface import (
     InputSource,
     PageSource,
@@ -219,7 +222,8 @@ def _parse_test(i, test_dict):
         defaults = {
             'compare': 'diff',
             'lines_diff': 0,
-            'delta': int(DEFAULT_DELTA),
+            'delta': DEFAULT_DELTA,
+            'delta_frac': DEFAULT_DELTA_FRAC,
             'sort': False,
         }
         # TODO

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1312,9 +1312,14 @@ When this attribute is true and ``compare`` is set to ``diff``, try to decompres
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="delta" type="xs:integer">
+    <xs:attribute name="delta" type="xs:integer" default="10000">
       <xs:annotation>
-        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the number of bytes different allowed (default 10000).</xs:documentation>
+        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the maximum allowed absolute size difference (in bytes) between the data set that is generated in the test and the file in ``test-data/`` that is referenced by the ``file`` attribute. Can be combined with ``delta_frac``.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="delta_frac" type="xs:float">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the maximum allowed relative size difference between the data set that is generated in the test and the file in ``test-data/`` that is referenced by the ``file`` attribute. A value of 0.1 means that the file that is generated in the test can differ by at most 10% of the file in ``test-data``. The default is not to check for  relative size difference. Can be combined with ``delta``.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -55,6 +55,7 @@
   <tool file="qc_stdout.xml" />
   <tool file="md5sum.xml" />
   <tool file="checksum.xml" />
+  <tool file="sim_size_delta.xml" />
   <tool file="composite_shapefile.xml" />
   <tool file="is_valid_xml.xml" />
   <tool file="param_value_from_file.xml"/>

--- a/test/functional/tools/sim_size_delta.xml
+++ b/test/functional/tools/sim_size_delta.xml
@@ -1,0 +1,22 @@
+<tool id="sim_size_delta" name="sim_size_delta" version="0.1.0">
+  <command><![CDATA[
+    head -c 80 '$in' > '$out_smaller' &&
+    cp '$in' '$out_larger' &&
+    head -c 20 '$in' >> '$out_larger'
+  ]]></command>
+  <inputs>
+    <param name="in" type="data" format="data"/>
+  </inputs>
+  <outputs>
+    <data name="out_smaller" format="data" label="smaller"/>
+    <data name="out_larger" format="data" label="larger"/>
+  </outputs>
+  <tests>
+    <!-- take a test file of 100b size and add/remove 20b -->
+    <test expect_num_outputs="2">
+      <param name="in" value="1.sff" ftype="txt" />
+      <output name="out_smaller" value="1.sff" compare="sim_size" delta="20" delta_frac="0.2"/>
+      <output name="out_larger" value="1.sff" compare="sim_size" delta="20" delta_frac="0.2"/>
+    </test>
+  </tests>
+</tool>


### PR DESCRIPTION
use case: I develop a a lare tool collection where some files differ much (ususally the large files) and some only a bit (the small files). by applying a large delta to all files meaningful differences in small files are not detected.

I guess this might also help here a bit https://github.com/galaxyproject/galaxy/issues/8514