### PR TITLE
[20.05] Improve tool recommendations

### DIFF
--- a/client/galaxy/scripts/components/ToolRecommendation.vue
+++ b/client/galaxy/scripts/components/ToolRecommendation.vue
@@ -4,9 +4,8 @@
             <h4>Tool recommendation</h4>
             You have used {{ getToolId }} tool. For further analysis, you could try using the following/recommended
             tools. The recommended tools are shown in the decreasing order of their scores predicted using machine
-            learning analysis on workflows. A tool with a higher score (closer to 100%) may fit better as the following
-            tool than a tool with a lower score. Please click on one of the following/recommended tools to open its
-            definition.
+            learning analysis on workflows. Therefore, tools at the top may be more useful than the ones at the bottom.
+            Please click on one of the following/recommended tools to open its definition.
         </div>
         <div v-else-if="deprecated" class="warningmessagelarge">
             You have used {{ getToolId }} tool. {{ deprecatedMessage }}

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1027,16 +1027,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~
-``tool_search_index_dir``
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Directory in which the toolbox search index is stored.
-:Default: ``tool_search_index``
-:Type: str
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``delay_tool_initialization``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1027,6 +1027,16 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_search_index_dir``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Directory in which the toolbox search index is stored.
+:Default: ``tool_search_index``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``delay_tool_initialization``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1027,6 +1027,16 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~
+``tool_search_index_dir``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Directory in which the toolbox search index is stored.
+:Default: ``tool_search_index``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``delay_tool_initialization``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -4144,7 +4154,7 @@
 :Description:
     Set the number of predictions/recommendations to be made by the
     model
-:Default: ``20``
+:Default: ``10``
 :Type: int
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -599,9 +599,6 @@ galaxy:
   # attribute.
   #tool_cache_data_dir: tool_cache
 
-  # Directory in which the toolbox search index is stored.
-  #tool_search_index_dir: tool_search_index
-
   # Set this to true to delay parsing of tool inputs and outputs until
   # they are needed. This results in faster startup times but uses more
   # memory when using forked Galaxy processes.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -599,6 +599,9 @@ galaxy:
   # attribute.
   #tool_cache_data_dir: tool_cache
 
+  # Directory in which the toolbox search index is stored.
+  #tool_search_index_dir: tool_search_index
+
   # Set this to true to delay parsing of tool inputs and outputs until
   # they are needed. This results in faster startup times but uses more
   # memory when using forked Galaxy processes.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -599,6 +599,9 @@ galaxy:
   # attribute.
   #tool_cache_data_dir: tool_cache
 
+  # Directory in which the toolbox search index is stored.
+  #tool_search_index_dir: tool_search_index
+
   # Set this to true to delay parsing of tool inputs and outputs until
   # they are needed. This results in faster startup times but uses more
   # memory when using forked Galaxy processes.
@@ -2017,7 +2020,7 @@ galaxy:
 
   # Set the number of predictions/recommendations to be made by the
   # model
