### PR TITLE
Added whitelisting option for user registration

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1231,7 +1231,7 @@
     using an email address belonging to a domain that is not on the
     list, registration will be enied. This is a more restrictive
     option than <blacklist_file>, and therefore, in case
-    <blacklist_file> is defined, <whitelist_file> will be ignored.
+    <whitelist_file> is defined, <blacklist_file> will be ignored.
 :Default: ``disposable_email_whitelist.conf``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1221,6 +1221,21 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~
+``whitelist_file``
+~~~~~~~~~~~~~~~~~~
+
+:Description:
+    E-mail domains whitelist is used for filtering out users that are
+    using email address not belonging to the instition/company domains
+    during the registration. If their address domain matches any
+    domain in the whitelist, they are refused the registration. This
+    is a more restrictive option than blacklist, and therefore, in
+    case the previous one is defined this one will be ignored.
+:Default: ``config/disposable_email_whitelist.conf``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``registration_warning_message``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3265,7 +3280,9 @@
 :Description:
     XML config file that contains the job metric collection
     configuration.
-:Default: ``config/job_metrics_conf.xml``
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``job_metrics_conf.xml``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1226,13 +1226,13 @@
 ~~~~~~~~~~~~~~~~~~
 
 :Description:
-    E-mail domains whitelist is used for filtering out users that are
-    using email address not belonging to the instition/company domains
-    during the registration. If their address domain matches any
-    domain in the whitelist, they are refused the registration. This
-    is a more restrictive option than blacklist, and therefore, in
-    case the previous one is defined this one will be ignored.
-:Default: ``config/disposable_email_whitelist.conf``
+    E-mail domains whitelist is used to specify allowed email address
+    domains. If the list is non-empty and a user attempts registration
+    using an email address belonging to a domain that is not on the
+    list, registration will be enied. This is a more restrictive
+    option than <blacklist_file>, and therefore, in case
+    <blacklist_file> is defined, <whitelist_file> will be ignored.
+:Default: ``disposable_email_whitelist.conf``
 :Type: str
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -468,7 +468,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         #  Create whitelist file to accept only certain email domains
         self.whitelist_content = None
         if self.whitelist_file:
-            self.whitelist_file = os.path.join(self.root, self.whitelist_file)
             try:
                 with open(self.whitelist_file) as f:
                     self.whitelist_content = [line.rstrip() for line in f]

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -465,6 +465,16 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             except IOError:
                 log.error("CONFIGURATION ERROR: Can't open supplied blacklist file from path: %s", self.blacklist_file)
 
+        #  Create whitelist file to accept only certain email domains
+        self.whitelist_content = None
+        if self.whitelist_file:
+            self.whitelist_file = os.path.join(self.root, self.whitelist_file)
+            try:
+                with open(self.whitelist_file) as f:
+                    self.whitelist_content = [line.rstrip() for line in f]
+            except IOError:
+                log.error("CONFIGURATION ERROR: Can't open supplied whitelist file from path: %s", self.whitelist_file)
+
         self.persistent_communication_rooms = listify(self.persistent_communication_rooms, do_strip=True)
         # The transfer manager and deferred job queue
         self.enable_beta_job_managers = string_as_bool(kwargs.get('enable_beta_job_managers', 'False'))

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -687,6 +687,14 @@ galaxy:
   # Example value 'config/disposable_email_blacklist.conf'
   #blacklist_file: null
 
+  # E-mail domains whitelist is used for filtering out users that are
+  # using email address not belonging to the instition/company domains
+  # during the registration. If their address domain matches any domain
+  # in the whitelist, they are refused the registration. This is a more
+  # restrictive option than blacklist, and therefore, in case the
+  # previous one is defined this one will be ignored.
+  #whitelist_file: config/disposable_email_whitelist.conf
+
   # Registration warning message is used to discourage people from
   # registering multiple accounts.  Applies mostly for the main Galaxy
   # instance. If no message specified the warning box will not be shown.
@@ -1607,7 +1615,9 @@ galaxy:
 
   # XML config file that contains the job metric collection
   # configuration.
-  #job_metrics_config_file: config/job_metrics_conf.xml
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #job_metrics_config_file: job_metrics_conf.xml
 
   # This option allows users to see the job metrics (except for
   # environment variables).

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -691,8 +691,8 @@ galaxy:
   # domains. If the list is non-empty and a user attempts registration
   # using an email address belonging to a domain that is not on the
   # list, registration will be enied. This is a more restrictive option
