### PR TITLE
[20.05] Fix webpack import proxy prefix

### DIFF
--- a/client/galaxy/scripts/onload/index.js
+++ b/client/galaxy/scripts/onload/index.js
@@ -6,15 +6,9 @@ import "bootstrap-tour";
 // Galaxy core styles
 import "scss/base.scss";
 
-// Set dynamically loaded webpack public path.
-// This is, by default, just `/static/dist`, but if galaxy is being served at a
-// prefix (e.g.  `<server>/galaxy/`), this must happen before any dynamic
-// bundle imports load, otherwise they will fail.
-import { getRootFromIndexLink } from "./getRootFromIndexLink";
-__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/${__webpack_public_path__.replace(
-    /^\/+/,
-    ""
-)}`;
+// Set up webpack's public path; nothing to import but the module has side
+// effects fixing webpack globals.
+import "./publicPath";
 
 // Module exports appear as objects on window.config in the browser
 export { standardInit } from "./standardInit";

--- a/client/galaxy/scripts/onload/index.js
+++ b/client/galaxy/scripts/onload/index.js
@@ -11,7 +11,10 @@ import "scss/base.scss";
 // prefix (e.g.  `<server>/galaxy/`), this must happen before any dynamic
 // bundle imports load, otherwise they will fail.
 import { getRootFromIndexLink } from "./getRootFromIndexLink";
-__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/,"")}/${__webpack_public_path__.replace(/^\/+/,"")}`;
+__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/${__webpack_public_path__.replace(
+    /^\/+/,
+    ""
+)}`;
 
 // Module exports appear as objects on window.config in the browser
 export { standardInit } from "./standardInit";

--- a/client/galaxy/scripts/onload/index.js
+++ b/client/galaxy/scripts/onload/index.js
@@ -6,6 +6,13 @@ import "bootstrap-tour";
 // Galaxy core styles
 import "scss/base.scss";
 
+// Set dynamically loaded webpack public path.
+// This is, by default, just `/static/dist`, but if galaxy is being served at a
+// prefix (e.g.  `<server>/galaxy/`), this must happen before any dynamic
+// bundle imports load, otherwise they will fail.
+import { getRootFromIndexLink } from "./getRootFromIndexLink";
+__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/,"")}/${__webpack_public_path__.replace(/^\/+/,"")}`;
+
 // Module exports appear as objects on window.config in the browser
 export { standardInit } from "./standardInit";
 export { initializations$, addInitialization, prependInitialization, clearInitQueue } from "./initQueue";

--- a/client/galaxy/scripts/onload/publicPath.js
+++ b/client/galaxy/scripts/onload/publicPath.js
@@ -5,8 +5,7 @@
  * dynamic bundle imports load, otherwise they will fail.
  */
 
-/* global __webpack_public_path__:writable */
-
 import { getRootFromIndexLink } from "./getRootFromIndexLink";
 
+// eslint-disable-next-line no-unused-vars, no-undef
 __webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/static/dist/`;

--- a/client/galaxy/scripts/onload/publicPath.js
+++ b/client/galaxy/scripts/onload/publicPath.js
@@ -4,9 +4,9 @@
  * a prefix (e.g.  `<server>/galaxy/`), this must be accounted for before any
  * dynamic bundle imports load, otherwise they will fail.
  */
+
+/* global __webpack_public_path__:writable */
+
 import { getRootFromIndexLink } from "./getRootFromIndexLink";
 
-__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/${__webpack_public_path__.replace(
-    /^\/+/,
-    ""
-)}`;
+__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/static/dist/`;

--- a/client/galaxy/scripts/onload/publicPath.js
+++ b/client/galaxy/scripts/onload/publicPath.js
@@ -1,0 +1,12 @@
+/**
+ * Set dynamically loaded webpack public path. (https://webpack.js.org/guides/public-path/#on-the-fly)
+ * This is, by default, just `/static/dist/`, but if galaxy is being served at
+ * a prefix (e.g.  `<server>/galaxy/`), this must be accounted for before any
+ * dynamic bundle imports load, otherwise they will fail.
+ */
+import { getRootFromIndexLink } from "./getRootFromIndexLink";
+
+__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/${__webpack_public_path__.replace(
+    /^\/+/,
+    ""
+)}`;


### PR DESCRIPTION
This fixes webpack dynamic imports when served with a prefix (like `<server>/mygalaxy/`)