### PR TITLE
[20.01] Incremental indexing for tool shed whoosh indexes

### DIFF
--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -26,6 +26,7 @@ def get_or_create_index(whoosh_index_dir):
     tool_index_dir = os.path.join(whoosh_index_dir, 'tools')
     if not os.path.exists(whoosh_index_dir):
         os.makedirs(whoosh_index_dir)
+    if not os.path.exists(tool_index_dir):
         os.makedirs(tool_index_dir)
     return _get_or_create_index(whoosh_index_dir, repo_schema), _get_or_create_index(tool_index_dir, tool_schema)
 
@@ -45,6 +46,8 @@ def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
     """
     Build two search indexes simultaneously
     One is for repositories and the other for tools.
+
+    Returns a tuple with number of repos and tools that were indexed.
     """
     model = ts_mapping.init(file_path, dburi, engine_options={}, create_tables=False)
     sa_session = model.context.current
@@ -83,6 +86,7 @@ def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
 
     log.info("Indexed repos: %s, tools: %s", repos_indexed, tools_indexed)
     log.info("Toolbox index finished %s", execution_timer)
+    return repos_indexed, tools_indexed
 
 
 def get_repos(sa_session, file_path, hgweb_config_dir, update_time=None, **kwargs):

--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -180,11 +180,11 @@ def load_one_dir(path):
             if root.tag == 'tool':
                 tool = {}
                 if root.find('help') is not None:
-                    tool.update(dict(help=root.find('help').text))
+                    tool.update(dict(help=unicodify(root.find('help').text)))
                 if root.find('description') is not None:
-                    tool.update(dict(description=root.find('description').text))
-                tool.update(dict(id=root.attrib.get('id'),
-                                 name=root.attrib.get('name'),
-                                 version=root.attrib.get('version')))
+                    tool.update(dict(description=unicodify(root.find('description').text)))
+                tool.update(dict(id=unicodify(root.attrib.get('id')),
+                                 name=unicodify(root.attrib.get('name')),
+                                 version=unicodify(root.attrib.get('version'))))
                 tools_in_dir.append(tool)
     return tools_in_dir

--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -88,7 +88,7 @@ def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
     return repos_indexed, tools_indexed
 
 
-def get_repos(sa_session, file_path, hgweb_config_dir, update_time=None, **kwargs):
+def get_repos(sa_session, file_path, hgweb_config_dir, **kwargs):
     """
     Load repos from DB and included tools from .xml configs.
     """
@@ -127,7 +127,7 @@ def get_repos(sa_session, file_path, hgweb_config_dir, update_time=None, **kwarg
         full_last_updated = repo.update_time.strftime("%Y-%m-%d %I:%M %p")
 
         # Load all changesets of the repo for lineage.
-        repo_path = hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name))
+        repo_path = os.path.join(hgweb_config_dir, hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name)))
         hg_repo = hg.repository(ui.ui(), repo_path.encode('utf-8'))
         lineage = []
         for changeset in hg_repo.changelog:

--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -6,7 +6,6 @@ from whoosh import index
 from whoosh.writing import AsyncWriter
 
 import tool_shed.webapp.model.mapping as ts_mapping
