### PR TITLE
InteractiveTool unit test fix

### DIFF
--- a/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
@@ -1,5 +1,6 @@
 import InteractiveTools from "./InteractiveTools";
 import { mount, createLocalVue } from "@vue/test-utils";
+import flushPromises from "flush-promises";
 import _l from "utils/localization";
 import Vue from "vue";
 import testInteractiveToolsResponse from "./testData/testInteractiveToolsResponse";
@@ -10,7 +11,9 @@ import axios from "axios";
 describe("ToolsView/ToolsView.vue", () => {
     const localVue = createLocalVue();
     localVue.filter("localize", (value) => _l(value));
-    let wrapper, emitted, axiosMock;
+    let wrapper;
+    let emitted;
+    let axiosMock;
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
@@ -26,9 +29,7 @@ describe("ToolsView/ToolsView.vue", () => {
         emitted = wrapper.emitted();
         axiosMock.onGet("/api/entry_points?running=true").reply(200, testInteractiveToolsResponse);
         axiosMock.onPost("/interactivetool/list").reply(200, { status: "ok", message: "ok" });
-        await Vue.nextTick();
-        await Vue.nextTick();
-        await Vue.nextTick();
+        await flushPromises();
     });
 
     afterEach(() => {
@@ -44,7 +45,6 @@ describe("ToolsView/ToolsView.vue", () => {
         function checkIfExists(tag, toolId) {
             return wrapper.find(tag + toolId).exists();
         }
-
         const toolId = testInteractiveToolsResponse[0].id;
         const tool = wrapper.vm.activeInteractiveTools.find((tool) => tool.id === toolId);
 
@@ -54,16 +54,14 @@ describe("ToolsView/ToolsView.vue", () => {
         // mark & delete tool
         const checkbox = wrapper.find("#checkbox-" + toolId);
         checkbox.trigger("click");
-        await Vue.nextTick();
+        await flushPromises();
         // ensure that the tool is marked
         assert(tool.marked === true, "clicking on checkbox did not mark corresponding tool!");
 
         const stopBtn = wrapper.find("#stopInteractiveTool");
         stopBtn.trigger("click");
 
-        await Vue.nextTick();
-        await Vue.nextTick();
-        await Vue.nextTick();
+        await flushPromises();
 
         const toolExists = wrapper.vm.activeInteractiveTools.includes((tool) => tool.id === toolId);
         // ensure that the tool was deleted from the list

--- a/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
@@ -7,7 +7,7 @@ import testInteractiveToolsResponse from "./testData/testInteractiveToolsRespons
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 
-describe("ToolsView/ToolsView.vue", () => {
+describe("InteractiveTools/InteractiveTools.vue", () => {
     const localVue = createLocalVue();
     localVue.filter("localize", (value) => _l(value));
     let wrapper;

--- a/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
@@ -2,7 +2,6 @@ import InteractiveTools from "./InteractiveTools";
 import { mount, createLocalVue } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import _l from "utils/localization";
-import Vue from "vue";
 import testInteractiveToolsResponse from "./testData/testInteractiveToolsResponse";
 
 import MockAdapter from "axios-mock-adapter";
@@ -12,7 +11,6 @@ describe("ToolsView/ToolsView.vue", () => {
     const localVue = createLocalVue();
     localVue.filter("localize", (value) => _l(value));
     let wrapper;
-    let emitted;
     let axiosMock;
 
     beforeEach(async () => {
@@ -26,7 +24,6 @@ describe("ToolsView/ToolsView.vue", () => {
                 },
             },
         });
-        emitted = wrapper.emitted();
         axiosMock.onGet("/api/entry_points?running=true").reply(200, testInteractiveToolsResponse);
         axiosMock.onPost("/interactivetool/list").reply(200, { status: "ok", message: "ok" });
         await flushPromises();
@@ -36,27 +33,24 @@ describe("ToolsView/ToolsView.vue", () => {
         axiosMock.restore();
     });
 
-    it("table should exist", async () => {
+    it("Interactive Tool Table renders", async () => {
         const table = wrapper.find("#workflow-table");
-        assert(table.exists() === true, "Interactive Tools table doesn't exist!");
+        assert(table.exists() === true, "Interactive Tools table doesn't exist");
     });
 
-    it("selected tool should disappear after stop button pressed", async () => {
+    it("IT should disappear after stop button pressed", async () => {
         function checkIfExists(tag, toolId) {
             return wrapper.find(tag + toolId).exists();
         }
         const toolId = testInteractiveToolsResponse[0].id;
         const tool = wrapper.vm.activeInteractiveTools.find((tool) => tool.id === toolId);
+        assert(checkIfExists("#link-", toolId) === true, "tool is not rendered");
+        assert(tool.marked === undefined || false, "tool was selected before click");
 
-        assert(checkIfExists("#link-", toolId) === true, "tool is not rendered!");
-        // ensure that the tool is not marked
-        assert(tool.marked === undefined || false, "tool was marked before click!");
-        // mark & delete tool
         const checkbox = wrapper.find("#checkbox-" + toolId);
         checkbox.trigger("click");
         await flushPromises();
-        // ensure that the tool is marked
-        assert(tool.marked === true, "clicking on checkbox did not mark corresponding tool!");
+        assert(tool.marked === true, "Clicking on checkbox did not select corresponding tool");
 
         const stopBtn = wrapper.find("#stopInteractiveTool");
         stopBtn.trigger("click");
@@ -64,8 +58,7 @@ describe("ToolsView/ToolsView.vue", () => {
         await flushPromises();
 
         const toolExists = wrapper.vm.activeInteractiveTools.includes((tool) => tool.id === toolId);
-        // ensure that the tool was deleted from the list
-        assert(toolExists === false, "tool was not deleted from the list!");
-        assert(checkIfExists("#link-", toolId) === false, "tool is rendered after deletion!");
+        assert(toolExists === false, "Interactive Tool was not deleted from the list");
+        assert(checkIfExists("#link-", toolId) === false, "Interactive Tool is still rendered after deletion");
     });
 });

--- a/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
@@ -48,8 +48,7 @@ describe("InteractiveTools/InteractiveTools.vue", () => {
         assert(tool.marked === undefined || false, "tool was selected before click");
 
         const checkbox = wrapper.find("#checkbox-" + toolId);
-        checkbox.trigger("click");
-        await flushPromises();
+        checkbox.setChecked();
         await flushPromises();
         assert(tool.marked === true, "Clicking on checkbox did not select corresponding tool");
 

--- a/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/galaxy/scripts/components/InteractiveTools/InteractiveTools.test.js
@@ -38,7 +38,7 @@ describe("ToolsView/ToolsView.vue", () => {
         assert(table.exists() === true, "Interactive Tools table doesn't exist");
     });
 
-    it("IT should disappear after stop button pressed", async () => {
+    it("Interactive Tool should disappear after stop button pressed", async () => {
         function checkIfExists(tag, toolId) {
             return wrapper.find(tag + toolId).exists();
         }
@@ -50,11 +50,11 @@ describe("ToolsView/ToolsView.vue", () => {
         const checkbox = wrapper.find("#checkbox-" + toolId);
         checkbox.trigger("click");
         await flushPromises();
+        await flushPromises();
         assert(tool.marked === true, "Clicking on checkbox did not select corresponding tool");
 
         const stopBtn = wrapper.find("#stopInteractiveTool");
         stopBtn.trigger("click");
-
         await flushPromises();
 
         const toolExists = wrapper.vm.activeInteractiveTools.includes((tool) => tool.id === toolId);

--- a/client/galaxy/scripts/components/Toolshed/SearchList/Repositories.test.js
+++ b/client/galaxy/scripts/components/Toolshed/SearchList/Repositories.test.js
@@ -2,7 +2,6 @@ import { mount } from "@vue/test-utils";
 import Repositories from "./Repositories";
 import { __RewireAPI__ as rewire } from "./Repositories";
 import Vue from "vue";
-import flushPromises from "flush-promises";
 
 describe("Repositories", () => {
     beforeEach(() => {


### PR DESCRIPTION
(split off #9795, since it's totally unrelated to the changes there, I just happened to try to fix it in that branch)

This test broke recently with the release of chrome 83 (as I eventually figured out).  Previously, you could trigger clicks on the hidden checkbox just fine with the `.trigger("click")` approach, but that no longer works.  Using `setChecked` from vue-test-utils sets the value and propagates model updates, making this all work again.