### PR TITLE
unify usage of Popen

### DIFF
--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -5,8 +5,8 @@ Author Peter van Heusden (pvh@sanbi.ac.za)
 """
 import logging
 import shlex
-from subprocess import PIPE, Popen
 
+from galaxy.tool_util.deps import commands
 from galaxy.util import string_as_bool
 from ..providers import AuthProvider
 
@@ -118,12 +118,13 @@ class PAM(AuthProvider):
             else:
                 auth_cmd = shlex.split('/usr/bin/sudo -n {}'.format(authentication_helper))
                 log.debug("PAM auth: external helper cmd: {}".format(auth_cmd))
-                proc = Popen(auth_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
                 message = '{}\n{}\n{}\n'.format(pam_service, pam_username, password)
-                (output, error) = proc.communicate(message)
-                status = proc.wait()
-                if status != 0 and error != '':
-                    log.debug("PAM auth: external authentication script had errors: status {} error {}".format(status, error))
+                try:
+                    output = commands.execute(auth_cmd, input=message)
+                except commands.CommandLineException as e:
+                    if e.stderr != '':
+                        log.debug("PAM auth: external authentication script had errors: status {} error {}".format(e.returncode, e.stderr))
+                    output = e.stdout
                 if output.strip() == 'True':
                     authenticated = True
                 else:

--- a/lib/galaxy/auth/providers/pam_auth.py
+++ b/lib/galaxy/auth/providers/pam_auth.py
@@ -6,8 +6,10 @@ Author Peter van Heusden (pvh@sanbi.ac.za)
 import logging
 import shlex
 
-from galaxy.tool_util.deps import commands
-from galaxy.util import string_as_bool
+from galaxy.util import (
+    commands,
+    string_as_bool
+)
 from ..providers import AuthProvider
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -18,8 +18,10 @@ from galaxy.datatypes.sniff import (
 from galaxy.datatypes.tabular import Tabular
 from galaxy.datatypes.util.generic_util import count_special_lines
 from galaxy.datatypes.xml import GenericXml
-from galaxy.tool_util.deps import commands
-from galaxy.util import unicodify
+from galaxy.util import (
+    commands,
+    unicodify
+)
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -37,7 +37,7 @@ def count_lines(filename, non_empty=False):
     try:
         out = commands.execute(cmd)
     except commands.CommandLineException as e:
-        log.error(str(e))
+        log.error(unicodify(e))
         return 0
     return int(out.split()[0])
 

--- a/lib/galaxy/datatypes/util/generic_util.py
+++ b/lib/galaxy/datatypes/util/generic_util.py
@@ -1,4 +1,4 @@
-from galaxy.tool_util.deps import commands
+from galaxy.util import commands
 
 
 def count_special_lines(word, filename, invert=False):

--- a/lib/galaxy/datatypes/util/generic_util.py
+++ b/lib/galaxy/datatypes/util/generic_util.py
@@ -1,19 +1,18 @@
-import subprocess
+from galaxy.tool_util.deps import commands
 
 
 def count_special_lines(word, filename, invert=False):
     """
