### PR TITLE
[20.01] Fix TwoBitFile handle not opened in binary mode

### DIFF
--- a/lib/galaxy/visualization/genomes.py
+++ b/lib/galaxy/visualization/genomes.py
@@ -392,7 +392,7 @@ class Genomes(object):
 
         # Read and return reference data.
         try:
-            twobit = TwoBitFile(open(twobit_file_name))
+            twobit = TwoBitFile(open(twobit_file_name, 'rb'))
             if chrom in twobit:
                 seq_data = twobit[chrom].get(int(low), int(high))
                 return GenomeRegion(chrom=chrom, start=low, end=high, sequence=seq_data)

--- a/tools/extract/extract_genomic_dna.py
+++ b/tools/extract/extract_genomic_dna.py
@@ -222,7 +222,7 @@ def __main__():
                 continue
         elif seq_path and os.path.isfile(seq_path):
             if not(twobitfile):
-                twobitfile = bx.seq.twobit.TwoBitFile(open(seq_path))
+                twobitfile = bx.seq.twobit.TwoBitFile(open(seq_path, 'rb'))
             try:
                 if options.gff and interpret_features:
                     # Create sequence from intervals within a feature.


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/sentry/main/issues/501741/:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd7 in position 77: invalid continuation byte
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 34, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 143, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 222, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/web/framework/decorators.py", line 57, in call_and_format
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/genomes.py", line 41, in show
    region = self.app.genomes.reference(trans, dbkey=id, chrom=chrom, low=low, high=high)
  File "galaxy/visualization/genomes.py", line 395, in reference
    twobit = TwoBitFile(open(twobit_file_name))
  File "bx/seq/twobit.py", line 56, in __init__
    strng = file.read(TWOBIT_MAGIC_SIZE)
  File "python3.6/codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
```