### PR TITLE
unicodify message

### DIFF
--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -78,6 +78,7 @@ def condor_submit(submit_file):
     try:
         submit = Popen(('condor_submit', submit_file), stdout=PIPE, stderr=STDOUT)
         message, _ = submit.communicate()
+        message=unicodify(message)
         if submit.returncode == 0:
             external_id = parse_external_id(message, type='condor')
         else:

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -78,7 +78,7 @@ def condor_submit(submit_file):
     try:
         submit = Popen(('condor_submit', submit_file), stdout=PIPE, stderr=STDOUT)
         message, _ = submit.communicate()
-        message=unicodify(message)
+        message = unicodify(message)
         if submit.returncode == 0:
             external_id = parse_external_id(message, type='condor')
         else:


### PR DESCRIPTION
Not sure if unicodify() is the way to go but I was getting an error calling parse_external_id() using Python 3.6.8 when submitting jobs to condor as the  output from communicate() was a byte sequence and not a string.


