### PR TITLE
[20.05] Switch to lxml for xml parsing

### DIFF
--- a/lib/galaxy/auth/util.py
+++ b/lib/galaxy/auth/util.py
@@ -1,12 +1,16 @@
 import errno
 import logging
-import xml.etree.ElementTree
 from collections import namedtuple
 
 import galaxy.auth.providers
 from galaxy.exceptions import Conflict
 from galaxy.security.validate_user_input import validate_publicname
-from galaxy.util import plugin_config, string_as_bool
+from galaxy.util import (
+    parse_xml,
+    parse_xml_string,
+    plugin_config,
+    string_as_bool,
+)
 
 
 log = logging.getLogger(__name__)
@@ -29,11 +33,11 @@ def get_authenticators(auth_config_file, auth_config_file_set):
     __plugins_dict = plugin_config.plugins_dict(galaxy.auth.providers, 'plugin_type')
     # parse XML
     try:
-        ct = xml.etree.ElementTree.parse(auth_config_file)
+        ct = parse_xml(auth_config_file)
         conf_root = ct.getroot()
     except (OSError, IOError) as exc:
         if exc.errno == errno.ENOENT and not auth_config_file_set:
-            conf_root = xml.etree.ElementTree.fromstring(AUTH_CONF_XML)
+            conf_root = parse_xml_string(AUTH_CONF_XML)
         else:
             raise
 

--- a/lib/galaxy/authnz/__init__.py
+++ b/lib/galaxy/authnz/__init__.py
@@ -24,13 +24,13 @@ class IdentityProvider(object):
         :type provider: string
         :param provider: is the name of the identity provider (e.g., Google).
 
-        :type config: xml.etree.ElementTree.Element
+        :type config: lxml.etree.ElementTree._Element
         :param config: Is the configuration element of the provider
             from the configuration file (e.g., oidc_config.xml).
             This element contains the all the provider-specific
             configuration elements.
 
-        :type backend_config: xml.etree.ElementTree.Element
+        :type backend_config: lxml.etree.ElementTree._Element
         :param backend_config: Is the configuration element of the backend of
             the provider from the configuration file (e.g.,
             oidc_backends_config.xml). This element contains all the

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -10,13 +10,13 @@ from cloudauthz import CloudAuthz
 from cloudauthz.exceptions import (
     CloudAuthzBaseException
 )
