### PR TITLE
[20.01] Fix workfow parameter connections and default values

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,10 +27,15 @@ jobs:
     steps:
     - name: Prune unused docker image, volumes and containers
       run: docker system prune -a -f
+    - name: Clean dotnet folder for space
+      if: matrix.subset == 'kubernetes'
+      run: rm -Rf /usr/share/dotnet
     - name: Setup Minikube
       if: matrix.subset == 'kubernetes'
       id: minikube
-      uses: CodingNagger/minikube-setup-action@v1.0.2
+      uses: CodingNagger/minikube-setup-action@v1.0.3
+      with:
+        minikube-version: "1.9.0-0_amd64"
     - name: Launch Minikube
       if: matrix.subset == 'kubernetes'
       run: eval ${{ steps.minikube.outputs.launcher }}

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -31,6 +31,7 @@ from galaxy.tools.parameters import (
 from galaxy.tools.parameters.basic import (
     BaseDataToolParameter,
     BooleanToolParameter,
+    ColorToolParameter,
     ConnectedValue,
     DataCollectionToolParameter,
     DataToolParameter,
@@ -815,8 +816,8 @@ class InputParameterModule(WorkflowModule):
         parameter_type_cond.test_param = input_parameter_type
         cases = []
 
-        for param_type in ["text", "integer", "float"]:
-            default_source = dict(name="default", label="Default Value", type=parameter_type)
+        for param_type in ["text", "integer", "float", "boolean", "color"]:
+            default_source = dict(name="default", label="Default Value", type=param_type)
             if param_type == "text":
                 if parameter_type == "text":
                     default = parameter_def.get("default") or ""
@@ -838,7 +839,22 @@ class InputParameterModule(WorkflowModule):
                     default = 0.0
                 default_source["value"] = default
                 input_default_value = FloatToolParameter(None, default_source)
-            # color parameter defaults?
+            elif param_type == "boolean":
+                if parameter_type == "boolean":
+                    default = parameter_def.get("default") or False
+                else:
+                    default = False
+                default_source["value"] = default
+                default_source["checked"] = default
+                input_default_value = BooleanToolParameter(None, default_source)
+            elif param_type == "color":
+                if parameter_type == 'color':
+                    default = parameter_def.get('default') or '#000000'
+                else:
+                    default = '#000000'
+                default_source["value"] = default
+                input_default_value = ColorToolParameter(None, default_source)
+
             optional_value = optional_param(optional)
             optional_cond = Conditional()
             optional_cond.name = "optional"
@@ -1023,6 +1039,8 @@ class InputParameterModule(WorkflowModule):
         if optional:
             default_value = parameter_def.get("default", self.default_default_value)
             parameter_kwds["value"] = default_value
+            if parameter_type == 'boolean':
+                parameter_kwds['checked'] = default_value
 
         if "value" not in parameter_kwds and parameter_type in ["integer", "float"]:
             parameter_kwds["value"] = str(0)


### PR DESCRIPTION
in workflow editor and run form.

The main problem was that
`default_source = dict(name="default", label="Default Value",
type=parameter_type)`, where `parameter_type` is the top-level
parameter that is always `text`. This has changed with the
Conditional introduced in 20.01.

In addition BooleanToolParameters use `check` instead of `value`.
I also added ColorToolParameter.

One thing for dev is that I think we should pull the default
values out of the optional conditional so we can set defaults
for required parameters.

Fixes https://github.com/galaxyproject/galaxy/issues/9646