### PR TITLE
[20.01] Fix setting annotation that contains only integers

### DIFF
--- a/lib/galaxy/util/sanitize_html.py
+++ b/lib/galaxy/util/sanitize_html.py
@@ -3,6 +3,9 @@ HTML Sanitizer (lists of acceptable_* ripped from feedparser)
 """
 import bleach
 
+from galaxy.util import unicodify
+
+
 _acceptable_elements = ['a', 'abbr', 'acronym', 'address', 'area', 'article',
         'aside', 'audio', 'b', 'big', 'blockquote', 'br', 'button', 'canvas',
         'caption', 'center', 'cite', 'code', 'col', 'colgroup', 'command',
@@ -45,4 +48,4 @@ def sanitize_html(htmlSource, allow_data_urls=False):
     kwd = dict(tags=_acceptable_elements, attributes=_acceptable_attributes, strip=True)
     if allow_data_urls:
         kwd["protocols"] = bleach.ALLOWED_PROTOCOLS + ["data"]
-    return bleach.clean(htmlSource, **kwd)
+    return bleach.clean(unicodify(htmlSource), **kwd)


### PR DESCRIPTION
This fixes https://sentry.galaxyproject.org/sentry/main/issues/572478/:
```
TypeError: argument cannot be of 'int' type, must be of text type
  File "galaxy/web/framework/decorators.py", line 157, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 353, in set_edit
    annotation = sanitize_html(payload.get('annotation'))
  File "galaxy/util/sanitize_html.py", line 48, in sanitize_html
    return bleach.clean(htmlSource, **kwd)
  File "bleach/__init__.py", line 84, in clean
    return cleaner.clean(text)
  File "bleach/sanitizer.py", line 162, in clean
    raise TypeError(message)
```

That said it looks like the client switches types based on what the user enters in what should be a text field ... that seems bad. This looks similar to what happens when you enter a literal null (xref https://github.com/galaxyproject/galaxy/issues/8375).