### PR TITLE
Allow tool submission with DatasetCollectionElements / make build_for_rerun consumable by API

### DIFF
--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -451,14 +451,14 @@ const View = Backbone.View.extend({
     /** Library datasets are displayed and selected together with history datasets,
         Dataset collection elements are displayed together with history dataset collections **/
     _patchValue: function (v) {
-        const patch_to = { ldda: "hda", dce: "hdca" };
+        const patchTo = { ldda: "hda", dce: "hdca" };
         if (v.values) {
             _.each(v.values, (v) => {
                 this._patchValue(v);
             });
-        } else if (patch_to[v.src]) {
+        } else if (patchTo[v.src]) {
             v.origin = v.src;
-            v.src = patch_to[v.src];
+            v.src = patchTo[v.src];
             v.id = `${v.origin}${v.id}`;
         }
     },

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1062,7 +1062,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             params_objects[key] = safe_loads(param_dict[key])
 
         def remap_objects(p, k, obj):
-            if isinstance(obj, dict) and "src" in obj and obj["src"] in ["hda", "hdca"]:
+            if isinstance(obj, dict) and "src" in obj and obj["src"] in ["hda", "hdca", "dce"]:
                 new_id = serialization_options.get_identifier_for_id(id_encoder, obj["id"])
                 new_obj = obj.copy()
                 new_obj["id"] = new_id

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -708,6 +708,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         self.input_datasets = []
         self.output_datasets = []
         self.input_dataset_collections = []
+        self.input_dataset_collection_elements = []
         self.output_dataset_collection_instances = []
         self.output_dataset_collections = []
         self.input_library_datasets = []
@@ -928,6 +929,9 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
 
     def add_input_dataset_collection(self, name, dataset_collection):
         self.input_dataset_collections.append(JobToInputDatasetCollectionAssociation(name, dataset_collection))
+
+    def add_input_dataset_collection_element(self, name, dataset_collection_element):
+        self.input_dataset_collection_elements.append(JobToInputDatasetCollectionElementAssociation(name, dataset_collection_element))
 
     def add_output_dataset_collection(self, name, dataset_collection_instance):
         self.output_dataset_collection_instances.append(JobToOutputDatasetCollectionAssociation(name, dataset_collection_instance))
@@ -1327,6 +1331,12 @@ class JobToInputDatasetCollectionAssociation(RepresentById):
     def __init__(self, name, dataset_collection):
         self.name = name
         self.dataset_collection = dataset_collection
+
+
+class JobToInputDatasetCollectionElementAssociation(RepresentById):
+    def __init__(self, name, dataset_collection_element):
+        self.name = name
+        self.dataset_collection_element = dataset_collection_element
 
 
 # Many jobs may map to one HistoryDatasetCollection using these for a given

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -671,6 +671,13 @@ model.JobToInputDatasetCollectionAssociation.table = Table(
     Column("dataset_collection_id", Integer, ForeignKey("history_dataset_collection_association.id"), index=True),
     Column("name", Unicode(255)))
 
+model.JobToInputDatasetCollectionElementAssociation.table = Table(
+    "job_to_input_dataset_collection_element", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("job_id", Integer, ForeignKey("job.id"), index=True),
+    Column("dataset_collection_element_id", Integer, ForeignKey("dataset_collection_element.id"), index=True),
+    Column("name", Unicode(255)))
+
 model.JobToImplicitOutputDatasetCollectionAssociation.table = Table(
     "job_to_implicit_output_dataset_collection", metadata,
     Column("id", Integer, primary_key=True),
@@ -2182,6 +2189,12 @@ mapper(model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetColl
         lazy=False)
 ))
 
+mapper(model.JobToInputDatasetCollectionElementAssociation, model.JobToInputDatasetCollectionElementAssociation.table, properties=dict(
+    job=relation(model.Job),
+    dataset_collection_element=relation(model.DatasetCollectionElement,
+    lazy=False)
+))
+
 mapper(model.JobToOutputDatasetCollectionAssociation, model.JobToOutputDatasetCollectionAssociation.table, properties=dict(
     job=relation(model.Job),
     dataset_collection_instance=relation(model.HistoryDatasetCollectionAssociation,
@@ -2311,6 +2324,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     parameters=relation(model.JobParameter, lazy=True),
     input_datasets=relation(model.JobToInputDatasetAssociation),
     input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, lazy=True),
+    input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation, lazy=True),
     output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
     any_output_dataset_deleted=column_property(
         exists([model.HistoryDatasetAssociation],

--- a/lib/galaxy/model/migrate/versions/0167_add_job_to_input_dataset_collection_element_association.py
+++ b/lib/galaxy/model/migrate/versions/0167_add_job_to_input_dataset_collection_element_association.py
@@ -1,0 +1,39 @@
+"""
+Migration script to add a new job_to_input_dataset_collection_element table to track job inputs.
+"""
+from __future__ import print_function
+
+import logging
+
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, Table, Unicode
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+job_to_input_dataset_collection_element_table = Table(
+    "job_to_input_dataset_collection_element", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("job_id", Integer, ForeignKey("job.id"), index=True),
+    Column("dataset_collection_element_id", Integer, ForeignKey("dataset_collection_element.id"), index=True),
+    Column("name", Unicode(255)))
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        job_to_input_dataset_collection_element_table.create()
+    except Exception:
+        log.exception("Creating job_to_input_dataset_collection_element table failed")
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        job_to_input_dataset_collection_element_table.drop()
+    except Exception:
+        log.exception("Dropping job_to_input_dataset_collection_element table failed")

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -436,6 +436,8 @@ class ModelImportStore(object):
                                                          element=model.DatasetCollectionElement.UNINITIALIZED_ELEMENT,
                                                          element_index=element_attrs['element_index'],
                                                          element_identifier=element_attrs['element_identifier'])
+                    if 'encoded_id' in element_attrs:
+                        object_import_tracker.dces_by_key[element_attrs['encoded_id']] = dce
                     if 'hda' in element_attrs:
                         hda_attrs = element_attrs['hda']
                         if object_key in hda_attrs:
@@ -557,7 +559,7 @@ class ModelImportStore(object):
                 # attach to this node... unless we've already encountered another dataset
                 # copied from that jobs output... in that case we are going to cheat and
                 # say this dataset was copied from that one. It wasn't in the original Galaxy
-                # instance but I think it is find to pretend in order to create a DAG here.
+                # instance but I think it is fine to pretend in order to create a DAG here.
                 hda_copied_from_sinks = object_import_tracker.hda_copied_from_sinks
                 if copied_from_object_key in hda_copied_from_sinks:
                     hda.copied_from_history_dataset_association = object_import_tracker.hdas_by_key[hda_copied_from_sinks[copied_from_object_key]]
@@ -625,6 +627,12 @@ class ModelImportStore(object):
                 hdca = object_import_tracker.hdca_copied_from_sinks[input_key]
             return hdca
 
+        def _find_dce(input_key):
+            dce = None
+            if input_key in object_import_tracker.dces_by_key:
+                dce = object_import_tracker.dces_by_key[input_key]
+            return dce
+
         #
         # Create jobs.
         #
@@ -636,7 +644,7 @@ class ModelImportStore(object):
                 assert self.import_options.allow_edit
                 assert not self.sessionless
                 job = self.sa_session.query(model.Job).get(job_attrs["id"])
-                self._connect_job_io(job, job_attrs, _find_hda, _find_hdca)
+                self._connect_job_io(job, job_attrs, _find_hda, _find_hdca, _find_dce)
                 self._flush()
                 continue
 
@@ -674,12 +682,12 @@ class ModelImportStore(object):
             self._flush()
 
             # Connect jobs to input and output datasets.
-            params = self._normalize_job_parameters(imported_job, job_attrs, _find_hda, _find_hdca)
+            params = self._normalize_job_parameters(imported_job, job_attrs, _find_hda, _find_hdca, _find_dce)
             for name, value in params.items():
                 # Transform parameter values when necessary.
                 imported_job.add_parameter(name, dumps(value))
 
-            self._connect_job_io(imported_job, job_attrs, _find_hda, _find_hdca)
+            self._connect_job_io(imported_job, job_attrs, _find_hda, _find_hdca, _find_dce)
             self._flush()
 
             if object_key in job_attrs:
@@ -745,6 +753,8 @@ class ObjectImportTracker(object):
         self.hdas_by_id = {}
         self.hdcas_by_key = {}
         self.hdcas_by_id = {}
+        self.dces_by_key = {}
+        self.dces_by_id = {}
         self.lddas_by_key = {}
         self.hda_copied_from_sinks = {}
         self.hdca_copied_from_sinks = {}
@@ -828,7 +838,7 @@ class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):
 
         self.archive_dir = archive_dir
 
-    def _connect_job_io(self, imported_job, job_attrs, _find_hda, _find_hdca):
+    def _connect_job_io(self, imported_job, job_attrs, _find_hda, _find_hdca, _find_dce):
         for output_key in job_attrs['output_datasets']:
             output_hda = _find_hda(output_key)
             if output_hda:
@@ -843,7 +853,7 @@ class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):
                 if input_hda:
                     imported_job.add_input_dataset(input_name, input_hda)
 
-    def _normalize_job_parameters(self, imported_job, job_attrs, _find_hda, _find_hdca):
+    def _normalize_job_parameters(self, imported_job, job_attrs, _find_hda, _find_hdca, _find_dce):
         def remap_objects(p, k, obj):
             if isinstance(obj, dict) and obj.get('__HistoryDatasetAssociation__', False):
                 imported_hda = _find_hda(obj[self.object_key])
@@ -873,7 +883,7 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
         else:
             self.import_history_encoded_id = None
 
-    def _connect_job_io(self, imported_job, job_attrs, _find_hda, _find_hdca):
+    def _connect_job_io(self, imported_job, job_attrs, _find_hda, _find_hdca, _find_dce):
 
         if 'input_dataset_mapping' in job_attrs:
             for input_name, input_keys in job_attrs['input_dataset_mapping'].items():
@@ -890,6 +900,14 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
                     input_hdca = _find_hdca(input_key)
                     if input_hdca:
                         imported_job.add_input_dataset_collection(input_name, input_hdca)
+
+        if 'input_dataset_collection_element_mapping' in job_attrs:
+            for input_name, input_keys in job_attrs['input_dataset_collection_element_mapping'].items():
+                input_keys = input_keys or []
+                for input_key in input_keys:
+                    input_dce = _find_dce(input_key)
+                    if input_dce:
+                        imported_job.add_input_dataset_collection_element(input_name, input_dce)
 
         if 'output_dataset_mapping' in job_attrs:
             for output_name, output_keys in job_attrs['output_dataset_mapping'].items():
@@ -913,9 +931,9 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
     def trust_hid(self, obj_attrs):
         return self.import_history_encoded_id and obj_attrs.get("history_encoded_id") == self.import_history_encoded_id
 
-    def _normalize_job_parameters(self, imported_job, job_attrs, _find_hda, _find_hdca):
+    def _normalize_job_parameters(self, imported_job, job_attrs, _find_hda, _find_hdca, _find_dce):
         def remap_objects(p, k, obj):
-            if isinstance(obj, dict) and "src" in obj and obj["src"] in ["hda", "hdca"]:
+            if isinstance(obj, dict) and "src" in obj and obj["src"] in ["hda", "hdca", "dce"]:
                 if obj["src"] == "hda":
                     imported_hda = _find_hda(obj["id"])
                     if imported_hda:
@@ -926,6 +944,12 @@ class DirectoryImportModelStoreLatest(BaseDirectoryImportModelStore):
                     imported_hdca = _find_hdca(obj["id"])
                     if imported_hdca:
                         new_id = imported_hdca.id
+                    else:
+                        new_id = None
+                elif obj["src"] == "dce":
+                    imported_dce = _find_dce(obj["id"])
+                    if imported_dce:
+                        new_id = imported_dce.id
                     else:
                         new_id = None
                 else:
@@ -1265,6 +1289,7 @@ class DirectoryModelExportStore(ModelExportStore):
             input_dataset_mapping = {}
             output_dataset_mapping = {}
             input_dataset_collection_mapping = {}
+            input_dataset_collection_element_mapping = {}
             output_dataset_collection_mapping = {}
             implicit_output_dataset_collection_mapping = {}
 
@@ -1295,6 +1320,14 @@ class DirectoryModelExportStore(ModelExportStore):
 
                     input_dataset_collection_mapping[name].append(self.exported_key(assoc.dataset_collection))
 
+            for assoc in job.input_dataset_collection_elements:
+                if assoc.dataset_collection_element:
+                    name = assoc.name
+                    if name not in input_dataset_collection_element_mapping:
+                        input_dataset_collection_element_mapping[name] = []
+
+                    input_dataset_collection_element_mapping[name].append(self.exported_key(assoc.dataset_collection_element))
+
             for assoc in job.output_dataset_collection_instances:
                 # Optional data outputs will not have a dataset.
                 if assoc.dataset_collection_instance:
@@ -1315,6 +1348,7 @@ class DirectoryModelExportStore(ModelExportStore):
 
             job_attrs['input_dataset_mapping'] = input_dataset_mapping
             job_attrs['input_dataset_collection_mapping'] = input_dataset_collection_mapping
+            job_attrs['input_dataset_collection_element_mapping'] = input_dataset_collection_element_mapping
             job_attrs['output_dataset_mapping'] = output_dataset_mapping
             job_attrs['output_dataset_collection_mapping'] = output_dataset_collection_mapping
             job_attrs['implicit_output_dataset_collection_mapping'] = implicit_output_dataset_collection_mapping

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1597,7 +1597,7 @@ class Tool(Dictifiable):
                 completed_job=completed_job,
                 collection_info=collection_info,
             )
