### PR TITLE
Added missing dev flag to hot module reload script, sourcemaps work now

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "watch": "gulp && yarn run save-build-hash && yarn run webpack-watch",
-    "webpack-dev-server": "gulp && webpack-dev-server --host 0.0.0.0 --port 8081",
+    "webpack-dev-server": "gulp && webpack-dev-server -d --host 0.0.0.0 --port 8081",
     "build": "NODE_ENV=development gulp && yarn run webpack && yarn run save-build-hash",
     "build-production": "NODE_ENV=production gulp && yarn run webpack-production && yarn run save-build-hash",
     "build-production-maps": "NODE_ENV=production gulp && yarn run webpack-production-maps && yarn run save-build-hash",


### PR DESCRIPTION
Webpack hot module reload script was missing the "-d" flag which causes source maps to be generated.

Developing in chrome without source maps is no fun.