-        searching for special 'words' using the grep tool
-        grep is used to speed up the searching and counting
-        The number of hits is returned.
+    searching for special 'words' using the grep tool
+    grep is used to speed up the searching and counting
+    The number of hits is returned.
     """
+    cmd = ["grep", "-c", "-E"]
+    if invert:
+        cmd.append('-v')
+    cmd.extend([word, filename])
     try:
-        cmd = ["grep", "-c", "-E"]
-        if invert:
-            cmd.append('-v')
-        cmd.extend([word, filename])
-        out = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        return int(out.communicate()[0].split()[0])
-    except Exception:
-        pass
-    return 0
+        out = commands.execute(cmd)
+    except commands.CommandLineException:
+        return 0
+    return int(out)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2209,7 +2209,7 @@ class JobWrapper(HasResourceParameters):
             try:
                 commands.execute(cmd)
             except commands.CommandLineException as e:
-                log.error('external script failed: %s' % e)
+                log.error('external script failed: %s' % unicodify(e))
 
     def change_ownership_for_run(self):
         job = self.get_job()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -53,15 +53,13 @@ from galaxy.jobs.runners import BaseJobRunner, JobState
 from galaxy.metadata import get_metadata_compute_strategy
 from galaxy.model import store
 from galaxy.objectstore import ObjectStorePopulator
-from galaxy.tool_util.deps import (
-    commands,
-    requirements
-)
+from galaxy.tool_util.deps import requirements
 from galaxy.tool_util.output_checker import (
     check_output,
     DETECTED_JOB_STATE,
 )
 from galaxy.util import (
+    commands,
     RWXRWXRWX,
     safe_makedirs,
     unicodify,

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -19,7 +19,8 @@ from galaxy.jobs.runners import (
 )
 from galaxy.util import (
     asbool,
-    commands
+    commands,
+    unicodify
 )
 
 drmaa = None
@@ -365,7 +366,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         except drmaa.InvalidJobException:
             log.exception("(%s/%s) User killed running job, but it was already dead" % (job.id, ext_id))
         except commands.CommandLineException as e:
-            log.error("(%s/%s) User killed running job, but command execution failed: %s" % (job.id, ext_id, e))
+            log.error("(%s/%s) User killed running job, but command execution failed: %s" % (job.id, ext_id, unicodify(e)))
         except Exception:
             log.exception("(%s/%s) User killed running job, but error encountered removing from DRM queue" % (job.id, ext_id))
 
@@ -412,7 +413,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         try:
             stdoutdata = commands.execute(cmd)
         except commands.CommandLineException as e:
-            log.exception("External_runjob failed %s" % e)
+            log.exception("External_runjob failed %s" % unicodify(e))
             return None
         # The expected output is a single line containing a single numeric value:
         # the DRMAA job-ID. If not the case, will throw an error.

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -17,8 +17,10 @@ from galaxy.jobs.runners import (
     AsynchronousJobRunner,
     AsynchronousJobState
 )
-from galaxy.tool_util.deps import commands
-from galaxy.util import asbool
+from galaxy.util import (
+    asbool,
+    commands
+)
 
 drmaa = None
 

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -363,7 +363,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         except drmaa.InvalidJobException:
             log.exception("(%s/%s) User killed running job, but it was already dead" % (job.id, ext_id))
         except commands.CommandLineException as e:
-            log.exception("(%s/%s) User killed running job, but command execution failed: %s" % (job.id, ext_id, e))
+            log.error("(%s/%s) User killed running job, but command execution failed: %s" % (job.id, ext_id, e))
         except Exception:
             log.exception("(%s/%s) User killed running job, but error encountered removing from DRM queue" % (job.id, ext_id))
 

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -411,7 +411,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         cmd.extend([str(username), jobtemplate_filename])
         log.info("Running command %s" % cmd)
         try:
-            stdoutdata = commands.execute(cmd)
+            stdoutdata = commands.execute(cmd).strip()
         except commands.CommandLineException as e:
             log.exception("External_runjob failed %s" % unicodify(e))
             return None

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -51,7 +51,7 @@ class SlurmJobRunner(DRMAAJobRunner):
             try:
                 stdout = commands.execute(cmd)
             except commands.CommandLineException as e:
-                if e.stderr == 'SLURM accounting storage is disabled':
+                if e.stderr.strip() == 'SLURM accounting storage is disabled':
                     log.warning('SLURM accounting storage is not properly configured, unable to run sacct')
                     return
                 raise e
@@ -73,7 +73,7 @@ class SlurmJobRunner(DRMAAJobRunner):
                 cluster = None
             cmd.extend(['show', 'job', job_id])
             try:
-                stdout = commands.execute(cmd)
+                stdout = commands.execute(cmd).strip()
             except commands.CommandLineException as e:
                 if e.stderr == 'slurm_load_jobs error: Invalid job id specified\n':
                     # The job may be old, try to get its state with sacct

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -4,13 +4,12 @@ SLURM job control via the DRMAA API.
 import os
 import re
 import shutil
-import subprocess
 import tempfile
 import time
 
 from galaxy import model
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
-from galaxy.util import unicodify
+from galaxy.tool_util.deps import commands
 from galaxy.util.logging import get_logger
 
 log = get_logger(__name__)
@@ -49,18 +48,17 @@ class SlurmJobRunner(DRMAAJobRunner):
             if cluster:
                 cmd.extend(['-M', cluster])
             cmd.extend(['-j', job_id])
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate()
-            if p.returncode != 0:
-                stderr = unicodify(stderr).strip()
-                if stderr == 'SLURM accounting storage is disabled':
+            try:
+                stdout = commands.execute(cmd)
+            except commands.CommandLineException as e:
+                if e.stderr == 'SLURM accounting storage is disabled':
                     log.warning('SLURM accounting storage is not properly configured, unable to run sacct')
                     return
-                raise Exception('`%s` returned %s, stderr: %s' % (' '.join(cmd), p.returncode, stderr))
+                raise e
             # First line is for 'job_id'
             # Second line is for 'job_id.batch' (only available after the batch job is complete)
             # Following lines are for the steps 'job_id.0', 'job_id.1', ... (but Galaxy does not use steps)
-            first_line = unicodify(stdout).splitlines()[0]
+            first_line = stdout.splitlines()[0]
             # Strip whitespaces and the final '+' (if present), only return the first word
             return first_line.strip().rstrip('+').split()[0]
 
@@ -74,19 +72,16 @@ class SlurmJobRunner(DRMAAJobRunner):
                 job_id = ajs.job_id
                 cluster = None
             cmd.extend(['show', 'job', job_id])
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate()
-            if p.returncode != 0:
-                # Will need to be more clever here if this message is not consistent
-                stderr = unicodify(stderr)
-                if stderr == 'slurm_load_jobs error: Invalid job id specified\n':
+            try:
+                stdout = commands.execute(cmd)
+            except commands.CommandLineException as e:
+                if e.stderr == 'slurm_load_jobs error: Invalid job id specified\n':
                     # The job may be old, try to get its state with sacct
                     job_state = _get_slurm_state_with_sacct(job_id, cluster)
                     if job_state:
                         return job_state
                     return 'NOT_FOUND'
-                raise Exception('`%s` returned %s, stderr: %s' % (' '.join(cmd), p.returncode, stderr))
-            stdout = unicodify(stdout).strip()
+                raise e
             # stdout is a single line in format "key1=value1 key2=value2 ..."
             job_info_keys = []
             job_info_values = []

--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -9,7 +9,7 @@ import time
 
 from galaxy import model
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
-from galaxy.tool_util.deps import commands
+from galaxy.util import commands
 from galaxy.util.logging import get_logger
 
 log = get_logger(__name__)

--- a/lib/galaxy/jobs/runners/univa.py
+++ b/lib/galaxy/jobs/runners/univa.py
@@ -30,8 +30,8 @@ import signal
 import time
 
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
-from galaxy.tool_util.deps import commands
 from galaxy.util import (
+    commands,
     size_to_bytes
 )
 

--- a/lib/galaxy/jobs/runners/univa.py
+++ b/lib/galaxy/jobs/runners/univa.py
@@ -158,7 +158,7 @@ class UnivaJobRunner(DRMAAJobRunner):
         # way seems more generic
         cmd = ['qstat', '-u', '"*"']
         try:
-            stdout = commands.execute(cmd).split()
+            stdout = commands.execute(cmd).strip()
         except commands.CommandLineException as e:
             log.error(unicodify(e))
             raise self.drmaa.InternalException()
@@ -208,7 +208,7 @@ class UnivaJobRunner(DRMAAJobRunner):
                     slp *= 2
                     continue
                 else:
-                    log.exception(unicodify(e))
+                    log.error(unicodify(e))
                     return self.drmaa.JobState.UNDETERMINED
             else:
                 break

--- a/lib/galaxy/jobs/runners/univa.py
+++ b/lib/galaxy/jobs/runners/univa.py
@@ -32,7 +32,8 @@ import time
 from galaxy.jobs.runners.drmaa import DRMAAJobRunner
 from galaxy.util import (
     commands,
-    size_to_bytes
+    size_to_bytes,
+    unicodify
 )
 
 log = logging.getLogger(__name__)
@@ -159,7 +160,7 @@ class UnivaJobRunner(DRMAAJobRunner):
         try:
             stdout = commands.execute(cmd)
         except commands.CommandLineException as e:
-            log.error(str(e))
+            log.error(unicodify(e))
             raise self.drmaa.InternalException()
         state = self.drmaa.JobState.UNDETERMINED
         for line in stdout.split('\n'):
@@ -207,7 +208,7 @@ class UnivaJobRunner(DRMAAJobRunner):
                     slp *= 2
                     continue
                 else:
-                    log.exception(str(e))
+                    log.exception(unicodify(e))
                     return self.drmaa.JobState.UNDETERMINED
             else:
                 break

--- a/lib/galaxy/jobs/runners/univa.py
+++ b/lib/galaxy/jobs/runners/univa.py
@@ -158,7 +158,7 @@ class UnivaJobRunner(DRMAAJobRunner):
         # way seems more generic
         cmd = ['qstat', '-u', '"*"']
         try:
-            stdout = commands.execute(cmd)
+            stdout = commands.execute(cmd).split()
         except commands.CommandLineException as e:
             log.error(unicodify(e))
             raise self.drmaa.InternalException()
@@ -201,7 +201,7 @@ class UnivaJobRunner(DRMAAJobRunner):
         # max wait is approx 1min)
         while True:
             try:
-                stdout = commands.execute(cmd)
+                stdout = commands.execute(cmd).strip()
             except commands.CommandLineException as e:
                 if slp <= 32 and "job id {jobid} not found".format(jobid=job_id) in e.stderr:
                     time.sleep(slp)

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -18,8 +18,6 @@ DEFAULT_QUERY_CLASSAD = dict(
     notification='NEVER',
 )
 
-PROBLEM_RUNNING_CONDOR_SUBMIT = \
-    "Problem encountered while running condor_submit."
 PROBLEM_PARSING_EXTERNAL_ID = \
     "Failed to find job id from condor_submit"
 

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -78,7 +78,7 @@ def condor_submit(submit_file):
     try:
         message = commands.execute(('condor_submit', submit_file))
     except commands.CommandLineException as e:
-        message = str(e)
+        message = unicodify(e)
     else:
         try:
             external_id = parse_external_id(message, type='condor')

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -6,8 +6,10 @@ from subprocess import (
     check_call
 )
 
-from galaxy.tool_util.deps import commands
-from galaxy.util import unicodify
+from galaxy.util import (
+    commands,
+    unicodify
+)
 from ..external import parse_external_id
 
 DEFAULT_QUERY_CLASSAD = dict(

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -3,12 +3,10 @@ Condor helper utilities.
 """
 from subprocess import (
     CalledProcessError,
-    check_call,
-    PIPE,
-    Popen,
-    STDOUT
+    check_call
 )
 
