### PR TITLE
[19.09] Fix `SearchGuiArchive.set_meta()`

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -2111,8 +2111,7 @@ class SearchGuiArchive(CompressedArchive):
                 with zipfile.ZipFile(dataset.file_name) as tempzip:
                     if 'searchgui.properties' in tempzip.namelist():
                         with tempzip.open('searchgui.properties') as fh:
-                            for line in fh:
-                                line = line.decode()
+                            for line in io.TextIOWrapper(fh):
                                 if line.startswith('searchgui.version'):
                                     version = line.split('=')[1].strip()
                                     dataset.metadata.searchgui_version = version

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -2112,6 +2112,7 @@ class SearchGuiArchive(CompressedArchive):
                     if 'searchgui.properties' in tempzip.namelist():
                         with tempzip.open('searchgui.properties') as fh:
                             for line in fh:
+                                line = line.decode()
                                 if line.startswith('searchgui.version'):
                                     version = line.split('=')[1].strip()
                                     dataset.metadata.searchgui_version = version

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import binascii
 import gzip
+import io
 import logging
 import os
 import shutil


### PR DESCRIPTION
probably with py3 reading a file from a zip file became binary. hence `startswith` and `split` fail. 

Q is if this is the best possible fix? 

- Maybe use binary-strings for `split` and `startswith`?
- Or is there something is galaxy.utils that could help?

I target 19.09 because this is the version I'm currently running on. Could be changed to 20.01 and I cherry pick for my instance.
