### PR TITLE
Feature/3937 advanced search tooltip

### DIFF
--- a/client/galaxy/scripts/mvc/history/multi-panel.js
+++ b/client/galaxy/scripts/mvc/history/multi-panel.js
@@ -865,6 +865,7 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
                 this.filters = [];
                 this.renderColumns(0);
             },
+            advsearchlink: true,
         });
 
         // input to search datasets
@@ -901,6 +902,7 @@ var MultiPanelColumns = Backbone.View.extend(baseMVC.LoggableMixin).extend({
                     column.panel.clearSearch();
                 });
             },
+            advsearchlink: true,
         });
 
         // resize first (fixed position) column on page resize

--- a/client/galaxy/scripts/mvc/list/list-view.js
+++ b/client/galaxy/scripts/mvc/list/list-view.js
@@ -666,6 +666,7 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
                 onfirstsearch: _.bind(this._firstSearch, this),
                 onsearch: _.bind(this.searchItems, this),
                 onclear: _.bind(this.clearSearch, this),
+                advsearchlink: true,
             });
             return $where;
         },

--- a/client/galaxy/scripts/ui/search-input.js
+++ b/client/galaxy/scripts/ui/search-input.js
@@ -126,24 +126,24 @@ function searchInput(parentNode, options) {
                 'data-placement="bottom" ',
                 'data-content="',
                 _l(
-                    "You can use advanced searches here using keyword search and syntax like name=&#8220;My DataSet&#8221;"
+                    "<p>You can use advanced searches here using keywords and syntax like <em>name=mydataset</em> or <em>state=error</em>."
                 ),
                 "<br/>",
                 _l(
-                    "Supported keywords for Advanced Searching are: name, format, database, annotation, description, info, tag, hid, and state."
+                    "Supported keywords are <em>name, format, database, annotation, description, info, tag, hid, and state</em>."
                 ),
                 "<br/>",
-                _l("To learn more: "),
-                "<a href='https://galaxyproject.org/tutorials/histories/#advanced-searching'>",
-                _l("Advanced Searching Tutorials"),
-                '</a>" title="',
-                _l("Advanced Search Tips"),
+                _l("To learn more visit "),
+                "<a href='https://galaxyproject.org/tutorials/histories/#advanced-searching' target='_blank'>",
+                _l("the Hub"),
+                '.</a></p>" title="',
+                _l("search tips"),
                 '"></span>',
             ].join("")
         )
             .tooltip({ placement: "bottom" })
             .click(function () {
-                $('[data-toggle="advSearchPopover"]').popover({ html: true });
+                $('[data-toggle="advSearchPopover"]').popover({ html: true, container: '.history-right-panel' });
             });
     }
 

--- a/client/galaxy/scripts/ui/search-input.js
+++ b/client/galaxy/scripts/ui/search-input.js
@@ -30,6 +30,7 @@ function searchInput(parentNode, options) {
         onsearch: function (inputVal) {},
         minSearchLen: 0,
         escWillClear: true,
+        advsearchlink: null,
         oninit: function () {},
     };
 
@@ -116,6 +117,32 @@ function searchInput(parentNode, options) {
             });
     }
 
