### PR TITLE
View support for galaxy model, hdca.job_state_summary option

### DIFF
--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -254,4 +254,11 @@ class HDCASerializer(
                                                      history_id=self.app.security.encode_id(i.history_id),
                                                      id=self.app.security.encode_id(i.id),
                                                      type=self.hdca_manager.model_class.content_type),
+            'job_state_summary'         : self.serialize_job_state_summary
         })
+
+    def serialize_job_state_summary(self, hdca, key, **context):
+        states = hdca.job_state_summary.__dict__.copy()
+        del states['_sa_instance_state']
+        del states['hdca_id']
+        return states

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -236,7 +236,8 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
         contained_ids = id_map[self.contained_class_type_name]
         id_map[self.contained_class_type_name] = self._contained_id_map(contained_ids)
         subcontainer_ids = id_map[self.subcontainer_class_type_name]
-        id_map[self.subcontainer_class_type_name] = self._subcontainer_id_map(subcontainer_ids)
+        serialization_params = kwargs.get('serialization_params', None)
+        id_map[self.subcontainer_class_type_name] = self._subcontainer_id_map(subcontainer_ids, serialization_params=serialization_params)
 
         # cycle back over the union query to create an ordered list of the objects returned in queries 2 & 3 above
         contents = []
@@ -398,7 +399,7 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
             .options(eagerload('annotations')))
         return dict((row.id, row) for row in query.all())
 
-    def _subcontainer_id_map(self, id_list):
+    def _subcontainer_id_map(self, id_list, serialization_params=None):
         """Return an id to model map of all subcontainer-type models in the id_list."""
         if not id_list:
             return []
@@ -408,6 +409,14 @@ class HistoryContentsManager(containers.ContainerManagerMixin):
             .options(eagerload('collection'))
             .options(eagerload('tags'))
             .options(eagerload('annotations')))
+
+        # This will conditionally join a potentially costly job_state summary
+        # All the paranoia if-checking makes me wonder if serialization_params
+        # should really be a property of the manager class instance
+        if serialization_params and serialization_params['keys']:
+            if 'job_state_summary' in serialization_params['keys']:
+                query = query.options(eagerload('job_state_summary'))
+
         return dict((row.id, row) for row in query.all())
 
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -43,6 +43,8 @@ from galaxy.model.orm.engine_factory import build_engine
 from galaxy.model.orm.now import now
 from galaxy.model.security import GalaxyRBACAgent
 from galaxy.model.triggers import install_timestamp_triggers
+from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
+from galaxy.model.view.utils import install_views
 
 log = logging.getLogger(__name__)
 
@@ -2377,6 +2379,11 @@ simple_mapping(model.HistoryDatasetCollectionAssociation,
         backref=backref("history_dataset_collection_associations", uselist=True),
         uselist=False,
     ),
+    job_state_summary=relation(HistoryDatasetCollectionJobStateSummary,
+        primaryjoin=((model.HistoryDatasetCollectionAssociation.table.c.id == HistoryDatasetCollectionJobStateSummary.__table__.c.hdca_id)),
+        foreign_keys=HistoryDatasetCollectionJobStateSummary.__table__.c.hdca_id,
+        uselist=False
+    ),
     tags=relation(model.HistoryDatasetCollectionTagAssociation,
         order_by=model.HistoryDatasetCollectionTagAssociation.table.c.id,
         backref='dataset_collections'),
@@ -2876,6 +2883,7 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     if create_tables:
         metadata.create_all()
         install_timestamp_triggers(engine)
+        install_views(engine)
         # metadata.engine.commit()
 
     result.create_tables = create_tables

