### PR TITLE
Fix ELIXIR AAI

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -114,8 +114,9 @@ class PSAAuthnz(IdentityProvider):
 
         # Secondary AuthZ with Google identities is currently supported
         if provider != "google":
-            del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
-            del self.config["SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT"]
+            if 'SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER' in self.config:
+                del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
+                del self.config["SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT"]
 
     def _setup_idp(self, oidc_backend_config):
         self.config[setting_name('AUTH_EXTRA_ARGUMENTS')] = {'access_type': 'offline'}

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -116,6 +116,7 @@ class PSAAuthnz(IdentityProvider):
         if provider != "google":
             if 'SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER' in self.config:
                 del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
+            if 'SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT' in self.config:
                 del self.config["SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT"]
 
     def _setup_idp(self, oidc_backend_config):


### PR DESCRIPTION
As suggested by @hexylena on Gitter https://gitter.im/galaxyproject/admins?at=5e95af245b98016d6a35f178:

___

Gildas Le Corguillé @lecorguille avr. 14 14:39
>Bonjour,
>Have there been any changes in the Elixir AAI I missed?
```
Traceback (most recent call last):
  File "/shared/mfs/data/galaxy/server/lib/galaxy/authnz/managers.py", line 156, in _get_authnz_backend
    return True, "", identity_provider_class(unified_provider_name, self.oidc_config, self.oidc_backends_config[unified_provider_name])
  File "/shared/mfs/data/galaxy/server/lib/galaxy/authnz/psa_authnz.py", line 117, in __init__
    del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
KeyError: 'SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER'
The user is getting : Login failed for an unknown reason.
```
Helena Rasche @hexylena avr. 14 14:40
>there have been changes, I got an email some days ago about them changing which attributes are sent but that shouldn't affect that.
> that looks like an easy fix at least, just wrap in an if > 'SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER' in self.config:

Gildas Le Corguillé @lecorguille avr. 14 17:04
```python
        # Secondary AuthZ with Google identities is currently supported
        if provider != "google":
            if 'SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER' in self.config:
                del self.config["SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER"]
                del self.config["SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT"]
```
___

I don't really know if it's armless or not but it works.