### PR TITLE
[20.01] Drop manage_dependency_relationships option

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -697,19 +697,6 @@
 :Type: int
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``manage_dependency_relationships``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Enable use of an in-memory registry with bi-directional
-    relationships between repositories (i.e., in addition to lists of
-    dependencies for a repository, keep an in-memory registry of
-    dependent items for each repository.
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``tool_data_table_config_path``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -91,9 +91,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         check_migrate_tools = self.config.check_migrate_tools
         self._configure_models(check_migrate_databases=self.config.check_migrate_databases, check_migrate_tools=check_migrate_tools, config_file=config_file)
 
-        # Manage installed tool shed repositories.
         self.installed_repository_manager = InstalledRepositoryManager(self)
-
         self._configure_datatypes_registry(self.installed_repository_manager)
         galaxy.model.set_datatypes_registry(self.datatypes_registry)
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -447,12 +447,6 @@ galaxy:
   # between 1 and 24.
   #hours_between_check: 12
 
-  # Enable use of an in-memory registry with bi-directional
-  # relationships between repositories (i.e., in addition to lists of
-  # dependencies for a repository, keep an in-memory registry of
-  # dependent items for each repository.
-  #manage_dependency_relationships: false
-
   # XML config file that contains data table entries for the
   # ToolDataTableManager.  This file is manually # maintained by the
   # Galaxy administrator (.sample used if default does not exist).

--- a/lib/galaxy/tool_shed/galaxy_install/install_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/install_manager.py
@@ -215,10 +215,6 @@ class InstallToolDependencyManager(object):
                         if tool_dependency and tool_dependency.status in [self.install_model.ToolDependency.installation_status.INSTALLED,
                                                                           self.install_model.ToolDependency.installation_status.ERROR]:
                             installed_packages.append(tool_dependency)
-                            if self.app.config.manage_dependency_relationships:
-                                # Add the tool_dependency to the in-memory dictionaries in the installed_repository_manager.
-                                self.app.installed_repository_manager.handle_tool_dependency_install(tool_shed_repository,
-                                                                                                     tool_dependency)
         return installed_packages
 
     def install_via_fabric(self, tool_shed_repository, tool_dependency, install_dir, package_name=None, custom_fabfile_path=None,
@@ -946,10 +942,6 @@ class InstallRepositoryManager(object):
                 basic_util.remove_dir(work_dir)
             self.update_tool_shed_repository_status(tool_shed_repository,
                                                     self.install_model.ToolShedRepository.installation_status.INSTALLED)
-            if self.app.config.manage_dependency_relationships:
-                # Add the installed repository and any tool dependencies to the in-memory dictionaries
-                # in the installed_repository_manager.
-                self.app.installed_repository_manager.handle_repository_install(tool_shed_repository)
         else:
             # An error occurred while cloning the repository, so reset everything necessary to enable another attempt.
             repository_util.set_repository_attributes(self.app,

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -528,15 +528,6 @@ mapping:
           server process should be able to check for repository updates.  The
           setting for hours_between_check should be an integer between 1 and 24.
 
-      manage_dependency_relationships:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          Enable use of an in-memory registry with bi-directional relationships between
-          repositories (i.e., in addition to lists of dependencies for a repository,
-          keep an in-memory registry of dependent items for each repository.
-
       tool_data_table_config_path:
         type: str
         default: config/tool_data_table_conf.xml


### PR DESCRIPTION
Fixes
```
galaxy.tool_shed.galaxy_install.installed_repository_manager DEBUG 2020-02-28 10:57:01,109 [p:94029,w:0,m:0] [MainThread] Adding an entry for version 2.2.4 of package bowtie2 to runtime_tool_dependencies_of_installed_tool_dependencies.
Traceback (most recent call last):
  File "lib/galaxy/webapps/galaxy/buildapp.py", line 48, in app_factory
    app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
  File "lib/galaxy/app.py", line 95, in __init__
    self.installed_repository_manager = InstalledRepositoryManager(self)
  File "lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py", line 84, in __init__
    self.load_dependency_relationships()
  File "lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py", line 734, in load_dependency_relationships
    self.add_entry_to_runtime_tool_dependencies_of_installed_tool_dependencies(tool_dependency)
  File "lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py", line 218, in add_entry_to_runtime_tool_dependencies_of_installed_tool_dependencies
    status=None)
  File "lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py", line 604, in get_runtime_dependent_tool_dependency_tuples
    required_env_shell_file_path = tool_dependency.get_env_shell_file_path(self.app)
  File "lib/galaxy/model/tool_shed_install/__init__.py", line 522, in get_env_shell_file_path
    installation_directory = self.installation_directory(app)
  File "lib/galaxy/model/tool_shed_install/__init__.py", line 534, in installation_directory
    return os.path.join(app.tool_dependency_dir,
  File "lib/galaxy/config/__init__.py", line 1186, in tool_dependency_dir
    return self.toolbox.dependency_manager.default_base_path
AttributeError: 'UniverseApplication' object has no attribute 'toolbox'
```
reported by @scholtalbers