### PR TITLE
[20.05] Custos login notice wording tweak

### DIFF
--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -54,9 +54,9 @@
 
                                     <p class="mt-3">
                                         <small class="text-muted">
-                                            * Galaxy uses CILogon via Custos to enable you to Log In from this
+                                            * Galaxy uses CILogon via Custos to enable you to log in from this
                                             organization. By clicking 'Sign In', you agree to the
-                                            <a href="https://ca.cilogon.org/policy/privacy">CILogon privacy policy</a>
+                                            <a href="https://ca.cilogon.org/policy/privacy">CILogon</a> privacy policy
                                             and you agree to share your username, email address, and affiliation with
                                             CILogon, Custos, and Galaxy.
                                         </small>

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -58,8 +58,7 @@
                                             organization. By clicking 'Sign In', you agree to the
                                             <a href="https://ca.cilogon.org/policy/privacy">CILogon privacy policy</a>
                                             and you agree to share your username, email address, and affiliation with
-                                            CILogon and Galaxy. You also agree for CILogon to issue a certificate that
-                                            allows Galaxy to act on your behalf.
+                                            CILogon, Custos, and Galaxy.
                                         </small>
                                     </p>
                                 </div>


### PR DESCRIPTION
Custos login is live on test.galaxyproject.org now, and we realized we should tweak the warning language slightly.  We don't use the myproxy scope and don't need some of the language here.  We'll also want to link the custos privacy policy when it is available.