--- a/lib/galaxy/model/migrate/versions/0166_job_state_summary_view.py
+++ b/lib/galaxy/model/migrate/versions/0166_job_state_summary_view.py
@@ -1,0 +1,27 @@
+"""
+Job state trigger syncs update_time in hdca table.
+Add job-state-summary view for hdca elements
+"""
+from __future__ import print_function
+
+import logging
+
+from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
+from galaxy.model.view.utils import CreateView, DropView
+
+log = logging.getLogger(__name__)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    # drop first because sqlite does not support or_replace
+    downgrade(migrate_engine)
+    create_view = CreateView(HistoryDatasetCollectionJobStateSummary)
+    # print(str(create_view.compile(migrate_engine)))
+    migrate_engine.execute(create_view)
+
+
+def downgrade(migrate_engine):
+    drop_view = DropView(HistoryDatasetCollectionJobStateSummary)
+    # print(str(drop_view.compile(migrate_engine)))
+    migrate_engine.execute(drop_view)

--- a/lib/galaxy/model/view/__init__.py
+++ b/lib/galaxy/model/view/__init__.py
@@ -1,0 +1,62 @@
+"""
+Galaxy sql view models
+"""
+from sqlalchemy import Integer, MetaData
+from sqlalchemy.orm import mapper
+from sqlalchemy.sql import column, text
+from sqlalchemy_utils import create_view
+
+from .utils import View
+
+metadata = MetaData()
+
+
+class HistoryDatasetCollectionJobStateSummary(View):
+
+    __view__ = text("""
+        SELECT
+            hdca.id as hdca_id,
+            SUM(CASE WHEN state = 'new' THEN 1 ELSE 0 END) AS new,
+            SUM(CASE WHEN state = 'resubmitted' THEN 1 ELSE 0 END) AS resubmitted,
+            SUM(CASE WHEN state = 'waiting' THEN 1 ELSE 0 END) AS waiting,
+            SUM(CASE WHEN state = 'queued' THEN 1 ELSE 0 END) AS queued,
+            SUM(CASE WHEN state = 'running' THEN 1 ELSE 0 END) AS running,
+            SUM(CASE WHEN state = 'ok' THEN 1 ELSE 0 END) AS ok,
+            SUM(CASE WHEN state = 'error' THEN 1 ELSE 0 END) AS error,
+            SUM(CASE WHEN state = 'failed' THEN 1 ELSE 0 END) AS failed,
+            SUM(CASE WHEN state = 'paused' THEN 1 ELSE 0 END) AS paused,
+            SUM(CASE WHEN state = 'deleted' THEN 1 ELSE 0 END) AS deleted,
+            SUM(CASE WHEN state = 'deleted_new' THEN 1 ELSE 0 END) AS deleted_new,
+            SUM(CASE WHEN state = 'upload' THEN 1 ELSE 0 END) AS upload,
+            SUM(CASE WHEN job.id IS NOT NULL THEN 1 ELSE 0 END) AS all_jobs
+        FROM history_dataset_collection_association hdca
+        LEFT JOIN implicit_collection_jobs icj
+            ON icj.id = hdca.implicit_collection_jobs_id
+        LEFT JOIN implicit_collection_jobs_job_association icjja
+            ON icj.id = icjja.implicit_collection_jobs_id
+        LEFT JOIN job
+            ON icjja.job_id = job.id
+        GROUP BY hdca.id
+    """)
+
+    __view__ = __view__.columns(
+        column('hdca_id', Integer),
+        column('new', Integer),
+        column('resubmitted', Integer),
+        column('waiting', Integer),
+        column('queued', Integer),
+        column('running', Integer),
+        column('ok', Integer),
+        column('error', Integer),
+        column('failed', Integer),
+        column('paused', Integer),
+        column('deleted', Integer),
+        column('deleted_new', Integer),
+        column('upload', Integer),
+        column('all_jobs', Integer)
+    )
+
+    __table__ = create_view('collection_job_state_summary_view', __view__, metadata)
+
+
+mapper(HistoryDatasetCollectionJobStateSummary, HistoryDatasetCollectionJobStateSummary.__table__)

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -1,0 +1,48 @@
+"""
+View wrappers, currently using sqlalchemy_views
+"""
+from inspect import getmembers
+
+from sqlalchemy.ext import compiler
+from sqlalchemy_utils import view
+
+
+class View(object):
+    is_view = True
+
+
+class DropView(view.DropView):
+    def __init__(self, ViewModel, **kwargs):
+        super().__init__(str(ViewModel.__table__.name), **kwargs)
+
+
+@compiler.compiles(DropView, "sqlite")
+def compile_drop_materialized_view(element, compiler, **kw):
+    # modified because sqlalchemy_utils adds a cascade for
+    # sqlite even though sqlite does not support cascade keyword
+    return 'DROP {}VIEW IF EXISTS {}'.format(
+        'MATERIALIZED ' if element.materialized else '',
+        element.name
+    )
+
+
+class CreateView(view.CreateView):
+    def __init__(self, ViewModel, **kwargs):
+        super().__init__(str(ViewModel.__table__.name), ViewModel.__view__, **kwargs)
+
+
+def is_view_model(o):
+    return hasattr(o, '__view__') and issubclass(o, View)
+
+
+def install_views(engine):
+    import galaxy.model.view
+    views = getmembers(galaxy.model.view, is_view_model)
+    for (name, ViewModel) in views:
+        # adding DropView here because our unit-testing calls this function when
+        # it mocks the app and CreateView will attempt to rebuild an existing
+        # view in a database that is already made, the right answer is probably
+        # to change the sql that gest emitted when CreateView is rendered.
+        engine.execute(DropView(ViewModel))
+        engine.execute(CreateView(ViewModel))
+        print('here')

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -45,4 +45,3 @@ def install_views(engine):
         # to change the sql that gest emitted when CreateView is rendered.
         engine.execute(DropView(ViewModel))
         engine.execute(CreateView(ViewModel))
