### PR TITLE
[20.01] Fix data manager table headers

### DIFF
--- a/client/galaxy/scripts/components/admin/DataManager/DataManagerTable.vue
+++ b/client/galaxy/scripts/components/admin/DataManager/DataManagerTable.vue
@@ -17,11 +17,7 @@
                             <b-container>
                                 <b-row align-v="center">
                                     <b-col cols="auto">
-                                        <b-button
-                                            @click="reload()"
-                                            v-b-tooltip.hover
-                                            :title="buttonLabel"
-                                        >
+                                        <b-button @click="reload()" v-b-tooltip.hover :title="buttonLabel">
                                             <span class="fa fa-refresh" />
                                         </b-button>
                                     </b-col>
@@ -71,7 +67,7 @@ export default {
     },
     computed: {
         dataTableName() {
-            return this.dataTable && this.dataTable.name ? this.dataTable.name : 'null';
+            return this.dataTable && this.dataTable.name ? this.dataTable.name : "null";
         },
         buttonLabel() {
             return `Reload ${this.dataTableName} tool data table`;

--- a/client/galaxy/scripts/components/admin/DataManager/DataManagerTable.vue
+++ b/client/galaxy/scripts/components/admin/DataManager/DataManagerTable.vue
@@ -13,22 +13,24 @@
             <b-row>
                 <b-col>
                     <b-card id="data-table-card" flush>
-                        <b-container v-slot:header>
-                            <b-row align-v="center">
-                                <b-col cols="auto">
-                                    <b-button
-                                        @click="reload()"
-                                        v-b-tooltip.hover
-                                        :title="'Reload ' + this.dataTable['name'] + ' tool data table'"
-                                    >
-                                        <span class="fa fa-refresh" />
-                                    </b-button>
-                                </b-col>
-                                <b-col>
-                                    <b>{{ this.dataTable["name"] }}</b>
-                                </b-col>
-                            </b-row>
-                        </b-container>
+                        <template v-slot:header>
+                            <b-container>
+                                <b-row align-v="center">
+                                    <b-col cols="auto">
+                                        <b-button
+                                            @click="reload()"
+                                            v-b-tooltip.hover
+                                            :title="buttonLabel"
+                                        >
+                                            <span class="fa fa-refresh" />
+                                        </b-button>
+                                    </b-col>
+                                    <b-col>
+                                        <b>{{ dataTableName }}</b>
+                                    </b-col>
+                                </b-row>
+                            </b-container>
+                        </template>
                         <b-table
                             :fields="fields(this.dataTable['columns'])"
                             :items="dataTable['data']"
@@ -68,6 +70,12 @@ export default {
         };
     },
     computed: {
+        dataTableName() {
+            return this.dataTable && this.dataTable.name ? this.dataTable.name : 'null';
+        },
+        buttonLabel() {
+            return `Reload ${this.dataTableName} tool data table`;
+        },
         breadcrumbItems() {
             return [
                 {
@@ -75,7 +83,7 @@ export default {
                     to: "/"
                 },
                 {
-                    text: this.dataTable["name"]
+                    text: this.dataTableName
                 }
             ];
         }
@@ -88,7 +96,7 @@ export default {
         },
         reload() {
             axios
-                .get(`${getAppRoot()}data_manager/reload_tool_data_tables?table_name=${this.dataTable["name"]}`)
+                .get(`${getAppRoot()}data_manager/reload_tool_data_tables?table_name=${this.dataTableName}`)
                 .then(response => {
                     if (response.data.dataTable) {
                         this.dataTable = response.data.dataTable;


### PR DESCRIPTION
This restores the header with the data table name and reload button.  I'm going to add linting in dev for these invalid slot specifications so this stops happening.