### PR TITLE
[19.09] Fix `TypeError: OSError object is not subscriptable` under Python 3

### DIFF
--- a/test/base/driver_util.py
+++ b/test/base/driver_util.py
@@ -310,13 +310,15 @@ def _tool_data_table_config_path(default_tool_data_table_config_path=None):
     return tool_data_table_config_path
 
 
-def nose_config_and_run(argv=None, env=None, ignore_files=[], plugins=None):
+def nose_config_and_run(argv=None, env=None, ignore_files=None, plugins=None):
     """Setup a nose context and run tests.
 
     Tests are specified by argv (defaulting to sys.argv).
     """
     if env is None:
         env = os.environ
+    if ignore_files is None:
+        ignore_files = []
     if plugins is None:
         plugins = nose.plugins.manager.DefaultPluginManager()
     if argv is None:
@@ -472,7 +474,7 @@ def get_webapp_global_conf():
 def wait_for_http_server(host, port, sleep_amount=0.1, sleep_tries=150):
     """Wait for an HTTP server to boot up."""
     # Test if the server is up
-    for i in range(sleep_tries):
+    for _ in range(sleep_tries):
         # directly test the app, not the proxy
         conn = http_client.HTTPConnection(host, port)
         try:
@@ -497,7 +499,7 @@ def attempt_ports(port):
         raise Exception("An existing process seems bound to specified test server port [%s]" % port)
     else:
         random.seed()
-        for i in range(0, 9):
+        for _ in range(0, 9):
             port = str(random.randint(8000, 10000))
             yield port
 
@@ -515,7 +517,7 @@ def serve_webapp(webapp, port=None, host=None):
             server = httpserver.serve(webapp, host=host, port=port, start_loop=False)
             break
         except socket.error as e:
-            if e[0] == 98:
+            if e.errno == 98:
                 continue
             raise
 
@@ -947,7 +949,7 @@ class GalaxyTestDriver(TestDriver):
                 # one - other just read the properties above and use the default
                 # implementation from this file.
                 galaxy_config = getattr(config_object, "galaxy_config", None)
-                if hasattr(galaxy_config, '__call__'):
+                if callable(galaxy_config):
                     galaxy_config = galaxy_config()
                 if galaxy_config is None:
                     setup_galaxy_config_kwds = dict(
@@ -1038,7 +1040,9 @@ class GalaxyTestDriver(TestDriver):
             return test_classes
         return functional.test_toolbox
 
-    def run_tool_test(self, tool_id, index=0, resource_parameters={}):
+    def run_tool_test(self, tool_id, index=0, resource_parameters=None):
+        if resource_parameters is None:
+            resource_parameters = {}
         host, port, url = target_url_parts()
         galaxy_interactor_kwds = {
             "galaxy_url": url,


### PR DESCRIPTION
Fix the following exception:

```
test/integration/test_cli_runners.py:90:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/galaxy_test/driver/integration_util.py:73: in setUpClass
    cls._test_driver.setup(config_object=cls)
lib/galaxy_test/driver/driver_util.py:942: in setup
    self._register_and_run_servers(config_object)
lib/galaxy_test/driver/driver_util.py:1008: in _register_and_run_servers
    config_object=config_object,
lib/galaxy_test/driver/driver_util.py:827: in launch_server
    host=host, port=port
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

webapp = <paste.urlmap.URLMap object at 0x7f011b68c110>, port = '8845'
host = '127.0.0.1'

    def serve_webapp(webapp, port=None, host=None):
        """Serve the webapp on a recommend port or a free one.

        Return the port the webapp is running on.
        """
        server = None
        for port in attempt_ports(port):
            try:
                server = httpserver.serve(webapp, host=host, port=port, start_loop=False)
                break
            except socket.error as e:
>               if e[0] == 98:
E               TypeError: 'OSError' object is not subscriptable
```

Also use `e.errno` instead of `e.args[0]` to get the errno of `socket.error`, since the latter may return an error string depending on how the exception was raised.

Also:
- move standard library imports to the top
- fix issues reported by flake8-bugbear