### PR TITLE
Plugin build hash bugfix

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -104,7 +104,7 @@ function buildPlugins(callback) {
                     );
                     console.log(`Building ${plugin_name}`);
                     child_process.spawnSync("yarn", ["build"], { cwd: f, stdio: "inherit", shell: true });
-                    child_process.exec(`"(git rev-parse HEAD 2>/dev/null || echo \`\`) > ${hash_file_path} "`);
+                    child_process.exec(`(git rev-parse HEAD 2>/dev/null || echo \`\`) > ${hash_file_path}`);
                 }
             });
         });


### PR DESCRIPTION
This fixes shell interpretation of the hash saving command.

(without this, there's a silent "no command found" because it was trying to run a quoted string as a shell command)