### PR TITLE
[20.01] History import/export fixes

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3136,6 +3136,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
             return rval
 
         rval = super(HistoryDatasetAssociation, self).serialize(id_encoder, serialization_options)
+        rval['state'] = self.state
         rval["hid"] = self.hid
         rval["annotation"] = unicodify(getattr(self, 'annotation', ''))
         rval["tags"] = self.make_tag_string_list()

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -828,6 +828,7 @@ class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):
         for output_key in job_attrs['output_datasets']:
             output_hda = _find_hda(output_key)
             if output_hda:
+                output_hda.state = imported_job.state
                 imported_job.add_output_dataset(output_hda.name, output_hda)
 
         if 'input_mapping' in job_attrs:
@@ -890,6 +891,7 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
                 for output_key in output_keys:
                     output_hda = _find_hda(output_key)
                     if output_hda:
+                        output_hda.state = imported_job.state
                         imported_job.add_output_dataset(output_name, output_hda)
 
         if 'output_dataset_collection_mapping' in job_attrs:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -82,6 +82,7 @@ class ModelImportStore(object):
             self.sessionless = True
         self.user = user
         self.import_options = import_options or ImportOptions()
+        self.dataset_state_serialized = True
 
     @abc.abstractmethod
     def defines_new_history(self):
@@ -183,6 +184,9 @@ class ModelImportStore(object):
         object_key = self.object_key
 
         for dataset_attrs in datasets_attrs:
+
+            if 'state' not in dataset_attrs:
+                self.dataset_state_serialized = False
 
             def handle_dataset_object_edit(dataset_instance):
                 if "dataset" in dataset_attrs:
@@ -321,7 +325,7 @@ class ModelImportStore(object):
                         dataset_instance.dataset.deleted = True
                         dataset_instance.dataset.purged = True
                     else:
-                        dataset_instance.state = dataset_instance.states.OK
+                        dataset_instance.state = dataset_attrs.get('state', dataset_instance.states.OK)
                         self.object_store.update_from_file(dataset_instance.dataset, file_name=temp_dataset_file_name, create=True)
 
                         # Import additional files if present. Histories exported previously might not have this attribute set.
@@ -828,7 +832,9 @@ class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):
         for output_key in job_attrs['output_datasets']:
             output_hda = _find_hda(output_key)
             if output_hda:
-                output_hda.state = imported_job.state
+                if not self.dataset_state_serialized:
+                    # dataset state has not been serialized, get state from job
+                    output_hda.state = imported_job.state
                 imported_job.add_output_dataset(output_hda.name, output_hda)
 
         if 'input_mapping' in job_attrs:
@@ -891,7 +897,9 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
                 for output_key in output_keys:
                     output_hda = _find_hda(output_key)
                     if output_hda:
-                        output_hda.state = imported_job.state
+                        if not self.dataset_state_serialized:
+                            # dataset state has not been serialized, get state from job
+                            output_hda.state = imported_job.state
                         imported_job.add_output_dataset(output_name, output_hda)
 
         if 'output_dataset_collection_mapping' in job_attrs:

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -239,7 +239,7 @@ class HistoriesApiTestCase(ApiTestCase):
 
     @skip_without_tool("job_properties")
     def test_import_export_failed_job(self):
-        history_name = "for_export_include_deleted"
+        history_name = "for_export_include_failed_job"
         history_id = self.dataset_populator.new_history(name=history_name)
         self.dataset_populator.run_tool('job_properties', inputs={'failbool': True}, history_id=history_id, assert_ok=False)
         self.dataset_populator.wait_for_history(history_id, assert_ok=False)

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -182,7 +182,7 @@ class HistoriesApiTestCase(ApiTestCase):
         history_name = "for_export_default"
         history_id = self.dataset_populator.new_history(name=history_name)
         self.dataset_populator.new_dataset(history_id, content="1 2 3")
-        deleted_hda = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+        deleted_hda = self.dataset_populator.new_dataset(history_id, content="1 2 3", wait=True)
         self.dataset_populator.delete_dataset(history_id, deleted_hda["id"])
         deleted_details = self.dataset_populator.get_history_dataset_details(history_id, id=deleted_hda["id"])
         assert deleted_details["deleted"]
@@ -214,7 +214,7 @@ class HistoriesApiTestCase(ApiTestCase):
         history_name = "for_export_include_deleted"
         history_id = self.dataset_populator.new_history(name=history_name)
         self.dataset_populator.new_dataset(history_id, content="1 2 3")
-        deleted_hda = self.dataset_populator.new_dataset(history_id, content="1 2 3")
+        deleted_hda = self.dataset_populator.new_dataset(history_id, content="1 2 3", wait=True)
         self.dataset_populator.delete_dataset(history_id, deleted_hda["id"])
 
         imported_history_id = self._reimport_history(history_id, history_name, wait_on_history_length=2, export_kwds={"include_deleted": "True"})
@@ -223,12 +223,13 @@ class HistoriesApiTestCase(ApiTestCase):
         def upload_job_check(job):
             assert job["tool_id"] == "upload1"
 
-        def check_ok(hda):
+        def check_deleted_not_purged(hda):
             assert hda["state"] == "ok", hda
             assert hda["deleted"] is True, hda
+            assert hda["purged"] is False, hda
 
         self._check_imported_dataset(history_id=imported_history_id, hid=1, job_checker=upload_job_check)
-        self._check_imported_dataset(history_id=imported_history_id, hid=2, hda_checker=check_ok, job_checker=upload_job_check)
+        self._check_imported_dataset(history_id=imported_history_id, hid=2, hda_checker=check_deleted_not_purged, job_checker=upload_job_check)
 
         imported_content = self.dataset_populator.get_history_dataset_content(
             history_id=imported_history_id,

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -115,10 +115,12 @@ def test_export_dataset():
     app, sa_session, h = _setup_history_for_export("Datasets History")
 
     d1, d2 = _create_datasets(sa_session, h, 2)
+    d1.state = d2.state = 'ok'
 
     j = model.Job()
     j.user = h.user
     j.tool_id = "cat1"
+    j.state = 'ok'
 
     j.add_input_dataset("input1", d1)
     j.add_output_dataset("out_file1", d2)


### PR DESCRIPTION
Prior to this you could export histories with failed datasets, but on import the dataset state would be set to OK (despite the job state being correctly set to error).

The fix is to also export the HDA state. Additionally Galaxy will fallback to using the job state if the HDA state has not been serialized. Includes unit tests and API tests. The last commit should make the `test_import_export_include_deleted` test more stable. 

