### PR TITLE
Encrypt extra user preferences

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -1,6 +1,7 @@
 """
 Manager and Serializer for Users.
 """
+import json
 import logging
 import random
 import socket
@@ -315,7 +316,9 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     # ---- preferences
     def preferences(self, user):
-        return dict((key, value) for key, value in user.preferences.items())
+        return dict((key, value) if key != 'extra_user_preferences' else
+                    (key, json.dumps(user.get_extra_preferences(self.app.security)))
+                    for key, value in user.preferences.items())
 
     # ---- roles and permissions
     def private_role(self, user):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -372,16 +372,25 @@ class User(Dictifiable, RepresentById):
         self.credentials = []
         # ? self.roles = []
 
-    @property
-    def extra_preferences(self):
+    def get_extra_preferences(self, security):
         data = {}
         extra_user_preferences = self.preferences.get('extra_user_preferences')
         if extra_user_preferences:
             try:
-                data = json.loads(extra_user_preferences)
+                decoded_user_prefs = security.decode_str(
+                    extra_user_preferences, kind="prefs")
+                data = json.loads(decoded_user_prefs)
             except Exception:
-                pass
+                try:
+                    # backward compatibility with unencrypted preferences
+                    data = json.loads(extra_user_preferences)
+                except Exception:
+                    pass
         return data
+
+    def set_extra_preferences(self, security, value):
+        self.preferences["extra_user_preferences"] = security.encode_str(
+            json.dumps(value), kind="prefs")
 
     def set_password_cleartext(self, cleartext):
         """

--- a/test/unit/test_id_encode_decode.py
+++ b/test/unit/test_id_encode_decode.py
@@ -131,3 +131,10 @@ def test_encode_decode_guid():
     encoded_key = test_helper_1.encode_guid(session_key)
     decoded_key = test_helper_1.decode_guid(encoded_key)
     assert session_key == decoded_key, "%s != %s" % (session_key, decoded_key)
+
+
+def test_encode_decode_str():
+    assert test_helper_1.encode_id("hello") != "hello"
+    assert test_helper_1.encode_id("hello") != test_helper_1.encode_id("world")
+    # But decoding an encoded string brings back to original string
+    assert "hello" == test_helper_1.decode_id(test_helper_1.encode_id("hello"))


### PR DESCRIPTION
This PR encrypts extra user preferences, allowing extra data such as ~passwords~API keys to be stored in user preferences.

While not all preferences need to be encrypted, with this PR, extra_user_preferences can be used to store sensitive information, such as the owncloud username/API key example shown below.
![image](https://user-images.githubusercontent.com/2070605/84579082-a1652600-ade8-11ea-97fb-2782ae4871a6.png)
