### PR TITLE
[20.05] Output SRA manifest as tabular dataset

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/data.js
+++ b/client/galaxy/scripts/mvc/dataset/data.js
@@ -316,7 +316,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         _.each(
             chunk.ck_data.split("\n"),
             function (line, index) {
-                if (line !== "") {
+                if (line !== "" && index >= chunk.data_line_offset) {
                     data_table.append(this._renderRow(line));
                 }
             },

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -356,7 +356,7 @@
     </datatype>
     <datatype extension="sff" type="galaxy.datatypes.binary:Sff" mimetype="application/octet-stream" display_in_upload="true" description="A binary file in 'Standard Flowgram Format' with a '.sff' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Sff"/>
     <datatype extension="sra" type="galaxy.datatypes.binary:Sra" mimetype="application/octet-stream" display_in_upload="true" description="A binary file archive format from the NCBI Sequence Read Archive with a '.sra' file extension." description_url="http://www.ncbi.nlm.nih.gov/books/n/helpsra/SRA_Overview_BK/#SRA_Overview_BK.4_SRA_Data_Structure"/>
-    <datatype extension="sra_manifest.tabular" type="galaxy.datatypes.tabular:SraManifest"/>
+    <datatype extension="sra_manifest.tabular" type="galaxy.datatypes.tabular:SraManifest" display_in_upload="true"/>
     <datatype extension="svg" type="galaxy.datatypes.xml:GenericXml" mimetype="image/svg+xml" subclass="true"/>
     <datatype extension="taxonomy" type="galaxy.datatypes.tabular:Taxonomy" display_in_upload="true"/>
     <datatype extension="tabular" type="galaxy.datatypes.tabular:Tabular" auto_compressed_types="gz" display_in_upload="true" description="Any data in tab delimited format (tabular)." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Tabular_.28tab_delimited.29">

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -356,6 +356,7 @@
     </datatype>
     <datatype extension="sff" type="galaxy.datatypes.binary:Sff" mimetype="application/octet-stream" display_in_upload="true" description="A binary file in 'Standard Flowgram Format' with a '.sff' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Sff"/>
     <datatype extension="sra" type="galaxy.datatypes.binary:Sra" mimetype="application/octet-stream" display_in_upload="true" description="A binary file archive format from the NCBI Sequence Read Archive with a '.sra' file extension." description_url="http://www.ncbi.nlm.nih.gov/books/n/helpsra/SRA_Overview_BK/#SRA_Overview_BK.4_SRA_Data_Structure"/>
+    <datatype extension="sra_manifest.tabular" type="galaxy.datatypes.tabular:SraManifest"/>
     <datatype extension="svg" type="galaxy.datatypes.xml:GenericXml" mimetype="image/svg+xml" subclass="true"/>
     <datatype extension="taxonomy" type="galaxy.datatypes.tabular:Taxonomy" display_in_upload="true"/>
     <datatype extension="tabular" type="galaxy.datatypes.tabular:Tabular" auto_compressed_types="gz" display_in_upload="true" description="Any data in tab delimited format (tabular)." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Tabular_.28tab_delimited.29">

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -429,6 +429,10 @@ class SraManifest(Tabular):
     ext = 'sra_manifest.tabular'
     data_line_offset = 1
 
+    def set_meta(self, dataset, **kwds):
+        super(SraManifest, self).set_meta(dataset, **kwds)
+        dataset.metadata.comment_lines = 1
+
     def get_column_names(self, first_line):
         return first_line.strip().split('\t')
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -92,7 +92,7 @@ class TabularData(data.Text):
         elif to_ext or not preview:
             to_ext = to_ext or dataset.extension
             return self._serve_raw(trans, dataset, to_ext, **kwd)
-        elif dataset.metadata.columns > 50:
+        elif dataset.metadata.columns > 100:
             # Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
             # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
             # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.

--- a/tools/data_source/sra.xml
+++ b/tools/data_source/sra.xml
@@ -1,12 +1,28 @@
 <tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.0" profile="16.04">
     <description>server</description>
-    <command>python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit</command>
+    <command><![CDATA[
+    python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit &&
+    python '$csv_to_tsv'
+    ]]></command>
+    <configfiles>
+    <configfile name="csv_to_tsv">
+import csv
+
+
+with open('$output') as in_fh:
+    rows = [r for r in csv.reader(in_fh)]
+with open('$output', 'w') as out_fh:
+    tsvout = csv.writer(out_fh, delimiter='\t')
+    for row in rows:
+        tsvout.writerow(row)
+    </configfile>
+    </configfiles>
     <inputs action="https://www.ncbi.nlm.nih.gov/sra" check_values="false" method="get">
         <display>go to SRA server $GALAXY_URL</display>
         <param name="GALAXY_URL" type="baseurl" value="/tool_runner?tool_id=sra_source" />
     </inputs>
     <outputs>
-        <data name="output" format="csv" />
+        <data name="output" format="sra_manifest.tabular"/>
     </outputs>
     <options sanitize="False" refresh="True"/>
     <citations>

--- a/tools/data_source/sra.xml
+++ b/tools/data_source/sra.xml
@@ -1,4 +1,4 @@
-<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.0" profile="16.04">
+<tool name="SRA" id="sra_source" tool_type="data_source" version="1.0.1" profile="16.04">
     <description>server</description>
     <command><![CDATA[
     python '$__tool_directory__/data_source.py' '$output' $__app__.config.output_size_limit &&


### PR DESCRIPTION
This adds a new datatype that is mostly the same as Tabular, but that skips rendering of the first line, which contains the column names (that depend on user selection on the SRA run selector).
(This should be useful for other datatypes that have or set `column_name` as well).

<img width="807" alt="Screenshot 2020-06-18 at 18 54 59" src="https://user-images.githubusercontent.com/6804901/85050792-e9909980-b196-11ea-96d0-2db922202738.png">

This also makes the sra_source tool output a tsv file instead of a csv file, which should make operations on this file more streamlined in Galaxy (i.e use in the rule builder, relabel, tagging, etc) and that makes it easier to feed the manifest into the fasterq-dump tool.

It would be great of we can get this into 20.05 for the SRA webinar (https://galaxyproject.org/news/2020-06-galaxy-update/#galaxy-and-the-ncbi-sequence-read-archive-sra) next week. Calling this a bug is a bit of a stretch ... so let me know if I should better target dev.