### PR TITLE
Allow composite and extra file uploads via data fetch API.

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -90,6 +90,21 @@ def stream_to_file(stream, suffix='', prefix='', dir=None, text=False, **kwd):
     return stream_to_open_named_file(stream, fd, temp_name, **kwd)
 
 
+def handle_composite_file(datatype, src_path, extra_files, name, is_binary, tmp_dir, tmp_prefix, upload_opts):
+    if not is_binary:
+        if upload_opts.get('space_to_tab'):
+            convert_newlines_sep2tabs(src_path, tmp_dir=tmp_dir, tmp_prefix=tmp_prefix)
+        else:
+            convert_newlines(src_path, tmp_dir=tmp_dir, tmp_prefix=tmp_prefix)
+
+    file_output_path = os.path.join(extra_files, name)
+    shutil.move(src_path, file_output_path)
+
+    # groom the dataset file content if required by the corresponding datatype definition
+    if datatype and datatype.dataset_content_needs_grooming(file_output_path):
+        datatype.groom_dataset_content(file_output_path)
+
+
 def convert_newlines(fname, in_place=True, tmp_dir=None, tmp_prefix="gxupload", block_size=128 * 1024, regexp=None):
     """
     Converts in place a file from universal line endings

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -18,6 +18,7 @@ from galaxy.model.store.discover import (
     ModelPersistenceContext,
     persist_elements_to_folder,
     persist_elements_to_hdca,
+    persist_extra_files,
     persist_hdas,
     RegexCollectedDatasetMatch,
     SessionlessModelPersistenceContext,
@@ -420,19 +421,7 @@ def collect_primary_datasets(job_context, output, input_ext):
                 extra_files_path = new_primary_datasets_attributes.get('extra_files', None)
                 if extra_files_path:
                     extra_files_path_joined = os.path.join(job_working_directory, extra_files_path)
-                    primary_data.dataset.create_extra_files_path()
-                    for root, dirs, files in os.walk(extra_files_path_joined):
-                        extra_dir = os.path.join(primary_data.extra_files_path, root.replace(extra_files_path_joined, '', 1).lstrip(os.path.sep))
-                        extra_dir = os.path.normpath(extra_dir)
-                        for f in files:
-                            job_context.object_store.update_from_file(
-                                primary_data.dataset,
-                                extra_dir=extra_dir,
-                                alt_name=f,
-                                file_name=os.path.join(root, f),
-                                create=True,
-                                preserve_symlinks=True
-                            )
+                    persist_extra_files(job_context.object_store, extra_files_path_joined, primary_data)
             job_context.add_datasets_to_history([primary_data], for_output_dataset=outdata)
             # Add dataset to return dict
             primary_datasets[name][designation] = primary_data

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -186,6 +186,12 @@ class NavigatesGalaxy(HasDriver):
         else:
             return response.json()
 
+    def api_post(self, endpoint, data=None):
+        data = data or {}
+        full_url = self.build_url("api/" + endpoint, for_selenium=False)
+        response = requests.post(full_url, data=data, cookies=self.selenium_to_requests_cookies())
+        return response.json()
+
     def api_delete(self, endpoint, raw=False):
         full_url = self.build_url("api/" + endpoint, for_selenium=False)
         response = requests.delete(full_url, cookies=self.selenium_to_requests_cookies())
@@ -369,9 +375,16 @@ class NavigatesGalaxy(HasDriver):
     def get_logged_in_user(self):
         return self.api_get("users/current")
 
-    def get_api_key(self):
+    def get_api_key(self, force=False):
+        # If force is false, use the form inputs API and allow the key to be absent.
+        if not force:
+            return self.api_get("users/%s/api_key/inputs" % self.get_user_id())["inputs"][0]["value"]
+        else:
+            return self.api_post("users/%s/api_key" % self.get_user_id())
+
+    def get_user_id(self):
         user = self.get_logged_in_user()
-        return self.api_get("users/%s/api_key/inputs" % user["id"])["inputs"][0]["value"]
+        return user["id"]
 
     def is_logged_in(self):
         return "email" in self.get_logged_in_user()

--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -1,0 +1,198 @@
+"""Client for staging inputs for Galaxy Tools and Workflows.
+
+Implement as a connector to serve a bridge between galactic_job_json
+utility and a Galaxy API library.
+"""
+import abc
+import json
+import logging
+import os
+
+import six
+import yaml
+
+from galaxy.tool_util.cwl.util import (
+    DirectoryUploadTarget,
+    FileLiteralTarget,
+    FileUploadTarget,
+    galactic_job_json,
+    path_or_uri_to_uri,
+)
+
+log = logging.getLogger(__name__)
+
+UPLOAD_TOOL_ID = "upload1"
+LOAD_TOOLS_FROM_PATH = True
+
+
+@six.add_metaclass(abc.ABCMeta)
+class StagingInterace(object):
+    """Client that parses a job input and populates files into the Galaxy API.
+
+    Abstract class that must override _post (and optionally other things such
+    _attach_file, _log, etc..) to adapt to bioblend (for Planemo) or using the
+    tool test interactor infrastructure.
+    """
+
+    @abc.abstractmethod
+    def _post(self, api_path, payload, files_attached=False):
+        """Make a post to the Galaxy API along supplied path."""
+
+    def _attach_file(self, path):
+        return open(path, 'rb')
+
+    def _tools_post(self, payload, files_attached=False):
+        tool_response = self._post("tools", payload, files_attached=files_attached)
+        for job in tool_response.get("jobs", []):
+            self._handle_job(job)
+        return tool_response
+
+    def _handle_job(self, job_response):
+        """Implementer can decide if to wait for job(s) individually or not here."""
+
+    def stage(self, tool_or_workflow, history_id, job=None, job_path=None, use_path_paste=LOAD_TOOLS_FROM_PATH):
+        files_attached = [False]
+
+        def upload_func(upload_target):
+
+            def _attach_file(upload_payload, uri, index=0):
+                uri = path_or_uri_to_uri(uri)
+                is_path = uri.startswith("file://")
+                if not is_path or use_path_paste:
+                    upload_payload["inputs"]["files_%d|url_paste" % index] = uri
+                else:
+                    files_attached[0] = True
+                    path = uri[len("file://"):]
+                    upload_payload["__files"]["files_%d|file_data" % index] = self._attach_file(path)
+
+            if isinstance(upload_target, FileUploadTarget):
+                file_path = upload_target.path
+                upload_payload = _upload_payload(
+                    history_id,
+                    file_type=upload_target.properties.get('filetype', None) or "auto",
+                )
+                name = _file_path_to_name(file_path)
+                upload_payload["inputs"]["files_0|auto_decompress"] = False
+                upload_payload["inputs"]["auto_decompress"] = False
+                if file_path is not None:
+                    _attach_file(upload_payload, file_path)
+                upload_payload["inputs"]["files_0|NAME"] = name
+                if upload_target.secondary_files:
+                    _attach_file(upload_payload, upload_target.secondary_files, index=1)
+                    upload_payload["inputs"]["files_1|type"] = "upload_dataset"
+                    upload_payload["inputs"]["files_1|auto_decompress"] = True
+                    upload_payload["inputs"]["file_count"] = "2"
+                    upload_payload["inputs"]["force_composite"] = "True"
+                # galaxy.exceptions.RequestParameterInvalidException: Not input source type
+                # defined for input '{'class': 'File', 'filetype': 'imzml', 'composite_data':
+                # ['Example_Continuous.imzML', 'Example_Continuous.ibd']}'.\n"}]]
+
+                if upload_target.composite_data:
+                    for i, composite_data in enumerate(upload_target.composite_data):
+                        upload_payload["inputs"]["files_%s|type" % i] = "upload_dataset"
+                        _attach_file(upload_payload, composite_data, index=i)
+
+                self._log("upload_payload is %s" % upload_payload)
+                return self._tools_post(upload_payload, files_attached=files_attached[0])
+            elif isinstance(upload_target, FileLiteralTarget):
+                payload = _upload_payload(history_id, file_type="auto", auto_decompress=False)
+                payload["inputs"]["files_0|url_paste"] = upload_target.contents
+                return self._tools_post(payload)
+            elif isinstance(upload_target, DirectoryUploadTarget):
+                tar_path = upload_target.tar_path
+
+                upload_payload = _upload_payload(
+                    history_id,
+                    file_type="tar",
+                )
+                upload_payload["inputs"]["files_0|auto_decompress"] = False
+                _attach_file(upload_payload, tar_path)
+                tar_upload_response = self._tools_post(upload_payload, files_attached=files_attached[0])
+                convert_payload = dict(
+                    tool_id="CONVERTER_tar_to_directory",
+                    tool_inputs={"input1": {"src": "hda", "id": tar_upload_response["outputs"][0]["id"]}},
+                    history_id=history_id,
+                )
+                convert_response = self._tools_post(convert_payload)
+                assert "outputs" in convert_response, convert_response
+                return convert_response
+            else:
+                content = json.dumps(upload_target.object)
+                payload = _upload_payload(history_id, file_type="expression.json")
+                payload["files_0|url_paste"] = content
+                return self._tools_post(payload)
+
+        def create_collection_func(element_identifiers, collection_type):
+            payload = {
+                "name": "dataset collection",
+                "instance_type": "history",
+                "history_id": history_id,
+                "element_identifiers": element_identifiers,
+                "collection_type": collection_type,
+                "fields": None if collection_type != "record" else "auto",
+            }
+            return self._post("dataset_collections", payload)
+
+        if job_path is not None:
+            assert job is None
+            with open(job_path, "r") as f:
+                job = yaml.safe_load(f)
+            job_dir = os.path.dirname(job_path)
+        else:
+            assert job is not None
+            # Figure out what "." should be here instead.
+            job_dir = "."
+
+        job_dict, datasets = galactic_job_json(
+            job,
+            job_dir,
+            upload_func,
+            create_collection_func,
+            tool_or_workflow,
+        )
+        return job_dict, datasets
+
+    # extension point for planemo to override logging
+    def _log(self, message):
+        log.debug(message)
+
+
+class InteractorStaging(StagingInterace):
+
+    def __init__(self, galaxy_interactor):
+        self.galaxy_interactor = galaxy_interactor
+
+    def _post(self, api_path, payload, files_attached=False):
+        response = self.galaxy_interactor._post(api_path, payload, json=True)
+        assert response.status_code == 200, response.text
+        return response.json()
+
+    def _handle_job(self, job_response):
+        self.galaxy_interactor.wait_for_job(job_response["id"])
+
+def _file_path_to_name(file_path):
+    if file_path is not None:
+        name = os.path.basename(file_path)
+    else:
+        name = "defaultname"
+    return name
+
+
+def _upload_payload(history_id, tool_id=UPLOAD_TOOL_ID, file_type="auto", dbkey="?", **kwd):
+    """Adapted from bioblend tools client."""
+    payload = {}
+    payload["history_id"] = history_id
+    payload["tool_id"] = tool_id
+    tool_input = {}
+    tool_input["file_type"] = file_type
+    tool_input["dbkey"] = dbkey
+    if not kwd.get('to_posix_lines', True):
+        tool_input['files_0|to_posix_lines'] = False
+    elif kwd.get('space_to_tab', False):
+        tool_input['files_0|space_to_tab'] = 'Yes'
+    if 'file_name' in kwd:
+        tool_input["files_0|NAME"] = kwd['file_name']
+    tool_input["files_0|type"] = "upload_dataset"
+    payload["inputs"] = tool_input
+    payload["__files"] = {}
+    return payload

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -117,8 +117,8 @@ def galactic_job_json(
         upload_response = upload_func(target)
         return response_to_hda(target, upload_response)
 
-    def upload_file_literal(contents):
-        target = FileLiteralTarget(contents)
+    def upload_file_literal(contents, **kwd):
+        target = FileLiteralTarget(contents, **kwd)
         upload_response = upload_func(target)
         return response_to_hda(target, upload_response)
 
@@ -179,6 +179,9 @@ def galactic_job_json(
         # format to match output definitions in tool, where did filetype come from?
         filetype = value.get("filetype", None) or value.get("format", None)
         composite_data_raw = value.get("composite_data", None)
+        kwd = {}
+        if "tags" in value:
+            kwd["tags"] = value.get("tags")
         if composite_data_raw:
             composite_data = []
             for entry in composite_data_raw:
@@ -188,13 +191,13 @@ def galactic_job_json(
                 else:
                     path = entry
                 composite_data.append(path)
-            rval_c = upload_file_with_composite_data(None, composite_data, filetype=filetype)
+            rval_c = upload_file_with_composite_data(None, composite_data, filetype=filetype, **kwd)
             return rval_c
 
         if file_path is None:
             contents = value.get("contents", None)
             if contents is not None:
-                return upload_file_literal(contents)
+                return upload_file_literal(contents, **kwd)
 
             return value
 
@@ -221,7 +224,7 @@ def galactic_job_json(
             tf.close()
             secondary_files_tar_path = tmp.name
 
-        return upload_file(file_path, secondary_files_tar_path, filetype=filetype)
+        return upload_file(file_path, secondary_files_tar_path, filetype=filetype, **kwd)
 
     def replacement_directory(value):
         file_path = value.get("location", None) or value.get("path", None)
@@ -332,6 +335,7 @@ class FileLiteralTarget(object):
 
     def __init__(self, contents, **kwargs):
         self.contents = contents
+        self.properties = kwargs
 
     def __str__(self):
         return "FileLiteralTarget[path=%s] with %s" % (self.path, self.properties)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -623,6 +623,13 @@ class GalaxyInteractorApi(object):
         params, data = self.__inject_api_key(data=data, key=key, admin=admin, anon=anon)
         # no params for POST
         data.update(params)
+
+        # handle encoded files
+        if files is None:
+            files = data.get("__files", None)
+            if files is not None:
+                del data["__files"]
+
         return requests.post("%s/%s" % (self.api_url, path), data=data, files=files)
 
     def _delete(self, path, data=None, key=None, admin=False, anon=False):

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -1,0 +1,28 @@
+"""Abstraction for waiting on API conditions to become true."""
+
+import time
+
+
+def wait_on(function, desc, timeout):
+    """Wait for function to return non-None value."""
+    delta = .25
+    iteration = 0
+    while True:
+        total_wait = delta * iteration
+        if total_wait > timeout:
+            timeout_message = "Timed out after %s seconds waiting on %s." % (
+                total_wait, desc
+            )
+            raise TimeoutAssertionError(timeout_message)
+        iteration += 1
+        value = function()
+        if value is not None:
+            return value
+        time.sleep(delta)
+
+
+class TimeoutAssertionError(AssertionError):
+    """Derivative of AssertionError indicating wait_on exceeded max time."""
+
+    def __init__(self, message):
+        super(TimeoutAssertionError, self).__init__(message)

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -242,20 +242,18 @@ def _fetch_target(upload_config, target):
             os.mkdir(extra_files_path)
 
             def walk_extra_files(items, prefix=""):
-                print(items)
                 for item in items:
-                    print(item)
                     if "elements" in item:
                         name = item.get("name")
                         if not prefix:
                             item_prefix = name
                         else:
-                            item_prefix = prefix + "/" + name
+                            item_prefix = os.path.join(prefix, name)
                         walk_extra_files(item.get("elements"), prefix=item_prefix)
                     else:
                         name, src_path = _has_src_to_path(upload_config, item)
                         if prefix:
-                            rel_path = prefix + "/" + name
+                            rel_path = os.path.join(prefix, name)
                         else:
                             rel_path = name
 

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -291,10 +291,15 @@ def _bagit_to_items(directory):
 
 def _decompress_target(upload_config, target):
     elements_from_name, elements_from_path = _has_src_to_path(upload_config, target, is_dataset=False)
+    # by default Galaxy will check for a directory with a single file and interpret that
+    # as the new root for expansion, this is a good user experience for uploading single
+    # files in a archive but not great from an API perspective. Allow disabling by setting
+    # fuzzy_root to False to literally interpret the target.
+    fuzzy_root = target.get("fuzzy_root", True)
     temp_directory = os.path.abspath(tempfile.mkdtemp(prefix=elements_from_name, dir="."))
     cf = CompressedFile(elements_from_path)
-    cf.extract(temp_directory)
-    return temp_directory
+    result = cf.extract(temp_directory)
+    return result if fuzzy_root else temp_directory
 
 
 def elements_tree_map(f, items):

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -410,6 +410,8 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         """Adapt clean API to tool-constrained API.
         """
         request_version = '1'
+        if "history_id" not in payload:
+            raise exceptions.RequestParameterMissingException("history_id must be specified")
         history_id = payload.pop("history_id")
         clean_payload = {}
         files_payload = {}

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -14,8 +14,8 @@ from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
-    load_data_dict,
     skip_without_tool,
+    stage_rules_test_data,
     uses_test_history,
 )
 from ._framework import ApiTestCase
@@ -612,7 +612,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
     def _apply_rules_and_check(self, example):
         with self.dataset_populator.test_history() as history_id:
-            inputs, _, _ = load_data_dict(history_id, {"input": example["test_data"]}, self.dataset_populator, self.dataset_collection_populator)
+            inputs = stage_rules_test_data(self.galaxy_interactor, history_id, example)
             hdca = inputs["input"]
             inputs = {
                 "input": {"src": "hdca", "id": hdca["id"]},

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -15,7 +15,7 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     LibraryPopulator,
     skip_without_tool,
-    stage_rules_test_data,
+    stage_rules_example,
     uses_test_history,
 )
 from ._framework import ApiTestCase
@@ -615,7 +615,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
     def _apply_rules_and_check(self, example):
         with self.dataset_populator.test_history() as history_id:
-            inputs = stage_rules_test_data(self.galaxy_interactor, history_id, example)
+            inputs = stage_rules_example(self.galaxy_interactor, history_id, example)
             hdca = inputs["input"]
             inputs = {
                 "input": {"src": "hdca", "id": hdca["id"]},

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -382,6 +382,9 @@ class ToolsTestCase(ApiTestCase, TestsTools):
                     "extra_files": {
                         "items_from": "archive",
                         "src": "files",
+                        # Prevent Galaxy from checking for a single file in
+                        # a directory and re-interpreting the archive
+                        "fuzzy_root": False,
                     }
                 }],
             }]

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -10,6 +10,7 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     skip_if_site_down,
     skip_without_datatype,
+    stage_inputs,
     uses_test_history,
 )
 from ._framework import ApiTestCase
@@ -209,6 +210,24 @@ class ToolsUploadTestCase(ApiTestCase):
             assert roadmaps_content.strip() == "roadmaps content", roadmaps_content
 
     @skip_without_datatype("velvet")
+    @uses_test_history(require_new=False)
+    def test_composite_datatype_stage(self, history_id):
+        job = {
+            "input1": {
+                "class": "File",
+                "format": "velvet",
+                "composite_data": [
+                    "test-data/simple_line.txt",
+                    "test-data/simple_line_alternative.txt",
+                    "test-data/simple_line_x2.txt",
+                ]
+            }
+        }
+        print(history_id)
+        inputs, datsets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
+
+    @skip_without_datatype("velvet")
+    @uses_test_history(require_new=False)
     def test_composite_datatype_space_to_tab(self):
         # Like previous test but set one upload with space_to_tab to True to
         # verify that works.

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -242,7 +242,7 @@ class ToolsUploadTestCase(ApiTestCase):
 
     @skip_without_datatype("velvet")
     @uses_test_history(require_new=False)
-    def test_composite_datatype_stage(self, history_id):
+    def test_composite_datatype_stage_fetch(self, history_id):
         job = {
             "input1": {
                 "class": "File",
@@ -257,6 +257,23 @@ class ToolsUploadTestCase(ApiTestCase):
         inputs, datsets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
 
     @skip_without_datatype("velvet")
+    @uses_test_history(require_new=False)
+    def test_composite_datatype_stage_upload1(self, history_id):
+        job = {
+            "input1": {
+                "class": "File",
+                "format": "velvet",
+                "composite_data": [
+                    "test-data/simple_line.txt",
+                    "test-data/simple_line_alternative.txt",
+                    "test-data/simple_line_x2.txt",
+                ]
+            }
+        }
+        inputs, datsets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False, use_fetch_api=False)
+
+    @skip_without_datatype("velvet")
+    @uses_test_history(require_new=False)
     def test_composite_datatype_space_to_tab(self):
         # Like previous test but set one upload with space_to_tab to True to
         # verify that works.

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -211,6 +211,37 @@ class ToolsUploadTestCase(ApiTestCase):
 
     @skip_without_datatype("velvet")
     @uses_test_history(require_new=False)
+    def test_composite_datatype_fetch(self, history_id):
+        destination = {"type": "hdas"}
+        targets = [{
+            "destination": destination,
+            "items": [{
+                "src": "composite",
+                "ext": "velvet",
+                "composite": {
+                    "items": [
+                        {"src": "pasted", "paste_content": "sequences content"},
+                        {"src": "pasted", "paste_content": "roadmaps content"},
+                        {"src": "pasted", "paste_content": "log content"},
+                    ]
+                },
+            }],
+        }]
+        payload = {
+            "history_id": history_id,
+            "targets": json.dumps(targets),
+        }
+        fetch_response = self.dataset_populator.fetch(payload)
+        self._assert_status_code_is(fetch_response, 200)
+        outputs = fetch_response.json()["outputs"]
+        assert len(outputs) == 1
+        output = outputs[0]
+
+        roadmaps_content = self._get_roadmaps_content(history_id, output)
+        assert roadmaps_content.strip() == "roadmaps content", roadmaps_content
+
+    @skip_without_datatype("velvet")
+    @uses_test_history(require_new=False)
     def test_composite_datatype_stage(self, history_id):
         job = {
             "input1": {
@@ -223,11 +254,9 @@ class ToolsUploadTestCase(ApiTestCase):
                 ]
             }
         }
-        print(history_id)
         inputs, datsets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False)
 
     @skip_without_datatype("velvet")
-    @uses_test_history(require_new=False)
     def test_composite_datatype_space_to_tab(self):
         # Like previous test but set one upload with space_to_tab to True to
         # verify that works.

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -274,20 +274,19 @@ class ToolsUploadTestCase(ApiTestCase):
 
     @skip_without_datatype("velvet")
     @uses_test_history(require_new=False)
-    def test_composite_datatype_space_to_tab(self):
+    def test_composite_datatype_space_to_tab(self, history_id):
         # Like previous test but set one upload with space_to_tab to True to
         # verify that works.
-        with self.dataset_populator.test_history() as history_id:
-            dataset = self._velvet_upload(history_id, extra_inputs={
-                "files_1|url_paste": "roadmaps content",
-                "files_1|type": "upload_dataset",
-                "files_1|space_to_tab": "Yes",
-                "files_2|url_paste": "log content",
-                "files_2|type": "upload_dataset",
-            })
+        dataset = self._velvet_upload(history_id, extra_inputs={
+            "files_1|url_paste": "roadmaps content",
+            "files_1|type": "upload_dataset",
+            "files_1|space_to_tab": "Yes",
+            "files_2|url_paste": "log content",
+            "files_2|type": "upload_dataset",
+        })
 
-            roadmaps_content = self._get_roadmaps_content(history_id, dataset)
-            assert roadmaps_content.strip() == "roadmaps\tcontent", roadmaps_content
+        roadmaps_content = self._get_roadmaps_content(history_id, dataset)
+        assert roadmaps_content.strip() == "roadmaps\tcontent", roadmaps_content
 
     @skip_without_datatype("velvet")
     def test_composite_datatype_posix_lines(self):

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -44,7 +44,10 @@ class UsesApiTestCaseMixin(object):
     def _setup_interactor(self):
         self.user_api_key = get_user_api_key()
         self.master_api_key = get_master_api_key()
-        self.galaxy_interactor = ApiTestInteractor(self)
+        self.galaxy_interactor = self._get_interactor()
+
+    def _get_interactor(self, api_key=None):
+        return ApiTestInteractor(self, api_key=api_key)
 
     def _setup_user(self, email, password=None, is_admin=True):
         self.galaxy_interactor.ensure_user_with_email(email, password=password)
@@ -115,10 +118,10 @@ class ApiTestInteractor(BaseInteractor):
     tool functional tests) for testing the API generally.
     """
 
