### PR TITLE
Fix refactoring in linkifing libraries description

### DIFF
--- a/client/galaxy/scripts/mvc/library/library-librarylist-view.js
+++ b/client/galaxy/scripts/mvc/library/library-librarylist-view.js
@@ -136,7 +136,7 @@ var LibraryListView = Backbone.View.extend({
             $("#center").css("overflow", "auto");
         }
 
-        linkifyHtmlElements("[description=true]");
+        linkifyHtmlElements("[data-linkify=true]");
     },
 
     fetchDeleted: function () {


### PR DESCRIPTION
fix refactoring typo in https://github.com/galaxyproject/galaxy/pull/9746/files#diff-b83467811fbbeac22dcb8303e80384fbR139

Just a little typo in https://github.com/galaxyproject/galaxy/pull/9746. Should be easy to merge ;)