-  # than <blacklist_file>, and therefore, in case <blacklist_file> is
-  # defined, <whitelist_file> will be ignored.
+  # than <blacklist_file>, and therefore, in case <whitelist_file> is
+  # defined, <blacklist_file> will be ignored.
   #whitelist_file: disposable_email_whitelist.conf
 
   # Registration warning message is used to discourage people from

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -687,13 +687,13 @@ galaxy:
   # Example value 'config/disposable_email_blacklist.conf'
   #blacklist_file: null
 
-  # E-mail domains whitelist is used for filtering out users that are
-  # using email address not belonging to the instition/company domains
-  # during the registration. If their address domain matches any domain
-  # in the whitelist, they are refused the registration. This is a more
-  # restrictive option than blacklist, and therefore, in case the
-  # previous one is defined this one will be ignored.
-  #whitelist_file: config/disposable_email_whitelist.conf
+  # E-mail domains whitelist is used to specify allowed email address
+  # domains. If the list is non-empty and a user attempts registration
+  # using an email address belonging to a domain that is not on the
+  # list, registration will be enied. This is a more restrictive option
+  # than <blacklist_file>, and therefore, in case <blacklist_file> is
+  # defined, <whitelist_file> will be ignored.
+  #whitelist_file: disposable_email_whitelist.conf
 
   # Registration warning message is used to discourage people from
   # registering multiple accounts.  Applies mostly for the main Galaxy

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -348,8 +348,8 @@ tool_shed:
   # domains. If the list is non-empty and a user attempts registration
   # using an email address belonging to a domain that is not on the
   # list, registration will be enied. This is a more restrictive option
-  # than <blacklist_file>, and therefore, in case <blacklist_file> is
-  # defined, <whitelist_file> will be ignored.
+  # than <blacklist_file>, and therefore, in case <whitelist_file> is
+  # defined, <blacklist_file> will be ignored.
   #whitelist_file: disposable_email_whitelist.conf
 
   # Append "/{brand}" to the "Galaxy" text in the masthead.

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -344,6 +344,14 @@ tool_shed:
   # the registration.
   #blacklist_file: config/disposable_email_blacklist.conf
 
+  # E-mail domains whitelist is used to specify allowed email address
+  # domains. If the list is non-empty and a user attempts registration
+  # using an email address belonging to a domain that is not on the
+  # list, registration will be enied. This is a more restrictive option
+  # than <blacklist_file>, and therefore, in case <blacklist_file> is
+  # defined, <whitelist_file> will be ignored.
+  #whitelist_file: disposable_email_whitelist.conf
+
   # Append "/{brand}" to the "Galaxy" text in the masthead.
   #brand: null
 

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -46,6 +46,13 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False):
             domain = ('.').join(domain.split('.')[-2:])
         if domain in trans.app.config.blacklist_content:
             message = "Please enter your permanent email address."
+    #  If the whitelist is not empty filter out any domain not in the list.
+    elif trans.app.config.whitelist_content is not None:
+        domain = email.split('@')[1]
+        if len(domain.split('.')) > 2:
+            domain = ('.').join(domain.split('.')[-2:])
+        if domain not in trans.app.config.whitelist_content:
+            message = "Please enter an allowed domain email address for this server."
     return message
 
 

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -39,6 +39,13 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False):
         message = "Email address cannot be more than %d characters in length." % EMAIL_MAX_LEN
     elif check_dup and trans.sa_session.query(trans.app.model.User).filter(func.lower(trans.app.model.User.table.c.email) == email.lower()).first():
         message = "User with email '%s' already exists." % email
+    #  If the whitelist is not empty filter out any domain not in the list and ignore blacklist.
+    elif trans.app.config.whitelist_content is not None:
+        domain = email.split('@')[1]
+        if len(domain.split('.')) > 2:
+            domain = ('.').join(domain.split('.')[-2:])
+        if domain not in trans.app.config.whitelist_content:
+            message = "Please enter an allowed domain email address for this server."
     #  If the blacklist is not empty filter out the disposable domains.
     elif trans.app.config.blacklist_content is not None:
         domain = email.split('@')[1]
@@ -46,13 +53,6 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False):
             domain = ('.').join(domain.split('.')[-2:])
         if domain in trans.app.config.blacklist_content:
             message = "Please enter your permanent email address."
-    #  If the whitelist is not empty filter out any domain not in the list.
-    elif trans.app.config.whitelist_content is not None:
-        domain = email.split('@')[1]
-        if len(domain.split('.')) > 2:
-            domain = ('.').join(domain.split('.')[-2:])
-        if domain not in trans.app.config.whitelist_content:
-            message = "Please enter an allowed domain email address for this server."
     return message
 
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -904,7 +904,8 @@ mapping:
 
       whitelist_file:
         type: str
