### PR TITLE
Add CSS class to messages in error report pages to make errors more visible

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/dataset-error.js
+++ b/client/galaxy/scripts/mvc/dataset/dataset-error.js
@@ -127,7 +127,7 @@ var View = Backbone.View.extend({
         if (job_messages) {
             message += "<p>Execution resulted in the following messages:</p>";
             for (const job_message of job_messages) {
-                message += `<p><pre>${_.escape(job_message["desc"])}</pre></p>`;
+                message += `<p><pre class="rounded code">${_.escape(job_message["desc"])}</pre></p>`;
             }
         }
         if (tool_stderr) {


### PR DESCRIPTION
From

![image](https://user-images.githubusercontent.com/458683/80689005-37a0ef00-8abc-11ea-95e9-34ef261d4dcf.png)


To

![image](https://user-images.githubusercontent.com/458683/80688988-2eb01d80-8abc-11ea-9b93-a7aeadc627b0.png)
