### PR TITLE
Resize D3 tree and make it responsive

### DIFF
--- a/client/galaxy/scripts/components/ToolRecommendation.vue
+++ b/client/galaxy/scripts/components/ToolRecommendation.vue
@@ -105,20 +105,48 @@ export default {
         },
         renderD3Tree(predictedTools) {
             const duration = 750;
-            const x = 620;
-            const y = 260;
-            const tree = d3.layout.tree().size([y, x]);
-            const diagonal = d3.svg.diagonal().projection(d => {
-                return [d.y, d.x];
-            });
+            //const x = 0 //620;
+            //const y = 0 //260;
             const svg = d3
                 .select("#tool-recommendation")
                 .append("svg")
                 .attr("class", "tree-size")
-                .append("g")
-                .attr("transform", "translate(" + 250 + "," + 20 + ")");
+                .append("g");
+                //.attr("transform", "translate(" + 250 + "," + 20 + ")");
             let i = 0;
             let root = null;
+            let x = 0,
+            y = 0,
+            translateX = 0,
+            clientH = 0,
+            clientW = 0;
+            
+            //.attr("viewBox", "0 0 " + w + " " + h )
+            //.attr("preserveAspectRatio", "xMinYMin meet")
+
+            console.log(svg);
+            
+            // temp1[0]["0"].parentNode.setAttribute("viewBox", "50 0 427 146")
+
+            clientH = svg[0]["0"].parentNode.clientHeight;
+            clientW = svg[0]["0"].parentNode.clientWidth;
+            y = parseInt(clientH * 0.5);
+            x = parseInt(clientW * 0.5);
+            translateX = parseInt(clientW * 0.2);
+
+            console.log(clientH, clientW, y, x);
+            console.log(translateX);
+            
+            let svgElem = svg[0][0].parentNode;
+            svgElem.setAttribute("viewBox", "0 0 " + x + " " + y);
+            svgElem.setAttribute("preserveAspectRatio", "xMinYMin");
+            svg[0][0].setAttribute("transform", "translate(" + translateX + ", 0)");
+
+            const tree = d3.layout.tree().size([y, x]);
+            
+            const diagonal = d3.svg.diagonal().projection(d => {
+                return [d.y, d.x];
+            });
             const update = source => {
                 // Compute the new tree layout.
                 const nodes = tree.nodes(root).reverse();

--- a/client/galaxy/scripts/components/ToolRecommendation.vue
+++ b/client/galaxy/scripts/components/ToolRecommendation.vue
@@ -105,42 +105,31 @@ export default {
         },
         renderD3Tree(predictedTools) {
             const duration = 750;
-            //const x = 0 //620;
-            //const y = 0 //260;
             const svg = d3
                 .select("#tool-recommendation")
                 .append("svg")
                 .attr("class", "tree-size")
                 .append("g");
-                //.attr("transform", "translate(" + 250 + "," + 20 + ")");
             let i = 0;
             let root = null;
-            let x = 0,
-            y = 0,
-            translateX = 0,
-            clientH = 0,
-            clientW = 0;
-            
-            //.attr("viewBox", "0 0 " + w + " " + h )
-            //.attr("preserveAspectRatio", "xMinYMin meet")
+            let x = 0;
+            let y = 0;
+            let translateX = 0;
+            let clientH = 0;
+            let clientW = 0;
 
-            console.log(svg);
-            
-            // temp1[0]["0"].parentNode.setAttribute("viewBox", "50 0 427 146")
+            const gElem = svg[0][0];
+            const svgElem = gElem.parentNode;
 
-            clientH = svg[0]["0"].parentNode.clientHeight;
-            clientW = svg[0]["0"].parentNode.clientWidth;
-            y = parseInt(clientH * 0.5);
-            x = parseInt(clientW * 0.5);
-            translateX = parseInt(clientW * 0.2);
+            clientH = svgElem.clientHeight;
+            clientW = svgElem.clientWidth;
+            y = parseInt(clientH * 0.9);
+            x = parseInt(clientW * 0.6);
+            translateX = parseInt(clientW * 0.15);
 
-            console.log(clientH, clientW, y, x);
-            console.log(translateX);
-            
-            let svgElem = svg[0][0].parentNode;
-            svgElem.setAttribute("viewBox", "0 0 " + x + " " + y);
+            svgElem.setAttribute("viewBox", "0 0 " + x + " " + clientH);
             svgElem.setAttribute("preserveAspectRatio", "xMinYMin");
-            svg[0][0].setAttribute("transform", "translate(" + translateX + ", 0)");
+            gElem.setAttribute("transform", "translate(" + translateX + ", 5)");
 
             const tree = d3.layout.tree().size([y, x]);
             

--- a/client/galaxy/scripts/components/ToolRecommendation.vue
+++ b/client/galaxy/scripts/components/ToolRecommendation.vue
@@ -115,14 +115,11 @@ export default {
             let x = 0;
             let y = 0;
             let translateX = 0;
-            let clientH = 0;
-            let clientW = 0;
 
             const gElem = svg[0][0];
             const svgElem = gElem.parentNode;
-
-            clientH = svgElem.clientHeight;
-            clientW = svgElem.clientWidth;
+            const clientH = svgElem.clientHeight;
+            const clientW = svgElem.clientWidth;
             y = parseInt(clientH * 0.9);
             x = parseInt(clientW * 0.6);
             translateX = parseInt(clientW * 0.15);
@@ -132,7 +129,7 @@ export default {
             gElem.setAttribute("transform", "translate(" + translateX + ", 5)");
 
             const tree = d3.layout.tree().size([y, x]);
-            
+
             const diagonal = d3.svg.diagonal().projection(d => {
                 return [d.y, d.x];
             });

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1661,7 +1661,7 @@ body.reports {
             stroke-width: 0.1rem;
         }
         text {
-            font: 0.35rem sans-serif;
+            font: 0.4rem sans-serif;
         }
     }
 

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1661,7 +1661,7 @@ body.reports {
             stroke-width: 0.3rem;
         }
         text {
-            font: 0.75rem sans-serif;
+            font: 0.4rem sans-serif;
         }
     }
 
@@ -1675,8 +1675,7 @@ body.reports {
 
     .tree-size {
         width: 96%;
-        height: 50%;
-        position: absolute;
+        height: 40%;
     }
 
     .link {

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -1658,10 +1658,10 @@ body.reports {
         circle {
             fill: lighten($brand-primary, 20%);
             stroke: lighten($brand-primary, 20%);
-            stroke-width: 0.3rem;
+            stroke-width: 0.1rem;
         }
         text {
-            font: 0.4rem sans-serif;
+            font: 0.35rem sans-serif;
         }
     }
 
@@ -1674,13 +1674,13 @@ body.reports {
     }
 
     .tree-size {
-        width: 96%;
-        height: 40%;
+        width: 100%;
+        height: 50%;
     }
 
     .link {
         fill: none;
         stroke: lighten($brand-primary, 20%);
-        stroke-width: 0.3rem;
+        stroke-width: 0.2rem;
     }
 }


### PR DESCRIPTION
This PR fixes an issue related to resizing and responsive of D3 tree with respect to zoom level for https://github.com/galaxyproject/galaxy/pull/9440

Tree with different zoom levels of screen

![z1](https://user-images.githubusercontent.com/3022518/77238274-13a1e200-6bcf-11ea-8f83-bf0e198fdf09.png)

![z5](https://user-images.githubusercontent.com/3022518/77238276-1997c300-6bcf-11ea-8387-c9ada93350fa.png)

![z4](https://user-images.githubusercontent.com/3022518/77238277-1ac8f000-6bcf-11ea-8d27-895004eaa9df.png)

![z3](https://user-images.githubusercontent.com/3022518/77238279-1b618680-6bcf-11ea-948a-ac6149f782f5.png)

![z2](https://user-images.githubusercontent.com/3022518/77238280-1b618680-6bcf-11ea-8052-3c4d1edda400.png)

ping @guerler 
