### PR TITLE
Babel peer dependency fix,

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -88,6 +88,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
+    "@babel/helper-validator-identifier": "^7.9.5",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
     "@vue/test-utils": "^1.0.0-beta.31",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -240,6 +240,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz#9dbdb2bb55ef14aaa01fe8c99b629bd5352d8610"


### PR DESCRIPTION
Adds a seemingly undocumented babel peer dependency required for our particular version; to be dropped as an explicit dependency in https://github.com/galaxyproject/galaxy/pull/9739 (which fixes this in a core babel version upgrade)