### PR TITLE
Optimize setting external ID for jobs.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1422,6 +1422,14 @@ class JobWrapper(HasResourceParameters):
         if flush:
             self.sa_session.flush()
 
+    def set_external_id(self, external_id, job=None, flush=True):
+        if job is None:
+            job = self.get_job()
+        job.job_runner_external_id = external_id
+        self.sa_session.add(job)
+        if flush:
+            self.sa_session.flush()
+
     @property
     def home_target(self):
         home_target = self.tool.home_target

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -111,7 +111,7 @@ class ShellJobRunner(AsynchronousJobRunner):
         log.info("(%s) queued with identifier: %s" % (galaxy_id_tag, external_job_id))
 
         # store runner information for tracking if Galaxy restarts
-        job_wrapper.set_job_destination(job_destination, external_job_id)
+        job_wrapper.set_external_id(external_job_id)
 
         # Store state information for job
         ajs.job_id = external_job_id

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -157,7 +157,7 @@ class CondorJobRunner(AsynchronousJobRunner):
         log.info("(%s) queued as %s" % (galaxy_id_tag, external_job_id))
 
         # store runner information for tracking if Galaxy restarts
-        job_wrapper.set_job_destination(job_destination, external_job_id)
+        job_wrapper.set_external_id(external_job_id)
 
         # Store DRM related state information for job
         cjs.job_id = external_job_id

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -222,7 +222,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         log.info("(%s) queued as %s" % (galaxy_id_tag, external_job_id))
 
         # store runner information for tracking if Galaxy restarts
-        job_wrapper.set_job_destination(job_destination, external_job_id)
+        job_wrapper.set_external_id(external_job_id)
 
         # Store DRM related state information for job
         ajs.job_id = external_job_id

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -159,7 +159,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         # define job attributes in the AsyncronousJobState for follow-up
         ajs.job_id = k8s_job_name
         # store runner information for tracking if Galaxy restarts
-        job_wrapper.set_job_destination(job_wrapper.job_destination, k8s_job_name)
+        job_wrapper.set_external_id(k8s_job_name)
         self.monitor_queue.put(ajs)
 
     def __get_pull_policy(self):

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -112,9 +112,10 @@ class LocalJobRunner(BaseJobRunner):
                 self._procs.append(proc)
 
             try:
-                job_wrapper.set_job_destination(job_wrapper.job_destination, proc.pid)
-                job_wrapper.change_state(model.Job.states.RUNNING)
-
+                job = job_wrapper.get_job()
+                # Flush job with change_state.
+                job_wrapper.set_external_id(proc.pid, job=job, flush=False)
+                job_wrapper.change_state(model.Job.states.RUNNING, job=job)
                 self._handle_container(job_wrapper, proc)
 
                 terminated = self.__poll_if_needed(proc, job_wrapper, job_id)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -389,8 +389,10 @@ class PulsarJobRunner(AsynchronousJobRunner):
             )
             job_id = pulsar_submit_job(client, client_job_description, remote_job_config)
             log.info("Pulsar job submitted with job_id %s" % job_id)
-            job_wrapper.set_job_destination(job_destination, job_id)
-            job_wrapper.change_state(model.Job.states.QUEUED)
+            job = job_wrapper.get_job()
+            # Flush with change_state.
+            job_wrapper.set_external_id(job_id, job=job, flush=False)
+            job_wrapper.change_state(model.Job.states.QUEUED, job=job)
         except Exception:
             job_wrapper.fail("failure running job", exception=True)
             log.exception("failure running job %d", job_wrapper.job_id)

--- a/test/unit/jobs/test_runner_local.py
+++ b/test/unit/jobs/test_runner_local.py
@@ -171,7 +171,7 @@ class MockJobWrapper(object):
     def prepare(self):
         self.prepare_called = True
 
-    def set_job_destination(self, job_destination, external_id):
+    def set_external_id(self, external_id, **kwd):
         self.job.job_runner_external_id = external_id
 
     def get_command_line(self):
@@ -186,7 +186,7 @@ class MockJobWrapper(object):
     def get_state(self):
         return self.state
 
-    def change_state(self, state):
+    def change_state(self, state, job=None):
         self.state = state
 
     def get_output_fnames(self):


### PR DESCRIPTION
Local and DRMAA runner update job_destination params but I think this has been done in enqueue and we don't need rewrite for no reason. I checked out the runners and they don't update the parameters. Resubmission might(?) but I think the resubmit integration tests will suss out whether we need to re-save the job destination parameters in here. Lets hope not.

Last graph in following chart is average times in ms for this code block before (first peaks) and after (third peaks) for 100 jobs with on output each. Second peak is a hybrid of optimizations bundled with an attempt to update the HDCA update_time.

<img width="1642" alt="Screen Shot 2020-04-30 at 9 08 21 AM" src="https://user-images.githubusercontent.com/216771/80714432-ecd6a580-8ac2-11ea-8617-5f8331529028.png">