+from galaxy.tool_util.deps import commands
 from galaxy.util import unicodify
 from ..external import parse_external_id
 
@@ -76,15 +74,14 @@ def condor_submit(submit_file):
     """
     external_id = None
     try:
-        submit = Popen(('condor_submit', submit_file), stdout=PIPE, stderr=STDOUT)
-        message, _ = submit.communicate()
-        message = unicodify(message)
-        if submit.returncode == 0:
+        message = commands.execute(('condor_submit', submit_file))
+    except commands.CommandLineException as e:
+        message = str(e)
+    else:
+        try:
             external_id = parse_external_id(message, type='condor')
-        else:
+        except Exception:
             message = PROBLEM_PARSING_EXTERNAL_ID
-    except Exception as e:
-        message = unicodify(e)
     return external_id, message
 
 

--- a/lib/galaxy/jobs/runners/util/sudo.py
+++ b/lib/galaxy/jobs/runners/util/sudo.py
@@ -22,5 +22,6 @@ def sudo_popen(*args, **kwargs):
         full_command.extend([SUDO_USER_ARG, user])
     full_command.extend(args)
     log.info("About to execute the following sudo command - [%s]" % ' '.join(full_command))
+    
     p = Popen(full_command, shell=False, stdout=PIPE, stderr=PIPE)
     return p

--- a/lib/galaxy/jobs/runners/util/sudo.py
+++ b/lib/galaxy/jobs/runners/util/sudo.py
@@ -22,6 +22,5 @@ def sudo_popen(*args, **kwargs):
         full_command.extend([SUDO_USER_ARG, user])
     full_command.extend(args)
     log.info("About to execute the following sudo command - [%s]" % ' '.join(full_command))
-    
     p = Popen(full_command, shell=False, stdout=PIPE, stderr=PIPE)
     return p

--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -12,15 +12,12 @@ import packaging.version
 import six
 from six.moves import shlex_quote
 
-from galaxy.tool_util.deps.commands import CommandLineException
 from galaxy.util import (
+    commands,
     smart_str,
     unicodify
 )
-from . import (
-    commands,
-    installable
-)
+from . import installable
 
 log = logging.getLogger(__name__)
 
@@ -533,7 +530,7 @@ def best_search_result(conda_target, conda_context, channels_override=None, offl
         hits = json.loads(res).get(conda_target.package, [])[::-1]
         hits = sorted(hits, key=lambda hit: hit['build_number'], reverse=True)
         hits = sorted(hits, key=lambda hit: packaging.version.parse(hit['version']), reverse=True)
-    except CommandLineException:
+    except commands.CommandLineException:
         log.error("Could not execute: '%s'", search_cmd)
         hits = []
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -11,7 +11,7 @@ from galaxy.util import (
     string_as_bool,
     unicodify,
 )
-from ..commands import shell
+from galaxy.util.commands import shell
 from ..container_classes import CONTAINER_CLASSES
 from ..container_resolvers import (
     ContainerResolver,

--- a/lib/galaxy/tool_util/deps/docker_util.py
+++ b/lib/galaxy/tool_util/deps/docker_util.py
@@ -6,7 +6,7 @@ import os
 
 from six.moves import shlex_quote
 
-from .commands import argv_to_str
+from galaxy.util.commands import argv_to_str
 
 DEFAULT_DOCKER_COMMAND = "docker"
 DEFAULT_SUDO = False

--- a/lib/galaxy/tool_util/deps/dockerfiles.py
+++ b/lib/galaxy/tool_util/deps/dockerfiles.py
@@ -1,11 +1,11 @@
 import logging
 import os
 
-from galaxy.tool_util.deps import commands
 from galaxy.tool_util.deps import docker_util
 from galaxy.tool_util.deps.container_classes import docker_cache_path
 from galaxy.tool_util.deps.requirements import parse_requirements_from_xml
 from galaxy.tool_util.loader_directory import load_tool_elements_from_path
+from galaxy.util import commands
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -26,10 +26,11 @@ try:
 except ImportError:
     yaml = None
 
-from galaxy.tool_util.deps import commands, installable
+from galaxy.tool_util.deps import installable
 from galaxy.tool_util.deps.conda_util import best_search_result
 from galaxy.tool_util.deps.docker_util import command_list as docker_command_list
 from galaxy.util import (
+    commands,
     safe_makedirs,
     unicodify,
 )

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -326,12 +326,14 @@ def create_paramfile(trans, uploaded_datasets):
             cmd = shlex.split(trans.app.config.external_chown_script)
             cmd.extend([path, pwent[0], str(pwent[3])])
         except Exception as e:
-            log.debug('Failed to construct command to change ownership %s' % str(e))
+            log.debug('Failed to construct command to change ownership %s' %
+                      unicodify(e))
         log.debug('Changing ownership of %s with: %s' % (path, ' '.join(cmd)))
         try:
             commands.execute(cmd)
         except commands.CommandLineException as e:
-            log.warning('Changing ownership of uploaded file %s failed: %s', path, str(e))
+            log.warning('Changing ownership of uploaded file %s failed: %s',
+                        path, unicodify(e))
 
     tool_params = []
     json_file_path = None

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -3,7 +3,6 @@ import logging
 import os
 import shlex
 import socket
-import subprocess
 import tempfile
 from collections import OrderedDict
 from json import dump, dumps
@@ -20,6 +19,7 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.model import tags
+from galaxy.tool_util.deps import commands
 from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
@@ -323,12 +323,13 @@ def create_paramfile(trans, uploaded_datasets):
             pwent = trans.user.system_user_pwent(trans.app.config.real_system_username)
             cmd = shlex.split(trans.app.config.external_chown_script)
             cmd.extend([path, pwent[0], str(pwent[3])])
-            log.debug('Changing ownership of %s with: %s' % (path, ' '.join(cmd)))
-            p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate()
-            assert p.returncode == 0, stderr
         except Exception as e:
-            log.warning('Changing ownership of uploaded file %s failed: %s', path, unicodify(e))
+            log.debug('Failed to construct command to change ownership %s' % str(e))
+        log.debug('Changing ownership of %s with: %s' % (path, ' '.join(cmd)))
+        try:
+            commands.execute(cmd)
+        except commands.CommandLineException as e:
+            log.warning('Changing ownership of uploaded file %s failed: %s', path, str(e))
 
     tool_params = []
     json_file_path = None

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -19,8 +19,10 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.model import tags
-from galaxy.tool_util.deps import commands
-from galaxy.util import unicodify
+from galaxy.util import (
+    commands,
+    unicodify
+)
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/tools/expressions/util.py
+++ b/lib/galaxy/tools/expressions/util.py
@@ -1,4 +1,4 @@
-from galaxy.tool_util.deps.commands import which
+from galaxy.util.commands import which
 
 
 def find_engine(config):

--- a/lib/galaxy/util/commands.py
+++ b/lib/galaxy/util/commands.py
@@ -114,7 +114,7 @@ def argv_to_str(command_argv, quote=True):
 def _wait(cmds, input=None, **popen_kwds):
     p = subprocess.Popen(cmds, **popen_kwds)
     stdout, stderr = p.communicate(input)
-    stdout, stderr = unicodify(stdout).strip(), unicodify(stderr).strip()
+    stdout, stderr = unicodify(stdout), unicodify(stderr)
     if p.returncode != 0:
         raise CommandLineException(argv_to_str(cmds), stdout, stderr, p.returncode)
     return stdout

--- a/lib/galaxy/util/commands.py
+++ b/lib/galaxy/util/commands.py
@@ -89,12 +89,13 @@ def shell_process(cmds, env=None, **kwds):
     return p
 
 
-def execute(cmds):
+def execute(cmds, input=None):
     """Execute commands and throw an exception on a non-zero exit.
