### PR TITLE
Selenium Multi-History View

### DIFF
--- a/client/galaxy/scripts/mvc/history/multi-panel.js
+++ b/client/galaxy/scripts/mvc/history/multi-panel.js
@@ -212,10 +212,14 @@ var HistoryViewColumn = Backbone.View.extend(baseMVC.LoggableMixin).extend({
         `<div class="text-right col-4">
             <% if( !data.history.purged ){ %>
                 <div class="panel-menu btn-group">
-                    <button type="button" class="btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                    <button 
+                    history-dropdown-btn="<%= data.history.id %>" 
+                    type="button"
+                    class="btn btn-secondary dropdown-toggle"
+                    data-toggle="dropdown">
                         <span class="caret"></span>
                     </button>
-                    <div class="dropdown-menu" role="menu">
+                    <div history-dropdown-menu="<%= data.history.id %>"  class="dropdown-menu" role="menu">
                         <% if( !data.history.deleted ){ %>
                             <a class="dropdown-item copy-history" href="javascript:void(0);">
                                 ${_l("Copy")}

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -172,9 +172,30 @@ multi_history_view:
 
   selectors:
     _: '.multi-panel-history'
+    histories: '.middle .history-column'
     current_label: '.current-label'
     create_new_button: '.create-new'
     drag_drop_help: '.history-drop-target-help'
+    switch_history: '.switch-to'
+    history_dropdown_btn: '[history-dropdown-btn="${history_id}"]'
+    copy: '.copy-history'
+    delete: '.copy-history'
+    current_history_check: '#history-column-${history_id} .current-label'
+    empty_message_check: '.empty-message'
+
+
+  history_dropdown_menu:
+    selectors:
+      _: '[history-dropdown-menu="${history_id}"]'
+      delete:  '[history-dropdown-menu="${history_id}"] > .delete-history'
+      purge:  '[history-dropdown-menu="${history_id}"] > .purge-history'
+  copy_history_modal:
+    selectors:
+      _: '.modal-dialog'
+      copy_btn:
+        type: xpath
+        selector: '//button[contains(text(), "Copy")]'
+
 
 history_copy_elements:
 

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -2,6 +2,8 @@ from .framework import (
     selenium_test,
     SeleniumTestCase
 )
+from selenium.common.exceptions import NoSuchElementException
+
 
 
 class HistoryMultiViewTestCase(SeleniumTestCase):
@@ -27,15 +29,8 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
     @selenium_test
     def test_list_list_display(self):
         history_id = self.current_history_id()
-        collection = self.dataset_collection_populator.create_list_of_list_in_history(history_id).json()
-        collection_hid = collection["hid"]
-
-        self.home()
-
-        self.components.history_panel.multi_view_button.wait_for_and_click()
-
-        selector = self.history_panel_wait_for_hid_state(collection_hid, "ok")
-        self.click(selector)
+        method = self.dataset_collection_populator.create_list_of_list_in_history(history_id).json
+        selector = self.prepare_multi_history_view(method)
         first_level_element_selector = selector.descendant(".dataset-collection-element")
         self.wait_for_and_click(first_level_element_selector)
         dataset_selector = first_level_element_selector.descendant(".dataset")
@@ -47,15 +42,9 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
     @selenium_test
     def test_list_list_list_display(self):
         history_id = self.current_history_id()
-        collection = self.dataset_collection_populator.create_nested_collection(history_id, collection_type="list:list:list").json()
-        collection_hid = collection["hid"]
+        method = self.dataset_collection_populator.create_nested_collection(history_id, collection_type="list:list:list").json
+        selector = self.prepare_multi_history_view(method)
 
-        self.home()
-
-        self.components.history_panel.multi_view_button.wait_for_and_click()
-
-        selector = self.history_panel_wait_for_hid_state(collection_hid, "ok")
-        self.click(selector)
         first_level_element_selector = selector.descendant(".dataset-collection-element")
         self.wait_for_and_click(first_level_element_selector)
         second_level_element_selector = first_level_element_selector.descendant(".dataset-collection-element")
@@ -65,3 +54,104 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
 
         self.sleep_for(self.wait_types.UX_TRANSITION)
         self.screenshot("multi_history_list_list_list")
+
+    @selenium_test
+    def test_copy_history(self):
+        history_id = self.current_history_id()
+        method = self.dataset_collection_populator.create_list_in_history(history_id, contents=["0", "1", "0", "1"]).json
+
+        self.prepare_multi_history_view(method)
+        self.copy_history(history_id)
+        self.assert_history(history_id, histories_number=2)
+
+
+    @selenium_test
+    def test_delete_history(self):
+        history_id = self.current_history_id()
+        method = self.dataset_collection_populator.create_list_in_history(history_id, contents=["0", "1", "0", "1"]).json
+
+        self.prepare_multi_history_view(method)
+        self.copy_history(history_id)
+        self.components.multi_history_view.history_dropdown_btn(history_id=history_id).wait_for_and_click()
+        # click on delete button with corresponding history_id
+        self.components.multi_history_view.history_dropdown_menu.delete(history_id=history_id).wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        self.assert_history(history_id, should_exist=False)
+
+
+    @selenium_test
+    def test_purge_history(self):
+        history_id = self.current_history_id()
+        method = self.dataset_collection_populator.create_list_in_history(history_id, contents=["0", "1", "0", "1"]).json
+
+        self.prepare_multi_history_view(method)
+        self.copy_history(history_id)
+        self.components.multi_history_view.history_dropdown_btn(history_id=history_id).wait_for_and_click()
+        # click on purge button with corresponding history_id
+        self.components.multi_history_view.history_dropdown_menu.purge(history_id=history_id).wait_for_and_click()
+
+        self.driver.switch_to_alert().accept()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        self.assert_history(history_id, should_exist=False)
+
+    @selenium_test
+    def test_switching_history(self):
+        history_id = self.current_history_id()
+        method = self.dataset_collection_populator.create_list_in_history(history_id, contents=["0", "1", "0", "1"]).json
+
+        self.prepare_multi_history_view(method)
+        self.copy_history(history_id)
+        self.components.multi_history_view.switch_history.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.assert_history(history_id, histories_number=2)
+        # assert that id of current history equals history_id
+        assert self.components.multi_history_view.current_history_check(history_id=history_id).is_displayed
+        self.components.multi_history_view.switch_history.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        # assert that 'history_id' is not current history
+        self.assertRaises(NoSuchElementException, lambda:
+                          self.components.multi_history_view.current_history_check(history_id=history_id).is_displayed)
+
+    @selenium_test
+    def test_create_new_history(self):
+        history_id = self.current_history_id()
+        method = self.dataset_collection_populator.create_list_in_history(history_id, contents=["0", "1", "0", "1"]).json
+
+        self.prepare_multi_history_view(method)
+        # assert that empty history is not created in advance
+        self.components.multi_history_view.empty_message_check.assert_absent_or_hidden()
+
+        self.components.multi_history_view.create_new_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        self.assert_history(history_id, histories_number=2)
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        # assert that empty history is present
+        self.components.multi_history_view.empty_message_check.wait_for_present()
+
+
+    def assert_history(self, history_id, histories_number=1, should_exist=True):
+        histories = self.components.multi_history_view.histories.all()
+        assert len(histories) == histories_number
+        # search for history with history_id
+        assert should_exist == any(history.get_attribute("id") == "history-column-" + history_id for history in histories)
+
+    def copy_history(self, history_id):
+        self.components.multi_history_view.history_dropdown_btn(history_id=history_id).wait_for_and_click()
+        self.components.multi_history_view.copy.wait_for_and_click()
+        self.components.multi_history_view.copy_history_modal.copy_btn.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+    def prepare_multi_history_view(self, collection_populator_method):
+        collection = collection_populator_method()
+        collection_hid = collection["hid"]
+
+        self.home()
+        self.components.history_panel.multi_view_button.wait_for_and_click()
+
+        selector = self.history_panel_wait_for_hid_state(collection_hid, "ok")
+        self.click(selector)
+        return selector

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -1,9 +1,9 @@
+from selenium.common.exceptions import NoSuchElementException
+
 from .framework import (
     selenium_test,
     SeleniumTestCase
 )
-from selenium.common.exceptions import NoSuchElementException
-
 
 
 class HistoryMultiViewTestCase(SeleniumTestCase):
@@ -64,7 +64,6 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
         self.copy_history(history_id)
         self.assert_history(history_id, histories_number=2)
 
-
     @selenium_test
     def test_delete_history(self):
         history_id = self.current_history_id()
@@ -78,7 +77,6 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
         self.sleep_for(self.wait_types.UX_RENDER)
 
         self.assert_history(history_id, should_exist=False)
-
 
     @selenium_test
     def test_purge_history(self):
@@ -131,7 +129,6 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
 
         # assert that empty history is present
         self.components.multi_history_view.empty_message_check.wait_for_present()
-
 
     def assert_history(self, history_id, histories_number=1, should_exist=True):
         histories = self.components.multi_history_view.histories.all()


### PR DESCRIPTION
Another round of expanding test coverage from https://github.com/galaxyproject/galaxy/issues/3241
What is implemented:
- Multi-history view
  - [x]  Creating new history from this view.
  - [x]  Switching.
  - [x]  Copying.
  - [x]  Deleting and Purging

I want to finish Multi-history View, but some thing from https://github.com/galaxyproject/galaxy/issues/3241 are not really clear to me. @jmchilton what did you mean by ```Dataset rendering``` and ```Retest a subset of history panel operations (multiple dataset operations, etc..)```. Don't we already test subsets  in  ```test_list_list_list_display``` and ```test_list_list_display```? 


Otherwise, everyone who's interested, feel free to review available tests