### PR TITLE
Make AuthN attribute optional for Azure and GCP.

### DIFF
--- a/lib/galaxy/managers/cloudauthzs.py
+++ b/lib/galaxy/managers/cloudauthzs.py
@@ -61,7 +61,7 @@ class CloudAuthzsSerializer(base.ModelSerializer):
             'user_id'      : lambda i, k, **c: self.app.security.encode_id(i.user_id),
             'provider'     : lambda i, k, **c: str(i.provider),
             'config'       : lambda i, k, **c: i.config,
-            'authn_id'     : lambda i, k, **c: self.app.security.encode_id(i.authn_id),
+            'authn_id'     : lambda i, k, **c: self.app.security.encode_id(i.authn_id) if i.authn_id else None,
             'last_update'  : lambda i, k, **c: str(i.last_update),
             'last_activity': lambda i, k, **c: str(i.last_activity),
             'create_time'  : lambda i, k, **c: str(i.create_time),

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5963,7 +5963,7 @@ class CustosAuthnzToken(RepresentById):
         self.refresh_expiration_time = refresh_expiration_time
 
 
-class CloudAuthz(RepresentById):
+class CloudAuthz(object):
     def __init__(self, user_id, provider, config, authn_id, description=""):
         self.id = None
         self.user_id = user_id
@@ -5986,6 +5986,7 @@ class CloudAuthz(RepresentById):
     def equals(self, user_id, provider, authn_id, config):
         return (self.user_id == user_id
                 and self.provider == provider
+                and self.authn_id
                 and self.authn_id == authn_id
                 and len({k: self.config[k] for k in self.config if k in config
                          and self.config[k] == config[k]}) == len(self.config))

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5975,14 +5975,6 @@ class CloudAuthz(object):
         self.last_activity = datetime.now()
         self.description = description
 
-    def __eq__(self, other):
-        if not isinstance(other, CloudAuthz):
-            return False
-        return self.equals(other.user_id, other.provider, other.authn_id, other.config)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
     def equals(self, user_id, provider, authn_id, config):
         return (self.user_id == user_id
                 and self.provider == provider

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -104,7 +104,7 @@ class CloudAuthzController(BaseAPIController):
             missing_arguments.append('config')
 
         authn_id = payload.get('authn_id', None)
-        if authn_id is None:
+        if authn_id is None and provider.lower() not in ["azure", "gcp"]:
             missing_arguments.append('authn_id')
 
         if len(missing_arguments) > 0:
@@ -118,16 +118,17 @@ class CloudAuthzController(BaseAPIController):
             log.debug(msg_template.format("invalid config type `{}`, expect `dict`".format(type(config))))
             raise RequestParameterInvalidException('Invalid type for the required `config` variable; expect `dict` '
                                                    'but received `{}`.'.format(type(config)))
-        try:
-            authn_id = self.decode_id(authn_id)
-        except Exception:
-            log.debug(msg_template.format("cannot decode authn_id `" + str(authn_id) + "`"))
-            raise MalformedId('Invalid `authn_id`!')
+        if authn_id:
+            try:
+                authn_id = self.decode_id(authn_id)
+            except Exception:
+                log.debug(msg_template.format("cannot decode authn_id `" + str(authn_id) + "`"))
+                raise MalformedId('Invalid `authn_id`!')
 
-        try:
-            trans.app.authnz_manager.can_user_assume_authn(trans, authn_id)
-        except Exception as e:
-            raise e
+            try:
+                trans.app.authnz_manager.can_user_assume_authn(trans, authn_id)
+            except Exception as e:
+                raise e
 
         # No two authorization configuration with
         # exact same key/value should exist.

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -148,7 +148,6 @@ class CloudAuthzController(BaseAPIController):
             )
             view = self.cloudauthz_serializer.serialize_to_view(new_cloudauthz, trans=trans, **self._parse_serialization_params(kwargs, 'summary'))
             log.debug('Created a new cloudauthz record for the user id `{}` '.format(str(trans.user.id)))
-            trans.response.status = '200'
             return view
         except Exception as e:
             log.exception(msg_template.format("exception while creating the new cloudauthz record"))

--- a/test/integration/cloudauthz/test_cloudauthz.py
+++ b/test/integration/cloudauthz/test_cloudauthz.py
@@ -1,0 +1,49 @@
+"""
+
+You may run this test using the following command:
+./run_tests.sh test/integration/cloudauthz/test_cloudauthz.py:DefineCloudAuthzTestCase.test_post_cloudauthz_without_authn -s
+"""
+
+import json
+
+from galaxy_test.driver import integration_util
+
+
+class BaseCloudAuthzTestCase(integration_util.IntegrationTestCase):
+    framework_tool_and_types = True
+
+    def setUp(self):
+        super(BaseCloudAuthzTestCase, self).setUp()
+
+
+class DefineCloudAuthzTestCase(BaseCloudAuthzTestCase):
+
+    def setUp(self):
+        super(DefineCloudAuthzTestCase, self).setUp()
+
+    def test_post_cloudauthz_without_authn(self):
+        """
+        This test asserts if a cloudauthz object
+        can be successfully posted to the cloudauthz API
+        (i.e., api/cloud/authz).
+        """
+        provider = "azure"
+        tenant_id = "abc"
+        client_id = "def"
+        client_secret = "ghi"
+        with self._different_user("vahid@test.com"):
+
+            # The payload for the POST API.
+            payload = {
+                "provider": provider,
+                "config": {
+                    "tenant_id": tenant_id,
+                    "client_id": client_id,
+                    "client_secret": client_secret
+                }
+            }
+
+            response = self._post(path="cloud/authz", data=payload)
+            cloudauthz = json.loads(response.content)
+
+            assert cloudauthz["provider"] == provider

