### PR TITLE
Fix bug;  simplify creation of default shed conf files

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
@@ -62,8 +62,8 @@ class DataManagerHandler(object):
 
             # If conf file does not exist, create it.
             if not os.path.exists(shed_data_manager_conf_filename):
+                log.info('Creating shed data manager config with default contents: %s', shed_data_manager_conf_filename)
                 with open(shed_data_manager_conf_filename, 'w') as fh:
-                    log.info('Creating shed data manager config with default contents: %s', shed_data_manager_conf_filename)
                     fh.write(SHED_DATA_MANAGER_CONF_XML)
 
             # Load existing data managers.

--- a/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py
@@ -1,4 +1,3 @@
-import errno
 import logging
 import os
 import time
@@ -60,16 +59,15 @@ class DataManagerHandler(object):
             repository_tools_by_guid = {}
             for tool_tup in repository_tools_tups:
                 repository_tools_by_guid[tool_tup[1]] = dict(tool_config_filename=tool_tup[0], tool=tool_tup[2])
+
+            # If conf file does not exist, create it.
+            if not os.path.exists(shed_data_manager_conf_filename):
+                with open(shed_data_manager_conf_filename, 'w') as fh:
+                    log.info('Creating shed data manager config with default contents: %s', shed_data_manager_conf_filename)
+                    fh.write(SHED_DATA_MANAGER_CONF_XML)
+
             # Load existing data managers.
-            try:
-                tree, error_message = parse_xml(shed_data_manager_conf_filename, check_exists=False)
-            except (OSError, IOError) as exc:
-                if exc.errno == errno.ENOENT:
-                    with open(shed_data_manager_conf_filename, 'w') as fh:
-                        fh.write(SHED_DATA_MANAGER_CONF_XML)
-                    tree, error_message = parse_xml(shed_data_manager_conf_filename)
-                else:
-                    raise
+            tree, error_message = parse_xml(shed_data_manager_conf_filename)
             if tree is None:
                 return rval
             config_elems = [elem for elem in tree.getroot()]

--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -41,8 +41,8 @@ class ToolPanelManager(object):
 
         # If shed_tool_conf file does not exist, create it.
         if not os.path.exists(shed_tool_conf_filename):
+            log.info('Creating shed tool config with default contents: %s', shed_tool_conf_filename)
             with open(shed_tool_conf_filename, 'w') as fh:
-                log.info('Creating shed tool config with default contents: %s', shed_tool_conf_filename)
                 fh.write(shed_tool_conf_dict['create'])
 
         tree, error_message = parse_xml(shed_tool_conf_filename)

--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -66,11 +66,12 @@ def create_element(tag, attributes=None, sub_elements=None):
     return None
 
 
-def parse_xml(file_name, check_exists=True):
+def parse_xml(file_name):
     """Returns a parsed xml tree with comments intact."""
-    error_message = ''
-    if check_exists and not os.path.exists(file_name):
+    if not os.path.exists(file_name):
         return None, "File does not exist %s" % str(file_name)
+
+    error_message = ''
     try:
         tree = galaxy_parse_xml(file_name, remove_comments=False, strip_whitespace=False)
     except Exception as e:


### PR DESCRIPTION
1\. Fix bug #9777 

2\. Explicitly check for file existence (before creating default file) instead of relying on exception handling. 

The logic prior to #9759 (try parsing file; if exception occurs, create default file) worked because `parse_xml` tried to open the file using a `with` statement, without handling the exception that occurred if the file was not found. ([see prev. version](https://github.com/galaxyproject/galaxy/blob/c998d709d85363344a1a92ef9514cdeca86815f8/lib/galaxy/util/tool_shed/xml_util.py#L94)) That exception was handled by the caller, `ToolPanelManager`, with the default file created inside the `except` clause.

The current version of `parse_xml` handles all exceptions (good!), so the caller's `except` clause responsible for creating the default file is never reached. Although we could check the exception type and re-raise it (if `errno.ENOENT`), I think, this version is simpler and more straightforward. Also, we're not using exception handling to implement control flow.

2\. We do not need to wrap the call to `parse_xml` in `try/except` because any exceptions are handled.

3\. The same applies to `data_manager.py`.

4\. We no longer need the `check_exists` parameter in `parse_xml`.

5\. I've removed [this line](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py#L50): if the file is not loaded a (more specific) exception will be logged anyway.

Ideally, this needs dedicated automated tests, but that may delay fixing the referenced bug, which I think is more important here.

Ping @natefoo, @mvdbeek