### PR TITLE
Implement HDCA update_time

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1376,9 +1376,9 @@ class JobWrapper(HasResourceParameters):
             job.info = info
         job.set_state(state)
         self.sa_session.add(job)
+        job.update_output_states()
         if flush:
             self.sa_session.flush()
-        job.update_output_dataset_states()
 
     def get_state(self):
         job = self.get_job()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1714,14 +1714,13 @@ class JobWrapper(HasResourceParameters):
         self.tool.call_hook('exec_after_process', self.app, inp_data=inp_data,
                             out_data=out_data, param_dict=param_dict,
                             tool=self.tool, stdout=job.stdout, stderr=job.stderr)
-        job.command_line = unicodify(self.command_line)
 
         collected_bytes = 0
         # Once datasets are collected, set the total dataset size (includes extra files)
         for dataset_assoc in job.output_datasets:
             if not dataset_assoc.dataset.dataset.purged:
-                dataset_assoc.dataset.dataset.set_total_size()
-                collected_bytes += dataset_assoc.dataset.dataset.get_total_size()
+                # don't call get_total_size - forces a flush we don't want in here.
+                collected_bytes += dataset_assoc.dataset.dataset.set_total_size()
 
         if job.user:
             job.user.adjust_total_disk_usage(collected_bytes)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1719,8 +1719,7 @@ class JobWrapper(HasResourceParameters):
         # Once datasets are collected, set the total dataset size (includes extra files)
         for dataset_assoc in job.output_datasets:
             if not dataset_assoc.dataset.dataset.purged:
-                # don't call get_total_size - forces a flush we don't want in here.
-                collected_bytes += dataset_assoc.dataset.dataset.set_total_size()
+                collected_bytes += dataset_assoc.dataset.set_total_size()
 
         if job.user:
             job.user.adjust_total_disk_usage(collected_bytes)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2400,6 +2400,7 @@ class Dataset(StorableObject, RepresentById):
             if self.object_store.exists(self, extra_dir=rel_path, dir_only=True):
                 for root, dirs, files in os.walk(self.extra_files_path):
                     self.total_size += sum([os.path.getsize(os.path.join(root, file)) for file in files if os.path.exists(os.path.join(root, file))])
+        return self.total_size
 
     def has_data(self):
         """Detects whether there is any data"""

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1150,6 +1150,58 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         for dataset_assoc in self.output_datasets:
             return dataset_assoc.dataset.tool_version
 
