### PR TITLE
[WIP] fixes for <parallelism> with containers

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -27,7 +27,11 @@ from galaxy.datatypes.sniff import (
     iter_headers,
     validate_tabular,
 )
-from galaxy.util import compression_utils
+from galaxy.util import (
+    commands,
+    compression_utils,
+    unicodify
+)
 from . import dataproviders
 
 if sys.version_info > (3,):
@@ -534,8 +538,14 @@ class Sam(Tabular):
         shutil.move(split_files[0], output_file)
 
         if len(split_files) > 1:
-            cmd = ['egrep', '-v', '-h', '^@'] + split_files[1:] + ['>>', output_file]
-            subprocess.check_call(cmd, shell=True)
+            cmd = ['grep', '-E', '-v', '-h', '^@'] + split_files[1:]
+            try:
+                out = commands.execute(cmd)
+            except commands.CommandLineException as e:
+                log.error(unicodify(e))
+                raise
+            with open(output_file, 'a') as oh:
+                oh.write(out)
 
     merge = staticmethod(merge)
 


### PR DESCRIPTION
Some problems that I stumbled upon here: https://github.com/galaxyproject/tools-devteam/pull/555 when containerized testing is used:

- [ ] `GALAXYROOT/extract_dataset_parts.sh: .venv/bin/activate: line 157: syntax error: bad substitution`
- [ ] `/tmp/tmpd3oovgq5/job_working_directory/000/2/task_10/tool_script.sh: line 22: /tmp/tmpd3oovgq5/job_working_directory/000/2/task_10/dataset_91ad311f-7f82-4fd0-9324-6652beb11bfe.dat: Read-only file system`

Another bug already 'fixed'

- [x] egrep in sam.merge
- [ ] maybe use `grep -E`?
