### PR TITLE
Workflow reports: multiple argument & add single job parameter

### DIFF
--- a/client/galaxy/scripts/components/JobParameters/JobParameters.test.js
+++ b/client/galaxy/scripts/components/JobParameters/JobParameters.test.js
@@ -1,0 +1,89 @@
+import Vuex from "vuex";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { mount, createLocalVue } from "@vue/test-utils";
+import flushPromises from "flush-promises";
+import JobParameters from "./JobParameters";
+import paramResponse from "./parameters-response.json";
+
+const JOB_ID = "foo";
+
+describe("JobMetrics/JobMetrics.vue", () => {
+    const localVue = createLocalVue();
+    localVue.use(Vuex);
+
+    let wrapper, emitted, axiosMock;
+
+    const linkParam = paramResponse.parameters.find(element =>  Array.isArray(element.value))
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet(`/api/jobs/${JOB_ID}/parameters_display`).reply(200, paramResponse);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    it("should not render a div if no plugins found in store", async () => {
+        const propsData = {
+            jobId: JOB_ID,
+        };
+        const wrapper = mount(JobParameters, {
+            propsData,
+            localVue,
+        });
+        await flushPromises();
+
+        const checkTableParameter = (element, expectedTitle, expectedValue, link) => {
+            const tds = element.findAll("td")
+            expect(tds.length).to.equals(2);
+            expect(tds.at(0).text()).to.equals(expectedTitle);
+            expect(tds.at(1).text()).to.equals(expectedValue);
+            if (link) {
+                const a_element = tds.at(1).find("a")
+                expect(a_element.attributes('href')).to.equals(link);
+            }
+        }
+        // parameter table
+        const tbody = wrapper.find("#tool-parameters > tbody")
+        expect(tbody.exists()).to.equals(true);
+
+        // table elements
+        const elements = tbody.findAll("tr");
+        expect(elements.length).to.equals(3);
+
+        checkTableParameter(elements.at(0), "Add this value", "22")
+        checkTableParameter(elements.at(1), linkParam.text, `${linkParam.value[0].hid}: ${linkParam.value[0].name}`, `/datasets/${linkParam.value[0].id}/show_params`)
+        checkTableParameter(elements.at(2), "Iterate?", "NO")
+    });
+
+    it("should show only single parameter", async () => {
+        const propsData = {
+            jobId: JOB_ID,
+            param: "Iterate?"
+        };
+
+        const getSingleParam = async (propsData) => {
+            const wrapper = mount(JobParameters, {
+                propsData,
+                localVue,
+            });
+            await flushPromises();
+            return wrapper.find("#single-param")
+        }
+
+        const singleParam = await getSingleParam(propsData)
+
+        expect(singleParam.text()).to.equals("NO");
+
+        const propsDataLink = {
+            jobId: JOB_ID,
+            param: linkParam.text
+        };
+
+        const singleParamLink = await getSingleParam(propsDataLink)
+        const link = singleParamLink.find("a").attributes('href')
+        expect(link).to.equals(`/datasets/${linkParam.value[0].id}/show_params`);
+    });
+});

