### PR TITLE
[20.01] Cannot find migrate directory for tools database

### DIFF
--- a/lib/galaxy/model/orm/scripts.py
+++ b/lib/galaxy/model/orm/scripts.py
@@ -29,7 +29,7 @@ DATABASE = {
         },
     "tools":
         {
-            'repo': 'tool_shed/galaxy_install/migrate',
+            'repo': 'galaxy/model/tool_shed_install/migrate',
             'default_sqlite_file': 'universe.sqlite',
             'config_override': 'GALAXY_CONFIG_',
         },


### PR DESCRIPTION
Upgrading from Galaxy 19.05 to 20.01 getting nice stacktrace indicating that could not from migrate directory for [tools section](https://github.com/galaxyproject/galaxy/blob/release_20.01/lib/galaxy/model/orm/scripts.py#L32).

Looks like it moved from Release 19.05 to release 20.01