### PR TITLE
Make mutable_config_dir configurable + rename

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -10,6 +10,20 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~
+``managed_config_dir``
+~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The directory that will be prepended to relative paths in options
+    specifying config files controlled by Galaxy (such as
+    shed_tool_config_file, etc.). Must be writable by the user running
+    Galaxy.  Defaults to `<config_dir>/` if running Galaxy from source
+    or `<data_dir>/config` otherwise.
+:Default: ``None``
+:Type: str
+
+
 ~~~~~~~~~~~~
 ``data_dir``
 ~~~~~~~~~~~~
@@ -272,7 +286,7 @@
     upon tool installation, whereas Galaxy will fail to start if any
     files in tool_config_file cannot be read.
     The value of this option will be resolved with respect to
-    <mutable_config_dir>.
+    <managed_config_dir>.
 :Default: ``shed_tool_conf.xml``
 :Type: str
 
@@ -303,7 +317,7 @@
     tool shed upon a new release, they will be added to this tool
     config file.
     The value of this option will be resolved with respect to
-    <mutable_config_dir>.
+    <managed_config_dir>.
 :Default: ``migrated_tools_conf.xml``
 :Type: str
 
@@ -319,7 +333,7 @@
     administrator to alter the layout of the tool panel.  If not
     present, Galaxy will create it.
     The value of this option will be resolved with respect to
-    <mutable_config_dir>.
+    <managed_config_dir>.
 :Default: ``integrated_tool_panel.xml``
 :Type: str
 
@@ -735,7 +749,7 @@
     following file, which is parsed and applied to the
     ToolDataTableManager at server start up.
     The value of this option will be resolved with respect to
-    <mutable_config_dir>.
+    <managed_config_dir>.
 :Default: ``shed_tool_data_table_conf.xml``
 :Type: str
 
@@ -3305,7 +3319,7 @@
     File where Tool Shed based Data Managers are configured. This file
     will be created automatically upon data manager installation.
     The value of this option will be resolved with respect to
-    <mutable_config_dir>.
+    <managed_config_dir>.
 :Default: ``shed_data_manager_conf.xml``
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -147,7 +147,7 @@ class BaseAppConfiguration(object):
                 if self.config_dir is None:
                     self.config_dir = os.getcwd()
                 if self.data_dir is None:
-                    self.data_dir = os.path.join(self.config_dir, 'data')
+                    self.data_dir = self._in_config_dir('data')
                 if self.managed_config_dir is None:
                     self.managed_config_dir = self._in_data_dir('config')
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -149,7 +149,7 @@ class BaseAppConfiguration(object):
                 if self.data_dir is None:
                     self.data_dir = os.path.join(self.config_dir, 'data')
                 if self.managed_config_dir is None:
-                    self.managed_config_dir = os.path.join(self.data_dir, 'config')
+                    self.managed_config_dir = self._in_data_dir('config')
 
             # TODO: do we still need to support ../shed_tools when running_from_source?
             self.shed_tools_dir = self._in_data_dir('shed_tools')

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -152,7 +152,7 @@ class BaseAppConfiguration(object):
                     self.managed_config_dir = os.path.join(self.data_dir, 'config')
 
             # TODO: do we still need to support ../shed_tools when running_from_source?
-            self.shed_tools_dir = os.path.join(self.data_dir, 'shed_tools')
+            self.shed_tools_dir = self._in_data_dir('shed_tools')
 
             log.debug("Configuration directory is %s", self.config_dir)
             log.debug("Data directory is %s", self.data_dir)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -379,7 +379,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
         self.oidc = []
-        self.integrated_tool_panel_config = os.path.join(self.managed_config_dir, self.integrated_tool_panel_config)
+        self.integrated_tool_panel_config = self._in_managed_config_dir(self.integrated_tool_panel_config)
         integrated_tool_panel_tracking_directory = kwargs.get('integrated_tool_panel_tracking_directory')
         if integrated_tool_panel_tracking_directory:
             self.integrated_tool_panel_tracking_directory = os.path.join(self.root, integrated_tool_panel_tracking_directory)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -135,6 +135,8 @@ class BaseAppConfiguration(object):
             self.data_dir = config_kwargs.get('data_dir')
             self.sample_config_dir = os.path.join(os.path.dirname(__file__), 'sample')
             self.managed_config_dir = config_kwargs.get('managed_config_dir')
