### PR TITLE
Add option to text asserts to specify number of occurrences

### DIFF
--- a/lib/galaxy/tool_util/verify/asserts/text.py
+++ b/lib/galaxy/tool_util/verify/asserts/text.py
@@ -1,10 +1,14 @@
 import re
 
 
-def assert_has_text(output, text):
+def assert_has_text(output, text, n=None):
     """ Asserts specified output contains the substring specified by
     the argument text."""
-    assert output.find(text) >= 0, "Output file did not contain expected text '%s' (output '%s')" % (text, output)
+    if not n:
+        assert output.find(text) >= 0, "Output file did not contain expected text '%s' (output '%s')" % (text, output)
+    else:
+        matches = re.findall(re.escape(text), output)
+        assert len(matches) == int(n), "Expected %s matches for '%s' in output file (output '%s'); found %s" % (n, text, output, len(matches))
 
 
 def assert_not_has_text(output, text):
@@ -13,11 +17,15 @@ def assert_not_has_text(output, text):
     assert output.find(text) < 0, "Output file contains unexpected text '%s'" % text
 
 
-def assert_has_line(output, line):
+def assert_has_line(output, line, n=None):
     """ Asserts the specified output contains the line specified the
     argument line."""
-    match = re.search("^%s$" % re.escape(line), output, flags=re.MULTILINE)
-    assert match is not None, "No line of output file was '%s' (output was '%s') " % (line, output)
+    if not n:
+        match = re.search("^%s$" % re.escape(line), output, flags=re.MULTILINE)
+        assert match is not None, "No line of output file was '%s' (output was '%s') " % (line, output)
+    else:
+        matches = re.findall("^%s$" % re.escape(line), output, flags=re.MULTILINE)
+        assert len(matches) == int(n), "Expected %s lines matching '%s' in output file (output was '%s'); found %s" % (n, line, output, len(matches))
 
 
 def assert_has_n_lines(output, n):

--- a/lib/galaxy/tool_util/verify/asserts/text.py
+++ b/lib/galaxy/tool_util/verify/asserts/text.py
@@ -3,8 +3,9 @@ import re
 
 def assert_has_text(output, text, n=None):
     """ Asserts specified output contains the substring specified by
-    the argument text."""
-    if not n:
+    the argument text. The exact number of occurrences can be
+    optionally specified by the argument n."""
+    if n is None:
         assert output.find(text) >= 0, "Output file did not contain expected text '%s' (output '%s')" % (text, output)
     else:
         matches = re.findall(re.escape(text), output)
@@ -13,14 +14,15 @@ def assert_has_text(output, text, n=None):
 
 def assert_not_has_text(output, text):
     """ Asserts specified output does not contain the substring
-    specified the argument text."""
+    specified by the argument text."""
     assert output.find(text) < 0, "Output file contains unexpected text '%s'" % text
 
 
 def assert_has_line(output, line, n=None):
-    """ Asserts the specified output contains the line specified the
-    argument line."""
-    if not n:
+    """ Asserts the specified output contains the line specified by the
+    argument line. The exact number of occurrences can be optionally
+    specified by the argument n."""
+    if n is None:
         match = re.search("^%s$" % re.escape(line), output, flags=re.MULTILINE)
         assert match is not None, "No line of output file was '%s' (output was '%s') " % (line, output)
     else:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1664,7 +1664,7 @@ module.
     <xs:choice>
       <xs:element name="has_text" type="xs:anyType">
         <xs:annotation>
-          <xs:documentation><![CDATA[Asserts the specified ``text`` appears in the output (e.g. ``<has_text text="chr7">``).]]>
+          <xs:documentation><![CDATA[Asserts the specified ``text`` appears in the output (e.g. ``<has_text text="chr7">``). If the ``text`` is expected to occur a particular number of times, this value can be specified using ``n``.]]>
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -1682,7 +1682,7 @@ module.
       </xs:element>
       <xs:element name="has_line" type="xs:anyType">
         <xs:annotation>
-          <xs:documentation><![CDATA[Asserts a line matching the specified string (``line``) appears in the output (e.g. ``<has_line line="A full example line." />``).]]>
+          <xs:documentation><![CDATA[Asserts a line matching the specified string (``line``) appears in the output (e.g. ``<has_line line="A full example line." />``). If the ``line`` is expected to occur a particular number of times, this value can be specified using ``n``.]]>
           </xs:documentation>
         </xs:annotation>
       </xs:element>

--- a/test/functional/tools/validation_default.xml
+++ b/test/functional/tools/validation_default.xml
@@ -25,6 +25,8 @@
       <output name="out_file1">
          <assert_contents>
             <has_line line="__dq__ X echo __dq__moo" />
+            <has_line line="__dq__ X echo __dq__moo" n="1" />
+            <has_text text="o" n="3" />
             <has_n_lines n="1" />
             <has_size value="24"/>
             <has_size value="20" delta="5"/>


### PR DESCRIPTION
For example, this would be handy to check the number of chemical structures in an SD file; this uses `$$$$` as a separator, which can be counted to determine the number of molecules in the file.

After writing this code, I realized the same thing is actually already possible using regex: e.g. `<has_text_matching expression="^([^\$]+?\$\$\$\$){33}?$"/>` for a file containing 33 molecules. However, I think this would still be a convenient alternative: `<has_text text="$$$$" n="33"/>` is way nicer both to read and to write.