### PR TITLE
Remove `virtualenv<20` requirement for mulled tests

### DIFF
--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -22,7 +22,7 @@ jobs:
         path: ~/.cache/pip
         key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
     - name: Install tox
-      run: pip install tox 'virtualenv<20'
+      run: pip install tox
     - name: run tests
       run: tox -e mulled
       working-directory: 'galaxy root'


### PR DESCRIPTION
Introduced in commit d8773a9598bcab47fb123dd6db54d0d31445c25d , it is not needed any more since virtualenv 20.0.6 fixed the issue.