### PR TITLE
Modify loading of email white/blacklists

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1260,10 +1260,15 @@
 
 :Description:
     E-mail domains blacklist is used for filtering out users that are
-    using disposable email address during the registration.  If their
-    address domain matches any domain in the blacklist, they are
-    refused the registration.
-    Example value 'config/disposable_email_blacklist.conf'
+    using disposable email addresses at registration.  If their
+    address domain matches any domain on the list, they are refused
+    registration.
+    If this option is set, galaxy will expect the file to be at the
+    specified location and will raise an error if the file is not
+    found.
+    Example value 'email_blacklist.conf'
+    The value of this option will be resolved with respect to
+    <config_dir>.
 :Default: ``None``
 :Type: str
 
@@ -1276,10 +1281,17 @@
     E-mail domains whitelist is used to specify allowed email address
     domains. If the list is non-empty and a user attempts registration
     using an email address belonging to a domain that is not on the
-    list, registration will be enied. This is a more restrictive
+    list, registration will be denied. This is a more restrictive
     option than <blacklist_file>, and therefore, in case
-    <whitelist_file> is defined, <blacklist_file> will be ignored.
-:Default: ``disposable_email_whitelist.conf``
+    <whitelist_file> is set and is not empty, <blacklist_file> will be
+    ignored.
+    If this option is set, galaxy will expect the file to be at the
+    specified location and will raise an error if the file is not
+    found.
+    Example value 'email_whitelist.conf'
+    The value of this option will be resolved with respect to
+    <config_dir>.
+:Default: ``None``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1263,9 +1263,6 @@
     using disposable email addresses at registration.  If their
     address domain matches any domain on the list, they are refused
     registration.
-    If this option is set, galaxy will expect the file to be at the
-    specified location and will raise an error if the file is not
-    found.
     Example value 'email_blacklist.conf'
     The value of this option will be resolved with respect to
     <config_dir>.
@@ -1285,9 +1282,6 @@
     option than <blacklist_file>, and therefore, in case
     <whitelist_file> is set and is not empty, <blacklist_file> will be
     ignored.
-    If this option is set, galaxy will expect the file to be at the
-    specified location and will raise an error if the file is not
-    found.
     Example value 'email_whitelist.conf'
     The value of this option will be resolved with respect to
     <config_dir>.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -717,12 +717,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             }
 
     def _load_list_from_file(filepath):
-        try:
-            with open(filepath) as f:
-                return [line.strip() for line in f]
-        except IOError:
-            log.error("CONFIGURATION ERROR: Can't open supplied file: %s", filepath)
-            raise
+        with open(filepath) as f:
+            return [line.strip() for line in f]
 
     def _set_galaxy_infrastructure_url(self, kwargs):
         # indicate if this was not set explicitly, so dependending on the context a better default

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -475,24 +475,8 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         activation_email = kwargs.get('activation_email')
         self.email_from = self.email_from or activation_email
 
-        #  Get the disposable email domains blacklist file and its contents
-        self.blacklist_content = None
-        if self.blacklist_file:
-            self.blacklist_file = self._in_root_dir(self.blacklist_file)
-            try:
-                with open(self.blacklist_file) as f:
-                    self.blacklist_content = [line.rstrip() for line in f]
-            except IOError:
-                log.error("CONFIGURATION ERROR: Can't open supplied blacklist file from path: %s", self.blacklist_file)
-
-        #  Create whitelist file to accept only certain email domains
-        self.whitelist_content = None
-        if self.whitelist_file:
-            try:
-                with open(self.whitelist_file) as f:
-                    self.whitelist_content = [line.rstrip() for line in f]
-            except IOError:
-                log.error("CONFIGURATION ERROR: Can't open supplied whitelist file from path: %s", self.whitelist_file)
+        self.blacklist_content = self._load_list_from_file(self._in_config_dir(self.blacklist_file)) if self.blacklist_file else None
+        self.whitelist_content = self._load_list_from_file(self._in_config_dir(self.whitelist_file)) if self.whitelist_file else None
 
         self.persistent_communication_rooms = listify(self.persistent_communication_rooms, do_strip=True)
         # The transfer manager and deferred job queue
@@ -731,6 +715,14 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
                 'filename': kwargs['log_destination'],
                 'filters': ['stack']
             }
+
+    def _load_list_from_file(filepath):
+        try:
+            with open(filepath) as f:
+                return [line.strip() for line in f]
+        except IOError:
+            log.error("CONFIGURATION ERROR: Can't open supplied file: %s", filepath)
+            raise
 
     def _set_galaxy_infrastructure_url(self, kwargs):
         # indicate if this was not set explicitly, so dependending on the context a better default

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -703,8 +703,6 @@ galaxy:
   # using disposable email addresses at registration.  If their address
   # domain matches any domain on the list, they are refused
   # registration.
-  # If this option is set, galaxy will expect the file to be at the
-  # specified location and will raise an error if the file is not found.
   # Example value 'email_blacklist.conf'
   # The value of this option will be resolved with respect to
   # <config_dir>.
@@ -716,8 +714,6 @@ galaxy:
   # list, registration will be denied. This is a more restrictive option
   # than <blacklist_file>, and therefore, in case <whitelist_file> is
   # set and is not empty, <blacklist_file> will be ignored.
-  # If this option is set, galaxy will expect the file to be at the
-  # specified location and will raise an error if the file is not found.
   # Example value 'email_whitelist.conf'
   # The value of this option will be resolved with respect to
   # <config_dir>.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -700,19 +700,28 @@ galaxy:
   #instance_resource_url: null
 
   # E-mail domains blacklist is used for filtering out users that are
