### PR TITLE
add trust option

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -102,21 +102,19 @@ class GalaxyInteractorApi(object):
     def __init__(self, **kwds):
         self.api_url = "%s/api" % kwds["galaxy_url"].rstrip("/")
         self.master_api_key = kwds["master_api_key"]
-        self.api_key = self.__get_user_key(kwds.get("api_key"), kwds.get("master_api_key"), test_user=kwds.get("test_user"))
-        if kwds.get('user_api_key_is_admin_key', False):
-            self.master_api_key = self.api_key
-        self.keep_outputs_dir = kwds["keep_outputs_dir"]
-        self.verify = True
-        if kwds.get('trust', True):
+        self.verify = not kwds.get('noverify', False)
+        if not self.verify:
             # disable the following warning:
             # Unverified HTTPS request is being made.
             # Adding certificate verification is strongly advised.
             # See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
             import urllib3
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            self.verify = False
+        self.api_key = self.__get_user_key(kwds.get("api_key"), kwds.get("master_api_key"), test_user=kwds.get("test_user"))
+        if kwds.get('user_api_key_is_admin_key', False):
+            self.master_api_key = self.api_key
+        self.keep_outputs_dir = kwds["keep_outputs_dir"]
         self._target_galaxy_version = None
-
         self.uploads = {}
 
     @property

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -102,7 +102,7 @@ class GalaxyInteractorApi(object):
     def __init__(self, **kwds):
         self.api_url = "%s/api" % kwds["galaxy_url"].rstrip("/")
         self.master_api_key = kwds["master_api_key"]
-        self.verify = not kwds.get('noverify', False)
+        self.verify = kwds.get('verify', False)
         if not self.verify:
             # disable the following warning:
             # Unverified HTTPS request is being made.

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -106,6 +106,15 @@ class GalaxyInteractorApi(object):
         if kwds.get('user_api_key_is_admin_key', False):
             self.master_api_key = self.api_key
         self.keep_outputs_dir = kwds["keep_outputs_dir"]
+        self.verify = True
+        if kwds.get('trust', True):
+            # disable the following warning:
+            # Unverified HTTPS request is being made.
+            # Adding certificate verification is strongly advised.
+            # See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            self.verify = False
         self._target_galaxy_version = None
 
         self.uploads = {}
@@ -671,21 +680,21 @@ class GalaxyInteractorApi(object):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         # no params for POST
         data.update(params)
-        return requests.post("%s/%s" % (self.api_url, path), data=data, files=files)
+        return requests.post("%s/%s" % (self.api_url, path), data=data, files=files, verify=self.verify)
 
     def _delete(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         # no data for DELETE
         params.update(data)
-        return requests.delete("%s/%s" % (self.api_url, path), params=params)
+        return requests.delete("%s/%s" % (self.api_url, path), params=params, verify=self.verify)
 
     def _patch(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
-        return requests.patch("%s/%s" % (self.api_url, path), params=params, data=data)
+        return requests.patch("%s/%s" % (self.api_url, path), params=params, data=data, verify=self.verify)
 
     def _put(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
-        return requests.put("%s/%s" % (self.api_url, path), params=params, data=data)
+        return requests.put("%s/%s" % (self.api_url, path), params=params, data=data, verify=self.verify)
 
     def _get(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
@@ -694,7 +703,7 @@ class GalaxyInteractorApi(object):
         if path.startswith("/api"):
             path = path[len("/api"):]
         url = "%s/%s" % (self.api_url, path)
-        return requests.get(url, params=params)
+        return requests.get(url, params=params, verify=self.verify)
 
 
 class RunToolException(Exception):

--- a/lib/galaxy_test/driver/api.py
+++ b/lib/galaxy_test/driver/api.py
@@ -126,7 +126,6 @@ class ApiTestInteractor(BaseInteractor):
     def __init__(self, test_case):
         admin = getattr(test_case, "require_admin_user", False)
         test_user = TEST_USER if not admin else ADMIN_TEST_USER
-        self.verify = True
         super(ApiTestInteractor, self).__init__(test_case, test_user=test_user)
 
     # This variant the lower level get and post methods are meant to be used

--- a/lib/galaxy_test/driver/api.py
+++ b/lib/galaxy_test/driver/api.py
@@ -45,7 +45,6 @@ class UsesApiTestCaseMixin(object):
     def _setup_interactor(self):
         self.user_api_key = get_user_api_key()
         self.master_api_key = get_master_api_key()
-        self.verify = True
         self.galaxy_interactor = ApiTestInteractor(self)
 
     def _setup_user(self, email, password=None, is_admin=True):
@@ -127,6 +126,7 @@ class ApiTestInteractor(BaseInteractor):
     def __init__(self, test_case):
         admin = getattr(test_case, "require_admin_user", False)
         test_user = TEST_USER if not admin else ADMIN_TEST_USER
+        self.verify = True
         super(ApiTestInteractor, self).__init__(test_case, test_user=test_user)
 
     # This variant the lower level get and post methods are meant to be used

--- a/lib/galaxy_test/driver/api.py
+++ b/lib/galaxy_test/driver/api.py
@@ -45,6 +45,7 @@ class UsesApiTestCaseMixin(object):
     def _setup_interactor(self):
         self.user_api_key = get_user_api_key()
         self.master_api_key = get_master_api_key()
+        self.verify = True
         self.galaxy_interactor = ApiTestInteractor(self)
 
     def _setup_user(self, email, password=None, is_admin=True):


### PR DESCRIPTION
This allows the "planemo test" command working with a self signed certificate

Option is documented in Planemo like this:
> @click.option(
>     "--trust",
>     is_flag=True,
>     help="When set, Requests will trust SSL certificates for HTTPS requests. "
>          "It sets verify=False in requests call",
>     default=False,
> )

`verify=True` is the default for Requests.