### PR TITLE
Unify default values used for delta (sim_size)

### DIFF
--- a/lib/galaxy/tool_util/parser/util.py
+++ b/lib/galaxy/tool_util/parser/util.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+DEFAULT_DELTA = "10000"
+
 
 def is_dict(item):
     return isinstance(item, dict) or isinstance(item, OrderedDict)

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -9,7 +9,7 @@ from math import isinf
 import packaging.version
 
 from galaxy.tool_util.deps import requirements
-from galaxy.tool_util.parser import DEFAULT_DELTA
+from galaxy.tool_util.parser.util import DEFAULT_DELTA
 from galaxy.util import string_as_bool, xml_text, xml_to_string
 from .interface import (
     InputSource,

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -613,7 +613,6 @@ def __parse_test_attributes(output_elem, attrib, parse_elements=False, parse_dis
     # Number of lines to allow to vary in logs (for dates, etc)
     attributes['lines_diff'] = int(attrib.pop('lines_diff', '0'))
     # Allow a file size to vary if sim_size compare
-    attributes['delta'] = int(attrib.pop('delta', '10000'))
     attributes['delta'] = int(attrib.pop('delta', DEFAULT_DELTA))
     attributes['sort'] = string_as_bool(attrib.pop('sort', False))
     attributes['decompress'] = string_as_bool(attrib.pop('decompress', False))

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -9,6 +9,7 @@ from math import isinf
 import packaging.version
 
 from galaxy.tool_util.deps import requirements
+from galaxy.tool_util.parser import DEFAULT_DELTA
 from galaxy.util import string_as_bool, xml_text, xml_to_string
 from .interface import (
     InputSource,
@@ -613,6 +614,7 @@ def __parse_test_attributes(output_elem, attrib, parse_elements=False, parse_dis
     attributes['lines_diff'] = int(attrib.pop('lines_diff', '0'))
     # Allow a file size to vary if sim_size compare
     attributes['delta'] = int(attrib.pop('delta', '10000'))
+    attributes['delta'] = int(attrib.pop('delta', DEFAULT_DELTA))
     attributes['sort'] = string_as_bool(attrib.pop('sort', False))
     attributes['decompress'] = string_as_bool(attrib.pop('decompress', False))
     extra_files = []

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -218,7 +218,7 @@ def _parse_test(i, test_dict):
         defaults = {
             'compare': 'diff',
             'lines_diff': 0,
-            'delta': DEFAULT_DELTA,
+            'delta': int(DEFAULT_DELTA),
             'sort': False,
         }
         # TODO

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -1,8 +1,8 @@
 from collections import OrderedDict
 
 import packaging.version
-
 from galaxy.tool_util.deps import requirements
+from galaxy.tool_util.parser.util import DEFAULT_DELTA
 from .interface import (
     InputSource,
     PageSource,
@@ -218,7 +218,7 @@ def _parse_test(i, test_dict):
         defaults = {
             'compare': 'diff',
             'lines_diff': 0,
-            'delta': 1000,
+            'delta': DEFAULT_DELTA,
             'sort': False,
         }
         # TODO

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import packaging.version
+
 from galaxy.tool_util.deps import requirements
 from galaxy.tool_util.parser.util import DEFAULT_DELTA
 from .interface import (

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -16,7 +16,7 @@ try:
 except ImportError:
     pysam = None
 
-from galaxy.tool_util.parser import DEFAULT_DELTA
+from galaxy.tool_util.parser.util import DEFAULT_DELTA
 from galaxy.util import unicodify
 from galaxy.util.compression_utils import get_fileobj
 from .asserts import verify_assertions

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -16,6 +16,7 @@ try:
 except ImportError:
     pysam = None
 
+from galaxy.tool_util.parser import DEFAULT_DELTA
 from galaxy.util import unicodify
 from galaxy.util.compression_utils import get_fileobj
 from .asserts import verify_assertions
@@ -131,7 +132,7 @@ def verify(
             elif compare == 're_match_multiline':
                 files_re_match_multiline(local_name, temp_name, attributes=attributes)
             elif compare == 'sim_size':
-                delta = attributes.get('delta', '10000')
+                delta = int(attributes.get('delta', DEFAULT_DELTA))
                 s1 = len(output_content)
                 s2 = os.path.getsize(local_name)
                 if abs(s1 - s2) > int(delta):

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -131,7 +131,7 @@ def verify(
             elif compare == 're_match_multiline':
                 files_re_match_multiline(local_name, temp_name, attributes=attributes)
             elif compare == 'sim_size':
-                delta = attributes.get('delta', '100')
+                delta = attributes.get('delta', '10000')
                 s1 = len(output_content)
                 s2 = os.path.getsize(local_name)
                 if abs(s1 - s2) > int(delta):

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1314,7 +1314,7 @@ When this attribute is true and ``compare`` is set to ``diff``, try to decompres
     </xs:attribute>
     <xs:attribute name="delta" type="xs:integer">
       <xs:annotation>
-        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the number of bytes different allowed (default 10.000).</xs:documentation>
+        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the number of bytes different allowed (default 10000).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1314,7 +1314,7 @@ When this attribute is true and ``compare`` is set to ``diff``, try to decompres
     </xs:attribute>
     <xs:attribute name="delta" type="xs:integer">
       <xs:annotation>
-        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the number of bytes different allowed.</xs:documentation>
+        <xs:documentation xml:lang="en">If ``compare`` is set to ``sim_size``, this is the number of bytes different allowed (default 10.000).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>


### PR DESCRIPTION
cherry picked from https://github.com/galaxyproject/galaxy/pull/9425

TODOs:

- [x] verify that 10000 is really the default currently used 
- [x] apply `int()` also to yaml parsing
