### PR TITLE
Remove DO_NOT_TEST from config unit tests

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3845,11 +3845,11 @@
     from workflow_resource_params_file). If this this is a function
     reference it will be passed various inputs (workflow model object
     and user) and it should produce a list of input IDs. If it is a
-    path it is expected to an XML or YAML file describing how to map
-    group names to parameter descriptions (additional types of
+    path it is expected to be an XML or YAML file describing how to
+    map group names to parameter descriptions (additional types of
     mappings via these files could be implemented but haven't yet -
     for instance using workflow tags to do the mapping).
-:Default: ``config/workflow_resource_mapper_conf.yml``
+:Default: ``None``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1381,9 +1381,7 @@
 ~~~~~~~~~~~~~~~~
 
 :Description:
-    This flag enables an AWS cost estimate for every job based on their runtime matrices.
-    CPU, RAM and runtime usage is mapped against AWS pricing table.
-    Please note, that those numbers are only estimates.
+    Enable AWS estimate.
 :Default: ``false``
 :Type: bool
 
@@ -2329,8 +2327,7 @@
 :Description:
     Heartbeat log filename. Can accept the template variables
     {server_name} and {pid}
-    Sample default 'heartbeat_{server_name}.log'
-:Default: ``None``
+:Default: ``heartbeat_{server_name}.log``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3852,7 +3852,8 @@
     map group names to parameter descriptions (additional types of
     mappings via these files could be implemented but haven't yet -
     for instance using workflow tags to do the mapping).
-    Sample default path 'config/workflow_resource_mapper_conf.yml'
+    Sample default path
+    'config/workflow_resource_mapper_conf.yml.sample'
 :Default: ``None``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1381,7 +1381,10 @@
 ~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable AWS estimate.
+    This flag enables an AWS cost estimate for every job based on
+    their runtime matrices. CPU, RAM and runtime usage is mapped
+    against AWS pricing table. Please note, that those numbers are
+    only estimates.
 :Default: ``false``
 :Type: bool
 
@@ -3849,6 +3852,7 @@
     map group names to parameter descriptions (additional types of
     mappings via these files could be implemented but haven't yet -
     for instance using workflow tags to do the mapping).
+    Sample default path 'config/workflow_resource_mapper_conf.yml'
 :Default: ``None``
 :Type: str
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -601,8 +601,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         # Heartbeat log file name override
         if self.global_conf is not None and 'heartbeat_log' in self.global_conf:
             self.heartbeat_log = self.global_conf['heartbeat_log']
-        if self.heartbeat_log is None:
-            self.heartbeat_log = 'heartbeat_{server_name}.log'
         # Determine which 'server:' this is
         self.server_name = 'main'
         for arg in sys.argv:

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -494,14 +494,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         # you want yours tools to be broken in the future.
         self.enable_beta_tool_formats = string_as_bool(kwargs.get('enable_beta_tool_formats', 'False'))
 
-        workflow_resource_params_mapper = kwargs.get("workflow_resource_params_mapper")
-        if not workflow_resource_params_mapper:
-            workflow_resource_params_mapper = None
-        elif ":" not in workflow_resource_params_mapper:
-            # Assume it is not a Python function, so a file
-            workflow_resource_params_mapper = self._in_root_dir(workflow_resource_params_mapper)
-        # else: a Python a function!
-        self.workflow_resource_params_mapper = workflow_resource_params_mapper
+        if self.workflow_resource_params_mapper and ':' not in self.workflow_resource_params_mapper:
+            # Assume it is not a Python function, so a file; else: a Python function
+            self.workflow_resource_params_mapper = self._in_root_dir(self.workflow_resource_params_mapper)
 
         self.pbs_application_server = kwargs.get('pbs_application_server', "")
         self.pbs_dataset_server = kwargs.get('pbs_dataset_server', "")

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1889,7 +1889,8 @@ galaxy:
   # to parameter descriptions (additional types of mappings via these
   # files could be implemented but haven't yet - for instance using
   # workflow tags to do the mapping).
-  # Sample default path 'config/workflow_resource_mapper_conf.yml'
+  # Sample default path
+  # 'config/workflow_resource_mapper_conf.yml.sample'
   #workflow_resource_params_mapper: null
 
   # Optional configuration file similar to `job_config_file` to specify

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1164,8 +1164,7 @@ galaxy:
 
   # Heartbeat log filename. Can accept the template variables
   # {server_name} and {pid}
-  # Sample default 'heartbeat_{server_name}.log'
-  #heartbeat_log: null
+  #heartbeat_log: heartbeat_{server_name}.log
 
   # Log to Sentry Sentry is an open source logging and error aggregation
   # platform.  Setting sentry_dsn will enable the Sentry middleware and

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1883,11 +1883,11 @@ galaxy:
   # workflow_resource_params_file). If this this is a function reference
   # it will be passed various inputs (workflow model object and user)
   # and it should produce a list of input IDs. If it is a path it is
-  # expected to an XML or YAML file describing how to map group names to
-  # parameter descriptions (additional types of mappings via these files
-  # could be implemented but haven't yet - for instance using workflow
-  # tags to do the mapping).
-  #workflow_resource_params_mapper: config/workflow_resource_mapper_conf.yml
+  # expected to be an XML or YAML file describing how to map group names
+  # to parameter descriptions (additional types of mappings via these
+  # files could be implemented but haven't yet - for instance using
+  # workflow tags to do the mapping).
+  #workflow_resource_params_mapper: null
 
   # Optional configuration file similar to `job_config_file` to specify
   # which Galaxy processes should schedule workflows.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -761,7 +761,9 @@ galaxy:
   # Enable InteractiveTools.
   #interactivetools_enable: false
 
-  # Enable AWS estimate.
+  # This flag enables an AWS cost estimate for every job based on their
+  # runtime matrices. CPU, RAM and runtime usage is mapped against AWS
+  # pricing table. Please note, that those numbers are only estimates.
   #aws_estimate: false
 
   # Proxy host - assumed to just be hosted on the same hostname and port
@@ -1887,6 +1889,7 @@ galaxy:
   # to parameter descriptions (additional types of mappings via these
   # files could be implemented but haven't yet - for instance using
   # workflow tags to do the mapping).
+  # Sample default path 'config/workflow_resource_mapper_conf.yml'
   #workflow_resource_params_mapper: null
 
   # Optional configuration file similar to `job_config_file` to specify

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2839,14 +2839,13 @@ mapping:
 
       workflow_resource_params_mapper:
         type: str
-        default: config/workflow_resource_mapper_conf.yml
         required: false
         desc: |
           This parameter describes how to map users and workflows to a set of workflow
           resource parameter to present (typically input IDs from workflow_resource_params_file).
           If this this is a function reference it will be passed various inputs (workflow model
           object and user) and it should produce a list of input IDs. If it is a path
-          it is expected to an XML or YAML file describing how to map group names to parameter
+          it is expected to be an XML or YAML file describing how to map group names to parameter
           descriptions (additional types of mappings via these files could be implemented but
           haven't yet - for instance using workflow tags to do the mapping).
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1709,12 +1709,10 @@ mapping:
 
       heartbeat_log:
         type: str
+        default: heartbeat_{server_name}.log
         required: false
         desc: |
-          Heartbeat log filename. Can accept the template variables {server_name} and
-          {pid}
-
-          Sample default 'heartbeat_{server_name}.log'
+          Heartbeat log filename. Can accept the template variables {server_name} and {pid}
 
       sentry_dsn:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1031,7 +1031,9 @@ mapping:
         default: false
         required: false
         desc: |
-          Enable AWS estimate.
+          This flag enables an AWS cost estimate for every job based on their runtime matrices.
+          CPU, RAM and runtime usage is mapped against AWS pricing table.
+          Please note, that those numbers are only estimates.
 
       interactivetools_proxy_host:
         type: str
@@ -2848,6 +2850,8 @@ mapping:
           it is expected to be an XML or YAML file describing how to map group names to parameter
           descriptions (additional types of mappings via these files could be implemented but
           haven't yet - for instance using workflow tags to do the mapping).
+
+          Sample default path 'config/workflow_resource_mapper_conf.yml'
 
       workflow_schedulers_config_file:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2851,7 +2851,7 @@ mapping:
           descriptions (additional types of mappings via these files could be implemented but
           haven't yet - for instance using workflow tags to do the mapping).
 
-          Sample default path 'config/workflow_resource_mapper_conf.yml'
+          Sample default path 'config/workflow_resource_mapper_conf.yml.sample'
 
       workflow_schedulers_config_file:
         type: str

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -12,7 +12,6 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 # TODO: all these will be fixed
 DO_NOT_TEST = [
-    'heartbeat_log',
     'ftp_upload_dir_template',
     'workflow_resource_params_mapper',
     'amqp_internal_connection',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -6,12 +6,12 @@ import pytest
 
 from galaxy import config
 from galaxy.util import listify
+from galaxy.web.formatting import expand_pretty_datetime_format
 
 TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 # TODO: all these will be fixed
 DO_NOT_TEST = [
-    'pretty_datetime_format',
     'heartbeat_log',
     'ftp_upload_dir_template',
     'workflow_resource_params_mapper',
@@ -38,6 +38,7 @@ class ExpectedValues:
             'object_store_store_by': 'uuid',
             'password_expiration_period': timedelta,
             'persistent_communication_rooms': listify_strip,
+            'pretty_datetime_format': expand_pretty_datetime_format,
             'statsd_host': '',  # TODO: do we need '' as the default?
             'tool_config_file': listify_strip,
             'tool_data_table_config_path': listify_strip,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -12,7 +12,6 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 # TODO: all these will be fixed
 DO_NOT_TEST = [
-    'ftp_upload_dir_template',
     'workflow_resource_params_mapper',
     'amqp_internal_connection',
 ]
@@ -33,6 +32,7 @@ class ExpectedValues:
         self._resolvers = {
             'database_connection': self.get_expected_database_connection,
             'disable_library_comptypes': [''],  # TODO: we can do better
+            'ftp_upload_dir_template': self.get_expected_ftp_upload_dir_template,
             'mulled_channels': listify_strip,
             'object_store_store_by': 'uuid',
             'password_expiration_period': timedelta,
@@ -151,6 +151,9 @@ class ExpectedValues:
 
     def get_expected_database_connection(self, value):
         return 'sqlite:///{}/universe.sqlite?isolation_level=IMMEDIATE'.format(self._config.data_dir)
+
+    def get_expected_ftp_upload_dir_template(self, value):
+        return '${ftp_upload_dir}%s${ftp_upload_dir_identifier}' % os.path.sep
 
 
 @pytest.fixture

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -12,7 +12,6 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 # TODO: all these will be fixed
 DO_NOT_TEST = [
-    'workflow_resource_params_mapper',
     'amqp_internal_connection',
 ]
 


### PR DESCRIPTION
100% of schema-derived config properties are covered by unit tests. 
Detailed comments in commit messages.