### PR TITLE
Pass through IOError/OSError in tool_shed parse_xml

### DIFF
--- a/lib/galaxy/util/tool_shed/xml_util.py
+++ b/lib/galaxy/util/tool_shed/xml_util.py
@@ -73,6 +73,8 @@ def parse_xml(file_name, check_exists=True):
         return None, "File does not exist %s" % str(file_name)
     try:
         tree = galaxy_parse_xml(file_name, remove_comments=False, strip_whitespace=False)
+    except (IOError, OSError):
+        raise
     except Exception as e:
         error_message = "Exception attempting to parse %s: %s" % (str(file_name), unicodify(e))
         log.exception(error_message)


### PR DESCRIPTION
Not opening the file here led to all errors being caught, when we counted on OSError/IOError being passed on. This broke in https://github.com/galaxyproject/galaxy/pull/9759. Alternative to https://github.com/galaxyproject/galaxy/pull/9779