### PR TITLE
Adding user id to key so savedRules are specific for users

### DIFF
--- a/client/src/components/RuleBuilder/SavedRulesSelector.test.js
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.test.js
@@ -30,7 +30,7 @@ describe("SavedRulesSelector", () => {
     });
 
     it("should emit a click event when a session is clicked", async () => {
-        wrapper.setProps({user: "test_user"})
+        wrapper.setProps({ user: "test_user" });
         const testRules = {
             rules: [
                 {

--- a/client/src/components/RuleBuilder/SavedRulesSelector.test.js
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.test.js
@@ -12,7 +12,6 @@ describe("SavedRulesSelector", () => {
             propsData: {
                 // Add a unique prefix for this test run so the test is not affected by local storage values
                 prefix: "test_prefix_" + new Date().toISOString() + "_",
-                user: "test_user",
             },
             attachTo: getNewAttachNode(),
         });
@@ -31,6 +30,7 @@ describe("SavedRulesSelector", () => {
     });
 
     it("should emit a click event when a session is clicked", async () => {
+        wrapper.setProps({user: "test_user"})
         const testRules = {
             rules: [
                 {

--- a/client/src/components/RuleBuilder/SavedRulesSelector.test.js
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.test.js
@@ -12,6 +12,7 @@ describe("SavedRulesSelector", () => {
             propsData: {
                 // Add a unique prefix for this test run so the test is not affected by local storage values
                 prefix: "test_prefix_" + new Date().toISOString() + "_",
+                user: "test_user",
             },
             attachTo: getNewAttachNode(),
         });

--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -25,6 +25,8 @@ import Vue from "vue";
 import _l from "utils/localization";
 import BootstrapVue from "bootstrap-vue";
 import moment from "moment";
+import { getGalaxyInstance } from "app";
+
 Vue.use(BootstrapVue);
 export default {
     data: function () {
@@ -35,19 +37,23 @@ export default {
     },
     created() {
         let counter = 0;
-        for (let i = 0; i < localStorage.length; i++) {
-            if (localStorage.key(i).startsWith(this.prefix)) {
-                var savedSession = localStorage.getItem(localStorage.key(i));
-                if (savedSession) {
-                    var key = localStorage.key(i);
-                    this.savedRules.push({
-                        dateTime: key.substring(this.prefix.length),
-                        rule: savedSession,
-                    });
-                }
-                counter++;
-                if (counter == 10) {
-                    break;
+        if (this.user == null) {
+            return;
+        } else {
+            for (let i = 0; i < localStorage.length; i++) {
+                if (localStorage.key(i).startsWith(this.prefix + this.user)) {
+                    var savedSession = localStorage.getItem(localStorage.key(i));
+                    if (savedSession) {
+                        var key = localStorage.key(i);
+                        this.savedRules.push({
+                            dateTime: key.substring(this.prefix.length + this.user.length),
+                            rule: savedSession,
+                        });
+                    }
+                    counter++;
+                    if (counter == 10) {
+                        break;
+                    }
                 }
             }
         }
@@ -56,6 +62,10 @@ export default {
         prefix: {
             type: String,
             default: "galaxy_rules_",
+        },
+        user: {
+            type: String,
+            default: getGalaxyInstance().user.id,
         },
     },
     computed: {
@@ -69,7 +79,7 @@ export default {
         },
         saveSession(jsonRulesString) {
             var dateTimeString = new Date().toISOString();
-            var key = this.prefix + dateTimeString;
+            var key = this.prefix + this.user + dateTimeString;
             localStorage.setItem(key, jsonRulesString);
             this.savedRules.push({
                 dateTime: dateTimeString,

--- a/client/src/components/RuleBuilder/SavedRulesSelector.vue
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.vue
@@ -65,7 +65,7 @@ export default {
         },
         user: {
             type: String,
-            default: getGalaxyInstance().user.id,
+            default: getGalaxyInstance() ? getGalaxyInstance().user.id : "",
         },
     },
     computed: {


### PR DESCRIPTION
Why: So that Saved Rules are specific to a user
What:  Added User ID to the key saved in Local Storage
How: Create a rule as one user, and save it; then try to access it as another user or as someone who is not logged in.