### PR TITLE
Remove mapping related abstraction classes from workflow client, increase node header contrast

### DIFF
--- a/client/galaxy/scripts/components/Workflow/Editor/Node.test.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.test.js
@@ -11,15 +11,15 @@ describe("Node", () => {
                 type: "tool"
             }
         });
-        const icon = wrapper.find("i");
-        expect(icon.classes()).to.contain("fa-wrench");
-        const toolLinks = wrapper.findAll("a");
-        expect(toolLinks.length).to.equal(2);
+        const icon = wrapper.findAll("i");
+        expect(icon.at(2).classes()).to.contain("fa-wrench");
+        const toolLinks = wrapper.findAll("i");
+        expect(toolLinks.length).to.equal(3);
         wrapper.setProps({ type: "subworkflow" });
         await Vue.nextTick();
-        expect(icon.classes()).to.contain("fa-sitemap");
-        const subworkflowLinks = wrapper.findAll("a");
-        expect(subworkflowLinks.length).to.equal(1);
+        expect(icon.at(2).classes()).to.contain("fa-sitemap");
+        const subworkflowLinks = wrapper.findAll("i");
+        expect(subworkflowLinks.length).to.equal(2);
         const workflowTitle = wrapper.find(".node-title");
         expect(workflowTitle.text()).to.equal("node-title");
     });

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div class="node-header unselectable clearfix">
-            <b-dropdown right no-caret class="float-right" toggle-class="py-0" offset="50" variant="info" size="sm">
+            <b-dropdown right no-caret class="node-dropdown float-right" toggle-class="py-0" offset="50" variant="info" size="sm">
                 <template v-slot:button-content>
                     <i :class="iconClass" />
                 </template>

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -1,7 +1,6 @@
 <template>
     <div>
         <div class="node-header unselectable clearfix">
-            <span class="node-title">{{ title }}</span>
             <b-dropdown right no-caret class="float-right" toggle-class="py-0" offset="50" variant="info" size="sm">
                 <template v-slot:button-content>
                     <i :class="iconClass" />
@@ -28,6 +27,7 @@
                     Remove
                 </b-dropdown-item>
             </b-dropdown>
+            <span class="node-title">{{ title }}</span>
         </div>
         <div class="node-body">
             <div>

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -7,7 +7,7 @@
                 class="node-dropdown float-right"
                 toggle-class="py-0"
                 offset="50"
-                variant="info"
+                variant="primary"
                 size="sm"
             >
                 <template v-slot:button-content>

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -38,8 +38,12 @@
 </template>
 
 <script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
 import WorkflowIcons from "components/Workflow/icons";
 import LoadingSpan from "components/LoadingSpan";
