### PR TITLE
Adjust dataset error reporting page, remove email option, remove long info text

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -176,7 +176,7 @@ var View = Backbone.View.extend({
                     type: "text",
                     hidden: true,
                     name: "email",
-                    value: Galaxy.user.email
+                    value: Galaxy.user.get("email")
                 },
                 {
                     type: "text",

--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -169,10 +169,16 @@ var View = Backbone.View.extend({
 
     /** Convert tab template */
     _getBugFormTemplate: function(dataset, job) {
+        const Galaxy = getGalaxyInstance();
         const form = new Form({
             inputs: [
                 {
-                    options: [],
+                    type: "text",
+                    hidden: true,
+                    name: "email",
+                    value: Galaxy.user.email
+                },
+                {
                     type: "text",
                     area: true,
                     name: "message",

--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -108,9 +108,11 @@ var View = Backbone.View.extend({
                 Start here: <a
                 href="https://galaxyproject.org/support/tool-error/"
                 target="_blank"> My job ended with an error. What can I do?</a>
-            </p>
-            <h3>Issue Report</h3>`);
-        this.$el.append(this._getBugFormTemplate(dataset, job));
+            </p>`);
+        const Galaxy = getGalaxyInstance();
+        if (Galaxy.user.id) {
+            this.$el.append("<h3>Issue Report</h3>").append(this._getBugFormTemplate(dataset, job));
+        }
     },
 
     job_summary: function(job) {

--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -103,11 +103,15 @@ var View = Backbone.View.extend({
             ${this.job_summary(job)}
             <h3>Troubleshooting</h3>
             <p>
-                There are a number of help resources to self diagnose and
+                There are a number of helpful resources to self diagnose and
                 correct problems.
-                Start here: <a
-                href="https://galaxyproject.org/support/tool-error/"
-                target="_blank"> My job ended with an error. What can I do?</a>
+                <br>
+                Start here:
+                <b>
+                    <a href="https://galaxyproject.org/support/tool-error/" target="_blank">
+                        My job ended with an error. What can I do?
+                    </a>
+                </b>
             </p>`);
         const Galaxy = getGalaxyInstance();
         if (Galaxy.user.id) {

--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -113,10 +113,7 @@ var View = Backbone.View.extend({
                     </a>
                 </b>
             </p>`);
-        const Galaxy = getGalaxyInstance();
-        if (Galaxy.user.id) {
-            this.$el.append("<h3>Issue Report</h3>").append(this._getBugFormTemplate(dataset, job));
-        }
+        this.$el.append("<h3>Issue Report</h3>").append(this._getBugFormTemplate(dataset, job));
     },
 
     job_summary: function(job) {
@@ -170,13 +167,15 @@ var View = Backbone.View.extend({
     /** Convert tab template */
     _getBugFormTemplate: function(dataset, job) {
         const Galaxy = getGalaxyInstance();
+        const userEmail = Galaxy.user.get("email");
         const form = new Form({
             inputs: [
                 {
                     type: "text",
-                    hidden: true,
+                    hidden: !!userEmail,
                     name: "email",
-                    value: Galaxy.user.get("email")
+                    value: userEmail,
+                    label: "Please provide your email:"
                 },
                 {
                     type: "text",


### PR DESCRIPTION
Fixes #9296. This PR simplifies the error reporting page, the email information is redundant and should be changed in the User Preference view, if necessary. Also this PR removes the statements referring to the "usual" behavior of a Galaxy Administrator. Error reporting can be very helpful and, in my opinion should be made as easy as possible, even if administrators might not be able to respond adequately to all reports in due time. This PR also makes minor title and style adjustments to the error reporting page.