### PR TITLE
[20.01] Backport auth process lock fix

### DIFF
--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -89,9 +89,7 @@ def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=KEY_LENGTH, hashfunc=H
             h = mac.copy()
             h.update(x)
             digest = h.digest()
-            if six.PY2:
-                return digest, [ord(_) for _ in digest]
-            return digest, digest
+            return digest, [ord(_) for _ in digest]
 
         buf = []
         salt = smart_str(salt)

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -6,8 +6,6 @@ from operator import xor
 from os import urandom
 from struct import Struct
 
-import six
-
 from galaxy.util import (
     safe_str_cmp,
     smart_str,

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -17,7 +17,7 @@ from galaxy.util import (
 SALT_LENGTH = 12
 KEY_LENGTH = 24
 HASH_FUNCTION = 'sha256'
-COST_FACTOR = 10000
+COST_FACTOR = 100000
 
 
 def hash_password(password):
@@ -67,13 +67,12 @@ def check_password_PBKDF2(guess, hashed):
 _pack_int = Struct('>I').pack
 
 
-def pbkdf2_bin(data, salt, iterations=1000, keylen=KEY_LENGTH, hashfunc=HASH_FUNCTION):
+def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=KEY_LENGTH, hashfunc=HASH_FUNCTION):
     """Returns a binary digest for the PBKDF2 hash algorithm of `data`
     with the given `salt`.  It iterates `iterations` time and produces a
     key of `keylen` bytes.  By default SHA-256 is used as hash function,
     a different hashlib `hashfunc` can be provided.
     """
-
     if hasattr(hashlib, 'pbkdf2_hmac'):
         # Use hashlib.pbkdf2_hmac, new in python 2.7.8
         data = smart_str(data)

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -80,9 +80,7 @@ def pbkdf2_bin(data, salt, iterations=COST_FACTOR, keylen=KEY_LENGTH, hashfunc=H
         return hashlib.pbkdf2_hmac(hashfunc, data, salt, iterations, keylen)
     else:
         # Use the old implementation of hashing as a fallback
-        if isinstance(hashfunc, six.string_types):
-            hashfunc = getattr(hashlib, hashfunc, None)
-        hashfunc = hashfunc or hashlib.sha1
+        hashfunc = getattr(hashlib, hashfunc, None)
         mac = hmac.new(smart_str(data), None, hashfunc)
 
         def _pseudorandom(x, mac=mac):

--- a/lib/galaxy/security/passwords.py
+++ b/lib/galaxy/security/passwords.py
@@ -47,7 +47,7 @@ def hash_password_PBKDF2(password):
     # Generate a random salt
     salt = b64encode(urandom(SALT_LENGTH))
     # Apply the pbkdf2 encoding
-    hashed_password = pbkdf2_bin(password, salt, COST_FACTOR, KEY_LENGTH, getattr(hashlib, HASH_FUNCTION))
+    hashed_password = pbkdf2_bin(password, salt, COST_FACTOR, KEY_LENGTH, HASH_FUNCTION)
     encoded_password = unicodify(b64encode(hashed_password))
     # Format
     return 'PBKDF2${0}${1}${2}${3}'.format(HASH_FUNCTION, COST_FACTOR, unicodify(salt), encoded_password)
@@ -57,7 +57,7 @@ def check_password_PBKDF2(guess, hashed):
     # Split the database representation to extract cost_factor and salt
     name, hash_function, cost_factor, salt, encoded_original = hashed.split('$', 5)
     # Hash the guess using the same parameters
-    hashed_guess = pbkdf2_bin(guess, salt, int(cost_factor), KEY_LENGTH, getattr(hashlib, hash_function))
+    hashed_guess = pbkdf2_bin(guess, salt, int(cost_factor), KEY_LENGTH, hash_function)
     encoded_guess = unicodify(b64encode(hashed_guess))
     return safe_str_cmp(encoded_original, encoded_guess)
 
@@ -67,29 +67,39 @@ def check_password_PBKDF2(guess, hashed):
 _pack_int = Struct('>I').pack
 
 
-def pbkdf2_bin(data, salt, iterations=1000, keylen=24, hashfunc=None):
+def pbkdf2_bin(data, salt, iterations=1000, keylen=KEY_LENGTH, hashfunc=HASH_FUNCTION):
     """Returns a binary digest for the PBKDF2 hash algorithm of `data`
     with the given `salt`.  It iterates `iterations` time and produces a
-    key of `keylen` bytes.  By default SHA-1 is used as hash function,
+    key of `keylen` bytes.  By default SHA-256 is used as hash function,
     a different hashlib `hashfunc` can be provided.
     """
-    hashfunc = hashfunc or hashlib.sha1
-    mac = hmac.new(smart_str(data), None, hashfunc)
 
-    def _pseudorandom(x, mac=mac):
-        h = mac.copy()
-        h.update(x)
-        digest = h.digest()
-        if six.PY2:
-            return digest, [ord(_) for _ in digest]
-        return digest, digest
+    if hasattr(hashlib, 'pbkdf2_hmac'):
+        # Use hashlib.pbkdf2_hmac, new in python 2.7.8
+        data = smart_str(data)
+        salt = smart_str(salt)
+        return hashlib.pbkdf2_hmac(hashfunc, data, salt, iterations, keylen)
+    else:
+        # Use the old implementation of hashing as a fallback
+        if isinstance(hashfunc, six.string_types):
+            hashfunc = getattr(hashlib, hashfunc, None)
+        hashfunc = hashfunc or hashlib.sha1
+        mac = hmac.new(smart_str(data), None, hashfunc)
 
-    buf = []
-    salt = smart_str(salt)
-    for block in range(1, -(-keylen // mac.digest_size) + 1):
-        digest, rv = _pseudorandom(salt + _pack_int(block))
-        for _ in range(iterations - 1):
-            digest, u = _pseudorandom(digest)
-            rv = starmap(xor, zip(rv, u))
-        buf.extend(rv)
-    return bytes(bytearray(buf))[:keylen]
+        def _pseudorandom(x, mac=mac):
+            h = mac.copy()
+            h.update(x)
+            digest = h.digest()
+            if six.PY2:
+                return digest, [ord(_) for _ in digest]
+            return digest, digest
+
+        buf = []
+        salt = smart_str(salt)
+        for block in range(1, -(-keylen // mac.digest_size) + 1):
+            digest, rv = _pseudorandom(salt + _pack_int(block))
+            for _ in range(iterations - 1):
+                digest, u = _pseudorandom(digest)
+                rv = starmap(xor, zip(rv, u))
+            buf.extend(rv)
+        return bytes(bytearray(buf))[:keylen]


### PR DESCRIPTION
flattened backport of, and with additions to (for compatibility), #9642 

I managed to see this in 3.6.10, which prompted me to want to finish this backport if it's going to affect more python versions than 3.7+

When we merge this forward we can drop the compatibility logic if we really want to cut off older pythons, but an informal survey of admins did find a few at 2.7.5, which wouldn't work without the failthrough.