### PR TITLE
[20.01] Don't treat ConnectedValues as runtime input

### DIFF
--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -136,7 +136,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
             replace = new_value != no_replacement_value
         if replace:
             input_values[input.name] = new_value
-        elif replace_optional_connections and is_runtime_value(value):
+        elif replace_optional_connections and is_runtime_value(value) and hasattr(input, 'value'):
             input_values[input.name] = input.value
 
     def get_current_case(input, input_values):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -540,7 +540,7 @@ class SubWorkflowModule(WorkflowModule):
                     if input.type in ['data', 'data_collection']:
                         return
 
-                    if is_runtime_value(value):
+                    if is_runtime_value(value) and runtime_to_json(value)["__class__"] != "ConnectedValue":
                         input_name = "%d|%s" % (step.order_index, prefixed_name)
                         inputs[input_name] = InputProxy(input, input_name)
 


### PR DESCRIPTION
This is needed for connected workflow parameters in subworkflows.
Otherwise these values need to be filled in in the workflow run form (which isn't correct and also doesn't work).