+    //advanced Search popover
+    function $advancedSearchPopover() {
+        return $(
+            [
+                '<span class="search-advanced fa fa-question-circle" ',
+                'data-toggle="advSearchPopover" ',
+                'data-placement="bottom" ',
+                'data-content="',
+                _l("You can use advanced searches here using keyword search and syntax like name=&#8220;My DataSet&#8221;"),
+                '<br/>',
+                _l("Supported keywords for Advanced Searching are: name, format, database, annotation, description, info, tag, hid, and state."),
+                '<br/>',
+                _l("To learn more: "),
+                "<a href='https://galaxyproject.org/tutorials/histories/#advanced-searching'>",
+                _l("Advanced Searching Tutorials"),
+                '</a>" title="',
+                _l("Advanced Search Tips"),
+                '"></span>',
+            ].join("")
+        )
+            .tooltip({ placement: "bottom" })
+            .click(function () {
+                $('[data-toggle="advSearchPopover"]').popover({ html: true });
+            });
+    }
+
     // .................................................................... loadingIndicator rendering
     // a button for clearing the search bar, placed on the right hand side
     function $loadingIndicator() {
@@ -146,8 +173,17 @@ function searchInput(parentNode, options) {
     if (jQuery.type(options) === "object") {
         options = jQuery.extend(true, {}, defaults, options);
     }
+
+    var buttonsArr = [$clearBtn(), $loadingIndicator()];
+    if (options.advsearchlink) {
+        buttonsArr.push($advancedSearchPopover());
+    }
+
+    var buttonDiv = $('<div class "search-button-panel"></div>');
+    $(buttonDiv).prepend(buttonsArr);
+
     //NOTE: prepended
-    return $parentNode.addClass("search-input").prepend([$input(), $clearBtn(), $loadingIndicator()]);
+    return $parentNode.addClass("search-input").prepend([$input(), $(buttonDiv)]);
 }
 
 // as jq plugin

--- a/client/galaxy/scripts/ui/search-input.js
+++ b/client/galaxy/scripts/ui/search-input.js
@@ -125,10 +125,14 @@ function searchInput(parentNode, options) {
                 'data-toggle="advSearchPopover" ',
                 'data-placement="bottom" ',
                 'data-content="',
-                _l("You can use advanced searches here using keyword search and syntax like name=&#8220;My DataSet&#8221;"),
-                '<br/>',
-                _l("Supported keywords for Advanced Searching are: name, format, database, annotation, description, info, tag, hid, and state."),
-                '<br/>',
+                _l(
+                    "You can use advanced searches here using keyword search and syntax like name=&#8220;My DataSet&#8221;"
+                ),
+                "<br/>",
+                _l(
+                    "Supported keywords for Advanced Searching are: name, format, database, annotation, description, info, tag, hid, and state."
+                ),
+                "<br/>",
                 _l("To learn more: "),
                 "<a href='https://galaxyproject.org/tutorials/histories/#advanced-searching'>",
                 _l("Advanced Searching Tutorials"),

--- a/client/galaxy/scripts/ui/search-input.js
+++ b/client/galaxy/scripts/ui/search-input.js
@@ -143,7 +143,7 @@ function searchInput(parentNode, options) {
         )
             .tooltip({ placement: "bottom" })
             .click(function () {
-                $('[data-toggle="advSearchPopover"]').popover({ html: true, container: '.history-right-panel' });
+                $('[data-toggle="advSearchPopover"]').popover({ html: true, container: ".history-right-panel" });
             });
     }
 

--- a/client/galaxy/style/scss/ui/search-input.scss
+++ b/client/galaxy/style/scss/ui/search-input.scss
@@ -2,6 +2,11 @@
     ::placeholder {
         color: $text-muted;
     }
+
+    border: $border-default;
+    border-radius: 1rem;
+    background: #fff;
+    .search-advanced,
     .search-clear,
     .search-loading {
         @extend .mr-2;
@@ -10,6 +15,13 @@
         top: -27px;
         font-size: 1.2rem;
         color: $text-muted;
+    }
+    .search-advanced {
+        margin-right: 5px !important;
+    }
+    .search-advanced:hover {
+        color: $brand-info;
+        cursor: pointer;
     }
     .search-clear:hover {
         color: $brand-info;
@@ -29,7 +41,7 @@
         font-size: $font-size-base;
         line-height: $line-height-base;
         color: $text-color;
-        border: $border-default;
+        border: 0px;
         @include border-radius($border-radius-extralarge);
         max-width: auto;
         background: $white;


### PR DESCRIPTION
Why?
To increase awareness and ease of access to Advanced Searching in Histories.

How?
Added a popover with embedded link to Advanced Searching documentation to the input-query component, as an optional (default is null) value.

How to Test:

Pull my branch
sh run.sh
Click on the ? icon in the Histories panel search box. Note how it takes you to the documentation.
Notice how the search box in the tool panel does not have an icon, despite using a common component.
Navigate to "view all histories". Note: All of the search input boxes here are are also equipped with Advanced Search button/link.