+            if self.managed_config_dir:
+                self.managed_config_dir = os.path.abspath(self.managed_config_dir)
 
             if running_from_source:
                 if not self.config_dir:

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -133,37 +133,36 @@ class BaseAppConfiguration(object):
                 self.config_dir = os.path.abspath(self.config_dir)
 
             self.data_dir = config_kwargs.get('data_dir')
-            # mutable_config_dir is intentionally not configurable. You can
-            # override individual mutable configs with config options, but they
-            # should be considered Galaxy-controlled data files and will by default
-            # just live in the data dir
             self.sample_config_dir = os.path.join(os.path.dirname(__file__), 'sample')
+            self.managed_config_dir = config_kwargs.get('managed_config_dir')
 
             if running_from_source:
                 if self.config_dir is None:
                     self.config_dir = os.path.join(self.root, 'config')
                 if self.data_dir is None:
                     self.data_dir = os.path.join(self.root, 'database')
-                self.mutable_config_dir = self.config_dir
+                if self.managed_config_dir is None:
+                    self.managed_config_dir = self.config_dir
             else:
                 if self.config_dir is None:
                     self.config_dir = os.getcwd()
                 if self.data_dir is None:
                     self.data_dir = os.path.join(self.config_dir, 'data')
-                self.mutable_config_dir = os.path.join(self.data_dir, 'config')
+                if self.managed_config_dir is None:
+                    self.managed_config_dir = os.path.join(self.data_dir, 'config')
 
             # TODO: do we still need to support ../shed_tools when running_from_source?
             self.shed_tools_dir = os.path.join(self.data_dir, 'shed_tools')
 
             log.debug("Configuration directory is %s", self.config_dir)
             log.debug("Data directory is %s", self.data_dir)
-            log.debug("Mutable config directory is %s", self.mutable_config_dir)
+            log.debug("Managed config directory is %s", self.managed_config_dir)
 
         _set_global_conf()
         _set_config_directories()
 
-    def _in_mutable_config_dir(self, path):
-        return os.path.join(self.mutable_config_dir, path)
+    def _in_managed_config_dir(self, path):
+        return os.path.join(self.managed_config_dir, path)
 
     def _in_config_dir(self, path):
         return os.path.join(self.config_dir, path)
@@ -380,7 +379,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
         self.oidc = []
-        self.integrated_tool_panel_config = os.path.join(self.mutable_config_dir, self.integrated_tool_panel_config)
+        self.integrated_tool_panel_config = os.path.join(self.managed_config_dir, self.integrated_tool_panel_config)
         integrated_tool_panel_tracking_directory = kwargs.get('integrated_tool_panel_tracking_directory')
         if integrated_tool_panel_tracking_directory:
             self.integrated_tool_panel_tracking_directory = os.path.join(self.root, integrated_tool_panel_tracking_directory)