--- a/client/galaxy/scripts/components/JobParameters/JobParameters.test.js
+++ b/client/galaxy/scripts/components/JobParameters/JobParameters.test.js
@@ -14,7 +14,7 @@ describe("JobMetrics/JobMetrics.vue", () => {
 
     let wrapper, emitted, axiosMock;
 
-    const linkParam = paramResponse.parameters.find(element =>  Array.isArray(element.value))
+    const linkParam = paramResponse.parameters.find((element) => Array.isArray(element.value));
 
     beforeEach(() => {
         axiosMock = new MockAdapter(axios);
@@ -36,32 +36,37 @@ describe("JobMetrics/JobMetrics.vue", () => {
         await flushPromises();
 
         const checkTableParameter = (element, expectedTitle, expectedValue, link) => {
-            const tds = element.findAll("td")
+            const tds = element.findAll("td");
             expect(tds.length).to.equals(2);
             expect(tds.at(0).text()).to.equals(expectedTitle);
             expect(tds.at(1).text()).to.equals(expectedValue);
             if (link) {
-                const a_element = tds.at(1).find("a")
-                expect(a_element.attributes('href')).to.equals(link);
+                const a_element = tds.at(1).find("a");
+                expect(a_element.attributes("href")).to.equals(link);
             }
-        }
+        };
         // parameter table
-        const tbody = wrapper.find("#tool-parameters > tbody")
+        const tbody = wrapper.find("#tool-parameters > tbody");
         expect(tbody.exists()).to.equals(true);
 
         // table elements
         const elements = tbody.findAll("tr");
         expect(elements.length).to.equals(3);
 
-        checkTableParameter(elements.at(0), "Add this value", "22")
-        checkTableParameter(elements.at(1), linkParam.text, `${linkParam.value[0].hid}: ${linkParam.value[0].name}`, `/datasets/${linkParam.value[0].id}/show_params`)
-        checkTableParameter(elements.at(2), "Iterate?", "NO")
+        checkTableParameter(elements.at(0), "Add this value", "22");
+        checkTableParameter(
+            elements.at(1),
+            linkParam.text,
+            `${linkParam.value[0].hid}: ${linkParam.value[0].name}`,
+            `/datasets/${linkParam.value[0].id}/show_params`
+        );
+        checkTableParameter(elements.at(2), "Iterate?", "NO");
     });
 
     it("should show only single parameter", async () => {
         const propsData = {
             jobId: JOB_ID,
-            param: "Iterate?"
+            param: "Iterate?",
         };
 
         const getSingleParam = async (propsData) => {
@@ -70,20 +75,20 @@ describe("JobMetrics/JobMetrics.vue", () => {
                 localVue,
             });
             await flushPromises();
-            return wrapper.find("#single-param")
-        }
+            return wrapper.find("#single-param");
+        };
 
-        const singleParam = await getSingleParam(propsData)
+        const singleParam = await getSingleParam(propsData);
 
         expect(singleParam.text()).to.equals("NO");
 
         const propsDataLink = {
             jobId: JOB_ID,
-            param: linkParam.text
+            param: linkParam.text,
         };
 
-        const singleParamLink = await getSingleParam(propsDataLink)
-        const link = singleParamLink.find("a").attributes('href')
+        const singleParamLink = await getSingleParam(propsDataLink);
+        const link = singleParamLink.find("a").attributes("href");
         expect(link).to.equals(`/datasets/${linkParam.value[0].id}/show_params`);
     });
 });

--- a/client/galaxy/scripts/components/JobParameters/JobParameters.vue
+++ b/client/galaxy/scripts/components/JobParameters/JobParameters.vue
@@ -1,43 +1,48 @@
 <template>
