### PR TITLE
[20.01] Make watcher more resilient to missing files

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -462,16 +462,22 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 return None
             # there is no job responding to this job_id, it is either lost or something happened.
             log.error("No Jobs are available under expected selector app=%s", job_state.job_id)
-            with open(job_state.error_file, 'w') as error_file:
-                error_file.write("No Kubernetes Jobs are available under expected selector app=%s\n" % job_state.job_id)
-            self.mark_as_failed(job_state)
+            try:
+                with open(job_state.error_file, 'w') as error_file:
+                    error_file.write("No Kubernetes Jobs are available under expected selector app=%s\n" % job_state.job_id)
+                self.mark_as_failed(job_state)
+            except FileNotFoundError:
+                log.error("Job directory already cleaned up. Assuming already handled for selector app=%s", job_state.job_id)
             return job_state
         else:
             # there is more than one job associated to the expected unique job id used as selector.
             log.error("More than one Kubernetes Job associated to job id '%s'", job_state.job_id)
-            with open(job_state.error_file, 'w') as error_file:
-                error_file.write("More than one Kubernetes Job associated with job id '%s'\n" % job_state.job_id)
-            self.mark_as_failed(job_state)
+            try:
+                with open(job_state.error_file, 'w') as error_file:
+                    error_file.write("More than one Kubernetes Job associated with job id '%s'\n" % job_state.job_id)
+                self.mark_as_failed(job_state)
+            except FileNotFoundError:
+                log.error("Job directory already cleaned up. Assuming already handled for selector app=%s", job_state.job_id)
             return job_state
 
     def _handle_job_failure(self, job, job_state):

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -466,7 +466,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 with open(job_state.error_file, 'w') as error_file:
                     error_file.write("No Kubernetes Jobs are available under expected selector app=%s\n" % job_state.job_id)
                 self.mark_as_failed(job_state)
-            except FileNotFoundError:
+            except IOError:
                 log.error("Job directory already cleaned up. Assuming already handled for selector app=%s", job_state.job_id)
             return job_state
         else:
@@ -476,7 +476,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 with open(job_state.error_file, 'w') as error_file:
                     error_file.write("More than one Kubernetes Job associated with job id '%s'\n" % job_state.job_id)
                 self.mark_as_failed(job_state)
-            except FileNotFoundError:
+            except IOError:
                 log.error("Job directory already cleaned up. Assuming already handled for selector app=%s", job_state.job_id)
             return job_state
 


### PR DESCRIPTION
This is to solve:
```
FileNotFoundError: [Errno 2] No such file or directory: '/galaxy/server/database/jobs_directory/000/148/galaxy_148.e'
urllib3.connectionpool DEBUG 2020-05-07 12:26:50,738 https://10.43.0.1:443 "GET /apis/batch/v1/namespaces/initial/jobs?labelSelector=app%3Dgalaxy-galaxy-1588845970-148 HTTP/1.1" 200 145
galaxy.jobs.runners.kubernetes ERROR 2020-05-07 12:26:50,745 No Jobs are available under expected selector app=galaxy-galaxy-1588845970-148
galaxy.jobs.runners ERROR 2020-05-07 12:26:50,746 Unhandled exception checking active jobs
Traceback (most recent call last):
File "/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 708, in monitor
self.check_watched_items()
File "/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 735, in check_watched_items
new_async_job_state = self.check_watched_item(async_job_state)
File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 469, in check_watched_item
with open(job_state.error_file, 'w') as error_file:
FileNotFoundError: [Errno 2] No such file or directory: '/galaxy/server/database/jobs_directory/000/148/galaxy_148.e'
```