### PR TITLE
[WIP] Implement nested collection inputs for workflow tests

### DIFF
--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -1,0 +1,196 @@
+"""Client for staging inputs for Galaxy Tools and Workflows.
+
+Implement as a connector to serve a bridge between galactic_job_json
+utility and a Galaxy API library.
+"""
+import abc
+import json
+import logging
+import os
+
+import six
+
+from galaxy.tool_util.cwl.util import (
+    DirectoryUploadTarget,
+    FileLiteralTarget,
+    FileUploadTarget,
+    galactic_job_json,
+    path_or_uri_to_uri,
+)
+
+log = logging.getLogger(__name__)
+
+UPLOAD_TOOL_ID = "upload1"
+LOAD_TOOLS_FROM_PATH = True
+
+
+@six.add_metaclass(abc.ABCMeta)
+class StagingInterace(object):
+    """Client that parses a job input and populates files into the Galaxy API.
+
+    Abstract class that must override _post (and optionally other things such
+    _attach_file, _log, etc..) to adapt to bioblend (for Planemo) or using the
+    tool test interactor infrastructure.
+    """
+
+    @abc.abstractmethod
+    def _post(self, api_path, payload, files_attached=False):
+        """Make a post to the Galaxy API along supplied path."""
+
+    def _attach_file(self, path):
+        return open(path, 'rb')
+
+    def _tools_post(self, payload, files_attached=False):
+        tool_response = self._post("tools", payload, files_attached=files_attached)
+        for job in tool_response.get("jobs", []):
+            self._handle_job(job)
+        return tool_response
+
+    def _handle_job(self, job_response):
+        """Implementer can decide if to wait for job(s) individually or not here."""
+
+    def stage(self, tool_or_workflow, history_id, job=None, job_path=None, use_path_paste=LOAD_TOOLS_FROM_PATH, default_job_dir=None):
+        files_attached = [False]
+
+        def upload_func(upload_target):
+
+            def _attach_file(upload_payload, uri, index=0):
+                uri = path_or_uri_to_uri(uri)
+                is_path = uri.startswith("file://")
+                if not is_path or use_path_paste:
+                    upload_payload["inputs"]["files_%d|url_paste" % index] = uri
+                else:
+                    files_attached[0] = True
+                    path = uri[len("file://"):]
+                    upload_payload["files_%d|file_data" % index] = self._attach_file(path)
+
+            if isinstance(upload_target, FileUploadTarget):
+                file_path = upload_target.path
+                upload_payload = _upload_payload(
+                    history_id,
+                    file_type=upload_target.properties.get('filetype', None) or "auto",
+                )
+                name = _file_path_to_name(file_path)
+                upload_payload["inputs"]["files_0|auto_decompress"] = False
+                upload_payload["inputs"]["auto_decompress"] = False
+                if file_path is not None:
+                    _attach_file(upload_payload, file_path)
+                upload_payload["inputs"]["files_0|NAME"] = name
+                if upload_target.secondary_files:
+                    _attach_file(upload_payload, upload_target.secondary_files, index=1)
+                    upload_payload["inputs"]["files_1|type"] = "upload_dataset"
+                    upload_payload["inputs"]["files_1|auto_decompress"] = True
+                    upload_payload["inputs"]["file_count"] = "2"
+                    upload_payload["inputs"]["force_composite"] = "True"
+                # galaxy.exceptions.RequestParameterInvalidException: Not input source type
+                # defined for input '{'class': 'File', 'filetype': 'imzml', 'composite_data':
+                # ['Example_Continuous.imzML', 'Example_Continuous.ibd']}'.\n"}]]
+
+                if upload_target.composite_data:
+                    for i, composite_data in enumerate(upload_target.composite_data):
+                        upload_payload["inputs"]["files_%s|type" % i] = "upload_dataset"
+                        _attach_file(upload_payload, composite_data, index=i)
+
+                self._log("upload_payload is %s" % upload_payload)
+                return self._tools_post(upload_payload, files_attached=files_attached[0])
+            elif isinstance(upload_target, FileLiteralTarget):
+                payload = _upload_payload(history_id, file_type="auto", auto_decompress=False)
+                payload["inputs"]["files_0|url_paste"] = upload_target.contents
+                return self._tools_post(payload)
+            elif isinstance(upload_target, DirectoryUploadTarget):
+                tar_path = upload_target.tar_path
+
+                upload_payload = _upload_payload(
+                    history_id,
+                    file_type="tar",
+                )
+                upload_payload["inputs"]["files_0|auto_decompress"] = False
+                _attach_file(upload_payload, tar_path)
+                tar_upload_response = self._tools_post(upload_payload, files_attached=files_attached[0])
+                convert_payload = dict(
+                    tool_id="CONVERTER_tar_to_directory",
+                    tool_inputs={"input1": {"src": "hda", "id": tar_upload_response["outputs"][0]["id"]}},
+                    history_id=history_id,
+                )
+                convert_response = self._tools_post(convert_payload)
+                assert "outputs" in convert_response, convert_response
+                return convert_response
+            else:
+                content = json.dumps(upload_target.object)
+                payload = _upload_payload(history_id, file_type="expression.json")
+                payload["files_0|url_paste"] = content
+                return self._tools_post(payload)
+
+        def create_collection_func(element_identifiers, collection_type):
+            payload = {
+                "name": "dataset collection",
+                "instance_type": "history",
+                "history_id": history_id,
+                "element_identifiers": element_identifiers,
+                "collection_type": collection_type,
+                "fields": None if collection_type != "record" else "auto",
+            }
+            return self._post("dataset_collections", payload)
+
+        if job_path is not None:
+            assert job is None
+            with open(job_path, "r") as f:
+                job = yaml.safe_load(f)
+            job_dir = os.path.dirname(job_path)
+        else:
+            assert job is not None
+            # Figure out what "." should be here instead.
+            job_dir = default_job_dir or "."
+
+        job_dict, datasets = galactic_job_json(
+            job,
+            job_dir,
+            upload_func,
+            create_collection_func,
+            tool_or_workflow,
+        )
+        return job_dict, datasets
+
+    # extension point for planemo to override logging
+    def _log(self, message):
+        log.debug(message)
+
+
+class InteractorStaging(StagingInterace):
+
+    def __init__(self, galaxy_interactor):
+        self.galaxy_interactor = galaxy_interactor
+
+    def _post(self, api_path, payload, files_attached=False):
+        response = self.galaxy_interactor._post(api_path, payload, json=True)
+        assert response.status_code == 200, response.text
+        return response.json()
+
+    def _handle_job(self, job_response):
+        self.galaxy_interactor.wait_for_job(job_response["id"])
+
+def _file_path_to_name(file_path):
+    if file_path is not None:
+        name = os.path.basename(file_path)
+    else:
+        name = "defaultname"
+    return name
+
+
+def _upload_payload(history_id, tool_id=UPLOAD_TOOL_ID, file_type="auto", dbkey="?", **kwd):
+    """Adapted from bioblend tools client."""
+    payload = {}
+    payload["history_id"] = history_id
+    payload["tool_id"] = tool_id
+    tool_input = {}
+    tool_input["file_type"] = file_type
+    tool_input["dbkey"] = dbkey
+    if not kwd.get('to_posix_lines', True):
+        tool_input['files_0|to_posix_lines'] = False
+    elif kwd.get('space_to_tab', False):
+        tool_input['files_0|space_to_tab'] = 'Yes'
+    if 'file_name' in kwd:
+        tool_input["files_0|NAME"] = kwd['file_name']
+    tool_input["files_0|type"] = "upload_dataset"
+    payload["inputs"] = tool_input
+    return payload

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -252,22 +252,38 @@ def galactic_job_json(
         hdca_id = collection["id"]
         return {"src": "hdca", "id": hdca_id}
 
-    def replacement_collection(value):
+    def to_elements(value, rank_collection_type):
         collection_element_identifiers = []
-        assert "collection_type" in value
         assert "elements" in value
-
-        collection_type = value["collection_type"]
         elements = value["elements"]
 
+        is_nested_collection = ":" in rank_collection_type
         for element in elements:
-            dataset = replacement_item(element, force_to_file=True)
-            collection_element = dataset.copy()
-            collection_element["name"] = element["identifier"]
-            collection_element_identifiers.append(collection_element)
+            if not is_nested_collection:
+                # flat collection
+                dataset = replacement_item(element, force_to_file=True)
+                collection_element = dataset.copy()
+                collection_element["name"] = element["identifier"]
+                collection_element_identifiers.append(collection_element)
+            else:
+                #nested collection
+                sub_collection_type = rank_collection_type[rank_collection_type.find(":") + 1:]
+                collection_element = {
+                    "name": element["identifier"],
+                    "src": "new_collection",
+                    "collection_type": sub_collection_type,
+                    "element_identifiers": to_elements(element, sub_collection_type)
+                }
+                collection_element_identifiers.append(collection_element)
 
-        # TODO: handle nested lists/arrays
-        collection = collection_create_func(collection_element_identifiers, collection_type)
+        return collection_element_identifiers
+
+    def replacement_collection(value):
+        assert "collection_type" in value
+        collection_type = value["collection_type"]
+        elements = to_elements(value, collection_type)
+
+        collection = collection_create_func(elements, collection_type)
         dataset_collections.append(collection)
         hdca_id = collection["id"]
         return {"src": "hdca", "id": hdca_id}

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -623,6 +623,13 @@ class GalaxyInteractorApi(object):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         # no params for POST
         data.update(params)
+
+        # handle encoded files
+        if files is None:
+            files = data.get("__files", None)
+            if files is not None:
+                del data["__files"]
+
         return requests.post("%s/%s" % (self.api_url, path), data=data, files=files)
 
     def _delete(self, path, data=None, key=None, admin=False, anon=False):

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -257,7 +257,7 @@ class GalaxyInteractorApi(object):
                     msg = "Failed to verify dataset metadata, metadata key [%s] was not found." % key
                     raise Exception(msg)
 
-    def wait_for_job(self, job_id, history_id, maxseconds):
+    def wait_for_job(self, job_id, history_id=None, maxseconds=DEFAULT_TOOL_TEST_WAIT):
         self.wait_for(lambda: self.__job_ready(job_id, history_id), maxseconds=maxseconds)
 
     def wait_for(self, func, what='tool test run', **kwd):
@@ -470,7 +470,7 @@ class GalaxyInteractorApi(object):
     def delete_history(self, history):
         return None
 
-    def __job_ready(self, job_id, history_id):
+    def __job_ready(self, job_id, history_id=None):
         if job_id is None:
             raise ValueError("__job_ready passed empty job_id")
         job_json = self._get("jobs/%s" % job_id).json()
@@ -478,7 +478,7 @@ class GalaxyInteractorApi(object):
         try:
             return self._state_ready(state, error_msg="Job in error state.")
         except Exception:
-            if VERBOSE_ERRORS:
+            if VERBOSE_ERRORS and history_id is not None:
                 self._summarize_history(history_id)
             raise
 
@@ -619,10 +619,8 @@ class GalaxyInteractorApi(object):
             params['key'] = key
         return params, data
 
-    def _post(self, path, data=None, files=None, key=None, admin=False, anon=False):
+    def _post(self, path, data=None, files=None, key=None, admin=False, anon=False, json=None):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
-        # no params for POST
-        data.update(params)
 
         # handle encoded files
         if files is None:
@@ -630,7 +628,17 @@ class GalaxyInteractorApi(object):
             if files is not None:
                 del data["__files"]
 
-        return requests.post("%s/%s" % (self.api_url, path), data=data, files=files)
+        kwd = {
+            'files': files,
+        }
+        if json:
+            kwd['json'] = data
+            kwd['params'] = params
+        else:
+            data.update(params)
+            kwd['data'] = data
+
+        return requests.post("%s/%s" % (self.api_url, path), **kwd)
 
     def _delete(self, path, data=None, key=None, admin=False, anon=False):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -1,0 +1,28 @@
+"""Abstraction for waiting on API conditions to become true."""
+
+import time
+
+
+def wait_on(function, desc, timeout):
+    """Wait for function to return non-None value."""
+    delta = .25
+    iteration = 0
+    while True:
+        total_wait = delta * iteration
+        if total_wait > timeout:
+            timeout_message = "Timed out after %s seconds waiting on %s." % (
+                total_wait, desc
+            )
+            raise TimeoutAssertionError(timeout_message)
+        iteration += 1
+        value = function()
+        if value is not None:
+            return value
+        time.sleep(delta)
+
+
+class TimeoutAssertionError(AssertionError):
+    """Derivative of AssertionError indicating wait_on exceeded max time."""
+
+    def __init__(self, message):
+        super(TimeoutAssertionError, self).__init__(message)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -14,8 +14,8 @@ from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
-    load_data_dict,
     skip_without_tool,
+    stage_rules_test_data,
     uses_test_history,
 )
 from ._framework import ApiTestCase
