### PR TITLE
[20.01] Fix login to accounts using different email capitalization

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -489,7 +489,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
                 return "Failed to produce password reset token. User not found."
 
     def get_reset_token(self, trans, email):
-        reset_user = trans.sa_session.query(self.app.model.User).filter(func.lower(self.app.model.User.table.c.email) == email.lower()).first()
+        reset_user = trans.sa_session.query(self.app.model.User).filter(self.app.model.User.table.c.email == email.lower()).first()
+        if not reset_user and email != email.lower():
+            reset_user = trans.sa_session.query(self.app.model.User).filter(func.lower(self.app.model.User.table.c.email) == email.lower()).first()
         if reset_user:
             prt = self.app.model.PasswordResetToken(reset_user)
             trans.sa_session.add(prt)

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -135,9 +135,14 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
         if not login or not password:
             return self.message_exception(trans, "Please specify a username and password.")
         user = trans.sa_session.query(trans.app.model.User).filter(or_(
-            func.lower(trans.app.model.User.table.c.email) == login.lower(),
+            trans.app.model.User.table.c.email == login,
             trans.app.model.User.table.c.username == login
         )).first()
+        if not user and login.lower() != login:
+            user = trans.sa_session.query(trans.app.model.User).filter(or_(
+                func.lower(trans.app.model.User.table.c.email) == login.lower(),
+                trans.app.model.User.table.c.username == login
+            )).first()
         log.debug("trans.app.config.auth_config_file: %s" % trans.app.config.auth_config_file)
         if user is None:
             message, user = self.__autoregistration(trans, login, password)

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -139,10 +139,9 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
             trans.app.model.User.table.c.username == login
         )).first()
         if not user and login.lower() != login:
-            user = trans.sa_session.query(trans.app.model.User).filter(or_(
-                func.lower(trans.app.model.User.table.c.email) == login.lower(),
-                trans.app.model.User.table.c.username == login
-            )).first()
+            user = trans.sa_session.query(trans.app.model.User).filter(
+                func.lower(trans.app.model.User.table.c.email) == login.lower()
+            ).first()
         log.debug("trans.app.config.auth_config_file: %s" % trans.app.config.auth_config_file)
         if user is None:
             message, user = self.__autoregistration(trans, login, password)


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/8631 added case-insensitive matches to user emails. If two accounts with different email capitalizations exist one of them will be picked at random for login.
To fix this we first check for exact match and only if there is no direct match we lowercase the comparison.