### PR TITLE
Allow input element created by editable-text.js to change value on click/lose focus

### DIFF
--- a/client/src/ui/editable-text.js
+++ b/client/src/ui/editable-text.js
@@ -74,13 +74,13 @@ $.fn.make_text_editable = function (config_dict) {
         } else {
             input_elt = $("<input type='text'/>")
                 .attr({ value: $.trim(cur_text), size: num_cols })
-                .blur(() => {
-                    set_text(cur_text);
+                .blur(e => {
+                     set_text($(e.currentTarget).val());
                 })
-                .keyup(function (e) {
+                .keyup(function(e){
                     if (e.keyCode === 27) {
                         // Escape key.
-                        $(this).trigger("blur");
+                        set_text(cur_text);
                     } else if (e.keyCode === 13) {
                         // Enter key.
                         set_text($(this).val());

--- a/client/src/ui/editable-text.js
+++ b/client/src/ui/editable-text.js
@@ -75,15 +75,16 @@ $.fn.make_text_editable = function (config_dict) {
             input_elt = $("<input type='text'/>")
                 .attr({ value: $.trim(cur_text), size: num_cols })
                 .blur(e => {
-                     set_text($(e.currentTarget).val());
+                    const new_text = $(e.currentTarget).val(); 
+                    set_text(new_text);
                 })
-                .keyup(function(e){
+                .keyup((e) => {
                     if (e.keyCode === 27) {
                         // Escape key.
                         set_text(cur_text);
                     } else if (e.keyCode === 13) {
                         // Enter key.
-                        set_text($(this).val());
+                         $(e.currentTarget).trigger("blur");
                     }
 
                     // Do not propogate event to avoid unwanted side effects.

--- a/client/src/ui/editable-text.js
+++ b/client/src/ui/editable-text.js
@@ -74,8 +74,8 @@ $.fn.make_text_editable = function (config_dict) {
         } else {
             input_elt = $("<input type='text'/>")
                 .attr({ value: $.trim(cur_text), size: num_cols })
-                .blur(e => {
-                    const new_text = $(e.currentTarget).val(); 
+                .blur((e) => {
+                    const new_text = $(e.currentTarget).val();
                     set_text(new_text);
                 })
                 .keyup((e) => {
@@ -84,7 +84,7 @@ $.fn.make_text_editable = function (config_dict) {
                         set_text(cur_text);
                     } else if (e.keyCode === 13) {
                         // Enter key.
-                         $(e.currentTarget).trigger("blur");
+                        $(e.currentTarget).trigger("blur");
                     }
 
                     // Do not propogate event to avoid unwanted side effects.


### PR DESCRIPTION
Addresses the following issues reported twice:
https://github.com/galaxyproject/galaxy/issues/9630
https://github.com/galaxyproject/galaxy/issues/6713

Clicking outside of editable input text will now update input value. This seems like the expected behavior on most websites. This affects histories, collections, workflows, etc...