### PR TITLE
Allow uploading directly from the tool form

### DIFF
--- a/client/galaxy/scripts/components/DataDialog/DataDialog.vue
+++ b/client/galaxy/scripts/components/DataDialog/DataDialog.vue
@@ -23,6 +23,10 @@
                 <div class="fa fa-caret-left mr-1" />
                 Back
             </b-btn>
+            <b-btn size="sm" class="float-left mr-1" @click="newUpload">
+                <div class="fa fa-upload ml-1" />
+                Upload
+            </b-btn>
             <b-btn
                 v-if="multiple"
                 size="sm"
@@ -44,6 +48,7 @@ import SelectionDialogMixin from "components/SelectionDialog/SelectionDialogMixi
 import { UrlTracker } from "./utilities";
 import { Model } from "./model";
 import { Services } from "./services";
+import { mountUploadModal } from "components/Upload";
 
 Vue.use(BootstrapVue);
 
@@ -124,6 +129,16 @@ export default {
             } else {
                 this.load(record.url);
             }
+        },
+        newUpload: function () {
+            const propsData = {
+                multiple: this.multiple,
+                format: this.format,
+                callback: this.callback,
+                modalShow: true,
+            };
+            mountUploadModal(propsData);
+            this.modalShow = false;
         },
         /** Called when selection is complete, values are formatted and parsed to external callback **/
         finalize: function () {

--- a/client/galaxy/scripts/components/Datatypes/index.test.js
+++ b/client/galaxy/scripts/components/Datatypes/index.test.js
@@ -20,7 +20,9 @@ describe("Datatypes/index.js", () => {
             axiosMock.onGet(`/api/datatypes/types_and_mapping`).reply(200, typesAndMappingResponse);
             await getDatatypesMapper().then((mapper) => {
                 expect(mapper.isSubType("txt", "data")).to.equals(true);
+                expect(mapper.isSubType("txt", "txt")).to.equals(true);
                 expect(mapper.isSubType("data", "txt")).to.equals(false);
+                expect(mapper.isSubTypeOfAny("data", ["txt", "data"])).to.equals(true);
             });
         });
     });

--- a/client/galaxy/scripts/components/Datatypes/model.js
+++ b/client/galaxy/scripts/components/Datatypes/model.js
@@ -10,4 +10,8 @@ export class DatatypesMapperModel {
         parent = mapping.ext_to_class_name[parent];
         return mapping.class_to_classes[child] && parent in mapping.class_to_classes[child];
     }
+
+    isSubTypeOfAny(child, parents) {
+        return parents.some((parent) => this.isSubType(child, parent));
+    }
 }

--- a/client/galaxy/scripts/components/Upload/Collection.vue
+++ b/client/galaxy/scripts/components/Upload/Collection.vue
@@ -42,7 +42,7 @@
             </select2>
         </template>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="app.hide()">
+            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="app.dismiss()">
                 {{ btnCloseTitle }}
             </b-button>
             <b-button
@@ -139,6 +139,7 @@ export default {
             listExtensions: [],
             listGenomes: [],
             running: false,
+            multiple: true, // needed for uploadbox stuff - always allow multiple uploads for collections
             counterAnnounce: 0,
             counterSuccess: 0,
             counterError: 0,
@@ -158,7 +159,7 @@ export default {
             btnBuildTitle: _l("Build"),
             btnStopTitle: _l("Pause"),
             btnResetTitle: _l("Reset"),
-            btnCloseTitle: _l("Close"),
+            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
         };
     },
     created() {

--- a/client/galaxy/scripts/components/Upload/Composite.vue
+++ b/client/galaxy/scripts/components/Upload/Composite.vue
@@ -34,7 +34,7 @@
             </select2>
         </template>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" @click="app.hide()">
+            <b-button ref="btnClose" class="ui-button-default" @click="app.dismiss()">
                 {{ btnCloseTitle }}
             </b-button>
             <b-button
@@ -74,7 +74,7 @@ export default {
             showHelper: true,
             btnResetTitle: _l("Reset"),
             btnStartTitle: _l("Start"),
-            btnCloseTitle: _l("Close"),
+            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
             readyStart: false,
         };
     },

