### PR TITLE
GitLab error reporting - further features

### DIFF
--- a/lib/galaxy/config/sample/error_report.yml.sample
+++ b/lib/galaxy/config/sample/error_report.yml.sample
@@ -72,7 +72,10 @@
 # repository of the tool by querying the ToolShed where the tool comes from
 # (if applicable). Set verbose to true if you want the message to be displayed
 # to the user. The 'gitlab_default_repo_only' flags ensures all errors are
-# submitted to the default repository only.
+# submitted to the default repository only. The 'gitlab_new_issue_on_closed' flag
+# ensures that, when set to true, if an issue is closed it will create a new issue.
+# The 'gitlab_labels' flag allows to submit an array of labels that are added to
+# each issues.
 # - type: gitlab
 #   verbose: false
 #   user_submission: true
@@ -82,3 +85,7 @@
 #   gitlab_default_repo_name: galaxy
 #   gitlab_default_repo_only: true
 #   gitlab_allow_proxy: false
+#   gitlab_new_issue_on_closed: true
+#   gitlab_labels:
+#     - Label1
+#     - Label2

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -17,7 +17,6 @@ try:
     import gitlab
 except ImportError:
     gitlab = None
-    
 from galaxy.util import string_as_bool
 from .base_git import BaseGitPlugin
 

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -123,7 +123,7 @@ class GitLabPlugin(BaseGitPlugin):
                 try:
                     if gitlab_projecturl not in self.git_project_cache:
                         self.git_project_cache[gitlab_projecturl] = self.gitlab.projects.get(gitlab_urlencodedpath)
-                catch gitlab.GitlabGetError:
+                except gitlab.GitlabGetError:
                     # Handle scenario where the repository doesn't exist so we can still continue
                     log.warn("GitLab error reporting - Repository '%s' doesn't exist, using default repository." % gitlab_urlencodedpath)
                     # Redo some of the previous steps to recover from such an issue but continue issue creation

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -13,6 +13,11 @@ else:
     import urllib.parse as urllib
     urlparse = urllib
 
+try:
+    import gitlab
+except ImportError:
+    pass
+    
 from galaxy.util import string_as_bool
 from .base_git import BaseGitPlugin
 
@@ -41,7 +46,8 @@ class GitLabPlugin(BaseGitPlugin):
         self.gitlab_labels = kwargs.get("gitlab_labels", [])
 
         try:
-            import gitlab
+            if 'gitlab' not in sys.modules:
+                raise ImportError
             self.gitlab = self.gitlab_connect()
             self.gitlab.auth()
 
@@ -206,7 +212,6 @@ class GitLabPlugin(BaseGitPlugin):
 
     def _open_issue(self, error_message, error_title, gitlab_projecturl, gl_project, gl_userid, issue_cache_key):
         """ Open an issue """
-        import gitlab
         try:
             # Create a new issue.
             self._create_issue(issue_cache_key, error_title, error_message, gl_project, gl_userid=gl_userid)

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -37,6 +37,8 @@ class GitLabPlugin(BaseGitPlugin):
         self.git_default_repo_name = kwargs.get('gitlab_default_repo_name', False)
         self.git_default_repo_only = string_as_bool(kwargs.get('gitlab_default_repo_only', True))
         self.gitlab_use_proxy = string_as_bool(kwargs.get('gitlab_allow_proxy', True))
+        self.gitlab_new_issue_on_closed = string_as_bool(kwargs.get("gitlab_new_issue_on_closed", False))
+        self.gitlab_labels = kwargs.get("gitlab_labels", [])
 
         try:
             import gitlab
@@ -147,23 +149,26 @@ class GitLabPlugin(BaseGitPlugin):
 
                 log.info(error_title in self.issue_cache[issue_cache_key])
                 if error_title not in self.issue_cache[issue_cache_key]:
-                    try:
-                        # Create a new issue.
-                        self._create_issue(issue_cache_key, error_title, error_message, gl_project, gl_userid=gl_userid)
-                    except (gitlab.GitlabOwnershipError, gitlab.GitlabGetError):
-                        gitlab_projecturl = "/".join((self.git_default_repo_owner, self.git_default_repo_name))
-                        gitlab_urlencodedpath = urllib.quote_plus(gitlab_projecturl)
-                        # Make sure we are always logged in, then retrieve the GitLab project if it isn't cached.
-                        self.gitlab = self.gitlab_connect()
-                        if gitlab_projecturl not in self.git_project_cache:
-                            self.git_project_cache[gitlab_projecturl] = self.gitlab.projects.get(gitlab_urlencodedpath)
-                        gl_project = self.git_project_cache[gitlab_projecturl]
-
-                        # Submit issue to default project
-                        self._create_issue(issue_cache_key, error_title, error_message, gl_project, gl_userid=gl_userid)
+                    self._open_issue(error_message, error_title, gitlab_projecturl, gl_project, gl_userid,
+                                     issue_cache_key)
                 else:
