### PR TITLE
[20.01] Prevent exception in toolshed if userid is 'current'

### DIFF
--- a/lib/tool_shed/webapp/api/users.py
+++ b/lib/tool_shed/webapp/api/users.py
@@ -106,11 +106,7 @@ class UsersController(BaseAPIController):
         """
         user = None
         # user is requesting data about themselves
-        if id == "current" and trans.user:
-            user = trans.user
-        else:
-            user = suc.get_user(trans.app, id)
-
+        user = trans.user if id == 'current' else suc.get_user(trans.app, id)
         if user is None:
             user_dict = dict(message='Unable to locate user record for id %s.' % (str(id)),
                              status='error')


### PR DESCRIPTION
and the user is not already logged in (=trans.user is None).

Fixes https://sentry.galaxyproject.org/sentry/toolshed/issues/568664/ ...  I don't think that's the source of the current instabilities but there's definitely no point in decoding an id that is just the string `'current'`