-
 from galaxy.tool_util.loader_directory import load_tool_elements_from_path
 from galaxy.util import (
     directory_hash_id,

--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -1,0 +1,187 @@
+import logging
+import os
+
+from mercurial import hg, ui
+from whoosh import index
+from whoosh.writing import AsyncWriter
+
+import tool_shed.webapp.model.mapping as ts_mapping
+
+from galaxy.tool_util.loader_directory import load_tool_elements_from_path
+from galaxy.util import (
+    directory_hash_id,
+    ExecutionTimer,
+    pretty_print_time_interval,
+    unicodify
+)
+from tool_shed.webapp import model
+from tool_shed.webapp.search.repo_search import schema as repo_schema
+from tool_shed.webapp.search.tool_search import schema as tool_schema
+from tool_shed.webapp.util.hgweb_config import HgWebConfigManager
+
+log = logging.getLogger(__name__)
+
+
+def get_or_create_index(whoosh_index_dir):
+    tool_index_dir = os.path.join(whoosh_index_dir, 'tools')
+    if not os.path.exists(whoosh_index_dir):
+        os.makedirs(whoosh_index_dir)
+        os.makedirs(tool_index_dir)
+    return _get_or_create_index(whoosh_index_dir, repo_schema), _get_or_create_index(tool_index_dir, tool_schema)
+
+
+def _get_or_create_index(index_dir, schema):
+    if index.exists_in(index_dir):
+        idx = index.open_dir(index_dir)
+        try:
+            assert idx.schema == repo_schema
+            return idx
+        except AssertionError:
+            log.warning("Index at '%s' uses outdated schema, creating new index", index_dir)
+    return index.create_in(index_dir, schema=schema)
+
+
+def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
+    """
+    Build two search indexes simultaneously
+    One is for repositories and the other for tools.
+    """
+    model = ts_mapping.init(file_path, dburi, engine_options={}, create_tables=False)
+    sa_session = model.context.current
+    repo_index, tool_index = get_or_create_index(whoosh_index_dir)
+
+    repo_index_writer = AsyncWriter(repo_index)
+    tool_index_writer = AsyncWriter(tool_index)
+    repos_indexed = 0
+    tools_indexed = 0
+
+    execution_timer = ExecutionTimer()
+    with repo_index.searcher() as searcher:
+        for repo in get_repos(sa_session, file_path, hgweb_config_dir, **kwargs):
+            tools_list = repo.pop('tools_list')
+            repo_id = repo['id']
+            indexed_document = searcher.document(id=repo_id)
+            if indexed_document:
+                if indexed_document['full_last_updated'] == repo.get('full_last_updated'):
+                    # We're done, since we sorted repos by update time
+                    break
+                else:
+                    # Got an update, delete the previous document
+                    repo_index_writer.delete_by_term('id', repo_id)
+
+            repo_index_writer.add_document(**repo)
+
+            #  Tools get their own index
+            for tool in tools_list:
+                tool_index_writer.add_document(**tool)
+                tools_indexed += 1
+
+            repos_indexed += 1
+
+    tool_index_writer.commit()
+    repo_index_writer.commit()
+
+    log.info("Indexed repos: %s, tools: %s", repos_indexed, tools_indexed)
+    log.info("Toolbox index finished %s", execution_timer)
+
+
+def get_repos(sa_session, file_path, hgweb_config_dir, update_time=None, **kwargs):
+    """
+    Load repos from DB and included tools from .xml configs.
+    """
+    hgwcm = HgWebConfigManager()
+    hgwcm.hgweb_config_dir = hgweb_config_dir
+    # Do not index deleted, deprecated, or "tool_dependency_definition" type repositories.
+    q = sa_session.query(model.Repository).filter_by(deleted=False).filter_by(deprecated=False).order_by(model.Repository.update_time.desc())
+    q = q.filter(model.Repository.type != 'tool_dependency_definition')
+    for repo in q:
+        category_names = []
+        for rca in sa_session.query(model.RepositoryCategoryAssociation).filter(model.RepositoryCategoryAssociation.repository_id == repo.id):
+            for category in sa_session.query(model.Category).filter(model.Category.id == rca.category.id):
+                category_names.append(category.name.lower())
+        categories = (",").join(category_names)
+        repo_id = repo.id
+        name = repo.name
+        description = repo.description
+        long_description = repo.long_description
+        homepage_url = repo.homepage_url
+        remote_repository_url = repo.remote_repository_url
+
+        times_downloaded = repo.times_downloaded or 0
+
+        repo_owner_username = ''
+        if repo.user_id is not None:
+            user = sa_session.query(model.User).filter(model.User.id == repo.user_id).one()
+            repo_owner_username = user.username.lower()
+
+        approved = 'no'
+        for review in repo.reviews:
+            if review.approved == 'yes':
+                approved = 'yes'
+                break
+
+        last_updated = pretty_print_time_interval(repo.update_time)
+        full_last_updated = repo.update_time.strftime("%Y-%m-%d %I:%M %p")
+
+        # Load all changesets of the repo for lineage.
+        repo_path = hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name))
+        hg_repo = hg.repository(ui.ui(), repo_path.encode('utf-8'))
+        lineage = []
+        for changeset in hg_repo.changelog:
+            lineage.append(unicodify(changeset) + ":" + unicodify(hg_repo[changeset]))
+        repo_lineage = str(lineage)
+
+        #  Parse all the tools within repo for a separate index.
+        tools_list = []
+        path = os.path.join(file_path, *directory_hash_id(repo.id))
+        path = os.path.join(path, "repo_%d" % repo.id)
+        if os.path.exists(path):
+            tools_list.extend(load_one_dir(path))
+            for root, dirs, files in os.walk(path):
+                if '.hg' in dirs:
+                    dirs.remove('.hg')
+                for dirname in dirs:
+                    tools_in_dir = load_one_dir(os.path.join(root, dirname))
+                    tools_list.extend(tools_in_dir)
+
+        yield (dict(id=repo_id,
+                    name=name,
+                    description=description,
+                    long_description=long_description,
+                    homepage_url=homepage_url,
+                    remote_repository_url=remote_repository_url,
+                    repo_owner_username=repo_owner_username,
+                    times_downloaded=times_downloaded,
+                    approved=approved,
+                    last_updated=last_updated,
+                    full_last_updated=full_last_updated,
+                    tools_list=tools_list,
+                    repo_lineage=repo_lineage,
+                    categories=categories))
+
+
+def debug_handler(path, exc_info):
+    """
+    By default the underlying tool parsing logs warnings for each exception.
+    This is very chatty hence this metod changes it to debug level.
+    """
+    log.debug("Failed to load tool with path %s." % path, exc_info=exc_info)
+
+
+def load_one_dir(path):
+    tools_in_dir = []
+    tool_elems = load_tool_elements_from_path(path, load_exception_handler=debug_handler)
+    if tool_elems:
+        for elem in tool_elems:
+            root = elem[1].getroot()
+            if root.tag == 'tool':
+                tool = {}
+                if root.find('help') is not None:
+                    tool.update(dict(help=root.find('help').text))
+                if root.find('description') is not None:
+                    tool.update(dict(description=root.find('description').text))
+                tool.update(dict(id=root.attrib.get('id'),
+                                 name=root.attrib.get('name'),
+                                 version=root.attrib.get('version')))
+                tools_in_dir.append(tool)
+    return tools_in_dir

