### PR TITLE
Hide masthead dropdown on iframe click 

### DIFF
--- a/client/galaxy/scripts/components/Masthead/MastheadItem.vue
+++ b/client/galaxy/scripts/components/Masthead/MastheadItem.vue
@@ -115,7 +115,7 @@ export default {
             };
         },
         galaxyIframe() {
-            return document.querySelector("iframe#galaxy_main");
+            return document.getElementById("galaxy_main");
         },
     },
     created() {

--- a/client/galaxy/scripts/components/Masthead/MastheadItem.vue
+++ b/client/galaxy/scripts/components/Masthead/MastheadItem.vue
@@ -126,10 +126,14 @@ export default {
         }
     },
     mounted() {
-        this.getGalaxyIframe.addEventListener("load", this.iframeListener);
+        if (this.getGalaxyIframe) {
+            this.getGalaxyIframe.addEventListener("load", this.iframeListener);
+        }
     },
     destroyed() {
-        this.getGalaxyIframe.removeEventListener("load", this.iframeListener);
+        if (this.getGalaxyIframe) {
+            this.getGalaxyIframe.removeEventListener("load", this.iframeListener);
+        }
     },
     methods: {
         iframeListener() {

--- a/client/galaxy/scripts/components/Masthead/MastheadItem.vue
+++ b/client/galaxy/scripts/components/Masthead/MastheadItem.vue
@@ -23,6 +23,7 @@
         </template>
     </b-nav-item>
     <b-nav-item-dropdown
+        ref="dropdown"
         v-else
         :class="classes"
         :style="styles"
@@ -161,6 +162,12 @@ export default {
             return typeof url === "string" && url.indexOf("//") === -1 && url.charAt(0) != "/"
                 ? this.appRoot + url
                 : url;
+        },
+        mounted() {
+            window.addEventListener("blur", () => {
+                // This doesn't work yet.
+                this.$refs.dropdown.hide(true);
+            });
         },
     },
 };

--- a/client/galaxy/scripts/components/Masthead/MastheadItem.vue
+++ b/client/galaxy/scripts/components/Masthead/MastheadItem.vue
@@ -115,7 +115,7 @@ export default {
             };
         },
         getGalaxyIframe() {
-            return document.querySelector('iframe#galaxy_main');
+            return document.querySelector("iframe#galaxy_main");
         },
     },
     created() {
@@ -124,21 +124,19 @@ export default {
                 this.tab.onbeforeunload();
             });
         }
-
     },
     mounted() {
-        this.getGalaxyIframe.addEventListener("load",  this.iframeListener);
+        this.getGalaxyIframe.addEventListener("load", this.iframeListener);
     },
     destroyed() {
         this.getGalaxyIframe.removeEventListener("load", this.iframeListener);
     },
     methods: {
-        iframeListener(){
-            return this.getGalaxyIframe.contentDocument.addEventListener('click', this.hideDropdown);
+        iframeListener() {
+            return this.getGalaxyIframe.contentDocument.addEventListener("click", this.hideDropdown);
         },
         hideDropdown() {
-            if (this.$refs.dropdown)
-                this.$refs.dropdown.hide();
+            if (this.$refs.dropdown) this.$refs.dropdown.hide();
         },
         open(tab, event) {
             if (tab.onclick) {

--- a/client/galaxy/scripts/components/Masthead/MastheadItem.vue
+++ b/client/galaxy/scripts/components/Masthead/MastheadItem.vue
@@ -114,6 +114,9 @@ export default {
                 visibility: this.tab.visible ? "visible" : "hidden",
             };
         },
+        getGalaxyIframe() {
+            return document.querySelector('iframe#galaxy_main');
+        },
     },
     created() {
         if (this.tab.onbeforeunload) {
@@ -121,8 +124,22 @@ export default {
                 this.tab.onbeforeunload();
             });
         }
+
+    },
+    mounted() {
+        this.getGalaxyIframe.addEventListener("load",  this.iframeListener);
+    },
+    destroyed() {
+        this.getGalaxyIframe.removeEventListener("load", this.iframeListener);
     },
     methods: {
+        iframeListener(){
+            return this.getGalaxyIframe.contentDocument.addEventListener('click', this.hideDropdown);
+        },
+        hideDropdown() {
+            if (this.$refs.dropdown)
+                this.$refs.dropdown.hide();
+        },
         open(tab, event) {
             if (tab.onclick) {
                 return this.propogateClick(tab, event);
@@ -162,12 +179,6 @@ export default {
             return typeof url === "string" && url.indexOf("//") === -1 && url.charAt(0) != "/"
                 ? this.appRoot + url
                 : url;
-        },
-        mounted() {
-            window.addEventListener("blur", () => {
-                // This doesn't work yet.
-                this.$refs.dropdown.hide(true);
-            });
         },
     },
 };

--- a/client/galaxy/scripts/components/Masthead/MastheadItem.vue
+++ b/client/galaxy/scripts/components/Masthead/MastheadItem.vue
@@ -114,7 +114,7 @@ export default {
                 visibility: this.tab.visible ? "visible" : "hidden",
             };
         },
-        getGalaxyIframe() {
+        galaxyIframe() {
             return document.querySelector("iframe#galaxy_main");
         },
     },
@@ -126,18 +126,18 @@ export default {
         }
     },
     mounted() {
-        if (this.getGalaxyIframe) {
-            this.getGalaxyIframe.addEventListener("load", this.iframeListener);
+        if (this.galaxyIframe) {
+            this.galaxyIframe.addEventListener("load", this.iframeListener);
         }
     },
     destroyed() {
-        if (this.getGalaxyIframe) {
-            this.getGalaxyIframe.removeEventListener("load", this.iframeListener);
+        if (this.galaxyIframe) {
+            this.galaxyIframe.removeEventListener("load", this.iframeListener);
         }
     },
     methods: {
         iframeListener() {
-            return this.getGalaxyIframe.contentDocument.addEventListener("click", this.hideDropdown);
+            return this.galaxyIframe.contentDocument.addEventListener("click", this.hideDropdown);
         },
         hideDropdown() {
             if (this.$refs.dropdown) this.$refs.dropdown.hide();


### PR DESCRIPTION
After https://github.com/galaxyproject/galaxy/pull/9071, we discovered a minor issue. Masthead dropdown menu didn't hide on iframe click. 
This PR fixes this problem.

Initially, we intended to use [blur event](https://stackoverflow.com/questions/11351726/bootstrap-dropdown-doesnt-collapse-when-clicking-over-iframe). However, after a short offline discussion with @dannon, we decided to use `galaxy_main` selector instead. Since there is only this iframe in Galaxy (please correct me if I am wrong), we only listen for `galaxy_main`. It might be a cleaner solution, than adding `blur` listener to the whole `window`.

visual:

![Peek 2020-05-19 17-50](https://user-images.githubusercontent.com/15801412/82348477-3bf46400-99f9-11ea-999a-461ec3287615.gif)
