### PR TITLE
Cleanup and refactoring client code around upload/data dialog

### DIFF
--- a/client/galaxy/scripts/components/Upload/Collection.vue
+++ b/client/galaxy/scripts/components/Upload/Collection.vue
@@ -247,12 +247,8 @@ export default {
 
         _eventBuild: function () {
             const Galaxy = getGalaxyInstance();
-            var allHids = [];
-            _.forEach(this.collection.models, (upload) => {
-                allHids.push.apply(allHids, upload.get("hids"));
-            });
-            var models = _.map(allHids, (hid) => Galaxy.currHistoryPanel.collection.getByHid(hid));
-            var selection = new Galaxy.currHistoryPanel.collection.constructor(models);
+            const models = this.getUploadedModels();
+            const selection = new Galaxy.currHistoryPanel.collection.constructor(models);
             // I'm building the selection wrong because I need to set this historyId directly.
             selection.historyId = Galaxy.currHistoryPanel.collection.historyId;
             Galaxy.currHistoryPanel.buildCollection(this.collectionType, selection, true);

--- a/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
+++ b/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
@@ -1,5 +1,4 @@
 import _l from "utils/localization";
-import _ from "underscore";
 import $ from "jquery";
 import Select2 from "components/Select2";
 import Popover from "mvc/ui/ui-popover";
@@ -9,6 +8,7 @@ import UploadWrapper from "./UploadWrapper";
 import { getGalaxyInstance } from "app";
 import UploadFtp from "mvc/upload/upload-ftp";
 import LazyLimited from "mvc/lazy/lazy-limited";
+import { findExtension } from "./utils";
 
 export default {
     components: {
@@ -61,12 +61,12 @@ export default {
                     data: this.app.toData(list),
                     url: this.app.uploadPath,
                     success: (message) => {
-                        _.each(list, (model) => {
+                        list.forEach((model) => {
                             this._eventSuccess(model.id, message);
                         });
                     },
                     error: (message) => {
-                        _.each(list, (model) => {
+                        list.forEach((model) => {
                             self._eventError(model.id, message);
                         });
                     },
@@ -225,10 +225,7 @@ export default {
             return $(this.$refs.uploadTable);
         },
         extensionDetails(extension) {
-            var details = _.findWhere(this.listExtensions, {
-                id: extension,
-            });
-            return details;
+            return findExtension(this.listExtensions, extension);
         },
         initExtensionInfo() {
             $(this.$refs.footerExtensionInfo)

--- a/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
+++ b/client/galaxy/scripts/components/Upload/UploadBoxMixin.js
@@ -283,5 +283,14 @@ export default {
                 }
             });
         },
+        getUploadedModels: function () {
+            const Galaxy = getGalaxyInstance();
+            const allHids = [];
+            this.collection.models.forEach((upload) => {
+                allHids.push.apply(allHids, upload.get("hids"));
+            });
+            const models = allHids.map((hid) => Galaxy.currHistoryPanel.collection.getByHid(hid));
+            return models;
+        },
     },
 };

--- a/client/galaxy/scripts/components/Upload/UploadModal.vue
+++ b/client/galaxy/scripts/components/Upload/UploadModal.vue
@@ -12,7 +12,7 @@
         <template v-slot:modal-header>
             <h4 class="title" tabindex="0">{{ title }}</h4>
         </template>
-        <b-tabs v-if="historyAvailable">
+        <b-tabs v-if="ready">
             <b-tab title="Regular" id="regular" button-id="tab-title-link-regular">
                 <default :app="this" :lazy-load-max="50" />
             </b-tab>
@@ -27,7 +27,7 @@
             </b-tab>
         </b-tabs>
         <div v-else>
-            Loading required information from Galaxy server.
+            <loading-span message="Loading required information from Galaxy server." />
         </div>
     </b-modal>
 </template>
@@ -44,6 +44,7 @@ import Composite from "./Composite";
 import Collection from "./Collection";
 import Default from "./Default";
 import RulesInput from "./RulesInput";
+import LoadingSpan from "components/LoadingSpan";
 
 Vue.use(BootstrapVue);
 
@@ -53,6 +54,7 @@ export default {
         Composite,
         Default,
         RulesInput,
+        LoadingSpan,
     },
     props: {
         modalStatic: {
@@ -101,6 +103,8 @@ export default {
             currentUser: null,
             listGenomes: [],
             listExtensions: [],
+            genomesSet: false,
+            extensionsSet: false,
         };
     },
     created: function () {
@@ -116,18 +120,25 @@ export default {
         // load extensions
         UploadUtils.getUploadDatatypes(
             (listExtensions) => {
+                this.extensionsSet = true;
                 this.listExtensions = listExtensions;
             },
-            this.datatypesDisableSuto,
+            this.datatypesDisableAuto,
             this.auto
         );
 
         // load genomes
         UploadUtils.getUploadGenomes((listGenomes) => {
+            this.genomesSet = true;
             this.listGenomes = listGenomes;
         }, this.defaultGenome);
 
         this.initStateWhenHistoryReady();
+    },
+    computed: {
+        ready() {
+            return this.genomesSet && this.extensionsSet && this.historyAvailable;
+        },
     },
     methods: {
         show() {

--- a/client/galaxy/scripts/components/Upload/config.js
+++ b/client/galaxy/scripts/components/Upload/config.js
@@ -1,0 +1,14 @@
+import { getGalaxyInstance } from "app";
+import { getAppRoot } from "onload";
+
+export function initializeUploadDefaults(propsData = {}) {
+    const Galaxy = getGalaxyInstance();
+    const appRoot = getAppRoot();
+    return Object.assign(propsData, {
+        uploadPath: Galaxy.config.nginx_upload_path || `${appRoot}api/tools`,
+        chunkUploadSize: Galaxy.config.chunk_upload_size,
+        ftpUploadSite: Galaxy.config.ftp_upload_site,
+        defaultGenome: Galaxy.config.default_genome,
+        defaultExtension: Galaxy.config.default_extension,
+    });
+}

--- a/client/galaxy/scripts/components/Upload/index.js
+++ b/client/galaxy/scripts/components/Upload/index.js
@@ -2,3 +2,5 @@
  * External entry point for Upload components (currently only the modal).
  */
 export { default as UploadModal } from "./UploadModal";
+
+export { initializeUploadDefaults } from "./config";

--- a/client/galaxy/scripts/components/Upload/index.js
+++ b/client/galaxy/scripts/components/Upload/index.js
@@ -1,0 +1,4 @@
+/**
+ * External entry point for Upload components (currently only the modal).
+ */
+export { default as UploadModal } from "./UploadModal";

--- a/client/galaxy/scripts/components/Upload/utils.js
+++ b/client/galaxy/scripts/components/Upload/utils.js
@@ -1,0 +1,7 @@
+/*
+ * Utilities for working with upload data structures.
+ */
+
+export function findExtension(extensions, id) {
+    return extensions.find((extension) => extension.id == id);
+}

--- a/client/galaxy/scripts/entry/panels/tool-panel.js
+++ b/client/galaxy/scripts/entry/panels/tool-panel.js
@@ -1,6 +1,6 @@
 import $ from "jquery";
 import Backbone from "backbone";
-import UploadModal from "components/Upload/UploadModal";
+import { UploadModal } from "components/Upload";
 import _l from "utils/localization";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload";

--- a/client/galaxy/scripts/entry/panels/tool-panel.js
+++ b/client/galaxy/scripts/entry/panels/tool-panel.js
@@ -1,9 +1,8 @@
 import $ from "jquery";
 import Backbone from "backbone";
-import { UploadModal } from "components/Upload";
+import { UploadModal, initializeUploadDefaults } from "components/Upload";
 import _l from "utils/localization";
 import { getGalaxyInstance } from "app";
-import { getAppRoot } from "onload";
 import Vue from "vue";
 import ToolBox from "../../components/Panels/ToolBox";
 import SidePanel from "../../components/Panels/SidePanel";
@@ -12,17 +11,10 @@ import { mountVueComponent } from "../../utils/mountVueComponent";
 const ToolPanel = Backbone.View.extend({
     initialize: function () {
         const Galaxy = getGalaxyInstance();
-        const appRoot = getAppRoot();
 
         // add upload modal
         const modalInstance = Vue.extend(UploadModal);
-        const propsData = {
-            uploadPath: Galaxy.config.nginx_upload_path || `${appRoot}api/tools`,
-            chunkUploadSize: Galaxy.config.chunk_upload_size,
-            ftpUploadSite: Galaxy.config.ftp_upload_site,
-            defaultGenome: Galaxy.config.default_genome,
-            defaultExtension: Galaxy.config.default_extension,
-        };
+        const propsData = initializeUploadDefaults();
         const vm = document.createElement("div");
         $("body").append(vm);
         const upload = new modalInstance({

--- a/client/galaxy/scripts/mvc/ui/ui-select-content.js
+++ b/client/galaxy/scripts/mvc/ui/ui-select-content.js
@@ -256,12 +256,11 @@ const View = Backbone.View.extend({
 
     /** Change of current select field */
     _changeCurrent: function () {
-        const self = this;
         _.each(this.fields, (field, i) => {
-            const cnf = self.config[i];
-            if (self.model.get("current") == i) {
+            const cnf = this.config[i];
+            if (this.model.get("current") == i) {
                 field.$el.show();
-                _.each(self.$batch, ($batchfield, batchmode) => {
+                _.each(this.$batch, ($batchfield, batchmode) => {
                     if (cnf.batch == batchmode) {
                         $batchfield.show();
                     } else {
@@ -269,11 +268,11 @@ const View = Backbone.View.extend({
                     }
                 });
                 if (cnf.src == "hda") {
-                    self.button_dialog.show();
+                    this.button_dialog.show();
                 } else {
-                    self.button_dialog.hide();
+                    this.button_dialog.hide();
                 }
-                self.button_type.value(i);
+                this.button_type.value(i);
             } else {
                 field.$el.hide();
             }


### PR DESCRIPTION
This is a number of atomic cleanup and refactoring commits that enable #9809 to be just a clean single commit adding the functionality to embed uploads into the tool form and/or data selection dialog box. See individual commits for details - but it is all small stuff - removing underscore, fixing initialization of the upload form, eliminating older style ``self``, etc.. 
