### PR TITLE
Defer evaluation of (dynamic) destinations to allow multiple resubmissions

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -350,6 +350,7 @@ class JobHandlerQueue(Monitors):
         try:
             config_job_destination = self.app.job_config.get_destination(job.destination_id)
             job_destination.resubmit = config_job_destination.resubmit
+            job_destination.env = config_job_destination.env
         except KeyError:
             log.debug(
                 "(%s) Recovered destination id (%s) does not exist in job config (but this may be normal in the case of a dynamically generated destination)",

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -356,7 +356,7 @@ class JobHandlerQueue(Monitors):
                 job.id,
                 job.destination_id,
             )
-        job_wrapper.job_runner_mapper.cached_job_destination = job_destination
+        job_wrapper.job_runner_mapper.cache_job_destination(job_destination)
         return job_wrapper
 
     def __monitor(self):

--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -114,8 +114,6 @@ def _handle_resubmit_definitions(resubmit_definitions, app, job_runner, job_stat
         else:
             new_destination = job_state.job_destination
 
-        # Resolve dynamic if necessary
-        new_destination = job_state.job_wrapper.job_runner_mapper.cache_job_destination(new_destination)
         # Reset job state
         job_state.job_wrapper.clear_working_directory()
         job_state.job_wrapper.invalidate_external_metadata()
@@ -126,9 +124,6 @@ def _handle_resubmit_definitions(resubmit_definitions, app, job_runner, job_stat
             job_runner.sa_session.add(job)
             # Is this safe to do here?
             job_runner.sa_session.flush()
-        # Cache the destination to prevent rerunning dynamic after
-        # resubmit
-        job_state.job_wrapper.job_runner_mapper.cached_job_destination = new_destination
         # Handle delaying before resubmission if needed.
         raw_delay = resubmit.get("delay")
         if raw_delay:

--- a/test/functional/tools/exit_code_from_env.xml
+++ b/test/functional/tools/exit_code_from_env.xml
@@ -2,7 +2,7 @@
     <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
 echo 'Hello' > '$out_file1' &&
-: \${GX_TARGET_EXIT_CODE:-0} &&
+: \${GX_TARGET_EXIT_CODE:=0} &&
 exit \${GX_TARGET_EXIT_CODE}
     ]]></command>
     <inputs>

--- a/test/functional/tools/exit_code_from_env_default_fail.xml
+++ b/test/functional/tools/exit_code_from_env_default_fail.xml
@@ -1,0 +1,22 @@
+<tool id="exit_code_from_env_default_fail" name="exit_code_from_env_default_fail" version="1.0.0">
+    <!-- tool fails except if env variable GX_TARGET_EXIT_CODE is set
+         e.g. in job destination  -->
+    <command detect_errors="exit_code"><![CDATA[
+echo 'Hello' > '$out_file1' &&
+: \${GX_TARGET_EXIT_CODE:=2} &&
+exit \${GX_TARGET_EXIT_CODE}
+    ]]></command>
+    <inputs>
+        <param name="input" type="integer" label="Dummy" value="6" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_failure="true" expect_exit_code="2">
+            <param name="input" value="5" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -95,6 +95,7 @@
   <tool file="exit_code_oom.xml" />
   <tool file="exit_code_from_file.xml" />
   <tool file="exit_code_from_env.xml" />
+  <tool file="exit_code_from_env_default_fail.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="options_from_metadata_file.xml" />
   <tool file="output_order.xml" />

--- a/test/integration/resubmission_dynamic_multiple_job_conf.xml
+++ b/test/integration/resubmission_dynamic_multiple_job_conf.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!-- 
+    Slimmed down resubmission_job_conf.xml for testing resubmission created from
+    dynamic destination.
+-->
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="1"/>
+        <plugin id="failure_runner" type="runner" load="integration.resubmission_runners:FailsJobRunner" workers="1">
+        </plugin>
+        <plugin id="dynamic" type="runner">
+            <param id="rules_module">integration.resubmission_rules</param>
+        </plugin>
+    </plugins>
+
+    <destinations default="initial_destination">
+        <destination id="initial_destination" runner="dynamic">
+            <param id="type">python</param>
+            <param id="function">dynamic_resubmit_initial</param>
+        </destination>
+        <destination id="secondary_destination" runner="dynamic">
+            <param id="type">python</param>
+            <param id="function">dynamic_resubmit_secondary</param>
+        </destination>
+        <destination id="tertiary_destination" runner="dynamic">
+            <param id="type">python</param>
+            <param id="function">dynamic_resubmit_tertiary</param>
+        </destination>
+
+        <!-- Upload destination. -->
+        <destination id="local" runner="local">
+        </destination>
+
+    </destinations>
+
+    <tools>
+        <tool class="local" destination="local" />
+    </tools>
+
+</job_conf>

--- a/test/integration/resubmission_rules/rules.py
+++ b/test/integration/resubmission_rules/rules.py
@@ -20,3 +20,48 @@ def dynamic_resubmit_once(resource_params):
         )
     ]
     return job_destination