-    def __init__(self, test_case):
+    def __init__(self, test_case, api_key=None):
         admin = getattr(test_case, "require_admin_user", False)
         test_user = TEST_USER if not admin else ADMIN_TEST_USER
-        super(ApiTestInteractor, self).__init__(test_case, test_user=test_user)
+        super(ApiTestInteractor, self).__init__(test_case, test_user=test_user, api_key=api_key)
 
     # This variant the lower level get and post methods are meant to be used
     # directly to test API - instead of relying on higher-level constructs for

--- a/lib/galaxy_test/base/interactor.py
+++ b/lib/galaxy_test/base/interactor.py
@@ -3,12 +3,12 @@ from galaxy.tool_util.verify.interactor import GalaxyInteractorApi
 
 class TestCaseGalaxyInteractor(GalaxyInteractorApi):
 
-    def __init__(self, functional_test_case, test_user=None):
+    def __init__(self, functional_test_case, test_user=None, api_key=None):
         self.functional_test_case = functional_test_case
         super(TestCaseGalaxyInteractor, self).__init__(
             galaxy_url=functional_test_case.url,
-            master_api_key=functional_test_case.master_api_key,
-            api_key=functional_test_case.user_api_key,
+            master_api_key=getattr(functional_test_case, "master_api_key", None),
+            api_key=api_key or getattr(functional_test_case, "user_api_key", None),
             test_user=test_user,
             keep_outputs_dir=getattr(functional_test_case, "keepOutdir", None),
         )

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -3,7 +3,6 @@ import json
 import os
 import random
 import string
