### PR TITLE
Optimize history_content union and filtering query

### DIFF
--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -294,12 +294,11 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
             if orm_filter.filter_type == "orm_function":
                 contained_query = contained_query.filter(orm_filter.filter(self.contained_class))
                 subcontainer_query = subcontainer_query.filter(orm_filter.filter(self.subcontainer_class))
-        contents_query = contained_query.union(subcontainer_query)
+            elif orm_filter.filter_type == "orm":
+                contained_query = self._apply_orm_filter(contained_query, orm_filter.filter)
+                subcontainer_query = self._apply_orm_filter(subcontainer_query, orm_filter.filter)
 
-        for orm_filter in filters:
-            if orm_filter.filter_type == "orm":
-                contents_query = contents_query.filter(orm_filter.filter)
-
+        contents_query = contained_query.union_all(subcontainer_query)
         contents_query = contents_query.order_by(*order_by)
 
         if limit is not None:
@@ -307,6 +306,15 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
         if offset is not None:
             contents_query = contents_query.offset(offset)
         return contents_query
+
+    def _apply_orm_filter(self, qry, orm_filter):
+        if isinstance(orm_filter, sql.elements.BinaryExpression):
+            for match in filter(lambda col: col['name'] == orm_filter.left.name, qry.column_descriptions):
+                column = match['expr']
+                new_filter = orm_filter._clone()
+                new_filter.left = column
+                qry = qry.filter(new_filter)
+        return qry
 
     def _contents_common_columns(self, component_class, **kwargs):
         columns = []

--- a/test/unit/managers/test_HistoryContentsManager.py
+++ b/test/unit/managers/test_HistoryContentsManager.py
@@ -6,7 +6,6 @@ import random
 import unittest
 
 from sqlalchemy import column, desc, false, true
-from sqlalchemy.sql import text
 
 from galaxy.managers import base, collections, hdas, history_contents
 from galaxy.managers.histories import HistoryManager
@@ -29,6 +28,7 @@ class HistoryAsContainerBaseTestCase(BaseTestCase, CreatesCollectionsMixin):
         self.hda_manager = hdas.HDAManager(self.app)
         self.collection_manager = collections.DatasetCollectionManager(self.app)
         self.contents_manager = history_contents.HistoryContentsManager(self.app)
+        self.history_contents_filters = history_contents.HistoryContentsFilters(self.app)
 
     def add_hda_to_history(self, history, **kwargs):
         dataset = self.hda_manager.dataset_manager.create()
@@ -120,6 +120,7 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.assertEqual(self.contents_manager.contents(history, offset=len(contents)), [])
 
     def test_orm_filtering(self):
+        parse_filter = self.history_contents_filters.parse_filter
         user2 = self.user_manager.create(**user2_data)
         history = self.history_manager.create(name='history', user=user2)
         contents = []
@@ -136,7 +137,7 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.app.model.context.flush()
 
         # TODO: cross db compat?
-        filters = [parsed_filter(filter_type="orm", filter=text('deleted = 1'))]
+        filters = [parse_filter('deleted', 'eq', 'True')]
         self.assertEqual(self.contents_manager.contents(history, filters=filters), deleted)
 
         # even stranger that sqlalx can use the first model in the union (HDA) for columns across the union
@@ -154,7 +155,7 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         invisible = [contents[2], contents[5], contents[6]]
         self.app.model.context.flush()
 
-        filters = [parsed_filter("orm", text('visible = 0'))]
+        filters = [parse_filter('visible', 'eq', 'False')]
         self.assertEqual(self.contents_manager.contents(history, filters=filters), invisible)
         self.assertEqual(self.contents_manager.contents(history,
             filters=[parsed_filter("orm", HDA.visible == false())]), invisible)
@@ -164,8 +165,10 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
 
         self.log("should allow filtering more than one attribute")
         deleted_and_invisible = [contents[6]]