--- a/lib/tool_shed/webapp/search/repo_search.py
+++ b/lib/tool_shed/webapp/search/repo_search.py
@@ -5,7 +5,7 @@ import sys
 
 import whoosh.index
 from whoosh import scoring
-from whoosh.fields import NUMERIC, KEYWORD, Schema, STORED, TEXT
+from whoosh.fields import KEYWORD, NUMERIC, Schema, STORED, TEXT
 from whoosh.qparser import MultifieldParser
 from whoosh.query import And, Every, Term
 

--- a/lib/tool_shed/webapp/search/repo_search.py
+++ b/lib/tool_shed/webapp/search/repo_search.py
@@ -5,7 +5,7 @@ import sys
 
 import whoosh.index
 from whoosh import scoring
-from whoosh.fields import KEYWORD, Schema, STORED, TEXT
+from whoosh.fields import NUMERIC, KEYWORD, Schema, STORED, TEXT
 from whoosh.qparser import MultifieldParser
 from whoosh.query import And, Every, Term
 
@@ -18,7 +18,7 @@ if sys.version_info > (3,):
 log = logging.getLogger(__name__)
 
 schema = Schema(
-    id=STORED,
+    id=NUMERIC(stored=True),
     name=TEXT(field_boost=1.7, stored=True),
     description=TEXT(field_boost=1.5, stored=True),
     long_description=TEXT(stored=True),

--- a/scripts/tool_shed/build_ts_whoosh_index.py
+++ b/scripts/tool_shed/build_ts_whoosh_index.py
@@ -23,8 +23,8 @@ from galaxy.util.script import (
     app_properties_from_args,
     populate_config_args
 )
-from tool_shed.webapp import config as ts_config
 from tool_shed.util.shed_index import build_index
+from tool_shed.webapp import config as ts_config
 
 log = logging.getLogger()
 log.addHandler(logging.StreamHandler(sys.stdout))

--- a/scripts/tool_shed/build_ts_whoosh_index.py
+++ b/scripts/tool_shed/build_ts_whoosh_index.py
@@ -17,35 +17,14 @@ import logging
 import os
 import sys
 
-import profilehooks
-from mercurial import hg, ui
-from whoosh import index
-from whoosh.writing import AsyncWriter
-
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'lib')))
 
-import tool_shed.webapp.model.mapping as ts_mapping
-from galaxy.tool_util.loader_directory import load_tool_elements_from_path
-from galaxy.util import (
-    directory_hash_id,
-    ExecutionTimer,
-    pretty_print_time_interval,
-    unicodify
-)
 from galaxy.util.script import (
     app_properties_from_args,
     populate_config_args
 )
