### PR TITLE
Added support for dynamically refreshing drilldowns

### DIFF
--- a/client/galaxy/scripts/mvc/ui/ui-drilldown.js
+++ b/client/galaxy/scripts/mvc/ui/ui-drilldown.js
@@ -16,7 +16,14 @@ var View = Options.BaseIcons.extend({
     },
 
     /** Set states for selected values */
+    _getValue: function () {
+        const value = Options.BaseIcons.prototype._getValue.call(this);
+        return {value: value || this.last_clicked_node, last_clicked_node: this.last_clicked_node};
+    },
+
+    /** Set states for selected values */
     _setValue: function (new_value) {
+        new_value = (new_value && 'last_clicked_node' in new_value) ? new_value['value'] : new_value;
         Options.BaseIcons.prototype._setValue.call(this, new_value);
         if (new_value !== undefined && new_value !== null && this.header_index) {
             var self = this;
@@ -35,6 +42,7 @@ var View = Options.BaseIcons.extend({
         var $button = this.$(`.button-${header_id}`);
         var $subgroup = this.$(`.subgroup-${header_id}`);
         $button.data("is_expanded", is_expanded);
+        this.last_clicked_node = $button.attr('value');
         if (is_expanded) {
             $subgroup.show();
             $button.removeClass("fa-plus-square").addClass("fa-minus-square");
@@ -54,6 +62,7 @@ var View = Options.BaseIcons.extend({
             var $button = $el.find(`.button-${header_id}`);
             $button.on("click", () => {
                 self._setState(header_id, !$button.data("is_expanded"));
+                self.trigger("change");
             });
         }
 
@@ -69,8 +78,10 @@ var View = Options.BaseIcons.extend({
                 if (has_options) {
                     var header_id = Utils.uid();
                     var $button = $("<span/>")
+                        .attr('value', level.value)
+                        .data('is_expanded', level.expanded)
                         .addClass(`button-${header_id}`)
-                        .addClass("ui-drilldown-button fa fa-plus-square");
+                        .addClass("ui-drilldown-button fa " + (level.expanded ? "fa-minus-square": "fa-plus-square"));
                     var $subgroup = $("<div/>").addClass(`subgroup-${header_id}`).addClass("ui-drilldown-subgroup");
                     $group.append(
                         $("<div/>")
@@ -86,6 +97,10 @@ var View = Options.BaseIcons.extend({
                     iterate($subgroup, level.options, new_header);
                     $group.append($subgroup);
                     attach($group, header_id);
+                    if (level.expanded) {
+                        $group.show();
+                        $subgroup.show();
+                    }
                 } else {
                     $group.append(
                         self._templateOption({


### PR DESCRIPTION
While the drilldown component allows hierarchical structures to be displayed in a tool form, currently, the entire tree must be preloaded. This is often not feasible when the tree structure is complex.

This PR adds support for fetching additional child nodes as the tree structure is explored, by making a server request on each node expansion. The change is largely backward compatible, except that when `refresh_on_change` is True, the client component includes data on which node was expanded along with the currently selected value(s).

This allows server side code to retrieve the expanded node's value and fetch its child nodes only.

For example, with the following definition:
```
<param name="target_folder" refresh_on_change="true" type="drill_down" display="radio" hierarchy="exact"
           multiple="true" label="Choose Target Directory"
           dynamic_options="get_owncloud_folders(trans=__trans__, target_folder=target_folder, list_dirs_only=True)"
           help="Select target folder to save files in.">
    </param>
```

The following data is sent over the wire when a node is expanded:

![image](https://user-images.githubusercontent.com/2070605/83888018-dfb67180-a766-11ea-8256-a4ed15e10fa5.png)

With the following result:

![image](https://user-images.githubusercontent.com/2070605/83887961-cad9de00-a766-11ea-8b3e-ed3a9aa34aec.png)

There is a working version of a tool that uses this here:
https://galaxy-aust-staging.genome.edu.au/

Select Get Data -> Import from OwnCloud

Tool source: https://github.com/usegalaxy-au/Galaxy-Owncloud-Integration/blob/master/Galaxy_OwncloudImportExport/send_to_owncloud.xml