### PR TITLE
Add support for relative paths in dependency resolver mappings

### DIFF
--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -5,7 +5,7 @@ from abc import (
     abstractmethod,
     abstractproperty,
 )
-
+import os.path
 import six
 import yaml
 
@@ -89,9 +89,23 @@ class MappableDependencyResolver(object):
         mapping_files = dependency_manager.get_resolver_option(self, "mapping_files", explicit_resolver_options=kwds)
         mappings = []
         if mapping_files:
+            search_dirs = [os.getcwd()]
+            if isinstance(dependency_manager.default_base_path, str):
+                search_dirs.append(dependency_manager.default_base_path)
+
+            def candidates(path):
+                if os.path.isabs(path):
+                    yield path
+                else:
+                    for search_dir in search_dirs:
+                        yield os.path.join(search_dir, path)
+
             mapping_files = listify(mapping_files)
             for mapping_file in mapping_files:
-                mappings.extend(MappableDependencyResolver._mapping_file_to_list(mapping_file))
+                for full_path in candidates(mapping_file):
+                    if os.path.exists(full_path):
+                        mappings.extend(MappableDependencyResolver._mapping_file_to_list(full_path))
+                        break
         self._mappings = mappings
 
     @staticmethod

--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -1,11 +1,12 @@
 """The module defines the abstract interface for dealing tool dependency resolution plugins."""
 import errno
+import os.path
 from abc import (
     ABCMeta,
     abstractmethod,
     abstractproperty,
 )
-import os.path
+
 import six
 import yaml
 

--- a/test/unit/tool_util/test_tool_deps.py
+++ b/test/unit/tool_util/test_tool_deps.py
@@ -751,6 +751,7 @@ def __dependency_manager_for_config(app_config, resolution_config=None):
 
 
 class _SimpleDependencyManager(object):
+    default_base_path = None
 
     def get_resolver_option(self, resolver, key, explicit_resolver_options={}):
         return explicit_resolver_options.get(key)


### PR DESCRIPTION
I have been using the dependency resolver feature of tool_util from cwltool, however there is no support for dependency mapping files to specified by a relative path (I really want this for maintaining a set of such files in a way that can be shared between multiple users of an HPC system)

In this patch I implement the feature I want. Please let me know if this needs any other work and I do this on Wednesday.

Thanks for the useful library!