### PR TITLE
Use mixin for config settings code shared between Galaxy and TS

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -317,6 +317,15 @@ class CommonConfigurationMixin(object):
         """Determine if the provided user is listed in `admin_users`."""
         return user is not None and user.email in self.admin_users_list
 
+    @property
+    def sentry_dsn_public(self):
+        """
+        Sentry URL with private key removed for use in client side scripts,
+        sentry server will need to be configured to accept events
+        """
+        if self.sentry_dsn:
+            return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
+
 
 class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     deprecated_options = ('database_file', 'track_jobs_in_database')
@@ -723,17 +732,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
                 'UWSGI_PORT': port
             })
-
-    @property
-    def sentry_dsn_public(self):
-        """
-        Sentry URL with private key removed for use in client side scripts,
-        sentry server will need to be configured to accept events
-        """
-        if self.sentry_dsn:
-            return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
-        else:
-            return None
 
     def parse_config_file_options(self, kwargs):
         """Backwards compatibility for config files moved to the config/ dir."""

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -337,6 +337,13 @@ class CommonConfigurationMixin(object):
         # Warning: the value of self.config_dict['foo'] may be different from self.foo
         return self.config_dict.get(key, default)
 
+    def _ensure_directory(self, path):
+        if path not in [None, False] and not os.path.isdir(path):
+            try:
+                os.makedirs(path)
+            except Exception as e:
+                raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
+
 
 class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     deprecated_options = ('database_file', 'track_jobs_in_database')
@@ -806,26 +813,21 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     def ensure_tempdir(self):
         self._ensure_directory(self.new_file_path)
 
-    def _ensure_directory(self, path):
-        if path not in [None, False] and not os.path.isdir(path):
-            try:
-                os.makedirs(path)
-            except Exception as e:
-                raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
-
     def check(self):
-        paths_to_check = [self.tool_data_path, self.data_dir, self.managed_config_dir]
-        # Check that required directories exist
+        # Check that required directories exist; attempt to create otherwise
+        paths_to_check = [
+            self.data_dir,
+            self.ftp_upload_dir,
+            self.library_import_dir,
+            self.managed_config_dir,
+            self.new_file_path,
+            self.nginx_upload_store,
+            self.object_store_cache_path,
+            self.template_cache_path,
+            self.tool_data_path,
+            self.user_library_import_dir,
+        ]
         for path in paths_to_check:
-            if path not in [None, False] and not os.path.isdir(path):
-                try:
-                    os.makedirs(path)
-                except Exception as e:
-                    raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, unicodify(e)))
-        # Create the directories that it makes sense to create
-        for path in (self.new_file_path, self.template_cache_path, self.ftp_upload_dir,
-                     self.library_import_dir, self.user_library_import_dir,
-                     self.nginx_upload_store, self.object_store_cache_path):
             self._ensure_directory(path)
         # Check that required files exist
         tool_configs = self.tool_configs

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -326,6 +326,17 @@ class CommonConfigurationMixin(object):
         if self.sentry_dsn:
             return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
 
+    def get_bool(self, key, default):  
+        # Warning: the value of self.config_dict['foo'] may be different from self.foo
+        if key in self.config_dict:
+            return string_as_bool(self.config_dict[key])
+        else:
+            return default
+
+    def get(self, key, default=None):
+        # Warning: the value of self.config_dict['foo'] may be different from self.foo
+        return self.config_dict.get(key, default)
+
 
 class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     deprecated_options = ('database_file', 'track_jobs_in_database')
@@ -791,15 +802,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         except IOError:
             if explicit:
                 log.warning("Sanitize log file explicitly specified as '%s' but does not exist, continuing with no tools whitelisted.", self.sanitize_whitelist_file)
-
-    def get(self, key, default=None):
-        return self.config_dict.get(key, default)
-
-    def get_bool(self, key, default):
-        if key in self.config_dict:
-            return string_as_bool(self.config_dict[key])
-        else:
-            return default
 
     def ensure_tempdir(self):
         self._ensure_directory(self.new_file_path)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -118,6 +118,10 @@ class BaseAppConfiguration(object):
         self._create_attributes_from_raw_config()  # Create attributes based on raw_config
         self._resolve_paths()  # Overwrite attribute values with resolved paths
 
+    def resolve_path(self, path):
+        """Resolve a path relative to Galaxy's root."""
+        return self._in_root_dir(path)
+
     def _set_config_base(self, config_kwargs):
 
         def _set_global_conf():
@@ -244,6 +248,9 @@ class BaseAppConfiguration(object):
         _cache = {}
         for key in self.schema.paths_to_resolve:
             resolve(key)
+
+    def _in_root_dir(self, path):
+        return os.path.join(self.root, path)
 
     def _in_managed_config_dir(self, path):
         return os.path.join(self.managed_config_dir, path)
@@ -399,7 +406,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         ]
         self.template_path = os.path.join(self.root, kwargs.get("template_path", "templates"))
         self.job_queue_cleanup_interval = int(kwargs.get("job_queue_cleanup_interval", "5"))
-        self.cluster_files_directory = self.resolve_path(self.cluster_files_directory)
+        self.cluster_files_directory = self._in_root_dir(self.cluster_files_directory)
 
         # Fall back to legacy job_working_directory config variable if set.
         self.jobs_directory = os.path.join(self.data_dir, kwargs.get("jobs_directory", self.job_working_directory))
