### PR TITLE
Do not open hgweb_config in binary mode

### DIFF
--- a/lib/tool_shed/webapp/util/hgweb_config.py
+++ b/lib/tool_shed/webapp/util/hgweb_config.py
@@ -80,7 +80,7 @@ class HgWebConfigManager(object):
             # raise Exception( "Required file %s does not exist - check config setting for hgweb_config_dir." % hgweb_config )
             # ...but now we just log the missing file and create a new empty one.
             log.debug("Required file %s does not exist, so creating a new, empty file.  Check your config setting for hgweb_config_dir." % hgweb_config)
-            hgweb_config_file = open(hgweb_config, 'wb')
+            hgweb_config_file = open(hgweb_config, 'w')
             hgweb_config_file.write(new_hgweb_config_template)
             hgweb_config_file.close()
         return os.path.abspath(hgweb_config)


### PR DESCRIPTION
Fixes TS error on clean startup under Python3: 

Same as: #5639
Under Python3, strings can not be written to byte mode file handlers.
writing resulted in:
TypeError: a bytes-like object is required, not 'str'