### PR TITLE
Allow submission of tools with unset hidden parameters

### DIFF
--- a/client/src/mvc/tool/tool-form.js
+++ b/client/src/mvc/tool/tool-form.js
@@ -337,7 +337,7 @@ const View = Backbone.View.extend({
                 Galaxy.emit.debug("tool-form::validate()", "Retrieving input objects failed.");
                 continue;
             }
-            if (!input_def.optional && input_value == null) {
+            if (!input_def.optional && input_value == null && input_def.type != "hidden") {
                 this.form.highlight(input_id);
                 return false;
             }

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -32,19 +32,21 @@ def lint_inputs(tool_xml, lint_ctx):
         if param_type == "data":
             if "format" not in param_attrib:
                 lint_ctx.warn("Param input [%s] with no format specified - 'data' format will be assumed.", param_name)
-
-        if param_type == "select":
+        elif param_type == "select":
             dynamic_options = param.get("dynamic_options", None)
             if dynamic_options is None:
                 dynamic_options = param.find("options")
 
             select_options = _find_with_attribute(param, 'option', 'value')
             if any(['value' not in option.attrib for option in select_options]):
-                lint_ctx.error("Option without value")
+                lint_ctx.error("Select [%s] has option without value", param_name)
 
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
+        elif param_type in ["hidden", "hidden_data"]:
+            if "value" not in param_attrib:
+                lint_ctx.error("Hidden param [%s] has no value", param_name)
 
         # TODO: Validate type, much more...
 

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -45,8 +45,8 @@ def lint_inputs(tool_xml, lint_ctx):
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
         elif param_type in ["hidden", "hidden_data"]:
-            if "value" not in param_attrib:
-                lint_ctx.error("Hidden param [%s] has no value", param_name)
+            if "value" not in param_attrib and ('optional' not in option.attrib or option.attrib['optional'] == 'false'):
+                lint_ctx.error("Hidden non-optional param [%s] has no value (make it optional or provide a value)", param_name)
 
         # TODO: Validate type, much more...
 

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -44,10 +44,6 @@ def lint_inputs(tool_xml, lint_ctx):
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
-        elif param_type in ["hidden", "hidden_data"]:
-            if "value" not in param_attrib and ('optional' not in option.attrib or option.attrib['optional'] == 'false'):
-                lint_ctx.error("Hidden non-optional param [%s] has no value (make it optional or provide a value)", param_name)
-
         # TODO: Validate type, much more...
 
     conditional_selects = tool_xml.findall("./inputs//conditional")

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -37,7 +37,7 @@ def lint_inputs(tool_xml, lint_ctx):
             if dynamic_options is None:
                 dynamic_options = param.find("options")
 
-            select_options = _find_with_attribute(param, 'option', 'value')
+            select_options = param.findall('./option')
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error("Select [%s] has option without value", param_name)
 

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -15,14 +15,16 @@ def lint_tsts(tool_xml, lint_ctx):
     num_valid_tests = 0
     for test in tests:
         has_test = False
-        test_expect = {"expect_failure", "expect_exit_code", "expect_num_outputs"}
+        test_expect = ("expect_failure", "expect_exit_code", "expect_num_outputs")
         for te in test_expect:
             if te in test.attrib:
                 has_test = True
-        test_assert = {"assert_stdout", "assert_stderr", "assert_command"}
+                break
+        test_assert = ("assert_stdout", "assert_stderr", "assert_command")
         for ta in test_assert:
             if len(test.findall(ta)) > 0:
                 has_test = True
+                break
 
         output_data_names, output_collection_names = _collect_output_names(tool_xml)
         found_output_test = False

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -15,14 +15,14 @@ def lint_tsts(tool_xml, lint_ctx):
     num_valid_tests = 0
     for test in tests:
         has_test = False
-        if "expect_failure" in test.attrib or "expect_exit_code" in test.attrib:
-            has_test = True
-        if len(test.findall("assert_stdout")) > 0:
-            has_test = True
-        if len(test.findall("assert_stderr")) > 0:
-            has_test = True
-        if len(test.findall("assert_command")) > 0:
-            has_test = True
+        test_expect = {"expect_failure", "expect_exit_code", "expect_num_outputs"}
+        for te in test_expect:
+            if te in test.attrib:
+                has_test = True
+        test_assert = {"assert_stdout", "assert_stderr", "assert_command"}
+        for ta in test_assert:
+            if len(test.findall(ta)) > 0:
+                has_test = True
 
         output_data_names, output_collection_names = _collect_output_names(tool_xml)
         found_output_test = False


### PR DESCRIPTION
A hidden parameter without value leads to a tool that can't be executed.

```
<tool id="test" name="test" version="1.0">
    <description>blah</description>
    <command detect_errors="exit_code">
        echo 1 > $out
    </command>
    <inputs>
        <param name="test" argument="-test" type="hidden"/>
    </inputs>
    <outputs>
        <data name="out" format="txt"/>
    </outputs>
    <tests>
        <test expect_num_outputs="1"/>
    </tests>
</tool>
```

Hard to find this, because even `planemo test` will be successful.

- Reformulated one error mesage where the param name was missing.
  So the error is now easier to find in the tool.
- Allow for a test that has only expect_num_outputs