-from tool_shed.webapp import (
-    config as ts_config,
-    model as ts_model
-)
-from tool_shed.webapp.search.repo_search import schema as repo_schema
-from tool_shed.webapp.search.tool_search import schema as tool_schema
-from tool_shed.webapp.util.hgweb_config import HgWebConfigManager
-
-if sys.version_info > (3,):
-    long = int
+from tool_shed.webapp import config as ts_config
+from tool_shed.util.shed_index import build_index
 
 log = logging.getLogger()
 log.addHandler(logging.StreamHandler(sys.stdout))
@@ -71,169 +50,6 @@ def parse_arguments():
         for i in vars(args).items():
             log.debug('%s: %s' % i)
     return args
-
-
-def get_or_create_index(whoosh_index_dir):
-    tool_index_dir = os.path.join(whoosh_index_dir, 'tools')
-    if not os.path.exists(whoosh_index_dir):
-        os.makedirs(whoosh_index_dir)
-        os.makedirs(tool_index_dir)
-    return _get_or_create_index(whoosh_index_dir, repo_schema), _get_or_create_index(tool_index_dir, tool_schema)
-
-
-def _get_or_create_index(index_dir, schema):
-    try:
-        return index.open_dir(index_dir, schema=schema)
-    except index.EmptyIndexError:
-        return index.create_in(index_dir, schema=schema)
-
-
-@profilehooks.profile
-def build_index(whoosh_index_dir, file_path, hgweb_config_dir, dburi, **kwargs):
-    """
-    Build two search indexes simultaneously
-    One is for repositories and the other for tools.
-    """
-    model = ts_mapping.init(file_path, dburi, engine_options={}, create_tables=False)
-    sa_session = model.context.current
-    repo_index, tool_index = get_or_create_index(whoosh_index_dir)
-
-    repo_index_writer = AsyncWriter(repo_index)
-    tool_index_writer = AsyncWriter(tool_index)
-    repos_indexed = 0
-    tools_indexed = 0
-
-    execution_timer = ExecutionTimer()
-    with repo_index.searcher() as searcher:
-        for repo in get_repos(sa_session, file_path, hgweb_config_dir, **kwargs):
-            tools_list = repo.pop('tools_list')
-            repo_id = repo['id']
-            indexed_document = searcher.document(id=repo_id)
-            if indexed_document:
-                if indexed_document['full_last_updated'] == repo.get('full_last_updated'):
-                    # We're done, since we sorted repos by update time
-                    break
-                else:
-                    # Got an update, delete the previous document
-                    repo_index_writer.delete_by_term('id', repo_id)
-
-            repo_index_writer.add_document(**repo)
-
-            #  Tools get their own index
-            for tool in tools_list:
-                tool_index_writer.add_document(**tool)
-                tools_indexed += 1
-
-            repos_indexed += 1
-
-    tool_index_writer.commit()
-    repo_index_writer.commit()
-
-    log.info("Indexed repos: %s, tools: %s", repos_indexed, tools_indexed)
-    log.info("Toolbox index finished %s", execution_timer)
-
-
-def get_repos(sa_session, file_path, hgweb_config_dir, update_time=None, **kwargs):
-    """
-    Load repos from DB and included tools from .xml configs.
-    """
-    hgwcm = HgWebConfigManager()
-    hgwcm.hgweb_config_dir = hgweb_config_dir
-    # Do not index deleted, deprecated, or "tool_dependency_definition" type repositories.
-    q = sa_session.query(ts_model.Repository).filter_by(deleted=False).filter_by(deprecated=False).order_by(ts_model.Repository.update_time.desc())
-    q = q.filter(ts_model.Repository.type != 'tool_dependency_definition')
-
-    for repo in q:
-        category_names = []
-        for rca in sa_session.query(ts_model.RepositoryCategoryAssociation).filter(ts_model.RepositoryCategoryAssociation.repository_id == repo.id):
-            for category in sa_session.query(ts_model.Category).filter(ts_model.Category.id == rca.category.id):
-                category_names.append(category.name.lower())
-        categories = (",").join(category_names)
-        repo_id = repo.id
-        name = repo.name
-        description = repo.description
-        long_description = repo.long_description
-        homepage_url = repo.homepage_url
-        remote_repository_url = repo.remote_repository_url
-
-        times_downloaded = repo.times_downloaded or 0
-
-        repo_owner_username = ''
-        if repo.user_id is not None:
-            user = sa_session.query(ts_model.User).filter(ts_model.User.id == repo.user_id).one()
-            repo_owner_username = user.username.lower()
-
-        approved = 'no'
-        for review in repo.reviews:
-            if review.approved == 'yes':
-                approved = 'yes'
-                break
-
-        last_updated = pretty_print_time_interval(repo.update_time)
-        full_last_updated = repo.update_time.strftime("%Y-%m-%d %I:%M %p")
-
-        # Load all changesets of the repo for lineage.
-        repo_path = hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name))
-        hg_repo = hg.repository(ui.ui(), repo_path.encode('utf-8'))
-        lineage = []
-        for changeset in hg_repo.changelog:
-            lineage.append(unicodify(changeset) + ":" + unicodify(hg_repo[changeset]))
-        repo_lineage = str(lineage)
-
-        #  Parse all the tools within repo for a separate index.
-        tools_list = []
-        path = os.path.join(file_path, *directory_hash_id(repo.id))
-        path = os.path.join(path, "repo_%d" % repo.id)
-        if os.path.exists(path):
-            tools_list.extend(load_one_dir(path))
-            for root, dirs, files in os.walk(path):
-                if '.hg' in dirs:
-                    dirs.remove('.hg')
-                for dirname in dirs:
-                    tools_in_dir = load_one_dir(os.path.join(root, dirname))
-                    tools_list.extend(tools_in_dir)
-
-        yield (dict(id=repo_id,
-                    name=name,
-                    description=description,
-                    long_description=long_description,
-                    homepage_url=homepage_url,
-                    remote_repository_url=remote_repository_url,
-                    repo_owner_username=repo_owner_username,
-                    times_downloaded=times_downloaded,
-                    approved=approved,
-                    last_updated=last_updated,
-                    full_last_updated=full_last_updated,
-                    tools_list=tools_list,
-                    repo_lineage=repo_lineage,
-                    categories=categories))
-
-
-def load_one_dir(path):
-    tools_in_dir = []
-    tool_elems = load_tool_elements_from_path(path, load_exception_handler=debug_handler)
-    if tool_elems:
-        for elem in tool_elems:
-            root = elem[1].getroot()
-            if root.tag == 'tool':
-                tool = {}
-                if root.find('help') is not None:
-                    tool.update(dict(help=root.find('help').text))
-                if root.find('description') is not None:
-                    tool.update(dict(description=root.find('description').text))
-                tool.update(dict(id=root.attrib.get('id'),
-                                 name=root.attrib.get('name'),
-                                 version=root.attrib.get('version')))
-                tools_in_dir.append(tool)
-    return tools_in_dir
-
-
-def debug_handler(path, exc_info):
-    """
-    By default the underlying tool parsing logs warnings for each exception.
-    This is very chatty hence this metod changes it to debug level.
-    """
-    log.debug("Failed to load tool with path %s." % path, exc_info=exc_info)
 
 
 def main():

