### PR TITLE
[20.01] Input dataset module format filtering fix; 

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -661,7 +661,7 @@ class InputModule(WorkflowModule):
         if "format" in state:
             formats = state["format"]
             if formats:
-                formats = ",".join(formats)
+                formats = ",".join(listify(formats))
                 state["format"] = formats
         state = json.dumps(state)
         return state


### PR DESCRIPTION
This would previously turn `fasta` into `f,,,,a,,,,s,,,...` and so on when you actually tried to run a workflow using this functionality. It was possible to increasingly proliferate commas on runs to the point where it crashed a webserver.

From 281961976a0

