### PR TITLE
Check if path is set before joining

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -246,16 +246,19 @@ class BaseAppConfiguration(object):
             resolve(key)
 
     def _in_managed_config_dir(self, path):
-        return os.path.join(self.managed_config_dir, path)
+        return self._in_dir(self.managed_config_dir, path)
 
     def _in_config_dir(self, path):
-        return os.path.join(self.config_dir, path)
+        return self._in_dir(self.config_dir, path)
 
     def _in_sample_dir(self, path):
-        return os.path.join(self.sample_config_dir, path)
+        return self._in_dir(self.sample_config_dir, path)
 
     def _in_data_dir(self, path):
-        return os.path.join(self.data_dir, path)
+        return self._in_dir(self.data_dir, path)
+
+    def _in_dir(self, _dir, path):
+        return os.path.join(_dir, path) if path else _dir
 
     def _parse_config_file_options(self, defaults, listify_defaults, config_kwargs):
         for var, values in defaults.items():

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -258,7 +258,7 @@ class BaseAppConfiguration(object):
         return self._in_dir(self.data_dir, path)
 
     def _in_dir(self, _dir, path):
-        return os.path.join(_dir, path) if path else _dir
+        return os.path.join(_dir, path) if path else None
 
     def _parse_config_file_options(self, defaults, listify_defaults, config_kwargs):
         for var, values in defaults.items():


### PR DESCRIPTION
If a config property is not set (is null), then resolving it w.r.t a parent using any of the `_in_foo_dir()` helpers will raise an error as all of them use `os.path.join` that expects a string. To address this, one can set any such path to `''`, like this: https://github.com/galaxyproject/galaxy/blob/dev/lib/tool_shed/webapp/config.py#L153
EDIT: Or check every such path before calling the helper.

Checking this centrally (as done in this PR) solves not only the issue of duplication, ~~but makes the code conceptually clean: if `foo` belongs in directory `bar` we shouldn't have to set it to anything, least of all an empty string, just to have it resolve correctly.~~ EDIT: as per code review: we won't assume this if (a) the path is not set by the user; and (b) a default is not specified in the schema.

I encountered this issue while running a clean install after #9379 . That PR adds `in_root_dir`; I'll  rebase it after this is merged.