-
-        filters = [parsed_filter("orm", text('deleted = 1')), parsed_filter("orm", text('visible = 0'))]
+        filters = [
+            parse_filter('deleted', 'eq', 'True'),
+            parse_filter('visible', 'eq', 'False')
+        ]
         self.assertEqual(self.contents_manager.contents(history, filters=filters), deleted_and_invisible)
         self.assertEqual(self.contents_manager.contents(history,
             filters=[parsed_filter("orm", HDA.deleted == true()), parsed_filter("orm", HDA.visible == false())]), deleted_and_invisible)
@@ -176,8 +179,12 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.log("should allow filtering more than one attribute")
         deleted_and_invisible = [contents[6]]
         # note the two syntaxes both work
+        filters = [
+            parse_filter('deleted', 'eq', 'True'),
+            parse_filter('visible', 'eq', 'False')
+        ]
         self.assertEqual(self.contents_manager.contents(history,
-            filters=[parsed_filter("orm", text('deleted = 1')), parsed_filter("orm", text('visible = 0'))]), deleted_and_invisible)
+            filters=filters), deleted_and_invisible)
         self.assertEqual(self.contents_manager.contents(history,
             filters=[parsed_filter("orm", HDA.deleted == true()), parsed_filter("orm", HDA.visible == false())]), deleted_and_invisible)
         offset_too_far = self.contents_manager.contents(history,
@@ -250,6 +257,7 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         self.assertEqual(results, [contents[3]])
 
     def test_filtered_counting(self):
+        parse_filter = self.history_contents_filters.parse_filter
         user2 = self.user_manager.create(**user2_data)
         history = self.history_manager.create(name='history', user=user2)
         contents = []
@@ -271,10 +279,13 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
 
         HDA = self.hda_manager.model_class
         self.assertEqual(self.contents_manager.contents_count(history, filters=[parsed_filter("orm", HDA.deleted == true())]), 3)
-        filters = [parsed_filter("orm", text('visible = 0'))]
+        filters = [parse_filter('visible', 'eq', 'False')]
         self.assertEqual(self.contents_manager.contents_count(history, filters=filters), 3)
 
-        filters = [parsed_filter("orm", text('deleted = 1')), parsed_filter("orm", text('visible = 0'))]
+        filters = [
+            parse_filter('deleted', 'eq', 'True'),
+            parse_filter('visible', 'eq', 'False')
+        ]
         self.assertEqual(self.contents_manager.contents_count(history, filters=filters), 1)
 
     def test_type_id(self):


### PR DESCRIPTION
This is a subset of #9591. It was requested that this chunk be separated from the other changes in that PR to ease testing complexity. Additionally, these optimizations do not add any new functionality and should be able to work on the existing code as-is.


### Optimize the primary history contents join

Attempting to create a more efficient history contents query. The api/history/#/contents endpoint is one that the client needs to hit frequently for updates and I found that the primary mechanism that unions history datasets and history collections into one query was running inefficiently.

I think the basic strategy of the original code is reasonable, but it looks like nobody was paying attention to the SQL that was emitted by sqlalchemy.

Essentially what i did was to turn the primary history contents join from this:

```sql
select manycontentfields
from (
   select hda_fields 
   from history_dataset_association 
   where history_id = xyz
   union
   select hdca_fields 
   from history_dataset_collection_association 
   where history_id = xyz
)
where name = 'foo'
and deleted = false
and purged = false
and update_time > 5minsago
order by hid desc
limit 100 offset 0
```

Into this:

```sql
select manycontentfields
from (
   select hda_fields 
   from history_dataset_association 
   where history_id = xyz
   and name = 'foo'
   and deleted = false
   and purged = false
   and update_time > 5minsago

   union all

   select hdca_fields 
   from history_dataset_collection_association 
   where history_id = xyz
   and name = 'foo'
   and deleted = false
   and purged = false
   and update_time > 5minsago
)
order by hid desc
limit 100 offset 0
```

It's not a big change, but the current code materializes (loads in entirety) 2 whole tables, stacks them on top of each other, and sorts through them looking for duplicates that will never exist. I would imagine this gets pretty ugly for big histories. The new union will only result in a few rows.

Changing "union" to "union all" gives a performance bump too because "union" also sorts through all those table results looking for duplicates that will not exist. Union all just stacks the results