### PR TITLE
[20.05] Log exception if reading tool file failed unexpectedly

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -679,7 +679,11 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
             if labels is not None:
                 tool.labels = labels
         except (IOError, OSError) as exc:
-            log.error("Error reading tool configuration file from path '%s': %s", path, unicodify(exc))
+            msg = "Error reading tool configuration file from path '%s': %s", path, unicodify(exc)
+            if exc.errno == ENOENT:
+                log.error(msg)
+            else:
+                log.exception(msg)
         except Exception:
             log.exception("Error reading tool from path: %s", path)
 


### PR DESCRIPTION
We saw `galaxy.tools.toolbox.base ERROR 2020-05-26 10:30:37,058 [p:15012,w:0,m:0] [MainThread] Error reading tool configuration file from path 'data_source/ucsc_tablebrowser.xml': [Errno 11] Resource temporarily unavailable` on main, and were not quite sure whether to blame CVMFS or the tool cache.

This should help clarify that.