### PR TITLE
restore tool_util.deps.commands

### DIFF
--- a/lib/galaxy/tool_util/deps/commands.py
+++ b/lib/galaxy/tool_util/deps/commands.py
@@ -1,0 +1,7 @@
+import logging
+
+import galaxy.util.commands as commands
+
+log = logging.getLogger(__name__)
+
+log.warning("importing galaxy.tool_util.deps.commands is deprecated use galaxy.util.commands instead")

--- a/lib/galaxy/tool_util/deps/commands.py
+++ b/lib/galaxy/tool_util/deps/commands.py
@@ -1,7 +1,6 @@
-import logging
+import warnings
 
 import galaxy.util.commands as commands
 
-log = logging.getLogger(__name__)
 
-log.warning("importing galaxy.tool_util.deps.commands is deprecated use galaxy.util.commands instead")
+warnings.warn("Importing galaxy.tool_util.deps.commands is deprecated, use galaxy.util.commands instead", DeprecationWarning)

--- a/lib/galaxy/tool_util/deps/commands.py
+++ b/lib/galaxy/tool_util/deps/commands.py
@@ -1,6 +1,16 @@
 import warnings
 
-import galaxy.util.commands as commands
+from galaxy.util.commands import (  # noqa: F401
+    argv_to_str,
+    CommandLineException,
+    download_command,
+    execute,
+    redirect_aware_commmunicate,
+    redirecting_io,
+    shell,
+    shell_process,
+    which,
+)
 
 
 warnings.warn("Importing galaxy.tool_util.deps.commands is deprecated, use galaxy.util.commands instead", DeprecationWarning)


### PR DESCRIPTION
In https://github.com/galaxyproject/galaxy/pull/9544 `tool_util.deps.commands` was moved to `utils.commands`

since this probaly breaks planemo we restore it such that it just imports from the new location logs a deprecation warning.

Not sure if this is correct, but I did not want to forget about it. 

Is there some mechanism to deal with deprecation, e.g. should be fix a release when this is going to be removed?