### PR TITLE
adds tool test showing problem with Infinity handling

### DIFF
--- a/test/functional/tools/infinity.xml
+++ b/test/functional/tools/infinity.xml
@@ -1,0 +1,40 @@
+<!-- test for correct handling of Infinity, -Infinity, NaN of 
+     JSON en/decoder in Galaxy (i.e. in galaxy.util.json) -->
+<tool id="infinity" name="infinity" version="0.1.0">
+  <command><![CDATA[
+    echo "text $intext" > '$NaN' &&
+    echo "float $infloat" >> '$NaN' &&
+    echo "select $inselect" >> '$NaN' &&
+    echo "param $Infinity" >> '$NaN'
+  ]]></command>
+  <inputs>
+    <param name="intext" type="text" value=""/>
+    <param name="infloat" type="float" value=""/>
+    <param name="inselect" type="select" >
+        <option value="Infinity">Infinity</option>
+        <option value="NaN">NaN</option>
+    </param>
+    <param name="Infinity" type="text" value=""/>
+  </inputs>
+  <outputs>
+    <data name="NaN" format="txt" label="out"/>
+  </outputs>
+  <tests>
+    <test expect_num_outputs="1">
+      <param name="intext" value="Infinity" />
+      <param name="infloat" value="Inf" />
+      <param name="inselect" value="Infinity" />
+      <param name="Infinity" value="VAL" />
+      <output name="NaN" file="1.txt" compare="sim_size" delta_frac="Infinity">
+        <assert_contents>
+          <has_line line="text Infinity"/>
+          <has_line line="float inf"/>
+          <has_line line="select Infinity"/>
+          <has_line line="param VAL"/>
+          <has_text_matching expression="Infinity"/>
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>
+

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -56,6 +56,7 @@
   <tool file="md5sum.xml" />
   <tool file="checksum.xml" />
   <tool file="composite_shapefile.xml" />
+  <tool file="infinity.xml"/>
   <tool file="is_valid_xml.xml" />
   <tool file="param_value_from_file.xml"/>
   <!--


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/9425 ...

Problem seems to be that delta_frac is encoded to json at some point where `Inf` is encoded by `'__Infinity__'` but decoding is not doing the back translation. 

So far I could not find another attribute value that is affected.

This special treatment of `Inf`, `-Inf` and `NaN` in Galaxy has been introduced here: https://github.com/galaxyproject/galaxy/commit/8f72dfe8ee1a3e4394976ef272057961030891c0

Possibilities:

- use python's default handling of encoding `Inf` as the string `'Infinity'`, .... The downside would be that all occurrences of `'Infinity'` would be affected. So `'__Infinity__'` seems to add a a bit more safety. But it would be faster since `swap_inf_nan` becomes obsolete.
- implement a backtranslation function like so: https://github.com/galaxyproject/galaxy/commit/8f72dfe8ee1a3e4394976ef272057961030891c0 which has the problem that it adds run time (like `swap_inf_nan` which does the translation during encoding).
- subclass the encoders / decoders of the python json module and overwrite the handling of `Inf`, ... But since this seems quite hardcoded (https://github.com/python/cpython/blob/b0be6b3b94fbdf31b796adc19dc86a04a52b03e1/Lib/json/encoder.py#L231) I don't see an obvious way to do this future proof.