### PR TITLE
Disable workflow parameter switch for data inputs, augment form handling

### DIFF
--- a/client/galaxy/scripts/components/Panels/ToolBoxWorkflow.vue
+++ b/client/galaxy/scripts/components/Panels/ToolBoxWorkflow.vue
@@ -77,13 +77,16 @@ export default {
         },
         workflows: {
             type: Array,
+            required: true
         },
         dataManagers: {
             type: Array,
+            required: true
         },
         moduleSections: {
             type: Array,
-        },
+            required: true
+        }
     },
     computed: {
         workflowSection() {

--- a/client/galaxy/scripts/components/Panels/ToolBoxWorkflow.vue
+++ b/client/galaxy/scripts/components/Panels/ToolBoxWorkflow.vue
@@ -77,16 +77,16 @@ export default {
         },
         workflows: {
             type: Array,
-            required: true
+            required: true,
         },
         dataManagers: {
             type: Array,
-            required: true
+            required: true,
         },
         moduleSections: {
             type: Array,
-            required: true
-        }
+            required: true,
+        },
     },
     computed: {
         workflowSection() {

--- a/client/galaxy/scripts/components/Workflow/Editor/Attributes.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Attributes.vue
@@ -68,15 +68,19 @@ export default {
         },
         annotation: {
             type: String,
+            default: "",
         },
         version: {
             type: Number,
+            default: null,
         },
         versions: {
             type: Array,
+            default: null,
         },
         parameters: {
             type: Array,
+            default: null,
         },
     },
     data() {

--- a/client/galaxy/scripts/components/Workflow/Editor/EditorPanel.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/EditorPanel.vue
@@ -6,11 +6,11 @@
             </div>
         </div>
         <div class="unified-panel-body workflow-right">
-            <div v-if="canvas" class="m-1">
+            <div class="m-1" v-show="canvas">
                 <slot name="attributes" />
                 <div id="right-content" class="right-content" />
             </div>
-            <ReportHelp v-else />
+            <ReportHelp v-show="!canvas" />
         </div>
     </div>
 </template>

--- a/client/galaxy/scripts/components/Workflow/Editor/Index.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Index.vue
@@ -4,8 +4,8 @@
             <template v-slot:panel>
                 <ToolBoxWorkflow
                     :toolbox="toolbox"
-                    :module-sections="module_sections"
-                    :data-managers="data_managers"
+                    :module-sections="moduleSections"
+                    :data-managers="dataManagers"
                     :workflows="workflows"
                     @onInsertTool="onInsertTool"
                     @onInsertModule="onInsertModule"
@@ -110,30 +110,39 @@ export default {
     props: {
         id: {
             type: String,
+            required: true,
         },
         version: {
             type: Number,
+            required: true,
         },
         name: {
             type: String,
+            required: true,
         },
         tags: {
             type: Array,
+            required: true,
         },
         annotation: {
             type: String,
+            required: true,
         },
-        module_sections: {
+        moduleSections: {
             type: Array,
+            required: true,
         },
-        data_managers: {
+        dataManagers: {
             type: Array,
+            required: true,
         },
         workflows: {
             type: Array,
+            required: true,
         },
         toolbox: {
             type: Array,
+            required: true,
         },
     },
     data() {

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -59,7 +59,7 @@ export default {
         node: {
             type: Object,
             default: null,
-        }
+        },
     },
     computed: {
         iconClass() {

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -46,6 +46,7 @@ export default {
     props: {
         id: {
             type: String,
+            default: "",
         },
         title: {
             type: String,
@@ -57,7 +58,8 @@ export default {
         },
         node: {
             type: Object,
-        },
+            default: null,
+        }
     },
     computed: {
         iconClass() {

--- a/client/galaxy/scripts/components/Workflow/Editor/utilities.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/utilities.js
@@ -144,9 +144,9 @@ export function getWorkflowParameters(nodes) {
             });
         }
         if (node.post_job_actions) {
-            Object.entries(node.post_job_actions).forEach(([k, pja]) => {
+            Object.values(node.post_job_actions).forEach((pja) => {
                 if (pja.action_arguments) {
-                    Object.entries(pja.action_arguments).forEach(([k, action_argument]) => {
+                    Object.values(pja.action_arguments).forEach((action_argument) => {
                         if (typeof action_argument === "string") {
                             const arg_matches = action_argument.match(parameter_re);
                             if (arg_matches) {
@@ -198,7 +198,8 @@ export function saveAs(workflow) {
                     window.location = `${getAppRoot()}workflow/editor?id=${id}`;
                     hide_modal();
                 })
-                .fail(() => {
+                .fail((err) => {
+                    console.debug(err);
                     hide_modal();
                     alert("Saving this workflow failed. Please contact this site's administrator.");
                 });

--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -23,9 +23,6 @@ export default FormBase.extend({
         this.deferred = new Deferred();
         FormBase.prototype.initialize.call(this, options);
 
-        // optional model update
-        this._update(this.model.get("initialmodel"));
-
         // listen to history panel
         if (this.model.get("listen_to_history") && Galaxy.currHistoryPanel) {
             this.listenTo(Galaxy.currHistoryPanel.collection, "change", () => {
@@ -39,9 +36,9 @@ export default FormBase.extend({
     },
 
     /** Allows tool form variation to update tool model */
-    _update: function (callback) {
+    _update: function() {
         var self = this;
-        callback = callback || this.model.get("buildmodel");
+        var callback = this.model.get("buildmodel");
         if (callback) {
             this.deferred.reset();
             this.deferred.execute((process) => {

--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -39,7 +39,7 @@ export default FormBase.extend({
     },
 
     /** Allows tool form variation to update tool model */
-    _update: function() {
+    _update: function () {
         var self = this;
         var callback = this.model.get("buildmodel");
         if (callback) {

--- a/client/galaxy/scripts/mvc/tool/tool-form-base.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-base.js
@@ -23,6 +23,9 @@ export default FormBase.extend({
         this.deferred = new Deferred();
         FormBase.prototype.initialize.call(this, options);
 
+        // optional model update
+        this._update();
+
         // listen to history panel
         if (this.model.get("listen_to_history") && Galaxy.currHistoryPanel) {
             this.listenTo(Galaxy.currHistoryPanel.collection, "change", () => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -94,12 +94,12 @@ export class ToolForm {
         var options = form.model.attributes;
         Utils.deepeach(options.inputs, (input) => {
             if (input.type) {
-                input.connectable = true;
                 if (["data", "data_collection"].indexOf(input.type) != -1) {
                     input.type = "hidden";
                     input.info = `Data input '${input.name}' (${Utils.textify(input.extensions)})`;
                     input.value = { __class__: "RuntimeValue" };
                 } else if (!input.fixed) {
+                    input.connectable = true;
                     input.collapsible_value = {
                         __class__: "RuntimeValue",
                     };

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -21,13 +21,13 @@ export class DefaultForm {
                         id: node.id,
                         type: node.type,
                         content_id: node.content_id,
-                        inputs: self.form.data.create()
+                        inputs: self.form.data.create(),
                     })
-                    .then(response => {
+                    .then((response) => {
                         const data = response.data;
                         node.update_field_data(data);
                     });
-            }
+            },
         });
     }
 }
@@ -54,12 +54,12 @@ export class ToolForm {
                     tool_id: options.id,
                     tool_version: options.version,
                     type: "tool",
-                    inputs: Object.assign({}, form.data.create())
+                    inputs: Object.assign({}, form.data.create()),
                 };
                 Galaxy.emit.debug("tool-form-workflow::postchange()", "Sending current state.", current_state);
                 axios
                     .post(`${getAppRoot()}api/workflows/build_module`, current_state)
-                    .then(response => {
+                    .then((response) => {
                         const data = response.data;
                         self._customize(data);
                         self.form.model.set(data.config_form);
@@ -73,16 +73,16 @@ export class ToolForm {
                         Galaxy.emit.debug("tool-form-workflow::postchange()", "Received new model.", data);
                         process.resolve();
                     })
-                    .catch(response => {
+                    .catch((response) => {
                         Galaxy.emit.debug("tool-form-workflow::postchange()", "Refresh request failed.", response);
                         process.reject();
                     });
-            }
+            },
         });
     }
     _customize(node) {
         const inputs = node.config_form.inputs;
-        Utils.deepeach(inputs, input => {
+        Utils.deepeach(inputs, (input) => {
             if (input.type) {
                 if (["data", "data_collection"].indexOf(input.type) != -1) {
                     input.type = "hidden";
@@ -145,7 +145,7 @@ function _addLabelAnnotation(self, node) {
                 duplicate && "Duplicate label. Please fix this before saving the workflow."
             );
             self.form.trigger("change");
-        }
+        },
     });
 }
 

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -16,16 +16,17 @@ export class DefaultForm {
         this.form = new Form({
             ...options,
             onchange() {
-                axios.post(`${getAppRoot()}api/workflows/build_module`, {
-                    id: node.id,
-                    type: node.type,
-                    content_id: node.content_id,
-                    inputs: self.form.data.create()
-                })
-                .then(response => {
-                    const data = response.data;
-                    node.update_field_data(data);
-                });
+                axios
+                    .post(`${getAppRoot()}api/workflows/build_module`, {
+                        id: node.id,
+                        type: node.type,
+                        content_id: node.content_id,
+                        inputs: self.form.data.create()
+                    })
+                    .then(response => {
+                        const data = response.data;
+                        node.update_field_data(data);
+                    });
             }
         });
     }
@@ -345,7 +346,6 @@ function _addSections(self, node) {
     var inputs = node.config_form.inputs;
     var post_job_actions = node.post_job_actions;
     var output_id = node.output_terminals && Object.keys(node.output_terminals)[0];
-
     if (output_id) {
         inputs.push({
             name: `pja__${output_id}__EmailAction`,

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -316,8 +316,7 @@ class Workflow extends EventEmitter {
         const report = this.report;
         return { steps: nodes, report: report };
     }
-    from_simple(data, initialImport_) {
-        var initialImport = initialImport_ === undefined ? true : initialImport_;
+    from_simple(data, initialImport = true) {
         var wf = this;
         var offset = 0;
         if (initialImport) {

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -49,7 +49,7 @@ class Workflow extends EventEmitter {
     set_node(node, data) {
         node.init_field_data(data);
         node.update_field_data(data);
-        $.each(node.output_terminals, (ot_id, ot) => {
+        Object.values(node.output_terminals).forEach((ot) => {
             node.addWorkflowOutput(ot.name);
             node.markWorkflowOutput(ot.name);
         });
@@ -195,20 +195,20 @@ class Workflow extends EventEmitter {
     }
     remove_all() {
         var wf = this;
-        $.each(this.nodes, (k, v) => {
-            v.destroy();
-            wf.remove_node(v);
+        Object.values(this.nodes).forEach((node) => {
+            node.destroy();
+            wf.remove_node(node);
         });
     }
     rectify_workflow_outputs() {
         // Find out if we're using workflow_outputs or not.
         var using_workflow_outputs = false;
         var has_existing_pjas = false;
-        $.each(this.nodes, (k, node) => {
+        Object.values(this.nodes).forEach((node) => {
             if (node.type === "tool" && node.workflow_outputs && node.workflow_outputs.length > 0) {
                 using_workflow_outputs = true;
             }
-            $.each(node.post_job_actions, (pja_id, pja) => {
+            Object.values(node.post_job_actions).forEach((pja) => {
                 if (pja.action_type === "HideDatasetAction") {
                     has_existing_pjas = true;
                 }
@@ -216,26 +216,26 @@ class Workflow extends EventEmitter {
         });
         if (using_workflow_outputs !== false || has_existing_pjas !== false) {
             // Using workflow outputs, or has existing pjas.  Remove all PJAs and recreate based on outputs.
-            $.each(this.nodes, (k, node) => {
+            Object.values(this.nodes).forEach((node) => {
                 var node_changed = false;
                 if (node.post_job_actions === null) {
                     node.post_job_actions = {};
                     node_changed = true;
                 }
                 var pjas_to_rem = [];
-                $.each(node.post_job_actions, (pja_id, pja) => {
+                Object.entries(node.post_job_actions).forEach(([pja_id, pja]) => {
                     if (pja.action_type == "HideDatasetAction") {
                         pjas_to_rem.push(pja_id);
                     }
                 });
                 if (pjas_to_rem.length > 0) {
-                    $.each(pjas_to_rem, (i, pja_name) => {
+                    pjas_to_rem.forEach((pja_name) => {
                         node_changed = true;
                         delete node.post_job_actions[pja_name];
                     });
                 }
                 if (using_workflow_outputs) {
-                    $.each(node.output_terminals, (ot_id, ot) => {
+                    Object.values(node.output_terminals).forEach((ot) => {
                         var create_pja = !node.isWorkflowOutput(ot.name);
                         if (create_pja === true) {
                             node_changed = true;
@@ -258,14 +258,14 @@ class Workflow extends EventEmitter {
     }
     to_simple() {
         var nodes = {};
-        $.each(this.nodes, (i, node) => {
+        Object.values(this.nodes).forEach((node) => {
             var input_connections = {};
-            $.each(node.input_terminals, (k, t) => {
+            Object.values(node.input_terminals).forEach((t) => {
                 input_connections[t.name] = null;
                 // There should only be 0 or 1 connectors, so this is
                 // really a sneaky if statement
                 var cons = [];
-                $.each(t.connectors, (i, c) => {
+                t.connectors.forEach((c, i) => {
                     if (c.handle1) {
                         var con_dict = {
                             id: c.handle1.node.id,
@@ -282,8 +282,8 @@ class Workflow extends EventEmitter {
             });
             var post_job_actions = {};
             if (node.post_job_actions) {
-                $.each(node.post_job_actions, (i, act) => {
-                    var pja = {
+                Object.values(node.post_job_actions).forEach((act) => {
+                    const pja = {
                         action_type: act.action_type,
                         output_name: act.output_name,
                         action_arguments: act.action_arguments,
@@ -329,13 +329,13 @@ class Workflow extends EventEmitter {
         var using_workflow_outputs = false;
         wf.workflow_version = data.version;
         wf.report = data.report || {};
-        $.each(data.steps, (id, step) => {
+        Object.entries(data.steps).forEach(([id, step]) => {
             var node = wf.prebuildNode(step.type, step.name, step.content_id);
             // If workflow being copied into another, wipe UUID and let
             // Galaxy assign new ones.
             if (!initialImport) {
                 step.uuid = null;
-                $.each(step.workflow_outputs, (name, workflow_output) => {
+                step.workflow_outputs.forEach((workflow_output) => {
                     workflow_output.uuid = null;
                 });
             }
@@ -357,7 +357,7 @@ class Workflow extends EventEmitter {
                 if (node.workflow_outputs.length > 0) {
                     using_workflow_outputs = true;
                 } else {
-                    $.each(node.post_job_actions || [], (pja_id, pja) => {
+                    Object.values(node.post_job_actions).forEach((pja) => {
                         if (pja.action_type === "HideDatasetAction") {
                             using_workflow_outputs = true;
                         }
@@ -367,14 +367,14 @@ class Workflow extends EventEmitter {
         });
         wf.id_counter = max_id + 1;
         // Second pass, connections
-        $.each(data.steps, (id, step) => {
+        Object.entries(data.steps).forEach(([id, step]) => {
             const node = wf.nodes[parseInt(id) + offset];
-            $.each(step.input_connections, (k, v) => {
+            Object.entries(step.input_connections).forEach(([k, v]) => {
                 if (v) {
-                    if (!$.isArray(v)) {
+                    if (!Array.isArray(v)) {
                         v = [v];
                     }
-                    $.each(v, (l, x) => {
+                    v.forEach((x) => {
                         const other_node = wf.nodes[parseInt(x.id) + offset];
                         const c = new Connector(this.canvas_manager);
                         c.connect(other_node.output_terminals[x.output_name], node.input_terminals[k]);
@@ -384,7 +384,7 @@ class Workflow extends EventEmitter {
             });
             if (using_workflow_outputs) {
                 // Ensure that every output terminal has a WorkflowOutput or HideDatasetAction.
-                $.each(node.output_terminals, (ot_id, ot) => {
+                Object.values(node.output_terminals).forEach((ot) => {
                     if (node.post_job_actions[`HideDatasetAction${ot.name}`] === undefined) {
                         node.addWorkflowOutput(ot.name);
                         node.markWorkflowOutput(ot.name);
@@ -450,7 +450,7 @@ class Workflow extends EventEmitter {
         var n_pred = {};
         var successors = {};
         // First pass to initialize arrays even for nodes with no connections
-        $.each(this.nodes, (id, node) => {
+        Object.keys(this.nodes).forEach((id) => {
             if (n_pred[id] === undefined) {
                 n_pred[id] = 0;
             }
@@ -459,9 +459,9 @@ class Workflow extends EventEmitter {
             }
         });
         // Second pass to count predecessors and successors
-        $.each(this.nodes, (id, node) => {
-            $.each(node.input_terminals, (j, t) => {
-                $.each(t.connectors, (k, c) => {
+        Object.values(this.nodes).forEach((node) => {
+            Object.values(node.input_terminals).forEach((t) => {
+                t.connectors.forEach((c) => {
                     // A connection exists from `other` to `node`
                     var other = c.handle1.node;
                     // node gains a predecessor
@@ -504,14 +504,14 @@ class Workflow extends EventEmitter {
         var h_pad = 80;
         var v_pad = 30;
         var left = h_pad;
-        $.each(node_ids_by_level, (i, ids) => {
+        node_ids_by_level.forEach((ids) => {
             // We keep nodes in the same order in a level to give the user
             // some control over ordering
             ids.sort((a, b) => $(all_nodes[a].element).position().top - $(all_nodes[b].element).position().top);
             // Position each node
             var max_width = 0;
             var top = v_pad;
-            $.each(ids, (j, id) => {
+            ids.forEach((id) => {
                 var node = all_nodes[id];
                 var element = $(node.element);
                 $(element).css({ top: top, left: left });
@@ -521,7 +521,7 @@ class Workflow extends EventEmitter {
             left += max_width + h_pad;
         });
         // Need to redraw all connectors
-        $.each(all_nodes, (_, node) => {
+        Object.values(all_nodes).forEach((node) => {
             node.redraw();
         });
     }
@@ -531,7 +531,7 @@ class Workflow extends EventEmitter {
         var ymin = Infinity;
         var ymax = -Infinity;
         var p;
-        $.each(this.nodes, (id, node) => {
+        Object.values(this.nodes).forEach((node) => {
             var e = $(node.element);
             p = e.position();
             xmin = Math.min(xmin, p.left);

--- a/client/galaxy/scripts/utils/simple-error.js
+++ b/client/galaxy/scripts/utils/simple-error.js
@@ -9,5 +9,6 @@ export function errorMessageAsString(e) {
 }
 
 export function rethrowSimple(e) {
+    console.debug(e);
     throw errorMessageAsString(e);
 }

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -618,7 +618,6 @@ class WorkflowContentsManager(UsesAnnotations):
                     data['upgrade_messages'][step.order_index] = {module.tool.name: "\n".join(module.version_changes)}
             # Get user annotation.
             annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, step) or ''
-            config_form = module.get_config_form(step=step)
             # Pack attributes into plain dictionary
             step_dict = {
                 'id': step.order_index,
@@ -630,7 +629,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 'errors': module.get_errors(),
                 'inputs': module.get_all_inputs(connectable_only=True),
                 'outputs': module.get_all_outputs(),
-                'config_form': config_form,
+                'config_form': module.get_config_form(step=step),
                 'annotation': annotation_str,
                 'post_job_actions': {},
                 'uuid': str(step.uuid) if step.uuid else None,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -617,6 +617,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 else:
                     data['upgrade_messages'][step.order_index] = {module.tool.name: "\n".join(module.version_changes)}
             # Get user annotation.
+            config_form = module.get_config_form(step=step)
             annotation_str = self.get_item_annotation_str(trans.sa_session, trans.user, step) or ''
             # Pack attributes into plain dictionary
             step_dict = {
@@ -629,7 +630,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 'errors': module.get_errors(),
                 'inputs': module.get_all_inputs(connectable_only=True),
                 'outputs': module.get_all_outputs(),
-                'config_form': module.get_config_form(step=step),
+                'config_form': config_form,
                 'annotation': annotation_str,
                 'post_job_actions': {},
                 'uuid': str(step.uuid) if step.uuid else None,

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -707,8 +707,8 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             'version'                 : version,
             'annotation'              : self.get_item_annotation_str(trans.sa_session, trans.user, stored),
             'toolbox'                 : trans.app.toolbox.to_dict(trans),
-            'module_sections'         : module_sections,
-            'data_managers'           : data_managers,
+            'moduleSections'          : module_sections,
+            'dataManagers'            : data_managers,
             'workflows'               : workflows
         }
 


### PR DESCRIPTION
This PR disables the workflow parameter double-arrow switch for data inputs, since those are already attached to the workflow nodes. Additionally it fixes switching between workflow tool forms and the reports help in the editor panel. The customization flow for workflow tool forms has been revised such that it does not require additional callbacks. The PR also removes `jquery` from the `workflow-forms` class.