### PR TITLE
[20.01] Fix incorrect variable assignment

### DIFF
--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -538,7 +538,7 @@ class WeblessApplicationStack(ApplicationStack):
                 or (dialect.name == 'mysql' and dialect.server_version_info >= (8, 0, 1))):
             add_method = HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
         else:
-            HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
+            add_method = HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
         if add_method in job_config.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS:
             remove_methods.append(add_method)
             add_method = HANDLER_ASSIGNMENT_METHODS.DB_PREASSIGN


### PR DESCRIPTION
@nuwang spotted this in a failed startup; still trying to sort out exactly how we hit this.  My initial hunch was that the dialect name might be `postgres` instead of `postgresql`, but I have not tested.  Could also have been an older version of postgersql (<9.5; I'll check).