@@ -411,7 +418,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         # should probably drop the backward compatiblity to save the path check.
         self.container_image_cache_path = os.path.join(self.data_dir, kwargs.get("container_image_cache_path", "container_images"))
         if not os.path.exists(self.container_image_cache_path):
-            self.container_image_cache_path = self.resolve_path(kwargs.get("container_image_cache_path", os.path.join(self.data_dir, "container_cache")))
+            self.container_image_cache_path = self._in_root_dir(kwargs.get("container_image_cache_path", os.path.join(self.data_dir, "container_cache")))
         self.output_size_limit = int(kwargs.get('output_size_limit', 0))
         # activation_email was used until release_15.03
         activation_email = kwargs.get('activation_email')
@@ -448,7 +455,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             workflow_resource_params_mapper = None
         elif ":" not in workflow_resource_params_mapper:
             # Assume it is not a Python function, so a file
-            workflow_resource_params_mapper = self.resolve_path(workflow_resource_params_mapper)
+            workflow_resource_params_mapper = self._in_root_dir(workflow_resource_params_mapper)
         # else: a Python a function!
         self.workflow_resource_params_mapper = workflow_resource_params_mapper
 
@@ -523,7 +530,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             self.nginx_upload_store = os.path.abspath(self.nginx_upload_store)
         self.object_store = kwargs.get('object_store', 'disk')
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
-        self.object_store_cache_path = self.resolve_path(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
+        self.object_store_cache_path = self._in_root_dir(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
         if self.object_store_store_by is None:
             self.object_store_store_by = 'id'
             if not self.file_path_set and self.file_path.endswith('objects'):
@@ -622,7 +629,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.manage_dynamic_proxy = self.dynamic_proxy_manage  # Set to false if being launched externally
 
         # InteractiveTools propagator mapping file
-        self.interactivetool_map = self.resolve_path(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
+        self.interactivetool_map = self._in_root_dir(kwargs.get("interactivetools_map", os.path.join(self.data_dir, "interactivetools_map.sqlite")))
         self.interactivetool_prefix = kwargs.get("interactivetools_prefix", "interactivetool")
 
         self.containers_conf = parse_containers_config(self.containers_config_file)
@@ -724,9 +731,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
             return None
 
     def parse_config_file_options(self, kwargs):
-        """
-        Backwards compatibility for config files moved to the config/ dir.
-        """
+        """Backwards compatibility for config files moved to the config/ dir."""
         defaults = dict(
             auth_config_file=[self._in_config_dir('auth_conf.xml')],
             build_sites_config_file=[self._in_config_dir('build_sites.yml'), self._in_sample_dir('build_sites.yml.sample')],
@@ -839,11 +844,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         """
         return user is not None and user.email in self.admin_users_list
 
-    def resolve_path(self, path):
-        """ Resolve a path relative to Galaxy's root.
-        """
-        return os.path.join(self.root, path)
-
     @staticmethod
     def _parse_allowed_origin_hostnames(kwargs):
         """
@@ -869,7 +869,7 @@ Configuration = GalaxyAppConfiguration
 
 
 def reload_config_options(current_config):
-    """ Reload modified reloadable config options """
+    """Reload modified reloadable config options."""
     modified_config = read_properties_from_file(current_config.config_file)
     for option in current_config.schema.reloadable_options:
         if option in modified_config:
@@ -970,8 +970,7 @@ def configure_logging(config):
 
 
 class ConfiguresGalaxyMixin(object):
-    """ Shared code for configuring Galaxy-like app objects.
-    """
+    """Shared code for configuring Galaxy-like app objects."""
 
     def _configure_genome_builds(self, data_table_name="__dbkeys__", load_old_style=True):
         self.genome_builds = GenomeBuilds(self, data_table_name=data_table_name, load_old_style=load_old_style)
@@ -1108,9 +1107,7 @@ class ConfiguresGalaxyMixin(object):
             self.tool_shed_registry = galaxy.tool_shed.tool_shed_registry.Registry()
 
     def _configure_models(self, check_migrate_databases=False, check_migrate_tools=False, config_file=None):
-        """
-        Preconditions: object_store must be set on self.
-        """
+        """Preconditions: object_store must be set on self."""
         db_url = get_database_url(self.config)
         install_db_url = self.config.install_database_connection
         # TODO: Consider more aggressive check here that this is not the same

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -326,7 +326,7 @@ class CommonConfigurationMixin(object):
         if self.sentry_dsn:
             return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
 
-    def get_bool(self, key, default):  
+    def get_bool(self, key, default):
         # Warning: the value of self.config_dict['foo'] may be different from self.foo
         if key in self.config_dict:
             return string_as_bool(self.config_dict[key])

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -525,13 +525,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration):
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
         self.object_store_cache_path = self.resolve_path(kwargs.get("object_store_cache_path", os.path.join(self.data_dir, "object_store_cache")))
         if self.object_store_store_by is None:
-            if not self.file_path_set:
-                if self.file_path.endswith('objects'):
-                    self.object_store_store_by = 'uuid'
-                else:
-                    self.object_store_store_by = 'id'
-            else:
-                self.object_store_store_by = 'id'
+            self.object_store_store_by = 'id'
+            if not self.file_path_set and self.file_path.endswith('objects'):
+                self.object_store_store_by = 'uuid'
         assert self.object_store_store_by in ['id', 'uuid'], "Invalid value for object_store_store_by [%s]" % self.object_store_store_by
         # Handle AWS-specific config options for backward compatibility
         if kwargs.get('aws_access_key') is not None:

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -246,10 +246,12 @@ tool_shed:
   #allow_user_deletion: false
 
   # For use by email messages sent from the Tool Shed.
-  #smtp_server: smtp.your_tool_shed_server
+  # (smtp.your_tool_shed_server)
+  #smtp_server: null
 
   # For use by email messages sent from the Tool Shed.
-  #email_from: your_tool_shed_email@server
+  # (your_tool_shed_email@server)
+  #email_from: null
 
   # If your SMTP server requires a username and password, you can
   # provide them here (password in cleartext here, but if your server
@@ -377,7 +379,7 @@ tool_shed:
   # logged are grid views, tool searches, and use of "recently" used
   # tools menu.  The log_events and log_actions functionality will
   # eventually be merged.
-  #log_actions: true
+  #log_actions: false
 
   # Password expiration period (in days). Users are required to change
   # their password every x days. Users will be redirected to the change

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -51,10 +51,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         pass  # Intentionally does nothing. To enable, remove + call base __init__().
 
     def __init__(self, **kwargs):
-        self.config_dict = kwargs
-        self.root = kwargs.get('root_dir', '.')
-
-        self._set_config_base(kwargs)
+        super(ToolShedAppConfiguration, self).__init__(**kwargs)
 
         # Resolve paths of other config files
         self.parse_config_file_options(kwargs)
@@ -66,34 +63,16 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.version_major = VERSION_MAJOR
         self.version = VERSION
         # Database related configuration
-        self.database_connection = kwargs.get("database_connection", False)
         self.database_connection = kwargs.get("database_connection",
                                               "sqlite:///%s?isolation_level=IMMEDIATE" % resolve_path("community.sqlite", self.data_dir))
         self.database_engine_options = get_database_engine_options(kwargs)
         self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
-        # Repository and Tool search API
-        self.toolshed_search_on = string_as_bool(kwargs.get("toolshed_search_on", True))
-        self.whoosh_index_dir = kwargs.get("whoosh_index_dir", 'database/toolshed_whoosh_indexes')
-        self.repo_name_boost = kwargs.get("repo_name_boost", 0.9)
-        self.repo_description_boost = kwargs.get("repo_description_boost", 0.6)
-        self.repo_long_description_boost = kwargs.get("repo_long_description_boost", 0.5)
-        self.repo_homepage_url_boost = kwargs.get("repo_homepage_url_boost", 0.3)
-        self.repo_remote_repository_url_boost = kwargs.get("repo_remote_repository_url_boost", 0.2)
-        self.repo_owner_username_boost = kwargs.get("repo_owner_username_boost", 0.3)
-        self.tool_name_boost = kwargs.get("tool_name_boost", 1.2)
-        self.tool_description_boost = kwargs.get("tool_description_boost", 0.6)
-        self.tool_help_boost = kwargs.get("tool_help_boost", 0.4)
-        self.tool_repo_owner_username = kwargs.get("tool_repo_owner_username", 0.3)
-        # Analytics
-        self.ga_code = kwargs.get("ga_code", None)
-        self.session_duration = int(kwargs.get('session_duration', 0))
         # Where dataset files are stored
-        self.file_path = resolve_path(kwargs.get("file_path", "database/community_files"), self.root)
-        self.new_file_path = resolve_path(kwargs.get("new_file_path", "database/tmp"), self.root)
+        self.file_path = resolve_path(self.file_path, self.root)
+        self.new_file_path = resolve_path(self.new_file_path, self.root)
         self.cookie_path = kwargs.get("cookie_path", None)
         self.cookie_domain = kwargs.get("cookie_domain", None)
         self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
-        self.id_secret = kwargs.get("id_secret", "changethisinproductiontoo")
         # Tool stuff
         self.tool_path = resolve_path(kwargs.get("tool_path", "tools"), self.root)
         self.tool_secret = kwargs.get("tool_secret", "")
@@ -105,11 +84,8 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.ftp_upload_dir = kwargs.get('ftp_upload_dir', None)
         self.update_integrated_tool_panel = False
         # Galaxy flavor Docker Image
-        self.enable_galaxy_flavor_docker_image = string_as_bool(kwargs.get("enable_galaxy_flavor_docker_image", "False"))
-        self.use_remote_user = string_as_bool(kwargs.get("use_remote_user", "False"))
         self.user_activation_on = None
         self.registration_warning_message = kwargs.get('registration_warning_message', None)
-        self.terms_url = kwargs.get('terms_url', None)
         self.blacklist_location = kwargs.get('blacklist_file', None)
         self.blacklist_content = None
         self.whitelist_location = kwargs.get('whitelist_file', None)
@@ -118,41 +94,26 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.remote_user_header = kwargs.get("remote_user_header", 'HTTP_REMOTE_USER')
         self.remote_user_logout_href = kwargs.get("remote_user_logout_href", None)
         self.remote_user_secret = kwargs.get("remote_user_secret", None)
-        self.require_login = string_as_bool(kwargs.get("require_login", "False"))
-        self.allow_user_creation = string_as_bool(kwargs.get("allow_user_creation", "True"))
-        self.allow_user_deletion = string_as_bool(kwargs.get("allow_user_deletion", "False"))
         self.template_path = templates_path
         self.template_cache_path = resolve_path(kwargs.get("template_cache_path", "database/compiled_templates/community"), self.root)
-        self.admin_users = kwargs.get("admin_users", "")
         self.admin_users_list = [u.strip() for u in self.admin_users.split(',') if u]
-        self.mailing_join_addr = kwargs.get('mailing_join_addr', "galaxy-announce-join@bx.psu.edu")
         self.error_email_to = kwargs.get('error_email_to', None)
         self.smtp_server = kwargs.get('smtp_server', None)
-        self.smtp_username = kwargs.get('smtp_username', None)
-        self.smtp_password = kwargs.get('smtp_password', None)
         self.smtp_ssl = kwargs.get('smtp_ssl', None)
         self.email_from = kwargs.get('email_from', None)
         self.nginx_upload_path = kwargs.get('nginx_upload_path', False)
         self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
-        self.brand = kwargs.get('brand', None)
-        self.pretty_datetime_format = expand_pretty_datetime_format(kwargs.get('pretty_datetime_format', '$locale (UTC)'))
+        self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
         # Configuration for the message box directly below the masthead.
-        self.message_box_visible = string_as_bool(kwargs.get('message_box_visible', False))
-        self.message_box_content = kwargs.get('message_box_content', None)
-        self.message_box_class = kwargs.get('message_box_class', 'info')
-        self.support_url = kwargs.get('support_url', 'https://galaxyproject.org/support')
         self.wiki_url = kwargs.get('wiki_url', 'https://galaxyproject.org/')
         self.blog_url = kwargs.get('blog_url', None)
         self.screencasts_url = kwargs.get('screencasts_url', None)
         self.log_events = False
         self.cloud_controller_instance = False
         self.server_name = ''
-        # Error logging with sentry
-        self.sentry_dsn = kwargs.get('sentry_dsn', None)
         # Where the tool shed hgweb.config file is stored - the default is the Galaxy installation directory.
-        self.hgweb_config_dir = resolve_path(kwargs.get('hgweb_config_dir', ''), self.root)
+        self.hgweb_config_dir = resolve_path(self.hgweb_config_dir, self.root)
         # Proxy features
-        self.apache_xsendfile = kwargs.get('apache_xsendfile', False)
         self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
         self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script', None)
         # Parse global_conf and save the parser

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -105,18 +105,9 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.blacklist_content = None
         self.whitelist_location = kwargs.get('whitelist_file')
         self.whitelist_content = None
-        self.remote_user_maildomain = kwargs.get('remote_user_maildomain')
-        self.remote_user_header = kwargs.get('remote_user_header', 'HTTP_REMOTE_USER')
-        self.remote_user_logout_href = kwargs.get('remote_user_logout_href')
-        self.remote_user_secret = kwargs.get('remote_user_secret')
         self.template_path = templates_path
         self.template_cache_path = self._in_root_dir(kwargs.get('template_cache_path', 'database/compiled_templates/community'))
         self.error_email_to = kwargs.get('error_email_to')
-        self.smtp_server = kwargs.get('smtp_server')
-        self.smtp_ssl = kwargs.get('smtp_ssl')
-        self.email_from = kwargs.get('email_from')
-        self.nginx_upload_path = kwargs.get('nginx_upload_path', False)
-        self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
         self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
         # Configuration for the message box directly below the masthead.
         self.wiki_url = kwargs.get('wiki_url', 'https://galaxyproject.org/')
@@ -128,7 +119,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         # Where the tool shed hgweb.config file is stored - the default is the Galaxy installation directory.
         self.hgweb_config_dir = self._in_root_dir(self.hgweb_config_dir)
         # Proxy features
-        self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
         self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script')
         # Parse global_conf and save the parser
         global_conf = kwargs.get('global_conf')
@@ -137,10 +127,9 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         if global_conf and '__file__' in global_conf and '.yml' not in global_conf['__file__']:
             global_conf_parser.read(global_conf['__file__'])
         self.running_functional_tests = string_as_bool(kwargs.get('running_functional_tests', False))
-        self.citation_cache_type = kwargs.get('citation_cache_type', 'file')
         self.citation_cache_data_dir = self._in_root_dir(kwargs.get('citation_cache_data_dir', 'database/tool_shed_citations/data'))
         self.citation_cache_lock_dir = self._in_root_dir(kwargs.get('citation_cache_lock_dir', 'database/tool_shed_citations/locks'))
-        self.password_expiration_period = timedelta(days=int(kwargs.get('password_expiration_period', 0)))
+        self.password_expiration_period = timedelta(days=int(self.password_expiration_period))
 
         # Security/Policy Compliance
         self.redact_username_during_deletion = False

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -134,15 +134,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         # Backwards compatibility for names used in too many places to fix
         self.datatypes_config = self.datatypes_config_file
 
-    def get(self, key, default=None):
-        return self.config_dict.get(key, default)
-
-    def get_bool(self, key, default):
-        if key in self.config_dict:
-            return string_as_bool(self.config_dict[key])
-        else:
-            return default
-
     def check(self):
         # Check that required directories exist.
         paths_to_check = [self.root, self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -11,6 +11,7 @@ from six.moves import configparser
 
 from galaxy.config import BaseAppConfiguration, CommonConfigurationMixin
 from galaxy.config.schema import AppSchema
+from galaxy.exceptions import ConfigurationError
 from galaxy.util import string_as_bool
 from galaxy.version import VERSION, VERSION_MAJOR
 from galaxy.web.formatting import expand_pretty_datetime_format
@@ -22,10 +23,6 @@ templates_path = os.path.join(ts_webapp_path, "templates")
 
 TOOLSHED_APP_NAME = 'tool_shed'
 TOOLSHED_CONFIG_SCHEMA_PATH = 'lib/tool_shed/webapp/config_schema.yml'
-
-
-class ConfigurationError(Exception):
-    pass
 
 
 class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -41,15 +41,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
     def _load_schema(self):
         return AppSchema(TOOLSHED_CONFIG_SCHEMA_PATH, TOOLSHED_APP_NAME)
 
-    def _update_raw_config_from_kwargs(self, kwargs):
-        pass  # Intentionally does nothing. To enable, remove + call base __init__().
-
-    def _create_attributes_from_raw_config(self):
-        pass  # Intentionally does nothing. To enable, remove + call base __init__().
-
-    def _resolve_paths(self, paths_to_resolve):
-        pass  # Intentionally does nothing. To enable, remove + call base __init__().
-
     def __init__(self, **kwargs):
         super(ToolShedAppConfiguration, self).__init__(**kwargs)
 

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -136,13 +136,15 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
 
     def check(self):
         # Check that required directories exist.
-        paths_to_check = [self.root, self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]
+        paths_to_check = [self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]
+
         for path in paths_to_check:
             if path not in [None, False] and not os.path.isdir(path):
                 try:
                     os.makedirs(path)
                 except Exception as e:
                     raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
+
         # Create the directories that it makes sense to create.
         for path in self.file_path, \
             self.template_cache_path, \
@@ -152,6 +154,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
                     os.makedirs(path)
                 except Exception as e:
                     raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
+
         # Check that required files exist.
         if not os.path.isfile(self.datatypes_config):
             raise ConfigurationError("File not found: %s" % self.datatypes_config)

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 
 from six.moves import configparser
 
-from galaxy.config import BaseAppConfiguration
+from galaxy.config import BaseAppConfiguration, CommonConfigurationMixin
 from galaxy.config.schema import AppSchema
 from galaxy.util import string_as_bool
 from galaxy.version import VERSION, VERSION_MAJOR
@@ -28,7 +28,7 @@ class ConfigurationError(Exception):
     pass
 
 
-class ToolShedAppConfiguration(BaseAppConfiguration):
+class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     default_config_file_name = 'tool_shed.yml'
 
     def _load_schema(self):
@@ -80,7 +80,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         self.remote_user_secret = kwargs.get("remote_user_secret", None)
         self.template_path = templates_path
         self.template_cache_path = self._in_root_dir(kwargs.get("template_cache_path", "database/compiled_templates/community"))
-        self.admin_users_list = [u.strip() for u in self.admin_users.split(',') if u]
         self.error_email_to = kwargs.get('error_email_to', None)
         self.smtp_server = kwargs.get('smtp_server', None)
         self.smtp_ssl = kwargs.get('smtp_ssl', None)
@@ -182,13 +181,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration):
         # Check that required files exist.
         if not os.path.isfile(self.datatypes_config):
             raise ConfigurationError("File not found: %s" % self.datatypes_config)
-
-    def is_admin_user(self, user):
-        """
-        Determine if the provided user is listed in `admin_users`.
-        """
-        admin_users = self.get("admin_users", "").split(",")
-        return user is not None and user.email in admin_users
 
 
 Configuration = ToolShedAppConfiguration

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -139,23 +139,17 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.datatypes_config = self.datatypes_config_file
 
     def check(self):
-        # Check that required directories exist.
-        paths_to_check = [self.file_path, self.hgweb_config_dir, self.tool_data_path, self.template_path]
+        # Check that required directories exist; attempt to create otherwise
+        paths_to_check = [
+            self.file_path,
+            self.hgweb_config_dir,
+            self.template_path,
+            self.tool_data_path,
+            self.template_cache_path,
+            os.path.join(self.tool_data_path, 'shared', 'jars'),
+        ]
         for path in paths_to_check:
-            if path not in [None, False] and not os.path.isdir(path):
-                try:
-                    os.makedirs(path)
-                except Exception as e:
-                    raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
-        # Create the directories that it makes sense to create.
-        for path in self.file_path, \
-            self.template_cache_path, \
-                os.path.join(self.tool_data_path, 'shared', 'jars'):
-            if path not in [None, False] and not os.path.isdir(path):
-                try:
-                    os.makedirs(path)
-                except Exception as e:
-                    raise ConfigurationError("Unable to create missing directory: %s\n%s" % (path, e))
+            self._ensure_directory(path)
         # Check that required files exist.
         if not os.path.isfile(self.datatypes_config):
             raise ConfigurationError("File not found: %s" % self.datatypes_config)

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -22,7 +22,7 @@ from galaxy.web.formatting import expand_pretty_datetime_format
 log = logging.getLogger(__name__)
 
 ts_webapp_path = os.path.abspath(os.path.dirname(__file__))
-templates_path = os.path.join(ts_webapp_path, "templates")
+templates_path = os.path.join(ts_webapp_path, 'templates')
 
 TOOLSHED_APP_NAME = 'tool_shed'
 TOOLSHED_CONFIG_SCHEMA_PATH = 'lib/tool_shed/webapp/config_schema.yml'
@@ -36,91 +36,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
 
     def __init__(self, **kwargs):
         super(ToolShedAppConfiguration, self).__init__(**kwargs)
-
-        # Resolve paths of other config files
-        self.parse_config_file_options(kwargs)
-
-        # Collect the umask and primary gid from the environment
-        self.umask = os.umask(0o77)  # get the current umask
-        os.umask(self.umask)  # can't get w/o set, so set it back
-        self.gid = os.getgid()  # if running under newgrp(1) we'll need to fix the group of data created on the cluster
-        self.version_major = VERSION_MAJOR
-        self.version = VERSION
-        # Database related configuration
-        if not self.database_connection:  # Provide default if not supplied by user
-            self.database_connection = 'sqlite:///%s?isolation_level=IMMEDIATE' % self._in_data_dir('community.sqlite')
-        self.database_engine_options = get_database_engine_options(kwargs)
-        self.database_create_tables = string_as_bool(kwargs.get("database_create_tables", "True"))
-        # Where dataset files are stored
-        self.file_path = self._in_root_dir(self.file_path)
-        self.new_file_path = self._in_root_dir(self.new_file_path)
-        self.cookie_path = kwargs.get("cookie_path", None)
-        self.cookie_domain = kwargs.get("cookie_domain", None)
-        self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
-        # Tool stuff
-        self.tool_path = self._in_root_dir(kwargs.get("tool_path", "tools"))
-        self.tool_secret = kwargs.get("tool_secret", "")
-        self.tool_data_path = os.path.join(os.getcwd(), kwargs.get("tool_data_path", "shed-tool-data"))
-        self.tool_data_table_config_path = None
-        self.integrated_tool_panel_config = self._in_root_dir(kwargs.get('integrated_tool_panel_config', 'integrated_tool_panel.xml'))
-        self.builds_file_path = self._in_root_dir(kwargs.get("builds_file_path", os.path.join(self.tool_data_path, 'shared', 'ucsc', 'builds.txt')))
-        self.len_file_path = self._in_root_dir(kwargs.get("len_file_path", os.path.join(self.tool_data_path, 'shared', 'ucsc', 'chrom')))
-        self.ftp_upload_dir = kwargs.get('ftp_upload_dir', None)
-        self.update_integrated_tool_panel = False
-        # Galaxy flavor Docker Image
-        self.user_activation_on = None
-        self.registration_warning_message = kwargs.get('registration_warning_message', None)
-        self.blacklist_location = kwargs.get('blacklist_file', None)
-        self.blacklist_content = None
-        self.whitelist_location = kwargs.get('whitelist_file', None)
-        self.whitelist_content = None
-        self.remote_user_maildomain = kwargs.get("remote_user_maildomain", None)
-        self.remote_user_header = kwargs.get("remote_user_header", 'HTTP_REMOTE_USER')
-        self.remote_user_logout_href = kwargs.get("remote_user_logout_href", None)
-        self.remote_user_secret = kwargs.get("remote_user_secret", None)
-        self.template_path = templates_path
-        self.template_cache_path = self._in_root_dir(kwargs.get("template_cache_path", "database/compiled_templates/community"))
-        self.error_email_to = kwargs.get('error_email_to', None)
-        self.smtp_server = kwargs.get('smtp_server', None)
-        self.smtp_ssl = kwargs.get('smtp_ssl', None)
-        self.email_from = kwargs.get('email_from', None)
-        self.nginx_upload_path = kwargs.get('nginx_upload_path', False)
-        self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
-        self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
-        # Configuration for the message box directly below the masthead.
-        self.wiki_url = kwargs.get('wiki_url', 'https://galaxyproject.org/')
-        self.blog_url = kwargs.get('blog_url', None)
-        self.screencasts_url = kwargs.get('screencasts_url', None)
-        self.log_events = False
-        self.cloud_controller_instance = False
-        self.server_name = ''
-        # Where the tool shed hgweb.config file is stored - the default is the Galaxy installation directory.
-        self.hgweb_config_dir = self._in_root_dir(self.hgweb_config_dir)
-        # Proxy features
-        self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
-        self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script', None)
-        # Parse global_conf and save the parser
-        global_conf = kwargs.get('global_conf', None)
-        global_conf_parser = configparser.ConfigParser()
-        self.global_conf_parser = global_conf_parser
-        if global_conf and "__file__" in global_conf and ".yml" not in global_conf["__file__"]:
-            global_conf_parser.read(global_conf['__file__'])
-        self.running_functional_tests = string_as_bool(kwargs.get('running_functional_tests', False))
-        self.citation_cache_type = kwargs.get("citation_cache_type", "file")
-        self.citation_cache_data_dir = self._in_root_dir(kwargs.get("citation_cache_data_dir", "database/tool_shed_citations/data"))
-        self.citation_cache_lock_dir = self._in_root_dir(kwargs.get("citation_cache_lock_dir", "database/tool_shed_citations/locks"))
-        self.password_expiration_period = timedelta(days=int(kwargs.get("password_expiration_period", 0)))
-
-        # Security/Policy Compliance
-        self.redact_username_during_deletion = False
-        self.redact_email_during_deletion = False
-        self.redact_username_in_logs = False
-        self.enable_beta_gdpr = string_as_bool(kwargs.get("enable_beta_gdpr", False))
-        if self.enable_beta_gdpr:
-            self.redact_username_during_deletion = True
-            self.redact_email_during_deletion = True
-            self.redact_username_in_logs = True
-            self.allow_user_deletion = True
+        self._process_config(kwargs)
 
     @property
     def shed_tool_data_path(self):
@@ -132,9 +48,7 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
         )
-
         self._parse_config_file_options(defaults, dict(), kwargs)
-
         # Backwards compatibility for names used in too many places to fix
         self.datatypes_config = self.datatypes_config_file
 
@@ -152,7 +66,92 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             self._ensure_directory(path)
         # Check that required files exist.
         if not os.path.isfile(self.datatypes_config):
-            raise ConfigurationError("File not found: %s" % self.datatypes_config)
+            raise ConfigurationError('File not found: %s' % self.datatypes_config)
+
+    def _process_config(self, kwargs):
+        # Resolve paths of other config files
+        self.parse_config_file_options(kwargs)
+        # Collect the umask and primary gid from the environment
+        self.umask = os.umask(0o77)  # get the current umask
+        os.umask(self.umask)  # can't get w/o set, so set it back
+        self.gid = os.getgid()  # if running under newgrp(1) we'll need to fix the group of data created on the cluster
+        self.version_major = VERSION_MAJOR
+        self.version = VERSION
+        # Database related configuration
+        if not self.database_connection:  # Provide default if not supplied by user
+            self.database_connection = 'sqlite:///%s?isolation_level=IMMEDIATE' % self._in_data_dir('community.sqlite')
+        self.database_engine_options = get_database_engine_options(kwargs)
+        self.database_create_tables = string_as_bool(kwargs.get('database_create_tables', 'True'))
+        # Where dataset files are stored
+        self.file_path = self._in_root_dir(self.file_path)
+        self.new_file_path = self._in_root_dir(self.new_file_path)
+        self.cookie_path = kwargs.get('cookie_path')
+        self.cookie_domain = kwargs.get('cookie_domain')
+        self.enable_quotas = string_as_bool(kwargs.get('enable_quotas', False))
+        # Tool stuff
+        self.tool_path = self._in_root_dir(kwargs.get('tool_path', 'tools'))
+        self.tool_secret = kwargs.get('tool_secret', '')
+        self.tool_data_path = os.path.join(os.getcwd(), kwargs.get('tool_data_path', 'shed-tool-data'))
+        self.tool_data_table_config_path = None
+        self.integrated_tool_panel_config = self._in_root_dir(kwargs.get('integrated_tool_panel_config', 'integrated_tool_panel.xml'))
+        self.builds_file_path = self._in_root_dir(kwargs.get('builds_file_path', os.path.join(self.tool_data_path, 'shared', 'ucsc', 'builds.txt')))
+        self.len_file_path = self._in_root_dir(kwargs.get('len_file_path', os.path.join(self.tool_data_path, 'shared', 'ucsc', 'chrom')))
+        self.ftp_upload_dir = kwargs.get('ftp_upload_dir')
+        self.update_integrated_tool_panel = False
+        # Galaxy flavor Docker Image
+        self.user_activation_on = None
+        self.registration_warning_message = kwargs.get('registration_warning_message')
+        self.blacklist_location = kwargs.get('blacklist_file')
+        self.blacklist_content = None
+        self.whitelist_location = kwargs.get('whitelist_file')
+        self.whitelist_content = None
+        self.remote_user_maildomain = kwargs.get('remote_user_maildomain')
+        self.remote_user_header = kwargs.get('remote_user_header', 'HTTP_REMOTE_USER')
+        self.remote_user_logout_href = kwargs.get('remote_user_logout_href')
+        self.remote_user_secret = kwargs.get('remote_user_secret')
+        self.template_path = templates_path
+        self.template_cache_path = self._in_root_dir(kwargs.get('template_cache_path', 'database/compiled_templates/community'))
+        self.error_email_to = kwargs.get('error_email_to')
+        self.smtp_server = kwargs.get('smtp_server')
+        self.smtp_ssl = kwargs.get('smtp_ssl')
+        self.email_from = kwargs.get('email_from')
+        self.nginx_upload_path = kwargs.get('nginx_upload_path', False)
+        self.log_actions = string_as_bool(kwargs.get('log_actions', 'False'))
+        self.pretty_datetime_format = expand_pretty_datetime_format(self.pretty_datetime_format)
+        # Configuration for the message box directly below the masthead.
+        self.wiki_url = kwargs.get('wiki_url', 'https://galaxyproject.org/')
+        self.blog_url = kwargs.get('blog_url')
+        self.screencasts_url = kwargs.get('screencasts_url')
+        self.log_events = False
+        self.cloud_controller_instance = False
+        self.server_name = ''
+        # Where the tool shed hgweb.config file is stored - the default is the Galaxy installation directory.
+        self.hgweb_config_dir = self._in_root_dir(self.hgweb_config_dir)
+        # Proxy features
+        self.nginx_x_accel_redirect_base = kwargs.get('nginx_x_accel_redirect_base', False)
+        self.drmaa_external_runjob_script = kwargs.get('drmaa_external_runjob_script')
+        # Parse global_conf and save the parser
+        global_conf = kwargs.get('global_conf')
+        global_conf_parser = configparser.ConfigParser()
+        self.global_conf_parser = global_conf_parser
+        if global_conf and '__file__' in global_conf and '.yml' not in global_conf['__file__']:
+            global_conf_parser.read(global_conf['__file__'])
+        self.running_functional_tests = string_as_bool(kwargs.get('running_functional_tests', False))
+        self.citation_cache_type = kwargs.get('citation_cache_type', 'file')
+        self.citation_cache_data_dir = self._in_root_dir(kwargs.get('citation_cache_data_dir', 'database/tool_shed_citations/data'))
+        self.citation_cache_lock_dir = self._in_root_dir(kwargs.get('citation_cache_lock_dir', 'database/tool_shed_citations/locks'))
+        self.password_expiration_period = timedelta(days=int(kwargs.get('password_expiration_period', 0)))
+
+        # Security/Policy Compliance
+        self.redact_username_during_deletion = False
+        self.redact_email_during_deletion = False
+        self.redact_username_in_logs = False
+        self.enable_beta_gdpr = string_as_bool(kwargs.get('enable_beta_gdpr', False))
+        if self.enable_beta_gdpr:
+            self.redact_username_during_deletion = True
+            self.redact_email_during_deletion = True
+            self.redact_username_in_logs = True
+            self.allow_user_deletion = True
 
 
 Configuration = ToolShedAppConfiguration

--- a/lib/tool_shed/webapp/config.py
+++ b/lib/tool_shed/webapp/config.py
@@ -4,7 +4,6 @@ Universe configuration builder.
 import logging
 import logging.config
 import os
-import re
 from datetime import timedelta
 
 from six.moves import configparser
@@ -122,19 +121,6 @@ class ToolShedAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     @property
     def shed_tool_data_path(self):
         return self.tool_data_path
-
-    @property
-    def sentry_dsn_public(self):
-        """
-        Sentry URL with private key removed for use in client side scripts,
-        sentry server will need to be configured to accept events
-        """
-        # TODO refactor this to a common place between toolshed/galaxy config, along
-        # with other duplicated methods.
-        if self.sentry_dsn:
-            return re.sub(r"^([^:/?#]+:)?//(\w+):(\w+)", r"\1//\2", self.sentry_dsn)
-        else:
-            return None
 
     def parse_config_file_options(self, kwargs):
         defaults = dict(

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -289,17 +289,17 @@ mapping:
 
       smtp_server:
         type: str
-        default: smtp.your_tool_shed_server
         required: false
         desc: |
           For use by email messages sent from the Tool Shed.
+          (smtp.your_tool_shed_server)
 
       email_from:
         type: str
-        default: your_tool_shed_email@server
         required: false
         desc: |
           For use by email messages sent from the Tool Shed.
+          (your_tool_shed_email@server)
 
       smtp_username:
         type: str
@@ -530,7 +530,7 @@ mapping:
 
       log_actions:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
           Turn on logging of user actions to the database.  Actions currently logged

--- a/lib/tool_shed/webapp/config_schema.yml
+++ b/lib/tool_shed/webapp/config_schema.yml
@@ -208,7 +208,6 @@ mapping:
 
       remote_user_maildomain:
         type: str
-        default: null
         required: false
         desc: |
           If use_remote_user is enabled and your external authentication
@@ -228,7 +227,6 @@ mapping:
 
       remote_user_logout_href:
         type: str
-        default: null
         required: false
         desc: |
           If use_remote_user is enabled, you can set this to a URL that will log your
@@ -457,7 +455,6 @@ mapping:
 
       nginx_x_accel_redirect_base:
         type: str
-        default: null
         required: false
         desc: |
           The same download handling can be done by nginx using X-Accel-Redirect.  This
@@ -466,7 +463,6 @@ mapping:
 
       nginx_upload_path:
         type: str
-        default: null
         required: false
         desc: |
           This value overrides the action set on the file upload form, e.g. the web
@@ -496,7 +492,6 @@ mapping:
 
       brand:
         type: str
-        default: null
         required: false
         desc: |
           Append "/{brand}" to the "Galaxy" text in the masthead.
@@ -549,7 +544,6 @@ mapping:
 
       sentry_dsn:
         type: str
-        default: null
         required: false
         desc: |
           Log to Sentry
@@ -569,7 +563,6 @@ mapping:
 
       terms_url:
         type: str
-        default: null
         required: false
         desc: |
           The URL linked by the "Terms and Conditions" link in the "Help" menu, as well


### PR DESCRIPTION
EDIT: this one is ready. However, as it is based on #9379 (first new commit is c2afc0a: "use mixin for common config settings"), it would be easiest to first get that one merged (pending review), after which I'll rebase this one.

Note to reviewer: as in 9379, the commits (11 total) are atomic, each focused on one type of edit. I've added commit messages where those edits are not self-explanatory. I think, looking at the  changes per commit, sequentially, would make more sense than all changes combined. 

Main theme: factor out common configuration settings into a mixin class. Much of TS's config code is duplication of code in Galaxy's main config object (there's even a TODO in the code: https://github.com/galaxyproject/galaxy/blob/dev/lib/tool_shed/webapp/config.py#L191 )

Argument for *not* moving common code into `BaseAppConfiguration`:
- `BaseAppConfiguration` contains code that is *used by the configuration code* of both apps, Galaxy and TS - i.e., base config paths, schema loading, etc.
- `CommonConfigurationMixin` will contain code that *happens to be present* in both
  Galaxy and TS, but deals with individual configuration properties.

I didn't move all common code into the mixin: there are many settings that are the same for both Galaxy and TS; however, factoring out individual lines, that are identical, would make the configuration of both apps much less readable. I think it's more important to have the individual config steps in one place (i.e., one method) for each app, even if some properties happen to have the same values.

The rest is mostly minor cleanup.

For comparison: 
- TS config before: https://github.com/galaxyproject/galaxy/blob/dev/lib/tool_shed/webapp/config.py
- TS config after: https://github.com/galaxyproject/galaxy/blob/6d6427296c9c8da9305d4e1d279b2dc66c5e76c0/lib/tool_shed/webapp/config.py