@@ -580,7 +580,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
     def _apply_rules_and_check(self, example):
         with self.dataset_populator.test_history() as history_id:
-            inputs, _, _ = load_data_dict(history_id, {"input": example["test_data"]}, self.dataset_populator, self.dataset_collection_populator)
+            inputs = stage_rules_test_data(self.galaxy_interactor, history_id, example)
             hdca = inputs["input"]
             inputs = {
                 "input": {"src": "hdca", "id": hdca["id"]},

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -3,7 +3,6 @@ import json
 import os
 import random
 import string
-import time
 import unittest
 from collections import namedtuple
 from functools import wraps
@@ -25,6 +24,10 @@ from pkg_resources import resource_string
 from six import StringIO
 
 from galaxy.tool_util.verify.test_data import TestDataResolver
+from galaxy.tool_util.verify.wait import (
+    TimeoutAssertionError,
+    wait_on as tool_util_wait_on,
+)
 from galaxy.util import unicodify
 from . import api_asserts
 
@@ -1560,23 +1563,4 @@ class GiWorkflowPopulator(BaseWorkflowPopulator, GiPostGetMixin):
 
 
 def wait_on(function, desc, timeout=DEFAULT_TIMEOUT):
-    delta = .25
-    iteration = 0
-    while True:
-        total_wait = delta * iteration
-        if total_wait > timeout:
-            timeout_message = "Timed out after %s seconds waiting on %s." % (
-                total_wait, desc
-            )
-            raise TimeoutAssertionError(timeout_message)
-        iteration += 1
-        value = function()
-        if value is not None:
-            return value
-        time.sleep(delta)
-
-
-class TimeoutAssertionError(AssertionError):
-
-    def __init__(self, message):
-        super(TimeoutAssertionError, self).__init__(message)
+    return tool_util_wait_on(function, desc, timeout)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -693,20 +693,9 @@ class DatasetPopulator(BaseDatasetPopulator):
         return self.galaxy_interactor.api_key
 
     def _post(self, route, data=None, files=None, admin=False):
-        if data is None:
-            data = {}
-
-        if files is None:
-            files = data.get("__files", None)
-            if files is not None:
-                del data["__files"]
-
         return self.galaxy_interactor.post(route, data, files=files, admin=admin)
 
     def _put(self, route, data=None):
-        if data is None:
-            data = {}
-
         return self.galaxy_interactor.put(route, data)
 
     def _get(self, route, data=None, admin=False):

--- a/lib/galaxy_test/base/rules_test_data.py
+++ b/lib/galaxy_test/base/rules_test_data.py
@@ -67,11 +67,11 @@ EXAMPLE_1 = {
         "elements": [
             {
                 "identifier": "i1",
-                "content": "0"
+                "contents": "0"
             },
             {
                 "identifier": "i2",
-                "content": "1"
+                "contents": "1"
             },
         ]
     },
@@ -104,11 +104,11 @@ EXAMPLE_2 = {
         "elements": [
             {
                 "identifier": "i1",
-                "content": "0"
+                "contents": "0"
             },
             {
                 "identifier": "i2",
-                "content": "1"
+                "contents": "1"
             },
         ]
     },
@@ -143,6 +143,21 @@ EXAMPLE_3 = {
     },
     "test_data": {
         "type": "list:paired",
+        "elements": [
+            {
+                "identifier": "test0",
+                "elements": [
+                    {
+                        "identifier": "forward",
+                        "contents": "TestData123"
+                    },
+                    {
+                        "identifier": "reverse",
+                        "contents": "TestData123"
+                    },
+                ]
+            }
+        ]
     },
     "check": check_example_3,
     "output_hid": 6,

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -2,7 +2,11 @@ import json
 
 from galaxy.selenium.navigates_galaxy import retry_call_during_transitions
 from galaxy_test.base import rules_test_data
-from galaxy_test.base.populators import flakey, load_data_dict, skip_if_github_down
+from galaxy_test.base.populators import (
+    flakey,
+    skip_if_github_down,
+    stage_rules_test_data,
+)
 from .framework import (
     managed_history,
     retry_assertion_during_transitions,
@@ -344,7 +348,7 @@ https://raw.githubusercontent.com/jmchilton/galaxy/apply_rules_tutorials/test-da
 
         self.home()
         history_id = self.current_history_id()
-        inputs, _, _ = load_data_dict(history_id, {"input": example["test_data"]}, self.dataset_populator, self.dataset_collection_populator)
+        inputs = stage_rules_test_data(self.galaxy_interactor, history_id, example)
         self.dataset_populator.wait_for_history(history_id)
         self.home()
         self._tool_open_apply_rules()


### PR DESCRIPTION
This ties together seemingly random threads to get this done and tested within Galaxy.

There is this function in ``galaxy.tool_util.cwl.util`` called ``galactic_job_json`` that parses a CWL-style "job" (the inputs for a tool or a workflow execution as a JSON object) and parses it into a representation for Galaxy - uploading inputs to Galaxy as needed. The interaction with the API was originally abstracted out as two functions so that the Galaxy test code (in the CWL branch) and the Planemo driver code could interact with the API in different ways. Planemo used bioblend (loosely) and the Galaxy code used the test framework's "populators" abstractions.

This PR creates a new a layer above ``galactic_job_json`` that has some extension points that the Planemo/bioblend layer can take advantage of but by default will just use the galaxy_interactor stuff already being used by tool tests using galaxy-tool-util. So this new layer doesn't depend on test "populators" or bioblend and should allow important code to be shared between the Galaxy test framework, the CWL branch of Galaxy, and Planemo. Having to update the code in both places was a significant problem with the CWL branch.

Here is a commit demonstrating how it simplifies the CWL branch (jmchilton@d9e774f). I don't have a matching commit for Planemo yet but the code is located here https://github.com/galaxyproject/planemo/blob/master/planemo/galaxy/activity.py#L181 that will be simplified after this commit is utilized.

This main big commit here establishes that layer, refactors a couple of tool tests to use it, and then extends it to implement nested collections.

Another positive upshot of this commit is there is now some in core test coverage of ``galactic_job_json`` - an important library function.

There are some other smaller commits here to setup some stuff in galaxy-tool-util to be shared between Galaxy testing populators and Planemo.