### PR TITLE
Guess encoding and convert to utf-8 during upload

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -7,8 +7,10 @@ from __future__ import absolute_import
 
 import binascii
 import collections
+import contextlib
 import errno
 import importlib
+import io
 import json
 import os
 import random
@@ -42,6 +44,7 @@ from boltons.iterutils import (
     default_enter,
     remap,
 )
+from chardet.universaldetector import UniversalDetector
 from six import binary_type, iteritems, PY2, string_types, text_type
 from six.moves import (
     xrange,
@@ -123,6 +126,25 @@ def is_binary(value):
         if binary_char in value:
             return True
     return False
+
+
+def guess_encoding(fname, block_size=CHUNK_SIZE):
+    """Return detected source encoding"""
+    detector = UniversalDetector()
+    could_be_utf_8 = True
+    with open(fname, 'rb') as fh:
+        for chunk in file_reader(fh, block_size):
+            try:
+                chunk.decode('utf-8')
+            except UnicodeDecodeError:
+                # Always go with utf-8 if possible
+                could_be_utf_8 = False
+            detector.feed(chunk)
+            if detector.done:
+                break
+    detector.close()
+    result = detector.result['encoding'] if not could_be_utf_8 else 'utf-8'
+    return result
 
 
 def is_uuid(value):
@@ -215,12 +237,12 @@ def file_iter(fname, sep=None):
 
 def file_reader(fp, chunk_size=CHUNK_SIZE):
     """This generator yields the open fileobject in chunks (default 64k). Closes the file at the end"""
-    while 1:
-        data = fp.read(chunk_size)
-        if not data:
-            break
-        yield data
-    fp.close()
+    sentinel = b"" if 'b' in fp.mode else ""
+    try:
+        for chunk in iter(partial(fp.read, CHUNK_SIZE), sentinel):
+            yield chunk
+    finally:
+        fp.close()
 
 
 def unique_id(KEY_SIZE=128):
@@ -1279,6 +1301,15 @@ def stringify_dictionary_keys(in_dict):
     for key, value in iteritems(in_dict):
         out_dict[str(key)] = value
     return out_dict
+
+
+@contextlib.contextmanager
+def writable_mkstemp(final_destination=None, mode='wb', **kwargs):
+    fd, temp_name = tempfile.mkstemp(*kwargs)
+    with io.open(fd, mode=mode) as fh:
+        yield temp_name, fh
+    if final_destination:
+        shutil.move(temp_name, final_destination)
 
 
 def mkstemp_ln(src, prefix='mkstemp_ln_'):

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -4,6 +4,7 @@ import sys
 import tarfile
 import zipfile
 
+import chardet
 from six import BytesIO
 from six.moves import filter
 
@@ -60,6 +61,9 @@ def check_binary(name, file_path=True):
     else:
         temp = BytesIO(name)
     try:
+        chunk = temp.read(1024)
+        if chardet.detect(chunk)['encoding']:
+            return False
         return util.is_binary(temp.read(1024))
     finally:
         temp.close()

--- a/packages/util/requirements.txt
+++ b/packages/util/requirements.txt
@@ -1,5 +1,6 @@
 bleach
 boltons
+chardet
 bz2file; python_version < '3.3'
 docutils
 markupsafe

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -1,5 +1,7 @@
 from tempfile import NamedTemporaryFile
 
+import pytest
+
 from galaxy import util
 
 SECTION_XML = """<?xml version="1.0" ?>
@@ -27,6 +29,19 @@ def test_strip_control_characters_nested():
     assert util.strip_control_characters_nested(l)[0] == stripped_s
     assert util.strip_control_characters_nested(t)[0] == stripped_s
     assert util.strip_control_characters_nested(d)[42] == stripped_s
+
+
+@pytest.mark.parametrize('b,encoding', [
+    (b'ABCDEF', 'utf-8'),
+    ('héllo@galaxy'.encode('ISO-8859-1'), 'ISO-8859-1'),
+    (b'\x1f\x8b\x08\x04\x00\x00\x00\x00\x00\xff\x06\x00BC\x02\x00\xeb\r\x9dZModW\x11\xf5\xb0', None),
+])
+def test_guess_encoding(b, encoding):
+    with NamedTemporaryFile(mode='wb') as fh:
+        fh.write(b)
+        fh.flush()
+        guessed_encoding = util.guess_encoding(fh.name)
+    assert guessed_encoding == encoding, "Expected encoding %s, got %s" % (encoding, guessed_encoding)
 
 
 def test_parse_xml_string():


### PR DESCRIPTION
This uses the chardet library, but overwrites any guessed
encoding with utf-8 if no UnicodeDecodeError is raised.

This also makes the is_binary check more stringent, allowing sniffing of
datasets with charpoints out of the utf-8 range (latin-1
and various windows encodings elicit this).

Closes https://github.com/galaxyproject/galaxy/issues/5250