### PR TITLE
Refactor toward real cohesion toward testing packages. (1/n)

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -4,6 +4,7 @@ import routes
 
 from galaxy import managers
 from galaxy.exceptions import ObjectNotFound
+from galaxy.managers.base import decode_id
 from galaxy.managers.collections_util import (
     api_payload_to_create_params,
     dictify_dataset_collection_instance,
@@ -52,7 +53,7 @@ class DatasetCollectionsController(
         instance_type = payload.pop("instance_type", "history")
         if instance_type == "history":
             history_id = payload.get('history_id')
-            history_id = self.decode_id(history_id)
+            history_id = decode_id(self.app, history_id)
             history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
             create_params["parent"] = history
         elif instance_type == "library":
@@ -115,7 +116,7 @@ class DatasetCollectionsController(
             instance_type=instance_type)
 
         # check to make sure the dsc is part of the validated hdca
-        decoded_parent_id = trans.app.security.decode_id(parent_id)
+        decoded_parent_id = decode_id(self.app, parent_id)
         if not hdca.contains_collection(decoded_parent_id):
             errmsg = 'Requested dataset collection is not contained within indicated history content'
             raise ObjectNotFound(errmsg)

--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -2,9 +2,6 @@ from galaxy_test.base.api_asserts import (
     assert_has_keys,
     assert_not_has_keys,
 )
-from galaxy_test.base.populators import (
-    LibraryPopulator
-)
 from ._framework import ApiTestCase
 
 TEST_KEYS_FOR_ALL_USERS = [
@@ -26,10 +23,6 @@ TEST_KEYS_FOR_ADMIN_ONLY = [
 
 class ConfigurationApiTestCase(ApiTestCase):
 
-    def setUp(self):
-        super(ConfigurationApiTestCase, self).setUp()
-        self.library_populator = LibraryPopulator(self.galaxy_interactor)
-
     def test_normal_user_configuration(self):
         config = self._get_configuration()
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)
@@ -39,18 +32,6 @@ class ConfigurationApiTestCase(ApiTestCase):
         config = self._get_configuration(admin=True)
         assert_has_keys(config, *TEST_KEYS_FOR_ALL_USERS)
         assert_has_keys(config, *TEST_KEYS_FOR_ADMIN_ONLY)
-
-    def test_admin_decode_id(self):
-        new_lib = self.library_populator.new_library('DecodeTestLibrary')
-        decode_response = self._get("configuration/decode/" + new_lib["id"], admin=True)
-        response_id = decode_response.json()["decoded_id"]
-        decoded_library_id = self.security.decode_id(new_lib["id"])
-        assert decoded_library_id == response_id
-        # fake valid folder id by prepending F
-        valid_encoded_folder_id = 'F' + new_lib["id"]
-        folder_decode_response = self._get("configuration/decode/" + valid_encoded_folder_id, admin=True)
-        folder_response_id = folder_decode_response.json()["decoded_id"]
-        assert decoded_library_id == folder_response_id
 
     def test_normal_user_decode_id(self):
         decode_response = self._get("configuration/decode/badhombre", admin=False)

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -3,6 +3,7 @@ import tarfile
 
 from six import BytesIO
 
+from galaxy_test.base.api_asserts import assert_object_id_error
 from galaxy_test.base.populators import DatasetCollectionPopulator, DatasetPopulator, skip_if_github_down
 from ._framework import ApiTestCase
 
@@ -287,10 +288,10 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         hdca, contents_url = self._create_collection_contents_pair()
         response = self._get(contents_url)
         self._assert_status_code_is(response, 200)
-        fake_collection_id = self.security.encode_id(1000)
+        fake_collection_id = '5d7db0757a2eb7ef'
         fake_contents_url = '/api/dataset_collections/%s/contents/%s' % (hdca['id'], fake_collection_id)
         error_response = self._get(fake_contents_url)
-        self._assert_status_code_is(error_response, 404)
+        assert_object_id_error(error_response)
 
     def test_show_dataset_collection_contents(self):
         # Get contents_url from history contents, use it to show the first level

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -6,6 +6,7 @@ from requests import (
     put
 )
 
+from galaxy_test.base.api_asserts import assert_object_id_error
 from galaxy_test.base.populators import skip_without_tool
 from ._framework import ApiTestCase
 
@@ -63,10 +64,10 @@ class UsersApiTestCase(ApiTestCase):
             self._assert_status_code_is(update_response, 403)
 
             # non-existent
-            no_user_id = self.security.encode_id(100)
+            no_user_id = '5d7db0757a2eb7ef'
             update_url = self._api_url("users/%s" % (no_user_id), use_key=True)
             update_response = put(update_url, data=json.dumps(dict(username=new_name)))
-            self._assert_status_code_is(update_response, 404)
+            assert_object_id_error(update_response)
 
     def test_admin_update(self):
         new_name = 'flexo'

--- a/lib/galaxy_test/base/api_asserts.py
+++ b/lib/galaxy_test/base/api_asserts.py
@@ -44,4 +44,16 @@ def assert_error_code_is(response, error_code):
     assert err_code == int(error_code), ASSERT_FAIL_ERROR_CODE % (err_code, int(error_code))
 
 
+def assert_object_id_error(response):
+    # for tests that use fake object IDs - API might throw MalformedId (400) or
+    # or ObjectNotFound (404) - depending if the ID happens to be parseable with
+    # servers API key.
+    error_code = response.status_code
+    assert error_code in [400, 404]
+    if error_code == 400:
+        assert_error_code_is(response, 400009)
+    else:
+        assert_error_code_is(response, 404001)
+
+
 assert_has_key = assert_has_keys

--- a/lib/galaxy_test/base/env.py
+++ b/lib/galaxy_test/base/env.py
@@ -1,0 +1,24 @@
+"""Base utilities for working Galaxy test environments.
+"""
+import os
+import socket
+
+DEFAULT_WEB_HOST = socket.gethostbyname('localhost')
+
+
+def setup_keep_outdir():
+    keep_outdir = os.environ.get('GALAXY_TEST_SAVE', '')
+    if keep_outdir > '':
+        try:
+            os.makedirs(keep_outdir)
+        except Exception:
+            pass
+    return keep_outdir
+
+
+def target_url_parts():
+    host = socket.gethostbyname(os.environ.get('GALAXY_TEST_HOST', DEFAULT_WEB_HOST))
+    port = os.environ.get('GALAXY_TEST_PORT')
+    default_url = "http://%s:%s" % (host, port)
+    url = os.environ.get('GALAXY_TEST_EXTERNAL', default_url)
+    return host, port, url

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -41,13 +41,13 @@ from galaxy.util import asbool, download_to_file, galaxy_directory
 from galaxy.util.properties import load_app_properties
 from galaxy.web import buildapp
 from galaxy_test.base.api_util import get_master_api_key, get_user_api_key
+from galaxy_test.base.env import DEFAULT_WEB_HOST, target_url_parts
 from galaxy_test.base.instrument import StructuredTestDataPlugin
 from galaxy_test.base.nose_util import run
 from tool_shed.webapp.app import UniverseApplication as ToolshedUniverseApplication
 from .test_logging import logging_config_file
 
 galaxy_root = galaxy_directory()
-DEFAULT_WEB_HOST = socket.gethostbyname('localhost')
 DEFAULT_CONFIG_PREFIX = "GALAXY"
 GALAXY_TEST_DIRECTORY = os.path.join(galaxy_root, "test")
 GALAXY_TEST_FILE_DIR = "test-data,https://github.com/galaxyproject/galaxy-test-data.git"
@@ -1078,24 +1078,6 @@ def drive_test(test_driver_class):
     sys.exit(test_driver.run())
 
 
-def setup_keep_outdir():
-    keep_outdir = os.environ.get('GALAXY_TEST_SAVE', '')
-    if keep_outdir > '':
-        try:
-            os.makedirs(keep_outdir)
-        except Exception:
-            pass
-    return keep_outdir
-
-
-def target_url_parts():
-    host = socket.gethostbyname(os.environ.get('GALAXY_TEST_HOST', DEFAULT_WEB_HOST))
-    port = os.environ.get('GALAXY_TEST_PORT')
-    default_url = "http://%s:%s" % (host, port)
-    url = os.environ.get('GALAXY_TEST_EXTERNAL', default_url)
-    return host, port, url
-
-
 __all__ = (
     "copy_database_template",
     "build_logger",
@@ -1106,9 +1088,7 @@ __all__ = (
     "database_conf",
     "get_webapp_global_conf",
     "nose_config_and_run",
-    "setup_keep_outdir",
     "setup_galaxy_config",
-    "target_url_parts",
     "TestDriver",
     "wait_for_http_server",
 )

--- a/lib/galaxy_test/driver/testcase.py
+++ b/lib/galaxy_test/driver/testcase.py
@@ -6,7 +6,8 @@ import unittest
 
 from galaxy.security import idencoding
 from galaxy.tool_util.verify.test_data import TestDataResolver
-from .driver_util import GalaxyTestDriver, setup_keep_outdir, target_url_parts
+from galaxy_test.base.env import setup_keep_outdir, target_url_parts
+from .driver_util import GalaxyTestDriver
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy_test/driver/testcase.py
+++ b/lib/galaxy_test/driver/testcase.py
@@ -4,7 +4,6 @@ import logging
 import os
 import unittest
 
-from galaxy.security import idencoding
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.env import setup_keep_outdir, target_url_parts
 from .driver_util import GalaxyTestDriver
@@ -15,7 +14,7 @@ log = logging.getLogger(__name__)
 class FunctionalTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.security = idencoding.IdEncodingHelper(id_secret='changethisinproductiontoo')
+
         self.history_id = os.environ.get('GALAXY_TEST_HISTORY_ID', None)
         self.host, self.port, self.url = target_url_parts()
         self.test_data_resolver = TestDataResolver()

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -10,8 +10,8 @@ except ImportError:
 
 from galaxy.tool_util.verify.interactor import GalaxyInteractorApi, verify_tool
 from galaxy.tools import DataManagerTool
+from galaxy_test.base.env import setup_keep_outdir, target_url_parts
 from galaxy_test.base.instrument import register_job_data
-from galaxy_test.driver.driver_util import setup_keep_outdir, target_url_parts
 from galaxy_test.driver.testcase import FunctionalTestCase
 
 log = logging.getLogger(__name__)

--- a/test/integration/test_configuration_decode.py
+++ b/test/integration/test_configuration_decode.py
@@ -1,0 +1,23 @@
+from galaxy_test.base.populators import (
+    LibraryPopulator
+)
+from galaxy_test.driver import integration_util
+
+
+class ConfigurationDecodeIntegrationTestCase(integration_util.IntegrationTestCase):
+
+    def setUp(self):
+        super(ConfigurationDecodeIntegrationTestCase, self).setUp()
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
+
+    def test_admin_decode_id(self):
+        new_lib = self.library_populator.new_library('DecodeTestLibrary')
+        decode_response = self._get("configuration/decode/" + new_lib["id"], admin=True)
+        response_id = decode_response.json()["decoded_id"]
+        decoded_library_id = self._app.security.decode_id(new_lib["id"])
+        assert decoded_library_id == response_id
+        # fake valid folder id by prepending F
+        valid_encoded_folder_id = 'F' + new_lib["id"]
+        folder_decode_response = self._get("configuration/decode/" + valid_encoded_folder_id, admin=True)
+        folder_response_id = folder_decode_response.json()["decoded_id"]
+        assert decoded_library_id == folder_response_id


### PR DESCRIPTION
For publishing useful tests to PyPI, there needs to be a base TestCase class for API, Framework, Selenium, etc... tests that doesn't depend on the Galaxy app - and instead just knows and utilizes the API.

The relevant TODO from the code is in ``lib/galaxy_test/api/_framework.py``.

```
# TODO: implement a remote-only version of ApiTestCase if galaxy_test.driver isn't
# available. Most of these tests do not depend on Galaxy internals.
from galaxy_test.driver.api import ApiTestCase

__all__ = ('ApiTestCase', )
```

Practically speaking, this means better separation of utilities and environment parsing out of ``lib/galaxy_test/driver`` and into ``lib/galaxy_test/base``. This is because the former depends on ``galaxy-web-apps`` and the latter doesn't. It also means making sure the API/Selenium/Framework tests do not depend on internals - things that need a fixed Galaxy configuration should be pushed into integration test suite and the API tests should be runnable against any Galaxy instance.

The first commit here is a step toward better separation described above and the second commit loosens the requirements of the API tests so we no longer need a security object when running the tests (further reducing the dependencies of the galaxy-test-base package also).