+    if input is not None then the string is sent to the process' stdin.
 
     Return the standard output if the commands are successful
     """
-    return _wait(cmds, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    return _wait(cmds, input=input, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 def argv_to_str(command_argv, quote=True):
@@ -110,9 +111,10 @@ def argv_to_str(command_argv, quote=True):
     return " ".join(map_func(c) for c in command_argv if c is not None)
 
 
-def _wait(cmds, **popen_kwds):
+def _wait(cmds, input=None, **popen_kwds):
     p = subprocess.Popen(cmds, **popen_kwds)
-    stdout, stderr = p.communicate()
+    stdout, stderr = p.communicate(input)
+    stdout, stderr = unicodify(stdout).strip(), unicodify(stderr).strip()
     if p.returncode != 0:
         raise CommandLineException(argv_to_str(cmds), stdout, stderr, p.returncode)
     return stdout

--- a/lib/galaxy/util/sockets.py
+++ b/lib/galaxy/util/sockets.py
@@ -1,7 +1,7 @@
 import random
-import shlex
 import socket
-import subprocess
+
+from galaxy.tool_util.deps import commands
 
 
 def get_ip():
@@ -37,11 +37,11 @@ def __unused_port_on_range(range):
     assert range[0] and range[1]
 
     # Find all ports that are already occupied
-    cmd_netstat = shlex.split("netstat tuln")
-    p1 = subprocess.Popen(cmd_netstat, stdout=subprocess.PIPE)
+    cmd_netstat = ["netstat", "tuln"]
+    stdout = commands.execute(cmd_netstat)
 
     occupied_ports = set()
-    for line in p1.stdout.read().split('\n'):
+    for line in stdout.split('\n'):
         if line.startswith('tcp') or line.startswith('tcp6'):
             col = line.split()
             local_address = col[3]

--- a/lib/galaxy/util/sockets.py
+++ b/lib/galaxy/util/sockets.py
@@ -1,7 +1,7 @@
 import random
 import socket
 
-from galaxy.tool_util.deps import commands
+from galaxy.util import commands
 
 
 def get_ip():

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -9,8 +9,8 @@ from unittest import skip, SkipTest, TestCase
 
 import pytest
 
-from galaxy.tool_util.deps.commands import which
 from galaxy.tool_util.verify.test_data import TestDataResolver
+from galaxy.util.commands import which
 from .api import UsesApiTestCaseMixin
 from .driver_util import GalaxyTestDriver
 

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -4,7 +4,7 @@ import json
 import os
 import unittest
 
-from galaxy.tool_util.deps.commands import which
+from galaxy.util.commands import which
 from galaxy_test.base.populators import (
     DatasetPopulator,
 )


### PR DESCRIPTION
work toward https://github.com/galaxyproject/galaxy/issues/9251 

most of the "easy" cases are done. here is a list of the remaining grouped by the reason why its not an easy case:

- [ ] close_fds
  - lib/galaxy/containers/__init__.py
  - lib/galaxy/visualization/plugins/interactive_environments.py
  - lib/galaxy/tools/expressions/evaluation.py
  - lib/galaxy/tool_shed/galaxy_install/tool_dependencies/recipe/install_environment.py + bufsize + cwd
- [ ] use stdin
  - lib/galaxy/datatypes/converters/bgzip.py
- [ ] use returned process 
  - lib/galaxy/datatypes/dataproviders/external.py
  - lib/galaxy/util/lazy_process.py
  - lib/galaxy/jobs/runners/util/sudo.py
  - lib/galaxy_test/driver/driver_util.py + preexec_fn + cwd
- [ ] use env -> maybe shell_process
  - lib/galaxy/tool_util/deps/brew_exts.py
  - lib/galaxy/tool_util/deps/commands.py + shell
  - lib/galaxy/tool_util/deps/resolvers/modules.py
  - lib/galaxy/tool_util/deps/resolvers/lmod.py
  - lib/galaxy/util/pastescript/serve.py
  - lib/galaxy/jobs/runners/__init__.py + shell clse_fds, preexec_fn
  - lib/galaxy/jobs/runners/condor.py   + -"-
  - lib/galaxy/jobs/runners/local.py    + -"-
  - lib/galaxy/jobs/runners/util/cli/shell/local.py + -"-
- [ ] use shell=True
  - lib/galaxy/tool_util/deps/container_classes.py
  - lib/galaxy/tool_util/verify/test_data.py (because it uses strings and command chaining with &&)
  - lib/galaxy/job_metrics/collectl/cli.py
- [ ] read ony begin of stdout
  - lib/galaxy/tool_shed/galaxy_install/migrate/check.py
  - lib/galaxy/jobs/transfer_manager.py