--- a/scripts/tool_shed/build_ts_whoosh_index.py
+++ b/scripts/tool_shed/build_ts_whoosh_index.py
@@ -190,10 +190,10 @@ def get_repos(sa_session, file_path, hgweb_config_dir, **kwargs):
 
         # Load all changesets of the repo for lineage.
         repo_path = hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name))
-        hg_repo = hg.repository(ui.ui(), repo_path)
+        hg_repo = hg.repository(ui.ui(), repo_path.encode('utf-8'))
         lineage = []
         for changeset in hg_repo.changelog:
-            lineage.append(str(changeset) + ":" + str(hg_repo[changeset]))
+            lineage.append(unicodify(changeset) + ":" + unicodify(hg_repo[changeset]))
         repo_lineage = str(lineage)
 
         #  Parse all the tools within repo for a separate index.

--- a/test/unit/shed_unit/test_shed_index.py
+++ b/test/unit/shed_unit/test_shed_index.py
@@ -1,13 +1,14 @@
 import os
-import requests
 import shutil
 import tarfile
 import tempfile
 from collections import namedtuple
 
 import pytest
-from tool_shed.util.shed_index import build_index
+import requests
 from whoosh import index
+
+from tool_shed.util.shed_index import build_index
 
 URL = 'https://github.com/mvdbeek/toolshed-test-data/blob/master/toolshed_community_files.tgz?raw=true'
 

--- a/test/unit/shed_unit/test_shed_index.py
+++ b/test/unit/shed_unit/test_shed_index.py
@@ -3,6 +3,7 @@ import shutil
 import tarfile
 import tempfile
 from collections import namedtuple
