### PR TITLE
Move sanitize_whitelist into mutable_config_dir

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2150,7 +2150,9 @@
     this file are trusted and will not have their HTML sanitized on
     display.  This can be manually edited or manipulated through the
     Admin control panel -- see "Manage Display Whitelist"
-:Default: ``config/sanitize_whitelist.txt``
+    The value of this option will be resolved with respect to
+    <mutable_config_dir>.
+:Default: ``sanitize_whitelist.txt``
 :Type: str
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -485,7 +485,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.pbs_dataset_server = kwargs.get('pbs_dataset_server', "")
         self.pbs_dataset_path = kwargs.get('pbs_dataset_path', "")
         self.pbs_stage_path = kwargs.get('pbs_stage_path', "")
-        self.sanitize_whitelist_file = os.path.join(self.root, self.sanitize_whitelist_file)
+        self.sanitize_whitelist_file = self._in_mutable_config_dir(self.sanitize_whitelist_file)
         self.allowed_origin_hostnames = self._parse_allowed_origin_hostnames(kwargs)
         if "trust_jupyter_notebook_conversion" not in kwargs:
             # if option not set, check IPython-named alternative, falling back to schema default if not set either

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -485,7 +485,17 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.pbs_dataset_server = kwargs.get('pbs_dataset_server', "")
         self.pbs_dataset_path = kwargs.get('pbs_dataset_path', "")
         self.pbs_stage_path = kwargs.get('pbs_stage_path', "")
-        self.sanitize_whitelist_file = self._in_mutable_config_dir(self.sanitize_whitelist_file)
+
+        _sanitize_whitelist_path = self._in_managed_config_dir(self.sanitize_whitelist_file)
+        if not os.path.isfile(_sanitize_whitelist_path):  # then check old default location
+            deprecated = os.path.join(self.root, 'config/sanitize_whitelist.txt')
+            if os.path.isfile(deprecated):
+                log.warning("The path '%s' for the 'sanitize_whitelist_file' config option is "
+                    "deprecated and will be no longer checked in a future release. Please consult "
+                    "the latest version of the sample configuration file." % deprecated)
+                _sanitize_whitelist_path = deprecated
+        self.sanitize_whitelist_file = _sanitize_whitelist_path
+
         self.allowed_origin_hostnames = self._parse_allowed_origin_hostnames(kwargs)
         if "trust_jupyter_notebook_conversion" not in kwargs:
             # if option not set, check IPython-named alternative, falling back to schema default if not set either

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1085,7 +1085,9 @@ galaxy:
   # this file are trusted and will not have their HTML sanitized on
   # display.  This can be manually edited or manipulated through the
   # Admin control panel -- see "Manage Display Whitelist"
-  #sanitize_whitelist_file: config/sanitize_whitelist.txt
+  # The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
+  #sanitize_whitelist_file: sanitize_whitelist.txt
 
   # By default Galaxy will serve non-HTML tool output that may
   # potentially contain browser executable JavaScript content as plain

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1579,13 +1579,15 @@ mapping:
 
       sanitize_whitelist_file:
         type: str
-        default: config/sanitize_whitelist.txt
+        default: sanitize_whitelist.txt
         required: false
         desc: |
           Whitelist sanitization file.
           Datasets created by tools listed in this file are trusted and will not have
           their HTML sanitized on display.  This can be manually edited or manipulated
           through the Admin control panel -- see "Manage Display Whitelist"
+
+          The value of this option will be resolved with respect to <mutable_config_dir>.
 
       serve_xss_vulnerable_mimetypes:
         type: bool

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -115,7 +115,7 @@ RESOLVE = {
     'object_store_config_file': 'config_dir',
     'oidc_backends_config_file': 'config_dir',
     'oidc_config_file': 'config_dir',
-    'sanitize_whitelist_file': 'root_dir',
+    'sanitize_whitelist_file': 'managed_config_dir',
     'shed_data_manager_config_file': 'managed_config_dir',
     'shed_tool_config_file': 'managed_config_dir',
     'shed_tool_data_path': 'tool_data_path',


### PR DESCRIPTION
As per recent discussion on gitter.
Rationale: keep consistent with galaxy helm chart setup (see https://gitter.im/galaxyproject/dev?at=5e5804e25c32162f5ba51485 ) 
Ping @almahmoud @dannon 