+
+Vue.use(BootstrapVue);
 
 export default {
     components: {

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -1,40 +1,26 @@
 <template>
     <div>
         <div class="node-header unselectable clearfix">
-            <b-dropdown
-                right
-                no-caret
-                class="node-dropdown float-right"
-                toggle-class="py-0"
-                offset="50"
+            <b-button
+                class="node-destroy py-0 float-right"
                 variant="primary"
                 size="sm"
+                aria-label="clone node"
+                @click="onDestroy"
             >
-                <template v-slot:button-content>
-                    <i :class="iconClass" />
-                </template>
-                <b-dropdown-item
-                    v-if="canClone"
-                    aria-label="clone node"
-                    role="button"
-                    href="#"
-                    class="node-clone"
-                    @click="onClone"
-                >
-                    <span class="fa fa-fw fa-files-o" />
-                    Duplicate
-                </b-dropdown-item>
-                <b-dropdown-item
-                    aria-label="destroy node"
-                    role="button"
-                    href="#"
-                    class="node-destroy"
-                    @click="onDestroy"
-                >
-                    <span class="fa fa-fw fa-trash" />
-                    Remove
-                </b-dropdown-item>
-            </b-dropdown>
+                <i class="fa fa-times" />
+            </b-button>
+            <b-button
+                v-if="canClone"
+                class="node-clone py-0 float-right"
+                variant="primary"
+                size="sm"
+                aria-label="clone node"
+                @click="onClone"
+            >
+                <i class="fa fa-files-o" />
+            </b-button>
+            <i :class="iconClass" />
             <span class="node-title">{{ title }}</span>
         </div>
         <div class="node-body">

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -14,7 +14,7 @@
                     class="node-clone"
                     @click="onClone"
                 >
-                    <span class="fa-icon-button fa fa-files-o" />
+                    <span class="fa fa-fw fa-files-o" />
                     Duplicate
                 </b-dropdown-item>
                 <b-dropdown-item
@@ -24,7 +24,7 @@
                     class="node-destroy"
                     @click="onDestroy"
                 >
-                    <span class="fa-icon-button fa fa-fw fa-trash" />
+                    <span class="fa fa-fw fa-trash" />
                     Remove
                 </b-dropdown-item>
             </b-dropdown>

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -5,23 +5,29 @@
                 <i :class="iconClass" />
                 <span class="node-title">{{ title }}</span>
             </div>
-            <div class="buttons float-right">
-                <a
+            <b-dropdown right class="float-right" toggle-class="py-0" offset="50" variant="primary" size="sm">
+                <b-dropdown-item
                     v-if="canClone"
-                    class="fa-icon-button fa fa-files-o node-clone"
                     aria-label="clone node"
                     role="button"
                     href="#"
+                    class="node-clone"
                     @click="onClone"
-                />
-                <a
-                    class="fa-icon-button fa fa-times node-destroy"
+                >
+                    <span class="fa-icon-button fa fa-files-o" />
+                    Duplicate
+                </b-dropdown-item>
+                <b-dropdown-item
                     aria-label="destroy node"
                     role="button"
                     href="#"
+                    class="node-destroy"
                     @click="onDestroy"
-                />
-            </div>
+                >
+                    <span class="fa-icon-button fa fa-fw fa-trash" />
+                    Remove
+                </b-dropdown-item>
+            </b-dropdown>
         </div>
         <div class="node-body">
             <div>

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -65,7 +65,7 @@ export default {
         iconClass() {
             const iconType = WorkflowIcons[this.type];
             if (iconType) {
-                return `icon fa ${iconType}`;
+                return `icon fa fa-fw ${iconType}`;
             }
             return null;
         },

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -1,7 +1,15 @@
 <template>
     <div>
         <div class="node-header unselectable clearfix">
-            <b-dropdown right no-caret class="node-dropdown float-right" toggle-class="py-0" offset="50" variant="info" size="sm">
+            <b-dropdown
+                right
+                no-caret
+                class="node-dropdown float-right"
+                toggle-class="py-0"
+                offset="50"
+                variant="info"
+                size="sm"
+            >
                 <template v-slot:button-content>
                     <i :class="iconClass" />
                 </template>

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -1,11 +1,11 @@
 <template>
     <div>
         <div class="node-header unselectable clearfix">
-            <div class="header float-left">
-                <i :class="iconClass" />
-                <span class="node-title">{{ title }}</span>
-            </div>
-            <b-dropdown right class="float-right" toggle-class="py-0" offset="50" variant="primary" size="sm">
+            <span class="node-title">{{ title }}</span>
+            <b-dropdown right no-caret class="float-right" toggle-class="py-0" offset="50" variant="info" size="sm">
+                <template v-slot:button-content>
+                    <i :class="iconClass" />
+                </template>
                 <b-dropdown-item
                     v-if="canClone"
                     aria-label="clone node"

--- a/client/galaxy/scripts/components/Workflow/Editor/services.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/services.js
@@ -45,6 +45,7 @@ export async function loadWorkflow(workflow, id, version) {
         workflow.canvas_manager.draw_overview();
         return data;
     } catch (e) {
+        console.debug(e);
         rethrowSimple(e);
     }
 }

--- a/client/galaxy/scripts/mvc/workflow/workflow-connector.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-connector.js
@@ -7,7 +7,6 @@ const zIndex = 1000;
 const cpFactor = 10;
 const canvasExtra = 100;
 const handleMarginX = 8;
-const handleMarginY = 5;
 const ribbonMargin = 4;
 const ribbonInnerSingle = 4;
 const ribbonOuterSingle = 6;
@@ -91,9 +90,9 @@ class Connector {
 
         // Find the position of each handle
         let start_x = relativeLeft(handle1.element) + handleMarginX;
-        let start_y = relativeTop(handle1.element) + handleMarginY;
+        let start_y = relativeTop(handle1.element) + 0.5 * $(handle1.element).height();
         let end_x = relativeLeft(handle2.element) + handleMarginX;
-        let end_y = relativeTop(handle2.element) + handleMarginY;
+        let end_y = relativeTop(handle2.element) + 0.5 * $(handle2.element).height();
 
         // Calculate canvas area
         const canvas_min_x = Math.min(start_x, end_x);

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -51,6 +51,7 @@ class Workflow extends EventEmitter {
         node.update_field_data(data);
         $.each(node.output_terminals, (ot_id, ot) => {
             node.addWorkflowOutput(ot.name);
+            node.markWorkflowOutput(ot.name);
         });
         this.activate_node(node);
     }

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import { getGalaxyInstance } from "app";
 import Connector from "mvc/workflow/workflow-connector";
 import { Toast } from "ui/toast";
 import { Node } from "mvc/workflow/workflow-node";
@@ -48,18 +47,10 @@ class Workflow extends EventEmitter {
         };
     }
     set_node(node, data) {
-        const Galaxy = getGalaxyInstance();
         node.init_field_data(data);
         node.update_field_data(data);
-        // Post init/update, for new modules we want to default to
-        // nodes being outputs
-        // TODO: Overhaul the handling of all this when we modernize
-        // the editor, replace callout image manipulation with a simple
-        // class toggle, etc.
         $.each(node.output_terminals, (ot_id, ot) => {
             node.addWorkflowOutput(ot.name);
-            var callout = $(node.element).find(`.callout.${ot.name.replace(/(?=[()])/g, "\\")}`);
-            callout.find("img").attr("src", `${Galaxy.root}static/images/fugue/asterisk-small.png`);
         });
         this.activate_node(node);
     }
@@ -102,7 +93,6 @@ class Workflow extends EventEmitter {
     attemptUpdateOutputLabel(node, outputName, label) {
         if (this.canLabelOutputWith(label)) {
             node.labelWorkflowOutput(outputName, label);
-            node.nodeView.redrawWorkflowOutputs();
             return true;
         } else {
             return false;

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -319,7 +319,7 @@ export class Node {
         });
         // Cleanup any leftover terminals
         _.each(_.difference(_.values(nodeView.terminalViews), _.values(newTerminalViews)), unusedView => {
-            unusedView.el.terminal.destroy();
+            unusedView.terminal.destroy();
         });
         nodeView.terminalViews = newTerminalViews;
         node.nodeView.render();

--- a/client/galaxy/scripts/mvc/workflow/workflow-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-node.js
@@ -116,7 +116,7 @@ export class Node {
     _connectedMappedTerminals(terminals) {
         var mapped_outputs = [];
         $.each(terminals, (_, t) => {
-            var mapOver = t.mapOver();
+            var mapOver = t.mapOver;
             if (mapOver.isCollection) {
                 if (t.connectors.length > 0) {
                     mapped_outputs.push(t);
@@ -131,7 +131,7 @@ export class Node {
     _mappedTerminals(terminals) {
         var mappedTerminals = [];
         $.each(terminals, (_, t) => {
-            var mapOver = t.mapOver();
+            var mapOver = t.mapOver;
             if (mapOver.isCollection) {
                 mappedTerminals.push(t);
             }
@@ -141,7 +141,7 @@ export class Node {
     hasMappedOverInputTerminals() {
         var found = false;
         _.each(this.input_terminals, t => {
-            var mapOver = t.mapOver();
+            var mapOver = t.mapOver;
             if (mapOver.isCollection) {
                 found = true;
             }

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -137,6 +137,7 @@ class Terminal extends EventEmitter {
         $.each(this.connectors.slice(), (_, c) => {
             c.destroy();
         });
+        this.emit("change");
     }
     destroyInvalidConnections() {
         _.each(this.connectors, connector => {
@@ -144,6 +145,7 @@ class Terminal extends EventEmitter {
                 connector.destroyIfInvalid();
             }
         });
+        this.emit("change");
     }
     setMapOver(val) {
         let output_val = val;

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -126,6 +126,7 @@ class Terminal extends EventEmitter {
                 connector.handle2.resetCollectionTypeSource();
             }
         }
+        this.emit("change");
     }
     redraw() {
         $.each(this.connectors, (_, c) => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-terminals.js
@@ -171,6 +171,7 @@ class Terminal extends EventEmitter {
     }
     resetMapping() {
         this.mapOver = NULL_COLLECTION_TYPE_DESCRIPTION;
+        this.emit("change");
     }
     resetCollectionTypeSource() {
         const node = this.node;
@@ -375,7 +376,7 @@ class BaseInputTerminal extends Terminal {
 }
 
 class InputTerminal extends BaseInputTerminal {
-    update(input) {
+    update(input = {}) {
         this.datatypes = input.extensions;
         this.multiple = input.multiple;
         this.optional = input.optional;

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -127,12 +127,12 @@ export class OutputCalloutView {
         this.output = options.output;
         const view = this;
         const node = this.node;
+        const outputName = view.output.name;
         this.$el
-            .attr("class", `callout-terminal ${this.label}`)
+            .attr("class", `callout-terminal ${outputName}`)
             .css({ display: "none" })
             .append(
-                $("<icon class='mark-terminal fa fa-asterisk'/>").click(() => {
-                    const outputName = view.output.name;
+                $("<icon />").addClass("mark-terminal fa fa-asterisk").click(() => {
                     if (node.isWorkflowOutput(outputName)) {
                         node.removeWorkflowOutput(outputName);
                         view.$el.find("icon").removeClass("mark-terminal-active");

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -135,7 +135,6 @@ export class OutputCalloutView {
                 $("<icon />")
                     .addClass("mark-terminal")
                     .click(() => {
-                        this.render();
                         if (node.isWorkflowOutput(outputName)) {
                             node.removeWorkflowOutput(outputName);
                         } else {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -5,7 +5,7 @@ export class DataInputView {
         this.input = options.input;
         this.nodeView = options.nodeView;
         this.terminalElement = options.terminalElement;
-        this.$el = $("<div class='form-row dataRow input-data-row'/>");
+        this.$el = $(`<div class="form-row dataRow input-data-row"/>`);
         this.$el.attr("name", this.input.name).html(this.input.label || this.input.name);
         if (!options.skipResize) {
             this.$el.css({
@@ -29,7 +29,7 @@ export class DataInputView {
 
 export class DataOutputView {
     constructor(app, options = {}) {
-        this.$el = $("<div class='form-row dataRow'/>");
+        this.$el = $(`<div class="form-row dataRow"/>`);
         this.output = options.output;
         this.terminalElement = options.terminalElement;
         this.nodeView = options.nodeView;
@@ -37,8 +37,9 @@ export class DataOutputView {
         let label = output.label || output.name;
         const node = this.nodeView.node;
         const isInput = output.extensions.indexOf("input") >= 0;
+        const datatype = output.force_datatype || output.extensions.join(", ");
         if (!isInput) {
-            label = `${label} (${output.force_datatype || output.extensions.join(", ")})`;
+            label = `${label} (${datatype})`;
         }
         this.$el.html(label);
         this.calloutView = null;
@@ -49,7 +50,7 @@ export class DataOutputView {
                 node: node
             });
             this.calloutView = calloutView;
-            this.$el.append(calloutView.$el);
+            this.$el.prepend(calloutView.$el);
         }
         this.$el.css({
             position: "absolute",
@@ -70,14 +71,14 @@ export class DataOutputView {
     }
     redrawWorkflowOutput() {
         if (this.calloutView) {
-            this.calloutView.resetImage();
+            this.calloutView.render();
         }
     }
 }
 
 export class ParameterOutputView {
     constructor(app, options = {}) {
-        this.$el = $("<div class='form-row dataRow'/>");
+        this.$el = $(`<div class="form-row dataRow"/>`);
         this.output = options.output;
         this.terminalElement = options.terminalElement;
         this.nodeView = options.nodeView;
@@ -114,7 +115,7 @@ export class ParameterOutputView {
     }
     redrawWorkflowOutput() {
         if (this.calloutView) {
-            this.calloutView.resetImage();
+            this.calloutView.render();
         }
     }
 }
@@ -130,18 +131,17 @@ export class OutputCalloutView {
         const outputName = view.output.name;
         this.$el
             .attr("class", `callout-terminal ${outputName}`)
-            .css({ display: "none" })
             .append(
                 $("<icon />")
-                    .addClass("mark-terminal fa fa-asterisk")
+                    .addClass("mark-terminal")
                     .click(() => {
+                        this.render();
                         if (node.isWorkflowOutput(outputName)) {
                             node.removeWorkflowOutput(outputName);
-                            view.$el.find("icon").removeClass("mark-terminal-active");
                         } else {
                             node.addWorkflowOutput(outputName);
-                            view.$el.find("icon").addClass("mark-terminal-active");
                         }
+                        this.render();
                         app.has_changes = true;
                         app.canvas_manager.draw_overview();
                     })
@@ -150,16 +150,9 @@ export class OutputCalloutView {
                 delay: 500,
                 title: "Mark dataset as a workflow output. All unmarked datasets will be hidden."
             });
-
-        this.$el.css({
-            top: "50%",
-            margin: "-8px 0px 0px 0px",
-            right: 8
-        });
-        this.$el.show();
-        this.resetImage();
+        this.render();
     }
-    resetImage() {
+    render() {
         if (!this.node.isWorkflowOutput(this.output.name)) {
             this.$el.find("icon").removeClass("mark-terminal-active");
         } else {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -132,17 +132,19 @@ export class OutputCalloutView {
             .attr("class", `callout-terminal ${outputName}`)
             .css({ display: "none" })
             .append(
-                $("<icon />").addClass("mark-terminal fa fa-asterisk").click(() => {
-                    if (node.isWorkflowOutput(outputName)) {
-                        node.removeWorkflowOutput(outputName);
-                        view.$el.find("icon").removeClass("mark-terminal-active");
-                    } else {
-                        node.addWorkflowOutput(outputName);
-                        view.$el.find("icon").addClass("mark-terminal-active");
-                    }
-                    app.has_changes = true;
-                    app.canvas_manager.draw_overview();
-                })
+                $("<icon />")
+                    .addClass("mark-terminal fa fa-asterisk")
+                    .click(() => {
+                        if (node.isWorkflowOutput(outputName)) {
+                            node.removeWorkflowOutput(outputName);
+                            view.$el.find("icon").removeClass("mark-terminal-active");
+                        } else {
+                            node.addWorkflowOutput(outputName);
+                            view.$el.find("icon").addClass("mark-terminal-active");
+                        }
+                        app.has_changes = true;
+                        app.canvas_manager.draw_overview();
+                    })
             )
             .tooltip({
                 delay: 500,

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -148,7 +148,7 @@ export class OutputCalloutView {
             )
             .tooltip({
                 delay: 500,
-                title: "Mark dataset as a workflow output. All unmarked datasets will be hidden."
+                title: "Check dataset as output, unchecked datasets will be hidden."
             });
         this.render();
     }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-data.js
@@ -126,9 +126,8 @@ export class OutputCalloutView {
         this.label = options.label;
         this.node = options.node;
         this.output = options.output;
-        const view = this;
         const node = this.node;
-        const outputName = view.output.name;
+        const outputName = this.output.name;
         this.$el
             .attr("class", `callout-terminal ${outputName}`)
             .append(
@@ -147,7 +146,7 @@ export class OutputCalloutView {
             )
             .tooltip({
                 delay: 500,
-                title: "Check dataset as output, unchecked datasets will be hidden."
+                title: "Unchecked output datasets will be hidden."
             });
         this.render();
     }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -86,7 +86,7 @@ export class NodeView {
             skipResize: skipResize
         });
         var ib = inputView.$el;
-        body.append(ib.prepend(terminalView.terminalElements()));
+        body.append(ib.prepend(terminalView.el));
         return terminalView;
     }
 
@@ -116,7 +116,7 @@ export class NodeView {
         const terminalView = this.terminalViewForOutput(output);
         const outputView = this.outputViewforOutput(output, terminalView);
         this.outputViews[output.name] = outputView;
-        this.node_body.append(outputView.$el.append(terminalView.terminalElements()));
+        this.node_body.append(outputView.$el.append(terminalView.el));
     }
 
     redrawWorkflowOutputs() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-node.js
@@ -64,7 +64,7 @@ export class NodeView {
             terminalViewClass = TerminalViews.InputParameterTerminalView;
         }
         if (terminalView && !(terminalView instanceof terminalViewClass)) {
-            terminalView.el.terminal.destroy();
+            terminalView.terminal.destroy();
             terminalView = null;
         }
         if (!terminalView) {
@@ -73,7 +73,7 @@ export class NodeView {
                 input: input
             });
         } else {
-            var terminal = terminalView.el.terminal;
+            var terminal = terminalView.terminal;
             terminal.update(input);
             terminal.destroyInvalidConnections();
         }

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -31,15 +31,14 @@ class BaseInputTerminalView {
         this.$el.on("dropend", (e, d) => self.onDropEnd(e, d));
         this.$el.on("drop", (e, d) => self.onDrop(e, d));
         this.$el.on("hover", () => self.onHover());
-        //this.terminal.on("change", this.render.bind(this));
+        this.terminal.on("change", this.render.bind(this));
     }
     render() {
-        console.log("here");
-        /*if (this.terminal.mapOver && this.terminal.mapOver.isCollection) {
-             this.$el.addClass("multiple");
-         } else {
-             this.$el.removeClass("multiple");
-         }*/
+        if (this.terminal.mapOver && this.terminal.mapOver.isCollection) {
+            this.$el.find("icon").addClass("multiple");
+        } else {
+            this.$el.find("icon").removeClass("multiple");
+        }
     }
     onDropInit(e, d = {}) {
         var terminal = this.terminal;
@@ -182,6 +181,14 @@ export class BaseOutputTerminalView {
         this.$el.on("dragstart", (d, e) => self.onDragStart(d, e));
         this.$el.on("dragend", (d, e) => self.onDragEnd(d, e));
         this.$el.on("keydown", e => self.screenReaderSelectOutputNode(e));
+        this.terminal.on("change", this.render.bind(this));
+    }
+    render() {
+        if (this.terminal.mapOver && this.terminal.mapOver.isCollection) {
+            this.$el.find("icon").addClass("multiple");
+        } else {
+            this.$el.find("icon").removeClass("multiple");
+        }
     }
     screenReaderSelectOutputNode(e) {
         const inputChoiceKeyDown = e => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -227,7 +227,6 @@ export class BaseOutputTerminalView {
                     removeMenu();
                     new Connector(this.app.canvas_manager, this.terminal, inputTerminal).redraw();
                     ariaAlert("Node connected");
-
                     if (inputTerminal.connectors.length > 0) {
                         const t = $("<div/>")
                             .addClass("delete-terminal")
@@ -266,7 +265,6 @@ export class BaseOutputTerminalView {
             inputChoicesMenu.setAttribute("role", "menu");
             this.$el.attr("aria-grabbed", "true");
             this.$el.attr("aria-owns", "input-choices-menu");
-
             $(".input-terminal").each((i, el) => {
                 const input = $(el);
                 const inputTerminal = input.context.terminal;
@@ -290,7 +288,6 @@ export class BaseOutputTerminalView {
                 ariaAlert("There are no available inputs for this selected output");
             }
         };
-
         if (e.keyCode === 32) {
             //Space
             ariaAlert("Node selected");
@@ -321,9 +318,7 @@ export class BaseOutputTerminalView {
         var h = $("<div class='drag-terminal'/>")
             .appendTo("#canvas-container")
             .get(0);
-
         h.dropTooltip = "";
-
         // Terminal and connection to display noodle while dragging
         $(h).tooltip({
             title: function() {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -17,9 +17,6 @@ class BaseInputTerminalView {
         node.cid = NODEINDEX++;
         const id = `node-${node.cid}-input-${name}`;
         const terminal = this.terminalForInput(input);
-        new Terminals.TerminalMapping({
-            terminal: terminal
-        });
         this.el.terminal = terminal;
         this.$el.attr("input-name", name);
         this.$el.attr("id", id);
@@ -161,9 +158,6 @@ export class BaseOutputTerminalView {
         node.cid = NODEINDEX++;
         const id = `node-${node.cid}-output-${name}`;
         const terminal = this.terminalForOutput(output);
-        new Terminals.TerminalMapping({
-            terminal: terminal
-        });
         this.el.terminal = terminal;
         this.$el.attr(
             "aria-label",

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -5,40 +5,8 @@ import ariaAlert from "utils/ariaAlert";
 
 var NODEINDEX = 0;
 
-class TerminalMappingView {
-    constructor(options = {}) {
-        this.$el = $("<div class='fa-icon-button fa fa-folder-o' />");
-        var mapText = "Run tool in parallel over collection";
-        this.$el.tooltip({ delay: 500, title: mapText });
-        this.model = options.model;
-        this.model.on("change", this.render.bind(this));
-    }
-    render() {
-        if (this.model.mapOver && this.model.mapOver.isCollection) {
-            this.$el.show();
-        } else {
-            this.$el.hide();
-        }
-    }
-}
-
-class TerminalView {
-    setupMappingView(terminalMappingClass, terminal) {
-        var terminalMapping = new terminalMappingClass({
-            terminal: terminal
-        });
-        var terminalMappingView = new TerminalMappingView({
-            model: terminalMapping
-        });
-        terminalMappingView.render();
-        terminal.terminalMappingView = terminalMappingView;
-        this.terminalMappingView = terminalMappingView;
-    }
-}
-
-class BaseInputTerminalView extends TerminalView {
-    constructor(app, options = {}, terminalMappingClass = null) {
-        super();
+class BaseInputTerminalView {
+    constructor(app, options = {}) {
         this.app = app;
         this.el = document.createElement("div");
         this.el.className = "terminal input-terminal";
@@ -49,7 +17,9 @@ class BaseInputTerminalView extends TerminalView {
         node.cid = NODEINDEX++;
         const id = `node-${node.cid}-input-${name}`;
         const terminal = this.terminalForInput(input);
-        this.setupMappingView(terminalMappingClass, terminal);
+        new Terminals.TerminalMapping({
+            terminal: terminal
+        });
         this.el.terminal = terminal;
         this.$el.attr("input-name", name);
         this.$el.attr("id", id);
@@ -142,7 +112,7 @@ class BaseInputTerminalView extends TerminalView {
 
 export class InputTerminalView extends BaseInputTerminalView {
     constructor(app, options = {}) {
-        super(app, options, Terminals.TerminalMapping);
+        super(app, options);
     }
     terminalForInput(input) {
         return new Terminals.InputTerminal({
@@ -155,7 +125,7 @@ export class InputTerminalView extends BaseInputTerminalView {
 
 export class InputParameterTerminalView extends BaseInputTerminalView {
     constructor(app, options = {}) {
-        super(app, options, Terminals.TerminalMapping);
+        super(app, options);
     }
     terminalForInput(input) {
         return new Terminals.InputParameterTerminal({
@@ -168,7 +138,7 @@ export class InputParameterTerminalView extends BaseInputTerminalView {
 
 export class InputCollectionTerminalView extends BaseInputTerminalView {
     constructor(app, options = {}) {
-        super(app, options, Terminals.TerminalMapping);
+        super(app, options);
     }
     terminalForInput(input = {}) {
         return new Terminals.InputCollectionTerminal({
@@ -179,9 +149,8 @@ export class InputCollectionTerminalView extends BaseInputTerminalView {
     }
 }
 
-export class BaseOutputTerminalView extends TerminalView {
-    constructor(app, options, terminalMappingClass = null) {
-        super();
+export class BaseOutputTerminalView {
+    constructor(app, options) {
         this.app = app;
         this.el = document.createElement("div");
         this.el.className = "terminal output-terminal";
@@ -192,7 +161,9 @@ export class BaseOutputTerminalView extends TerminalView {
         node.cid = NODEINDEX++;
         const id = `node-${node.cid}-output-${name}`;
         const terminal = this.terminalForOutput(output);
-        this.setupMappingView(terminalMappingClass, terminal);
+        new Terminals.TerminalMapping({
+            terminal: terminal
+        });
         this.el.terminal = terminal;
         this.$el.attr(
             "aria-label",
@@ -376,7 +347,7 @@ export class BaseOutputTerminalView extends TerminalView {
 
 export class OutputTerminalView extends BaseOutputTerminalView {
     constructor(app, options = {}) {
-        super(app, options, Terminals.TerminalMapping);
+        super(app, options);
     }
     terminalForOutput(output) {
         var type = output.extensions;
@@ -391,7 +362,7 @@ export class OutputTerminalView extends BaseOutputTerminalView {
 
 export class OutputCollectionTerminalView extends BaseOutputTerminalView {
     constructor(app, options = {}) {
-        super(app, options, Terminals.TerminalMapping);
+        super(app, options);
     }
     terminalForOutput(output) {
         var collection_type = output.collection_type;
@@ -409,7 +380,7 @@ export class OutputCollectionTerminalView extends BaseOutputTerminalView {
 
 export class OutputParameterTerminalView extends BaseOutputTerminalView {
     constructor(app, options = {}) {
-        super(app, options, Terminals.TerminalMapping);
+        super(app, options);
     }
     terminalForOutput(output) {
         return new Terminals.OutputParameterTerminal({

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -34,9 +34,6 @@ class TerminalView {
         terminal.terminalMappingView = terminalMappingView;
         this.terminalMappingView = terminalMappingView;
     }
-    terminalElements() {
-        return [this.terminalMappingView.$el, this.el];
-    }
 }
 
 class BaseInputTerminalView extends TerminalView {

--- a/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view-terminals.js
@@ -35,9 +35,9 @@ class BaseInputTerminalView {
     }
     render() {
         if (this.terminal.mapOver && this.terminal.mapOver.isCollection) {
-            this.$el.find("icon").addClass("multiple");
+            this.$el.addClass("multiple");
         } else {
-            this.$el.find("icon").removeClass("multiple");
+            this.$el.removeClass("multiple");
         }
     }
     onDropInit(e, d = {}) {
@@ -185,9 +185,9 @@ export class BaseOutputTerminalView {
     }
     render() {
         if (this.terminal.mapOver && this.terminal.mapOver.isCollection) {
-            this.$el.find("icon").addClass("multiple");
+            this.$el.addClass("multiple");
         } else {
-            this.$el.find("icon").removeClass("multiple");
+            this.$el.removeClass("multiple");
         }
     }
     screenReaderSelectOutputNode(e) {

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -184,7 +184,6 @@ QUnit.test("can accept already connected inputs if input is multiple", function(
 
 QUnit.test("cannot accept already connected inputs if input is multiple but datatypes don't match", function(assert) {
     var other = { node: {}, datatypes: ["binary"] }; // binary is not txt
-
     this.multiple();
     this.with_test_connector(() => {
         assert.ok(!this.test_accept(other));
@@ -525,8 +524,7 @@ QUnit.module("Node view ", {
             output_terminals: {},
             markChanged: function() {},
             hasConnectedOutputTerminals: function() {},
-            connectedMappedInputTerminals: function() {},
-            disableMapOver: function() {}
+            connectedMappedInputTerminals: function() {}
         });
     },
     afterEach: function() {
@@ -543,7 +541,6 @@ QUnit.module("Node view ", {
         var outputTerminal = new Terminals.OutputTerminal({
             name: "TestOuptut",
             datatypes: [outputType],
-            disableMapOver: function() {},
             mapOver: Terminals.NULL_COLLECTION_TYPE_DESCRIPTION
         });
         outputTerminal.node = {
@@ -565,7 +562,6 @@ QUnit.module("Node view ", {
         var outputTerminal = new Terminals.OutputTerminal({
             name: "TestOuptut",
             datatypes: ["txt"],
-            disableMapOver: function() {},
             mapOver: new Terminals.CollectionTypeDescription("list")
         });
         outputTerminal.node = {
@@ -587,7 +583,6 @@ QUnit.module("Node view ", {
         var outputTerminal = new Terminals.OutputTerminal({
             name: "TestOuptut",
             datatypes: ["txt"],
-            disableMapOver: function() {},
             mapOver: new Terminals.CollectionTypeDescription("list")
         });
         outputTerminal.node = {
@@ -802,25 +797,28 @@ QUnit.test("equal", function(assert) {
 });
 
 QUnit.test("default constructor", function(assert) {
-    var terminal = new Terminals({});
+    var terminal = new Terminals.InputTerminal({});
     assert.ok(terminal.mapOver === Terminals.NULL_COLLECTION_TYPE_DESCRIPTION);
 });
 
 QUnit.test("constructing with mapOver", function(assert) {
-    var terminal = new Terminals({
+    var terminal = new Terminals.InputTerminal({
         mapOver: new Terminals.CollectionTypeDescription("list")
     });
     assert.ok(terminal.mapOver.collectionType == "list");
 });
 
-QUnit.test("disableMapOver", function(assert) {
-    var terminal = new Terminals({
+QUnit.test("resetMapping", function(assert) {
+    var terminal = new Terminals.InputTerminal({
         terminal: terminal,
         mapOver: new Terminals.CollectionTypeDescription("list")
     });
+    terminal.node = {
+        hasMappedOverInputTerminals: () => true
+    };
     var changeSpy = sinon.spy();
     terminal.on("change", changeSpy);
-    terminal.disableMapOver();
+    terminal.resetMapping();
     assert.ok(terminal.mapOver === Terminals.NULL_COLLECTION_TYPE_DESCRIPTION);
     assert.ok(changeSpy.called);
 });

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -199,9 +199,7 @@ QUnit.test("can accept list collection for empty multiple inputs", function(asse
     var other = {
         node: {},
         datatypes: ["tabular"],
-        mapOver: function() {
-            return new Terminals.CollectionTypeDescription("list");
-        }
+        mapOver: new Terminals.CollectionTypeDescription("list")
     };
     this.multiple();
     assert.ok(this.test_accept(other));
@@ -211,9 +209,7 @@ QUnit.test("cannot accept list collection for multiple input if collection alrea
     var other = {
         node: {},
         datatypes: ["tabular"],
-        mapOver: function() {
-            return new Terminals.CollectionTypeDescription("list");
-        }
+        mapOver: new Terminals.CollectionTypeDescription("list")
     };
     this.multiple();
     this.with_test_connector(() => {

--- a/client/galaxy/style/scss/theme/blue.scss
+++ b/client/galaxy/style/scss/theme/blue.scss
@@ -152,7 +152,7 @@ $state-running-border: $border-color;
 // Workflow editor
 $workflow-editor-bg: $white;
 $workflow-editor-grid-size: 0.7rem;
-$workflow-editor-grid-color: lighten($brand-primary, 60%);
+$workflow-editor-grid-color: lighten($brand-primary, 65%);
 $workflow-overview-bg: $panel-bg-color;
 $worfklow-node-width: 10rem;
 

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -16,7 +16,7 @@
             &.node-active {
                 z-index: 1001;
                 border: solid $white 1px;
-                box-shadow: 0 0 0 2px $brand-primary;
+                box-shadow: 0 0 0 3px $brand-primary;
             }
             .node-header {
                 @extend .card-header;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -78,7 +78,7 @@
                 color: $brand-light;
                 position: absolute;
                 z-index: 101;
-                > icon {
+                icon {
                     @extend .fa;
                     @extend .fa-chevron-circle-right;
                     color: $brand-primary;
@@ -86,18 +86,14 @@
                     left: 0px;
                     top: 0px;
                 }
-                > icon.multiple {
+                icon.multiple {
                     @extend .fa;
                     @extend .fa-chevron-circle-right;
-                    @extend .btn;
-                    @extend .btn-sm;
-                    @extend .btn-primary;
-                    @extend .p-1;
-                    @extend .mt-1;
-                    color: $white;
+                    color: $brand-primary;
                     position: absolute;
-                    left: -8px;
-                    top: -8px;
+                    font-size: 1.2rem;
+                    left: -5px;
+                    top: -5px;
                 }
             }
             .input-terminal {

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -25,10 +25,6 @@
                 cursor: move;
                 background: $brand-primary;
                 color: $white;
-                .node-dropdown {
-                    @extend .rounded;
-                    border: solid $border-color 1px;
-                }
             }
             .node-body {
                 @extend .card-body;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -79,7 +79,7 @@
                 @extend .mt-1;
                 color: $brand-light;
                 position: absolute;
-                z-index: 1500;
+                z-index: 101;
                 > icon {
                     @extend .fa;
                     @extend .fa-chevron-circle-right;
@@ -111,7 +111,7 @@
                 @extend .fa-circle;
                 color: $brand-success;
                 position: absolute;
-                z-index: 1500;
+                z-index: 101;
             }
             .mark-terminal {
                 cursor: pointer;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -100,12 +100,12 @@
             }
             .input-terminal.multiple {
                 font-size: 1.2rem;
-                left: -12px;
+                left: -11px;
                 top: 2px;
             }
             .output-terminal.multiple {
                 font-size: 1.2rem;
-                right: -12px;
+                right: -11px;
                 top: 2px;
             }
             .input-terminal-active.can-accept > icon {

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -89,23 +89,23 @@
             }
             .input-terminal {
                 @extend .base-terminal;
-                left: -9px;
+                left: -0.65rem;
             }
             .output-terminal {
                 @extend .base-terminal;
-                right: -9px;
+                right: -0.65rem;
                 &:hover > icon {
                     color: $brand-success;
                 }
             }
             .input-terminal.multiple {
                 font-size: 1.2rem;
-                left: -11px;
+                left: -0.8rem;
                 top: 2px;
             }
             .output-terminal.multiple {
                 font-size: 1.2rem;
-                right: -11px;
+                right: -0.8rem;
                 top: 2px;
             }
             .input-terminal-active.can-accept > icon {
@@ -131,15 +131,15 @@
             .delete-terminal {
                 @extend .btn;
                 @extend .btn-sm;
-                @extend .btn-info;
+                @extend .btn-danger;
                 @extend .fa;
                 @extend .fa-minus-circle;
                 @extend .p-1;
                 @extend .mt-1;
                 position: absolute;
                 z-index: 2500;
-                top: 0px;
-                left: -15px;
+                top: 2px;
+                left: -0.8rem;
             }
             .callout-terminal {
                 position: absolute;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -122,9 +122,12 @@
                 z-index: 101;
             }
             .mark-terminal {
-                cursor: pointer;
+                @extend .far;
+                @extend .fa-square;
                 color: $text-muted;
+                cursor: pointer;
                 &.mark-terminal-active {
+                    @extend .fa-check-square;
                     color: $brand-success;
                 }
             }
@@ -143,7 +146,8 @@
                 left: -0.8rem;
             }
             .callout-terminal {
-                position: absolute;
+                @extend .float-left;
+                @extend .mr-1;
             }
             .workflow-overview {
                 border-top-left-radius: 0.3rem;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -23,10 +23,8 @@
                 @extend .py-1;
                 @extend .px-2;
                 cursor: move;
-                background: $brand-secondary;
-                .header {
-                    width: $worfklow-node-width - 2rem;
-                }
+                background: $brand-primary;
+                color: $white;
             }
             .node-body {
                 @extend .card-body;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -86,6 +86,19 @@
                     left: 0px;
                     top: 0px;
                 }
+                > icon.multiple {
+                    @extend .fa;
+                    @extend .fa-chevron-circle-right;
+                    @extend .btn;
+                    @extend .btn-sm;
+                    @extend .btn-primary;
+                    @extend .p-1;
+                    @extend .mt-1;
+                    color: $white;
+                    position: absolute;
+                    left: -8px;
+                    top: -8px;
+                }
             }
             .input-terminal {
                 @extend .base-terminal;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -86,15 +86,6 @@
                     left: 0px;
                     top: 0px;
                 }
-                icon.multiple {
-                    @extend .fa;
-                    @extend .fa-chevron-circle-right;
-                    color: $brand-primary;
-                    position: absolute;
-                    font-size: 1.2rem;
-                    left: -5px;
-                    top: -5px;
-                }
             }
             .input-terminal {
                 @extend .base-terminal;
@@ -106,6 +97,16 @@
                 &:hover > icon {
                     color: $brand-success;
                 }
+            }
+            .input-terminal.multiple {
+                font-size: 1.2rem;
+                left: -12px;
+                top: 2px;
+            }
+            .output-terminal.multiple {
+                font-size: 1.2rem;
+                right: -12px;
+                top: 2px;
             }
             .input-terminal-active.can-accept > icon {
                 color: $brand-success;
@@ -130,7 +131,7 @@
             .delete-terminal {
                 @extend .btn;
                 @extend .btn-sm;
-                @extend .btn-primary;
+                @extend .btn-info;
                 @extend .fa;
                 @extend .fa-minus-circle;
                 @extend .p-1;

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -25,6 +25,10 @@
                 cursor: move;
                 background: $brand-primary;
                 color: $white;
+                .node-dropdown {
+                    @extend .rounded;
+                    border: solid $border-color 1px;
+                }
             }
             .node-body {
                 @extend .card-body;
@@ -124,11 +128,11 @@
             .mark-terminal {
                 @extend .far;
                 @extend .fa-square;
-                color: $text-muted;
+                color: $brand-primary;
                 cursor: pointer;
                 &.mark-terminal-active {
+                    @extend .fa;
                     @extend .fa-check-square;
-                    color: $brand-success;
                 }
             }
             .delete-terminal {

--- a/client/galaxy/style/scss/workflow.scss
+++ b/client/galaxy/style/scss/workflow.scss
@@ -136,6 +136,7 @@
                 @extend .fa-minus-circle;
                 @extend .p-1;
                 @extend .mt-1;
+                cursor: pointer;
                 position: absolute;
                 z-index: 2500;
                 top: 2px;

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -308,7 +308,6 @@ workflow_editor:
       _: "[node-label='${label}']"
 
       title: '${_} .node-title'
-      dropdown: '${_} .node-dropdown'
       destroy: '${_} .node-destroy'
       clone: '${_} .node-clone'
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -308,13 +308,14 @@ workflow_editor:
       _: "[node-label='${label}']"
 
       title: '${_} .node-title'
+      dropdown: '${_} .node-dropdown'
       destroy: '${_} .node-destroy'
       clone: '${_} .node-clone'
 
       output_terminal: "${_} [output-name='${name}']"
       input_terminal: "${_} [input-name='${name}']"
 
-      input_mapping_icon: "${_} [name='${name}'] .fa-folder-o"
+      input_mapping_icon: "${_} [name='${name}'] .multiple"
 
   selectors:
     canvas_body: '#workflow-canvas'

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -76,7 +76,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-
+        data_input_node.dropdown.wait_for_and_click();
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_data_input_deleted")

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -76,7 +76,6 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-        data_input_node.dropdown.wait_for_and_click()
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_data_input_deleted")
@@ -102,7 +101,6 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-        data_input_node.dropdown.wait_for_and_click()
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_data_collection_input_deleted")
@@ -129,7 +127,6 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-        data_input_node.dropdown.wait_for_and_click()
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_parameter_input_deleted")

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -76,7 +76,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-        data_input_node.dropdown.wait_for_and_click();
+        data_input_node.dropdown.wait_for_and_click()
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_data_input_deleted")
@@ -102,7 +102,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-
+        data_input_node.dropdown.wait_for_and_click()
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_data_collection_input_deleted")
@@ -129,7 +129,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         assert label == "input1", label
         # should work but Galaxy is broken.
         # assert editor.annotation_input.wait_for_value() == "my cool annotation"
-
+        data_input_node.dropdown.wait_for_and_click()
         data_input_node.destroy.wait_for_and_click()
         data_input_node.wait_for_absent()
         self.screenshot("workflow_editor_parameter_input_deleted")


### PR DESCRIPTION
Requires #9471. This PR removes the folder icon and instead uses an enlarged connector icon to indicate output and input mapping types. It also replaces the clickable-asterisk indicating workflow outputs with a checkbox. The PR increases the header variant from secondary to primary style and the transparency of the grid background from 60% to 65% to further highlight the workflow nodes. Additionally this PR consolidates and removes mapping related abstraction classes.

<b>Now</b>

<img width="721" alt="Screen Shot 2020-03-11 at 9 41 26 AM" src="https://user-images.githubusercontent.com/2105447/76423082-a1363400-637c-11ea-9bb3-ab9f41dbd052.png">

<b>Before</b>

<img width="700" alt="Screen Shot 2020-03-02 at 1 47 41 PM" src="https://user-images.githubusercontent.com/2105447/75754823-65a3c600-5cfb-11ea-8ee7-d26bda47f332.png">