-        except webob.exc.HTTPFound as e:
+        except (webob.exc.HTTPFound, exceptions.MessageException) as e:
             # if it's a webob redirect exception, pass it up the stack
             raise e
         except ToolInputsNotReadyException as e:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2131,7 +2131,7 @@ class Tool(Dictifiable):
             'requirements'  : [{'name' : r.name, 'version' : r.version} for r in self.requirements],
             'errors'        : state_errors,
             'tool_errors'   : self.tool_errors,
-            'state_inputs'  : params_to_strings(self.inputs, state_inputs, self.app),
+            'state_inputs'  : params_to_strings(self.inputs, state_inputs, self.app, use_security=True, nested=True),
             'job_id'        : trans.security.encode_id(job.id) if job else None,
             'job_remap'     : self._get_job_remap(job),
             'history_id'    : trans.security.encode_id(history.id) if history else None,

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -8,6 +8,7 @@ from json import dumps
 from six import string_types
 
 from galaxy import model
+from galaxy.exceptions import ItemAccessibilityException
 from galaxy.jobs.actions.post import ActionBox
 from galaxy.model import LibraryDatasetDatasetAssociation, WorkflowRequestInputParameter
 from galaxy.model.dataset_collections.builder import CollectionBuilder
@@ -100,12 +101,12 @@ class DefaultToolAction(object):
                 if collection_info and collection_info.is_mapped_over(input_name):
                     action_tuples = collection_info.map_over_action_tuples(input_name)
                     if not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