-from lxml import etree as ET
 from six.moves import builtins
 
 from galaxy import exceptions
 from galaxy import model
 from galaxy.util import (
     asbool,
+    etree,
     parse_xml,
     string_as_bool,
     unicodify,
@@ -62,7 +62,7 @@ class AuthnzManager(object):
             tree = parse_xml(config_file)
             root = tree.getroot()
             if root.tag != 'OIDC':
-                raise ET.ParseError("The root element in OIDC_Config xml file is expected to be `OIDC`, "
+                raise etree.ParseError("The root element in OIDC_Config xml file is expected to be `OIDC`, "
                                  "found `{}` instead -- unable to continue.".format(root.tag))
             for child in root:
                 if child.tag != 'Setter':
@@ -85,8 +85,8 @@ class AuthnzManager(object):
                 self.oidc_config[child.get('Property')] = func(child.get('Value'))
         except ImportError:
             raise
-        except ET.ParseError as e:
-            raise ET.ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
+        except etree.ParseError as e:
+            raise etree.ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
 
     def _get_idp_icon(self, idp):
         return self.oidc_backends_config[idp].get('icon') or DEFAULT_OIDC_IDP_ICONS.get(idp)
@@ -98,7 +98,7 @@ class AuthnzManager(object):
             tree = parse_xml(config_file)
             root = tree.getroot()
             if root.tag != 'OIDC':
-                raise ET.ParseError("The root element in OIDC config xml file is expected to be `OIDC`, "
+                raise etree.ParseError("The root element in OIDC config xml file is expected to be `OIDC`, "
                                  "found `{}` instead -- unable to continue.".format(root.tag))
             for child in root:
                 if child.tag != 'provider':
@@ -118,13 +118,13 @@ class AuthnzManager(object):
                     self.oidc_backends_implementation[idp] = 'custos'
                     self.app.config.oidc[idp] = {'icon': self._get_idp_icon(idp)}
                 else:
-                    raise ET.ParseError("Unknown provider specified")
+                    raise etree.ParseError("Unknown provider specified")
             if len(self.oidc_backends_config) == 0:
-                raise ET.ParseError("No valid provider configuration parsed.")
+                raise etree.ParseError("No valid provider configuration parsed.")
         except ImportError:
             raise
-        except ET.ParseError as e:
-            raise ET.ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
+        except etree.ParseError as e:
+            raise etree.ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
 
     def _parse_idp_config(self, config_xml):
         rtv = {

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -4,20 +4,23 @@ import logging
 import os
 import random
 import string
-import xml.etree.ElementTree as ET
-from xml.etree.ElementTree import ParseError
 
 import requests
 from cloudauthz import CloudAuthz
 from cloudauthz.exceptions import (
     CloudAuthzBaseException
 )
+from lxml import etree as ET
 from six.moves import builtins
 
 from galaxy import exceptions
 from galaxy import model
-from galaxy.util import asbool, string_as_bool
-from galaxy.util import unicodify
+from galaxy.util import (
+    asbool,
+    parse_xml,
+    string_as_bool,
+    unicodify,
+)
 from .custos_authnz import CustosAuthnz
 from .psa_authnz import (
     BACKENDS_NAME,
@@ -56,10 +59,10 @@ class AuthnzManager(object):
     def _parse_oidc_config(self, config_file):
         self.oidc_config = {}
         try:
-            tree = ET.parse(config_file)
+            tree = parse_xml(config_file)
             root = tree.getroot()
             if root.tag != 'OIDC':
-                raise ParseError("The root element in OIDC_Config xml file is expected to be `OIDC`, "
+                raise ET.ParseError("The root element in OIDC_Config xml file is expected to be `OIDC`, "
                                  "found `{}` instead -- unable to continue.".format(root.tag))
             for child in root:
                 if child.tag != 'Setter':
@@ -82,8 +85,8 @@ class AuthnzManager(object):
                 self.oidc_config[child.get('Property')] = func(child.get('Value'))
         except ImportError:
             raise
-        except ParseError as e:
-            raise ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
+        except ET.ParseError as e:
+            raise ET.ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
 
     def _get_idp_icon(self, idp):
         return self.oidc_backends_config[idp].get('icon') or DEFAULT_OIDC_IDP_ICONS.get(idp)
@@ -92,10 +95,10 @@ class AuthnzManager(object):
         self.oidc_backends_config = {}
         self.oidc_backends_implementation = {}
         try:
-            tree = ET.parse(config_file)
+            tree = parse_xml(config_file)
             root = tree.getroot()
             if root.tag != 'OIDC':
-                raise ParseError("The root element in OIDC config xml file is expected to be `OIDC`, "
+                raise ET.ParseError("The root element in OIDC config xml file is expected to be `OIDC`, "
                                  "found `{}` instead -- unable to continue.".format(root.tag))
             for child in root:
                 if child.tag != 'provider':
@@ -115,13 +118,13 @@ class AuthnzManager(object):
                     self.oidc_backends_implementation[idp] = 'custos'
                     self.app.config.oidc[idp] = {'icon': self._get_idp_icon(idp)}
                 else:
-                    raise ParseError("Unknown provider specified")
+                    raise ET.ParseError("Unknown provider specified")
             if len(self.oidc_backends_config) == 0:
-                raise ParseError("No valid provider configuration parsed.")
+                raise ET.ParseError("No valid provider configuration parsed.")
         except ImportError:
             raise
-        except ParseError as e:
-            raise ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
+        except ET.ParseError as e:
+            raise ET.ParseError("Invalid configuration at `{}`: {} -- unable to continue.".format(config_file, e))
 
     def _parse_idp_config(self, config_xml):
         rtv = {

--- a/lib/galaxy/datatypes/dataproviders/hierarchy.py
+++ b/lib/galaxy/datatypes/dataproviders/hierarchy.py
@@ -2,9 +2,10 @@
 Dataproviders that iterate over lines from their sources.
 """
 import logging
-from xml.etree.ElementTree import (
-    Element,
-    iterparse
+
+from lxml.etree import (
+    _Element,
+    iterparse,
 )
 
 from . import line
@@ -34,7 +35,7 @@ class XMLDataProvider(HierarchalDataProvider):
     """
     Data provider that converts selected XML elements to dictionaries.
     """
-    # using xml.etree's iterparse method to keep mem down
+    # using lxml.etree's iterparse method to keep mem down
     # TODO:   this, however (AFAIK), prevents the use of xpath
     settings = {
         'selector'  : 'str',  # urlencoded
@@ -68,7 +69,7 @@ class XMLDataProvider(HierarchalDataProvider):
         # TODO: fails with '#' - browser thinks it's an anchor - use urlencode
         # TODO: need removal/replacement of etree namespacing here - then move to string match
         return bool((selector is None) or
-                    (isinstance(element, Element) and selector in element.tag))
+                    (isinstance(element, _Element) and selector in element.tag))
 
     def element_as_dict(self, element):
         """

--- a/lib/galaxy/datatypes/dataproviders/hierarchy.py
+++ b/lib/galaxy/datatypes/dataproviders/hierarchy.py
@@ -3,10 +3,16 @@ Dataproviders that iterate over lines from their sources.
 """
 import logging
 
-from lxml.etree import (
-    _Element,
-    iterparse,
-)
+try:
+    from lxml.etree import (
+        _Element,
+        iterparse,
+    )
+except ImportError:
+    from xml.etree.ElementTree import (
+        Element as _Element,
+        iterparse,
+    )
 
 from . import line
 

--- a/lib/galaxy/datatypes/dataproviders/hierarchy.py
+++ b/lib/galaxy/datatypes/dataproviders/hierarchy.py
@@ -3,17 +3,7 @@ Dataproviders that iterate over lines from their sources.
 """
 import logging
 
-try:
-    from lxml.etree import (
-        _Element,
-        iterparse,
-    )
-except ImportError:
-    from xml.etree.ElementTree import (
-        Element as _Element,
-        iterparse,
-    )
-
+from galaxy.util import etree
 from . import line
 
 _TODO = """
@@ -74,8 +64,9 @@ class XMLDataProvider(HierarchalDataProvider):
         # TODO: add more flexibility here w/o re-implementing xpath
         # TODO: fails with '#' - browser thinks it's an anchor - use urlencode
         # TODO: need removal/replacement of etree namespacing here - then move to string match
+        Element = getattr(etree, '_Element', etree.Element)
         return bool((selector is None) or
-                    (isinstance(element, _Element) and selector in element.tag))
+                    (isinstance(element, Element) and selector in element.tag))
 
     def element_as_dict(self, element):
         """
@@ -110,7 +101,7 @@ class XMLDataProvider(HierarchalDataProvider):
                 yield child_data
 
     def __iter__(self):
-        context = iterparse(self.source, events=self.ITERPARSE_ALL_EVENTS)
+        context = etree.iterparse(self.source, events=self.ITERPARSE_ALL_EVENTS)
         context = iter(context)
 
         selected_element = None

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -8,9 +8,9 @@ import logging
 import os
 from collections import OrderedDict
 from string import Template
-from xml.etree.ElementTree import Element
 
 import yaml
+from lxml.etree import _Element
 
 import galaxy.util
 from galaxy.util import RW_R__R__
@@ -108,7 +108,7 @@ class Registry(object):
             #           type="galaxy.datatypes.blast:BlastXml" />
             compressed_sniffers = {}
             handling_proprietary_datatypes = False
-            if not isinstance(config, Element):
+            if not isinstance(config, _Element):
                 # Parse datatypes_conf.xml
                 tree = galaxy.util.parse_xml(config)
                 root = tree.getroot()

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -10,7 +10,6 @@ from collections import OrderedDict
 from string import Template
 
 import yaml
-from lxml.etree import _Element
 
 import galaxy.util
 from galaxy.util import RW_R__R__
@@ -108,7 +107,7 @@ class Registry(object):
             #           type="galaxy.datatypes.blast:BlastXml" />
             compressed_sniffers = {}
             handling_proprietary_datatypes = False
-            if not isinstance(config, _Element):
+            if isinstance(config, str):
                 # Parse datatypes_conf.xml
                 tree = galaxy.util.parse_xml(config)
                 root = tree.getroot()

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -6,13 +6,13 @@ from __future__ import print_function
 import sys
 from os.path import dirname, join
 
-import lxml.etree as ElementTree
 import pkg_resources
 import yaml
 
 from galaxy.containers import parse_containers_config
 from galaxy.util import (
     asbool,
+    etree,
     parse_xml,
     which,
 )
@@ -69,7 +69,7 @@ class ConditionalDependencies(object):
                             self.job_rule_modules.append(plugin.text)
                     except (OSError, IOError):
                         pass
-                except ElementTree.ParseError:
+                except etree.ParseError:
                     pass
             else:
                 try:

--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -5,14 +5,15 @@ from __future__ import print_function
 
 import sys
 from os.path import dirname, join
-from xml.etree import ElementTree
 
+import lxml.etree as ElementTree
 import pkg_resources
 import yaml
 
 from galaxy.containers import parse_containers_config
 from galaxy.util import (
     asbool,
+    parse_xml,
     which,
 )
 from galaxy.util.properties import (
@@ -58,13 +59,13 @@ class ConditionalDependencies(object):
             if '.xml' in job_conf_path:
                 try:
                     try:
-                        for plugin in ElementTree.parse(job_conf_path).find('plugins').findall('plugin'):
+                        for plugin in parse_xml(job_conf_path).find('plugins').findall('plugin'):
                             if 'load' in plugin.attrib:
                                 self.job_runners.append(plugin.attrib['load'])
                     except (OSError, IOError):
                         pass
                     try:
-                        for plugin in ElementTree.parse(job_conf_path).findall('.//destination/param[@id="rules_module"]'):
+                        for plugin in parse_xml(job_conf_path).findall('.//destination/param[@id="rules_module"]'):
                             self.job_rule_modules.append(plugin.text)
                     except (OSError, IOError):
                         pass
@@ -82,7 +83,7 @@ class ConditionalDependencies(object):
             "object_store_config_file",
             join(dirname(self.config_file), 'object_store_conf.xml'))
         try:
-            for store in ElementTree.parse(object_store_conf_xml).iter('object_store'):
+            for store in parse_xml(object_store_conf_xml).iter('object_store'):
                 if 'type' in store.attrib:
                     self.object_stores.append(store.attrib['type'])
         except (OSError, IOError):
@@ -93,7 +94,7 @@ class ConditionalDependencies(object):
             "auth_config_file",
             join(dirname(self.config_file), 'auth_conf.xml'))
         try:
-            for auth in ElementTree.parse(auth_conf_xml).findall('authenticator'):
+            for auth in parse_xml(auth_conf_xml).findall('authenticator'):
                 auth_type = auth.find('type')
                 if auth_type is not None:
                     self.authenticators.append(auth_type.text)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -19,7 +19,6 @@ from abc import (
     abstractmethod,
 )
 from json import loads
-from xml.etree import ElementTree
 
 import packaging.version
 import six
@@ -60,6 +59,7 @@ from galaxy.tool_util.output_checker import (
 )
 from galaxy.util import (
     commands,
+    parse_xml_string,
     RWXRWXRWX,
     safe_makedirs,
     unicodify,
@@ -522,7 +522,7 @@ class JobConfiguration(ConfiguresHandlers):
         """Loads the new-style job configuration from options in the job config file (by default, job_conf.xml).
 
         :param tree: Object representing the root ``<job_conf>`` object in the job config file.
-        :type tree: ``xml.etree.ElementTree.Element``
+        :type tree: ``lxml.etree._Element``
         """
         root = tree.getroot()
         log.debug('Loading job configuration from %s' % self.app.config.job_config_file)
@@ -573,7 +573,7 @@ class JobConfiguration(ConfiguresHandlers):
                 fields_names = self.resource_groups[resource_group]
                 fields = [self.resource_parameters[n] for n in fields_names]
                 if fields:
-                    conditional_element = ElementTree.fromstring(self.JOB_RESOURCE_CONDITIONAL_XML)
+                    conditional_element = parse_xml_string(self.JOB_RESOURCE_CONDITIONAL_XML)
                     when_yes_elem = conditional_element.findall('when')[1]
                     for parameter in fields:
                         when_yes_elem.append(parameter)
@@ -607,7 +607,7 @@ class JobConfiguration(ConfiguresHandlers):
         """Parses any child <param> tags in to a dictionary suitable for persistence.
 
         :param parent: Parent element in which to find child <param> tags.
-        :type parent: ``xml.etree.ElementTree.Element``
+        :type parent: ``lxml.etree._Element``
 
         :returns: dict
         """
@@ -618,7 +618,7 @@ class JobConfiguration(ConfiguresHandlers):
         """Parses any child <env> tags in to a dictionary suitable for persistence.
 
         :param parent: Parent element in which to find child <env> tags.
-        :type parent: ``xml.etree.ElementTree.Element``
+        :type parent: ``lxml.etree._Element``
 
         :returns: dict
         """
@@ -638,7 +638,7 @@ class JobConfiguration(ConfiguresHandlers):
         """Parses any child <resubmit> tags in to a dictionary suitable for persistence.
 
         :param parent: Parent element in which to find child <resubmit> tags.
-        :type parent: ``xml.etree.ElementTree.Element``
+        :type parent: ``lxml.etree._Element``
 
         :returns: dict
         """

--- a/lib/galaxy/jobs/dynamic_tool_destination.py
+++ b/lib/galaxy/jobs/dynamic_tool_destination.py
@@ -9,10 +9,11 @@ import os
 import re
 import sys
 from functools import reduce
-from xml.etree import ElementTree as ET
 
 import numpy as np
 import yaml
+
+from galaxy.util import parse_xml
 
 __version__ = '1.1.0'
 
@@ -1677,7 +1678,7 @@ def get_destination_list_from_job_config(job_config_location):
             log.debug(message)
 
     if job_config_location:
-        job_conf = ET.parse(job_config_location)
+        job_conf = parse_xml(job_config_location, strip_whitespace=False)
 
         # Add all destination IDs from the job configuration xml file
         for destination in job_conf.getroot().iter("destination"):

--- a/lib/galaxy/jobs/runners/util/cli/job/torque.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/torque.py
@@ -80,7 +80,7 @@ class Torque(BaseJobExec):
         rval = {}
         for line in status.strip().splitlines():
             try:
-                tree = parse_xml_string(line.strip)
+                tree = parse_xml_string(line.strip())
                 assert tree.tag == 'Data'
                 break
             except Exception:

--- a/lib/galaxy/jobs/runners/util/cli/job/torque.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/torque.py
@@ -1,8 +1,4 @@
 from logging import getLogger
-try:
-    import xml.etree.cElementTree as et
-except ImportError:
-    import xml.etree.ElementTree as et
 
 try:
     from galaxy.model import Job
@@ -12,6 +8,7 @@ except ImportError:
     from pulsar.util import enum
     job_states = enum(RUNNING='running', OK='complete', QUEUED='queued')
 
+from galaxy.util import parse_xml_string
 from ..job import BaseJobExec
 
 log = getLogger(__name__)
@@ -83,7 +80,7 @@ class Torque(BaseJobExec):
         rval = {}
         for line in status.strip().splitlines():
             try:
-                tree = et.fromstring(line.strip())
+                tree = parse_xml_string(line.strip)
                 assert tree.tag == 'Data'
                 break
             except Exception:

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -13,7 +13,6 @@ import shutil
 import threading
 import time
 from collections import OrderedDict
-from xml.etree import ElementTree
 
 import yaml
 try:
@@ -25,6 +24,7 @@ from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.util import (
     directory_hash_id,
     force_symlink,
+    parse_xml,
     umask_fix_perms,
 )
 from galaxy.util.bunch import Bunch
@@ -790,7 +790,7 @@ class DistributedObjectStore(NestedObjectStore):
                 "'distributed_object_store_config_file')"
 
             log.debug('Loading backends for distributed object store from %s', distributed_config)
-            config_xml = ElementTree.parse(distributed_config).getroot()
+            config_xml = parse_xml(distributed_config).getroot()
             legacy = True
         else:
             log.debug('Loading backends for distributed object store from %s', config_xml.get('id'))
@@ -992,7 +992,7 @@ def build_object_store_from_config(config, fsmon=False, config_xml=None, config_
                 # This is a top level invocation of build_object_store_from_config, and
                 # we have an object_store_conf.xml -- read the .xml and build
                 # accordingly
-                config_xml = ElementTree.parse(config.object_store_config_file).getroot()
+                config_xml = parse_xml(config.object_store_config_file).getroot()
                 store = config_xml.get('type')
             else:
                 with open(config_file, "rt") as f:

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 
 def parse_config_xml(config_xml):
     """Parse and validate config_xml, return dict for convenience
-    :param config_xml: (xml.etree.ElementTree.Element) root of XML subtree
+    :param config_xml: (lxml.etree.Element) root of XML subtree
     :returns: (dict) according to syntax
     :raises: various XML parse errors
     """

--- a/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
@@ -2,9 +2,13 @@ import errno
 import logging
 import os
 import time
-from xml.etree import ElementTree
 
-from galaxy.util import xml_to_string
+from lxml.etree import ElementTree
+
+from galaxy.util import (
+    parse_xml_string,
+    xml_to_string,
+)
 from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 from galaxy.util.tool_shed.xml_util import parse_xml
 from . import tool_panel_manager
@@ -40,7 +44,7 @@ class DataManagerHandler(object):
             root_str = '<?xml version="1.0"?><data_managers tool_path="%s"></data_managers>' % data_managers_path
         else:
             root_str = '<?xml version="1.0"?><data_managers></data_managers>'
-        root = ElementTree.fromstring(root_str)
+        root = parse_xml_string(root_str)
         for elem in config_elems:
             root.append(elem)
         try:

--- a/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
@@ -3,9 +3,8 @@ import logging
 import os
 import time
 
-from lxml.etree import ElementTree
-
 from galaxy.util import (
+    etree,
     parse_xml_string,
     xml_to_string,
 )
@@ -135,7 +134,7 @@ class DataManagerHandler(object):
                                                                       tool_path=shed_config_dict.get('tool_path', ''))
                     if data_manager:
                         rval.append(data_manager)
-                elif elem.tag is ElementTree.Comment:
+                elif elem.tag is etree.Comment:
                     pass
                 else:
                     log.warning("Encountered unexpected element '%s':\n%s" % (elem.tag, xml_to_string(elem)))

--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -1,12 +1,16 @@
 import errno
 import logging
-from xml.etree import ElementTree as XmlET
+
+import lxml.etree as XmlET
 
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tool_shed.util.basic_util import strip_path
 from galaxy.tool_shed.util.repository_util import get_repository_owner
 from galaxy.tool_shed.util.shed_util_common import get_tool_panel_config_tool_path_install_dir
-from galaxy.util import xml_to_string
+from galaxy.util import (
+    parse_xml_string,
+    xml_to_string,
+)
 from galaxy.util.renamed_temporary_file import RenamedTemporaryFile
 from galaxy.util.tool_shed.common_util import remove_protocol_and_user_from_clone_url
 from galaxy.util.tool_shed.xml_util import parse_xml
@@ -97,7 +101,7 @@ class ToolPanelManager(object):
         value of config_filename.
         """
         try:
-            root = XmlET.fromstring('<?xml version="1.0"?>\n<toolbox tool_path="%s"></toolbox>' % str(tool_path))
+            root = parse_xml_string('<?xml version="1.0"?>\n<toolbox tool_path="%s"></toolbox>' % str(tool_path))
             for elem in config_elems:
                 root.append(elem)
             with RenamedTemporaryFile(config_filename, mode='w') as fh:

--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -1,13 +1,12 @@
 import errno
 import logging
 
-import lxml.etree as XmlET
-
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.tool_shed.util.basic_util import strip_path
 from galaxy.tool_shed.util.repository_util import get_repository_owner
 from galaxy.tool_shed.util.shed_util_common import get_tool_panel_config_tool_path_install_dir
 from galaxy.util import (
+    etree,
     parse_xml_string,
     xml_to_string,
 )
@@ -113,24 +112,24 @@ class ToolPanelManager(object):
                            tool, tool_section):
         """Create and return an ElementTree tool Element."""
         if tool_section is not None:
-            tool_elem = XmlET.SubElement(tool_section, 'tool')
+            tool_elem = etree.SubElement(tool_section, 'tool')
         else:
-            tool_elem = XmlET.Element('tool')
+            tool_elem = etree.Element('tool')
         tool_elem.attrib['file'] = tool_file_path
         if not tool.guid:
             raise ValueError("tool has no guid")
         tool_elem.attrib['guid'] = tool.guid
-        tool_shed_elem = XmlET.SubElement(tool_elem, 'tool_shed')
+        tool_shed_elem = etree.SubElement(tool_elem, 'tool_shed')
         tool_shed_elem.text = tool_shed
-        repository_name_elem = XmlET.SubElement(tool_elem, 'repository_name')
+        repository_name_elem = etree.SubElement(tool_elem, 'repository_name')
         repository_name_elem.text = repository_name
-        repository_owner_elem = XmlET.SubElement(tool_elem, 'repository_owner')
+        repository_owner_elem = etree.SubElement(tool_elem, 'repository_owner')
         repository_owner_elem.text = owner
-        changeset_revision_elem = XmlET.SubElement(tool_elem, 'installed_changeset_revision')
+        changeset_revision_elem = etree.SubElement(tool_elem, 'installed_changeset_revision')
         changeset_revision_elem.text = changeset_revision
-        id_elem = XmlET.SubElement(tool_elem, 'id')
+        id_elem = etree.SubElement(tool_elem, 'id')
         id_elem.text = tool.id
-        version_elem = XmlET.SubElement(tool_elem, 'version')
+        version_elem = etree.SubElement(tool_elem, 'version')
         version_elem.text = tool.version
         return tool_elem
 
@@ -310,7 +309,7 @@ class ToolPanelManager(object):
         # { id: <ToolSection id>, version : <ToolSection version>, name : <TooSection name>}
         if tool_section_dict['id']:
             # Create a new tool section.
-            tool_section = XmlET.Element('section')
+            tool_section = etree.Element('section')
             tool_section.attrib['id'] = tool_section_dict['id']
             tool_section.attrib['name'] = tool_section_dict['name']
             tool_section.attrib['version'] = tool_section_dict['version']

--- a/lib/galaxy/tool_shed/tool_shed_registry.py
+++ b/lib/galaxy/tool_shed/tool_shed_registry.py
@@ -1,10 +1,10 @@
 import logging
-import xml.etree.ElementTree
 from collections import (
     namedtuple,
     OrderedDict,
 )
 
+from galaxy.util import parse_xml_string
 from galaxy.util.tool_shed.common_util import remove_protocol_from_tool_shed_url
 from galaxy.util.tool_shed.xml_util import parse_xml
 
@@ -32,7 +32,7 @@ class Registry(object):
                 return
             root = tree.getroot()
         else:
-            root = xml.etree.ElementTree.fromstring(DEFAULT_TOOL_SHEDS_CONF_XML)
+            root = parse_xml_string(DEFAULT_TOOL_SHEDS_CONF_XML)
             config = "internal default config"
         log.debug('Loading references to tool sheds from %s' % config)
         for elem in root.findall('tool_shed'):

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import shutil
-from xml.etree import ElementTree as XmlET
+
+import lxml.etree as XmlET
 
 from galaxy.tool_shed.util import hg_util
 from galaxy.util.tool_shed import xml_util

--- a/lib/galaxy/tool_shed/tools/data_table_manager.py
+++ b/lib/galaxy/tool_shed/tools/data_table_manager.py
@@ -2,9 +2,8 @@ import logging
 import os
 import shutil
 
-import lxml.etree as XmlET
-
 from galaxy.tool_shed.util import hg_util
+from galaxy.util import etree
 from galaxy.util.tool_shed import xml_util
 
 log = logging.getLogger(__name__)
@@ -19,21 +18,21 @@ class ShedToolDataTableManager(object):
                                       parent_elem=None, **kwd):
         """Create and return an ElementTree repository info Element."""
         if parent_elem is None:
-            elem = XmlET.Element('tool_shed_repository')
+            elem = etree.Element('tool_shed_repository')
         else:
-            elem = XmlET.SubElement(parent_elem, 'tool_shed_repository')
-        tool_shed_elem = XmlET.SubElement(elem, 'tool_shed')
+            elem = etree.SubElement(parent_elem, 'tool_shed_repository')
+        tool_shed_elem = etree.SubElement(elem, 'tool_shed')
         tool_shed_elem.text = tool_shed
-        repository_name_elem = XmlET.SubElement(elem, 'repository_name')
+        repository_name_elem = etree.SubElement(elem, 'repository_name')
         repository_name_elem.text = repository_name
-        repository_owner_elem = XmlET.SubElement(elem, 'repository_owner')
+        repository_owner_elem = etree.SubElement(elem, 'repository_owner')
         repository_owner_elem.text = owner
-        changeset_revision_elem = XmlET.SubElement(elem, 'installed_changeset_revision')
+        changeset_revision_elem = etree.SubElement(elem, 'installed_changeset_revision')
         changeset_revision_elem.text = changeset_revision
         # add additional values
         # TODO: enhance additional values to allow e.g. use of dict values that will recurse
         for key, value in kwd.items():
-            new_elem = XmlET.SubElement(elem, key)
+            new_elem = etree.SubElement(elem, key)
             new_elem.text = value
         return elem
 

--- a/lib/galaxy/tool_util/deps/requirements.py
+++ b/lib/galaxy/tool_util/deps/requirements.py
@@ -207,11 +207,11 @@ def parse_requirements_from_dict(root_dict):
 def parse_requirements_from_xml(xml_root):
     """
 
-    >>> from xml.etree import ElementTree
-    >>> def load_requirements( contents ):
+    >>> from galaxy.util import parse_xml_string
+    >>> def load_requirements(contents):
     ...     contents_document = '''<tool><requirements>%s</requirements></tool>'''
-    ...     root = ElementTree.fromstring( contents_document % contents )
-    ...     return parse_requirements_from_xml( root )
+    ...     root = parse_xml_string(contents_document % contents)
+    ...     return parse_requirements_from_xml(root)
     >>> reqs, containers = load_requirements('''<requirement>bwa</requirement>''')
     >>> reqs[0].name
     'bwa'

--- a/lib/galaxy/tool_util/deps/resolvers/brewed_tool_shed_packages.py
+++ b/lib/galaxy/tool_util/deps/resolvers/brewed_tool_shed_packages.py
@@ -5,8 +5,8 @@ via shed2tap (e.g. https://github.com/jmchilton/homebrew-toolshed).
 """
 import logging
 import os
-from xml.etree import ElementTree as ET
 
+from galaxy.util import parse_xml
 from . import (
     DependencyResolver,
     NullDependency
@@ -88,7 +88,7 @@ class HomebrewToolShedDependencyResolver(
 class RawDependencies(object):
 
     def __init__(self, dependencies_file):
-        self.root = ET.parse(dependencies_file).getroot()
+        self.root = parse_xml(dependencies_file).getroot()
         dependencies = []
         package_els = self.root.findall("package") or []
         for package_el in package_els:

--- a/lib/galaxy/tool_util/verify/asserts/xml.py
+++ b/lib/galaxy/tool_util/verify/asserts/xml.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import
 
 import re
-import xml.etree
 
-from galaxy.util import unicodify
+from galaxy.util import (
+    parse_xml_string,
+    unicodify,
+)
 
 
 # Helper functions used to work with XML output.
 def to_xml(output):
-    return xml.etree.ElementTree.fromstring(output)
+    return parse_xml_string(output)
 
 
 def xml_find_text(output, path):
@@ -35,7 +37,7 @@ def assert_is_valid_xml(output):
 def assert_has_element_with_path(output, path):
     """ Asserts the specified output has at least one XML element with a
     path matching the specified path argument. Valid paths are the
-    simplified subsets of XPath implemented by xml.etree;
+    simplified subsets of XPath implemented by lxml.etree;
     http://effbot.org/zone/element-xpath.htm for more information."""
     if xml_find(output, path) is None:
         errmsg = "Expected to find XML element matching expression %s, not such match was found." % path

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -16,7 +16,6 @@ try:
 except ImportError:
     # Use backport on python 2
     from pathlib2 import Path
-from xml.etree import ElementTree
 
 import packaging.version
 import webob.exc
@@ -90,9 +89,11 @@ from galaxy.util import (
     in_directory,
     listify,
     Params,
+    parse_xml_string,
     rst_to_html,
     string_as_bool,
     unicodify,
+    XML,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable
@@ -1221,7 +1222,7 @@ class Tool(Dictifiable):
                         case = ConditionalWhen()
                         case.value = case_value
                         if case_inputs:
-                            page_source = XmlPageSource(ElementTree.XML("<when>%s</when>" % case_inputs))
+                            page_source = XmlPageSource(XML("<when>%s</when>" % case_inputs))
                             case.inputs = self.parse_input_elem(page_source, enctypes, context)
                         else:
                             case.inputs = OrderedDict()
@@ -1313,7 +1314,7 @@ class Tool(Dictifiable):
             if resource_xml is not None:
                 inputs = root.find('inputs')
                 if inputs is None:
-                    inputs = ElementTree.fromstring('<inputs/>')
+                    inputs = parse_xml_string('<inputs/>')
                     root.append(inputs)
                 inputs.append(resource_xml)
 
@@ -2443,7 +2444,7 @@ class DataSourceTool(OutputParameterJSONTool):
     default_tool_action = DataSourceToolAction
 
     def _build_GALAXY_URL_parameter(self):
-        return ToolParameter.build(self, ElementTree.XML('<param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=%s" />' % self.id))
+        return ToolParameter.build(self, XML('<param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=%s" />' % self.id))
 
     def parse_inputs(self, tool_source):
         super(DataSourceTool, self).parse_inputs(tool_source)
@@ -2503,7 +2504,7 @@ class AsyncDataSourceTool(DataSourceTool):
     tool_type = 'data_source_async'
 
     def _build_GALAXY_URL_parameter(self):
-        return ToolParameter.build(self, ElementTree.XML('<param name="GALAXY_URL" type="baseurl" value="/async/%s" />' % self.id))
+        return ToolParameter.build(self, XML('<param name="GALAXY_URL" type="baseurl" value="/async/%s" />' % self.id))
 
 
 class DataDestinationTool(Tool):

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -17,7 +17,6 @@ import time
 from collections import OrderedDict
 from glob import glob
 from tempfile import NamedTemporaryFile
-from xml.etree import ElementTree
 
 import refgenconf
 import requests
@@ -205,7 +204,7 @@ class ToolDataTableManager(object):
         out_elems.extend(new_elems)
         out_path_is_new = not os.path.exists(full_path)
 
-        root = ElementTree.fromstring('<?xml version="1.0"?>\n<tables></tables>')
+        root = util.parse_xml_string('<?xml version="1.0"?>\n<tables></tables>')
         for elem in out_elems:
             root.append(elem)
         with RenamedTemporaryFile(full_path, mode='w') as out:

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -273,7 +273,7 @@ def populate_state(request_context, inputs, incoming, state, errors={}, prefix='
     """
     Populates nested state dict from incoming parameter values.
     >>> from collections import OrderedDict
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> from galaxy.util.bunch import Bunch
     >>> from galaxy.tools.parameters.basic import TextToolParameter, BooleanToolParameter
     >>> from galaxy.tools.parameters.grouping import Repeat

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -29,7 +29,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     If the callback returns a value, it will be replace the old value.
 
     >>> from collections import OrderedDict
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> from galaxy.util.bunch import Bunch
     >>> from galaxy.tools.parameters.basic import TextToolParameter, BooleanToolParameter
     >>> from galaxy.tools.parameters.grouping import Repeat

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -29,7 +29,7 @@ def visit_input_values(inputs, input_values, callback, name_prefix='', label_pre
     If the callback returns a value, it will be replace the old value.
 
     >>> from collections import OrderedDict
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> from galaxy.util.bunch import Bunch
     >>> from galaxy.tools.parameters.basic import TextToolParameter, BooleanToolParameter
     >>> from galaxy.tools.parameters.grouping import Repeat
@@ -273,7 +273,7 @@ def populate_state(request_context, inputs, incoming, state, errors={}, prefix='
     """
     Populates nested state dict from incoming parameter values.
     >>> from collections import OrderedDict
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> from galaxy.util.bunch import Bunch
     >>> from galaxy.tools.parameters.basic import TextToolParameter, BooleanToolParameter
     >>> from galaxy.tools.parameters.grouping import Repeat

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -8,8 +8,8 @@ import logging
 import os
 import os.path
 import re
-from xml.etree.ElementTree import XML
 
+from lxml.etree import XML
 from six import string_types
 from webob.compat import cgi_FieldStorage
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -9,7 +9,6 @@ import os
 import os.path
 import re
 
-from lxml.etree import XML
 from six import string_types
 from webob.compat import cgi_FieldStorage
 
@@ -19,7 +18,8 @@ from galaxy.tool_util.parser import get_input_source as ensure_input_source
 from galaxy.util import (
     sanitize_param,
     string_as_bool,
-    unicodify
+    unicodify,
+    XML,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import Dictifiable

--- a/lib/galaxy/tools/parameters/input_translation.py
+++ b/lib/galaxy/tools/parameters/input_translation.py
@@ -16,7 +16,7 @@ class ToolInputTranslator(object):
     This is used for data source tools
 
     >>> from galaxy.util import Params
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> translator = ToolInputTranslator.from_element(XML(
     ... '''
     ... <request_param_translation>

--- a/lib/galaxy/tools/parameters/input_translation.py
+++ b/lib/galaxy/tools/parameters/input_translation.py
@@ -15,8 +15,7 @@ class ToolInputTranslator(object):
     Handles Tool input translation.
     This is used for data source tools
 
-    >>> from galaxy.util import Params
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import Params, XML
     >>> translator = ToolInputTranslator.from_element(XML(
     ... '''
     ... <request_param_translation>

--- a/lib/galaxy/tools/parameters/sanitize.py
+++ b/lib/galaxy/tools/parameters/sanitize.py
@@ -15,7 +15,7 @@ class ToolParameterSanitizer(object):
     """
     Handles tool parameter specific sanitizing.
 
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> sanitizer = ToolParameterSanitizer.from_element(XML(
     ... '''
     ... <sanitizer invalid_char="">

--- a/lib/galaxy/tools/parameters/sanitize.py
+++ b/lib/galaxy/tools/parameters/sanitize.py
@@ -15,7 +15,7 @@ class ToolParameterSanitizer(object):
     """
     Handles tool parameter specific sanitizing.
 
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> sanitizer = ToolParameterSanitizer.from_element(XML(
     ... '''
     ... <sanitizer invalid_char="">

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -53,7 +53,7 @@ class RegexValidator(Validator):
     """
     Validator that evaluates a regular expression
 
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="text" value="10">
@@ -87,7 +87,7 @@ class ExpressionValidator(Validator):
     """
     Validator that evaluates a python expression using the value
 
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="text" value="10">
@@ -129,7 +129,7 @@ class InRangeValidator(Validator):
     """
     Validator that ensures a number is in a specified range
 
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="integer" value="10">
@@ -197,7 +197,7 @@ class LengthValidator(Validator):
     """
     Validator that ensures the length of the provided string (value) is in a specific range
 
-    >>> from xml.etree.ElementTree import XML
+    >>> from lxml.etree import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="text" value="foobar">

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -53,7 +53,7 @@ class RegexValidator(Validator):
     """
     Validator that evaluates a regular expression
 
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="text" value="10">
@@ -87,7 +87,7 @@ class ExpressionValidator(Validator):
     """
     Validator that evaluates a python expression using the value
 
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="text" value="10">
@@ -129,7 +129,7 @@ class InRangeValidator(Validator):
     """
     Validator that ensures a number is in a specified range
 
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="integer" value="10">
@@ -197,7 +197,7 @@ class LengthValidator(Validator):
     """
     Validator that ensures the length of the provided string (value) is in a specific range
 
-    >>> from lxml.etree import XML
+    >>> from galaxy.util import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="text" value="foobar">

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -8,8 +8,8 @@ from collections import (
     OrderedDict
 )
 from errno import ENOENT
-from xml.etree.ElementTree import ParseError
 
+from lxml.etree import ParseError
 from markupsafe import escape
 from six.moves.urllib.parse import urlparse
 

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -9,7 +9,6 @@ from collections import (
 )
 from errno import ENOENT
 
-from lxml.etree import ParseError
 from markupsafe import escape
 from six.moves.urllib.parse import urlparse
 
@@ -24,6 +23,7 @@ from galaxy.tool_util.deps import (
 )
 from galaxy.tool_util.loader_directory import looks_like_a_tool
 from galaxy.util import (
+    etree,
     ExecutionTimer,
     listify,
     parse_xml,
@@ -143,7 +143,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
                 continue
             try:
                 self._init_tools_from_config(config_filename)
-            except ParseError:
+            except etree.ParseError:
                 # Occasionally we experience "Missing required parameter 'shed_tool_conf'."
                 # This happens if parsing the shed_tool_conf fails, so we just sleep a second and try again.
                 # TODO: figure out why this fails occasionally (try installing hundreds of tools in batch ...).

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -270,7 +270,13 @@ def parse_xml(fname, strip_whitespace=True, remove_comments=True):
 
 
 def parse_xml_string(xml_string, strip_whitespace=True):
-    tree = etree.fromstring(xml_string)
+    try:
+        tree = etree.fromstring(xml_string)
+    except ValueError as e:
+        if 'strings with encoding declaration are not supported' in unicodify(e):
+            tree = etree.fromstring(xml_string.encode('utf-8'))
+        else:
+            raise e
     if strip_whitespace:
         for elem in tree.iter('*'):
             if elem.text is not None:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -40,7 +40,12 @@ from boltons.iterutils import (
     default_enter,
     remap,
 )
-from lxml import etree
+LXML_AVAILABLE = True
+try:
+    from lxml import etree
+except ImportError:
+    LXML_AVAILABLE = False
+    import xml.etree.ElementTree as etree
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 from six import binary_type, iteritems, PY2, string_types, text_type
@@ -240,7 +245,9 @@ def unique_id(KEY_SIZE=128):
 def parse_xml(fname, strip_whitespace=True, remove_comments=True):
     """Returns a parsed xml tree"""
     parser = None
-    if remove_comments:
+    if remove_comments and LXML_AVAILABLE:
+        # If using stdlib etree comments are always removed,
+        # but lxml doesn't do this by default
         parser = etree.XMLParser(remove_comments=True)
     try:
         # Restore ENOENT that would otherwise be an OSError in lxml

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -248,7 +248,7 @@ def parse_xml(fname, strip_whitespace=True, remove_comments=True):
     if remove_comments and LXML_AVAILABLE:
         # If using stdlib etree comments are always removed,
         # but lxml doesn't do this by default
-        parser = etree.XMLParser(remove_comments=True)
+        parser = etree.XMLParser(remove_comments=remove_comments)
     try:
         # Restore ENOENT that would otherwise be an OSError in lxml
         if not os.path.exists(fname):

--- a/lib/galaxy/util/plugin_config.py
+++ b/lib/galaxy/util/plugin_config.py
@@ -1,11 +1,11 @@
 import collections
-from xml.etree import ElementTree
 
 try:
     import yaml
 except ImportError:
     yaml = None
 
+from galaxy.util import parse_xml
 from galaxy.util.submodules import import_submodules
 
 
@@ -85,7 +85,7 @@ def plugin_source_from_path(path):
     if path.endswith(".yaml") or path.endswith(".yml") or path.endswith(".yaml.sample") or path.endswith(".yml.sample"):
         return PluginConfigSource('dict', __read_yaml(path))
     else:
-        return PluginConfigSource('xml', ElementTree.parse(path).getroot())
+        return PluginConfigSource('xml', parse_xml(path, remove_comments=True).getroot())
 
 
 def __read_yaml(path):

--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -3,12 +3,8 @@ import logging
 import os
 import tempfile
 
-try:
-    from lxml import etree
-except ImportError:
-    import xml.etree.ElementTree as etree
-
 from galaxy.util import (
+    etree,
     parse_xml as galaxy_parse_xml,
     unicodify,
     xml_to_string,

--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -3,7 +3,10 @@ import logging
 import os
 import tempfile
 
-import lxml.etree as XmlET
+try:
+    from lxml import etree
+except ImportError:
+    import xml.etree.ElementTree as etree
 
 from galaxy.util import (
     parse_xml as galaxy_parse_xml,
@@ -29,7 +32,7 @@ def create_element(tag, attributes=None, sub_elements=None):
     key / value pairs in the received attributes and sub_elements.
     """
     if tag:
-        elem = XmlET.Element(tag)
+        elem = etree.Element(tag)
         if attributes:
             # The received attributes is an odict to preserve ordering.
             for k, v in attributes.items():
@@ -44,12 +47,12 @@ def create_element(tag, attributes=None, sub_elements=None):
                         # The received sub_elements is an odict whose key is 'packages' and whose
                         # value is a list of ( name, version ) tuples.
                         for v_tuple in v:
-                            sub_elem = XmlET.SubElement(elem, 'package')
+                            sub_elem = etree.SubElement(elem, 'package')
                             sub_elem_name, sub_elem_version = v_tuple
                             sub_elem.set('name', sub_elem_name)
                             sub_elem.set('version', sub_elem_version)
                     elif isinstance(v, list):
-                        sub_elem = XmlET.SubElement(elem, k)
+                        sub_elem = etree.SubElement(elem, k)
                         # If v is a list, then it must be a list of tuples where the first
                         # item is the tag and the second item is the text value.
                         for v_tuple in v:
@@ -58,10 +61,10 @@ def create_element(tag, attributes=None, sub_elements=None):
                                 v_text = v_tuple[1]
                                 # Don't include fields that are blank.
                                 if v_text:
-                                    v_elem = XmlET.SubElement(sub_elem, v_tag)
+                                    v_elem = etree.SubElement(sub_elem, v_tag)
                                     v_elem.text = v_text
                     else:
-                        sub_elem = XmlET.SubElement(elem, k)
+                        sub_elem = etree.SubElement(elem, k)
                         sub_elem.text = v
         return elem
     return None

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,7 +1,7 @@
 import os
 from copy import deepcopy
-from xml.etree import ElementInclude, ElementTree
 
+from galaxy.util import parse_xml
 
 REQUIRED_PARAMETER = object()
 
@@ -49,7 +49,7 @@ def raw_xml_tree(path):
     """ Load raw (no macro expansion) tree representation of XML represented
     at the specified path.
     """
-    tree = _parse_xml(path)
+    tree = parse_xml(path, strip_whitespace=False, remove_comments=True)
     return tree
 
 
@@ -244,7 +244,7 @@ def _imported_macro_paths_from_el(macros_el):
 
 
 def _load_macro_file(path, xml_base_dir):
-    tree = _parse_xml(path)
+    tree = parse_xml(path)
     root = tree.getroot()
     return _load_macros(root, xml_base_dir)
 
@@ -303,13 +303,6 @@ class XmlMacroDef(object):
             token_name = "%s%s%s" % (wrap_char, key.upper(), wrap_char)
             tokens[token_name] = token_value
         return tokens
-
-
-def _parse_xml(fname):
-    tree = ElementTree.parse(fname)
-    root = tree.getroot()
-    ElementInclude.include(root)
-    return tree
 
 
 __all__ = (

--- a/lib/galaxy/visualization/data_providers/phyloviz/phyloxmlparser.py
+++ b/lib/galaxy/visualization/data_providers/phyloviz/phyloxmlparser.py
@@ -1,5 +1,4 @@
-from xml.etree import ElementTree
-
+from galaxy.util import parse_xml
 from .baseparser import (
     Base_Parser,
     Node,
@@ -23,9 +22,7 @@ class Phyloxml_Parser(Base_Parser):
 
     def parseFile(self, filePath):
         """passes a file and extracts its Phylogeny Tree content."""
-        phyloXmlFile = open(filePath, "r")
-
-        xmlTree = ElementTree.parse(phyloXmlFile)
+        xmlTree = parse_xml(filePath)
         xmlRoot = xmlTree.getroot()[0]
         self.nameSpaceIndex = xmlRoot.tag.rfind("}") + 1  # used later by the clean tag method to remove the name space in every element.tag
 

--- a/lib/galaxy/visualization/plugins/config_parser.py
+++ b/lib/galaxy/visualization/plugins/config_parser.py
@@ -187,7 +187,7 @@ class VisualizationsConfigParser(object):
             raise ParsingException('template or entry_point required')
 
         # parse by returning a sub-object and simply copying any attributes unused here
-        entry_point_attrib = entry_point.attrib.copy()
+        entry_point_attrib = dict(entry_point.attrib)
         entry_point_type = entry_point_attrib.pop('entry_point_type', 'mako')
         if entry_point_type not in self.ALLOWED_ENTRY_POINT_TYPES:
             raise ParsingException('Unknown entry_point type: ' + entry_point_type)

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -171,7 +171,7 @@ class ConfiguresHandlers(object):
         default and only one child.
 
         :param parent: Object representing a tag that may or may not have a 'default' attribute.
-        :type parent: ``xml.etree.ElementTree.Element``
+        :type parent: ``lxml.etree._Element``
         :param names: The list of destination or handler IDs or tags that were loaded.
         :type names: list of str
         :param auto: Automatically set a default if there is no default in the parent tag and there is only one child.
@@ -199,16 +199,16 @@ class ConfiguresHandlers(object):
 
     @staticmethod
     def _findall_with_required(parent, match, attribs=None):
-        """Like ``xml.etree.ElementTree.Element.findall()``, except only returns children that have the specified attribs.
+        """Like ``lxml.etree.Element.findall()``, except only returns children that have the specified attribs.
 
         :param parent: Parent element in which to find.
-        :type parent: ``xml.etree.ElementTree.Element``
+        :type parent: ``lxml.etree._Element``
         :param match: Name of child elements to find.
         :type match: str
         :param attribs: List of required attributes in children elements.
         :type attribs: list of str
 
-        :returns: list of ``xml.etree.ElementTree.Element``
+        :returns: list of ``lxml.etree._Element``
         """
         rval = []
         if attribs is None:

--- a/lib/galaxy/webapps/galaxy/api/forms.py
+++ b/lib/galaxy/webapps/galaxy/api/forms.py
@@ -2,10 +2,10 @@
 API operations on FormDefinition objects.
 """
 import logging
-from xml.etree.ElementTree import XML
 
 from galaxy import web
 from galaxy.forms.forms import form_factory
+from galaxy.util import XML
 from galaxy.webapps.base.controller import BaseAPIController, url_for
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -1,11 +1,13 @@
 import os
 from functools import partial
-from xml.etree import ElementTree
 
 import galaxy.workflow.schedulers
 from galaxy import model
 from galaxy.exceptions import HandlerAssignmentError
-from galaxy.util import plugin_config
+from galaxy.util import (
+    parse_xml,
+    plugin_config,
+)
 from galaxy.util.custom_logging import get_logger
 from galaxy.util.monitors import Monitors
 from galaxy.web_stack.handlers import ConfiguresHandlers, HANDLER_ASSIGNMENT_METHODS
@@ -186,7 +188,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         if use_default_scheduler:
             self.__init_default_scheduler()
         else:
-            plugins_element = ElementTree.parse(config_file).getroot()
+            plugins_element = parse_xml(config_file).getroot()
             self.__init_schedulers_for_element(plugins_element)
 
         if not self.__handlers_configured and self.__stack_has_pool:

--- a/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
@@ -116,7 +116,7 @@ class TestFreebayesRepository(ShedTwillTestCase):
                          uncompress_file=False,
                          remove_repo_files_not_in_tar=False,
                          commit_message='Uploaded malformed tool dependency XML.',
-                         strings_displayed=['Exception attempting to parse', 'not well-formed'],
+                         strings_displayed=['Exception attempting to parse', 'invalid element name'],
                          strings_not_displayed=[])
 
     def test_0030_upload_invalid_tool_dependency_xml(self):

--- a/scripts/validate_tools.sh
+++ b/scripts/validate_tools.sh
@@ -20,7 +20,7 @@ for p in "$@"; do
     echo "$path"
     PYTHONPATH=lib:$PYTHONPATH
     export PYTHONPATH
-    python -c "import galaxy.tool_util.loader; import xml.etree; xml.etree.ElementTree.dump(galaxy.tool_util.loader.load_tool('$path').getroot())" | xmllint --nowarning --noout --schema "$xsd_path" - 2> "$err_tmp"
+    python -c "import galaxy.tool_util.loader; import lxml.etree; lxml.etree.dump(galaxy.tool_util.loader.load_tool('$path').getroot())" | xmllint --nowarning --noout --schema "$xsd_path" - 2> "$err_tmp"
     if [ $? -eq 0 ]; then
         echo "ok $count";
     else

--- a/test/unit/objectstore/test_irods.py
+++ b/test/unit/objectstore/test_irods.py
@@ -1,9 +1,9 @@
 import os
-import xml.etree.ElementTree as ET
 
 import pytest
 
 from galaxy.objectstore.irods import parse_config_xml
+from galaxy.util import parse_xml
 
 SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 
@@ -18,7 +18,7 @@ CONFIG_FILE_NO_AUTH = os.path.join(SCRIPT_DIRECTORY, CONFIG_FILE_NAME_NO_AUTH)
 
 
 def test_parse_valid_config_xml():
-    tree = ET.parse(CONFIG_FILE)
+    tree = parse_xml(CONFIG_FILE)
     root = tree.getroot()
     config = parse_config_xml(root)
 
@@ -38,14 +38,14 @@ def test_parse_valid_config_xml():
 
 
 def test_parse_config_xml_no_extra_dir():
-    tree = ET.parse(CONFIG_FILE_NO_EXTRA_DIR)
+    tree = parse_xml(CONFIG_FILE_NO_EXTRA_DIR)
     root = tree.getroot()
     with pytest.raises(Exception, match='No extra_dir element in config XML tree'):
         parse_config_xml(root)
 
 
 def test_parse_config_xml_no_auth():
-    tree = ET.parse(CONFIG_FILE_NO_AUTH)
+    tree = parse_xml(CONFIG_FILE_NO_AUTH)
     root = tree.getroot()
     with pytest.raises(Exception, match='No auth element in config XML tree'):
         parse_config_xml(root)

--- a/test/unit/test_objectstore.py
+++ b/test/unit/test_objectstore.py
@@ -4,7 +4,6 @@ from shutil import rmtree
 from string import Template
 from tempfile import mkdtemp
 from uuid import uuid4
-from xml.etree import ElementTree
 
 import yaml
 from six import StringIO
@@ -15,7 +14,10 @@ from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.cloud import Cloud
 from galaxy.objectstore.pithos import PithosObjectStore
 from galaxy.objectstore.s3 import S3ObjectStore
-from galaxy.util import directory_hash_id
+from galaxy.util import (
+    directory_hash_id,
+    XML,
+)
 
 
 DISK_TEST_CONFIG = """<?xml version="1.0"?>
@@ -774,7 +776,7 @@ class TestConfig(object):
         if clazz is None:
             self.object_store = objectstore.build_object_store_from_config(config)
         elif config_file == "store.xml":
-            self.object_store = clazz.from_xml(config, ElementTree.fromstring(config_str))
+            self.object_store = clazz.from_xml(config, XML(config_str))
         else:
             self.object_store = clazz(config, yaml.safe_load(StringIO(config_str)))
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1,8 +1,8 @@
-import lxml.etree as ET
 import pytest
 
 from galaxy.tool_util.lint import LintContext
 from galaxy.tool_util.linters import inputs
+from galaxy.util import etree
 
 
 NO_SECTIONS_XML = """
@@ -35,6 +35,6 @@ TESTS = [
 @pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when'])
 def test_tool_xml(tool_xml, lint_func, assert_func):
     lint_ctx = LintContext('all')
-    tree = ET.ElementTree(element=ET.fromstring(tool_xml))
+    tree = etree.ElementTree(element=etree.fromstring(tool_xml))
     lint_ctx.lint(name="test_lint", lint_func=lint_func, lint_target=tree)
     assert assert_func(lint_ctx)

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1,5 +1,4 @@
-import xml.etree.ElementTree as ET
-
+import lxml.etree as ET
 import pytest
 
 from galaxy.tool_util.lint import LintContext

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -1,6 +1,5 @@
 import string
 import unittest
-from xml.etree.ElementTree import XML
 
 from galaxy import model
 from galaxy.exceptions import UserActivationRequiredException
@@ -10,6 +9,7 @@ from galaxy.tools.actions import (
     determine_output_format,
     on_text_for_names
 )
+from galaxy.util import XML
 from .. import tools_support
 
 

--- a/test/unit/tools/test_dataset_matcher.py
+++ b/test/unit/tools/test_dataset_matcher.py
@@ -1,12 +1,14 @@
 from unittest import TestCase
-from xml.etree.ElementTree import XML
 
 from galaxy import model
 from galaxy.tools.parameters import (
     basic,
     dataset_matcher
 )
-from galaxy.util import bunch
+from galaxy.util import (
+    bunch,
+    XML,
+)
 from .test_data_parameters import MockHistoryDatasetAssociation
 from ..tools_support import UsesApp
 

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -1,6 +1,7 @@
 import os
 from unittest import TestCase
-from xml.etree.ElementTree import XML
+
+from lxml.etree import XML
 
 from galaxy.job_execution.datasets import DatasetPath
 from galaxy.jobs import SimpleComputeEnvironment

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -1,8 +1,6 @@
 import os
 from unittest import TestCase
 
-from lxml.etree import XML
-
 from galaxy.job_execution.datasets import DatasetPath
 from galaxy.jobs import SimpleComputeEnvironment
 from galaxy.model import (
@@ -27,6 +25,7 @@ from galaxy.tools.parameters.grouping import (
     ConditionalWhen,
     Repeat
 )
+from galaxy.util import XML
 from galaxy.util.bunch import Bunch
 # Test fixtures for Galaxy infrastructure.
 from ..tools_support import UsesApp

--- a/test/unit/tools/test_tool_panel.py
+++ b/test/unit/tools/test_tool_panel.py
@@ -1,10 +1,10 @@
-from xml.etree import ElementTree as ET
+from lxml.etree import Element
 
 from galaxy.tools.toolbox import ToolSection
 
 
 def test_tool_section():
-    elem = ET.Element('section')
+    elem = Element('section')
     elem.attrib['name'] = "Cool Tools"
     elem.attrib['id'] = "cool1"
 

--- a/test/unit/tools/test_tool_panel.py
+++ b/test/unit/tools/test_tool_panel.py
@@ -1,10 +1,9 @@
-from lxml.etree import Element
-
 from galaxy.tools.toolbox import ToolSection
+from galaxy.util import etree
 
 
 def test_tool_section():
-    elem = Element('section')
+    elem = etree.Element('section')
     elem.attrib['name'] = "Cool Tools"
     elem.attrib['id'] = "cool1"
 

--- a/test/unit/tools/test_wrappers.py
+++ b/test/unit/tools/test_wrappers.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-from xml.etree.ElementTree import XML
 
 import pytest
 
@@ -20,6 +19,7 @@ from galaxy.tools.wrappers import (
     RawObjectWrapper,
     SelectToolParameterWrapper
 )
+from galaxy.util import XML
 from galaxy.util.bunch import Bunch
 
 

--- a/test/unit/tools/util.py
+++ b/test/unit/tools/util.py
@@ -1,9 +1,11 @@
 from unittest import TestCase
-from xml.etree.ElementTree import XML
 
 from galaxy import model
 from galaxy.tools.parameters import basic
-from galaxy.util import bunch
+from galaxy.util import (
+    bunch,
+    XML,
+)
 from ..tools_support import UsesApp
 
 

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -1,4 +1,8 @@
-from tempfile import NamedTemporaryFile
+import errno
+import os
+import tempfile
+
+import pytest
 
 from galaxy import util
 
@@ -35,7 +39,7 @@ def test_parse_xml_string():
 
 
 def test_parse_xml_file():
-    with NamedTemporaryFile(mode='w') as tmp:
+    with tempfile.NamedTemporaryFile(mode='w') as tmp:
         tmp.write(SECTION_XML)
         tmp.flush()
         section = util.parse_xml(tmp.name).getroot()
@@ -69,3 +73,12 @@ def test_xml_to_string_pretty():
     </tool>
 </section>"""
     assert s == PRETTY
+
+
+def test_parse_xml_enoent():
+    fd, path = tempfile.mkstemp()
+    os.close(fd)
+    os.remove(path)
+    with pytest.raises(IOError) as excinfo:
+        util.parse_xml(path)
+    assert excinfo.value.errno == errno.ENOENT


### PR DESCRIPTION
In https://github.com/galaxyproject/galaxy/pull/9610 I started parsing tool documents using lxml for better speed. Unfortunately you can't add `xml.etree.ElementTree.Element`s to documents parsed using lxml, so when we add some dynamic parameters like the JobResourceParameters we get this:
```
galaxy.tools.toolbox.base ERROR 2020-05-11 12:41:10,107 Error reading tool from path: toolshed.g2.bx.psu.edu/repos/devteam/bowtie2/749c918495f7/bowtie2/bowtie2_wrapper.xml
Traceback (most recent call last):
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/toolbox/base.py", line 657, in _load_tool_tag_set
    tool = self.load_tool(concrete_path, guid=guid, tool_shed_repository=tool_shed_repository, use_cached=False, tool_cache_data_dir=tool_cache_data_dir)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/toolbox/base.py", line 851, in load_tool
    tool = self.create_tool(config_file=config_file, tool_shed_repository=tool_shed_repository, guid=guid, tool_cache_data_dir=tool_cache_data_dir, **kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/__init__.py", line 298, in create_tool
    tool = self._create_tool_from_source(tool_source, config_file=config_file, **kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/__init__.py", line 316, in _create_tool_from_source
    return create_tool_from_source(self.app, tool_source, **kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/__init__.py", line 237, in create_tool_from_source
    tool = ToolClass(config_file, tool_source, app, **kwds)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/__init__.py", line 508, in __init__
    self.populate_resource_parameters(tool_source)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/tools/__init__.py", line 1318, in populate_resource_parameters
    inputs.append(resource_xml)
TypeError: Argument 'element' has incorrect type (expected lxml.etree._Element, got xml.etree.ElementTree.Element)
``` 

Here I switched all of our ElementTree usage to lxml (if available) and I also tried unifying the names with which we do the imports. The central place to import etree from should be `galaxy.util` now, which falls back to stdlib if lxml is not available (as could happen when using `galaxy-util`, `galaxy-tool-util`, etc).