### PR TITLE
Fix citation ids and vue unit test in ToolsView

### DIFF
--- a/client/galaxy/scripts/components/Citations.vue
+++ b/client/galaxy/scripts/components/Citations.vue
@@ -34,7 +34,7 @@
         <div v-else-if="citations.length">
             <b-btn v-b-toggle="id" variant="primary">Citations</b-btn>
             <b-collapse
-                :id="id"
+                :id="id.replace(/ /g, '_')"
                 class="mt-2"
                 @show="$emit('show')"
                 @shown="$emit('shown')"

--- a/client/galaxy/scripts/components/ToolsView/ToolsView.test.js
+++ b/client/galaxy/scripts/components/ToolsView/ToolsView.test.js
@@ -68,7 +68,7 @@ describe("ToolsView/ToolsView.vue", () => {
             .findAll('[type="button"]')
             .filter(button => button.text() === "Citations")
             .at(0);
-        const citation = wrapper.find("#" + infoButton.attributes("aria-controls"));
+        const citation = wrapper.find("#" + infoButton.attributes("aria-controls").replace(/ /g, "_"));
 
         assert(citation.isVisible() === false, "citation is visible before being triggered!");
         assert(infoButton.attributes("aria-expanded") === "false", "citation is expanded before being triggered!");


### PR DESCRIPTION
Thanks to failed test [here](https://circleci.com/gh/galaxyproject/galaxy/77652?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link), we realized that we have spaces in ids...

 Neither HTML4 nor HTML5 allows space characters in ID attribute values. So this PR replaces all spaces with underscores. Thus we also fix failed test (it's quite sad to see unit tests failing). Should be pretty straight forward and easy to merge. 