--- a/test/integration/cloudauthz/test_cloudauthz.py
+++ b/test/integration/cloudauthz/test_cloudauthz.py
@@ -36,14 +36,15 @@ class DefineCloudAuthzTestCase(BaseCloudAuthzTestCase):
             # The payload for the POST API.
             payload = {
                 "provider": provider,
-                "config": {
+                "config": json.dumps({
                     "tenant_id": tenant_id,
                     "client_id": client_id,
                     "client_secret": client_secret
-                }
+                })
             }
 
             response = self._post(path="cloud/authz", data=payload)
-            cloudauthz = json.loads(response.content)
+            response.raise_for_status()
+            cloudauthz = response.json()
 
             assert cloudauthz["provider"] == provider

--- a/test/integration/cloudauthz/test_cloudauthz.py
+++ b/test/integration/cloudauthz/test_cloudauthz.py
@@ -1,5 +1,4 @@
 """
-
 You may run this test using the following command:
 ./run_tests.sh test/integration/cloudauthz/test_cloudauthz.py:DefineCloudAuthzTestCase.test_post_cloudauthz_without_authn -s
 """
@@ -9,17 +8,8 @@ import json
 from galaxy_test.driver import integration_util
 
 
-class BaseCloudAuthzTestCase(integration_util.IntegrationTestCase):
+class DefineCloudAuthzTestCase(integration_util.IntegrationTestCase):
     framework_tool_and_types = True
-
-    def setUp(self):
-        super(BaseCloudAuthzTestCase, self).setUp()
-
-
-class DefineCloudAuthzTestCase(BaseCloudAuthzTestCase):
-
-    def setUp(self):
-        super(DefineCloudAuthzTestCase, self).setUp()
 
     def test_post_cloudauthz_without_authn(self):
         """


### PR DESCRIPTION
Authentication information (e.g., Google OIDC tokens) are used to identify a user to a cloud service provider and get temporary authorization tokens. Hence making an OIDC-based authentication of a user a prerequisite for cloud authorization. 

However, the authentication tokens are used for AWS only, and Azure and Google Cloud Platform (GCP) do not yet support/utilize them. Therefore, this PR makes these tokens optional for Azure and GCP. Doing so, those Galaxy instances authenticating a user via username and password, would not need to setup OIDC to use Azure and GCP. 

Additionally, this PR added integration tests asserting if a cloudauthz config can be POSTed to the `api/cloud/authz` API for `azure` or `gcp` without specifying `authn` information. This test is a following up from a chat on gitter; for a quick ref: 

> @VJalili : I am getting TypeError: unhashable type: 'CloudAuthz' when trying to add a new cloudauthz via POST to /api/cloud/authz running on latest dev. 
I tracked it all the way to [the config variable](https://github.com/galaxyproject/galaxy/blob/b37629b56b80672b8c88b38ae844d429935f9930/lib/galaxy/model/__init__.py#L5813). Renaming this variable fixes it.

> @mvdbeek: @VJalili the config attribute is backed by a JSONType column (https://github.com/mvdbeek/galaxy/blob/dev/lib/galaxy/model/mapping.py#L161). This means the config attribute should be something that can be serialzed as JSON. It looks like the config is actually a CloudAuthz instance in your case. The code on the dev branch should make sure the config is a dict (https://github.com/mvdbeek/galaxy/blob/dev/lib/galaxy/webapps/galaxy/api/cloudauthz.py#L119), so I’m not sure what’s going on in your case, but as a first step I would suggest writing an integration test for this.

The test is sending a POST request with the following object as payload where `config` is a dictionary ([xref](https://github.com/VJalili/galaxy/blob/809ca2c737fc6fa6a45d96a179e8c149a912e581/test/integration/cloudauthz/test_cloudauthz.py#L37-L44)):

```json
payload = {
    "provider": "azure",
     "config": {
        "tenant_id": "tenant_id",
        "client_id": "client_id",
        "client_secret": "client_secret"
    }
}
```

However, the API receives the following payload where `config` is a list: 

```json
{
    "provider": "azure", 
    "config": ["tenant_id", "client_id", "client_secret"], 
    "key": "..."
}
```

ping @mvdbeek 
