### PR TITLE
[20.01] Set UTF-8 for parsing tool xml

### DIFF
--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -91,11 +91,10 @@ def parse_xml(file_name, check_exists=True):
     if check_exists and not os.path.exists(file_name):
         return None, "File does not exist %s" % str(file_name)
 
-    with open(file_name, 'r') as fobj:
-        try:
-            tree = XmlET.parse(fobj, parser=XmlET.XMLParser(target=CommentedTreeBuilder()))
-        except Exception as e:
-            error_message = "Exception attempting to parse %s: %s" % (str(file_name), str(e))
-            log.exception(error_message)
-            return None, error_message
+    try:
+        tree = XmlET.parse(file_name, parser=XmlET.XMLParser(target=CommentedTreeBuilder()))
+    except Exception as e:
+        error_message = "Exception attempting to parse %s: %s" % (str(file_name), str(e))
+        log.exception(error_message)
+        return None, error_message
     return tree, error_message

--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -93,6 +93,8 @@ def parse_xml(file_name, check_exists=True):
 
     try:
         tree = XmlET.parse(file_name, parser=XmlET.XMLParser(target=CommentedTreeBuilder()))
+    except (IOError, OSError):
+        raise
     except Exception as e:
         error_message = "Exception attempting to parse %s: %s" % (str(file_name), str(e))
         log.exception(error_message)


### PR DESCRIPTION
When trying to install a tool (with Python3) that contained non-ascii characters (like toolshed.g2.bx.psu.edu/repos/rnateam/viennarna_rnafold/bdb786715d28/viennarna_rnafold/rnafold.xml), I encountered the error:

> UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 5074: ordinal not in range(128)

This change will set the encoding to UTF-8, which should not hurt when normally expecting ASCII encoding, as they are compatible to each other. Tested both on 20.01 and 20.05 - this fixed the problem.