+from io import BytesIO
 
 import pytest
 import requests
@@ -25,9 +26,8 @@ def whoosh_index_dir():
 @pytest.fixture(scope='module')
 def community_file_dir():
     extracted_archive_dir = tempfile.mkdtemp()
-    with tempfile.NamedTemporaryFile(suffix='_test_shed_index_archive.tgz', mode='wb') as outfile:
-        outfile.write(requests.get(URL).content)
-        tarfile.open(outfile.name, "r:gz").extractall(extracted_archive_dir)
+    b = BytesIO(requests.get(URL).content)
+    tarfile.open(fileobj=b, mode="r:gz").extractall(extracted_archive_dir)
     try:
         yield extracted_archive_dir
     finally:

--- a/test/unit/shed_unit/test_shed_index.py
+++ b/test/unit/shed_unit/test_shed_index.py
@@ -1,0 +1,64 @@
+import os
+import requests
+import shutil
+import tarfile
+import tempfile
+from collections import namedtuple
+
+import pytest
+from tool_shed.util.shed_index import build_index
+from whoosh import index
+
+URL = 'https://github.com/mvdbeek/toolshed-test-data/blob/master/toolshed_community_files.tgz?raw=true'
+
+
+@pytest.fixture
+def whoosh_index_dir():
+    try:
+        whoosh_index_dir = tempfile.mkdtemp(suffix='_whoosh_index_test')
+        yield whoosh_index_dir
+    finally:
+        shutil.rmtree(whoosh_index_dir)
+
+
+@pytest.fixture(scope='module')
+def community_file_dir():
+    extracted_archive_dir = tempfile.mkdtemp()
+    with tempfile.NamedTemporaryFile(suffix='_test_shed_index_archive.tgz', mode='wb') as outfile:
+        outfile.write(requests.get(URL).content)
+        tarfile.open(outfile.name, "r:gz").extractall(extracted_archive_dir)
+    try:
+        yield extracted_archive_dir
+    finally:
+        shutil.rmtree(extracted_archive_dir)
+
+
+@pytest.fixture()
+def community_file_structure(community_file_dir):
+    cf = namedtuple('community', 'file_path hgweb_config_dir dburi')
+    return cf(
+        file_path=os.path.join(community_file_dir, 'database', 'community_files'),
+        hgweb_config_dir=community_file_dir,
+        dburi="sqlite:///%s" % os.path.join(community_file_dir, 'database', 'community.sqlite')
+    )
+
+
+def test_build_index(whoosh_index_dir, community_file_structure):
+    repos_indexed, tools_indexed = build_index(whoosh_index_dir, community_file_structure.file_path, community_file_structure.hgweb_config_dir, community_file_structure.dburi)
+    assert repos_indexed == 1
+    assert tools_indexed == 1
+    idx = index.open_dir(whoosh_index_dir)
+    assert idx.doc_count() == 1
+    repos_indexed, tools_indexed = build_index(whoosh_index_dir, community_file_structure.file_path, community_file_structure.hgweb_config_dir, community_file_structure.dburi)
+    assert repos_indexed == 0
+    assert tools_indexed == 0
+    idx = index.open_dir(whoosh_index_dir)
+    assert idx.doc_count() == 1
+    writer = idx.writer()
+    writer.delete_by_term('id', 1)
+    writer.commit()
+    idx = index.open_dir(whoosh_index_dir)
+    assert idx.doc_count() == 0
+    repos_indexed, tools_indexed = build_index(whoosh_index_dir, community_file_structure.file_path, community_file_structure.hgweb_config_dir, community_file_structure.dburi)
+    assert repos_indexed == 1
+    assert tools_indexed == 1


### PR DESCRIPTION
The new TS client makes intensive use of the repo and tool whoosh indexes that are built outside of the repo update cycle. For deployers to find new repos in the admin interface we need to constantly rebuild the index (or couple repo updates with index updates, since they now are effectively tied together).
Doing this puts heavy load on the tool shed (it is almost unreachable during the last couple of days ...)

This PR implements incremental indexing by ordering repos by update time. Once we reach a repo that is present in the whoosh index and that has the same update time as the repo we're trying to add we break out of the update loop. This means in most cases we just need to index 0 or 1 new repos.

This includes unit tests for the core changes. I have uploaded a small fraction of repos form the IUC to a local tool shed. Without these changes indexing took 3 seconds, with the changes it's around 300 ms,
where most time is spent initializing the toolshed model.