### PR TITLE
[Selenium] History structure

### DIFF
--- a/client/galaxy/scripts/utils/metrics-logger.js
+++ b/client/galaxy/scripts/utils/metrics-logger.js
@@ -296,7 +296,7 @@ function usefulToString(arg) {
         } catch (e) {
             // If arg has cyclic reference, return String
             // otherwise rendering stops and we have incomplete page
-            console.error(e)
+            console.error(e);
             return String(arg);
         }
     }

--- a/client/galaxy/scripts/utils/metrics-logger.js
+++ b/client/galaxy/scripts/utils/metrics-logger.js
@@ -291,7 +291,14 @@ MetricsLogger.prototype._delayPost = function _delayPost() {
 function usefulToString(arg) {
     var asStr = String(arg);
     if (asStr == "[object Object]") {
-        asStr = JSON.stringify(arg);
+        try {
+            asStr = JSON.stringify(arg);
+        } catch (e) {
+            // If arg has cyclic reference, return String
+            // otherwise rendering stops and we have incomplete page
+            console.error(e)
+            return String(arg);
+        }
     }
     return asStr;
 }

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -172,6 +172,9 @@ history_panel:
     options_button: '#history-options-button'
     options_button_icon: '#history-options-button span.fa-cog'
     options_menu: '#history-options-button-menu'
+    options_show_history_structure:
+      type: xpath
+      selector: '//a[text()="Show Structure"]'
     new_history_button: '#history-new-button'
     multi_view_button: '#history-view-multi-button'
 
@@ -186,6 +189,13 @@ history_panel:
     tooltip_name: 'Click to rename history'
     new_name: 'Unnamed history'
     new_size: '(empty)'
+
+history_structure:
+  selectors:
+    _: '.tool'
+    header: '.tool > .header.clickable'
+    dataset: '.tool div.list-item.dataset.history-content'
+    details: '.tool .details'
 
 tool_panel:
 

--- a/lib/galaxy_test/selenium/test_history_structure.py
+++ b/lib/galaxy_test/selenium/test_history_structure.py
@@ -1,0 +1,42 @@
+from .framework import (
+    selenium_test,
+    managed_history,
+    SeleniumTestCase
+)
+
+
+class HistoryStructureTestCase(SeleniumTestCase):
+
+    ensure_registered = True
+
+    @selenium_test
+    @managed_history
+    def test_history_structure(self):
+        def assert_details(expected_to_be_visible):
+
+            error_message = "details are visible!"
+            if expected_to_be_visible:
+                error_message = "details are not visible!"
+
+            assert expected_to_be_visible == self.components.history_structure.details.is_displayed, error_message
+
+        self.perform_upload(self.get_filename("1.fasta"))
+        self.wait_for_history()
+        self.components.history_structure.header.assert_absent_or_hidden()
+        self.components.history_structure.dataset.assert_absent_or_hidden()
+        self.click_history_options()
+
+        self.components.history_panel.options_show_history_structure.wait_for_and_click()
+
+        # assert details are not visible before expand
+        self.components.history_structure.details.assert_absent_or_hidden()
+
+        self.components.history_structure.dataset.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        assert_details(True)
+        self.components.history_structure.header.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        assert_details(False)
+        self.components.history_structure.dataset.assert_absent_or_hidden()

--- a/lib/galaxy_test/selenium/test_history_structure.py
+++ b/lib/galaxy_test/selenium/test_history_structure.py
@@ -1,6 +1,6 @@
 from .framework import (
-    selenium_test,
     managed_history,
+    selenium_test,
     SeleniumTestCase
 )
 


### PR DESCRIPTION
Since, we are going to rework history structure in the following couple of weeks, this PR brings just basic test. 
Flow:
- upload test data 
- click on menu - history structure
- Assure dataset details are not visible 
- Expand dataset structure
- Expand dataset details
- Shrink dataset structure
- Assure details and dataset are not visible

Update:
forgot to mention. It also fixes JS logging. If we setup debug level on python, it produces cyclic object and ```JSON.stringify()``` breaks badly, then structure is not rendered properly. 
[This check](https://github.com/galaxyproject/galaxy/pull/9858/files#diff-d34fe858167e556f4301d76b6372ec8cR295) fixes the problem