### PR TITLE
[20.01] Allow anonymous downloading of public workflows

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -33,6 +33,7 @@ from galaxy.web import (
     expose_api,
     expose_api_anonymous_and_sessionless,
     expose_api_raw,
+    expose_api_raw_anonymous_and_sessionless,
     format_return_as_json,
 )
 from galaxy.webapps.base.controller import (
@@ -441,7 +442,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         invocation_response.update(rval)
         return invocation_response
 
-    @expose_api_raw
+    @expose_api_raw_anonymous_and_sessionless
     def workflow_dict(self, trans, workflow_id, **kwd):
         """
         GET /api/workflows/{encoded_workflow_id}/download

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -273,7 +273,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
         self._assert_status_code_is(show_response, 400)
 
     def test_cannot_show_private_workflow(self):
-        workflow_id = self.workflow_populator.simple_workflow("test_not_importportable")
+        workflow_id = self.workflow_populator.simple_workflow("test_not_importable")
         with self._different_user():
             show_response = self._get("workflows/%s" % workflow_id)
             self._assert_status_code_is(show_response, 403)
@@ -283,7 +283,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
             assert get(workflows_url).status_code == 403
 
     def test_cannot_download_private_workflow(self):
-        workflow_id = self.workflow_populator.simple_workflow("test_not_importportable")
+        workflow_id = self.workflow_populator.simple_workflow("test_not_downloadable")
         with self._different_user():
             with pytest.raises(AssertionError) as excinfo:
                 self._download_workflow(workflow_id)
@@ -292,7 +292,7 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
         assert get(workflows_url).status_code == 403
 
     def test_anon_can_download_public_workflow(self):
-        workflow_id = self.workflow_populator.simple_workflow("test_not_importportable", publish=True)
+        workflow_id = self.workflow_populator.simple_workflow("test_downloadable", publish=True)
         workflows_url = self._api_url("workflows/%s/download" % workflow_id)
         response = get(workflows_url)
         response.raise_for_status()

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -5,6 +5,7 @@ import time
 from json import dumps
 from uuid import uuid4
 
+import pytest
 from requests import delete, get, put
 
 from galaxy.exceptions import error_codes
@@ -280,6 +281,22 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase):
             # Try as anonymous user
             workflows_url = self._api_url("workflows/%s" % workflow_id)
             assert get(workflows_url).status_code == 403
+
+    def test_cannot_download_private_workflow(self):
+        workflow_id = self.workflow_populator.simple_workflow("test_not_importportable")
+        with self._different_user():
+            with pytest.raises(AssertionError) as excinfo:
+                self._download_workflow(workflow_id)
+            assert '403' in str(excinfo.value)
+        workflows_url = self._api_url("workflows/%s/download" % workflow_id)
+        assert get(workflows_url).status_code == 403
+
+    def test_anon_can_download_public_workflow(self):
+        workflow_id = self.workflow_populator.simple_workflow("test_not_importportable", publish=True)
+        workflows_url = self._api_url("workflows/%s/download" % workflow_id)
+        response = get(workflows_url)
+        response.raise_for_status()
+        assert response.json()['a_galaxy_workflow'] == 'true'
 
     def test_delete(self):
         workflow_id = self.workflow_populator.simple_workflow("test_delete")


### PR DESCRIPTION
This allows downloading public workflows without API key.
We already allow this in the workflow controller, and permissions are checked in the `get_stored_accessible_workflow` method in the WorkflowsManager class.