### PR TITLE
[20.01] Integration test for GxITs against remote proxies.

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1344,6 +1344,27 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``interactivetools_proxy_host``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Proxy host - assumed to just be hosted on the same hostname and
+    port as Galaxy by default.
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``interactivetools_map``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Map for interactivetool proxy.
+:Default: ``interactivetools_map.sqlite``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``visualizations_visible``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -634,8 +634,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.manage_dynamic_proxy = self.dynamic_proxy_manage  # Set to false if being launched externally
 
         # InteractiveTools propagator mapping file
-        self.interactivetool_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
+        self.interactivetools_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
         self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
+        self.interactivetool_proxy_host = kwargs.get("interactivetool_proxy_host", None)
 
         self.containers_conf = parse_containers_config(self.containers_config_file)
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -747,6 +747,13 @@ galaxy:
   # Enable InteractiveTools.
   #interactivetools_enable: false
 
+  # Proxy host - assumed to just be hosted on the same hostname and port
+  # as Galaxy by default.
+  #interactivetools_proxy_host: null
+
+  # Map for interactivetool proxy.
+  #interactivetools_map: interactivetools_map.sqlite
+
   # Show visualization tab and list in masthead.
   #visualizations_visible: true
 

--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -139,7 +139,7 @@ class InteractiveToolManager(object):
         self.security = app.security
         self.sa_session = app.model.context
         self.job_manager = app.job_manager
-        self.propagator = InteractiveToolSqlite(app.config.interactivetool_map, app.security.encode_id)
+        self.propagator = InteractiveToolSqlite(app.config.interactivetools_map, app.security.encode_id)
 
     def create_entry_points(self, job, tool, entry_points=None, flush=True):
         entry_points = entry_points or tool.ports
@@ -260,8 +260,13 @@ class InteractiveToolManager(object):
     def target_if_active(self, trans, entry_point):
         if entry_point.active and not entry_point.deleted:
             request_host = trans.request.host
-            rval = '%s//%s-%s.%s.%s.%s/' % (trans.request.host_url.split('//', 1)[0], trans.security.encode_id(entry_point.id),
-                    entry_point.token, entry_point.__class__.__name__.lower(), self.app.config.interactivetool_prefix, request_host)
+            protocol = trans.request.host_url.split('//', 1)[0]
+            entry_point_encoded_id = trans.security.encode_id(entry_point.id)
+            entry_point_class = entry_point.__class__.__name__.lower()
+            entry_point_prefix = self.app.config.interactivetool_prefix
+            interactivetool_proxy_host = self.app.config.interactivetool_proxy_host or request_host
+            rval = '%s//%s-%s.%s.%s.%s/' % (protocol, entry_point_encoded_id,
+                    entry_point.token, entry_point_class, entry_point_prefix, interactivetool_proxy_host)
             if entry_point.entry_url:
                 rval = '%s/%s' % (rval.rstrip('/'), entry_point.entry_url.lstrip('/'))
             return rval

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1004,6 +1004,19 @@ mapping:
         desc: |
           Enable InteractiveTools.
 
+      interactivetools_proxy_host:
+        type: str
+        desc: |
+          Proxy host - assumed to just be hosted on the same hostname and port as
+          Galaxy by default.
+
+      interactivetools_map:
+        type: str
+        default: interactivetools_map.sqlite
+        path_resolves_to: data_dir
+        desc: |
+          Map for interactivetool proxy.
+
       visualizations_visible:
         type: bool
         default: true


### PR DESCRIPTION
Instructions for setting up external goodies documented in docstring.

Small tweaks included:
 - Allow serving proxies on ports different than Galaxy (so it can target external proxies without nginx/uwsgi).
 - Fix up config options a bit.

Work toward https://github.com/galaxyproject/galaxy/issues/9448.