-                        raise Exception("User does not have permission to use a dataset provided for input.")
+                        raise ItemAccessibilityException("User does not have permission to use a dataset provided for input.")
                     for action, role_id in action_tuples:
                         record_permission(action, role_id)
                 else:
                     if not trans.app.security_agent.can_access_dataset(current_user_roles, data.dataset):
-                        raise Exception("User does not have permission to use a dataset (%s) provided for input." % data.id)
+                        raise ItemAccessibilityException("User does not have permission to use a dataset (%s) provided for input." % data.id)
                     permissions = trans.app.security_agent.get_permissions(data.dataset)
                     for action, roles in permissions.items():
                         for role in roles:
@@ -172,7 +173,7 @@ class DefaultToolAction(object):
 
                 action_tuples = collection.dataset_action_tuples
                 if not trans.app.security_agent.can_access_datasets(current_user_roles, action_tuples):
-                    raise Exception("User does not have permission to use a dataset provided for input.")
+                    raise ItemAccessibilityException("User does not have permission to use a dataset provided for input.")
                 for action, role_id in action_tuples:
                     record_permission(action, role_id)
 

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -706,10 +706,9 @@ class DefaultToolAction(object):
 
                 # TODO: verify can have multiple with same name, don't want to lose traceability
                 if isinstance(dataset_collection, model.HistoryDatasetCollectionAssociation):