-    <div class="tool-parameters">
-        <h3 v-if="includeTitle">Tool Parameters</h3>
-        <table class="tabletip" id="tool-parameters">
-            <thead>
-                <tr>
-                    <th>Input Parameter</th>
-                    <th>Value</th>
-                    <th v-if="anyNotes">Note for rerun</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr v-for="(parameter, pIndex) in parameters" :key="pIndex">
-                    <td :style="{ 'padding-left': `${(parameter.depth - 1) * 10}px` }">
-                        {{ parameter.text }}
-                    </td>
-                    <td v-if="Array.isArray(parameter.value)">
-                        <ul style="padding-inline-start: 25px;">
-                            <li v-for="(elVal, pvIndex) in parameter.value" :key="pvIndex">
-                                <span v-if="elVal.src == 'hda'">
-                                    <a :href="appRoot() + 'datasets/' + elVal.id + '/show_params'">
-                                        {{ elVal.hid }}: {{ elVal.name }}
-                                    </a>
-                                </span>
-                                <span v-else> {{ elVal.hid }}: {{ elVal.name }} </span>
-                            </li>
-                        </ul>
-                    </td>
-                    <td v-else>
-                        {{ parameter.value }}
-                    </td>
-                    <td v-if="anyNotes">
-                        <em v-if="parameter.notes">{{ parameter.notes }}</em>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-        <b-alert :show="hasParameterErrors" variant="danger">
-            One or more of your original parameters may no longer be valid or displayed properly.
-        </b-alert>
+    <div>
+        <div v-if="!isSingleParam" class="tool-parameters">
+            <h3 v-if="includeTitle">Tool Parameters</h3>
+            <table class="tabletip" id="tool-parameters">
+                <thead>
+                    <tr>
+                        <th>Input Parameter</th>
+                        <th>Value</th>
+                        <th v-if="anyNotes">Note for rerun</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr v-for="(parameter, pIndex) in parameters" :key="pIndex">
+                        <td :style="{ 'padding-left': `${(parameter.depth - 1) * 10}px` }">
+                            {{ parameter.text }}
+                        </td>
+                        <td v-if="Array.isArray(parameter.value)">
+                            <ul style="padding-inline-start: 25px;">
+                                <li v-for="(elVal, pvIndex) in parameter.value" :key="pvIndex">
+                                    <span v-if="elVal.src == 'hda'">
+                                        <a :href="appRoot() + 'datasets/' + elVal.id + '/show_params'">
+                                            {{ elVal.hid }}: {{ elVal.name }}
+                                        </a>
+                                    </span>
+                                    <span v-else> {{ elVal.hid }}: {{ elVal.name }} </span>
+                                </li>
+                            </ul>
+                        </td>
+                        <td v-else>
+                            {{ parameter.value }}
+                        </td>
+                        <td v-if="anyNotes">
+                            <em v-if="parameter.notes">{{ parameter.notes }}</em>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+            <b-alert :show="hasParameterErrors" variant="danger">
+                One or more of your original parameters may no longer be valid or displayed properly.
+            </b-alert>
+        </div>
+        <div v-if="isSingleParam">
+            {{ singleParam }}
+        </div>
     </div>
 </template>
 
@@ -62,6 +67,9 @@ export default {
             type: String,
             default: "hda",
         },
