### PR TITLE
[20.01] Fix data tables vue display

### DIFF
--- a/client/galaxy/scripts/components/admin/DataTablesGrid.vue
+++ b/client/galaxy/scripts/components/admin/DataTablesGrid.vue
@@ -3,15 +3,17 @@
         <template v-slot:title>
             Current data table registry contains {{ rows.length }} data tables
         </template>
-        <template slot:rows v-for="(row, index) in rows">
-            <tr :key="row.id" :class="[index % 2 === 0 ? 'tr' : 'odd_row']">
-                <td>
-                    <a href="javascript:void(0)" @click="handleTableNameClick">{{ row.name }}</a>
-                </td>
-                <td>{{ row.filename }}</td>
-                <td>{{ row.tool_data_path }}</td>
-                <td>{{ row.errors }}</td>
-            </tr>
+        <template v-slot:rows>
+            <template v-for="(row, index) in rows">
+                <tr :key="row.id" :class="[index % 2 === 0 ? 'tr' : 'odd_row']">
+                    <td>
+                        <a href="javascript:void(0)" @click="handleTableNameClick">{{ row.name }}</a>
+                    </td>
+                    <td>{{ row.filename }}</td>
+                    <td>{{ row.tool_data_path }}</td>
+                    <td>{{ row.errors }}</td>
+                </tr>
+            </template>
         </template>
     </base-grid>
 </template>


### PR DESCRIPTION
This restores the data tables display grid in the admin panel.  Previously no entries would render.

xref https://gitter.im/galaxyproject/dev?at=5e55953b8f8af6553a03a863