### PR TITLE
Fix masthead functionality for webhooks.

### DIFF
--- a/client/galaxy/scripts/components/Masthead/Masthead.vue
+++ b/client/galaxy/scripts/components/Masthead/Masthead.vue
@@ -87,6 +87,9 @@ export default {
                 }
             });
         },
+        addItem(item) {
+            this.tabs.push(item);
+        },
     },
     mounted() {
         this.quotaMeter.setElement(this.$refs["quota-meter-container"]);

--- a/client/galaxy/scripts/layout/masthead.js
+++ b/client/galaxy/scripts/layout/masthead.js
@@ -14,7 +14,7 @@ const View = Backbone.View.extend({
         const Galaxy = getGalaxyInstance();
         const self = this;
         this.options = options;
-
+        this._component = null;
         // build tabs
         this.collection = new Menu.Collection();
         this.collection
@@ -75,7 +75,7 @@ const View = Backbone.View.extend({
         const tabs = this.collection.models.map((el) => {
             return el.toJSON();
         });
-        mountVueComponent(Masthead)(
+        this._component = mountVueComponent(Masthead)(
             {
                 brandTitle: brandTitle,
                 brandLink: this.options.logo_url,
@@ -90,6 +90,10 @@ const View = Backbone.View.extend({
             el
         );
         return this;
+    },
+
+    addItem(item) {
+        this._component.addItem(item);
     },
 
     highlight: function (id) {

--- a/client/galaxy/scripts/layout/menu.js
+++ b/client/galaxy/scripts/layout/menu.js
@@ -8,6 +8,16 @@ import { CommunicationServerView } from "layout/communication-server-view";
 import Webhooks from "mvc/webhooks";
 import Utils from "utils/utils";
 
+function appendToPageMenu(item) {
+    const Galaxy = getGalaxyInstance();
+    // Galaxy.page is undefined for data libraries, workflows pages
+    if (Galaxy.page) {
+        Galaxy.page.masthead.addItem(item);
+    } else if (Galaxy.masthead) {
+        Galaxy.masthead.addItem(item);
+    }
+}
+
 export function logoutClick() {
     const galaxy = getGalaxyInstance();
     const session_csrf_token = galaxy.session_csrf_token;
@@ -153,16 +163,13 @@ const Collection = Backbone.Collection.extend({
                                 tooltip: webhook.config.tooltip,
                                 /*jslint evil: true */
                                 onclick: webhook.config.function && new Function(webhook.config.function),
+                                // fill in model defaults because this isn't added to
+                                // collection first, will make more sense when other
+                                // items aren't defined using backbone
+                                visible: true,
+                                target: "_parent",
                             };
-
-                            // Galaxy.page is undefined for data libraries, workflows pages
-                            const Galaxy = getGalaxyInstance();
-                            if (Galaxy.page) {
-                                Galaxy.page.masthead.collection.add(obj);
-                            } else if (Galaxy.masthead) {
-                                Galaxy.masthead.collection.add(obj);
-                            }
-
+                            appendToPageMenu(obj);
                             // Append masthead script and styles to Galaxy main
                             Utils.appendScriptStyle(webhook);
                         }

--- a/client/galaxy/scripts/layout/page.js
+++ b/client/galaxy/scripts/layout/page.js
@@ -14,7 +14,6 @@ const View = Backbone.View.extend({
     _panelids: ["left", "right"],
 
     initialize: function (options) {
-        const self = this;
         this.config = _.defaults(options.config || {}, {
             message_box_visible: false,
             message_box_content: "",
@@ -28,7 +27,7 @@ const View = Backbone.View.extend({
         // attach global objects, build mastheads
         const Galaxy = getGalaxyInstance();
         Galaxy.modal = this.modal = new Modal.View();
-        Galaxy.router = this.router = options.Router && new options.Router(self, options);
+        Galaxy.router = this.router = options.Router && new options.Router(this, options);
         this.masthead = new Masthead.View(this.config);
         this.center = new Panel.CenterPanel();
 
@@ -42,9 +41,9 @@ const View = Backbone.View.extend({
                 view.allow_title_display = true;
             }
             if (view.active_tab) {
-                self.masthead.highlight(view.active_tab);
+                this.masthead.highlight(view.active_tab);
             }
-            self.center.display(view);
+            this.center.display(view);
         };
 
         // build page template
@@ -73,10 +72,10 @@ const View = Backbone.View.extend({
                 const panel_class_name = panel_id.charAt(0).toUpperCase() + panel_id.slice(1);
                 const panel_class = options[panel_class_name];
                 if (panel_class) {
-                    const panel_instance = new panel_class(self, options);
-                    const panel_el = self.$(`#${panel_id}`);
-                    self[panel_instance.toString()] = panel_instance;
-                    self.panels[panel_id] = new Panel.SidePanel({
+                    const panel_instance = new panel_class(this, options);
+                    const panel_el = this.$(`#${panel_id}`);
+                    this[panel_instance.toString()] = panel_instance;
+                    this.panels[panel_id] = new Panel.SidePanel({
                         id: panel_id,
                         el: panel_el,
                         view: panel_instance,
@@ -143,14 +142,13 @@ const View = Backbone.View.extend({
 
     /** Render panels */
     renderPanels: function () {
-        const self = this;
         _.each(this._panelids, (panel_id) => {
-            const panel = self.panels[panel_id];
+            const panel = this.panels[panel_id];
             if (panel) {
                 panel.render();
             } else {
-                self.$center.css(panel_id, 0);
-                self.$(`#${panel_id}`).hide();
+                this.$center.css(panel_id, 0);
+                this.$(`#${panel_id}`).hide();
             }
         });
         return this;

--- a/client/galaxy/scripts/layout/scratchbook.js
+++ b/client/galaxy/scripts/layout/scratchbook.js
@@ -51,22 +51,6 @@ export default Backbone.View.extend({
                 }
             },
         });
-        this.frames
-            .on("add remove", () => {
-                if (this.frames.visible && this.frames.length() === 0) {
-                    this.frames.hide();
-                }
-                this.buttonLoad.set({
-                    note: this.frames.length(),
-                    visible: this.frames.length() > 0,
-                });
-            })
-            .on("show hide ", () => {
-                this.buttonLoad.set({
-                    toggle: this.frames.visible,
-                    icon: (this.frames.visible && "fa-eye") || "fa-eye-slash",
-                });
-            });
         this.history_cache = {};
     },
 


### PR DESCRIPTION
I was exploring replacing the Backbone collection for a menu definition with a POJO for a new crack at #9030 when I noticed I had no clue how Webhooks could work with the changes in #9071 - turns out I don't think do. This should fix the problem though.

This also has some other cleanups for layout stuff - including deleting some scratchbook code that should have been deleted in #9071 and ES6-ification. 