+        param: {
+            type: String,
+        },
         includeTitle: {
             type: Boolean,
             default: true,
@@ -71,6 +79,7 @@ export default {
         return {
             parameters: [],
             hasParameterErrors: false,
+            isSingleParam: false,
         };
     },
     created: function () {
@@ -81,6 +90,7 @@ export default {
             url = `${getAppRoot()}api/datasets/${this.datasetId}/parameters_display?hda_ldda=${this.datasetType}`;
         }
         this.ajaxCall(url);
+        this.isSingleParam = this.param !== undefined && this.param !== "undefined";
     },
     computed: {
         anyNotes: function () {
@@ -89,6 +99,13 @@ export default {
                 hasNotes = hasNotes || parameter.notes;
             });
             return hasNotes;
+        },
+        singleParam: function () {
+            if (!this.isSingleParam) return;
+            const parameter = this.parameters.find((parameter) => {
+                return parameter.text === this.param;
+            });
+            return parameter ? parameter.value : `Parameter "${this.param}" is not found!`;
         },
     },
     methods: {

--- a/client/galaxy/scripts/components/JobParameters/JobParameters.vue
+++ b/client/galaxy/scripts/components/JobParameters/JobParameters.vue
@@ -31,7 +31,7 @@
                 One or more of your original parameters may no longer be valid or displayed properly.
             </b-alert>
         </div>
-        <div v-if="isSingleParam">
+        <div id="single-param" v-if="isSingleParam">
             <div v-if="Array.isArray(singleParam)">
                 <JobParametersArrayValue v-bind:parameter_value="singleParam" />
             </div>

--- a/client/galaxy/scripts/components/JobParameters/JobParameters.vue
+++ b/client/galaxy/scripts/components/JobParameters/JobParameters.vue
@@ -16,16 +16,7 @@
                             {{ parameter.text }}
                         </td>
                         <td v-if="Array.isArray(parameter.value)">
-                            <ul style="padding-inline-start: 25px;">
-                                <li v-for="(elVal, pvIndex) in parameter.value" :key="pvIndex">
-                                    <span v-if="elVal.src == 'hda'">
-                                        <a :href="appRoot() + 'datasets/' + elVal.id + '/show_params'">
-                                            {{ elVal.hid }}: {{ elVal.name }}
-                                        </a>
-                                    </span>
-                                    <span v-else> {{ elVal.hid }}: {{ elVal.name }} </span>
-                                </li>
-                            </ul>
+                            <JobParametersArrayValue v-bind:parameter_value="parameter.value" />
                         </td>
                         <td v-else>
                             {{ parameter.value }}
@@ -41,7 +32,12 @@
             </b-alert>
         </div>
         <div v-if="isSingleParam">
-            {{ singleParam }}
+            <div v-if="Array.isArray(singleParam)">
+                <JobParametersArrayValue v-bind:parameter_value="singleParam" />
+            </div>
+            <td v-else>
+                {{ singleParam }}
+            </td>
         </div>
     </div>
 </template>
@@ -52,6 +48,7 @@ import axios from "axios";
 
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
+import JobParametersArrayValue from "./JobParametersArrayValue";
 
 Vue.use(BootstrapVue);
 
@@ -74,6 +71,9 @@ export default {
             type: Boolean,
             default: true,
         },
+    },
+    components: {
+        JobParametersArrayValue,
     },
     data() {
         return {

--- a/client/galaxy/scripts/components/JobParameters/JobParametersArrayValue.vue
+++ b/client/galaxy/scripts/components/JobParameters/JobParametersArrayValue.vue
@@ -24,7 +24,7 @@ Vue.use(BootstrapVue);
 export default {
     props: {
         parameter_value: {
-            type: String,
+            type: Array,
         },
     },
     methods: {

--- a/client/galaxy/scripts/components/JobParameters/JobParametersArrayValue.vue
+++ b/client/galaxy/scripts/components/JobParameters/JobParametersArrayValue.vue
@@ -1,0 +1,36 @@
+<template>
+    <div>
+        <ul style="padding-inline-start: 25px;">
+            <li v-for="(elVal, pvIndex) in parameter_value" :key="pvIndex">
+                <span v-if="elVal.src == 'hda'">
+                    <a :href="appRoot() + 'datasets/' + elVal.id + '/show_params'">
+                        {{ elVal.hid }}: {{ elVal.name }}
+                    </a>
+                </span>
+                <span v-else> {{ elVal.hid }}: {{ elVal.name }} </span>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+import { getAppRoot } from "onload/loadConfig";
+
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        parameter_value: {
+            type: String,
+        },
+    },
+    methods: {
+        appRoot: function () {
+            return getAppRoot();
+        },
+    },
+};
+</script>

--- a/client/galaxy/scripts/components/JobParameters/mount.js
+++ b/client/galaxy/scripts/components/JobParameters/mount.js
@@ -9,10 +9,12 @@ export const mountJobParameters = (propsData = {}) => {
     $(".job-parameters").each((index, el) => {
         const jobId = $(el).attr("job_id");
         const datasetId = $(el).attr("dataset_id");
+        const param = $(el).attr("param");
         const datasetType = $(el).attr("dataset_type") || "hda";
         const component = Vue.extend(JobParameters);
         propsData.jobId = jobId;
         propsData.datasetId = datasetId;
+        propsData.param = param;
         propsData.datasetType = datasetType;
         return new component({ propsData: propsData }).$mount(el);
     });

--- a/client/galaxy/scripts/components/JobParameters/parameters-response.json
+++ b/client/galaxy/scripts/components/JobParameters/parameters-response.json
@@ -1,0 +1,29 @@
+{
+  "parameters": [
+    {
+      "text": "Add this value",
+      "depth": 1,
+      "value": "22",
+      "notes": ""
+    },
+    {
+      "text": "to Dataset",
+      "depth": 1,
+      "value": [
+        {
+          "src": "hda",
+          "id": "b8a0d6158b9961df",
+          "hid": 84,
+          "name": "Cut on data 83"
+        }
+      ]
+    },
+    {
+      "text": "Iterate?",
+      "depth": 1,
+      "value": "NO",
+      "notes": ""
+    }
+  ],
+  "has_parameter_errors": false
+}

--- a/client/galaxy/scripts/components/Workflow/Editor/ReportHelp.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/ReportHelp.vue
@@ -13,9 +13,9 @@
             example would display a representation of the workflow in the resulting report:
         </p>
         <pre>
-\`\`\`galaxy
+```galaxy
 workflow_display()
-\`\`\`
+```
 </pre
         >
         <dl>
@@ -34,9 +34,19 @@ workflow_display()
             with:
         </p>
         <pre>
-\`\`\`galaxy
+```galaxy
 job_parameters(step="qc")
-\`\`\`
+```
+</pre
+        >
+        <p>
+           It is also possible to reference a single job parameter
+        </p>
+
+        <pre>
+```galaxy
+job_parameters(step="qc", param="parameter_text")
+```
 </pre
         >
         <dt><tt>tool_stderr</tt></dt>
@@ -54,9 +64,9 @@ job_parameters(step="qc")
         </p>
 
         <pre>
-\`\`\`galaxy
+```galaxy
 history_dataset_collection_display(output="Merged Bam")
-\`\`\`
+```
 </pre
         >
         <div v-html="datasetCommandsHtml" />

--- a/client/galaxy/scripts/components/Workflow/Editor/ReportHelp.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/ReportHelp.vue
@@ -40,7 +40,7 @@ job_parameters(step="qc")
 </pre
         >
         <p>
-           It is also possible to reference a single job parameter
+            It is also possible to reference a single job parameter
         </p>
 
         <pre>

--- a/lib/galaxy/managers/markdown_parse.py
+++ b/lib/galaxy/managers/markdown_parse.py
@@ -35,7 +35,9 @@ GALAXY_FLAVORED_MARKDOWN_CONTAINER_REGEX = "(%s)" % "|".join(ALL_CONTAINER_TYPES
 
 ARG_VAL_REGEX = r'''[\w_\-]+|\"[^\"]+\"|\'[^\']+\''''
 FUNCTION_ARG = r'\s*\w+\s*=\s*(?:%s)\s*' % ARG_VAL_REGEX
-FUNCTION_CALL_LINE_TEMPLATE = r'\s*%s\s*\((?:' + FUNCTION_ARG + r')?\)\s*'
+# embed commas between arguments
+FUNCTION_MULTIPLE_ARGS = r'(%s)(,%s)*' % (FUNCTION_ARG, FUNCTION_ARG)
+FUNCTION_CALL_LINE_TEMPLATE = r'\s*%s\s*\((?:' + FUNCTION_MULTIPLE_ARGS + r')?\)\s*'
 GALAXY_MARKDOWN_FUNCTION_CALL_LINE = re.compile(FUNCTION_CALL_LINE_TEMPLATE % GALAXY_FLAVORED_MARKDOWN_CONTAINER_REGEX)
 WHITE_SPACE_ONLY_PATTERN = re.compile(r"^[\s]+$")
 


### PR DESCRIPTION
This PR implements new features in workflow reports:

 - It's possible to pass two arguments to a single function call i.e. ```job_parameters(step="step_label", param="parameter_text")```

 - It brings functionality to mention single job parameter in corresponding workflow report
(A feature suggested by @wm75)

Example: 

Workflow report code:
https://gist.github.com/OlegZharkov/8653977d10d53a4e8528681e46b523b2

Will render to: 
![image](https://user-images.githubusercontent.com/15801412/80624768-7008e480-8a4c-11ea-994d-9ba94160809a.png)

If you want to try this branch and need a workflow, you're welcome to use [this file](https://files.gitter.im/OlegZharkov/7xRg/Galaxy-Workflow-Unnamed_workflow.ga). It's a regular workflow file (already with mentioned report). Feel free to change it.

Edit:
I forgot to mention what happens when job parameter is wrong:

this https://gist.github.com/OlegZharkov/68262a7769f2175df4d6d628cf794c26

will create: 

![image](https://user-images.githubusercontent.com/15801412/80627213-d2afaf80-8a4f-11ea-8cd5-69eec40b0162.png)
