### PR TITLE
Rename and modify current_history_contents method

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -207,6 +207,18 @@ class NavigatesGalaxy(HasDriver):
     def history_panel_name(self):
         return self.history_panel_name_element().text
 
+    def history_contents(self, history_id=None, view='summary', datasets_only=True):
+        if history_id is None:
+            history_id = self.current_history_id()
+        histories = self.api_get('histories?keys=id')
+        if history_id not in [h['id'] for h in histories]:
+            return {}
+        if datasets_only:
+            endpoint = 'histories/%s/contents?view=%s' % (history_id, view)
+        else:
+            endpoint = 'histories/%s?view=%s' % (history_id, view)
+        return self.api_get(endpoint)
+
     def current_history(self):
         full_url = self.build_url("history/current_history_json", for_selenium=False)
         response = requests.get(full_url, cookies=self.selenium_to_requests_cookies())
@@ -215,13 +227,8 @@ class NavigatesGalaxy(HasDriver):
     def current_history_id(self):
         return self.current_history()["id"]
 
-    def current_history_contents(self):
-        current_history_id = self.current_history_id()
-        history_contents = self.api_get("histories/%s/contents" % current_history_id)
-        return history_contents
-
     def latest_history_item(self):
-        history_contents = self.current_history_contents()
+        history_contents = self.history_contents()
         assert len(history_contents) > 0
         return history_contents[-1]
 

--- a/lib/galaxy_test/selenium/test_anon_history.py
+++ b/lib/galaxy_test/selenium/test_anon_history.py
@@ -48,7 +48,7 @@ class AnonymousHistoriesTestCase(SeleniumTestCase):
         # anonymous user. Make sure this new history is empty.
         self.home()
         self.history_panel_wait_for_history_loaded()
-        history_contents = self.current_history_contents()
+        history_contents = self.history_contents()
         assert len(history_contents) == 0
 
     def _upload_file_anonymous_then_register_user(self):

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -16,7 +16,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.perform_upload(self.get_filename("1.sam"))
 
         self.history_panel_wait_for_hid_ok(1)
-        history_contents = self.current_history_contents()
+        history_contents = self.history_contents()
         history_count = len(history_contents)
         assert history_count == 1, "Incorrect number of items in history - expected 1, found %d" % history_count
 
@@ -31,7 +31,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     def test_upload_specify_ext(self):
         self.perform_upload(self.get_filename("1.sam"), ext="txt")
         self.history_panel_wait_for_hid_ok(1)
-        history_contents = self.current_history_contents()
+        history_contents = self.history_contents()
         hda = history_contents[0]
         assert hda["name"] == '1.sam'
         assert hda["extension"] == "txt", hda
@@ -48,7 +48,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     def test_upload_specify_ext_all(self):
         self.perform_upload(self.get_filename("1.sam"), ext_all="txt")
         self.history_panel_wait_for_hid_ok(1)
-        history_contents = self.current_history_contents()
+        history_contents = self.history_contents()
         hda = history_contents[0]
         assert hda["name"] == '1.sam'
         assert hda["extension"] == "txt", hda
@@ -92,7 +92,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.history_panel_wait_for_hid_ok(3)
         self.history_panel_wait_for_hid_ok(1)
 
-        history_contents = self.current_history_contents()
+        history_contents = self.history_contents()
         hda = history_contents[0]
         assert hda["name"] == '1.tabular'
         assert hda["extension"] == "txt", hda


### PR DESCRIPTION
I think the new functionality will be useful in the future, when we want to retrieve or compare history contents or history datasets from sources other than the current active history.