### PR TITLE
Framework for Browser Testing of Custom Configured Galaxy Instances

### DIFF
--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -1,0 +1,45 @@
+name: Integration Selenium
+on: [push, pull_request]
+env:
+  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_SELENIUM_REMOTE: '1'
+  GALAXY_TEST_SELENIUM_REMOTE_PORT: "4444"
+  GALAXY_SKIP_CLIENT_BUILD: '0'
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version: [3.7]
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+      selenium:
+        image: selenium/standalone-chrome:3.141.59
+        ports:
+          - 4444:4444
+    steps:
+    - name: Prune unused docker image, volumes and containers
+      run: docker system prune -a -f
+    - uses: actions/checkout@v2
+      with:
+        path: 'galaxy root'
+    - uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Cache pip dir
+      uses: actions/cache@v1
+      id: pip-cache
+      with:
+        path: ~/.cache/pip
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+    - name: Run tests
+      run: './run_tests.sh -integration test/integration_selenium'
+      working-directory: 'galaxy root'

--- a/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
+++ b/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
@@ -260,6 +260,7 @@ export default {
             // add ftp file viewer
             this.ftp = new Popover({
                 title: _l("FTP files"),
+                class: "ftp-upload",
                 container: $(this.$refs.btnFtp),
             });
         },

