### PR TITLE
Use a Galaxy root path with a space for converters and mulled tests

### DIFF
--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -11,7 +11,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        path: 'galaxy root'
+    - name: Clone galaxyproject/galaxy-test-data
+      uses: actions/checkout@v2
+      with:
+        repository: galaxyproject/galaxy-test-data
+        path: galaxy-test-data
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
@@ -20,10 +25,10 @@ jobs:
       id: pip-cache
       with:
         path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
-    - name: fetch test data
-      run: git clone https://github.com/galaxyproject/galaxy-test-data && cp -R galaxy-test-data/* test-data
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+    - name: Move test data
+      run: rsync -av --remove-source-files --exclude .git galaxy-test-data/ 'galaxy root/test-data/'
     - name: Install planemo
       run: pip install planemo
     - name: Run tests
-      run: 'planemo test --galaxy_python_version ${{ matrix.python-version }} --galaxy_root .  lib/galaxy/datatypes/converters/*xml'
+      run: planemo test --galaxy_python_version ${{ matrix.python-version }} --galaxy_root 'galaxy root' 'galaxy root'/lib/galaxy/datatypes/converters/*xml

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -34,7 +34,6 @@ jobs:
         kubectl get pods
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 1
         path: 'galaxy root'
     - uses: actions/setup-python@v1
       with:
@@ -44,6 +43,7 @@ jobs:
       id: pip-cache
       with:
         path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
     - name: Run tests
       run: './run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'
+      working-directory: 'galaxy root'

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -9,19 +9,20 @@ jobs:
       matrix:
         python-version: [3.7]
     steps:
-    - name: Cache tox dir
-      uses: actions/cache@v1
-      id: cache-tox-mulled
-      with:
-        path: .tox/mulled
-        key: tox-mulled-${{ matrix.python-version }}
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 1
+        path: 'galaxy root'
     - uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Cache pip dir
+      uses: actions/cache@v1
+      id: pip-cache
+      with:
+        path: ~/.cache/pip
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
     - name: Install tox
-      run: pip install tox
+      run: pip install tox 'virtualenv<20'
     - name: run tests
       run: tox -e mulled
+      working-directory: 'galaxy root'


### PR DESCRIPTION
Also:
- Fix integration tests for checkout@v2 action: the working directory is not updated any more when `path` is specified
- Use checkout action to clone the galaxy-test-data repo and rsync to move them in place
- Install virtualenv<20 when running tests via tox in a directory containing spaces, xref. https://github.com/pypa/virtualenv/pull/1660