### PR TITLE
Port and Vuefy AWS estimate from EU

### DIFF
--- a/client/galaxy/scripts/components/JobMetrics/JobMetrics.test.js
+++ b/client/galaxy/scripts/components/JobMetrics/JobMetrics.test.js
@@ -5,6 +5,7 @@ import { mount, createLocalVue } from "@vue/test-utils";
 import { createStore } from "../../store";
 import flushPromises from "flush-promises";
 import JobMetrics from "./JobMetrics";
+import ec2 from "./ec2.json";
 
 const JOB_ID = "moo";
 
@@ -64,5 +65,64 @@ describe("JobMetrics/JobMetrics.vue", () => {
         expect(metricsTables.at(0).findAll("tr").length).to.equals(2);
         expect(metricsTables.at(1).find(".metrics_plugin_title").text()).to.equals("extended");
         expect(metricsTables.at(1).findAll("tr").length).to.equals(1);
+    });
+
+    it("should render correct AWS Estimates", async () => {
+        let deriveRenderedAwsEstimate = async (cores, seconds, memory) => {
+            const JOB_ID = Math.random().toString(36).substring(2);
+            const propsData = {
+                jobId: JOB_ID,
+                aws_estimate: "True",
+            };
+            const metricsResponse = [
+                { plugin: "core", name: "galaxy_slots", raw_value: cores },
+                { plugin: "core", name: "runtime_seconds", raw_value: seconds },
+                { plugin: "core", name: "galaxy_memory_mb", raw_value: memory },
+            ];
+            axiosMock.onGet(`/api/jobs/${JOB_ID}/metrics`).reply(200, metricsResponse);
+            const wrapper = mount(JobMetrics, {
+                store: testStore,
+                propsData,
+                localVue,
+            });
+            // Wait for axios and rendering.
+            await flushPromises();
+
+            const estimates = {};
+
+            if (!wrapper.find("#aws-estimate").exists()) return false;
+
+            estimates.cost = wrapper.find("#aws-estimate > b").text();
+            estimates.vcpus = wrapper.find("#aws_vcpus").text();
+            estimates.cpu = wrapper.find("#aws_cpu").text();
+            estimates.mem = wrapper.find("#aws_mem").text();
+            estimates.name = wrapper.find("#aws_name").text();
+
+            return estimates;
+        };
+        let assertAwsInstance = (estimates) => {
+            const instance = ec2.find((instance) => estimates.name === instance.name);
+            expect(estimates.mem).to.equals(instance.mem.toString());
+            expect(estimates.vcpus).to.equals(instance.vcpus.toString());
+            expect(estimates.cpu).to.equals(instance.cpu.toString());
+        };
+
+        let estimates_small = await deriveRenderedAwsEstimate("1.0000000", "9.0000000", "2048.0000000");
+
+        expect(estimates_small.name).to.equals("t2.small");
+        expect(estimates_small.cost).to.equals("0.00 USD");
+        assertAwsInstance(estimates_small);
+
+        let estimates_large = await deriveRenderedAwsEstimate("40.0000000", "18000.0000000", "194560.0000000");
+        expect(estimates_large.name).to.equals("m5d.12xlarge");
+        expect(estimates_large.cost).to.equals("16.32 USD");
+        assertAwsInstance(estimates_large);
+
+        let estimates_not_available = await deriveRenderedAwsEstimate(
+            "99999.0000000",
+            "18000.0000000",
+            "99999.0000000"
+        );
+        expect(estimates_not_available).to.equals(false);
     });
 });

--- a/client/galaxy/scripts/components/JobMetrics/JobMetrics.vue
+++ b/client/galaxy/scripts/components/JobMetrics/JobMetrics.vue
@@ -13,13 +13,18 @@
             </table>
         </div>
 
-        <div v-if="isAwsEstimate && awsEstimate">
+        <div id="aws-estimate" v-if="isAwsEstimate && awsEstimate">
             <h3>AWS estimate</h3>
             <b>{{ awsEstimate.price }} USD</b><br />
             This job requested {{ awsEstimate.vcpus }} cores and {{ awsEstimate.memory }} Gb. Given this, the smallest
-            EC2 machine we could find is {{ awsEstimate.instance.name }} ({{ awsEstimate.instance.mem }} GB /
-            {{ awsEstimate.instance.vcpus }} vCPUs / {{ awsEstimate.instance.cpu }}). That instance is priced at
-            {{ awsEstimate.instance.price }} USD/hour.
+            EC2 machine we could find is <span id="aws_name">{{ awsEstimate.instance.name }}</span> (<span
+                id="aws_mem"
+                >{{ awsEstimate.instance.mem }}</span
+            >
+            GB / <span id="aws_vcpus">{{ awsEstimate.instance.vcpus }}</span> vCPUs /
+            <span id="aws_cpu">{{ awsEstimate.instance.cpu }}</span
+            >). That instance is priced at {{ awsEstimate.instance.price }} USD/hour.<br />
+            Please note, that those numbers are only estimates, all jobs are always free of charge for all users.
         </div>
     </div>
 </template>