-import time
 import unittest
 from collections import namedtuple
 from functools import wraps
@@ -25,6 +24,10 @@ from pkg_resources import resource_string
 from six import StringIO
 
 from galaxy.tool_util.verify.test_data import TestDataResolver
+from galaxy.tool_util.verify.wait import (
+    TimeoutAssertionError,
+    wait_on as tool_util_wait_on,
+)
 from galaxy.util import unicodify
 from . import api_asserts
 
@@ -1560,23 +1563,4 @@ class GiWorkflowPopulator(BaseWorkflowPopulator, GiPostGetMixin):
 
 
 def wait_on(function, desc, timeout=DEFAULT_TIMEOUT):
-    delta = .25
-    iteration = 0
-    while True:
-        total_wait = delta * iteration
-        if total_wait > timeout:
-            timeout_message = "Timed out after %s seconds waiting on %s." % (
-                total_wait, desc
-            )
-            raise TimeoutAssertionError(timeout_message)
-        iteration += 1
-        value = function()
-        if value is not None:
-            return value
-        time.sleep(delta)
-
-
-class TimeoutAssertionError(AssertionError):
-
-    def __init__(self, message):
-        super(TimeoutAssertionError, self).__init__(message)
+    return tool_util_wait_on(function, desc, timeout)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -693,20 +693,9 @@ class DatasetPopulator(BaseDatasetPopulator):
         return self.galaxy_interactor.api_key
 
     def _post(self, route, data=None, files=None, admin=False):
