### PR TITLE
[20.01] Fix to_dict for upload1 tool

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2038,6 +2038,11 @@ class Tool(Dictifiable):
             tool_help = self.help.render(static_path=self.app.url_for('/static'), host_url=self.app.url_for('/', qualified=True))
             tool_help = unicodify(tool_help, 'utf-8')
 
+        if isinstance(self.action, tuple):
+            action = self.action[0] + self.app.url_for(self.action[1])
+        else:
+            action = self.app.url_for(self.action)
+
         # update tool model
         tool_model.update({
             'id'            : self.id,
@@ -2055,7 +2060,7 @@ class Tool(Dictifiable):
             'job_remap'     : self._get_job_remap(job),
             'history_id'    : trans.security.encode_id(history.id) if history else None,
             'display'       : self.display_interface,
-            'action'        : self.app.url_for(self.action),
+            'action'        : action,
             'method'        : self.method,
             'enctype'       : self.enctype
         })


### PR DESCRIPTION
This used to happen in tool_form.mako (https://github.com/galaxyproject/galaxy/blob/0637e0adeeafde44405f69581c3e9b2ae7123ef7/templates/webapps/galaxy/tool_form.mako#L299),
where the code was:
```
    # Handle calculating the redirect url for the special case where we have nginx proxy
    # upload and need to do url_for on the redirect portion of the tool action.
    try:
        tool_url = h.url_for(tool.action)
    except AttributeError:
        assert len(tool.action) == 2
        tool_url = tool.action[0] + h.url_for(tool.action[1])
```
Fixes https://sentry.galaxyproject.org/sentry/main/issues/300358/:
```
AttributeError: 'tuple' object has no attribute 'startswith'
  File "galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/tools.py", line 124, in build
    return tool.to_json(trans, kwd.get('inputs', kwd))
  File "galaxy/tools/__init__.py", line 2057, in to_json
    'action'        : self.app.url_for(self.action),
  File "routes/util.py", line 211, in url_for
    if url.startswith('/') and hasattr(config, 'environ') \
```