### PR TITLE
Rework client datatype handling logic for reuse

### DIFF
--- a/client/galaxy/scripts/components/Datatypes/factory.js
+++ b/client/galaxy/scripts/components/Datatypes/factory.js
@@ -1,0 +1,7 @@
+import { DatatypesMapperModel } from "./model.js";
+import { getDatatypes } from "./services";
+
+export async function getDatatypesMapper() {
+    const typesAndMapping = await getDatatypes();
+    return new DatatypesMapperModel(typesAndMapping);
+}

--- a/client/galaxy/scripts/components/Datatypes/index.js
+++ b/client/galaxy/scripts/components/Datatypes/index.js
@@ -1,0 +1,1 @@
+export { getDatatypesMapper } from "./factory.js";

--- a/client/galaxy/scripts/components/Datatypes/index.test.js
+++ b/client/galaxy/scripts/components/Datatypes/index.test.js
@@ -1,0 +1,27 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+
+import { getDatatypesMapper } from "./index";
+import { typesAndMappingResponse } from "./test_fixtures";
+
+describe("Datatypes/index.js", () => {
+    let axiosMock;
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
+
+    describe("getDatatypesMapper", () => {
+        it("should fetch logic from API for comparing datatypes in a hierarchy", async () => {
+            axiosMock.onGet(`/api/datatypes/types_and_mapping`).reply(200, typesAndMappingResponse);
+            await getDatatypesMapper().then((mapper) => {
+                expect(mapper.isSubType("txt", "data")).to.equals(true);
+                expect(mapper.isSubType("data", "txt")).to.equals(false);
+            });
+        });
+    });
+});

--- a/client/galaxy/scripts/components/Datatypes/model.js
+++ b/client/galaxy/scripts/components/Datatypes/model.js
@@ -1,0 +1,13 @@
+export class DatatypesMapperModel {
+    constructor(typesAndMapping) {
+        this.datatypes = typesAndMapping.datatypes;
+        this.datatypesMapping = typesAndMapping.datatypes_mapping;
+    }
+
+    isSubType(child, parent) {
+        const mapping = this.datatypesMapping;
+        child = mapping.ext_to_class_name[child];
+        parent = mapping.ext_to_class_name[parent];
+        return mapping.class_to_classes[child] && parent in mapping.class_to_classes[child];
+    }
+}

--- a/client/galaxy/scripts/components/Datatypes/services.js
+++ b/client/galaxy/scripts/components/Datatypes/services.js
@@ -1,0 +1,12 @@
+import axios from "axios";
+import { rethrowSimple } from "utils/simple-error";
+import { getAppRoot } from "onload/loadConfig";
+
+export async function getDatatypes() {
+    try {
+        const request = await axios.get(`${getAppRoot()}api/datatypes/types_and_mapping`);
+        return request.data;
+    } catch (e) {
+        rethrowSimple(e);
+    }
+}

--- a/client/galaxy/scripts/components/Datatypes/test_fixtures.js
+++ b/client/galaxy/scripts/components/Datatypes/test_fixtures.js
@@ -1,0 +1,10 @@
+import DatatypesMappingJson from "qunit/test-data/json/datatypes.mapping.json";
+import DatatypesJson from "qunit/test-data/json/datatypes.json";
+import { DatatypesMapperModel } from "./model.js";
+
+export const typesAndMappingResponse = {
+    datatypes: DatatypesJson,
+    datatypes_mapping: DatatypesMappingJson,
+};
+
+export const testDatatypesMapper = new DatatypesMapperModel(typesAndMappingResponse);

--- a/client/galaxy/scripts/components/ToolRecommendation.vue
+++ b/client/galaxy/scripts/components/ToolRecommendation.vue
@@ -17,7 +17,8 @@
 <script>
 import * as d3 from "d3";
 import { getAppRoot } from "onload/loadConfig";
