### PR TITLE
Python37 lock fix

### DIFF
--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -56,7 +56,7 @@ def check_password_PBKDF2(guess, hashed):
     return safe_str_cmp(encoded_original, encoded_guess)
 
 
-def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
+def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=24, hashfunc=None):
     """Returns a binary digest for the PBKDF2 hash algorithm of `data`
     with the given `salt`.  It iterates `iterations` time and produces a
     key of `keylen` bytes.  By default SHA-256 is used as hash function,

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -59,10 +59,10 @@ def check_password_PBKDF2(guess, hashed):
 def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
     """Returns a binary digest for the PBKDF2 hash algorithm of `data`
     with the given `salt`.  It iterates `iterations` time and produces a
-    key of `keylen` bytes.  By default SHA-1 is used as hash function,
+    key of `keylen` bytes.  By default SHA-256 is used as hash function,
     a different hashlib `hashfunc` can be provided.
     """
-    hashfunc = hashfunc or "sha1"
+    hashfunc = hashfunc or HASH_FUNCTION
     data = bytes(smart_str(data))
     salt = bytes(smart_str(salt))
 

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -62,9 +62,6 @@ def check_password_PBKDF2(guess, hashed):
     return safe_str_cmp(encoded_original, encoded_guess)
 
 
-# Inspiration taken from https://github.com/pallets/werkzeug/blob/master/src/werkzeug/security.py
-# (which itself was based on the previous version of the code here, from python-pbkdf2)
-
 def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
     """Returns a binary digest for the PBKDF2 hash algorithm of `data`
     with the given `salt`.  It iterates `iterations` time and produces a

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -11,7 +11,7 @@ from galaxy.util import (
 SALT_LENGTH = 12
 KEY_LENGTH = 24
 HASH_FUNCTION = 'sha256'
-COST_FACTOR = 10000
+COST_FACTOR = 100000
 
 
 def hash_password(password):

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -47,7 +47,7 @@ def hash_password_PBKDF2(password):
     # Generate a random salt
     salt = b64encode(urandom(SALT_LENGTH))
     # Apply the pbkdf2 encoding
-    hashed_password = pbkdf2_bin(password, salt, COST_FACTOR, KEY_LENGTH, getattr(hashlib, HASH_FUNCTION))
+    hashed_password = pbkdf2_bin(password, salt, COST_FACTOR, KEY_LENGTH, HASH_FUNCTION)
     encoded_password = unicodify(b64encode(hashed_password))
     # Format
     return 'PBKDF2${0}${1}${2}${3}'.format(HASH_FUNCTION, COST_FACTOR, unicodify(salt), encoded_password)
@@ -57,7 +57,7 @@ def check_password_PBKDF2(guess, hashed):
     # Split the database representation to extract cost_factor and salt
     name, hash_function, cost_factor, salt, encoded_original = hashed.split('$', 5)
     # Hash the guess using the same parameters
-    hashed_guess = pbkdf2_bin(guess, salt, int(cost_factor), KEY_LENGTH, getattr(hashlib, hash_function))
+    hashed_guess = pbkdf2_bin(guess, salt, int(cost_factor), KEY_LENGTH, hash_function)
     encoded_guess = unicodify(b64encode(hashed_guess))
     return safe_str_cmp(encoded_original, encoded_guess)
 
@@ -71,13 +71,8 @@ def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
     key of `keylen` bytes.  By default SHA-1 is used as hash function,
     a different hashlib `hashfunc` can be provided.
     """
-    hashfunc = hashfunc or hashlib.sha1
+    hashfunc = hashfunc or "sha1"
     data = bytes(smart_str(data))
     salt = bytes(smart_str(salt))
 
-    if callable(hashfunc):
-        _test_hash = hashfunc()
-        hash_name = getattr(_test_hash, "name", None)
-    else:
-        hash_name = hashfunc
-    return hashlib.pbkdf2_hmac(hash_name, data, salt, iterations, keylen)
+    return hashlib.pbkdf2_hmac(hashfunc, data, salt, iterations, keylen)

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -63,7 +63,7 @@ def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=24, hashfunc=None):
     a different hashlib `hashfunc` can be provided.
     """
     hashfunc = hashfunc or HASH_FUNCTION
-    data = bytes(smart_str(data))
-    salt = bytes(smart_str(salt))
+    data = smart_str(data)
+    salt = smart_str(salt)
 
     return hashlib.pbkdf2_hmac(hashfunc, data, salt, iterations, keylen)

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -1,12 +1,6 @@
 import hashlib
-import hmac
 from base64 import b64encode
-from itertools import starmap
-from operator import xor
 from os import urandom
-from struct import Struct
-
-import six
 
 from galaxy.util import (
     safe_str_cmp,

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -56,13 +56,12 @@ def check_password_PBKDF2(guess, hashed):
     return safe_str_cmp(encoded_original, encoded_guess)
 
 
-def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=24, hashfunc=None):
+def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=KEY_LENGTH, hashfunc=HASH_FUNCTION):
     """Returns a binary digest for the PBKDF2 hash algorithm of `data`
     with the given `salt`.  It iterates `iterations` time and produces a
     key of `keylen` bytes.  By default SHA-256 is used as hash function,
     a different hashlib `hashfunc` can be provided.
     """
-    hashfunc = hashfunc or HASH_FUNCTION
     data = smart_str(data)
     salt = smart_str(salt)
 


### PR DESCRIPTION
Fixes #9641 

One concern is that `pbkdf2_hmac` was added in python 2.7.8.  I'm not *that* worried about it because that was available July 2, 2014, and we're not supporting 2.7 anymore anyway, but...  It's worth thinking about.