@@ -91,6 +96,7 @@ export default {
             aws.instance = ec2.find((ec) => {
                 return ec.mem >= aws.memory && ec.vcpus >= aws.vcpus;
             });
+            if (aws.instance === undefined) return;
             aws.price = ((aws.seconds * aws.instance.price) / 3600).toFixed(2);
             return aws;
         },

--- a/client/galaxy/scripts/components/JobMetrics/ec2.json
+++ b/client/galaxy/scripts/components/JobMetrics/ec2.json
@@ -1,0 +1,306 @@
+[
+  {
+    "name": "t2.nano",
+    "mem": 0.5,
+    "price": 0.0067,
+    "priceunit": "Hrs",
+    "vcpus": 1,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "t3.nano",
+    "mem": 0.5,
+    "price": 0.006,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "t2.micro",
+    "mem": 1,
+    "price": 0.0134,
+    "priceunit": "Hrs",
+    "vcpus": 1,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "t3.micro",
+    "mem": 1,
+    "price": 0.012,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "t2.small",
+    "mem": 2,
+    "price": 0.0268,
+    "priceunit": "Hrs",
+    "vcpus": 1,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "t3.small",
+    "mem": 2,
+    "price": 0.024,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "m3.medium",
+    "mem": 3.75,
+    "price": 0.079,
+    "priceunit": "Hrs",
+    "vcpus": 1,
+    "cpu": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)"
+  },
+  {
+    "name": "t2.medium",
+    "mem": 4,
+    "price": 0.0536,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "t3.medium",
+    "mem": 4,
+    "price": 0.048,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "m3.large",
+    "mem": 7.5,
+    "price": 0.158,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)"
+  },
+  {
+    "name": "t2.large",
+    "mem": 8,
+    "price": 0.1072,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "t3.large",
+    "mem": 8,
+    "price": 0.096,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "m5.large",
+    "mem": 8,
+    "price": 0.115,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m5d.large",
+    "mem": 8,
+    "price": 0.136,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m4.large",
+    "mem": 8,
+    "price": 0.12,
+    "priceunit": "Hrs",
+    "vcpus": 2,
+    "cpu": "Intel Xeon E5-2676 v3 (Haswell)"
+  },
+  {
+    "name": "m3.xlarge",
+    "mem": 15,
+    "price": 0.315,
+    "priceunit": "Hrs",
+    "vcpus": 4,
+    "cpu": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)"
+  },
+  {
+    "name": "m5.xlarge",
+    "mem": 16,
+    "price": 0.23,
+    "priceunit": "Hrs",
+    "vcpus": 4,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m4.xlarge",
+    "mem": 16,
+    "price": 0.24,
+    "priceunit": "Hrs",
+    "vcpus": 4,
+    "cpu": "Intel Xeon E5-2676 v3 (Haswell)"
+  },
+  {
+    "name": "t3.xlarge",
+    "mem": 16,
+    "price": 0.192,
+    "priceunit": "Hrs",
+    "vcpus": 4,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "t2.xlarge",
+    "mem": 16,
+    "price": 0.2144,
+    "priceunit": "Hrs",
+    "vcpus": 4,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "m5d.xlarge",
+    "mem": 16,
+    "price": 0.272,
+    "priceunit": "Hrs",
+    "vcpus": 4,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m3.2xlarge",
+    "mem": 30,
+    "price": 0.632,
+    "priceunit": "Hrs",
+    "vcpus": 8,
+    "cpu": "Intel Xeon E5-2670 v2 (Ivy Bridge/Sandy Bridge)"
+  },
+  {
+    "name": "m5d.2xlarge",
+    "mem": 32,
+    "price": 0.544,
+    "priceunit": "Hrs",
+    "vcpus": 8,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m5.2xlarge",
+    "mem": 32,
+    "price": 0.46,
+    "priceunit": "Hrs",
+    "vcpus": 8,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m4.2xlarge",
+    "mem": 32,
+    "price": 0.48,
+    "priceunit": "Hrs",
+    "vcpus": 8,
+    "cpu": "Intel Xeon E5-2676 v3 (Haswell)"
+  },
+  {
+    "name": "t3.2xlarge",
+    "mem": 32,
+    "price": 0.384,
+    "priceunit": "Hrs",
+    "vcpus": 8,
+    "cpu": "Intel Skylake E5 2686 v5 (2.5 GHz)"
+  },
+  {
+    "name": "t2.2xlarge",
+    "mem": 32,
+    "price": 0.4288,
+    "priceunit": "Hrs",
+    "vcpus": 8,
+    "cpu": "Intel Xeon Family"
+  },
+  {
+    "name": "m5d.4xlarge",
+    "mem": 64,
+    "price": 1.088,
+    "priceunit": "Hrs",
+    "vcpus": 16,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m4.4xlarge",
+    "mem": 64,
+    "price": 0.96,
+    "priceunit": "Hrs",
+    "vcpus": 16,
+    "cpu": "Intel Xeon E5-2676 v3 (Haswell)"
+  },
+  {
+    "name": "m5.4xlarge",
+    "mem": 64,
+    "price": 0.92,
+    "priceunit": "Hrs",
+    "vcpus": 16,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m4.10xlarge",
+    "mem": 160,
+    "price": 2.4,
+    "priceunit": "Hrs",
+    "vcpus": 40,
+    "cpu": "Intel Xeon E5-2676 v3 (Haswell)"
+  },
+  {
+    "name": "m5d.12xlarge",
+    "mem": 192,
+    "price": 3.264,
+    "priceunit": "Hrs",
+    "vcpus": 48,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m5.12xlarge",
+    "mem": 192,
+    "price": 2.76,
+    "priceunit": "Hrs",
+    "vcpus": 48,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m4.16xlarge",
+    "mem": 256,
+    "price": 3.84,
+    "priceunit": "Hrs",
+    "vcpus": 64,
+    "cpu": "Intel Xeon E5-2686 v4 (Broadwell)"
+  },
+  {
+    "name": "m5d.metal",
+    "mem": 384,
+    "price": 6.528,
+    "priceunit": "Hrs",
+    "vcpus": 96,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m5.metal",
+    "mem": 384,
+    "price": 5.52,
+    "priceunit": "Hrs",
+    "vcpus": 96,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m5d.24xlarge",
+    "mem": 384,
+    "price": 6.528,
+    "priceunit": "Hrs",
+    "vcpus": 96,
+    "cpu": "Intel Xeon Platinum 8175"
+  },
+  {
+    "name": "m5.24xlarge",
+    "mem": 384,
+    "price": 5.52,
+    "priceunit": "Hrs",
+    "vcpus": 96,
+    "cpu": "Intel Xeon Platinum 8175"
+  }
+]

