### PR TITLE
[20.01] Make collection import from library import into correct history

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -522,6 +522,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
             dataset_collection_instance = service.create(
                 trans,
                 parent=history,
+                history=history,
                 **create_params
             )
         elif source == "hdca":

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -473,14 +473,15 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
         ld = self.library_populator.new_library_dataset("el1")
         ldda_id = ld["ldda_id"]
         element_identifiers = [{"name": "el1", "src": "ldda", "id": ldda_id}]
+        history_id = self._new_history()
         create_data = dict(
-            history_id=self.history_id,
+            history_id=history_id,
             type="dataset_collection",
             name="Test From Library",
             element_identifiers=json.dumps(element_identifiers),
             collection_type="list",
         )
-        create_response = self._post("histories/%s/contents/dataset_collections" % self.history_id, create_data)
+        create_response = self._post("histories/%s/contents/dataset_collections" % history_id, create_data)
         hdca = self.__check_create_collection_response(create_response)
         elements = hdca["elements"]
         assert len(elements) == 1
@@ -488,6 +489,7 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
         assert hda["hda_ldda"] == "hda"
         assert hda["history_content_type"] == "dataset"
         assert hda["copied_from_ldda_id"] == ldda_id
+        assert hda['history_id'] == history_id
 
     def test_hdca_from_inaccessible_library_datasets(self):
         library, library_dataset = self.library_populator.new_library_dataset_in_private_library("HDCACreateInaccesibleLibrary")


### PR DESCRIPTION
While Galaxy respected the history to create the collection in, the
dataset would be imported into trans.current_history, ignoring the
requested history

Fixes https://github.com/galaxyproject/galaxy/issues/8238