### PR TITLE
Add HyPhy composite file datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -162,6 +162,7 @@
     <datatype extension="h5ad" type="galaxy.datatypes.binary:Anndata" description="An HDF5-based anndata File" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="mz5" type="galaxy.datatypes.binary:H5" subclass="true" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="hyphy_results.json" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="false"/>
+    <datatype extension="hyphy" type="galaxy.datatypes.genetics:HyPhy" display_in_upload="true"/>
     <datatype extension="hivtrace" type="galaxy.datatypes.text:Json" mimetype="application/json" subclass="true" display_in_upload="false"/>
     <datatype extension="cool" type="galaxy.datatypes.binary:Cool" mimetype="application/octet-stream" display_in_upload="true"/>
     <datatype extension="mcool" type="galaxy.datatypes.binary:MCool" mimetype="application/octet-stream" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -1159,6 +1159,36 @@ class AllegroLOD(LinkageStudies):
         return True
 
 
+class HyPhy(Html):
+    """Class describing a HyPhy composite dataset to be consumed by the HyPhy Visualization plugin"""
+    MetadataElement(name="base_name", desc="base name for HyPhy dataset", default="HyPhy", readonly=True, set_in_upload=True)
+    file_ext = "hyphy"
+    composite_type = 'auto_primary_file'
+    allow_datatype_change = False
+
+    def __init__(self, **kwd):
+        Html.__init__(self, **kwd)
+        self.add_composite_file('hyphy.json', description='HyPhy Output')
+        self.add_composite_file('hyphy.structure', description='Protein Structure')
+        self.add_composite_file('hyphy.fasta', description='Sequence Alignment')
+
+    def generate_primary_file(self, dataset=None):
+        rval = ['<html><head><title>HyPhy Composite Dataset</title></head><p/>']
+        rval.append('<div>This composite dataset is composed of the following files:<p/><ul>')
+        for composite_name, composite_file in self.get_composite_files(dataset=dataset).items():
+            fn = composite_name
+            desc = composite_file.get('description')
+            opt_text = ''
+            if composite_file.optional:
+                opt_text = ' (optional)'
+            if composite_file.get('description'):
+                rval.append('<li><a href="%s" type="text/plain">%s (%s)</a>%s</li>' % (fn, fn, desc, opt_text))
+            else:
+                rval.append('<li><a href="%s" type="text/plain">%s</a>%s</li>' % (fn, fn, opt_text))
+        rval.append('</ul></div></html>')
+        return "\n".join(rval)
+
+
 if __name__ == '__main__':
     import doctest
     doctest.testmod(sys.modules[__name__])


### PR DESCRIPTION
This PR adds a composite file datatype for the HyPhy viewer which wraps three individual files into one for easier selection in visualizations. ping @stephenshank.