### PR TITLE
[Selenium] History DBkey and refactor dataset state

### DIFF
--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -120,6 +120,7 @@ history_panel:
       dbkey: '${_} .dbkey .value'
       info: '${_} .info .value'
       peek: '${_} .dataset-peek'
+      toolhelp_title: '${_} .toolhelp strong'
 
       # Title buttons...
       display_button: '${_} .icon-btn.display-btn'
@@ -129,6 +130,7 @@ history_panel:
       # Action buttons...
       download_button: '${_} .icon-btn.download-btn'
       info_button: '${_} .icon-btn.params-btn'
+      dbkey_button: '${_} .fa.fa-question'
       rerun_button: '${_} .icon-btn.rerun-btn'
       nametags: '${_} .nametags .badge-tags'
 
@@ -197,12 +199,27 @@ history_panel:
     new_name: 'Unnamed history'
     new_size: '(empty)'
 
+
 history_structure:
   selectors:
     _: '.tool'
     header: '.tool > .header.clickable'
     dataset: '.tool div.list-item.dataset.history-content'
     details: '.tool .details'
+
+edit_dataset_attributes:
+  selectors:
+    database_build_dropdown: '[data-label="Database/Build"]'
+    save_btn: '#submit_attributes'
+
+  dbkey_dropdown_results:
+    selectors:
+      _:  '#select2-drop  > .select2-results'
+      dbkey_dropdown_option:
+        type: xpath
+        selector: '//li[normalize-space() = "${dbkey_text}"]'
+
+
 
 tool_panel:
 

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -17,7 +17,6 @@ TEST_DBKEY_TEXT = 'Honeybee (Apis mellifera): apiMel3 (apiMel3)'
 
 
 class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
-
     hid = 1
 
     @selenium_test
@@ -33,7 +32,8 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         item.dbkey_button.wait_for_and_click()
         toolhelp_title_text = item.toolhelp_title.wait_for_visible().text
         # assert tool helptext
-        assert EXPECTED_TOOLHELP_TITLE_TEXT == toolhelp_title_text, "Toolhelp title [%s] was not expected text [%s]." % (EXPECTED_TOOLHELP_TITLE_TEXT, toolhelp_title_text)
+        assert EXPECTED_TOOLHELP_TITLE_TEXT == toolhelp_title_text, "Toolhelp title [%s] was not expected text [%s]." % (
+            EXPECTED_TOOLHELP_TITLE_TEXT, toolhelp_title_text)
 
         self.screenshot("history_panel_dataset_expanded")
 
@@ -46,11 +46,11 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         item.dbkey.wait_for_and_click()
         self.components.edit_dataset_attributes.database_build_dropdown.wait_for_and_click()
         # choose database option from 'Database/Build' dropdown, that equals to dbkey_text
-        self.components.edit_dataset_attributes.dbkey_dropdown_results.dbkey_dropdown_option(dbkey_text=TEST_DBKEY_TEXT).wait_for_and_click()
+        self.components.edit_dataset_attributes.dbkey_dropdown_results.dbkey_dropdown_option(
+            dbkey_text=TEST_DBKEY_TEXT).wait_for_and_click()
         self.components.edit_dataset_attributes.save_btn.wait_for_and_click()
         self.history_panel_wait_for_hid_ok(hid)
         self.assert_item_dbkey_displayed_as(hid, "apiMel3")
-
 
     def _prepare_dataset(self, hid):
         self.register()
@@ -63,7 +63,6 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         # Expand HDA and wait for details to show up.
         return self.history_panel_click_item_title(hid=hid, wait=True)
 
-
     def _assert_title_buttons(self, hid, expected_buttons=['display', 'edit', 'delete']):
         self._assert_buttons(hid, expected_buttons)
 
@@ -75,11 +74,11 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         for i in range(len(expected_buttons)):
 
             # ensure old tooltip expired
-            if(i > 0):
-               previous_button = item_button["%s_button" % expected_buttons[i - 1]].wait_for_visible()
-               if previous_button.get_attribute("aria-describedby") != None:
-                   # wait for tooltip to disappear
-                   self.components._.tooltip_balloon.wait_for_absent()
+            if i > 0:
+                previous_button = item_button["%s_button" % expected_buttons[i - 1]].wait_for_visible()
+                if previous_button.get_attribute("aria-describedby") is not None:
+                    # wait for tooltip to disappear
+                    self.components._.tooltip_balloon.wait_for_absent()
 
             button = item_button["%s_button" % expected_buttons[i]]
             self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_buttons[i]])

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -42,6 +42,7 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_dataset_change_dbkey(self, hid=hid):
         item = self._prepare_dataset(hid)
+        self.assert_item_dbkey_displayed_as(hid, "?")
         item.dbkey.wait_for_and_click()
         self.components.edit_dataset_attributes.database_build_dropdown.wait_for_and_click()
         # choose database option from 'Database/Build' dropdown, that equals to dbkey_text

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -71,14 +71,15 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     def _assert_buttons(self, hid, expected_buttons):
         item_button = self.history_panel_item_component(hid=hid)
-        for i in range(len(expected_buttons)):
+        for i, expected_button in enumerate(expected_buttons):
 
-            # ensure old tooltip expired
+            # ensure old tooltip expired,
+            # no tooltip appeared before the 1st element
             if i > 0:
                 previous_button = item_button["%s_button" % expected_buttons[i - 1]].wait_for_visible()
                 if previous_button.get_attribute("aria-describedby") is not None:
                     # wait for tooltip to disappear
                     self.components._.tooltip_balloon.wait_for_absent()
 