-                    # FIXME: when recording inputs for special tools (e.g. ModelOperationToolAction),
-                    # dataset_collection is actually a DatasetCollectionElement, which can't be added
-                    # to a jobs' input_dataset_collection relation, which expects HDCA instances
                     job.add_input_dataset_collection(name, dataset_collection)
+                elif isinstance(dataset_collection, model.DatasetCollectionElement):
+                    job.add_input_dataset_collection_element(name, dataset_collection)
 
         # If this an input collection is a reduction, we expanded it for dataset security, type
         # checking, and such, but the persisted input must be the original collection

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -192,7 +192,7 @@ def check_param(trans, param, incoming_value, param_values):
     return value, error
 
 
-def params_to_strings(params, param_values, app, nested=False):
+def params_to_strings(params, param_values, app, nested=False, use_security=False):
     """
     Convert a dictionary of parameter values to a dictionary of strings
     suitable for persisting. The `value_to_basic` method of each parameter
@@ -203,7 +203,7 @@ def params_to_strings(params, param_values, app, nested=False):
     rval = dict()
     for key, value in param_values.items():
         if key in params:
-            value = params[key].value_to_basic(value, app)
+            value = params[key].value_to_basic(value, app, use_security=use_security)
         rval[key] = value if nested else str(dumps(value, sort_keys=True))
     return rval
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2080,6 +2080,8 @@ class DataCollectionToolParameter(BaseDataToolParameter):
                 if isinstance(value, dict) and 'src' in value and 'id' in value:
                     if value['src'] == 'hdca':
                         rval = trans.sa_session.query(trans.app.model.HistoryDatasetCollectionAssociation).get(trans.security.decode_id(value['id']))
+                    elif value['src'] == 'dce':
+                        rval = trans.sa_session.query(trans.app.model.DatasetCollectionElement).get(trans.security.decode_id(value['id']))
         elif isinstance(value, string_types):
             if value.startswith("dce:"):
                 rval = trans.sa_session.query(trans.app.model.DatasetCollectionElement).get(value[len("dce:"):])
@@ -2112,7 +2114,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         d = super(DataCollectionToolParameter, self).to_dict(trans)
         d['extensions'] = self.extensions
         d['multiple'] = self.multiple
-        d['options'] = {'hda': [], 'hdca': []}
+        d['options'] = {'hda': [], 'hdca': [], 'dce': []}
 
         # return dictionary without options if context is unavailable
         history = trans.history
@@ -2123,6 +2125,17 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         dataset_matcher_factory = get_dataset_matcher_factory(trans)
         dataset_matcher = dataset_matcher_factory.dataset_matcher(self, other_values)
         dataset_collection_matcher = dataset_matcher_factory.dataset_collection_matcher(dataset_matcher)
+
+        # append DCE
+        if isinstance(other_values.get(self.name), galaxy.model.DatasetCollectionElement):
+            dce = other_values[self.name]
+            d['options']['dce'].append({
+                'id'   : trans.security.encode_id(dce.id),
+                'hid'  : None,
+                'name' : dce.element_identifier,
+                'src'  : 'dce',
+                'tags' : []
+            })
 
         # append directly matched collections
         for hdca, implicit_conversion in self.match_collections(trans, history, dataset_collection_matcher):

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -39,7 +39,7 @@ class Group(Dictifiable):
     def visible(self):
         return True
 
-    def value_to_basic(self, value, app):
+    def value_to_basic(self, value, app, use_security=False):
         """
         Convert value to a (possibly nested) representation using only basic
         types (dict, list, tuple, string_types, int, long, float, bool, None)
