### PR TITLE
[20.05] Backport Chira sniffer fix

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1542,15 +1542,7 @@ class ChiraSQLite(SQlite):
 
     def sniff(self, filename):
         if super(ChiraSQLite, self).sniff(filename):
-            try:
-                conn = sqlite.connect(filename)
-                c = conn.cursor()
-                tables_query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
-                result = c.execute(tables_query).fetchall()
-                result = [_[0] for _ in result]
-                return True
-            except Exception as e:
-                log.warning('%s, sniff Exception: %s', self, e)
+            self.sniff_table_names(filename, ['Chimeras'])
         return False
 
 


### PR DESCRIPTION
Otherwise all sqlite files would be sniffed as chira. broken in https://github.com/galaxyproject/galaxy/pull/9562, fixed in https://github.com/galaxyproject/galaxy/pull/9712.