### PR TITLE
Optimize submission of tools that output collections.

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -501,7 +501,7 @@ class DefaultToolAction(object):
                         })
                     reserve_hid_for_parent = output_collections.creating_hdca
                     history.add_datasets(trans.sa_session, created_element_datasets, set_hid=set_output_hid, quota=False, flush=False, reserve_hid_for_parent=reserve_hid_for_parent)
-                    if reserve_hid_for_parent:
+                    if reserve_hid_for_parent and len(created_element_datasets) > 0:
                         hid = created_element_datasets[-1].hid + 1
                     else:
                         hid = None


### PR DESCRIPTION
Some output timings for a tool that creates a pair vs a tool that creates two outputs. If you squint it looks like this branch reduces the delta between the two tools. Optimizing the individual parts of the code worked really well (logs statements not shown) but the final commutative product is a bit harder to see. I expected a bigger difference given the reported problems - might be worth taking another pass in the context of a mapping operation over a tool that produces pairs, this pass focused on executions that produce HDCAs which are difference than producing collections.

```
DEV

galaxy.tools.execute DEBUG 2020-05-29 18:35:29,208 [p:45925,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool collection_creates_pair request (748.437 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:36:00,763 [p:45925,w:1,m:0] [uWSGIWorker1Core0] Executed 1 job(s) for tool collection_creates_pair request (774.042 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:36:35,855 [p:45925,w:1,m:0] [uWSGIWorker1Core1] Executed 1 job(s) for tool collection_creates_pair request (689.054 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:37:27,540 [p:45925,w:1,m:0] [uWSGIWorker1Core1] Executed 1 job(s) for tool collection_creates_pair request (546.268 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:37:50,067 [p:45925,w:1,m:0] [uWSGIWorker1Core1] Executed 1 job(s) for tool collection_creates_pair request (621.726 ms)

THIS BRANCH

galaxy.tools.execute DEBUG 2020-05-29 18:47:11,421 [p:46643,w:1,m:0] [uWSGIWorker1Core3] Executed 1 job(s) for tool collection_creates_pair request (400.876 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:48:02,838 [p:46643,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool collection_creates_pair request (384.065 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:48:33,142 [p:46643,w:1,m:0] [uWSGIWorker1Core0] Executed 1 job(s) for tool collection_creates_pair request (424.079 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:49:00,472 [p:46643,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool collection_creates_pair request (450.527 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:49:42,292 [p:46643,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool create_2 request (324.669 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:50:01,887 [p:46643,w:1,m:0] [uWSGIWorker1Core1] Executed 1 job(s) for tool create_2 request (349.538 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:50:26,719 [p:46643,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool collection_creates_pair request (380.079 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:51:02,118 [p:46643,w:1,m:0] [uWSGIWorker1Core3] Executed 1 job(s) for tool collection_creates_pair request (378.154 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:52:07,148 [p:46643,w:1,m:0] [uWSGIWorker1Core3] Executed 1 job(s) for tool create_2 request (379.535 ms)


DEV

galaxy.tools.execute DEBUG 2020-05-29 18:53:29,193 [p:48758,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool create_2 request (418.890 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:54:08,498 [p:48758,w:1,m:0] [uWSGIWorker1Core0] Executed 1 job(s) for tool create_2 request (342.142 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:54:33,650 [p:48758,w:1,m:0] [uWSGIWorker1Core3] Executed 1 job(s) for tool create_2 request (369.027 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:55:00,766 [p:48758,w:1,m:0] [uWSGIWorker1Core3] Executed 1 job(s) for tool collection_creates_pair request (562.289 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:55:18,988 [p:48758,w:1,m:0] [uWSGIWorker1Core1] Executed 1 job(s) for tool collection_creates_pair request (510.890 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:55:48,110 [p:48758,w:1,m:0] [uWSGIWorker1Core2] Executed 1 job(s) for tool collection_creates_pair request (468.725 ms)

galaxy.tools.execute DEBUG 2020-05-29 18:56:25,401 [p:48758,w:1,m:0] [uWSGIWorker1Core3] Executed 1 job(s) for tool collection_creates_pair request (527.128 ms)
```