### PR TITLE
Skip migration if uninitialized database exists

### DIFF
--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -61,8 +61,7 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
         # Apply all scripts to get to current version
         migrate_to_current_version(engine, db_schema)
 
-    meta = MetaData(bind=engine)
-    if new_database:
+    def migrate_from_scratch():
         log.info("Creating new database from scratch, skipping migrations")
         current_version = migrate_repository.version().version
         mapping.init(file_path='/tmp', url=url, map_install_models=map_install_models, create_tables=True)
@@ -70,6 +69,13 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
         db_schema = schema.ControlledSchema(engine, migrate_repository)
         assert db_schema.version == current_version
         migrate()
+        if app:
+            # skips the tool migration process.
+            app.new_installation = True
+
+    meta = MetaData(bind=engine)
+    if new_database:
+        migrate_from_scratch()
         return
     elif app and getattr(app.config, 'database_auto_migrate', False):
         migrate()
@@ -79,12 +85,9 @@ def create_or_verify_database(url, galaxy_config_file, engine_options={}, app=No
     try:
         Table("dataset", meta, autoload=True)
     except NoSuchTableError:
-        # No 'dataset' table means a completely uninitialized database.  If we have an app, we'll
-        # set its new_installation setting to True so the tool migration process will be skipped.
-        if app:
-            app.new_installation = True
+        # No 'dataset' table means a completely uninitialized database.
         log.info("No database, initializing")
-        migrate()
+        migrate_from_scratch()
         return
     try:
         hda_table = Table("history_dataset_association", meta, autoload=True)


### PR DESCRIPTION
As we do when Galaxy created the database. This is useful if the database was pre-created because the Galaxy user doesn't have permissions to create new databases.