### PR TITLE
fix error in bundled tool: shrimp_color_wrapper

### DIFF
--- a/tools/metag_tools/shrimp_color_wrapper.xml
+++ b/tools/metag_tools/shrimp_color_wrapper.xml
@@ -29,7 +29,7 @@ python '$__tool_directory__/shrimp_color_wrapper.py' '$input_target' '$input_que
                 <param name="kmer" type="integer" value="-1" label="Kmer Std. Deviation Limit" help="-1 as None"/>
                 <param name="sw_match_value" type="integer" value="100" label="S-W Match Value" />
                 <param name="sw_mismatch_value" type="integer" value="-150" label="S-W Mismatch Value" />
-                <param name="sw_gap_open_ref"type="integer" value="-400" label="S-W Gap Open Penalty (Reference)" />
+                <param name="sw_gap_open_ref" type="integer" value="-400" label="S-W Gap Open Penalty (Reference)" />
                 <param name="sw_gap_open_query" type="integer" value="-400" label="S-W Gap Open Penalty (Query)" />
                 <param name="sw_gap_ext_ref" type="integer" value="-70" label="S-W Gap Extend Penalty (Reference)" />
                 <param name="sw_gap_ext_query" type="integer" value="-70" label="S-W Gap Extend Penalty (Query)" />


### PR DESCRIPTION
Whatever this tool is doing, there was an obvious error.

Got here while debugging another tool: 

- `planemo s --galaxy_root ~/projects/galaxy/ --extra_tools ~/projects/galaxy/lib/galaxy/tools/`
- changed a tool
- got an error during tool reload

Wondering why there isn't a test covering those tools?