### PR TITLE
Remove '.sample' from default value; rebuild schema

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -789,7 +789,9 @@
 :Description:
     File that defines the builds (dbkeys) available at sites used by
     display applications and the URL to those sites.
-:Default: ``config/build_sites.yml.sample``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``build_sites.yml``
 :Type: str
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -754,7 +754,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         """
         defaults = dict(
             auth_config_file=[self._in_config_dir('auth_conf.xml')],
-            build_sites_config_file=[self._in_config_dir('build_sites.yml')],
+            build_sites_config_file=[self._in_config_dir('build_sites.yml'), self._in_sample_dir('build_sites.yml.sample')],
             containers_config_file=[self._in_config_dir('containers_conf.yml')],
             data_manager_config_file=[self._in_config_dir('data_manager_conf.xml')],
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -489,7 +489,9 @@ galaxy:
 
   # File that defines the builds (dbkeys) available at sites used by
   # display applications and the URL to those sites.
-  #build_sites_config_file: config/build_sites.yml.sample
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #build_sites_config_file: build_sites.yml
 
   # File containing old-style genome builds.
   # The value of this option will be resolved with respect to

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -591,11 +591,13 @@ mapping:
 
       build_sites_config_file:
         type: str
-        default: config/build_sites.yml.sample
+        default: build_sites.yml
         required: false
         desc: |
           File that defines the builds (dbkeys) available at sites used by display applications
           and the URL to those sites.
+
+          The value of this option will be resolved with respect to <config_dir>.
 
       builds_file_path:
         type: str


### PR DESCRIPTION
Fixes build_sites_config_file default value. Re: #9426 