### PR TITLE
Do not automatically overwrite the output labels for subworkflows

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -488,7 +488,6 @@ class SubWorkflowModule(WorkflowModule):
                     for data_output in data_outputs:
                         data_output_uuid = data_output.get('uuid') or object()
                         if data_output['name'] == workflow_output['output_name'] or data_output_uuid == workflow_output_uuid:
-                            data_output['label'] = label
                             data_output['name'] = label
                             # That's the right data_output
                             break

--- a/test/unit/workflows/test_modules.py
+++ b/test/unit/workflows/test_modules.py
@@ -233,10 +233,8 @@ def test_subworkflow_new_outputs():
     assert len(outputs) == 2, len(outputs)
     output1, output2 = outputs
     assert output1["name"] == "out1"
-    assert output1["label"] == "out1"
     assert output1["extensions"] == ["input"]
     assert output2["name"] == "4:out_file1", output2["name"]
-    assert output2["label"] == "4:out_file1", output2["label"]
 
 
 def _construct_steps_for_map_over():


### PR DESCRIPTION
This PR improves enforcing unique subworkflow output labels by avoiding automated labeling of workflow outputs since that can easily lead to duplicated labels. This change only effects newly inserted subworkflows and the label/name visible to the user remains unchanged.

Example shown in release 20.01:

<img width="600" alt="Screen Shot 2020-06-26 at 3 17 03 PM" src="https://user-images.githubusercontent.com/2105447/85894178-422ceb80-b7c2-11ea-8811-c768f9b24b31.png">