### PR TITLE
[20.05] extract_genomic_dna.py: import Comment, Header from bx.tabular.io instead of bx.intervals.io

### DIFF
--- a/tools/extract/extract_genomic_dna.py
+++ b/tools/extract/extract_genomic_dna.py
@@ -19,7 +19,7 @@ import tempfile
 import bx.seq.nib
 import bx.seq.twobit
 from bx.cookbook import doc_optparse
-from bx.intervals.io import Comment, Header
+from bx.tabular.io import Comment, Header
 
 from galaxy.datatypes.util import gff_util
 from galaxy.tools.util.galaxyops import parse_cols_arg


### PR DESCRIPTION
A Galaxy user in Australia noticed that 'Extract Genomic DNA' had an import error.

Looks like bx.intervals.io used to import Comment and Header from bx.tabular.io but it no longer does.