--- a/client/galaxy/scripts/components/JobMetrics/mount.js
+++ b/client/galaxy/scripts/components/JobMetrics/mount.js
@@ -8,11 +8,13 @@ import { mountVueComponent } from "utils/mountVueComponent";
 export const mountJobMetrics = (propsData = {}) => {
     $(".job-metrics").each((index, el) => {
         const jobId = $(el).attr("job_id");
+        const aws_estimate = $(el).attr("aws_estimate");
         const datasetId = $(el).attr("dataset_id");
         const datasetType = $(el).attr("dataset_type") || "hda";
         propsData.jobId = jobId;
         propsData.datasetId = datasetId;
         propsData.datasetType = datasetType;
+        propsData.aws_estimate = aws_estimate;
         mountVueComponent(JobMetrics)(propsData, el);
     });
 };

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1381,7 +1381,9 @@
 ~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable AWS estimate.
+    This flag enables an AWS cost estimate for every job based on their runtime matrices.
+    CPU, RAM and runtime usage is mapped against AWS pricing table.
+    Please note, that those numbers are only estimates.
 :Default: ``false``
 :Type: bool
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1376,6 +1376,16 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~
+``aws_estimate``
+~~~~~~~~~~~~~~~~
+
+:Description:
+    Enable AWS estimate.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``interactivetools_proxy_host``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -761,6 +761,9 @@ galaxy:
   # Enable InteractiveTools.
   #interactivetools_enable: false
 
+  # Enable AWS estimate.
+  #aws_estimate: false
+
   # Proxy host - assumed to just be hosted on the same hostname and port
   # as Galaxy by default.
   #interactivetools_proxy_host: null

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -91,6 +91,7 @@ class ConfigSerializer(base.ModelSerializer):
             'inactivity_box_content'            : _use_config,
             'visualizations_visible'            : _use_config,
             'interactivetools_enable'           : _use_config,
+            'aws_estimate'                      : _use_config,
             'message_box_content'               : _use_config,
             'message_box_visible'               : _use_config,
             'message_box_class'                 : _use_config,

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1026,6 +1026,13 @@ mapping:
         desc: |
           Enable InteractiveTools.
 
+      aws_estimate:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Enable AWS estimate.
+
       interactivetools_proxy_host:
         type: str
         desc: |

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -113,7 +113,7 @@ ${ job.command_line | h }</pre>
 %endif
 
 %if job and (trans.user_is_admin or trans.app.config.expose_potentially_sensitive_job_metrics):
-<div class="job-metrics" dataset_id="${encoded_hda_id}" dataset_type="hda">
+<div class="job-metrics" dataset_id="${encoded_hda_id}" aws_estimate="${trans.app.config.aws_estimate}" dataset_type="hda">
 </div>
 %endif
 


### PR DESCRIPTION
Refactoring ```AWS estimate``` functionality from EU server, initially implemented [here]( https://github.com/usegalaxy-eu/galaxy/blob/release_19.09_europe/templates/show_params.mako#L121). 

Of course configurable and requires metrics to be enabled. Example:
![image](https://user-images.githubusercontent.com/15801412/79596237-7d36e280-80e0-11ea-936e-66059caad140.png)

Should I change text or add something? 