@@ -764,14 +763,14 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             job_resource_params_file=[self._in_config_dir('job_resource_params_conf.xml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
-            migrated_tools_config=[self._in_mutable_config_dir('migrated_tools_conf.xml')],
+            migrated_tools_config=[self._in_managed_config_dir('migrated_tools_conf.xml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
             object_store_config_file=[self._in_config_dir('object_store_conf.xml')],
             oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.xml')],
             oidc_config_file=[self._in_config_dir('oidc_config.xml')],
-            shed_data_manager_config_file=[self._in_mutable_config_dir('shed_data_manager_conf.xml')],
-            shed_tool_config_file=[self._in_mutable_config_dir('shed_tool_conf.xml')],
-            shed_tool_data_table_config=[self._in_mutable_config_dir('shed_tool_data_table_conf.xml')],
+            shed_data_manager_config_file=[self._in_managed_config_dir('shed_data_manager_conf.xml')],
+            shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
+            shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
             tool_sheds_config_file=[self._in_config_dir('tool_sheds_conf.xml')],
             user_preferences_extra_conf_path=[self._in_config_dir('user_preferences_extra_conf.yml')],
@@ -829,7 +828,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
                 raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
 
     def check(self):
-        paths_to_check = [self.tool_data_path, self.data_dir, self.mutable_config_dir]
+        paths_to_check = [self.tool_data_path, self.data_dir, self.managed_config_dir]
         # Check that required directories exist
         for path in paths_to_check:
             if path not in [None, False] and not os.path.isdir(path):

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -137,18 +137,18 @@ class BaseAppConfiguration(object):
             self.managed_config_dir = config_kwargs.get('managed_config_dir')
 
             if running_from_source:
-                if self.config_dir is None:
+                if not self.config_dir:
                     self.config_dir = os.path.join(self.root, 'config')
-                if self.data_dir is None:
+                if not self.data_dir:
                     self.data_dir = os.path.join(self.root, 'database')
-                if self.managed_config_dir is None:
+                if not self.managed_config_dir:
                     self.managed_config_dir = self.config_dir
             else:
-                if self.config_dir is None:
+                if not self.config_dir:
                     self.config_dir = os.getcwd()
-                if self.data_dir is None:
+                if not self.data_dir:
                     self.data_dir = self._in_config_dir('data')
-                if self.managed_config_dir is None:
+                if not self.managed_config_dir:
                     self.managed_config_dir = self._in_data_dir('config')
 
             # TODO: do we still need to support ../shed_tools when running_from_source?

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -113,6 +113,13 @@ galaxy:
   #config_dir: null
 
   # The directory that will be prepended to relative paths in options
+  # specifying config files controlled by Galaxy (such as
+  # shed_tool_config_file, etc.). Must be writable by the user running
+  # Galaxy.  Defaults to `<config_dir>/` if running Galaxy from source
+  # or `<data_dir>/config` otherwise.
+  #managed_config_dir: null
+
+  # The directory that will be prepended to relative paths in options
   # specifying Galaxy data/cache directories and files (such as the
   # default SQLite database, file_path, etc.). Defaults to `database/`
   # if running Galaxy from source or `<config_dir>/data` otherwise.
@@ -233,7 +240,7 @@ galaxy:
   # installation, whereas Galaxy will fail to start if any files in
   # tool_config_file cannot be read.
   # The value of this option will be resolved with respect to
-  # <mutable_config_dir>.
+  # <managed_config_dir>.
   #shed_tool_config_file: shed_tool_conf.xml
 
   # Enable / disable checking if any tools defined in the above non-shed
@@ -249,7 +256,7 @@ galaxy:
   # tool shed upon a new release, they will be added to this tool config
   # file.
   # The value of this option will be resolved with respect to
-  # <mutable_config_dir>.
+  # <managed_config_dir>.
   #migrated_tools_config: migrated_tools_conf.xml
 
   # File that contains the XML section and tool tags from all tool panel
@@ -258,7 +265,7 @@ galaxy:
   # to alter the layout of the tool panel.  If not present, Galaxy will
   # create it.
   # The value of this option will be resolved with respect to
-  # <mutable_config_dir>.
+  # <managed_config_dir>.
   #integrated_tool_panel_config: integrated_tool_panel.xml
 
   # Default path to the directory containing the tools defined in
@@ -463,7 +470,7 @@ galaxy:
   # is parsed and applied to the ToolDataTableManager at server start
   # up.
   # The value of this option will be resolved with respect to
-  # <mutable_config_dir>.
+  # <managed_config_dir>.
   #shed_tool_data_table_config: shed_tool_data_table_conf.xml
 
   # Directory where data used by tools is located.  See the samples in
@@ -1619,7 +1626,7 @@ galaxy:
   # File where Tool Shed based Data Managers are configured. This file
   # will be created automatically upon data manager installation.
   # The value of this option will be resolved with respect to
-  # <mutable_config_dir>.
+  # <managed_config_dir>.
   #shed_data_manager_config_file: shed_data_manager_conf.xml
 
   # Directory to store Data Manager based tool-data. Defaults to the

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -34,6 +34,15 @@ mapping:
           other Galaxy config files (e.g. datatypes_config_file). Defaults to the
           directory in which galaxy.yml is located.
 
+      managed_config_dir:
+        type: str
+        required: false
+        desc: |
+          The directory that will be prepended to relative paths in options specifying
+          config files controlled by Galaxy (such as shed_tool_config_file, etc.). Must be
+          writable by the user running Galaxy.  Defaults to `<config_dir>/` if running
+          Galaxy from source or `<data_dir>/config` otherwise.
+
       data_dir:
         type: str
         required: false
@@ -223,7 +232,7 @@ mapping:
           installation, whereas Galaxy will fail to start if any files in
           tool_config_file cannot be read.
 
-          The value of this option will be resolved with respect to <mutable_config_dir>.
+          The value of this option will be resolved with respect to <managed_config_dir>.
 
       check_migrate_tools:
         type: bool
@@ -245,7 +254,7 @@ mapping:
           scripts to install tools that have been migrated to the tool shed upon a new
           release, they will be added to this tool config file.
 
-          The value of this option will be resolved with respect to <mutable_config_dir>.
+          The value of this option will be resolved with respect to <managed_config_dir>.
 
       integrated_tool_panel_config:
         type: str
@@ -257,7 +266,7 @@ mapping:
           file can be changed by the Galaxy administrator to alter the layout of the
           tool panel.  If not present, Galaxy will create it.
 
-          The value of this option will be resolved with respect to <mutable_config_dir>.
+          The value of this option will be resolved with respect to <managed_config_dir>.
 
       tool_path:
         type: str
@@ -558,7 +567,7 @@ mapping:
           entries are automatically added to the following file, which is parsed and
           applied to the ToolDataTableManager at server start up.
 
-          The value of this option will be resolved with respect to <mutable_config_dir>.
+          The value of this option will be resolved with respect to <managed_config_dir>.
 
       tool_data_path:
         type: str
@@ -2444,7 +2453,7 @@ mapping:
           File where Tool Shed based Data Managers are configured. This file will be created
           automatically upon data manager installation.
 
-          The value of this option will be resolved with respect to <mutable_config_dir>.
+          The value of this option will be resolved with respect to <managed_config_dir>.
 
       galaxy_data_manager_data_path:
         type: str

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -181,7 +181,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         defaults = dict(
             auth_config_file=[self._in_config_dir('config/auth_conf.xml')],
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
-            shed_tool_data_table_config=[self._in_mutable_config_dir('shed_tool_data_table_conf.xml')],
+            shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
         )
 
         self._parse_config_file_options(defaults, dict(), kwargs)

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -19,6 +19,7 @@ Test assumptions for a default configuration:
 Configuration options NOT tested:
 - config_dir (value overridden for testing)
 - data_dir (value overridden for testing)
+- managed_config_dir (value depends on config_dir: see note above)
 - new_file_path (value overridden for testing)
 - logging (mapping loaded in config/; TODO)
 - dependency_resolution (nested properties; TODO)
@@ -42,7 +43,7 @@ PATH_CONFIG_PROPERTIES = [
     'root',
     'config_file',
     'config_dir',
-    'mutable_config_dir',
+    'managed_config_dir',
     'data_dir',
     'auth_config_file',
     'blacklist_file',
@@ -107,7 +108,7 @@ RESOLVE = {
     'auth_config_file': 'config_dir',
     'builds_file_path': 'tool_data_path',
     'dependency_resolvers_config_file': 'config_dir',
-    'integrated_tool_panel_config': 'config_dir',
+    'integrated_tool_panel_config': 'managed_config_dir',
     'involucro_path': 'root_dir',
     'job_resource_params_file': 'config_dir',
     'len_file_path': 'tool_data_path',
@@ -115,10 +116,10 @@ RESOLVE = {
     'oidc_backends_config_file': 'config_dir',
     'oidc_config_file': 'config_dir',
     'sanitize_whitelist_file': 'root_dir',
-    'shed_data_manager_config_file': 'mutable_config_dir',
-    'shed_tool_config_file': 'mutable_config_dir',
+    'shed_data_manager_config_file': 'managed_config_dir',
+    'shed_tool_config_file': 'managed_config_dir',
     'shed_tool_data_path': 'tool_data_path',
-    'shed_tool_data_table_config': 'mutable_config_dir',
+    'shed_tool_data_table_config': 'managed_config_dir',
     'tool_data_path': 'root_dir',
     'tool_path': 'root_dir',
     'tool_sheds_config_file': 'config_dir',
@@ -180,6 +181,7 @@ DO_NOT_TEST = [
     'job_working_directory',  # broken; may or may not be able to test
     'library_import_dir',  # broken: default overridden
     'logging',  # mapping loaded in config/
+    'managed_config_dir',  # depends on config_dir: see note above
     'markdown_export_css',  # default not used?
     'markdown_export_css_pages',  # default not used?
     'markdown_export_css_invocation_reports',  # default not used?
@@ -229,7 +231,7 @@ def get_config_data():
         return {
             'root_dir': DRIVER.app.config.root,
             'config_dir': DRIVER.app.config.config_dir,
-            'mutable_config_dir': DRIVER.app.config.mutable_config_dir,
+            'managed_config_dir': DRIVER.app.config.managed_config_dir,
             'data_dir': DRIVER.app.config.data_dir,
             'tool_data_path': DRIVER.app.config.tool_data_path,
         }


### PR DESCRIPTION
This replaces #9377 
As per recent discussions on gitter. Ref #9362
I haven't added any new tests or safeguards - it seems to be a straightforward change after all. Unless I'm missing something. I chose managed_config_dir, but I'm open to galaxy_managed_config_dir (or other suggestions).