@@ -85,7 +85,7 @@ class Repeat(Group):
     def label(self):
         return "Repeat (%s)" % self.title
 
-    def value_to_basic(self, value, app):
+    def value_to_basic(self, value, app, use_security=False):
         rval = []
         for d in value:
             rval_dict = {}
@@ -94,7 +94,7 @@ class Repeat(Group):
                 rval_dict['__index__'] = d['__index__']
             for input in self.inputs.values():
                 if input.name in d:
-                    rval_dict[input.name] = input.value_to_basic(d[input.name], app)
+                    rval_dict[input.name] = input.value_to_basic(d[input.name], app, use_security)
             rval.append(rval_dict)
         return rval
 
@@ -159,11 +159,11 @@ class Section(Group):
     def label(self):
         return "Section (%s)" % self.title
 
-    def value_to_basic(self, value, app):
+    def value_to_basic(self, value, app, use_security=False):
         rval = {}
         for input in self.inputs.values():
             if input.name in value:  # parameter might be absent in unverified workflow
-                rval[input.name] = input.value_to_basic(value[input.name], app)
+                rval[input.name] = input.value_to_basic(value[input.name], app, use_security)
         return rval
 
     def value_from_basic(self, value, app, ignore_errors=False):
@@ -277,7 +277,7 @@ class UploadDataset(Group):
             return "Extra primary file"
         return None
 
