### PR TITLE
linkify Data Libraries description and bugfix

### DIFF
--- a/client/galaxy/scripts/mvc/library/library-librarylist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-librarylist-view.js
@@ -5,6 +5,9 @@ import { getGalaxyInstance } from "app";
 import { Toast } from "ui/toast";
 import mod_library_model from "mvc/library/library-model";
 import mod_library_libraryrow_view from "mvc/library/library-libraryrow-view";
+import linkifyJq from 'linkifyjs/jquery';
+
+linkifyJq($, document);
 
 var LibraryListView = Backbone.View.extend({
     el: "#libraries_element",
@@ -129,8 +132,13 @@ var LibraryListView = Backbone.View.extend({
             );
             Galaxy.libraries.libraryToolbarView.renderPaginator(this.options);
         }
-        $('#center [data-toggle="tooltip"]').tooltip({ trigger: "hover" });
-        $("#center").css("overflow", "auto");
+        const $center_tooltip_el = $('#center [data-toggle="tooltip"]');
+        if (!$center_tooltip_el.attr('title')) {
+            $center_tooltip_el.tooltip({trigger: "hover"});
+            $("#center").css("overflow", "auto");
+        }
+        // linkify description
+        $('[description=true]').linkify();
     },
 
     fetchDeleted: function () {

--- a/client/galaxy/scripts/mvc/library/library-librarylist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-librarylist-view.js
@@ -5,9 +5,7 @@ import { getGalaxyInstance } from "app";
 import { Toast } from "ui/toast";
 import mod_library_model from "mvc/library/library-model";
 import mod_library_libraryrow_view from "mvc/library/library-libraryrow-view";
-import linkifyJq from "linkifyjs/jquery";
-
-linkifyJq($, document);
+import mod_util from "mvc/library/library-util";
 
 var LibraryListView = Backbone.View.extend({
     el: "#libraries_element",
@@ -137,8 +135,8 @@ var LibraryListView = Backbone.View.extend({
             $center_tooltip_el.tooltip({ trigger: "hover" });
             $("#center").css("overflow", "auto");
         }
-        // linkify description
-        $("[description=true]").linkify();
+
+        mod_util.linkifyHtmlElements("[description=true]");
     },
 
     fetchDeleted: function () {

--- a/client/galaxy/scripts/mvc/library/library-librarylist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-librarylist-view.js
@@ -5,7 +5,7 @@ import { getGalaxyInstance } from "app";
 import { Toast } from "ui/toast";
 import mod_library_model from "mvc/library/library-model";
 import mod_library_libraryrow_view from "mvc/library/library-libraryrow-view";
-import linkifyJq from 'linkifyjs/jquery';
+import linkifyJq from "linkifyjs/jquery";
 
 linkifyJq($, document);
 
@@ -133,12 +133,12 @@ var LibraryListView = Backbone.View.extend({
             Galaxy.libraries.libraryToolbarView.renderPaginator(this.options);
         }
         const $center_tooltip_el = $('#center [data-toggle="tooltip"]');
-        if (!$center_tooltip_el.attr('title')) {
-            $center_tooltip_el.tooltip({trigger: "hover"});
+        if (!$center_tooltip_el.attr("title")) {
+            $center_tooltip_el.tooltip({ trigger: "hover" });
             $("#center").css("overflow", "auto");
         }
         // linkify description
-        $('[description=true]').linkify();
+        $("[description=true]").linkify();
     },
 
     fetchDeleted: function () {

--- a/client/galaxy/scripts/mvc/library/library-librarylist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-librarylist-view.js
@@ -5,7 +5,7 @@ import { getGalaxyInstance } from "app";
 import { Toast } from "ui/toast";
 import mod_library_model from "mvc/library/library-model";
 import mod_library_libraryrow_view from "mvc/library/library-libraryrow-view";
-import mod_util from "mvc/library/library-util";
+import { linkifyHtmlElements } from "mvc/library/library-util";
 
 var LibraryListView = Backbone.View.extend({
     el: "#libraries_element",
@@ -136,7 +136,7 @@ var LibraryListView = Backbone.View.extend({
             $("#center").css("overflow", "auto");
         }
 
-        mod_util.linkifyHtmlElements("[description=true]");
+        linkifyHtmlElements("[description=true]");
     },
 
     fetchDeleted: function () {

--- a/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
@@ -65,7 +65,7 @@ var LibraryRowView = Backbone.View.extend({
         this.$el.find('[data-toggle="tooltip"]').tooltip({ trigger: "hover" });
 
         // linkify new description, after its change
-        mod_util.linkifyHtmlElements("[description=true]");
+        mod_util.linkifyHtmlElements("[data-linkify=true]");
     },
 
     /**
@@ -248,12 +248,12 @@ var LibraryRowView = Backbone.View.extend({
                     <% } %>
                     <% if(library.get("description")) { %>
                         <% if( (library.get("description")).length> 40 ) { %>
-                            <td description=true data-toggle="tooltip" data-placement="bottom"
+                            <td data-linkify=true data-toggle="tooltip" data-placement="bottom"
                                 title="<%= _.escape(library.get("description")) %>">
                                 <%= _.escape(library.get("description")).substring(0, 40) + "..." %>
                             </td>
                         <% } else { %>
-                            <td description=true><%= _.escape(library.get("description"))%></td>
+                            <td data-linkify=true><%= _.escape(library.get("description"))%></td>
                         <% } %>
                     <% } else { %>
                         <td></td>

--- a/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
@@ -4,6 +4,7 @@ import Backbone from "backbone";
 import { Toast } from "ui/toast";
 import { getGalaxyInstance } from "app";
 
+
 // galaxy library row view
 var LibraryRowView = Backbone.View.extend({
     events: {
@@ -38,6 +39,7 @@ var LibraryRowView = Backbone.View.extend({
         }
         this.prepareButtons(library);
         var tmpl = this.templateRow();
+
         this.setElement(
             tmpl({
                 library: library,
@@ -46,6 +48,7 @@ var LibraryRowView = Backbone.View.extend({
             })
         );
         this.$el.show();
+
         return this;
     },
 
@@ -62,6 +65,9 @@ var LibraryRowView = Backbone.View.extend({
         old_element.replaceWith(this.$el);
         /* now we attach new tooltips to the newly created row element */
         this.$el.find('[data-toggle="tooltip"]').tooltip({ trigger: "hover" });
+
+        // linkify new description, after its change
+        $('[description=true]').linkify();
     },
 
     /**
@@ -244,12 +250,12 @@ var LibraryRowView = Backbone.View.extend({
                     <% } %>
                     <% if(library.get("description")) { %>
                         <% if( (library.get("description")).length> 40 ) { %>
-                            <td data-toggle="tooltip" data-placement="bottom"
+                            <td description=true data-toggle="tooltip" data-placement="bottom"
                                 title="<%= _.escape(library.get("description")) %>">
                                 <%= _.escape(library.get("description")).substring(0, 40) + "..." %>
                             </td>
                         <% } else { %>
-                            <td><%= _.escape(library.get("description"))%></td>
+                            <td description=true><%= _.escape(library.get("description"))%></td>
                         <% } %>
                     <% } else { %>
                         <td></td>

--- a/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { Toast } from "ui/toast";
 import { getGalaxyInstance } from "app";
+import mod_util from "mvc/library/library-util";
 
 // galaxy library row view
 var LibraryRowView = Backbone.View.extend({
@@ -38,7 +39,6 @@ var LibraryRowView = Backbone.View.extend({
         }
         this.prepareButtons(library);
         var tmpl = this.templateRow();
-
         this.setElement(
             tmpl({
                 library: library,
@@ -47,7 +47,6 @@ var LibraryRowView = Backbone.View.extend({
             })
         );
         this.$el.show();
-
         return this;
     },
 
@@ -66,7 +65,7 @@ var LibraryRowView = Backbone.View.extend({
         this.$el.find('[data-toggle="tooltip"]').tooltip({ trigger: "hover" });
 
         // linkify new description, after its change
-        $("[description=true]").linkify();
+        mod_util.linkifyHtmlElements("[description=true]");
     },
 
     /**

--- a/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
@@ -4,7 +4,6 @@ import Backbone from "backbone";
 import { Toast } from "ui/toast";
 import { getGalaxyInstance } from "app";
 
-
 // galaxy library row view
 var LibraryRowView = Backbone.View.extend({
     events: {
@@ -67,7 +66,7 @@ var LibraryRowView = Backbone.View.extend({
         this.$el.find('[data-toggle="tooltip"]').tooltip({ trigger: "hover" });
 
         // linkify new description, after its change
-        $('[description=true]').linkify();
+        $("[description=true]").linkify();
     },
 
     /**

--- a/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
+++ b/client/galaxy/scripts/mvc/library/library-libraryrow-view.js
@@ -3,7 +3,7 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { Toast } from "ui/toast";
 import { getGalaxyInstance } from "app";
-import mod_util from "mvc/library/library-util";
+import { linkifyHtmlElements } from "mvc/library/library-util";
 
 // galaxy library row view
 var LibraryRowView = Backbone.View.extend({
@@ -65,7 +65,7 @@ var LibraryRowView = Backbone.View.extend({
         this.$el.find('[data-toggle="tooltip"]').tooltip({ trigger: "hover" });
 
         // linkify new description, after its change
-        mod_util.linkifyHtmlElements("[data-linkify=true]");
+        linkifyHtmlElements("[data-linkify=true]");
     },
 
     /**

--- a/client/galaxy/scripts/mvc/library/library-util.js
+++ b/client/galaxy/scripts/mvc/library/library-util.js
@@ -37,13 +37,13 @@ var generateComparator = (sort_key, sort_order) => (itemA, itemB) => {
 /**
  * Linkify Html elements matching the given selector
  */
-const linkifyHtmlElements = (selector) => {
+export function linkifyHtmlElements(selector) {
     const selectedElements = document.querySelectorAll(selector);
 
     selectedElements.forEach((element) => {
         element.innerHTML = linkify(element.innerHTML);
     });
-};
+}
 
 export default {
     generateComparator: generateComparator,

--- a/client/galaxy/scripts/mvc/library/library-util.js
+++ b/client/galaxy/scripts/mvc/library/library-util.js
@@ -35,13 +35,13 @@ var generateComparator = (sort_key, sort_order) => (itemA, itemB) => {
 };
 
 /**
- * Linkify Html Elements, that can be found with given selector
+ * Linkify Html elements matching the given selector
  */
-var linkifyHtmlElements = (selector) => {
-    var element = document.querySelectorAll(selector);
+const linkifyHtmlElements = (selector) => {
+    const selectedElements = document.querySelectorAll(selector);
 
-    element.forEach((description) => {
-        description.innerHTML = linkify(description.innerHTML);
+    selectedElements.forEach((element) => {
+        element.innerHTML = linkify(element.innerHTML);
     });
 };
 

--- a/client/galaxy/scripts/mvc/library/library-util.js
+++ b/client/galaxy/scripts/mvc/library/library-util.js
@@ -1,3 +1,4 @@
+import linkify from "linkifyjs/html";
 /**
  * Create alphabetical based two-argument comparator to handle library items (including folders)
  * If sort_key is not present it is set to ''.
@@ -32,6 +33,19 @@ var generateComparator = (sort_key, sort_order) => (itemA, itemB) => {
 
     return 0; // equal
 };
+
+/**
+ * Linkify Html Elements, that can be found with given selector
+ */
+var linkifyHtmlElements = (selector) => {
+    var element = document.querySelectorAll(selector);
+
+    element.forEach((description) => {
+        description.innerHTML = linkify(description.innerHTML);
+    });
+};
+
 export default {
     generateComparator: generateComparator,
+    linkifyHtmlElements: linkifyHtmlElements,
 };

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "jquery.cookie": "^1.4.1",
     "latex-parser": "^0.6.2",
     "latex-to-unicode-converter": "^0.5.2",
+    "linkifyjs": "^2.1.9",
     "markdown-it": "^8.4.2",
     "moment": "2.24.0",
     "popper.js": "^1.16.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8341,6 +8341,11 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
+linkifyjs@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-2.1.9.tgz#af06e45a2866ff06c4766582590d098a4d584702"
+  integrity sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==
+
 listify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/listify/-/listify-1.0.0.tgz#03ca7ba2d150d4267773f74e57558d1053d2bee3"


### PR DESCRIPTION
This PR will linkify elements in Library description. It will create an ```<a>``` element, that will open link a new tab on click
![image](https://user-images.githubusercontent.com/15801412/81437034-c53ea780-916a-11ea-8765-cb6bb7ea68d6.png)

Additionally, don't run ```$('#center [data-toggle="tooltip"]').tooltip({trigger: "hover"}```, if title is there. I guess, we don't really need an additional title on hover. I assume it was the reason, that caused tooltip glitch. 