### PR TITLE
[20.05] Sort Workflow list by last updated time instead of created time

### DIFF
--- a/client/galaxy/scripts/components/Workflow/WorkflowList.vue
+++ b/client/galaxy/scripts/components/Workflow/WorkflowList.vue
@@ -57,7 +57,7 @@
                     <template v-slot:cell(bookmark)="row">
                         <b-form-checkbox v-model="row.item.show_in_tool_panel" @change="bookmarkWorkflow(row.item)" />
                     </template>
-                    <template v-slot:cell(create_time)="data">
+                    <template v-slot:cell(update_time)="data">
                         <UtcDate :date="data.value" mode="elapsed" />
                     </template>
                     <template v-slot:cell(execute)="row">
@@ -117,8 +117,8 @@ export default {
                     sortable: true,
                 },
                 {
-                    label: "Created",
-                    key: "create_time",
+                    label: "Updated",
+                    key: "update_time",
                     sortable: true,
                 },
                 {

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4498,8 +4498,8 @@ class UCI(object):
 
 class StoredWorkflow(HasTags, Dictifiable, RepresentById):
 
-    dict_collection_visible_keys = ['id', 'name', 'create_time', 'published', 'deleted']
-    dict_element_visible_keys = ['id', 'name', 'create_time', 'published', 'deleted']
+    dict_collection_visible_keys = ['id', 'name', 'create_time', 'update_time', 'published', 'deleted']
+    dict_element_visible_keys = ['id', 'name', 'create_time', 'update_time', 'published', 'deleted']
 
     def __init__(self):
         self.id = None
@@ -4507,6 +4507,7 @@ class StoredWorkflow(HasTags, Dictifiable, RepresentById):
         self.name = None
         self.slug = None
         self.create_time = None
+        self.update_time = None
         self.published = False
         self.latest_workflow_id = None
         self.workflows = []


### PR DESCRIPTION
The workflow list contains a column which for a given workflow, displays the time passed since the workflow was created. This PR replaces this value and displays the time passed since a workflow was updated instead.