-            button = item_button["%s_button" % expected_buttons[i]]
-            self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_buttons[i]])
+            button = item_button["%s_button" % expected_button]
+            self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_button])

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -12,31 +12,56 @@ BUTTON_TOOLTIPS = {
     "info": 'View details',
     "rerun": 'Run this job again',
 }
+EXPECTED_TOOLHELP_TITLE_TEXT = 'Tool help for Upload File'
+TEST_DBKEY_TEXT = 'Honeybee (Apis mellifera): apiMel3 (apiMel3)'
 
 
 class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
+    hid = 1
+
     @selenium_test
-    def test_dataset_state(self):
-        self.register()
-        self.perform_upload(self.get_filename("1.fasta"))
-        self.history_panel_wait_for_hid_ok(1)
-        self.assert_item_name(1, "1.fasta")
-        self.assert_item_hid_text(1)
-        self._assert_title_buttons(1)
+    def test_dataset_state(self, hid=hid):
+        item = self._prepare_dataset(self.hid)
+        self.history_panel_item_body_component(hid, wait=True)
 
-        # Expand HDA and wait for details to show up.
-        self.history_panel_click_item_title(hid=1, wait=True)
-        self.history_panel_item_body_component(1, wait=True)
+        self.assert_item_summary_includes(hid, "1 sequence")
+        self.assert_item_dbkey_displayed_as(hid, "?")
+        self.assert_item_info_includes(hid, 'uploaded fasta file')
+        self.assert_item_peek_includes(hid, ">hg17")
 
-        self.assert_item_summary_includes(1, "1 sequence")
-        self.assert_item_dbkey_displayed_as(1, "?")
-        self.assert_item_info_includes(1, 'uploaded fasta file')
-        self.assert_item_peek_includes(1, ">hg17")
+        item.dbkey_button.wait_for_and_click()
+        toolhelp_title_text = item.toolhelp_title.wait_for_visible().text
+        # assert tool helptext
+        assert EXPECTED_TOOLHELP_TITLE_TEXT == toolhelp_title_text, "Toolhelp title [%s] was not expected text [%s]." % (EXPECTED_TOOLHELP_TITLE_TEXT, toolhelp_title_text)
 
         self.screenshot("history_panel_dataset_expanded")
 
-        self._assert_action_buttons(1)
+        self._assert_action_buttons(hid)
+
+    @selenium_test
+    def test_dataset_change_dbkey(self, hid=hid):
+        item = self._prepare_dataset(hid)
+        item.dbkey.wait_for_and_click()
+        self.components.edit_dataset_attributes.database_build_dropdown.wait_for_and_click()
+        # choose database option from 'Database/Build' dropdown, that equals to dbkey_text
+        self.components.edit_dataset_attributes.dbkey_dropdown_results.dbkey_dropdown_option(dbkey_text=TEST_DBKEY_TEXT).wait_for_and_click()
+        self.components.edit_dataset_attributes.save_btn.wait_for_and_click()
+        self.history_panel_wait_for_hid_ok(hid)
+        self.assert_item_dbkey_displayed_as(hid, "apiMel3")
+
+
+    def _prepare_dataset(self, hid):
+        self.register()
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.history_panel_wait_for_hid_ok(hid)
+        self.assert_item_name(hid, "1.fasta")
+        self.assert_item_hid_text(hid)
+        self._assert_title_buttons(hid)
+
+        # Expand HDA and wait for details to show up.
+        return self.history_panel_click_item_title(hid=hid, wait=True)
+
 
     def _assert_title_buttons(self, hid, expected_buttons=['display', 'edit', 'delete']):
         self._assert_buttons(hid, expected_buttons)
@@ -46,8 +71,14 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     def _assert_buttons(self, hid, expected_buttons):
         item_button = self.history_panel_item_component(hid=hid)
-        # Let old tooltip expire, etc...
-        for expected_button in expected_buttons:
-            self.sleep_for(self.wait_types.UX_TRANSITION)
-            button = item_button["%s_button" % expected_button]
-            self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_button])
+        for i in range(len(expected_buttons)):
+
+            # ensure old tooltip expired
+            if(i > 0):
+               previous_button = item_button["%s_button" % expected_buttons[i - 1]].wait_for_visible()
+               if previous_button.get_attribute("aria-describedby") != None:
+                   # wait for tooltip to disappear
+                   self.components._.tooltip_balloon.wait_for_absent()
+
+            button = item_button["%s_button" % expected_buttons[i]]
+            self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_buttons[i]])


### PR DESCRIPTION
Since we are going to merge new history soon, it would be nice to have selenium tests for some basic functionality.

This PR slightly reworks and complements `test_dataset_state` and brings selenium test for changing database key.

I guess, `test_dataset_change_dbkey` is pretty straight forward. It changes db key and asserts it.

about refactoring.... I don't think it's good idea to wait for `UX_TRANSITION` [here](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy_test/selenium/test_history_dataset_state.py#L51).

 It takes quite a while to complete this test (without `wait` I was getting mismatch, because previous tooltip didn't disappear yet, even with `wait_for_absent` in [navigates](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/selenium/navigates_galaxy.py#L1370)). So I added another check for tooltip absence. I check whether previous button still has `aria-describedby` attribute.



