### PR TITLE
Assign random password in user manager if none specified

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -106,7 +106,6 @@ class CustosAuthnz(IdentityProvider):
                         raise Exception("There already exists a user with email %s.  To associate this external login, you must first be logged in as that existing account." % email)
                 else:
                     user = trans.app.user_manager.create(email=email, username=username)
-                    user.set_random_password()
                     trans.sa_session.add(user)
                     trans.sa_session.flush()
             custos_authnz_token = CustosAuthnzToken(user=user,

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -93,7 +93,10 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """
         self._error_on_duplicate_email(email)
         user = self.model_class(email=email)
-        user.set_password_cleartext(password)
+        if password:
+            user.set_password_cleartext(password)
+        else:
+            user.set_random_password()
         user.username = username
         if self.app.config.user_activation_on:
             user.active = False

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -185,6 +185,14 @@ class UserManagerTestCase(BaseTestCase):
         response = json.loads(controller.login(self.trans, payload={"login": user2.username, "password": default_password}))
         self.assertEqual(response["message"], "Success.")
 
+    def test_empty_password(self):
+        self.log("should be able to create a user with no password")
+        user = self.user_manager.create(email='user@nopassword.com', username='nopassword')
+        self.assertIsNotNone(user.id)
+        self.assertIsNotNone(user.password)
+        # should not be able to login with a null or empty password
+        self.assertFalse(check_password("", user.password))
+        self.assertFalse(check_password(None, user.password))
 
 # =============================================================================
 class UserSerializerTestCase(BaseTestCase):


### PR DESCRIPTION
I ran into this error when trying to integrate an OpenID connect provider.

```
112.134.192.179 - - [01/Apr/2020:21:09:52 +1000] "GET /authnz/custos/callback?code=itp%3Aac%3A476282cd-194b-4d96-baf2-0cc465ee0760&state=UfFhjyMS8oPcJ4Z9rRliKRdgHJevDz HTTP/1.1" 500 - "https://galaxy-aust-staging.genome.edu.au/root/login?is_logout_redirect=true" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"
Traceback (most recent call last):
  File "lib/galaxy/authnz/managers.py", line 260, in callback
    return True, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
  File "lib/galaxy/authnz/custos_authnz.py", line 110, in callback
    user = trans.app.user_manager.create(email=email, username=username)
  File "lib/galaxy/managers/users.py", line 96, in create
    user.set_password_cleartext(password)
  File "lib/galaxy/model/__init__.py", line 393, in set_password_cleartext
    self.password = new_secure_hash(text_type=cleartext)
  File "lib/galaxy/util/hash_util.py", line 72, in new_secure_hash
galaxy.model.database_heartbeat DEBUG 2020-04-01 21:09:53,146 [p:10875,w:1,m:0] [database_heartbeart_main.web.1.thread] main.web.1 is not config watcher
    assert text_type is not None
AssertionError
```

It turns out that the user_manager does not handle empty passwords correctly. The issue appears to be straightforward, but was wondering whether this was caused by a recent code change perhaps?
