### PR TITLE
Add build artifact destination for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ database/job_working_directory
 database/jobs_directory
 database/mulled
 database/object_store_cache
+database/objects
 database/openid_consumer_cache
 database/pbs
 database/shed_tools

--- a/.gitignore
+++ b/.gitignore
@@ -179,8 +179,8 @@ packages/*/*.egg-info
 *.rej
 *~
 
-# Plugin build artifacts -- TODO make this more generic as a part of the standard plugin interface
+# standalone script + main, or build into dist.
+config/plugins/visualizations/**/static/dist
 config/plugins/visualizations/**/static/script.js
-# TODO: Really need to follow up on this and make it standard.
 config/plugins/visualizations/**/static/main.css
 config/plugins/visualizations/**/static/plugin_build_hash.txt

--- a/.gitignore
+++ b/.gitignore
@@ -21,20 +21,25 @@ lib/galaxy/web/framework/static/scripts
 lib/galaxy/web/framework/static/style
 
 # Database stuff
+database/*.sqlite
 database/beaker_sessions
 database/citations
 database/community_files
 database/compiled_templates
+database/dependencies
 database/files
-database/jobs_directory
 database/job_working_directory
+database/jobs_directory
+database/mulled
+database/object_store_cache
+database/openid_consumer_cache
 database/pbs
 database/shed_tools
 database/test_errors
 database/tmp
-database/*.sqlite
-database/openid_consumer_cache
-database/dependencies
+database/tool_cache
+database/tool_search_index
+
 
 # Python bytecode
 *.pyc

--- a/config/plugins/visualizations/chiraviz/templates/chiraviz.mako
+++ b/config/plugins/visualizations/chiraviz/templates/chiraviz.mako
@@ -1,5 +1,5 @@
 <%
-    app_root = h.url_for("/static/plugins/visualizations/chiraviz/static/")
+    app_root = h.url_for("/static/plugins/visualizations/chiraviz/static/dist/")
 %>
 
 <!DOCTYPE html>

--- a/config/plugins/visualizations/chiraviz/webpack.config.js
+++ b/config/plugins/visualizations/chiraviz/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     entry: "./src/index.js",
     output: {
         filename: "script.js",
-        path: path.resolve(__dirname, "static")
+        path: path.resolve(__dirname, "static/dist")
     },
     plugins: [
         new MiniCssExtractPlugin(),


### PR DESCRIPTION
`<plugin>/static/` is stuff that is included and available as static content.  This adds a `dist` for plugin build artifacts that is .gitignored.

Also updates a few other things I noticed that need to be in .gitignore.