### PR TITLE
Update the current_history method in navigates_galaxy.py

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -208,8 +208,9 @@ class NavigatesGalaxy(HasDriver):
         return self.history_panel_name_element().text
 
     def current_history(self):
-        history = self.api_get("histories")[0]
-        return history
+        full_url = self.build_url("history/current_history_json", for_selenium=False)
+        response = requests.get(full_url, cookies=self.selenium_to_requests_cookies())
+        return response.json()
 
     def current_history_id(self):
         return self.current_history()["id"]


### PR DESCRIPTION
In this method, it was assumed that the first returned history from the `/api/histories` endpoint would be the currently active history, but that list is returned in create-time descending order. The `/history/current_history_json` controller provides a way to retrieve the data the `current_history` method needs to return.