### PR TITLE
[20.01] Free space before running tests

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -21,6 +21,8 @@ jobs:
         ports:
           - 5432:5432
     steps:
+    - name: Prune unused docker image, volumes and containers
+      run: docker system prune -a -f
     - name: Setup Minikube
       if: matrix.subset == 'kubernetes'
       id: minikube


### PR DESCRIPTION
Otherwise kubernetes "taints" nodes with `node.kubernetes.io/disk-pressure` and cleans up old images ... it does take 5 minutes for that refresh to be signalled back, which is why the first couple of tests time out and then they start working again.  