-  #topk_recommendations: 20
+  #topk_recommendations: 10
 
   # Set path to the additional tool preferences from Galaxy admins. It
   # has two blocks. One for listing deprecated tools which will be

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -255,6 +255,7 @@ class ToolRecommendations():
         Return a payload with the tool sequences and recommended tools
         Return an empty payload with just the tool sequence if anything goes wrong within the try block
         """
+        tool_sequence = "freebayes,bowtie2"
         topk = trans.app.config.topk_recommendations
         prediction_data = dict()
         tool_sequence = tool_sequence.split(",")[::-1]

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -31,6 +31,7 @@ class ToolRecommendations():
         self.graph = None
         self.loaded_model = None
         self.compatible_tools = None
+        self.standard_connections = None
         self.max_seq_len = 25
 
     def get_predictions(self, trans, tool_sequence, remote_model_url):
@@ -93,6 +94,7 @@ class ToolRecommendations():
             # set the list of compatible tools
             self.compatible_tools = json.loads(trained_model['compatible_tools'][()])
             tool_weights = json.loads(trained_model['class_weights'][()])
+            self.standard_connections = json.loads(trained_model['standard_connections'][()])
             # sort the tools' usage dictionary
             tool_pos_sorted = [int(key) for key in tool_weights.keys()]
             for k in tool_pos_sorted:
@@ -168,6 +170,9 @@ class ToolRecommendations():
         if last_tool_name in self.compatible_tools:
             last_compatible_tools = self.compatible_tools[last_tool_name].split(",")
         prediction_data["is_deprecated"] = False
+        # get the list of datatype extensions of the last tool of the tool sequence
+        _, last_output_extensions = self.__get_tool_extensions(trans, self.all_tools[last_tool_name][0])
+        prediction_data["o_extensions"] = list(set(last_output_extensions))
         t_ids_scores = zip(tool_ids, tool_scores)
         # form the payload of the predicted tools to be shown
         for child, score in t_ids_scores:
@@ -206,12 +211,54 @@ class ToolRecommendations():
                 break
         return prediction_data
 
+    def __get_predicted_tools(self, base_tools, predictions, topk):
+        """
+        Get predicted tools. If predicted tools are less in number, combine them with published tools
+        """
+        intersection = list(set(predictions).intersection(set(base_tools)))
+        if len(intersection) < topk:
+            difference = list(set(base_tools).difference(set(predictions)))
+            intersection.extend(difference)
+        return intersection[:topk]
+
+    def __sort_by_usage(self, t_list, class_weights, d_dict):
+        """
+        Sort predictions by usage/class weights
+        """
+        tool_dict = dict()
+        for tool in t_list:
+            t_id = d_dict[tool]
+            tool_dict[tool] = class_weights[t_id]
+        tool_dict = dict(sorted(tool_dict.items(), key=lambda kv: kv[1], reverse=True))
+        return list(tool_dict.keys()), list(tool_dict.values())
+
+    def __separate_predictions(self, base_tools, predictions, last_tool_name, weight_values, topk):
+        """
+        Get predictions from published and normal workflows
+        """
+        last_base_tools = list()
+        predictions = predictions * weight_values
+        prediction_pos = np.argsort(predictions, axis=-1)
+        topk_prediction_pos = prediction_pos[-topk:]
+        # get tool ids
+        pred_tool_ids = [self.reverse_dictionary[int(tool_pos)] for tool_pos in topk_prediction_pos]
+        if last_tool_name in base_tools:
+            last_base_tools = base_tools[last_tool_name]
+            if type(last_base_tools).__name__ == "str":
+                # get published or compatible tools for the last tool in a sequence of tools
+                last_base_tools = last_base_tools.split(",")
+        # get predicted tools
+        p_tools = self.__get_predicted_tools(last_base_tools, pred_tool_ids, topk)
+        sorted_c_t, sorted_c_v = self.__sort_by_usage(p_tools, self.tool_weights_sorted, self.model_data_dictionary)
+        return sorted_c_t, sorted_c_v
+
     def __compute_tool_prediction(self, trans, tool_sequence):
         """
         Compute the predicted tools for a tool sequences
         Return a payload with the tool sequences and recommended tools
         Return an empty payload with just the tool sequence if anything goes wrong within the try block
         """
+        tool_sequence = "freebayes,bowtie2"
         topk = trans.app.config.topk_recommendations
         prediction_data = dict()
         tool_sequence = tool_sequence.split(",")[::-1]
@@ -221,9 +268,6 @@ class ToolRecommendations():
         # do prediction only if the last is present in the collections of tools
         if last_tool_name in self.model_data_dictionary:
             sample = np.zeros(self.max_seq_len)
-            # get the list of datatype extensions of the last tool of the tool sequence
-            _, last_output_extensions = self.__get_tool_extensions(trans, self.all_tools[last_tool_name][0])
-            prediction_data["o_extensions"] = list(set(last_output_extensions))
             # get tool names without slashes and create a sequence vector
             for idx, tool_name in enumerate(tool_sequence):
                 if tool_name.find("/") > -1:
@@ -234,6 +278,8 @@ class ToolRecommendations():
                     log.exception("Failed to find tool %s in model" % (tool_name))
                     return prediction_data
             sample = np.reshape(sample, (1, self.max_seq_len))
+            # boost the predicted scores using tools' usage
+            weight_values = list(self.tool_weights_sorted.values())
             # predict next tools for a test path
             try:
                 # use the same graph and session to predict
@@ -243,20 +289,21 @@ class ToolRecommendations():
             except Exception as e:
                 log.exception(e)
                 return prediction_data
-            prediction = np.reshape(prediction, (prediction.shape[1],))
-            # boost the predicted scores using tools' usage
-            weight_values = list(self.tool_weights_sorted.values())
-            prediction = prediction * weight_values
-            # normalize the predicted scores with max and sort the predictions
-            max_prediction = float(np.max(prediction))
-            if max_prediction == 0.0:
-                max_prediction = 1.0
-            prediction = prediction / max_prediction
-            prediction_pos = np.argsort(prediction, axis=-1)
-            # get topk prediction
-            topk_prediction_pos = prediction_pos[-topk:]
-            # read tool names using reverse dictionary
-            pred_tool_ids = [self.reverse_dictionary[int(tool_pos)] for tool_pos in topk_prediction_pos]
-            predicted_scores = [int(prediction[pos] * 100) for pos in topk_prediction_pos]
-            prediction_data = self.__filter_tool_predictions(trans, prediction_data, pred_tool_ids[::-1], predicted_scores[::-1], last_tool_name)
+            # get dimensions
+            nw_dimension = prediction.shape[1]
+            prediction = np.reshape(prediction, (nw_dimension,))
+            half_len = int(nw_dimension / 2)
+            # get recommended tools from published workflows
+            pub_t, pub_v = self.__separate_predictions(self.standard_connections, prediction[:half_len], last_tool_name, weight_values, topk)
+            # get recommended tools from normal workflows
+            c_t, c_v = self.__separate_predictions(self.compatible_tools, prediction[half_len:], last_tool_name, weight_values, topk)
+            # combine predictions coming from different workflows
+            # promote recommended tools coming from published workflows
+            # to the top and then show other recommendations
+            pub_t.extend(c_t)
+            pub_v.extend(c_v)
+            # remove duplicates if any
+            pub_t = list(dict.fromkeys(pub_t))
+            pub_v = list(dict.fromkeys(pub_v))
+            prediction_data = self.__filter_tool_predictions(trans, prediction_data, pub_t, pub_v, last_tool_name)
         return prediction_data

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -216,9 +216,6 @@ class ToolRecommendations():
         Get predicted tools. If predicted tools are less in number, combine them with published tools
         """
         intersection = list(set(predictions).intersection(set(base_tools)))
