### PR TITLE
fix options_filter_attribute: needs to be str

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1913,7 +1913,7 @@ class DataToolParameter(BaseDataToolParameter):
             ref = getattr(ref, attribute)
         if call_attribute:
             ref = ref()
-        return ref
+        return str(ref)
 
     def to_dict(self, trans, other_values={}):
         # create dictionary and fill default parameters


### PR DESCRIPTION
since in the tool xml the values can only be specified as str
also the attribute needs to be a str. currently, for instance,
filtering for non-str (e.g. int) metadata values does not work.

for instance this does not work so far

```
    <param ... type="data" format="fasta">
      <options options_filter_attribute="metadata.sequences">
        <filter type="add_value" value="1"/>
      </options>
    </param>
```

Not sure if there is another/better method to filter data params by metadata...?