-import { getDatatypeMapping, getToolPredictions } from "components/Workflow/Editor/modules/services";
+import { getDatatypesMapper } from "components/Datatypes";
+import { getToolPredictions } from "components/Workflow/Editor/modules/services";
 
 export default {
     props: {
@@ -53,10 +54,10 @@ export default {
                 tool_sequence: toolId,
             };
             getToolPredictions(requestData).then((responsePred) => {
-                getDatatypeMapping().then((datatypesMapping) => {
+                getDatatypesMapper().then((datatypesMapper) => {
                     const predData = responsePred.predicted_data;
-                    const extToType = datatypesMapping.ext_to_class_name;
-                    const typeToType = datatypesMapping.class_to_classes;
+                    const extToType = datatypesMapper.datatypesMapping.ext_to_class_name;
+                    const typeToType = datatypesMapper.datatypesMapping.class_to_classes;
                     this.deprecated = predData.is_deprecated;
                     this.deprecatedMessage = predData.message;
                     if (responsePred !== null && predData.children.length > 0) {

--- a/client/galaxy/scripts/components/Workflow/Editor/Index.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Index.vue
@@ -33,7 +33,7 @@
                             :content-id="step.content_id"
                             :step="step"
                             :key="key"
-                            :datatypes-mapping="datatypesMapping"
+                            :datatypes-mapper="datatypesMapper"
                             :get-manager="getManager"
                             :get-canvas-manager="getCanvasManager"
                             @onAdd="onAdd"
@@ -95,7 +95,8 @@
 </template>
 
 <script>
-import { getDatatypes, getModule, getVersions, saveWorkflow, loadWorkflow } from "./modules/services";
+import { getDatatypesMapper } from "components/Datatypes";
+import { getModule, getVersions, saveWorkflow, loadWorkflow } from "./modules/services";
 import {
     showWarnings,
     showUpgradeMessage,
@@ -179,16 +180,16 @@ export default {
             hasChanges: false,
             nodeIndex: 0,
             nodes: {},
-            datatypesMapping: {},
+            datatypesMapper: null,
             datatypes: [],
             report: {},
             activeNode: null,
         };
     },
     created() {
-        getDatatypes().then((response) => {
-            this.datatypesMapping = response.datatypes_mapping;
-            this.datatypes = response.datatypes;
+        getDatatypesMapper().then((mapper) => {
+            this.datatypesMapper = mapper;
+            this.datatypes = mapper.datatypes;
 
             // canvas overview management
             this.canvasManager = new WorkflowCanvas(this, this.$refs.canvas);

--- a/client/galaxy/scripts/components/Workflow/Editor/Node.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Node.vue
@@ -26,7 +26,7 @@
                 <Recommendations
                     :get-node="getNode"
                     :get-manager="getManager"
-                    :datatypes-mapping="datatypesMapping"
+                    :datatypes-mapper="datatypesMapper"
                     @onCreate="onCreate"
                 />
             </b-popover>
@@ -56,7 +56,7 @@
                 :input="input"
                 :get-node="getNode"
                 :get-manager="getManager"
-                :datatypes-mapping="datatypesMapping"
+                :datatypes-mapper="datatypesMapper"
                 @onAdd="onAddInput"
                 @onChange="onChange"
             />
@@ -124,7 +124,7 @@ export default {
             type: Function,
             default: null,
         },
-        datatypesMapping: {
+        datatypesMapper: {
             type: Object,
             default: null,
         },

--- a/client/galaxy/scripts/components/Workflow/Editor/NodeInput.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/NodeInput.vue
@@ -25,7 +25,7 @@ export default {
             type: Function,
             required: true,
         },
-        datatypesMapping: {
+        datatypesMapper: {
             type: Object,
             required: true,
         },
@@ -66,7 +66,7 @@ export default {
             }
             const terminal = new terminalClass({
                 node: this.getNode(),
-                datatypesMapping: this.datatypesMapping,
+                datatypesMapper: this.datatypesMapper,
                 name: input.name,
                 input: input,
                 element: this.$refs.terminal,

--- a/client/galaxy/scripts/components/Workflow/Editor/Recommendations.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Recommendations.vue
@@ -36,7 +36,7 @@ export default {
             type: Function,
             required: true,
         },
-        datatypesMapping: {
+        datatypesMapper: {
             type: Object,
             required: true,
         },
@@ -146,10 +146,7 @@ export default {
             });
         },
         _isSubType(child, parent) {
-            const mapping = this.datatypesMapping;
-            child = mapping.ext_to_class_name[child];
-            parent = mapping.ext_to_class_name[parent];
-            return mapping.class_to_classes[child] && parent in mapping.class_to_classes[child];
+            return this.datatypesMapper.isSubType(child, parent);
         },
     },
 };

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/services.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/services.js
@@ -13,18 +13,6 @@ export async function getVersions(id) {
     }
 }
 
-export async function getDatatypes() {
-    try {
-        const datatypesRequest = await axios.get(`${getAppRoot()}api/datatypes`);
-        const datatypes = datatypesRequest.data;
-        const mappingRequest = await axios.get(`${getAppRoot()}api/datatypes/mapping`);
-        const datatypes_mapping = mappingRequest.data;
-        return { datatypes, datatypes_mapping };
-    } catch (e) {
-        rethrowSimple(e);
-    }
-}
-
 export async function getModule(request_data) {
     try {
         const { data } = await axios.post(`${getAppRoot()}api/workflows/build_module`, request_data);

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/terminals.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/terminals.js
@@ -219,7 +219,7 @@ class Terminal extends EventEmitter {
 class BaseInputTerminal extends Terminal {
     constructor(attr) {
         super(attr);
-        this.datatypesMapping = attr.datatypesMapping;
+        this.datatypesMapper = attr.datatypesMapper;
         this.update(attr.input); // subclasses should implement this...
     }
     canAccept(other) {
@@ -348,10 +348,7 @@ class BaseInputTerminal extends Terminal {
         );
     }
     _isSubType(child, parent) {
-        const mapping = this.datatypesMapping;
-        child = mapping.ext_to_class_name[child];
-        parent = mapping.ext_to_class_name[parent];
-        return mapping.class_to_classes[child] && parent in mapping.class_to_classes[child];
+        return this.datatypesMapper.isSubType(child, parent);
     }
     _producesAcceptableDatatypeAndOptionalness(other) {
         if (!this.optional && !this.multiple && other.optional) {

--- a/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
+++ b/client/galaxy/scripts/qunit/tests/workflow_editor_tests.js
@@ -1,6 +1,6 @@
 /* global QUnit */
 import $ from "jquery";
-import DatatypesMapping from "qunit/test-data/json/datatypes.mapping.json";
+import { testDatatypesMapper } from "components/Datatypes/test_fixtures";
 import sinon from "sinon";
 import WorkflowNode from "components/Workflow/Editor/Node";
 import Terminals from "components/Workflow/Editor/modules/terminals";
@@ -49,7 +49,7 @@ function buildNode(propsData) {
     propsData.getCanvasManager = () => {
         return {};
     };
-    propsData.datatypesMapping = DatatypesMapping;
+    propsData.datatypesMapper = testDatatypesMapper;
     return new component({
         propsData: propsData,
         el: "#canvas-container",
@@ -63,7 +63,7 @@ QUnit.module("Input terminal model test", {
         this.input = { extensions: ["txt"], multiple: false, optional: false };
         const inputEl = $("<div>")[0];
         this.input_terminal = new Terminals.InputTerminal({
-            datatypesMapping: DatatypesMapping,
+            datatypesMapper: testDatatypesMapper,
             element: inputEl,
             input: this.input,
             node: this.node,
@@ -309,7 +309,7 @@ QUnit.module("Input collection terminal model test", {
         this.input = { extensions: ["txt"], collection_types: ["list"] };
         const inputEl = $("<div>")[0];
         this.input_terminal = new Terminals.InputCollectionTerminal({
-            datatypesMapping: DatatypesMapping,
+            datatypesMapper: testDatatypesMapper,
             element: inputEl,
             input: this.input,
             node: this.node,
@@ -869,7 +869,7 @@ QUnit.module("terminal mapping logic", {
         }
         const inputEl = $("<div>")[0];
         const inputTerminal = new Terminals.InputTerminal({
-            datatypesMapping: DatatypesMapping,
+            datatypesMapper: testDatatypesMapper,
             element: inputEl,
             input: input,
         });
@@ -887,7 +887,7 @@ QUnit.module("terminal mapping logic", {
         }
         const inputEl = $("<div>")[0];
         const inputTerminal = new Terminals.InputCollectionTerminal({
-            datatypesMapping: DatatypesMapping,
+            datatypesMapper: testDatatypesMapper,
             element: inputEl,
             input: input,
             node: node,

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -19,25 +19,28 @@ class DatatypesController(BaseAPIController):
         GET /api/datatypes
         Return an object containing upload datatypes.
         """
-        datatypes_registry = self._datatypes_registry
         try:
-            extension_only = asbool(kwd.get('extension_only', True))
-            upload_only = asbool(kwd.get('upload_only', True))
-            if extension_only:
-                if upload_only:
-                    return datatypes_registry.upload_file_formats
-                else:
-                    return [ext for ext in datatypes_registry.datatypes_by_extension]
-            else:
-                rval = []
-                for datatype_info_dict in datatypes_registry.datatype_info_dicts:
-                    if not datatype_info_dict.get('display_in_upload') and upload_only:
-                        continue
-                    rval.append(datatype_info_dict)
-                return rval
+            return self._index(trans, **kwd)
         except Exception as e:
             log.exception('Could not get datatypes')
             raise e
+
+    def _index(self, trans, **kwd):
+        datatypes_registry = self._datatypes_registry
+        extension_only = asbool(kwd.get('extension_only', True))
+        upload_only = asbool(kwd.get('upload_only', True))
+        if extension_only:
+            if upload_only:
+                return datatypes_registry.upload_file_formats
+            else:
+                return [ext for ext in datatypes_registry.datatypes_by_extension]
+        else:
+            rval = []
+            for datatype_info_dict in datatypes_registry.datatype_info_dicts:
+                if not datatype_info_dict.get('display_in_upload') and upload_only:
+                    continue
+                rval.append(datatype_info_dict)
+            return rval
 
     @expose_api_anonymous_and_sessionless
     def mapping(self, trans, **kwd):
@@ -46,29 +49,45 @@ class DatatypesController(BaseAPIController):
         Return a dictionary of class to class mappings.
         '''
         try:
-            ext_to_class_name = dict()
-            classes = []
-            for k, v in self._datatypes_registry.datatypes_by_extension.items():
-                c = v.__class__
-                ext_to_class_name[k] = c.__module__ + "." + c.__name__
-                classes.append(c)
-            class_to_classes = dict()
-
-            def visit_bases(types, cls):
-                for base in cls.__bases__:
-                    if issubclass(base, Data):
-                        types.add(base.__module__ + "." + base.__name__)
-                    visit_bases(types, base)
-            for c in classes:
-                n = c.__module__ + "." + c.__name__
-                types = {n}
-                visit_bases(types, c)
-                class_to_classes[n] = dict((t, True) for t in types)
-            return dict(ext_to_class_name=ext_to_class_name, class_to_classes=class_to_classes)
-
+            return self._mapping()
         except Exception as e:
             log.exception('Could not get datatype mapping')
             raise e
+
+    def _mapping(self):
+        ext_to_class_name = dict()
+        classes = []
+        for k, v in self._datatypes_registry.datatypes_by_extension.items():
+            c = v.__class__
+            ext_to_class_name[k] = c.__module__ + "." + c.__name__
+            classes.append(c)
+        class_to_classes = dict()
+
+        def visit_bases(types, cls):
+            for base in cls.__bases__:
+                if issubclass(base, Data):
+                    types.add(base.__module__ + "." + base.__name__)
+                visit_bases(types, base)
+        for c in classes:
+            n = c.__module__ + "." + c.__name__
+            types = {n}
+            visit_bases(types, c)
+            class_to_classes[n] = dict((t, True) for t in types)
+        return dict(ext_to_class_name=ext_to_class_name, class_to_classes=class_to_classes)
+
+    @expose_api_anonymous_and_sessionless
+    def types_and_mapping(self, trans, **kwd):
+        """
+        GET /api/datatypes/types_and_mapping
+
+        Combine the datatype information from (/api/datatypes) and the
+        mapping information from (/api/datatypes/mapping) into a single
+        response.
+        """
+        return {
+            "datatypes": self._index(trans, **kwd),
+            "datatypes_mapping": self._mapping(),
+        }
 
     @expose_api_anonymous_and_sessionless
     def sniffers(self, trans, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -3,12 +3,8 @@ API operations allowing clients to determine datatype supported by Galaxy.
 """
 import logging
 
-from galaxy import exceptions
 from galaxy.datatypes.data import Data
-from galaxy.util import (
-    asbool,
-    unicodify
-)
+from galaxy.util import asbool
 from galaxy.web import expose_api_anonymous_and_sessionless
 from galaxy.webapps.base.controller import BaseAPIController
 
@@ -41,10 +37,7 @@ class DatatypesController(BaseAPIController):
                 return rval
         except Exception as e:
             log.exception('Could not get datatypes')
-            if not isinstance(e, exceptions.MessageException):
-                raise exceptions.InternalServerError(unicodify(e))
-            else:
-                raise
+            raise e
 
     @expose_api_anonymous_and_sessionless
     def mapping(self, trans, **kwd):
@@ -75,10 +68,7 @@ class DatatypesController(BaseAPIController):
 
         except Exception as e:
             log.exception('Could not get datatype mapping')
-            if not isinstance(e, exceptions.MessageException):
-                raise exceptions.InternalServerError(unicodify(e))
-            else:
-                raise
+            raise e
 
     @expose_api_anonymous_and_sessionless
     def sniffers(self, trans, **kwd):
@@ -95,10 +85,7 @@ class DatatypesController(BaseAPIController):
             return rval
         except Exception as e:
             log.exception('Could not get datatypes')
-            if not isinstance(e, exceptions.MessageException):
-                raise exceptions.InternalServerError(unicodify(e))
-            else:
-                raise
+            raise e
 
     @expose_api_anonymous_and_sessionless
     def converters(self, trans, **kwd):

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -459,7 +459,7 @@ def populate_api_routes(webapp, app):
     webapp.mapper.resource('datatype',
                            'datatypes',
                            path_prefix='/api',
-                           collection={'sniffers': 'GET', 'mapping': 'GET', 'converters': 'GET', 'edam_data': 'GET', 'edam_formats': 'GET'},
+                           collection={'sniffers': 'GET', 'mapping': 'GET', 'converters': 'GET', 'edam_data': 'GET', 'edam_formats': 'GET', 'types_and_mapping': 'GET'},
                            parent_resources=dict(member_name='datatype', collection_name='datatypes'))
     webapp.mapper.resource('search', 'search', path_prefix='/api')
     webapp.mapper.connect('/api/pages/{id}.pdf', action='show_pdf', controller="pages", conditions=dict(method=["GET"]))

--- a/lib/galaxy_test/api/test_datatypes.py
+++ b/lib/galaxy_test/api/test_datatypes.py
@@ -38,6 +38,18 @@ class DatatypesApiTestCase(ApiTestCase):
         mapping_dict = response.json()
         self._assert_has_keys(mapping_dict, "ext_to_class_name", "class_to_classes")
 
+    def test_types_and_mapping(self):
+        response = self._get("datatypes/types_and_mapping")
+        self._assert_status_code_is(response, 200)
+        response_dict = response.json()
+        self._assert_has_keys(response_dict, "datatypes", "datatypes_mapping")
+        mapping_dict = response_dict["datatypes_mapping"]
+        self._assert_has_keys(mapping_dict, "ext_to_class_name", "class_to_classes")
+
+        datatypes = response_dict["datatypes"]
+        for common_type in ["tabular", "fasta"]:
+            assert common_type in datatypes, "%s not in %s" % (common_type, datatypes)
+
     def test_sniffers(self):
         response = self._get("datatypes/sniffers")
         self._assert_status_code_is(response, 200)


### PR DESCRIPTION
For #9809 I need to be able to determine if one short extension is a subtype of another short extension. This logic was duplicated a couple places in the workflow components so I wanted to extract it for reuse and eliminate this duplication. While I was in there I also implemented a new API that lets the client fetch the needed datatype data for the workflow editor in one call instead of two, I also implemented a test case for the extract logic and the new API endpoint (both in the client and in the API tests).
