### PR TITLE
[20.05] Drop custom in-process lock class

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -9,9 +9,7 @@ from dogpile.cache.api import (
     CachedValue,
     NO_VALUE,
 )
-from dogpile.cache.backends.file import AbstractFileLock
 from dogpile.cache.proxy import ProxyBackend
-from dogpile.util import ReadWriteMutex
 from lxml import etree
 from sqlalchemy.orm import (
     defer,
@@ -61,37 +59,13 @@ class JSONBackend(ProxyBackend):
         return unicodify(v.payload.to_string())
 
 
-class MutexLock(AbstractFileLock):
-    def __init__(self, filename):
-        self.mutex = ReadWriteMutex()
-
-    def acquire_read_lock(self, wait):
-        # No need for read lock. It is supposed to prevent the "dogpile" effect
-        # where multiple functions each create the cached resource, but I don't
-        # think we care.
-        return True
-
-    def acquire_write_lock(self, wait):
-        ret = self.mutex.acquire_write_lock(wait)
-        return wait or ret
-
-    def release_read_lock(self):
-        return True
-
-    def release_write_lock(self):
-        return self.mutex.release_write_lock()
-
-
 def create_cache_region(tool_cache_data_dir):
     if not os.path.exists(tool_cache_data_dir):
         os.makedirs(tool_cache_data_dir)
     region = make_region()
     region.configure(
         'dogpile.cache.dbm',
-        arguments={
-            "filename": os.path.join(tool_cache_data_dir, "cache.dbm"),
-            "lock_factory": MutexLock,
-        },
+        arguments={"filename": os.path.join(tool_cache_data_dir, "cache.dbm")},
         expiration_time=-1,
         wrap=[JSONBackend],
         replace_existing_backend=True,


### PR DESCRIPTION
This means the file based lock will be used.
There seems to be no performance penalty on
single-process instances, and this should
prevent
```
galaxy.tools.toolbox.base ERROR 2020-05-26 13:19:15,523 [p:23827,w:0,m:0] [MainThread] ("Error reading tool configuration file from path '%s': %s", 'toolshed.g2.bx.psu.edu/repos/iuc/bcftools_merge/27026ed52654/bcftools_merge/bcftools_merge.xml', '[Errno 11] Resource temporarily unavailable')
Traceback (most recent call last):
  File "lib/galaxy/tools/toolbox/base.py", line 657, in _load_tool_tag_set
    tool = self.load_tool(concrete_path, guid=guid, tool_shed_repository=tool_shed_repository, use_cached=False, tool_cache_data_dir=tool_cache_data_dir)
  File "lib/galaxy/tools/toolbox/base.py", line 855, in load_tool
    tool = self.create_tool(config_file=config_file, tool_shed_repository=tool_shed_repository, guid=guid, tool_cache_data_dir=tool_cache_data_dir, **kwds)
  File "lib/galaxy/tools/__init__.py", line 298, in create_tool
    tool_source = cache.get_or_create(config_file, creator=self.get_expanded_tool_source, expiration_time=-1, creator_args=((config_file,), {}))
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/dogpile/cache/region.py", line 962, in get_or_create
    async_creator,
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/dogpile/lock.py", line 185, in __enter__
    return self._enter()
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/dogpile/lock.py", line 94, in _enter
    generated = self._enter_create(value, createdtime)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/dogpile/lock.py", line 178, in _enter_create
    return self.creator()
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/dogpile/cache/region.py", line 923, in gen_value
    self.backend.set(key, value)
  File "lib/galaxy/tools/cache.py", line 33, in set
    with self.proxied._dbm_file(True) as dbm:
  File "/cvmfs/main.galaxyproject.org/deps/_conda/envs/_galaxy_/lib/python3.6/contextlib.py", line 81, in __enter__
    return next(self.gen)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/dogpile/cache/backends/file.py", line 218, in _dbm_file
    dbm = self.dbmmodule.open(self.filename, "w" if write else "r")
  File "/cvmfs/main.galaxyproject.org/deps/_conda/envs/_galaxy_/lib/python3.6/dbm/__init__.py", line 94, in open
    return mod.open(file, flag, mode)
_gdbm.error: [Errno 11] Resource temporarily unavailable
```