### PR TITLE
[20.01] Fix outputs written to storage despite outputs_to_working_directory

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -317,6 +317,7 @@ class ToolEvaluator(object):
             wrapper_kwds = dict(
                 datatypes_registry=self.app.datatypes_registry,
                 compute_environment=self.compute_environment,
+                io_type='output',
                 tool=tool,
                 name=name
             )


### PR DESCRIPTION
We need to start running some of the integration test cases in docker, and we need to activate `outputs_to_working_directory` when using `planemo --biocontainers`, that would have probably caught it, as you can't write straight to storage due to mounting storage in read-only (and that's how I found it).