### PR TITLE
Changed CSS overflow property from scroll to hidden to make table scrollable

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -446,7 +446,7 @@
                         :data="hotData.data"
                         :col-headers="colHeadersDisplay"
                         :read-only="true"
-                        :stretch-h="all"
+                        stretch-h="all"
                     >
                     </hot-table>
                 </div>

--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -446,7 +446,7 @@
                         :data="hotData.data"
                         :col-headers="colHeadersDisplay"
                         :read-only="true"
-                        stretch-h="all"
+                        :stretch-h="all"
                     >
                     </hot-table>
                 </div>
@@ -1977,19 +1977,19 @@ export default {
 <style>
 .table-column {
     width: 100%;
-    /* overflow: scroll; */
+    overflow: hidden;
 }
 .select2-container {
     min-width: 60px;
 }
 .vertical #hot-table {
     width: 100%;
-    overflow: scroll;
+    overflow: hidden;
     height: 400px;
 }
 .horizontal #hot-table {
     width: 100%;
-    overflow: scroll;
+    overflow: hidden;
     height: 250px;
 }
 .rule-builder-body {


### PR DESCRIPTION
    Why you made the changes (e.g. references to GitHub issues being fixed).
Potential solution to ticket #6100

    A description of the implementation of the changes.
Modified the CSS overflow property from scroll to hidden to make the table scrollable.

    How to test the changes, if you haven't included specific tests already.
Open the Rule Builder and supply a large amount of data (in terms of column-width/count and row count) to make sure you are able to scroll to see all of it. 