-        print('here')

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -904,7 +904,12 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
         view = serialization_params.pop('view')
 
         contents = self.history_contents_manager.contents(history,
-            filters=filters, limit=limit, offset=offset, order_by=order_by)
+            filters=filters,
+            limit=limit,
+            offset=offset,
+            order_by=order_by,
+            serialization_params=serialization_params)
+
         for content in contents:
 
             # TODO: remove split

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -538,3 +538,14 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
         self._assert_has_keys(query_hda, "id", "name")
         assert input_hda["name"] == query_hda["name"]
         assert input_hda["id"] == query_hda["id"]
+
+    def test_job_state_summary_field(self):
+        create_response = self.dataset_collection_populator.create_pair_in_history(self.history_id, contents=["123", "456"])
+        self._assert_status_code_is(create_response, 200)
+        contents_response = self._get("histories/%s/contents?v=dev&keys=job_state_summary&view=summary" % self.history_id)
+        self._assert_status_code_is(contents_response, 200)
+        contents = contents_response.json()
+        for c in filter(lambda c: c['history_content_type'] == 'dataset_collection', contents):
+            assert isinstance(c, dict)
+            assert 'job_state_summary' in c
+            assert isinstance(c['job_state_summary'], dict)


### PR DESCRIPTION
I split this view support out of the main history API PR (#9591) since we are exploring performance issues in that PR that are not related to the view support, and I would like to use database views for other features.


### New Module: galaxy.model.view

This PR includes a new mechanism to register and use/join sql views as ORM entities. 

For each view, a Table is defined for the row-schema of the view, and associated with a selectable which can be either an ORM query or a straight SQL string, representing the contents of the view select itself.

The gotcha is any foreign key declarations (for use in declaring ORM relationships) have to be explicitly defined in the "main" model relationship mapping declarations because the Table in the view definition is not registered on the same MetaData instance (because the view row schema is not really a table), and thus standard ForeignKey() Column parameters aren't going to recognize other tables in the db.

### Added collection job states summary as serialization option in the primary contents query

Added a serialization option to the HDCA result set that gives an overview of the job states working inside that collection by doing an additional eager subquery against the implicit jobs tables.

This extra field is optional and only appears in the query if the 'job_state_summary' key is present in the history contents request URL.