+
+
+def dynamic_resubmit_initial(resource_params):
+    job_destination = JobDestination()
+    job_destination["id"] = "initial_destination"
+    # Always fail on the first attempt.
+    job_destination["runner"] = "failure_runner"
+    # Resubmit to a valid environment.
+    job_destination["resubmit"] = [
+        dict(
+            condition="any_failure",
+            destination="secondary_destination",
+        )
+    ]
+    return job_destination
+
+
+def dynamic_resubmit_secondary(resource_params):
+    job_destination = JobDestination()
+    job_destination["id"] = "secondary_destination"
+    # Always fail on the first attempt.
+    job_destination["runner"] = "failure_runner"
+    # Resubmit to a valid environment.
+    job_destination["resubmit"] = [
+        dict(
+            condition="any_failure",
+            destination="tertiary_destination",
+        )
+    ]
+    return job_destination
+
+
+def dynamic_resubmit_tertiary(resource_params):
+    job_destination = JobDestination()
+    # Always fail on the first attempt.
+    job_destination["id"] = "tertiary_destination"
+    job_destination["runner"] = "failure_runner"
+    # Resubmit to a valid environment.
+    job_destination["resubmit"] = [
+        dict(
+            condition="any_failure",
+            environment="local",
+        )
+    ]
+    return job_destination

--- a/test/integration/resubmission_tool_detected_resubmit_twice_job_conf.xml
+++ b/test/integration/resubmission_tool_detected_resubmit_twice_job_conf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
+    </plugins>
+
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+
+    <destinations default="local_resubmit">
+        <destination id="local_resubmit" runner="local">
+            <env id="GX_TARGET_EXIT_CODE">4</env>
+            <resubmit condition="tool_detected_failure" destination="local_not_yet_good" />
+        </destination>
+
+        <destination id="local_not_yet_good" runner="local">
+            <env id="GX_TARGET_EXIT_CODE">4</env>
+            <resubmit condition="tool_detected_failure" destination="local_good" />
+        </destination>
+
+        <destination id="local_good" runner="local">
+            <env id="GX_TARGET_EXIT_CODE">0</env>
+        </destination>
+    </destinations>
+
+</job_conf>

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -21,6 +21,9 @@ JOB_RESUBMISSION_TOOL_DETECTED_ALWAYS_ERROR_JOB_CONFIG_FILE = os.path.join(
 JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_JOB_CONFIG_FILE = os.path.join(
     SCRIPT_DIRECTORY, "resubmission_tool_detected_resubmit_job_conf.xml"
 )
+JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_TWICE_JOB_CONFIG_FILE = os.path.join(
+    SCRIPT_DIRECTORY, "resubmission_tool_detected_resubmit_twice_job_conf.xml"
+)
 JOB_RESUBMISSION_JOB_RESOURCES_CONFIG_FILE = os.path.join(
     SCRIPT_DIRECTORY, "resubmission_job_resource_parameters_conf.xml"
 )
@@ -250,6 +253,17 @@ class JobResubmissionToolDetectedErrorResubmitsIntegrationTestCase(_BaseResubmis
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_JOB_CONFIG_FILE
+
+    def test_dynamic_resubmission(self):
+        self._assert_job_passes(tool_id="exit_code_from_env")
+
+
+# Verify the test tool will resubmit on failure tested above and will then pass in
+# an environment without a tool indicated error.
+class JobResubmissionToolDetectedErrorResubmitsTwiceIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_TWICE_JOB_CONFIG_FILE
 
     def test_dynamic_resubmission(self):
         self._assert_job_passes(tool_id="exit_code_from_env")

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -8,6 +8,9 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 JOB_RESUBMISSION_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_conf.yml")
 JOB_RESUBMISSION_DEFAULT_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_default_job_conf.xml")
 JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_dynamic_job_conf.xml")
+JOB_RESUBMISSION_DYNAMIC_MULTIPLE_JOB_CONFIG_FILE = os.path.join(
+    SCRIPT_DIRECTORY, "resubmission_dynamic_multiple_job_conf.xml"
+)
 JOB_RESUBMISSION_SMALL_MEMORY_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_small_memory_job_conf.xml")
 JOB_RESUBMISSION_SMALL_MEMORY_RESUBMISSION_TO_LARGE_JOB_CONFIG_FILE = os.path.join(
     SCRIPT_DIRECTORY, "resubmission_small_memory_resubmission_to_large_job_conf.xml"
@@ -193,6 +196,18 @@ class JobResubmissionDynamicIntegrationTestCase(_BaseResubmissionIntegerationTes
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = JOB_RESUBMISSION_DYNAMIC_JOB_CONFIG_FILE
+
+    def test_dynamic_resubmission(self):
+        self._assert_job_passes()
+
+
+class JobResubmissionDynamicMultipleIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = JOB_RESUBMISSION_DYNAMIC_MULTIPLE_JOB_CONFIG_FILE
 
     def test_dynamic_resubmission(self):
         self._assert_job_passes()


### PR DESCRIPTION
May fix https://github.com/galaxyproject/galaxy/issues/7118

Currently resubmit definitions computed in dynamic destinations get lost because they are not persisted: https://github.com/galaxyproject/galaxy/blob/737775f586c5ab4c4cef4f486dd8826a978ed6b1/lib/galaxy/jobs/handler.py#L215

which (I guess) is a good idea because they are in most cases (static destinations) identical to the info in job_conf (so it would be redundant to store them again). Unfortunately the consequence is that dynamic destinations cant compute resubmit destinations. Or in other words they (seem) to be able to resubmit only once. 

The idea of the PR is to defer calling the calculation of the dynamic destination. Before `galaxy.jobs.runners.state_handlers.resubmit._handle_resubmit_definitions` marked the job for resubmission and and called the dynamic destinations function (but the resubmit part got lost when the job reentered the queue). 

Now the new destination is calculated (and cached) when the job reenters the queue. 

The PR survived a first test on a dev instance with a singe dynamic destination that resubmits to itself. But I guess there are side effects .... 