### PR TITLE
[20.01] Pulsar Kubernetes Enhancements and Fixes

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,10 +27,15 @@ jobs:
     steps:
     - name: Prune unused docker image, volumes and containers
       run: docker system prune -a -f
+    - name: Clean dotnet folder for space
+      if: matrix.subset == 'kubernetes'
+      run: rm -Rf /usr/share/dotnet
     - name: Setup Minikube
       if: matrix.subset == 'kubernetes'
       id: minikube
-      uses: CodingNagger/minikube-setup-action@v1.0.2
+      uses: CodingNagger/minikube-setup-action@v1.0.3
+      with:
+        minikube-version: "1.9.0-0_amd64"
     - name: Launch Minikube
       if: matrix.subset == 'kubernetes'
       run: eval ${{ steps.minikube.outputs.launcher }}

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -123,7 +123,7 @@ pbr==5.4.4
 prettytable==0.7.2
 prov==1.5.1
 psutil==5.6.7
-pulsar-galaxy-lib==0.14.0.dev1
+pulsar-galaxy-lib==0.14.0.dev2
 pyasn1-modules==0.2.7
 pyasn1==0.4.8
 pycparser==2.19

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -19,6 +19,7 @@ from galaxy.jobs.runners import (
 from galaxy.jobs.runners.util.pykube_util import (
     DEFAULT_JOB_API_VERSION,
     ensure_pykube,
+    find_job_object_by_name,
     galaxy_instance_id,
     Job,
     job_object_dict,
@@ -26,6 +27,7 @@ from galaxy.jobs.runners.util.pykube_util import (
     produce_unique_k8s_job_name,
     pull_policy,
     pykube_client_from_dict,
+    stop_job,
 )
 from galaxy.util.bytesize import ByteSize
 
@@ -493,19 +495,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
     def __cleanup_k8s_job(self, job):
         k8s_cleanup_job = self.runner_params['k8s_cleanup_job']
-        job_failed = (job.obj['status']['failed'] > 0
-                      if 'failed' in job.obj['status'] else False)
-        # Scale down the job just in case even if cleanup is never
-        job.scale(replicas=0)
-        if (k8s_cleanup_job == "always" or
-                (k8s_cleanup_job == "onsuccess" and not job_failed)):
-            delete_options = {
-                "apiVersion": "v1",
-                "kind": "DeleteOptions",
-                "propagationPolicy": "Background"
-            }
-            r = job.api.delete(json=delete_options, **job.api_kwargs())
-            job.api.raise_for_status(r)
+        stop_job(job, k8s_cleanup_job)
 
     def __job_failed_due_to_walltime_limit(self, job):
         conditions = job.obj['status'].get('conditions') or []
@@ -534,11 +524,10 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         """Attempts to delete a dispatched job to the k8s cluster"""
         job = job_wrapper.get_job()
         try:
-            jobs = Job.objects(self._pykube_api).filter(
-                selector="app=" + self.__produce_unique_k8s_job_name(job.get_id_tag()),
-                namespace=self.runner_params['k8s_namespace'])
-            if len(jobs.response['items']) > 0:
-                job_to_delete = Job(self._pykube_api, jobs.response['items'][0])
+            name = self.__produce_unique_k8s_job_name(job.get_id_tag())
+            namespace = self.runner_params['k8s_namespace']
+            job_to_delete = find_job_object_by_name(self._pykube_api, name, namespace)
+            if job_to_delete:
                 self.__cleanup_k8s_job(job_to_delete)
             # TODO assert whether job parallelism == 0
             # assert not job_to_delete.exists(), "Could not delete job,"+job.job_runner_external_id+" it still exists"

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -868,7 +868,7 @@ KUBERNETES_DESTINATION_DEFAULTS = {
     "default_file_action": "remote_transfer",
     "rewrite_parameters": "true",
     "jobs_directory": "/pulsar_staging",
-    "pulsar_container_image": "galaxy/pulsar-pod-staging:0.13.0",
+    "pulsar_container_image": "galaxy/pulsar-pod-staging:0.14.0",
     "remote_container_handling": True,
     "k8s_enabled": True,
     "url": PARAMETER_SPECIFICATION_IGNORED,

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -85,8 +85,8 @@ def stop_job(job, cleanup="always"):
                   if 'failed' in job.obj['status'] else False)
     # Scale down the job just in case even if cleanup is never
     job.scale(replicas=0)
-    if (cleanup == "always" or
-            (cleanup == "onsuccess" and not job_failed)):
+    if (cleanup == "always"
+            or (cleanup == "onsuccess" and not job_failed)):
         delete_options = {
             "apiVersion": "v1",
             "kind": "DeleteOptions",

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -15,6 +15,8 @@ from .api import UsesApiTestCaseMixin
 from .driver_util import GalaxyTestDriver
 
 NO_APP_MESSAGE = "test_case._app called though no Galaxy has been configured."
+# Following should be for Homebrew Rabbitmq and Docker on Mac "amqp://guest:guest@localhost:5672//"
+AMQP_URL = os.environ.get("GALAXY_TEST_AMQP_URL", None)
 
 
 def _identity(func):
@@ -26,6 +28,12 @@ def skip_if_jenkins(cls):
         return skip
 
     return cls
+
+
+def skip_unless_amqp():
+    if AMQP_URL is not None:
+        return _identity
+    return pytest.mark.skip("AMQP_URL is not set, required for this test.")
 
 
 def skip_unless_executable(executable):

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -105,7 +105,7 @@ def job_config(template_str, jobs_directory):
 
 @integration_util.skip_unless_kubernetes()
 @integration_util.skip_unless_fixed_port()
-class KubernetesStagingContainerIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
+class BaseKubernetesStagingTest(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
 
     def setUp(self):
         super(KubernetesStagingContainerIntegrationTestCase, self).setUp()
@@ -116,6 +116,9 @@ class KubernetesStagingContainerIntegrationTestCase(BaseJobEnvironmentIntegratio
         # realpath for docker deployed in a VM on Mac, also done in driver_util.
         cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
         super(KubernetesStagingContainerIntegrationTestCase, cls).setUpClass()
+
+
+class KubernetesStagingContainerIntegrationTestCase(BaseKubernetesStagingTest):
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -134,17 +137,7 @@ class KubernetesStagingContainerIntegrationTestCase(BaseJobEnvironmentIntegratio
 
 @integration_util.skip_unless_kubernetes()
 @integration_util.skip_unless_fixed_port()
-class KubernetesDependencyResolutionIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
-
-    def setUp(self):
-        super(KubernetesDependencyResolutionIntegrationTestCase, self).setUp()
-        self.history_id = self.dataset_populator.new_history()
-
-    @classmethod
-    def setUpClass(cls):
-        # realpath for docker deployed in a VM on Mac, also done in driver_util.
-        cls.jobs_directory = os.path.realpath(tempfile.mkdtemp())
-        super(KubernetesDependencyResolutionIntegrationTestCase, cls).setUpClass()
+class KubernetesDependencyResolutionIntegrationTestCase(BaseKubernetesStagingTest):
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -12,6 +12,7 @@ rabbitmq installed via Homebrew, and if a fixed port is set for the test.
 
 """
 import os
+import random
 import string
 import tempfile
 
@@ -39,6 +40,7 @@ execution:
   environments:
     pulsar_k8s_environment:
       k8s_config_path: ${k8s_config_path}
+      k8s_galaxy_instance_id: ${instance_id}
       runner: pulsar_k8s
       docker_enabled: true
       docker_default_container_id: busybox:ubuntu-14.04
@@ -69,6 +71,7 @@ execution:
   environments:
     pulsar_k8s_environment:
       k8s_config_path: ${k8s_config_path}
+      k8s_galaxy_instance_id: ${instance_id}
       runner: pulsar_k8s
       pulsar_app_config:
         message_queue_url: '${container_amqp_url}'
@@ -86,8 +89,10 @@ tools:
 def job_config(template_str, jobs_directory):
     job_conf_template = string.Template(template_str)
     container_amqp_url = to_infrastructure_uri(AMQP_URL)
+    instance_id = ''.join(random.choice(string.ascii_lowercase) for i in range(8))
     job_conf_str = job_conf_template.substitute(jobs_directory=jobs_directory,
                                                 tool_directory=TOOL_DIR,
+                                                instance_id=instance_id,
                                                 k8s_config_path=integration_util.k8s_config_path(),
                                                 amqp_url=AMQP_URL,
                                                 container_amqp_url=container_amqp_url,

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -22,9 +22,16 @@ from .test_local_job_cancellation import CancelsJob
 from .test_containerized_jobs import EXTENDED_TIMEOUT, MulledJobTestCases
 from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
 
+from galaxy.jobs.runners.util.pykube_util import (
+    ensure_pykube,
+    Job,
+    Pod,
+    pykube_client_from_dict,
+)
+
 TOOL_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'tools'))
-AMQP_URL = os.environ.get("GALAXY_TEST_AMQP_URL", "amqp://guest:guest@localhost:5672//")
 GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST = os.environ.get("GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST", "host.docker.internal")
+AMQP_URL = integration_util.AMQP_URL
 
 
 CONTAINERIZED_TEMPLATE = """
@@ -104,6 +111,7 @@ def job_config(template_str, jobs_directory):
 
 
 @integration_util.skip_unless_kubernetes()
+@integration_util.skip_unless_amqp()
 class BaseKubernetesStagingTest(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
     # Test leverages $UWSGI_PORT in job code, need to set this up.
     require_uwsgi = True

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -16,18 +16,15 @@ import random
 import string
 import tempfile
 
-from galaxy_test.base.populators import skip_without_tool
-from galaxy_test.driver import integration_util
-from .test_local_job_cancellation import CancelsJob
-from .test_containerized_jobs import EXTENDED_TIMEOUT, MulledJobTestCases
-from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
-
 from galaxy.jobs.runners.util.pykube_util import (
-    ensure_pykube,
     Job,
-    Pod,
     pykube_client_from_dict,
 )
+from galaxy_test.base.populators import skip_without_tool
+from galaxy_test.driver import integration_util
+from .test_containerized_jobs import EXTENDED_TIMEOUT, MulledJobTestCases
+from .test_job_environments import BaseJobEnvironmentIntegrationTestCase
+from .test_local_job_cancellation import CancelsJob
 
 TOOL_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, 'tools'))
 GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST = os.environ.get("GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST", "host.docker.internal")

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -10,15 +10,9 @@ from galaxy_test.base.populators import (
 from galaxy_test.driver import integration_util
 
 
-class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
+class CancelsJob(object):
 
-    framework_tool_and_types = True
-
-    def setUp(self):
-        super(LocalJobCancellationTestCase, self).setUp()
-        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
-
-    def setup_cat_data_and_sleep(self, history_id):
+    def _setup_cat_data_and_sleep(self, history_id):
         hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3")
         running_inputs = {
             "input1": {"src": "hda", "id": hda1["id"]},
@@ -31,12 +25,21 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
             assert_ok=False,
         ).json()
         job_dict = running_response["jobs"][0]
-        return job_dict
+        return job_dict["id"]
+
+
+class LocalJobCancellationTestCase(CancelsJob, integration_util.IntegrationTestCase):
+
+    framework_tool_and_types = True
+
+    def setUp(self):
+        super(LocalJobCancellationTestCase, self).setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
     def test_cancel_job_with_admin_message(self):
         with self.dataset_populator.test_history() as history_id:
-            job_dict = self.setup_cat_data_and_sleep(history_id)
-            self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_dict['id']).json()['state'] != 'running',
+            job_id = self._setup_cat_data_and_sleep(history_id)
+            self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_id).json()['state'] != 'running',
                                             what="Wait for job to start running",
                                             maxseconds=60)
             app = self._app
@@ -48,7 +51,7 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
             job.set_state(app.model.Job.states.DELETED_NEW)
             sa_session.add(job)
             sa_session.flush()
-            self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_dict['id']).json()['state'] != 'error',
+            self.galaxy_interactor.wait_for(lambda: self._get("jobs/%s" % job_id).json()['state'] != 'error',
                                             what="Wait for job to end in error",
                                             maxseconds=60)
 
@@ -56,7 +59,7 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
         """
         """
         with self.dataset_populator.test_history() as history_id:
-            job_dict = self.setup_cat_data_and_sleep(history_id)
+            job_id = self._setup_cat_data_and_sleep(history_id)
 
             app = self._app
             sa_session = app.model.context.current
@@ -80,7 +83,7 @@ class LocalJobCancellationTestCase(integration_util.IntegrationTestCase):
             pid_exists = psutil.pid_exists(external_id)
             assert pid_exists
 
-            delete_response = self.dataset_populator.cancel_job(job_dict["id"])
+            delete_response = self.dataset_populator.cancel_job(job_id)
             assert delete_response.json() is True
 
             state = None

--- a/test/unit/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/jobs/job_conf.sample_advanced.yml
@@ -792,6 +792,11 @@ execution:
       docker_default_container_id: 'conda/miniconda2'
       # Specify a non-default Pulsar staging container.
       #pulsar_container_image: 'galaxy/pulsar-pod-staging:0.12.0'
+      # Generate job names with a string unique to this Galaxy (see
+      # Kubernetes runner description).
+      #k8s_galaxy_instance_id: mycoolgalaxy
+      # Path to Kubernetes configuration fil (see Kubernetes runner description.)
+      #k8s_config_path: /path/to/kubeconfig
 
     # Example CLI runners.
     ssh_torque:


### PR DESCRIPTION
- Rev Pulsar library and container in order to implement cancelling Kubernetes jobs when the Galaxy job is stopped.
- Implement a k8s_galaxy_instance parameter that namespaces jobs (and increases test robustness as a result).
- Eliminate the need to fix a port to run integration tests - using #9349

All this is important in its own right but also setup to implementing ITs on remote Kubernetes clusters - this work allows reproducibly recovering Job objects needed to poll for podIP address that will be needed in subsequent work.