-        if data is None:
-            data = {}
-
-        if files is None:
-            files = data.get("__files", None)
-            if files is not None:
-                del data["__files"]
-
         return self.galaxy_interactor.post(route, data, files=files, admin=admin)
 
     def _put(self, route, data=None):
-        if data is None:
-            data = {}
-
         return self.galaxy_interactor.put(route, data)
 
     def _get(self, route, data=None, admin=False):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1455,9 +1455,11 @@ def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_
     return inputs, label_map, has_uploads
 
 
-def stage_inputs(galaxy_interactor, history_id, job, use_path_paste=True):
+def stage_inputs(galaxy_interactor, history_id, job, use_path_paste=True, use_fetch_api=True):
     """Alternative to load_data_dict that uses production-style workflow inputs."""
-    inputs, datasets = InteractorStaging(galaxy_interactor).stage("workflow", history_id=history_id, job=job, use_path_paste=use_path_paste)
+    inputs, datasets = InteractorStaging(galaxy_interactor, use_fetch_api=use_fetch_api).stage(
+        "workflow", history_id=history_id, job=job, use_path_paste=use_path_paste,
+    )
     return inputs, datasets
 
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1376,6 +1376,7 @@ class DatasetCollectionPopulator(BaseDatasetCollectionPopulator):
 
 
 def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_populator):
