### PR TITLE
xsd, docs, and test for sort_by (discover_datasets)

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -605,12 +605,13 @@ def __parse_output_collection_elem(output_collection_elem):
 
 def __parse_element_tests(parent_element):
     element_tests = {}
-    for element in parent_element.findall("element"):
+    for idx, element in enumerate(parent_element.findall("element")):
         element_attrib = dict(element.attrib)
         identifier = element_attrib.pop('name', None)
         if identifier is None:
             raise Exception("Test primary dataset does not have a 'identifier'")
         element_tests[identifier] = __parse_test_attributes(element, element_attrib, parse_elements=True)
+        element_tests[identifier][1]["element_index"] = idx
     return element_tests
 
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -708,12 +708,6 @@ def verify_hid(filename, hda_id, attributes, test_data_downloader, hid="", datas
 def verify_collection(output_collection_def, data_collection, verify_dataset):
     name = output_collection_def.name
 
-    def get_element(elements, id):
-        for element in elements:
-            if element["element_identifier"] == id:
-                return element
-        return False
-
     expected_collection_type = output_collection_def.collection_type
     if expected_collection_type:
         collection_type = data_collection["collection_type"]
@@ -731,15 +725,23 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
             raise AssertionError(message)
 
     def verify_elements(element_objects, element_tests):
+        i = 0
         for element_identifier, element_test in element_tests.items():
             if isinstance(element_test, dict):
                 element_outfile, element_attrib = None, element_test
             else:
                 element_outfile, element_attrib = element_test
 
-            element = get_element(element_objects, element_identifier)
-            if not element:
-                template = "Failed to find identifier [%s] for testing, tool generated collection elements [%s]"
+            element = None
+            while i < len(element_objects):
+                if element_objects[i]["element_identifier"] == element_identifier:
+                    element = element_objects[i]
+                    i += 1
+                    break
+                i += 1
+
+            if element is None:
+                template = "Failed to find identifier [%s] for testing or elements in wrong order, tool generated collection elements [%s]"
                 message = template % (element_identifier, element_objects)
                 raise AssertionError(message)
 

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -725,8 +725,17 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
             raise AssertionError(message)
 
     def verify_elements(element_objects, element_tests):
-        i = 0
+        sorted_test_ids = [None] * len(element_tests)
         for element_identifier, element_test in element_tests.items():
+            if isinstance(element_test, dict):
+                element_outfile, element_attrib = None, element_test
+            else:
+                element_outfile, element_attrib = element_test
+            sorted_test_ids[element_attrib["element_index"]] = element_identifier
+
+        i = 0
+        for element_identifier in sorted_test_ids:
+            element_test = element_tests[element_identifier]
             if isinstance(element_test, dict):
                 element_outfile, element_attrib = None, element_test
             else:
@@ -741,8 +750,10 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
                 i += 1
 
             if element is None:
-                template = "Failed to find identifier [%s] for testing or elements in wrong order, tool generated collection elements [%s]"
-                message = template % (element_identifier, element_objects)
+                template = "Failed to find identifier '%s' of test collection %s in the tool generated collection elements %s (at the correct position)"
+                eo_ids = [_["element_identifier"] for _ in element_objects]
+                message = template % (element_identifier, sorted_test_ids,
+                                      eo_ids)
                 raise AssertionError(message)
 
             element_type = element["element_type"]

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4219,6 +4219,11 @@ More information can be found on Planemo's documentation for
         <xs:documentation xml:lang="en">Format (or datatype) of discovered datasets (an alias with ``format``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="sort_by" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">A string `[reverse_][SORT_COMP_]SORTBY` describing the desired sort order of the collection elements. `SORTBY` can be `filename`, `name`, `designation`, `dbkey` and the optional `SORT_COMP` can be either `lexical` or `numeric`. Default is lexical sorting by filename.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="visible" type="xs:boolean" use="optional">
       <xs:annotation>
         <xs:documentation xml:lang="en">Indication if this dataset is visible in output history. This defaults to ``false``, but probably shouldn't - be sure to set to ``true`` if that is your intention.</xs:documentation>
@@ -4274,7 +4279,7 @@ Galaxy, including:
     </xs:attribute>
     <xs:attribute name="sort_by" type="xs:string" use="optional">
       <xs:annotation>
-        <xs:documentation xml:lang="en">A string `[reverse_]SORTBY[_SORT_COMP]` describing the desired sort order of the collection elements. `SORTBY` can be `filename`, `name`, `designation`, `dbkey` and the optional `SORT_COMP` can be either `lexical` or `numeric`. Default is lexical sorting by filename.</xs:documentation>
+        <xs:documentation xml:lang="en">A string `[reverse_][SORT_COMP_]SORTBY` describing the desired sort order of the collection elements. `SORTBY` can be `filename`, `name`, `designation`, `dbkey` and the optional `SORT_COMP` can be either `lexical` or `numeric`. Default is lexical sorting by filename.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="visible" type="xs:boolean" use="optional">

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -325,7 +325,7 @@ def format_return_as_json(rval, jsonp_callback=None, pretty=False):
 
     Use `pretty=True` to return pretty printed json.
     """
-    dumps_kwargs = dict(indent=4) if pretty else {}
+    dumps_kwargs = dict(indent=4, sort_keys=True) if pretty else {}
     json = safe_dumps(rval, **dumps_kwargs)
     if jsonp_callback:
         json = "{}({});".format(jsonp_callback, json)

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -325,7 +325,7 @@ def format_return_as_json(rval, jsonp_callback=None, pretty=False):
 
     Use `pretty=True` to return pretty printed json.
     """
-    dumps_kwargs = dict(indent=4, sort_keys=True) if pretty else {}
+    dumps_kwargs = dict(indent=4) if pretty else {}
     json = safe_dumps(rval, **dumps_kwargs)
     if jsonp_callback:
         json = "{}({});".format(jsonp_callback, json)

--- a/test/functional/tools/discover_sort_by.xml
+++ b/test/functional/tools/discover_sort_by.xml
@@ -1,9 +1,10 @@
 <tool id="discover_sort_by" name="discover_sort_by" version="0.1.0">
     <command><![CDATA[
-    echo "1" > 1.txt &&
-    echo "2" > 2.txt &&
-    echo "10" > 10.txt
-  ]]></command>
+for i in \$(seq 1 10);
+do
+    echo "\$i" > \$i.txt;
+done
+]]></command>
   <inputs/>
   <outputs>
     <collection name="collection_numeric_name" type="list" label="num">
