### PR TITLE
[20.01] Fix uploading workflow archives

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -353,7 +353,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                 uploaded_file = archive_file.file
                 uploaded_file_name = uploaded_file.name
                 if os.path.getsize(os.path.abspath(uploaded_file_name)) > 0:
-                    archive_data = uploaded_file.read()
+                    archive_data = util.unicodify(uploaded_file.read())
                 else:
                     raise exceptions.MessageException("You attempted to upload an empty file.")
             else:


### PR DESCRIPTION
This fixes https://sentry.galaxyproject.org/sentry/main/issues/502038/:
```
TypeError: a bytes-like object is required, not 'str'
  File "galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/workflows.py", line 361, in create
    return self.__api_import_from_archive(trans, archive_data, "uploaded file")
  File "galaxy/webapps/galaxy/api/workflows.py", line 640, in __api_import_from_archive
    if "GalaxyWorkflow" in archive_data:
```
The actual uploaded data is still invalid, but a more meaningful message
will be raised with this fix.