### PR TITLE
[20.05] Custos spec fixes

### DIFF
--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -49,13 +49,13 @@
                                         v-if="Object.prototype.hasOwnProperty.call(oidc_idps, 'custos')"
                                         @click="submitCILogon('custos')"
                                         :disabled="selected === null"
-                                        >Sign in with Custos*</b-button
+                                        >Sign in with Custos *</b-button
                                     >
 
                                     <p class="mt-3">
                                         <small class="text-muted">
-                                            *Galaxy uses CILogon to enable you to Log In from this organization. By
-                                            clicking 'Sign In', you agree to the
+                                            * Galaxy uses CILogon via Custos to enable you to Log In from this
+                                            organization. By clicking 'Sign In', you agree to the
                                             <a href="https://ca.cilogon.org/policy/privacy">CILogon privacy policy</a>
                                             and you agree to share your username, email address, and affiliation with
                                             CILogon and Galaxy. You also agree for CILogon to issue a certificate that

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -30,11 +30,6 @@ class CustosAuthnz(IdentityProvider):
         self.config['url'] = oidc_backend_config['url']
         self.config['client_id'] = oidc_backend_config['client_id']
         self.config['client_secret'] = oidc_backend_config['client_secret']
-        if oidc_backend_config.get('credential_url'):
-            # Keycloak client secret used to get token for custos
-            self.config['credential_url'] = oidc_backend_config['credential_url']
-            if provider == 'custos':
-                self._get_custos_credentials()
         self.config['redirect_uri'] = oidc_backend_config['redirect_uri']
         self.config['ca_bundle'] = oidc_backend_config.get('ca_bundle', None)
         self.config['extra_params'] = {
@@ -220,6 +215,8 @@ class CustosAuthnz(IdentityProvider):
 
     def _load_config_for_custos(self):
         self.config['well_known_oidc_config_uri'] = self._get_well_known_uri_from_url(self.config['provider'])
+        self.config['credential_url'] = '/'.join([self.config['url'].rstrip('/'), 'credentials'])
+        self._get_custos_credentials()
         # Set custos endpoints
         clientIdAndSec = self.config['client_id'] + ":" + self.config['client_secret']
         eps = requests.get(self.config['well_known_oidc_config_uri'],

--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -222,7 +222,7 @@ class CustosAuthnz(IdentityProvider):
         self.config['well_known_oidc_config_uri'] = self._get_well_known_uri_from_url(self.config['provider'])
         # Set custos endpoints
         clientIdAndSec = self.config['client_id'] + ":" + self.config['client_secret']
-        eps = requests.get(self.config['url'],
+        eps = requests.get(self.config['well_known_oidc_config_uri'],
                            headers={"Authorization": "Basic %s" % util.unicodify(base64.b64encode(util.smart_str(clientIdAndSec)))},
                            verify=False, params={'client_id': self.config['client_id']})
         well_known_oidc_config = eps.json()

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -98,7 +98,7 @@ Please mind `http` and `https`.
         <!-- (Optional) Override the default idp hint -->
         <!-- <idphint>cilogon</idphint> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
-        <!-- <enable_idp_logout>true</enable_idp_logout> -->
+        <!-- <enable_idp_logout>false</enable_idp_logout> -->
         <!-- <icon>https://path/to/icon</icon>  -->
     </provider>
 
@@ -116,7 +116,7 @@ Please mind `http` and `https`.
         <!-- (Optional) Override the default idp hint -->
         <!-- <idphint>cilogon</idphint> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
-        <!-- <enable_idp_logout>true</enable_idp_logout> -->
+        <!-- <enable_idp_logout>false</enable_idp_logout> -->
         <!-- <icon>https://path/to/icon</icon>  -->
     </provider>
 

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -86,7 +86,7 @@ Please mind `http` and `https`.
     </provider>
 
     <provider name="Custos">
-        <url> ... </url>
+        <url>https://custos.scigap.org/apiserver/identity-management/v1.0.0/</url>
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>
         <redirect_uri>http://localhost:8000/authnz/custos/callback</redirect_uri>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -95,8 +95,6 @@ Please mind `http` and `https`.
         <!-- <ca_bundle>/path/to/ca_bundle</ca_bundle> -->
         <!-- (Optional) Override the default Custos well-known URL to point to a different instance -->
         <!-- <well_known_oidc_config_uri>https://.../.well-known/openid-configuration</well_known_oidc_config_uri> -->
-        <!-- (Optional) Override the default idp hint -->
-        <!-- <idphint>cilogon</idphint> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
         <!-- <enable_idp_logout>false</enable_idp_logout> -->
     </provider>

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -99,7 +99,6 @@ Please mind `http` and `https`.
         <!-- <idphint>cilogon</idphint> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
         <!-- <enable_idp_logout>false</enable_idp_logout> -->
-        <!-- <icon>https://path/to/icon</icon>  -->
     </provider>
 
     <provider name="Keycloak">

--- a/test/unit/authnz/test_custos_authnz.py
+++ b/test/unit/authnz/test_custos_authnz.py
@@ -34,11 +34,16 @@ class CustosAuthnzTestCase(unittest.TestCase):
     def setUp(self):
         self.orig_requests_get = requests.get
         requests.get = self.mockRequest({
-            self._get_well_known_url(): {"authorization_endpoint": "https://test-auth-endpoint",
-                     "token_endpoint": "https://test-token-endpoint",
-                     "userinfo_endpoint": "https://test-userinfo-endpoint",
-                     "end_session_endpoint": "https://test-end-session-endpoint"},
-            self._get_credential_url(): {"iam_client_secret": "TESTSECRET"}})
+            self._get_well_known_url(): {
+                "authorization_endpoint": "https://test-auth-endpoint",
+                "token_endpoint": "https://test-token-endpoint",
+                "userinfo_endpoint": "https://test-userinfo-endpoint",
+                "end_session_endpoint": "https://test-end-session-endpoint"
+            },
+            self._get_credential_url(): {
+                "iam_client_secret": "TESTSECRET"
+            }
+        })
         self.custos_authnz = custos_authnz.CustosAuthnz('Custos', {
             'VERIFY_SSL': True
         }, {

--- a/test/unit/authnz/test_custos_authnz.py
+++ b/test/unit/authnz/test_custos_authnz.py
@@ -25,14 +25,20 @@ class CustosAuthnzTestCase(unittest.TestCase):
         # https://test_base_uri/auth
         return 'https://iam.scigap.org/auth'
 
+    def _get_credential_url(self):
+        return '/'.join([self._get_idp_url(), 'credentials'])
+
+    def _get_well_known_url(self):
+        return '/'.join([self._get_idp_url(), '.well-known/openid-configuration'])
+
     def setUp(self):
         self.orig_requests_get = requests.get
-        requests.get = self.mockRequest(self._get_idp_url(), {
-            "authorization_endpoint": "https://test-auth-endpoint",
-            "token_endpoint": "https://test-token-endpoint",
-            "userinfo_endpoint": "https://test-userinfo-endpoint",
-            "end_session_endpoint": "https://test-end-session-endpoint"
-        })
+        requests.get = self.mockRequest({
+            self._get_well_known_url(): {"authorization_endpoint": "https://test-auth-endpoint",
+                     "token_endpoint": "https://test-token-endpoint",
+                     "userinfo_endpoint": "https://test-userinfo-endpoint",
+                     "end_session_endpoint": "https://test-end-session-endpoint"},
+            self._get_credential_url(): {"iam_client_secret": "TESTSECRET"}})
         self.custos_authnz = custos_authnz.CustosAuthnz('Custos', {
             'VERIFY_SSL': True
         }, {
@@ -103,14 +109,17 @@ class CustosAuthnzTestCase(unittest.TestCase):
             }
         custos_authnz._get_userinfo = get_userinfo
 
-    def mockRequest(self, url, resp):
+    def mockRequest(self, request_dict):
         def get(x, **kwargs):
-            assert x == url
-            return Response()
+            assert(x in request_dict)
+            return Response(request_dict[x])
 
         class Response(object):
+            def __init__(self, resp):
+                self.response = resp
+
             def json(self):
-                return resp
+                return self.response
 
         return get
 


### PR DESCRIPTION
Followup to https://github.com/galaxyproject/galaxy/pull/9730.

Drops credential URL from specification and fixes base_url handling to actually use resolved well_known_oidc_url.  So now url mirrors keycloak in being the base_url.