### PR TITLE
Strip leading whitespace before calling urlparse

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -6,9 +6,9 @@ import socket
 import tempfile
 from collections import OrderedDict
 from json import dump, dumps
+from urllib.parse import urlparse
 
 from six import StringIO
-from six.moves.urllib.parse import urlparse
 from sqlalchemy.orm import eagerload_all
 from webob.compat import cgi_FieldStorage
 
@@ -34,9 +34,11 @@ def validate_datatype_extension(datatypes_registry, ext):
 
 def validate_url(url, ip_allowlist):
     # If it doesn't look like a URL, ignore it.
-    if not (url.lstrip().startswith('http://') or url.lstrip().startswith('https://')):
+    if not (url.startswith('http://') or url.startswith('https://')):
         return url
 
+    # Strip leading whitespace before passing url to urlparse()
+    url = url.lstrip()
     # Extract hostname component
     parsed_url = urlparse(url).netloc
     # If credentials are in this URL, we need to strip those.

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -34,7 +34,7 @@ def validate_datatype_extension(datatypes_registry, ext):
 
 def validate_url(url, ip_allowlist):
     # If it doesn't look like a URL, ignore it.
-    if not (url.startswith('http://') or url.startswith('https://')):
+    if not (url.lstrip().startswith('http://') or url.lstrip().startswith('https://')):
         return url
 
     # Strip leading whitespace before passing url to urlparse()


### PR DESCRIPTION
Fixes #8196 
Also replace six with urllib

What's happening: with a leading whitespace, `urlparse` will return the following value:
```python
ParseResult(scheme='', netloc='', path=' https://docs.python.org/3/library/urllib.parse.html', params='', query='', fragment='') 
```
Trailing whitespace is irrelevant.

ping @martenson 