### PR TITLE
Add selenium test for admin toolshed operations.

### DIFF
--- a/client/galaxy/scripts/components/Toolshed/Index.vue
+++ b/client/galaxy/scripts/components/Toolshed/Index.vue
@@ -4,6 +4,7 @@
         <div v-else>
             <b-input-group class="mb-3">
                 <b-input
+                    id="toolshed-repo-search"
                     placeholder="Search Repositories"
                     v-model="queryInput"
                     @input="delayQuery"

--- a/client/galaxy/scripts/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/galaxy/scripts/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-modal :static="modalStatic" v-model="modalShow" @ok="onOk" @hide="onHide">
+    <b-modal id="repo-install-settings" :static="modalStatic" v-model="modalShow" @ok="onOk" @hide="onHide">
         <template v-slot:modal-header>
             <h4 class="title m-0">
                 {{ modalTitle }}

--- a/client/galaxy/scripts/components/Toolshed/SearchList/Repositories.vue
+++ b/client/galaxy/scripts/components/Toolshed/SearchList/Repositories.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-table striped :items="repositories" :fields="fields">
+        <b-table striped id="shed-search-results" :items="repositories" :fields="fields">
             <template v-slot:cell(name)="row">
                 <b-link href="javascript:void(0)" role="button" class="font-weight-bold" @click="row.toggleDetails">
                     {{ row.item.name }}

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -50,6 +50,10 @@ WAIT_TYPES = Bunch(
     JOB_COMPLETION=WaitType("job_completion", 30),
     # Wait time for a GIE to spawn.
     GIE_SPAWN=WaitType("gie_spawn", 30),
+    # Wait time for toolshed search
+    SHED_SEARCH=WaitType('shed_search', 30),
+    # Wait time for repository installation
+    REPO_INSTALL=WaitType('repo_install', 60),
 )
 
 # Choose a moderate wait type for operations that don't specify a type.

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -353,6 +353,11 @@ tour:
 
 admin:
 
+  toolshed:
+    selectors:
+      repo_search: '#toolshed-repo-search'
+      search_results: '#shed-search-results'
+
   index:
     selectors:
       datatypes: '#admin-link-datatypes'

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -19,10 +19,12 @@ class AdminAppTestCase(SeleniumTestCase):
         admin_component.index.toolshed.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.screenshot("admin_toolshed_landing")
-        # admin_component.toolshed.selectors.repo_search.wait_for_visible()
         repo_search_input = self.driver.find_element_by_id("toolshed-repo-search")
         repo_search_input.clear()
         repo_search_input.send_keys('all_fasta')
+        # If this hasn't succeeded after 30 seconds, the @flakey context should
+        # allow the test to still pass, since there should definitely be results
+        # after 30 seconds.
         self.sleep_for(self.wait_types.SHED_SEARCH)
         self.screenshot("admin_toolshed_search")
         admin_component.toolshed.search_results.wait_for_visible()
@@ -38,6 +40,8 @@ class AdminAppTestCase(SeleniumTestCase):
         ok_button.click()
         self.sleep_for(self.wait_types.REPO_INSTALL)
         self.screenshot('admin_toolshed_repo_installed')
+        # Unfortunately reusing the element isn't feasible, since the div
+        # containing the button gets replaced with a new div and button.
         uninstall_button = self.driver.find_element_by_xpath("(//button[contains(., 'Uninstall')])[1]")
         uninstall_button.click()
         self.sleep_for(self.wait_types.UX_TRANSITION)

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -15,19 +15,20 @@ class AdminAppTestCase(SeleniumTestCase):
         self.admin_login()
         self.admin_open()
         self.sleep_for(self.wait_types.UX_RENDER)
-        self.screenshot("admin_landing")
+        self.screenshot('admin_landing')
         admin_component.index.toolshed.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
-        self.screenshot("admin_toolshed_landing")
-        repo_search_input = self.driver.find_element_by_id("toolshed-repo-search")
+        self.screenshot('admin_toolshed_landing')
+        repo_search_input = self.driver.find_element_by_id('toolshed-repo-search')
         repo_search_input.clear()
         repo_search_input.send_keys('all_fasta')
         # If this hasn't succeeded after 30 seconds, the @flakey context should
         # allow the test to still pass, since there should definitely be results
         # after 30 seconds.
         self.sleep_for(self.wait_types.SHED_SEARCH)
-        self.screenshot("admin_toolshed_search")
+        self.screenshot('admin_toolshed_search')
         admin_component.toolshed.search_results.wait_for_visible()
+        # It's very unlikely that this data manager will ever stop existing.
         repository_row = self.driver.find_element_by_link_text('data_manager_fetch_genome_dbkeys_all_fasta')
         repository_row.click()
         self.sleep_for(self.wait_types.UX_RENDER)

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -1,3 +1,4 @@
+from galaxy_test.base.populators import flakey
 from .framework import (
     selenium_test,
     SeleniumTestCase,
@@ -9,7 +10,7 @@ class AdminAppTestCase(SeleniumTestCase):
     requires_admin = True
 
     @selenium_test
-    @flakey # This test relies on an external server that may or may not be available to the testing environment.
+    @flakey  # This test relies on an external server that may or may not be available to the testing environment.
     def test_admin_toolshed(self):
         admin_component = self.components.admin
         self.admin_login()

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -9,6 +9,41 @@ class AdminAppTestCase(SeleniumTestCase):
     requires_admin = True
 
     @selenium_test
+    @flakey # This test relies on an external server that may or may not be available to the testing environment.
+    def test_admin_toolshed(self):
+        admin_component = self.components.admin
+        self.admin_login()
+        self.admin_open()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot("admin_landing")
+        admin_component.index.toolshed.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot("admin_toolshed_landing")
+        # admin_component.toolshed.selectors.repo_search.wait_for_visible()
+        repo_search_input = self.driver.find_element_by_id("toolshed-repo-search")
+        repo_search_input.clear()
+        repo_search_input.send_keys('all_fasta')
+        self.sleep_for(self.wait_types.SHED_SEARCH)
+        self.screenshot("admin_toolshed_search")
+        admin_component.toolshed.search_results.wait_for_visible()
+        repository_row = self.driver.find_element_by_link_text('data_manager_fetch_genome_dbkeys_all_fasta')
+        repository_row.click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_toolshed_repo_details')
+        install_button = self.driver.find_element_by_xpath("(//button[contains(., 'Install')])[1]")
+        install_button.click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_toolshed_repo_install_settings')
+        ok_button = self.driver.find_element_by_xpath("//*[@id='repo-install-settings___BV_modal_footer_']/button[contains(., 'OK')]")
+        ok_button.click()
+        self.sleep_for(self.wait_types.REPO_INSTALL)
+        self.screenshot('admin_toolshed_repo_installed')
+        uninstall_button = self.driver.find_element_by_xpath("(//button[contains(., 'Uninstall')])[1]")
+        uninstall_button.click()
+        self.sleep_for(self.wait_types.UX_TRANSITION)
+        self.screenshot('admin_toolshed_repo_uninstalled')
+
+    @selenium_test
     def test_admin_server_display(self):
         admin_component = self.components.admin
         self.admin_login()


### PR DESCRIPTION
This covers the majority of operations under `Tool Shed Client` on #3241 

- Search
- Install
- Uninstall

I added two more wait durations, 30 seconds for SHED_SEARCH and 60 seconds for REPO_INSTALL, and some selectors in navigation.yml and element IDs where appropriate to make it a little easier for the tests to find the right DOM elements.