### PR TITLE
Fix `test_run_simple()` test broken on Python 2 by virtualenv 20.0.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,9 @@ jobs:
     <<: *set_workdir
     steps:
       - *restore_repo_cache
-      - *install_tox
+      # Temporary virtualenv pin added due to https://github.com/pypa/virtualenv/issues/1670
+      #- *install_tox
+      - run: sudo pip install tox virtualenv==20.0.4
       - run: tox -e py27-unit
   py35_docstring:
     docker:

--- a/test/unit/jobs/test_expression_run.py
+++ b/test/unit/jobs/test_expression_run.py
@@ -32,15 +32,14 @@ def test_run_simple():
         if "PYTHONPATH" in new_env:
             new_env['PYTHONPATH'] = "%s:%s" % (LIB_DIRECTORY, new_env["PYTHONPATH"])
         else:
-            new_env['PYTHONPATH'] = "%s" % (LIB_DIRECTORY)
+            new_env['PYTHONPATH'] = LIB_DIRECTORY
         new_env['GALAXY_EXPRESSION_INPUTS'] = environment_path
-        p = subprocess.Popen(
+        subprocess.check_call(
             args=expressions.EXPRESSION_SCRIPT_CALL,
             shell=True,
             cwd=test_directory,
             env=new_env,
         )
-        assert p.wait() == 0
         with open(os.path.join(test_directory, 'moo')) as f:
             out_content = f.read()
         assert out_content == '7', out_content


### PR DESCRIPTION
xref. pypa/virtualenv#1670

Example of failing py27-unit build on CircleCI: https://app.circleci.com/jobs/github/galaxyproject/galaxy/73395