+    def update_output_dataset_states(self):
+        sql = '''
+            UPDATE dataset
+            SET
+                state = :state,
+                update_time = :update_time
+            WHERE id IN (
+                SELECT hda.dataset_id FROM history_dataset_association hda
+                INNER JOIN job_to_output_dataset jtod
+                ON jtod.dataset_id = hda.id AND jtod.job_id = :job_id
+            );
+
+            UPDATE dataset
+            SET
+                state = :state,
+                update_time = :update_time
+            WHERE id IN (
+                SELECT ldda.dataset_id FROM library_dataset_dataset_association ldda
+                INNER JOIN job_to_output_library_dataset jtold
+                ON jtold.ldda_id = ldda.id AND jtold.job_id = :job_id
+            );
+
+            UPDATE history_dataset_association
+            SET
+                info = :info,
+                update_time = :update_time
+            WHERE id IN (
+                SELECT jtod.dataset_id
+                FROM job_to_output_dataset jtod
+                WHERE jtod.job_id = :job_id
+            );
+
+            UPDATE library_dataset_dataset_association
+            SET
+                info = :info,
+                update_time = :update_time
+            WHERE id IN (
+                SELECT jtold.ldda_id
+                FROM job_to_output_library_dataset jtold
+                WHERE jtold.job_id = :job_id
+            );
+        '''
+        sa_session = object_session(self)
+        params = {
+            'job_id': self.id,
+            'state': self.state,
+            'info': self.info,
+            'update_time': galaxy.model.orm.now.now()
+        }
+        sa_session.execute(sql, params)
+        sa_session.flush()
+
 
 class Task(JobLike, RepresentById):
     """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1127,6 +1127,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
 
     def set_final_state(self, final_state):
         self.set_state(final_state)
+        # TODO: migrate to where-in subqueries?
         statements = ['''
             UPDATE history_dataset_collection_association
             SET update_time = :update_time
@@ -1181,6 +1182,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             return dataset_assoc.dataset.tool_version
 
     def update_output_states(self):
+        # TODO: migrate to where-in subqueries?
         statements = ['''
             UPDATE history_dataset_collection_association
             SET update_time = :update_time
@@ -1247,7 +1249,6 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         }
         for statement in statements:
             sa_session.execute(statement, params)
-        # sa_session.flush()
 
 
 class Task(JobLike, RepresentById):
@@ -5330,9 +5331,6 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
 
         return rval
 
-    def update(self):
-        self.update_time = galaxy.model.orm.now.now()
-
     def add_input(self, content, step_id=None, step=None):
         assert step_id is not None or step is not None
 
@@ -5406,9 +5404,6 @@ class WorkflowInvocationStep(Dictifiable, RepresentById):
         # CANCELLED='cancelled',  TODO: implement and expose
         # FAILED='failed',  TODO: implement and expose
     )
-
-    def update(self):
-        self.workflow_invocation.update()
 
     @property
     def is_new(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1151,7 +1151,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             return dataset_assoc.dataset.tool_version
 
     def update_output_states(self):
-        sql = '''
+        statements = ['''
             UPDATE history_dataset_collection_association
             SET update_time = :update_time
             WHERE id in (
@@ -1167,7 +1167,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
                 FROM history_dataset_collection_association hdca2
                 WHERE hdca2.job_id = :job_id
             );
-
+        ''', '''
             UPDATE dataset
             SET
                 state = :state,
@@ -1177,7 +1177,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
                 INNER JOIN job_to_output_dataset jtod
                 ON jtod.dataset_id = hda.id AND jtod.job_id = :job_id
             );
-
+        ''', '''
             UPDATE dataset
             SET
                 state = :state,
@@ -1187,7 +1187,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
                 INNER JOIN job_to_output_library_dataset jtold
                 ON jtold.ldda_id = ldda.id AND jtold.job_id = :job_id
             );
-
+        ''', '''
             UPDATE history_dataset_association
             SET
                 info = :info,
@@ -1197,7 +1197,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
                 FROM job_to_output_dataset jtod
                 WHERE jtod.job_id = :job_id
             );
-
+        ''', '''
             UPDATE library_dataset_dataset_association
             SET
                 info = :info,
@@ -1207,7 +1207,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
                 FROM job_to_output_library_dataset jtold
                 WHERE jtold.job_id = :job_id
             );
-        '''
+        ''']
         sa_session = object_session(self)
         params = {
             'job_id': self.id,
@@ -1215,7 +1215,8 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             'info': self.info,
             'update_time': galaxy.model.orm.now.now()
         }
-        sa_session.execute(sql, params)
+        for statement in statements:
+            sa_session.execute(statement, params)
         # sa_session.flush()
 
 

--- a/test/unit/test_galaxy_mapping.py
+++ b/test/unit/test_galaxy_mapping.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import time
 import unittest
 import uuid
 
@@ -544,15 +543,6 @@ class MappingTests(unittest.TestCase):
         assert isinstance(subworkflow_invocation_assoc.parent_workflow_invocation, model.WorkflowInvocation)
 
         assert subworkflow_invocation_assoc.subworkflow_invocation.history.id == history_id
-
-        u1 = loaded_invocation.update_time
-        time.sleep(1)
-        loaded_invocation.steps[0].update()
-        self.expunge()
-        loaded_invocation = self.query(model.WorkflowInvocation).get(workflow_invocation.id)
-        u2 = loaded_invocation.update_time
-
-        assert u1 != u2
 
     def new_hda(self, history, **kwds):
         return history.add_dataset(self.model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds))


### PR DESCRIPTION
This brings in the state update optimization from #9571 - I prefer this to the trigger approach in #9515 in part because the trigger as implemented was broken (there was a syntax error and if it did work it would always update the info fields for instance - though they should not be copied over at the end of the job for instance when they've been set to other values elsewhere). I extended that approach to also be used when ``job.set_final_state`` is called and replaced our call that WorkflowInvocationStep update times with this lower-level SQL approach. 

All of that was largely just to be able to also bring in a change that updates HDCA update_time at the same time these other operations are being executed for #9591 and the new frontend history component.

I can't really show any speed up by doing all of this (#9691 was a much bigger effect - but relatively narrow and doesn't help line up things to alleviate my concerns around #7791). I think there is a small slowdown if anything as a result of all this in parallel. I hit some slow query updates and large spikes in times when testing that has me nervous but nothing consistent or blocking. So I'm not super comfortable with this... but I don't really feel comfortable slowing down anything based on my concerns without evidence and I did remember that we are essentially doing the same problematic synchronized writes around ``WorkflowInvocationStep`` just like HDCAs. So we're not introducing a new order of magnitude problem here. We are just doing it twice.

Perhaps problems around implementing that step update - including this hack - https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/__init__.py#L1744 are part of my concern with doing this for HDCAs also. Clearly we needed to do something hacky to get that working in the distance past and avoid difficult to debug/track lockups and I didn't understand why 😅.

There are a number of things we can do from this point to get back small amounts of the lost time and optimize things toward more efficient job state changes (for #7791). We can update the update time in the job source objects (for HDCAs and datasets for HDAs) since we join against those in the queries anyway - so why not speed up the writes and eliminate the extra join at that time. I outlined this a bit in https://github.com/galaxyproject/galaxy/pull/9591#issuecomment-620805706. Likewise, we should probably normalize dataset state and info so the jobs info is just used instead of copied around the database. Another important thing we can do is make the update of WorkflowInvocationStep and HDCA update time async with a MQ - get it out of the main job update loop - and throttle the updates for a given object, but that depends on infrastructure not yet ready.