--- a/client/galaxy/scripts/components/Upload/Default.vue
+++ b/client/galaxy/scripts/components/Upload/Default.vue
@@ -34,7 +34,7 @@
             </select2>
         </template>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="app.hide()">
+            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="app.dismiss()">
                 {{ btnCloseTitle }}
             </b-button>
             <b-button
@@ -54,6 +54,16 @@
                 :disabled="counterRunning == 0"
             >
                 {{ btnStopTitle }}
+            </b-button>
+            <b-button
+                ref="btnBuild"
+                class="ui-button-default"
+                id="btn-build"
+                @click="_eventSelect"
+                :disabled="!enableBuild"
+                :variant="enableBuild ? 'primary' : ''"
+            >
+                {{ btnSelectTitle }}
             </b-button>
             <b-button
                 ref="btnStart"
@@ -111,6 +121,12 @@ Vue.use(BootstrapVue);
 
 export default {
     mixins: [UploadBoxMixin],
+    props: {
+        multiple: {
+            type: Boolean,
+            default: true,
+        },
+    },
     data() {
         return {
             topInfo: "",
@@ -118,6 +134,7 @@ export default {
             showHelper: true,
             extension: this.app.defaultExtension,
             genome: this.app.defaultGenome,
+            callback: this.app.callback,
             listExtensions: [],
             listGenomes: [],
             running: false,
@@ -129,6 +146,7 @@ export default {
             uploadSize: 0,
             uploadCompleted: 0,
             enableReset: false,
+            enableBuild: false,
             enableStart: false,
             enableSources: false,
             btnLocalTitle: _l("Choose local files"),
@@ -136,7 +154,8 @@ export default {
             btnStartTitle: _l("Start"),
             btnStopTitle: _l("Pause"),
             btnResetTitle: _l("Reset"),
-            btnCloseTitle: _l("Close"),
+            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
+            btnSelectTitle: _l("Select"),
         };
     },
     created() {
@@ -149,6 +168,7 @@ export default {
         // file upload
         this.initUploadbox({
             url: this.app.uploadPath,
+            multiple: this.multiple,
             announce: (index, file) => {
                 this._eventAnnounce(index, file);
             },
@@ -200,6 +220,17 @@ export default {
         },
     },
     methods: {
+        _eventSelect: function () {
+            const models = this.getUploadedModels();
+            const asDict = models.map((model) => {
+                return {
+                    id: model.attributes.id, // model.id has datatype prefix
+                    src: model.src,
+                };
+            });
+            this.callback(asDict);
+            this.app.cancel();
+        },
         _newUploadModelProps: function (index, file) {
             return {
                 id: index,
@@ -213,8 +244,9 @@ export default {
 
         /** Success */
         _eventSuccess: function (index, message) {
+            var hids = _.pluck(message["outputs"], "hid");
             var it = this.collection.get(index);
-            it.set({ percentage: 100, status: "success" });
+            it.set({ percentage: 100, status: "success", hids: hids });
             this._updateStateForSuccess(it);
         },
 

--- a/client/galaxy/scripts/components/Upload/RulesInput.vue
+++ b/client/galaxy/scripts/components/Upload/RulesInput.vue
@@ -46,7 +46,7 @@
             ></textarea>
         </span>
         <template v-slot:buttons>
-            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="app.hide()">
+            <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="app.dismiss()">
                 {{ btnCloseTitle }}
             </b-button>
             <b-button
@@ -103,7 +103,7 @@ export default {
             selectionType: "paste",
             btnBuildTitle: _l("Build"),
             btnResetTitle: _l("Reset"),
-            btnCloseTitle: _l("Close"),
+            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
         };
     },
     created() {

--- a/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
+++ b/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
@@ -102,15 +102,15 @@ export default {
         },
         _updateStateForCounters: function () {
             this.setTopInfoBasedOnCounters();
-            this.enableReset =
-                this.counterRunning == 0 && this.counterAnnounce + this.counterSuccess + this.counterError > 0;
+            const counterNonRunning = this.counterAnnounce + this.counterSuccess + this.counterError;
+            this.enableReset = this.counterRunning == 0 && counterNonRunning > 0;
             this.enableStart = this.counterRunning == 0 && this.counterAnnounce > 0;
             this.enableBuild =
                 this.counterRunning == 0 &&
                 this.counterAnnounce == 0 &&
                 this.counterSuccess > 0 &&
                 this.counterError == 0;
-            this.enableSources = this.counterRunning == 0;
+            this.enableSources = this.counterRunning == 0 && (this.multiple || counterNonRunning == 0);
             var show_table = this.counterAnnounce + this.counterSuccess + this.counterError > 0;
             this.showHelper = !show_table;
         },
@@ -259,7 +259,7 @@ export default {
             return $(this.$refs.uploadTable);
         },
         extensionDetails(extension) {
-            return findExtension(this.listExtensions, extension);
+            return findExtension(this.effectiveExtensions, extension);
         },
         initExtensionInfo() {
             $(this.$refs.footerExtensionInfo)
@@ -283,7 +283,7 @@ export default {
             this.collection = new UploadModel.Collection();
         },
         initAppProperties() {
-            this.listExtensions = this.app.listExtensions;
+            this.listExtensions = this.app.effectiveExtensions;
             this.listGenomes = this.app.listGenomes;
             this.ftpUploadSite = this.app.currentFtp();
             this.fileSourcesConfigured = this.app.fileSourcesConfigured;

--- a/client/galaxy/scripts/components/Upload/index.js
+++ b/client/galaxy/scripts/components/Upload/index.js
@@ -4,3 +4,5 @@
 export { default as UploadModal } from "./UploadModal";
 
 export { initializeUploadDefaults } from "./config";
+
+export { mount as mountUploadModal } from "./mount";

--- a/client/galaxy/scripts/components/Upload/mount.js
+++ b/client/galaxy/scripts/components/Upload/mount.js
@@ -1,0 +1,13 @@
+import Vue from "vue";
+import UploadModal from "./UploadModal";
+import { initializeUploadDefaults } from "./config";
+
+export function mount(propsData = {}) {
+    propsData = initializeUploadDefaults(propsData);
+    const instance = Vue.extend(UploadModal);
+    const vm = document.createElement("div");
+    document.getElementsByTagName("body")[0].appendChild(vm);
+    new instance({
+        propsData: propsData,
+    }).$mount(vm);
+}

--- a/client/galaxy/scripts/components/Upload/test_helpers.js
+++ b/client/galaxy/scripts/components/Upload/test_helpers.js
@@ -10,7 +10,7 @@ export function mountWithApp(component, options = {}, propsData_ = {}) {
             return "ftp://localhost";
         },
         model: new Backbone.Model(),
-        listExtensions: [
+        effectiveExtensions: [
             { id: "ab1", text: "ab1", description: "A binary sequence file in 'ab1' format with a '.ab1'" },
             {
                 id: "affybatch",

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -272,8 +272,10 @@ const View = Backbone.View.extend({
                 });
                 if (cnf.src == "hda") {
                     this.button_dialog.show();
+                    this.upload_dialog.show();
                 } else {
                     this.button_dialog.hide();
+                    this.upload_dialog.hide();
                 }
                 this.button_type.value(i);
             } else {
@@ -306,7 +308,8 @@ const View = Backbone.View.extend({
 
         // prepare extension component of error message
         const data = self.model.get("data");
-        const extensions = Utils.textify(this.model.get("extensions"));
+        const formats = this.model.get("extensions");
+        const extensions = Utils.textify(formats);
         const src_labels = this.model.get("src_labels");
 
         // build radio button for data selectors
@@ -362,14 +365,38 @@ const View = Backbone.View.extend({
             },
         });
 
+        // build data dialog button
+        this.upload_dialog = new Ui.Button({
+            icon: "fa-upload",
+            tooltip: "Upload Dataset",
+            onclick: () => {
+                const current = this.model.get("current");
+                const cnf = this.config[current];
+                // model doesn't have format yet unfortunately, need to get through to here.
+                galaxy.data.dialog(
+                    (response) => {
+                        this._handleDropValues(response, false);
+                    },
+                    {
+                        multiple: cnf.multiple,
+                        formats: formats,
+                        new: true,
+                    }
+                );
+            },
+        });
+
         // append views
         const $fields = $("<div/>").addClass("overflow-auto w-100 py-2 py-lg-0 pr-lg-2 ");
         this.$el
             .empty()
             .addClass("d-flex flex-row flex-wrap flex-lg-nowrap")
             .append($("<div/>").append(this.button_type.$el))
-            .append($fields)
-            .append($("<div/>").append(this.button_dialog.$el));
+            .append($fields);
+        if (galaxy.config.enable_upload_from_form_button) {
+            this.$el.append($("<div style='margin-right: 5px;' />").append(this.upload_dialog.$el));
+        }
+        this.$el.append($("<div/>").append(this.button_dialog.$el));
         _.each(this.fields, (field) => {
             $fields.append(field.$el);
         });

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -393,7 +393,7 @@ const View = Backbone.View.extend({
             .addClass("d-flex flex-row flex-wrap flex-lg-nowrap")
             .append($("<div/>").append(this.button_type.$el))
             .append($fields);
-        if (galaxy.config.enable_upload_from_form_button) {
+        if (galaxy.config.upload_from_form_button == "always-on") {
             this.$el.append($("<div style='margin-right: 5px;' />").append(this.upload_dialog.$el));
         }
         this.$el.append($("<div/>").append(this.button_dialog.$el));

--- a/client/galaxy/scripts/utils/data.js
+++ b/client/galaxy/scripts/utils/data.js
@@ -5,6 +5,7 @@ import DataDialog from "components/DataDialog/DataDialog.vue";
 import { FilesDialog } from "components/FilesDialog";
 import WorkflowDialog from "components/SelectionDialog/WorkflowDialog.vue";
 import DatasetCollectionDialog from "components/SelectionDialog/DatasetCollectionDialog.vue";
+import { mountUploadModal } from "components/Upload";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
 
@@ -44,7 +45,12 @@ export function dialog(callback, options = {}) {
             root: galaxy.root,
             host: host,
         });
-        _mountSelectionDialog(DataDialog, options);
+        if (options.new) {
+            options.modalShow = true;
+            mountUploadModal(options);
+        } else {
+            _mountSelectionDialog(DataDialog, options);
+        }
     });
 }
 

--- a/client/galaxy/scripts/utils/uploadbox.js
+++ b/client/galaxy/scripts/utils/uploadbox.js
@@ -300,6 +300,7 @@ import { getAppRoot } from "onload/loadConfig";
                     alert(m);
                 },
                 complete: () => {},
+                multiple: true,
             },
             options
         );
@@ -320,7 +321,7 @@ import { getAppRoot } from "onload/loadConfig";
 
         // element
         var uploadinput = $(this).uploadinput({
-            multiple: true,
+            multiple: opts.multiple,
             onchange: (files) => {
                 _.each(files, (file) => {
                     file.chunk_mode = true;

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -316,6 +316,15 @@ body {
     }
 }
 
+.upload-dialog {
+    width: 900px;
+}
+
+.upload-dialog-body {
+    height: 500px;
+    overflow: hidden;
+}
+
 // ==== Masthead ====
 #masthead {
     @extend .p-0;

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -105,6 +105,7 @@ class ConfigSerializer(base.ModelSerializer):
             'python'                            : _defaults_to((sys.version_info.major, sys.version_info.minor)),
             'select_type_workflow_threshold'    : _use_config,
             'file_sources_configured'           : lambda config, key, **context: self.app.file_sources.custom_sources_configured,
+            'enable_upload_from_form_button'    : _use_config,
         }
 
 

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -105,7 +105,7 @@ class ConfigSerializer(base.ModelSerializer):
             'python'                            : _defaults_to((sys.version_info.major, sys.version_info.minor)),
             'select_type_workflow_threshold'    : _use_config,
             'file_sources_configured'           : lambda config, key, **context: self.app.file_sources.custom_sources_configured,
-            'enable_upload_from_form_button'    : _use_config,
+            'upload_from_form_button'           : _use_config,
         }
 
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2158,6 +2158,15 @@ mapping:
           When using LDAP for authentication, allow administrators to pre-populate users
           using an additional form on 'Create new user'
 
+      enable_upload_from_form_button:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          If enabled, add another button to tool form data inputs that allow uploading
+          data from the tool form in fewer clicks (at the expense of making the form more
+          complicated).
+
       allow_user_dataset_purge:
         type: bool
         default: true

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2158,15 +2158,18 @@ mapping:
           When using LDAP for authentication, allow administrators to pre-populate users
           using an additional form on 'Create new user'
 
-      enable_upload_from_form_button:
-        type: bool
-        default: false
+      upload_from_form_button:
+        type: str
+        default: 'always-off'
         required: false
+        enum: ['always-on', 'always-off']
         desc: |
-          If enabled, add another button to tool form data inputs that allow uploading
+          If 'always-on', add another button to tool form data inputs that allow uploading
           data from the tool form in fewer clicks (at the expense of making the form more
-          complicated).
+          complicated). This applies to workflows as well.
 
+          Avoiding making this a boolean because we may add options such as 'in-single-form-view'
+          or 'in-simplified-workflow-views'. https://github.com/galaxyproject/galaxy/pull/9809/files#r461889109
       allow_user_dataset_purge:
         type: bool
         default: true


### PR DESCRIPTION
Implementation of https://github.com/galaxyproject/galaxy/issues/9110.

![uploadform480](https://user-images.githubusercontent.com/216771/82711344-15ca0080-9c53-11ea-8e88-e14f70d2ce27.gif)

Video demonstrates two options for how to reach the upload dialog - embedding this right in the data selection row and placing it as another option in the data dialog. I suspect for the general Galaxy user experience, yet another button in the data selector row is too much so the second variant here might be a better default for stock Galaxy experiences. However, keeping the option for an embedded button for stand-alone tools-as-webapps and simplified workflows UX that want to hide the concepts of histories and libraries entirely seems like a good idea - it reduces the number of clicks and exposure to Galaxy concepts required to get going with a workflow run or tool execution. So I've hidden the extra button behind a new config option ``enable_upload_from_form_button``.

In addition to providing a shorthand for getting data quickly into tool form inputs, another goal is to simplify the upload experience based on the context provided by the form input parameters. For instance in the demo above, this is a single input - so collection and rules uploads are disabled and when a single file is chosen the options for adding more are not available. Not in the demo, but the browser file picker also does not allow multiple files to be chosen for instance.

In addition to handling "multiple vs single" logic, the form also now can be supplied with a set of "formats" (or short extensions) and the display will adapt to them. If the input can't be a composite file for instance that tab no longer available. The file types in the drop down are also restricted to "auto" and subtypes of the specified formats. This functionality uses the recently merged #9955 that refactored the client datatype comparison logic from the workflow editor for reuse in exactly this use case.