### PR TITLE
[20.01] Force container image names to lower case to satisfy Docker

### DIFF
--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -166,7 +166,8 @@ class ContainerDescription(object):
         resolve_dependencies=DEFAULT_CONTAINER_RESOLVE_DEPENDENCIES,
         shell=DEFAULT_CONTAINER_SHELL,
     ):
-        self.identifier = identifier
+        # Force to lowercase because container image names must be lowercase
+        self.identifier = identifier.lower() if identifier else None
         self.type = type
         self.resolve_dependencies = resolve_dependencies
         self.shell = shell

--- a/test/functional/tools/mulled_example_invalid_case.xml
+++ b/test/functional/tools/mulled_example_invalid_case.xml
@@ -1,0 +1,24 @@
+<!-- Containers with upper case names should be coerced to lower case as docker/singularity
+     do not accept mixed case image names -->
+<tool id="mulled_example_invalid_case" name="mulled_example_invalid_case" version="0.1.0">
+    <requirements>
+        <requirement type="package" version="0.7.15">bwa</requirement>
+        <container type="docker">quay.io/biocontainers/BwA:0.7.15--0</container>
+    </requirements>
+    <stdio>
+        <exit_code range="2:" />
+    </stdio>
+    <command><![CDATA[
+        bwa > $output_1 2>&1
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+      <data name="output_1" />
+    </outputs>
+    <help><![CDATA[
+        TODO: Fill in help.
+    ]]></help>
+    <tests>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -202,6 +202,7 @@
   <tool file="mulled_example_conflict.xml" />
   <tool file="mulled_example_simple.xml" />
   <tool file="mulled_example_explicit.xml" />
+  <tool file="mulled_example_invalid_case.xml" />
   <tool file="mulled_example_broken_no_requirements.xml" />
 
   <tool file="simple_constructs.yml" />

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -30,6 +30,12 @@ class MulledJobTestCases(object):
         output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
         assert "0.7.15-r1140" in output
 
+    def test_mulled_explicit_invalid_case(self):
+        self.dataset_populator.run_tool("mulled_example_invalid_case", {}, self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id, assert_ok=True)
+        output = self.dataset_populator.get_history_dataset_content(self.history_id, timeout=EXTENDED_TIMEOUT)
+        assert "0.7.15-r1140" in output
+
 
 class ContainerizedIntegrationTestCase(integration_util.IntegrationTestCase):
 


### PR DESCRIPTION
This is to prevent:
```
InvalidImageName: Failed to apply default image tag "quay.io/biocontainers/Mimodd:0.1.9--py36_0": couldn't parse image reference "quay.io/biocontainers/MiModD:0.1.9--py36_0": invalid reference format: repository name must be lowercase
```
as Docker does not allow mixed case image names.