-    def value_to_basic(self, value, app):
+    def value_to_basic(self, value, app, use_security=False):
         rval = []
         for d in value:
             rval_dict = {}
@@ -286,7 +286,7 @@ class UploadDataset(Group):
                 rval_dict['__index__'] = d['__index__']
             for input in self.inputs.values():
                 if input.name in d:
-                    rval_dict[input.name] = input.value_to_basic(d[input.name], app)
+                    rval_dict[input.name] = input.value_to_basic(d[input.name], app, use_security)
             rval.append(rval_dict)
         return rval
 
@@ -659,13 +659,13 @@ class Conditional(Group):
                 return index
         raise ValueError("No case matched value:", self.name, str_value)
 
-    def value_to_basic(self, value, app):
+    def value_to_basic(self, value, app, use_security=False):
         rval = dict()
         rval[self.test_param.name] = self.test_param.value_to_basic(value[self.test_param.name], app)
         current_case = rval['__current_case__'] = self.get_current_case(value[self.test_param.name])
         for input in self.cases[current_case].inputs.values():
             if input.name in value:  # parameter might be absent in unverified workflow
-                rval[input.name] = input.value_to_basic(value[input.name], app)
+                rval[input.name] = input.value_to_basic(value[input.name], app, use_security=use_security)
         return rval
 
     def value_from_basic(self, value, app, ignore_errors=False):

--- a/lib/galaxy/tools/parameters/meta.py
+++ b/lib/galaxy/tools/parameters/meta.py
@@ -202,6 +202,6 @@ def __collection_multirun_parameter(value):
     batch_values = util.listify(value['values'])
     if len(batch_values) == 1:
         batch_over = batch_values[0]
-        if isinstance(batch_over, dict) and ('src' in batch_over) and (batch_over['src'] == 'hdca'):
+        if isinstance(batch_over, dict) and ('src' in batch_over) and (batch_over['src'] in {'hdca', 'dce'}):
             return True
     return False

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -6,6 +6,7 @@ from operator import itemgetter
 
 import requests
 
+from galaxy_test.api.test_tools import TestsTools
 from galaxy_test.base.api_asserts import assert_status_code_is_ok
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
@@ -18,7 +19,7 @@ from galaxy_test.base.populators import (
 from ._framework import ApiTestCase
 
 
-class JobsApiTestCase(ApiTestCase):
+class JobsApiTestCase(ApiTestCase, TestsTools):
 
     def setUp(self):
         super(JobsApiTestCase, self).setUp()
@@ -575,6 +576,73 @@ class JobsApiTestCase(ApiTestCase):
             'f2': {'src': 'hdca', 'id': list_id_a},
         })
         self._job_search(tool_id='multi_data_param', history_id=history_id, inputs=inputs)
