### PR TITLE
Add trigger to optimize job change_state()

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1364,22 +1364,7 @@ class JobWrapper(HasResourceParameters):
             log.warning("(%s) Ignoring state change from '%s' to '%s' for job "
                         "that is already terminal", job.id, job.state, state)
             return
-        for dataset_assoc in job.output_datasets + job.output_library_datasets:
-            dataset = dataset_assoc.dataset
-            if not job_supplied:
-                self.sa_session.refresh(dataset)
-            state_changed = dataset.raw_set_dataset_state(state)
-            if state_changed:
-                # Arguably a hack to get state changes to appear in the history panel because
-                # the history panel polls on hda.update_time and ignores hda.dataset.update_time.
-                # For those less pragmatic needing a more theoretically sound reason for the update,
-                # perhaps arguments can be made that the entity that is the HDA
-                # really should be described as updated since its effective state did change and its
-                # RESTful representation in the API does change as a result of the above dataset update.
-                dataset.update()
-            if info:
-                dataset.info = info
-            self.sa_session.add(dataset)
+
         if info:
             job.info = info
         job.set_state(state)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -42,7 +42,7 @@ from galaxy.model.custom_types import JSONType, MetadataType, TrimmedString, UUI
 from galaxy.model.orm.engine_factory import build_engine
 from galaxy.model.orm.now import now
 from galaxy.model.security import GalaxyRBACAgent
-from galaxy.model.triggers import install_timestamp_triggers
+from galaxy.model.triggers import create_triggers
 
 log = logging.getLogger(__name__)
 
@@ -2872,11 +2872,10 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
 
     result = ModelMapping(model_modules, engine=engine)
 
-    # Create tables if needed
+    # Create tables + other database objects if needed
     if create_tables:
         metadata.create_all()
-        install_timestamp_triggers(engine)
-        # metadata.engine.commit()
+        create_triggers(engine)
 
     result.create_tables = create_tables
     # load local galaxy security policy

--- a/lib/galaxy/model/migrate/versions/0166_add_job_state_update_trigger.py
+++ b/lib/galaxy/model/migrate/versions/0166_add_job_state_update_trigger.py
@@ -1,0 +1,30 @@
+"""
+Migration script to add a trigger to Job table that updates associated datasets
+on job update.
+"""
+
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import MetaData
+
+from galaxy.model.triggers import JobStateTrigger
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+    trigger = JobStateTrigger(migrate_engine)
+    trigger.create()
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+    trigger = JobStateTrigger(migrate_engine)
+    trigger.drop()


### PR DESCRIPTION
This is the first step in addressing #8704 (also, relevant for #7791) 

This db trigger replaces the loop inside JobWrapper's `change_state()` method: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/__init__.py#L1367
On job state update, for each `HDA` and `LDDA` associated with the job via `JobToOutputDataset`/`JobToOutputLibraryDataset`:
  - `HDA`/`LDDA`: `info` and `update_time` are updated
  - associated `Dataset`: `state` and `update_time` are updated
All values are taken from the updated `Job` table row (including `update_time`).

NOTES: 
1. The dataset and HDA/LDDA `update_time` is updated *regardless* of whether the dataset's state has been changed. However, the trigger is fired only if the job's `info` or `state` column are mentioned in the update command (I assume SA's flush() would include them in the command only if those attributes had been modified, but I don't know for sure).
2. Suggested trigger naming convention based in part on @nsoranzo suggestion + https://severalnines.com/database-blog/postgresql-triggers-and-stored-function-basics
I think we *do* need to add an "action" suffix because there may be >1 triggers with the same table/when/operation specs. Also, readability.
3. I did not generate the trigger name automatically: IMHO flexibility+readability justify some minor redundancy.
4. I'm using one name for postgres trigger and trigger function. I can't think of a reason not to.
5. I explicitly drop the trigger *and* the function. I'm aware of the `cascade` option, but I think dropping objects explicitly makes sense here, especially for the migration downgrade use case (I'd prefer the code to list the objects being dropped).
6. This does not support MySQL. Should it?
7. The `update_time` value is obtained from the updated `Job`: that way we avoid having the Job's `update_time` set by the client and its associated datasets - by the database.
8. This does not include any tests yet. It should.
9. @Nerdinacan thank you for laying out all that groundwork for adding triggers. The code + discussion and code review in that PR were a great help!

This is ready for (initial) review, although I'm not sure what this may break..

Ping @jmchilton @natefoo @nsoranzo . 