-        if len(intersection) < topk:
-            difference = list(set(base_tools).difference(set(predictions)))
-            intersection.extend(difference)
         return intersection[:topk]
 
     def __sort_by_usage(self, t_list, class_weights, d_dict):
@@ -258,7 +255,6 @@ class ToolRecommendations():
         Return a payload with the tool sequences and recommended tools
         Return an empty payload with just the tool sequence if anything goes wrong within the try block
         """
-        tool_sequence = "freebayes,bowtie2"
         topk = trans.app.config.topk_recommendations
         prediction_data = dict()
         tool_sequence = tool_sequence.split(",")[::-1]

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -3054,7 +3054,7 @@ mapping:
 
       topk_recommendations:
         type: int
-        default: 20
+        default: 10
         required: false
         desc: |
           Set the number of predictions/recommendations to be made by the model


### PR DESCRIPTION
This PR improves tool recommendations by:
- Training on the latest workflows from the EU Galaxy server
- Showing recommendations coming from published and non-deleted workflows at the top (if available)
- Predicting recommendations even for tools present in low frequency in workflows (balancing training data by uniform random sampling)

This PR is dependent on the PR mentioned below:
The new model is available at https://github.com/galaxyproject/galaxy-test-data/pull/15

Some comparisons:

Category | Tool (or tool sequence) | Current recommendations | New recommendations
-- | -- | -- | --
Assembly | spades | bwa_memBowtie2fasta_filter_by_lengthprokkaabricatequastfasta-statsbandage_imageantismashmlst | 'bandage_image', 'fasta-stats', 'Bandage_info', 'bowtie2', 'bwa_mem' 'fasta_filter_by_length', 'prokka', 'abricate', 'quast', 'staramr_search', 'mlst', 'PlasFlow', 'busco'
Chemical TB | ctb_remDuplicates | None | ctb_remIons
  | ctb_remDuplicates,ctb_remIons | ctb_chemfp_mol2fps,ctb_compound_convert | 'ctb_chemfp_mol2fps', 'ctb_compound_convert'
  | ctb_remDuplicates,ctb_remIons,ctb_chemfp_mol2fps | ctb_simsearch,ctb_chemfp_butina_clustering | 'ctb_chemfp_butina_clustering', 'ctb_chemfp_nxn_clustering', 'ctb_simsearch', 'comp1'
RAD-Seq | stacks_procrad | Grep1,bwa,fastq_filter | 'fastqc', 'Grep1', 'bwa', 'fastq_filter', 'stacks_denovomap', 'bwa_wrapper'
Genome annotation | maker | gffread | 'gffread', 'maker_map_ids', 'jcvi_gff_stats'
Imaging | ip_filter_standard | None | 'ip_threshold', 'ip_count_objects', 'ip_histogram_equalization'
Mass spectrometry | mass_spectrometry_imaging_preprocessing | Mass_spectrometry_imaging_combine,Mass_spectrometry_imaging_mzplots,Mass_spectrometry_imaging_ion_images,mass_spectrometry_imaging_classification | Mass_spectrometry_imaging_preprocessing,Mass_spectrometry_imaging_mzplotsmass_spectrometry_imaging_qcMass_spectrometry_imaging_combineMass_spectrometry_imaging_segmentationsmass_spectrometry_imaging_ion_images
Single cell | raceid_main | None | 'seurat', 'raceid_trajectory'
  | rna_starsolo | 'dropletutils' | 'dropletutils', 'multiqc'
  | rna_starsolo,raceid_trajectory | None | 'raceid_inspecttrajectory
  | scanpy_regress_variable | Tool not available | scanpy_scale_data
  | scanpy_regress_variable,scanpy_scale_data | Tool not available | 'scanpy_run_pca', 'scanpy_find_variable_genes'
  | scanpy_find_cluster | scanpy_run_tsne,scanpy_find_markers,scanpy_run_umap | 'scanpy_find_markers', 'scanpy_run_tsne', 'scanpy_run_umap', 'scanpy_plot_embed'
SC HiC | schicexplorer_schicqualitycontrol | Tool not available | schicexplorer_schicnormalize
  | schicexplorer_schicqualitycontrol,schicexplorer_schicnormalize | Tools not available | 'schicexplorer_schicclustersvl', 'schicexplorer_schicconsensusmatrices', 'schicexplorer_schicplotclusterprofiles'
Animal detection on acoustic recording | vigiechiro_idvalid | None | 'vigiechiro_bilanenrichipf', 'vigiechiro_bilanenrichirp'