-        default: config/disposable_email_whitelist.conf
+        default: disposable_email_whitelist.conf
+        path_resolves_to: config_dir
         required: false
         desc: |
           E-mail domains whitelist is used to specify allowed email address domains.

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -912,7 +912,7 @@ mapping:
           If the list is non-empty and a user attempts registration using an email
           address belonging to a domain that is not on the list, registration will be
           enied. This is a more restrictive option than <blacklist_file>, and therefore,
-          in case <blacklist_file> is defined, <whitelist_file> will be ignored.
+          in case <whitelist_file> is defined, <blacklist_file> will be ignored.
 
       registration_warning_message:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -902,6 +902,16 @@ mapping:
 
           Example value 'config/disposable_email_blacklist.conf'
 
+      whitelist_file:
+        type: str
+        default: config/disposable_email_whitelist.conf
+        required: false
+        desc: |
+          E-mail domains whitelist is used for filtering out users that are using
+          email address not belonging to the instition/company domains during the
+          registration. If their address domain matches any domain in the whitelist,
+          they are refused the registration.
+
       registration_warning_message:
         type: str
         default: >-
@@ -2414,7 +2424,7 @@ mapping:
         required: false
         desc: |
           XML config file that contains the job metric collection configuration.
-          
+
           The value of this option will be resolved with respect to <config_dir>.
 
       expose_potentially_sensitive_job_metrics:

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -907,12 +907,11 @@ mapping:
         default: config/disposable_email_whitelist.conf
         required: false
         desc: |
-          E-mail domains whitelist is used for filtering out users that are using
-          email address not belonging to the instition/company domains during the
-          registration. If their address domain matches any domain in the whitelist,
-          they are refused the registration. This is a more restrictive option than
-          blacklist, and therefore, in case the previous one is defined this one
-          will be ignored.
+          E-mail domains whitelist is used to specify allowed email address domains.
+          If the list is non-empty and a user attempts registration using an email
+          address belonging to a domain that is not on the list, registration will be
+          enied. This is a more restrictive option than <blacklist_file>, and therefore,
+          in case <blacklist_file> is defined, <whitelist_file> will be ignored.
 
       registration_warning_message:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -910,7 +910,9 @@ mapping:
           E-mail domains whitelist is used for filtering out users that are using
           email address not belonging to the instition/company domains during the
           registration. If their address domain matches any domain in the whitelist,
-          they are refused the registration.
+          they are refused the registration. This is a more restrictive option than
+          blacklist, and therefore, in case the previous one is defined this one
+          will be ignored.
 
       registration_warning_message:
         type: str

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -492,7 +492,7 @@ mapping:
           If the list is non-empty and a user attempts registration using an email
           address belonging to a domain that is not on the list, registration will be
           enied. This is a more restrictive option than <blacklist_file>, and therefore,
-          in case <blacklist_file> is defined, <whitelist_file> will be ignored.
+          in case <whitelist_file> is defined, <blacklist_file> will be ignored.
 
       brand:
         type: str

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -482,16 +482,6 @@ mapping:
           disposable email address during the registration.  If their address domain
           matches any domain in the blacklist, they are refused the registration.
 
-      whitelist_file:
-        type: str
-        default: config/disposable_email_whitelist.conf
-        required: false
-        desc: |
-          E-mail domains whitelist is used for filtering out users that are using
-          email address not belonging to the instition/company domains during the
-          registration. If their address domain matches any domain in the whitelist,
-          they are refused the registration.
-
       brand:
         type: str
         default: null

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -482,6 +482,18 @@ mapping:
           disposable email address during the registration.  If their address domain
           matches any domain in the blacklist, they are refused the registration.
 
+      whitelist_file:
+        type: str
+        default: disposable_email_whitelist.conf
+        path_resolves_to: config_dir
+        required: false
+        desc: |
+          E-mail domains whitelist is used to specify allowed email address domains.
+          If the list is non-empty and a user attempts registration using an email
+          address belonging to a domain that is not on the list, registration will be
+          enied. This is a more restrictive option than <blacklist_file>, and therefore,
+          in case <blacklist_file> is defined, <whitelist_file> will be ignored.
+
       brand:
         type: str
         default: null

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -482,6 +482,16 @@ mapping:
           disposable email address during the registration.  If their address domain
           matches any domain in the blacklist, they are refused the registration.
 
+      whitelist_file:
+        type: str
+        default: config/disposable_email_whitelist.conf
+        required: false
+        desc: |
+          E-mail domains whitelist is used for filtering out users that are using
+          email address not belonging to the instition/company domains during the
+          registration. If their address domain matches any domain in the whitelist,
+          they are refused the registration.
+
       brand:
         type: str
         default: null


### PR DESCRIPTION
I added the option to avoid user registration if email domain does not match with the allowed ones for the server, specially usefull for private galaxy instances running in small institutions or companies.