### PR TITLE
weasyprint in requirements

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -194,3 +194,4 @@ webob==1.8.6
 whoosh==2.7.4
 wrapt==1.12.1
 zipp==1.2.0
+weasyprint==51


### PR DESCRIPTION
```weasyprint``` needed to be in ```requirements.txt``` in order to produce PDFs from workflow reports.
I guess, there was a reason not to put it there, so this PR is mostly just to start discussion about its relevance. Otherwise export button, just doesn't work.

[code reference](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/managers/markdown_util.py#L437)

There is also a possibility to export PDF using just frontend https://github.com/MrRio/jsPDF and I can try it out if needed. But since there is already implementation for PDF export (which works), it would be just easier to use it.
