### PR TITLE
[20.01] Fix disappearing datatypes after restart

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -91,10 +91,6 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         check_migrate_tools = self.config.check_migrate_tools
         self._configure_models(check_migrate_databases=self.config.check_migrate_databases, check_migrate_tools=check_migrate_tools, config_file=config_file)
 
-        self.installed_repository_manager = InstalledRepositoryManager(self)
-        self._configure_datatypes_registry(self.installed_repository_manager)
-        galaxy.model.set_datatypes_registry(self.datatypes_registry)
-
         # Security helper
         self._configure_security()
         # Tag handler
@@ -134,6 +130,11 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         self.tool_shed_repository_cache = ToolShedRepositoryCache(self)
         # Watch various config files for immediate reload
         self.watchers = ConfigWatchers(self)
+        self._configure_tool_config_files()
+        self.installed_repository_manager = InstalledRepositoryManager(self)
+        self._configure_datatypes_registry(self.installed_repository_manager)
+        galaxy.model.set_datatypes_registry(self.datatypes_registry)
+
         self._configure_toolbox()
 
         # Load Data Manager

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -999,6 +999,16 @@ class ConfiguresGalaxyMixin(object):
         else:
             log.warning('Waiting for toolbox reload timed out after 60 seconds')
 
+    def _configure_tool_config_files(self):
+        if self.config.shed_tool_config_file not in self.config.tool_configs:
+            self.config.tool_configs.append(self.config.shed_tool_config_file)
+        # The value of migrated_tools_config is the file reserved for containing only those tools that have been
+        # eliminated from the distribution and moved to the tool shed. If migration checking is disabled, only add it if
+        # it exists (since this may be an existing deployment where migrations were previously run).
+        if ((self.config.check_migrate_tools or os.path.exists(self.config.migrated_tools_config))
+                and self.config.migrated_tools_config not in self.config.tool_configs):
+            self.config.tool_configs.append(self.config.migrated_tools_config)
+
     def _configure_toolbox(self):
         from galaxy import tools
         from galaxy.managers.citations import CitationsManager
@@ -1011,14 +1021,6 @@ class ConfiguresGalaxyMixin(object):
         from galaxy.managers.tools import DynamicToolManager
         self.dynamic_tools_manager = DynamicToolManager(self)
         self._toolbox_lock = threading.RLock()
-        if self.config.shed_tool_config_file not in self.config.tool_configs:
-            self.config.tool_configs.append(self.config.shed_tool_config_file)
-        # The value of migrated_tools_config is the file reserved for containing only those tools that have been
-        # eliminated from the distribution and moved to the tool shed. If migration checking is disabled, only add it if
-        # it exists (since this may be an existing deployment where migrations were previously run).
-        if ((self.config.check_migrate_tools or os.path.exists(self.config.migrated_tools_config))
-                and self.config.migrated_tools_config not in self.config.tool_configs):
-            self.config.tool_configs.append(self.config.migrated_tools_config)
         self.toolbox = tools.ToolBox(self.config.tool_configs, self.config.tool_path, self)
         galaxy_root_dir = os.path.abspath(self.config.root)
         file_path = os.path.abspath(getattr(self.config, "file_path"))

--- a/lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/installed_repository_manager.py
@@ -577,7 +577,7 @@ class InstalledRepositoryManager(object):
     def get_repository_install_dir(self, tool_shed_repository):
         for tree in self.tool_trees:
             if tree is None:
-                return None
+                continue
             root = tree.getroot()
             tool_path = root.get('tool_path', None)
             if tool_path:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -111,7 +111,7 @@ def skip_if_site_down(url):
 
     def site_down():
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=10)
             return response.status_code != 200
         except Exception:
             return False

--- a/test/integration/test_shed_tool_tests.py
+++ b/test/integration/test_shed_tool_tests.py
@@ -1,3 +1,5 @@
+import os
+
 from galaxy_test.base.populators import skip_if_toolshed_down
 from galaxy_test.driver import integration_util
 from .uses_shed import UsesShed
@@ -25,6 +27,13 @@ class ToolShedDatatypeTestIntegrationTestCase(integration_util.IntegrationTestCa
 
     framework_tool_and_types = True
 
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls.configure_shed(config)
+
+    def handle_reconfigure_galaxy_config_kwds(self, config):
+        config["tool_shed_config_file"] = os.path.join(self.shed_tools_dir, "shed_tool_conf.xml")
+
     @skip_if_toolshed_down
     def test_datatype_installation(self):
         datatypes = self._get("datatypes").json()
@@ -33,6 +42,6 @@ class ToolShedDatatypeTestIntegrationTestCase(integration_util.IntegrationTestCa
         datatypes = self._get("datatypes").json()
         assert "cond" in datatypes
         # Make sure datatype survives restart
-        self.restart()
+        self.restart(handle_reconfig=self.handle_reconfigure_galaxy_config_kwds)
         datatypes = self._get("datatypes").json()
         assert "cond" in datatypes

--- a/test/integration/test_shed_tool_tests.py
+++ b/test/integration/test_shed_tool_tests.py
@@ -17,3 +17,22 @@ class ToolShedToolTestIntegrationTestCase(integration_util.IntegrationTestCase, 
     def test_tool_test(self):
         self.install_repository("devteam", "fastqc", "ff9530579d1f")
         self._run_tool_test("toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71")
+
+
+class ToolShedDatatypeTestIntegrationTestCase(integration_util.IntegrationTestCase, UsesShed):
+
+    """Test datatype installation"""
+
+    framework_tool_and_types = True
+
+    @skip_if_toolshed_down
+    def test_datatype_installation(self):
+        datatypes = self._get("datatypes").json()
+        assert "cond" not in datatypes
+        self.install_repository("sblanck", "smagexp_datatypes", "f174dc3d2641")
+        datatypes = self._get("datatypes").json()
+        assert "cond" in datatypes
+        # Make sure datatype survives restart
+        self.restart()
+        datatypes = self._get("datatypes").json()
+        assert "cond" in datatypes


### PR DESCRIPTION
The root cause is that InstalledRepositoryManager was started before the shed_tool_config_file was injected into the tool_configs list.