@@ -22,7 +23,7 @@
   <tests>
     <test expect_num_outputs="4">
       <param name="input1" value="tinywga.fam" />
-      <output_collection name="collection_numeric_name" type="list" count="3">
+      <output_collection name="collection_numeric_name" type="list" count="10">
         <element name="1">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
@@ -33,7 +34,7 @@
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
       </output_collection>
-      <output_collection name="collection_rev_numeric_name" type="list" count="3">
+      <output_collection name="collection_rev_numeric_name" type="list" count="10">
         <element name="10">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
@@ -44,7 +45,7 @@
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>
       </output_collection>
-      <output_collection name="collection_lexical_name" type="list" count="3">
+      <output_collection name="collection_lexical_name" type="list" count="10">
         <element name="1">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
         </element>

--- a/test/functional/tools/discover_sort_by.xml
+++ b/test/functional/tools/discover_sort_by.xml
@@ -20,14 +20,6 @@
     </data>
   </outputs>
   <tests>
-    <!-- note: this test is only checking for bugs in the sorting functions
-         but not for the actual sorting, since the.
-         even if the test lists the discovered datasets in the correct order
-         the order is currently not tested
-         - test is only if the elements listed in the test
-           are in the list of generated elements
-         - furthermore the order of the elements listed in the test
-           is not preserved in the test functions -->
     <test expect_num_outputs="4">
       <param name="input1" value="tinywga.fam" />
       <output_collection name="collection_numeric_name" type="list" count="3">

--- a/test/functional/tools/discover_sort_by.xml
+++ b/test/functional/tools/discover_sort_by.xml
@@ -1,0 +1,77 @@
+<tool id="discover_sort_by" name="discover_sort_by" version="0.1.0">
+    <command><![CDATA[
+    echo "1" > 1.txt &&
+    echo "2" > 2.txt &&
+    echo "10" > 10.txt
+  ]]></command>
+  <inputs/>
+  <outputs>
+    <collection name="collection_numeric_name" type="list" label="num">
+      <discover_datasets pattern="__name_and_ext__" sort_by="numeric_name"/>
+    </collection>
+    <collection name="collection_rev_numeric_name" type="list" label="num rev">
+      <discover_datasets pattern="__name_and_ext__" sort_by="reverse_numeric_name"/>
+    </collection>
+    <collection name="collection_lexical_name" type="list" label="num">
+      <discover_datasets pattern="__name_and_ext__" sort_by="lexical_name" />
+    </collection>
+    <data name="data_reverse_lexical_name">
+      <discover_datasets pattern="__name_and_ext__" format="txt" assign_primary_output="true" sort_by="reverse_lexical_name" visible="true"/>
+    </data>
+  </outputs>
+  <tests>
+    <!-- note: this test is only checking for bugs in the sorting functions
+         but not for the actual sorting, since the.
+         even if the test lists the discovered datasets in the correct order
+         the order is currently not tested
+         - test is only if the elements listed in the test
+           are in the list of generated elements
+         - furthermore the order of the elements listed in the test
+           is not preserved in the test functions -->
+    <test expect_num_outputs="4">
+      <param name="input1" value="tinywga.fam" />
+      <output_collection name="collection_numeric_name" type="list" count="3">
+        <element name="1">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+        <element name="2">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+        <element name="10">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+      </output_collection>
+      <output_collection name="collection_rev_numeric_name" type="list" count="3">
+        <element name="10">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+        <element name="2">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+        <element name="1">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+      </output_collection>
+      <output_collection name="collection_lexical_name" type="list" count="3">
+        <element name="1">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+        <element name="10">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+        <element name="2">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </element>
+      </output_collection>
+      <output name="data_reverse_lexical_name">
+        <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        <discovered_dataset designation="10">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </discovered_dataset>
+        <discovered_dataset designation="1">
+          <assert_contents><has_text_matching expression="^.*$"/></assert_contents>
+        </discovered_dataset>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -164,6 +164,7 @@
   <tool file="collection_creates_dynamic_nested_fail.xml" />
   <tool file="collection_cat_group_tag.xml" />
   <tool file="collection_cat_group_tag_multiple.xml" />
+  <tool file="discover_sort_by.xml" />
   <tool file="expression_forty_two.xml" />
   <tool file="expression_parse_int.xml" />
   <tool file="expression_log_line_count.xml" />


### PR DESCRIPTION
Since `planemo lint` failed so far for this attribute we can be quite sure that this was never used (in a tool)

- order of sort_comp and sort_by was wrong for sort_by in collections
- sort_by was missing for data output
- adds a test (though we can't check the generated order .. I manually tested with `planemo serve`)

follow up on https://github.com/galaxyproject/galaxy/pull/9674