-                    # Add a comment to an issue...
-                    self._append_issue(issue_cache_key, error_title, error_message, gitlab_urlencodedpath=gitlab_urlencodedpath)
+                    if not self.gitlab_new_issue_on_closed:
+                        # Check if issue is closed, otherwise reopen it
+                        issue_id = self.issue_cache[issue_cache_key][error_title]
+                        issue = gl_project.issues.get(issue_id)
+                        log.info("GitLab error reporting - Issue state is %s" % issue.state)
+                        if issue.state == 'closed':
+                            # Reopen issue
+                            issue.state_event = 'reopen'
+                            issue.save()
+                            log.info("GitLab error reporting - Reopened issue %s" % issue_id)
+
+                        # Add a comment to an issue...
+                        self._append_issue(issue_cache_key, error_title, error_message,
+                                           gitlab_urlencodedpath=gitlab_urlencodedpath)
+                    else:
+                        self._open_issue(error_message, error_title, gitlab_projecturl, gl_project, gl_userid,
+                                         issue_cache_key)
 
                 return ('Submitted error report to GitLab. Your issue number is <a href="%s/%s/issues/%s" '
                         'target="_blank">#%s</a>.' % (self.gitlab_base_url, gitlab_projecturl,
@@ -199,6 +204,26 @@ class GitLabPlugin(BaseGitPlugin):
             log.error("GitLab error reporting - No connection to GitLab. Cannot report error to GitLab.")
             return ('Internal Error.', 'danger')
 
+    def _open_issue(self, error_message, error_title, gitlab_projecturl, gl_project, gl_userid, issue_cache_key):
+        """ Open an issue """
+        import gitlab
+        try:
+            # Create a new issue.
+            self._create_issue(issue_cache_key, error_title, error_message, gl_project, gl_userid=gl_userid)
+        except (gitlab.GitlabOwnershipError, gitlab.GitlabGetError):
+            # Create an issue in the default location
+            gitlab_projecturl = "/".join((self.git_default_repo_owner, self.git_default_repo_name))
+            gitlab_urlencodedpath = urllib.quote_plus(gitlab_projecturl)
+            # Make sure we are always logged in, then retrieve the GitLab project if it isn't cached.
+            self.gitlab = self.gitlab_connect()
+            if gitlab_projecturl not in self.git_project_cache:
+                self.git_project_cache[gitlab_projecturl] = self.gitlab.projects.get(gitlab_urlencodedpath)
+            gl_project = self.git_project_cache[gitlab_projecturl]
+
+            # Submit issue to default project
+            self._create_issue(issue_cache_key, error_title, error_message, gl_project, gl_userid=gl_userid)
+        return gitlab_projecturl
+
     def _create_issue(self, issue_cache_key, error_title, error_message, project, **kwargs):
         # Set payload for the issue
         issue_data = {
@@ -213,6 +238,12 @@ class GitLabPlugin(BaseGitPlugin):
 
         # Create the issue on GitLab
         issue = project.issues.create(issue_data)
+
+        # Set labels
+        issue.labels = self.gitlab_labels
+        issue.save()
+
+        # Store in cache
         self.issue_cache[issue_cache_key][error_title] = issue.iid
 
     def _append_issue(self, issue_cache_key, error_title, error_message, **kwargs):

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -16,7 +16,7 @@ else:
 try:
     import gitlab
 except ImportError:
-    pass
+    gitlab = None
     
 from galaxy.util import string_as_bool
 from .base_git import BaseGitPlugin
@@ -46,14 +46,11 @@ class GitLabPlugin(BaseGitPlugin):
         self.gitlab_labels = kwargs.get("gitlab_labels", [])
 
         try:
-            if 'gitlab' not in sys.modules:
-                raise ImportError
+            if gitlab is None:
+                raise Exception("GitLab error reporting plugin is configured, but gitlab is not installed. Please install python-gitlab.")
             self.gitlab = self.gitlab_connect()
             self.gitlab.auth()
 
-        except ImportError:
-            log.error("GitLab error reporting - Please install python-gitlab to submit bug reports to GitLab.", exc_info=True)
-            self.gitlab = None
         except gitlab.GitlabAuthenticationError:
             log.error("GitLab error reporting - Could not authenticate with GitLab.", exc_info=True)
             self.gitlab = None


### PR DESCRIPTION
Allow adding labels to GitLab issues. Allow user to define behaviour on opening a new issue when the previous one has been closed.