-  # using disposable email address during the registration.  If their
-  # address domain matches any domain in the blacklist, they are refused
-  # the registration.
-  # Example value 'config/disposable_email_blacklist.conf'
+  # using disposable email addresses at registration.  If their address
+  # domain matches any domain on the list, they are refused
+  # registration.
+  # If this option is set, galaxy will expect the file to be at the
+  # specified location and will raise an error if the file is not found.
+  # Example value 'email_blacklist.conf'
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
   #blacklist_file: null
 
   # E-mail domains whitelist is used to specify allowed email address
   # domains. If the list is non-empty and a user attempts registration
   # using an email address belonging to a domain that is not on the
-  # list, registration will be enied. This is a more restrictive option
+  # list, registration will be denied. This is a more restrictive option
   # than <blacklist_file>, and therefore, in case <whitelist_file> is
-  # defined, <blacklist_file> will be ignored.
-  #whitelist_file: disposable_email_whitelist.conf
+  # set and is not empty, <blacklist_file> will be ignored.
+  # If this option is set, galaxy will expect the file to be at the
+  # specified location and will raise an error if the file is not found.
+  # Example value 'email_whitelist.conf'
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #whitelist_file: null
 
   # Registration warning message is used to discourage people from
   # registering multiple accounts.  Applies mostly for the main Galaxy

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -930,22 +930,32 @@ mapping:
         required: false
         desc: |
           E-mail domains blacklist is used for filtering out users that are using
-          disposable email address during the registration.  If their address domain
-          matches any domain in the blacklist, they are refused the registration.
+          disposable email addresses at registration.  If their address domain matches any
+          domain on the list, they are refused registration.
 
-          Example value 'config/disposable_email_blacklist.conf'
+          If this option is set, galaxy will expect the file to be at the specified
+          location and will raise an error if the file is not found.
+
+          Example value 'email_blacklist.conf'
+
+          The value of this option will be resolved with respect to <config_dir>.
 
       whitelist_file:
         type: str
-        default: disposable_email_whitelist.conf
-        path_resolves_to: config_dir
         required: false
         desc: |
           E-mail domains whitelist is used to specify allowed email address domains.
           If the list is non-empty and a user attempts registration using an email
           address belonging to a domain that is not on the list, registration will be
-          enied. This is a more restrictive option than <blacklist_file>, and therefore,
-          in case <whitelist_file> is defined, <blacklist_file> will be ignored.
+          denied. This is a more restrictive option than <blacklist_file>, and therefore,
+          in case <whitelist_file> is set and is not empty, <blacklist_file> will be ignored.
+
+          If this option is set, galaxy will expect the file to be at the specified
+          location and will raise an error if the file is not found.
+
+          Example value 'email_whitelist.conf'
+
+          The value of this option will be resolved with respect to <config_dir>.
 
       registration_warning_message:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -933,9 +933,6 @@ mapping:
           disposable email addresses at registration.  If their address domain matches any
           domain on the list, they are refused registration.
 
-          If this option is set, galaxy will expect the file to be at the specified
-          location and will raise an error if the file is not found.
-
           Example value 'email_blacklist.conf'
 
           The value of this option will be resolved with respect to <config_dir>.
@@ -949,9 +946,6 @@ mapping:
           address belonging to a domain that is not on the list, registration will be
           denied. This is a more restrictive option than <blacklist_file>, and therefore,
           in case <whitelist_file> is set and is not empty, <blacklist_file> will be ignored.
-
-          If this option is set, galaxy will expect the file to be at the specified
-          location and will raise an error if the file is not found.
 
           Example value 'email_whitelist.conf'
 

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -102,7 +102,6 @@ class ExpectedValues:
             'tool_sheds_config_file': self._in_config_dir('tool_sheds_conf.xml'),
             'tool_test_data_directories': self._in_root_dir('test-data'),
             'user_preferences_extra_conf_path': self._in_config_dir('user_preferences_extra_conf.yml'),
-            'whitelist_file': self._in_config_dir('disposable_email_whitelist.conf'),
             'workflow_resource_params_file': self._in_config_dir('workflow_resource_params_conf.xml'),
             'workflow_schedulers_config_file': self._in_config_dir('workflow_schedulers_conf.xml'),
         }


### PR DESCRIPTION
Fix #9780 + some refactoring + change of behavior:

Currently, an error is logged when galaxy tries to open a file based on the value of `whitelist_file` config option. This happens on each startup because the option has a default value specified in the schema, so it is always set. I think logging an error is misleading if the user did not set the option, in which case skipping loading the file is expected behavior.

I've considered several options, such as warning if the file is missing or raising an error only if the file is missing and the value is *not* the schema default. The behavior in this current version, I think, will be least surprising for the user: do not provide a default value (so the option will be set only if the user explicitly sets it), and raise (not log) an error if the specified file is not found. 

Specific changes:
- Refactor loading of whitelist and blacklist options: remove duplication
- Expect both files to be in <config_dir> (unless absolute path set). This was the case from the start, when `config/` [was hardcoded into the default value of `blacklist_file`](https://github.com/galaxyproject/galaxy/commit/3b5d8e58376d56a2c210aa043b385f5f1809cd5f#diff-aca5b6c2096078bc08a5a5af7b9b1bdaR270)
- Raise error if option is set but file is not found
- use `strip` instead of `rstrip` for each line (because why not)
- Remove default value from whitelist (least surprise)
- Minor edits to schema wording
- Make example file names consistent (remove "disposable" prefix: makes no sense in whitelist, and unnecessary in blacklist)
- Adjust unit test (value still tested, but not for a default path)

Other considerations:
- Should we provide [a graceful way for handling old settings](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/__init__.py#L514)? 
- This is a minor bug with multiple changes to behavior. I don't think we should backport it to 20.05.

