### PR TITLE
[20.05] Fix workflow steps import feature in workflow editor

### DIFF
--- a/client/galaxy/scripts/components/Workflow/Editor/services.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/services.js
@@ -33,12 +33,11 @@ export async function getModule(request_data) {
     }
 }
 
-export async function loadWorkflow(workflow, id, version) {
+export async function loadWorkflow(workflow, id, version, initialImport = true) {
     try {
         const versionQuery = version ? `version=${version}` : "";
         const { data } = await axios.get(`${getAppRoot()}workflow/load_workflow?_=true&id=${id}&${versionQuery}`);
-        workflow.remove_all();
-        workflow.from_simple(data, true);
+        workflow.from_simple(data, initialImport);
         workflow.has_changes = false;
         workflow.fit_canvas_to_nodes();
         workflow.scroll_to_nodes();

--- a/client/galaxy/scripts/components/Workflow/Editor/utilities.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/utilities.js
@@ -12,8 +12,7 @@ export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
     const _copy_into_workflow_ajax = () => {
         // Load workflow definition
         show_message("Importing workflow", "progress");
-        loadWorkflow(workflow, id, null).then((data) => {
-            workflow.from_simple(data, false);
+        loadWorkflow(workflow, id, null, false).then((data) => {
             // Determine if any parameters were 'upgraded' and provide message
             var upgrade_message = "";
             $.each(data.upgrade_messages, (k, v) => {

--- a/client/galaxy/scripts/mvc/workflow/workflow-manager.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-manager.js
@@ -323,6 +323,7 @@ class Workflow extends EventEmitter {
         var wf = this;
         var offset = 0;
         if (initialImport) {
+            wf.remove_all();
             wf.name = data.name;
         } else {
             offset = Object.keys(wf.nodes).length;


### PR DESCRIPTION
This changset ensures that imported workflow steps from other workflows do not conflict with existing nodes.

To test this:
Open the workflow editor, Insert any module, and then attempt to Insert steps from another workflow. The other workflows are listed at the at the bottom of the tool box panel on the left. Steps from other workflows can be inserted by clicking on the copy icon next to the workflow label. Currently, when inserting steps form other workflows existing steps are being removed, however they should persist and new steps should be added to the existing workflow instead. This PR fixes this issue.