+    """Load a dictionary as inputs to a workflow (test data focused)."""
 
     def open_test_data(test_dict, mode="rb"):
         test_data_resolver = TestDataResolver()
@@ -1458,6 +1459,15 @@ def stage_inputs(galaxy_interactor, history_id, job, use_path_paste=True):
     """Alternative to load_data_dict that uses production-style workflow inputs."""
     inputs, datasets = InteractorStaging(galaxy_interactor).stage("workflow", history_id=history_id, job=job, use_path_paste=use_path_paste)
     return inputs, datasets
+
+
+def stage_rules_test_data(galaxy_interactor, history_id, example):
+    """Wrapper around stage_inputs for staging collections defined by rules spec DSL."""
+    input_dict = example["test_data"].copy()
+    input_dict["collection_type"] = input_dict.pop("type")
+    input_dict["class"] = "Collection"
+    inputs, _ = stage_inputs(galaxy_interactor, history_id=history_id, job={"input": input_dict})
+    return inputs
 
 
 def wait_on_state(state_func, desc="state", skip_states=None, assert_ok=False, timeout=DEFAULT_TIMEOUT):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1463,7 +1463,7 @@ def stage_inputs(galaxy_interactor, history_id, job, use_path_paste=True, use_fe
     return inputs, datasets
 
 
-def stage_rules_test_data(galaxy_interactor, history_id, example):
+def stage_rules_example(galaxy_interactor, history_id, example):
     """Wrapper around stage_inputs for staging collections defined by rules spec DSL."""
     input_dict = example["test_data"].copy()
     input_dict["collection_type"] = input_dict.pop("type")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -23,6 +23,7 @@ from gxformat2._yaml import ordered_load
 from pkg_resources import resource_string
 from six import StringIO
 
+from galaxy.tool_util.client.staging import InteractorStaging
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.tool_util.verify.wait import (
     TimeoutAssertionError,
@@ -1451,6 +1452,12 @@ def load_data_dict(history_id, test_data, dataset_populator, dataset_collection_
             raise ValueError("Invalid test_data def %s" % test_data)
 
     return inputs, label_map, has_uploads
+
+
+def stage_inputs(galaxy_interactor, history_id, job, use_path_paste=True):
+    """Alternative to load_data_dict that uses production-style workflow inputs."""
+    inputs, datasets = InteractorStaging(galaxy_interactor).stage("workflow", history_id=history_id, job=job, use_path_paste=use_path_paste)
+    return inputs, datasets
 
 
 def wait_on_state(state_func, desc="state", skip_states=None, assert_ok=False, timeout=DEFAULT_TIMEOUT):

--- a/lib/galaxy_test/base/rules_test_data.py
+++ b/lib/galaxy_test/base/rules_test_data.py
@@ -67,11 +67,13 @@ EXAMPLE_1 = {
         "elements": [
             {
                 "identifier": "i1",
-                "content": "0"
+                "contents": "0",
+                "class": "File",
             },
             {
                 "identifier": "i2",
-                "content": "1"
+                "contents": "1",
+                "class": "File",
             },
         ]
     },
@@ -104,11 +106,13 @@ EXAMPLE_2 = {
         "elements": [
             {
                 "identifier": "i1",
-                "content": "0"
+                "contents": "0",
+                "class": "File",
             },
             {
                 "identifier": "i2",
-                "content": "1"
+                "contents": "1",
+                "class": "File",
             },
         ]
     },
@@ -143,6 +147,23 @@ EXAMPLE_3 = {
     },
     "test_data": {
         "type": "list:paired",
+        "elements": [
+            {
+                "identifier": "test0",
+                "elements": [
+                    {
+                        "identifier": "forward",
+                        "class": "File",
+                        "contents": "TestData123"
+                    },
+                    {
+                        "identifier": "reverse",
+                        "class": "File",
+                        "contents": "TestData123"
+                    },
+                ]
+            }
+        ]
     },
     "check": check_example_3,
     "output_hid": 6,
@@ -174,17 +195,20 @@ EXAMPLE_4 = {
         "elements": [
             {
                 "identifier": "i1",
-                "content": "0",
+                "contents": "0",
+                "class": "File",
                 "tags": ["random", "group:type:single"]
             },
             {
                 "identifier": "i2",
-                "content": "1",
+                "contents": "1",
+                "class": "File",
                 "tags": ["random", "group:type:paired"]
             },
             {
                 "identifier": "i3",
-                "content": "2",
+                "contents": "2",
+                "class": "File",
                 "tags": ["random", "group:type:paired"]
             },
         ]

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -263,6 +263,11 @@ class TestWithSeleniumMixin(NavigatesGalaxy, UsesApiTestCaseMixin):
 
         self.driver.save_screenshot(target)
 
+    def api_interactor_for_logged_in_user(self):
+        api_key = self.get_api_key(force=True)
+        interactor = self._get_interactor(api_key=api_key)
+        return interactor
+
     def write_screenshot_directory_file(self, label, content):
         target = self._screenshot_path(label, ".txt")
         if target is None:

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -2,7 +2,11 @@ import json
 
 from galaxy.selenium.navigates_galaxy import retry_call_during_transitions
 from galaxy_test.base import rules_test_data
-from galaxy_test.base.populators import flakey, load_data_dict, skip_if_github_down
+from galaxy_test.base.populators import (
+    flakey,
+    skip_if_github_down,
+    stage_rules_test_data,
+)
 from .framework import (
     managed_history,
     retry_assertion_during_transitions,
@@ -344,7 +348,7 @@ https://raw.githubusercontent.com/jmchilton/galaxy/apply_rules_tutorials/test-da
 
         self.home()
         history_id = self.current_history_id()
-        inputs, _, _ = load_data_dict(history_id, {"input": example["test_data"]}, self.dataset_populator, self.dataset_collection_populator)
+        stage_rules_test_data(self.galaxy_interactor, history_id, example)
         self.dataset_populator.wait_for_history(history_id)
         self.home()
         self._tool_open_apply_rules()

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -5,7 +5,7 @@ from galaxy_test.base import rules_test_data
 from galaxy_test.base.populators import (
     flakey,
     skip_if_github_down,
-    stage_rules_test_data,
+    stage_rules_example,
 )
 from .framework import (
     managed_history,
@@ -348,7 +348,7 @@ https://raw.githubusercontent.com/jmchilton/galaxy/apply_rules_tutorials/test-da
 
         self.home()
         history_id = self.current_history_id()
-        stage_rules_test_data(self.api_interactor_for_logged_in_user(), history_id, example)
+        stage_rules_example(self.api_interactor_for_logged_in_user(), history_id, example)
         self.dataset_populator.wait_for_history(history_id)
         self.home()
         self._tool_open_apply_rules()

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -348,7 +348,7 @@ https://raw.githubusercontent.com/jmchilton/galaxy/apply_rules_tutorials/test-da
 
         self.home()
         history_id = self.current_history_id()
-        stage_rules_test_data(self.galaxy_interactor, history_id, example)
+        stage_rules_test_data(self.api_interactor_for_logged_in_user(), history_id, example)
         self.dataset_populator.wait_for_history(history_id)
         self.home()
         self._tool_open_apply_rules()

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -204,27 +204,25 @@ def add_composite_file(dataset, registry, output_path, files_path):
 
         auto_decompress = composite_file_path.get('auto_decompress', True)
         if auto_decompress and not datatype.composite_type and CompressedFile.can_decompress(dp):
-            # It isn't an explictly composite datatype, so these are just extra files to attach
+            # It isn't an explicitly composite datatype, so these are just extra files to attach
             # as composite data. It'd be better if Galaxy was communicating this to the tool
             # a little more explicitly so we didn't need to dispatch on the datatype and so we
             # could attach arbitrary extra composite data to an existing composite datatype if
             # if need be? Perhaps that would be a mistake though.
             CompressedFile(dp).extract(files_path)
         else:
-            if not is_binary:
-                tmpdir = output_adjacent_tmpdir(output_path)
-                tmp_prefix = 'data_id_%s_convert_' % dataset.dataset_id
-                if composite_file_path.get('space_to_tab'):
-                    sniff.convert_newlines_sep2tabs(dp, tmp_dir=tmpdir, tmp_prefix=tmp_prefix)
-                else:
-                    sniff.convert_newlines(dp, tmp_dir=tmpdir, tmp_prefix=tmp_prefix)
-
-            file_output_path = os.path.join(files_path, name)
-            shutil.move(dp, file_output_path)
-
-            # groom the dataset file content if required by the corresponding datatype definition
-            if datatype.dataset_content_needs_grooming(file_output_path):
-                datatype.groom_dataset_content(file_output_path)
+            tmpdir = output_adjacent_tmpdir(output_path)
+            tmp_prefix = 'data_id_%s_convert_' % dataset.dataset_id
+            sniff.handle_composite_file(
+                datatype,
+                dp,
+                files_path,
+                name,
+                is_binary,
+                tmpdir,
+                tmp_prefix,
+                composite_file_path,
+            )
 
     # Do we have pre-defined composite files from the datatype definition.
     if dataset.composite_files:
@@ -282,7 +280,7 @@ def __write_job_metadata(metadata):
 def output_adjacent_tmpdir(output_path):
     """ For temp files that will ultimately be moved to output_path anyway
     just create the file directly in output_path's directory so shutil.move
-    will work optimially.
+    will work optimally.
     """
     return os.path.dirname(output_path)
 


### PR DESCRIPTION
This PR is doing a few interconnected things simultaneously - at a high level it is adding "composite file"/"extra files" functionality to the newer data fetch (or upload 2.0) API and it is enabling nested collection inputs and tags in workflow tests (continuing thread from https://github.com/galaxyproject/galaxy/pull/9803). Doing the former turned out to be needed to do the latter well.

# Extra Files API

This PR adds the ability to upload composite datatype files as well as free form directories of extra files to uploads done through the data fetch or upload 2.0 API. Both of these options have been in upload1 for a while. The API is much more natural to express composite and extra files in - and works much more naturally with collections and tags so it made a lot of sense to accomplish the second big task by implementing this first.

# Workflow Tests - Nested Collections and Tags 

There is this function in ``galaxy.tool_util.cwl.util`` called ``galactic_job_json`` that parses a CWL-style "job" (the inputs for a tool or a workflow execution as a JSON object) and parses it into a representation for Galaxy - uploading inputs to Galaxy as needed. The interaction with the API was originally abstracted out as two functions so that the Galaxy test code (in the CWL branch) and the Planemo driver code could interact with the API in different ways. Planemo used bioblend (loosely) and the Galaxy code used the test framework's "populators" abstractions.

This PR creates a new layer above `galactic_job_json` that has some extension points that the Planemo/bioblend layer can take advantage of but by default will just use the galaxy_interactor stuff already being used by tool tests using galaxy-tool-util. So this new layer doesn't depend on test "populators" or bioblend and should allow important code to be shared between the Galaxy test framework, the CWL branch of Galaxy, and Planemo. Having to update the code in both places was a significant problem with the CWL branch.

Here is a commit demonstrating how it simplifies the CWL branch (jmchilton/galaxy@d9e774f). I don't have a matching commit for Planemo yet but the code is located here https://github.com/galaxyproject/planemo/blob/master/planemo/galaxy/activity.py#L181 that will be simplified after this commit is utilized.

Another positive upshot of this commit is there is now some in core test coverage of galactic_job_json - an important library function.

There are some other smaller commits here to setup some stuff in galaxy-tool-util to be shared between Galaxy testing populators and Planemo and refactoring of test case stuff to get testing done well.