### PR TITLE
Datasource tool for SRA manifest

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -5,6 +5,7 @@
     <tool file="data_source/ucsc_tablebrowser.xml" />
     <!-- <tool file="data_source/ucsc_tablebrowser_test.xml" /> -->
     <tool file="data_source/ucsc_tablebrowser_archaea.xml" />
+    <tool file="data_source/sra.xml" />
     <tool file="data_source/ebi_sra.xml" />
     <tool file="data_source/fly_modencode.xml" />
     <tool file="data_source/intermine.xml" />

--- a/tools/data_source/sra.xml
+++ b/tools/data_source/sra.xml
@@ -8,7 +8,7 @@
 <tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.0">
     <description>server</description>
     <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
-    <inputs action="https://www.ncbi.nlm.nih.gov/Traces/study" check_values="false" method="get">
+    <inputs action="https://www.ncbi.nlm.nih.gov/sra" check_values="false" method="get">
         <display>go to SRA server $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=sra_source" />
     </inputs>

--- a/tools/data_source/sra.xml
+++ b/tools/data_source/sra.xml
@@ -1,28 +1,12 @@
-<?xml version="1.0"?>
-<!--
-    If the value of 'URL_method' is 'get', the request will consist of the value of 'URL' coming back in
-    the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
-    initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
--->
-
-<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.0">
+<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.0" profile="16.04">
     <description>server</description>
-    <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
+    <command>python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit</command>
     <inputs action="https://www.ncbi.nlm.nih.gov/sra" check_values="false" method="get">
         <display>go to SRA server $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=sra_source" />
     </inputs>
-    <request_param_translation>
-        <request_param galaxy_name="URL_method" remote_name="URL_method" missing="post" />
-        <request_param galaxy_name="URL" remote_name="URL" missing="" />
-        <request_param galaxy_name="name" remote_name="name" missing="SRA query" />
-        <request_param galaxy_name="info" remote_name="info" missing="SRA TEST" />
-        <request_param galaxy_name="data_type" remote_name="data_type" missing="auto" >
-        </request_param>
-    </request_param_translation>
-    <uihints minwidth="800"/>
     <outputs>
-        <data name="output" format="txt" />
+        <data name="output" format="csv" />
     </outputs>
     <options sanitize="False" refresh="True"/>
     <citations>
@@ -30,4 +14,3 @@
         <citation type="doi">10.1101/gr.229102</citation>
     </citations>
 </tool>
-

--- a/tools/data_source/sra.xml
+++ b/tools/data_source/sra.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+    If the value of 'URL_method' is 'get', the request will consist of the value of 'URL' coming back in
+    the initial response.  If value of 'URL_method' is 'post', any additional params coming back in the
+    initial response ( in addition to 'URL' ) will be encoded and appended to URL and a post will be performed.
+-->
+
+<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.0">
+    <description>server</description>
+    <command interpreter="python">data_source.py $output $__app__.config.output_size_limit</command>
+    <inputs action="https://www.ncbi.nlm.nih.gov/Traces/study" check_values="false" method="get">
+        <display>go to SRA server $GALAXY_URL</display>
+        <param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=sra_source" />
+    </inputs>
+    <request_param_translation>
+        <request_param galaxy_name="URL_method" remote_name="URL_method" missing="post" />
+        <request_param galaxy_name="URL" remote_name="URL" missing="" />
+        <request_param galaxy_name="name" remote_name="name" missing="SRA query" />
+        <request_param galaxy_name="info" remote_name="info" missing="SRA TEST" />
+        <request_param galaxy_name="data_type" remote_name="data_type" missing="auto" >
+        </request_param>
+    </request_param_translation>
+    <uihints minwidth="800"/>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <options sanitize="False" refresh="True"/>
+    <citations>
+        <citation type="doi">10.1093/database/bar011</citation>
+        <citation type="doi">10.1101/gr.229102</citation>
+    </citations>
+</tool>
+


### PR DESCRIPTION
To test this, load up Galaxy, find the SRA tool in the `Get Data` section. You will be redirected to https://www.ncbi.nlm.nih.gov/sra where you can search the SRA. Note the url that will look something like `https://www.ncbi.nlm.nih.gov/sra?GALAXY_URL=http%3A//galaxy-url.net%3A8080/tool_runner%3Ftool_id%3Dsra_source`. Copy the `GALAXY_URL=http%3A//galaxy-url.net%3A8080/tool_runner%3Ftool_id%3Dsra_source` part to your clipboard

If you found what you were looking for click on `Send results to Run selector`. This will send you to the old run selector, so you need to change the URL from `https://www.ncbi.nlm.nih.gov/Traces/study/...` to `https://www.ncbi.nlm.nih.gov/Traces/study2/...`

At this point the GALAXY_URL parameter seems to not be stored on the SRA side, so you will have to manually add the galaxy parameter for your instance in the url. To do that change `https://www.ncbi.nlm.nih.gov/Traces/study2/?query_key=1&WebEnv=NCID_1_72854674_130.14.22.33_5555_1586872005_763693960_0MetA0_S_HStore&o=acc_s%3Aa` to `https://www.ncbi.nlm.nih.gov/Traces/study2/?GALAXY_URL=http%3A//galaxy-url.net%3A8080/tool_runner%3Ftool_id%3Dsra_source&query_key=1&WebEnv=NCID_1_72854674_130.14.22.33_5555_1586872005_763693960_0MetA0_S_HStore&o=acc_s%3Aa`