+
+    # This endpoint is not great, but I think we need this for now.
+    @skip_without_tool("collection_paired_test")
+    @uses_test_history(require_new=False)
+    def test_job_build_for_rerun(self, history_id):
+        list_id_a = self.__history_with_ok_collection(collection_type='list:pair', history_id=history_id)
+        inputs = {'f1': {'batch': True, 'values': [{'src': 'hdca', 'id': list_id_a, 'map_over_type': 'paired'}]}}
+        run_response = self._run(
+            history_id=history_id,
+            tool_id="collection_paired_test",
+            inputs=inputs,
+            wait_for_job=True,
+            assert_ok=True,
+        )
+        rerun_params = self._get("jobs/%s/build_for_rerun" % run_response['jobs'][0]['id']).json()
+        # Since we call rerun on the first (and only) job we should get the expanded input
+        # which is a dataset collection element (and not the list:pair hdca that was used as input to the original
+        # job).
+        assert rerun_params['state_inputs']['f1']['values'][0]['src'] == 'dce'
+        run_response = self._run(
+            history_id=history_id,
+            tool_id="collection_paired_test",
+            inputs=rerun_params['state_inputs'],
+            wait_for_job=True,
+            assert_ok=True,
+        )
+
+    @skip_without_tool("identifier_collection")
+    @uses_test_history(require_new=False)
+    def test_job_build_for_rerun_list_list(self, history_id):
+        list_id_a = self.__history_with_ok_collection(collection_type='list', history_id=history_id)
+        list_id_b = self.__history_with_ok_collection(collection_type='list', history_id=history_id)
+        list_list = self.dataset_collection_populator.create_nested_collection(
+            history_id=history_id,
+            collection_type='list:list',
+            name='list list collection',
+            collection=[list_id_a, list_id_b]).json()
+        list_list_id = list_list['id']
+        first_element = list_list['elements'][0]
+        assert first_element['element_type'] == 'dataset_collection'
+        assert first_element['element_identifier'] == 'test0'
+        assert first_element['model_class'] == 'DatasetCollectionElement'
+        inputs = {'input1': {'batch': True, 'values': [{'src': 'hdca', 'id': list_list_id, 'map_over_type': 'list'}]}}
+        run_response = self._run(
+            history_id=history_id,
+            tool_id="identifier_collection",
+            inputs=inputs,
+            wait_for_job=True,
+            assert_ok=True,
+        )
+        assert len(run_response['jobs']) == 2
+        rerun_params = self._get("jobs/%s/build_for_rerun" % run_response['jobs'][0]['id']).json()
+        # Since we call rerun on the first (and only) job we should get the expanded input
+        # which is a dataset collection element (and not the list:list hdca that was used as input to the original
+        # job).
+        assert rerun_params['state_inputs']['input1']['values'][0]['src'] == 'dce'
+        rerun_response = self._run(
+            history_id=history_id,
+            tool_id="identifier_collection",
+            inputs=rerun_params['state_inputs'],
+            wait_for_job=True,
+            assert_ok=True,
+        )
+        assert len(rerun_response['jobs']) == 1
+        rerun_content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=rerun_response['outputs'][0])
+        run_content = self.dataset_populator.get_history_dataset_content(history_id=history_id, dataset=run_response['outputs'][0])
+        assert rerun_content == run_content
 
     def _job_search(self, tool_id, history_id, inputs):
         search_payload = self._search_payload(history_id=history_id, tool_id=tool_id, inputs=inputs)


### PR DESCRIPTION
This is necessary for re-running failed mapped-over jobs.
The most obvious example is rerunning a job that consumes a `paired` collection where the initial job was mapped over from a `list:paired` collection, but applies to all situations where we map nested collections over collection input.

This also makes the `state_inputs` part of `jobs/<id>/build_for_rerun` a valid input for submission via the tools api endpoint.