--- a/client/galaxy/scripts/mvc/ui/ui-popover.js
+++ b/client/galaxy/scripts/mvc/ui/ui-popover.js
@@ -21,7 +21,7 @@ export default Backbone.View.extend({
      * Show popover
      */
     show: function ($content) {
-        const btn = "<i class='fa fa-times-circle'/>";
+        const btn = "<i class='popover-close fa fa-times-circle'/>";
         $(this.$target).popover({
             title: `${this.options.title} ${btn}`,
             placement: this.options.placement,
@@ -29,6 +29,9 @@ export default Backbone.View.extend({
             html: true,
             trigger: "manual",
         });
+        if (this.options.class) {
+            $(this.$target).addClass(this.options.class);
+        }
         $(this.$target).popover("show");
 
         // add event to hide if click is outside of popup and not on container

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -464,6 +464,11 @@ gies:
 upload:
   selectors:
     tab: '#tab-title-link-${tab}'
+    ftp_add: '#btn-ftp'
+    ftp_popup: '.upload-ftp-body'
+    ftp_items: '.upload-ftp-row'
+    ftp_close: '.popover-header .popover-close'
+    row: '#upload-row-${n}'
     start: '.upload-button'
     rule_source_content: 'textarea.upload-rule-source-content'
     rule_select_data_type: '.rule-data-type'

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -140,6 +140,11 @@ class IntegrationInstance(UsesApiTestCaseMixin):
     def _run_tool_test(self, *args, **kwargs):
         return self._test_driver.run_tool_test(*args, **kwargs)
 
+    @classmethod
+    def temp_config_dir(cls, name):
+        # realpath here to get around problems with symlinks being blocked.
+        return os.path.realpath(os.path.join(cls._test_driver.galaxy_test_tmp_dir, name))
+
 
 class IntegrationTestCase(IntegrationInstance, TestCase):
     """Unit TestCase with utilities for spinning up Galaxy."""

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -200,13 +200,17 @@ class TestWithSeleniumMixin(NavigatesGalaxy, UsesApiTestCaseMixin):
     # GALAXY_TEST_SELENIUM_ADMIN_USER_PASSWORD
     requires_admin = False
 
-    def setup_selenium(self):
+    def _target_url_from_selenium(self):
         # Deal with the case when Galaxy has a different URL when being accessed by Selenium
         # then when being accessed by local API calls.
         if GALAXY_TEST_EXTERNAL_FROM_SELENIUM is not None:
-            self.target_url_from_selenium = GALAXY_TEST_EXTERNAL_FROM_SELENIUM
+            target_url_from_selenium = GALAXY_TEST_EXTERNAL_FROM_SELENIUM
         else:
-            self.target_url_from_selenium = self.url
+            target_url_from_selenium = self.url
+        return target_url_from_selenium
+
+    def setup_selenium(self):
+        self.target_url_from_selenium = self._target_url_from_selenium()
         self.snapshots = []
         self.setup_driver_and_session()
         if self.requires_admin and GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL == DEFAULT_ADMIN_USER:

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -276,7 +276,13 @@ report_file="run_functional_tests.html"
 coverage_arg=""
 xunit_report_file=""
 structured_data_report_file=""
-skip_client_build="--skip-client-build"
+SKIP_CLIENT_BUILD=${GALAXY_SKIP_CLIENT_BUILD:-1}
+if [ "$SKIP_CLIENT_BUILD" = "1" ];
+then
+    skip_client_build="--skip-client-build"
+else
+    skip_client_build=""
+fi
 
 if [ "$1" = "--dockerize" ];
 then

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -67,11 +67,6 @@ class BaseUploadContentConfigurationInstance(integration_util.IntegrationInstanc
         response = self.dataset_populator.fetch(payload, assert_ok=assert_ok)
         return response
 
-    @classmethod
-    def temp_config_dir(cls, name):
-        # realpath here to get around problems with symlinks being blocked.
-        return os.path.realpath(os.path.join(cls._test_driver.galaxy_test_tmp_dir, name))
-
     def _write_file(self, dir_path, content, filename="test"):
         """Helper for writing ftp/server dir files."""
         self._ensure_directory(dir_path)

--- a/test/integration_selenium/framework.py
+++ b/test/integration_selenium/framework.py
@@ -1,0 +1,23 @@
+from galaxy_test.driver import integration_util
+from galaxy_test.selenium import (
+    framework
+)
+
+selenium_test = framework.selenium_test
+
+
+class SeleniumIntegrationTestCase(integration_util.IntegrationTestCase, framework.TestWithSeleniumMixin):
+
+    def setUp(self):
+        super(SeleniumIntegrationTestCase, self).setUp()
+        self.setup_selenium()
+
+    def tearDown(self):
+        self.tear_down_selenium()
+        super(SeleniumIntegrationTestCase, self).tearDown()
+
+
+__all__ = (
+    'selenium_test',
+    'SeleniumIntegrationTestCase',
+)

--- a/test/integration_selenium/test_upload_ftp.py
+++ b/test/integration_selenium/test_upload_ftp.py
@@ -1,0 +1,39 @@
+import os
+
+from .framework import (
+    selenium_test,
+    SeleniumIntegrationTestCase
+)
+
+
+class UploadFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
+    ensure_registered = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        ftp_dir = cls.ftp_dir()
+        os.makedirs(ftp_dir)
+        config["ftp_upload_dir"] = ftp_dir
+        config["ftp_upload_site"] = "ftp://ftp.galaxyproject.com"
+
+    @classmethod
+    def ftp_dir(cls):
+        return cls.temp_config_dir("ftp")
+
+    @selenium_test
+    def test_upload_simplest(self):
+        email = self.get_logged_in_user()["email"]
+        user_ftp_dir = os.path.join(self.ftp_dir(), email)
+        os.makedirs(user_ftp_dir)
+        file_path = os.path.join(user_ftp_dir, "1.txt")
+        with open(file_path, "w")as f:
+            f.write("Hello World!")
+
+        self.home()
+        self.components.upload.start.wait_for_and_click()
+        self.components.upload.ftp_add.wait_for_and_click()
+        self.components.upload.ftp_popup.wait_for_visible()
+        self.components.upload.ftp_items().all()[0].click()
+        self.components.upload.ftp_close.wait_for_and_click()
+        self.components.upload.row(n=0).wait_for_visible()
+        self.upload_start()


### PR DESCRIPTION
During CI, all existing Selenium tests currently run against a single, static Galaxy instance with a fixed configuration (same as framework, API, etc..). The existing integration test framework runs each test in a customized Galaxy instance that is configured for the test - allowing testing of various non-standard options.

This PR introduces a new testing framework that allow Selenium testing of Galaxy instances configured using the integration test infrastructure - allowing browser testing of customized Galaxy instances. A test case testing the upload tool's FTP popover is included to exercise this infrastructure.

This PR includes infrastructure for running these tests using Github Actions. Github Actions are very convenient for integration tests because it is easy to configure custom services via Docker containers. So this PR should enable testing of functionality that requires Docker such as https://github.com/galaxyproject/galaxy/pull/9618 for instance. Our existing Docker tests run this way.

I don't think Jenkins should be replaced for Github Actions in general for Selenium testing since Jenkins publishes screenshots and detailed debug information with multiple useful files for each failure, but this does set us down a path toward being able to do that if we find an alternate way to publish or store that data.