### PR TITLE
Decouple API and Selenium tests from galaxy-test-driver (and the whole app!)

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1707,6 +1707,15 @@ def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):
                 f.write(chunk)
 
 
+class classproperty(object):
+
+    def __init__(self, f):
+        self.f = f
+
+    def __get__(self, obj, owner):
+        return self.f(owner)
+
+
 def get_executable():
     exe = sys.executable
     if exe.endswith('uwsgi'):

--- a/lib/galaxy_test/api/_framework.py
+++ b/lib/galaxy_test/api/_framework.py
@@ -1,5 +1,19 @@
-# TODO: implement a remote-only version of ApiTestCase if galaxy_test.driver isn't
-# available. Most of these tests do not depend on Galaxy internals.
-from galaxy_test.driver.api import ApiTestCase
+from galaxy_test.base.api import UsesApiTestCaseMixin
+from galaxy_test.base.testcase import FunctionalTestCase
+try:
+    from galaxy_test.driver.driver_util import GalaxyTestDriver
+except ImportError:
+    # Galaxy libraries and galaxy test driver not available, just assume we're
+    # targetting a remote Galaxy.
+    GalaxyTestDriver = None
+
+
+class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin):
+    galaxy_driver_class = GalaxyTestDriver
+
+    def setUp(self):
+        super(ApiTestCase, self).setUp()
+        self._setup_interactor()
+
 
 __all__ = ('ApiTestCase', )

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -3,22 +3,21 @@ from contextlib import contextmanager
 
 from six.moves.urllib.parse import urlencode
 
-from galaxy_test.base.api_asserts import (
+from .api_asserts import (
     assert_error_code_is,
     assert_has_keys,
     assert_not_has_keys,
     assert_status_code_is,
     assert_status_code_is_ok,
 )
-from galaxy_test.base.api_util import (
+from .api_util import (
     ADMIN_TEST_USER,
     get_master_api_key,
     get_user_api_key,
     OTHER_USER,
     TEST_USER,
 )
-from galaxy_test.base.interactor import TestCaseGalaxyInteractor as BaseInteractor
-from .testcase import FunctionalTestCase
+from .interactor import TestCaseGalaxyInteractor as BaseInteractor
 
 
 class UsesApiTestCaseMixin(object):
@@ -109,13 +108,6 @@ class UsesApiTestCaseMixin(object):
         return "1234567890123456"
 
     _assert_has_key = _assert_has_keys
-
-
-class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin):
-
-    def setUp(self):
-        super(ApiTestCase, self).setUp()
-        self._setup_interactor()
 
 
 class ApiTestInteractor(BaseInteractor):

--- a/lib/galaxy_test/base/env.py
+++ b/lib/galaxy_test/base/env.py
@@ -1,7 +1,9 @@
 """Base utilities for working Galaxy test environments.
 """
+import fcntl
 import os
 import socket
+import struct
 
 DEFAULT_WEB_HOST = socket.gethostbyname('localhost')
 
@@ -22,3 +24,12 @@ def target_url_parts():
     default_url = "http://%s:%s" % (host, port)
     url = os.environ.get('GALAXY_TEST_EXTERNAL', default_url)
     return host, port, url
+
+
+def get_ip_address(ifname):
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(fcntl.ioctl(
+        s.fileno(),
+        0x8915,  # SIOCGIFADDR
+        struct.pack('256s', ifname[:15].encode('utf-8'))
+    )[20:24])

--- a/lib/galaxy_test/base/testcase.py
+++ b/lib/galaxy_test/base/testcase.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+
+import logging
+import os
+import unittest
+
+from galaxy.tool_util.verify.test_data import TestDataResolver
+from galaxy_test.base.env import setup_keep_outdir, target_url_parts
+
+log = logging.getLogger(__name__)
+
+
+class FunctionalTestCase(unittest.TestCase):
+    """Base class for tests targetting actual Galaxy servers.
+
+    Subclass should override galaxy_driver_class if a Galaxy server
+    needs to be launched to run the test, this base class assumes a
+    server is already running.
+    """
+    galaxy_driver_class = None
+
+    def setUp(self):
+        self.history_id = os.environ.get('GALAXY_TEST_HISTORY_ID', None)
+        self.host, self.port, self.url = target_url_parts()
+        self.test_data_resolver = TestDataResolver()
+        self.keepOutdir = setup_keep_outdir()
+
+    @classmethod
+    def setUpClass(cls):
+        """Configure and start Galaxy for a test."""
+        cls._test_driver = None
+
+        if cls.galaxy_driver_class is not None and not os.environ.get("GALAXY_TEST_ENVIRONMENT_CONFIGURED"):
+            cls._test_driver = cls.galaxy_driver_class()
+            cls._test_driver.setup(config_object=cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Shutdown Galaxy server and cleanup temp directory."""
+        if cls._test_driver:
+            cls._test_driver.tear_down()
+
+    def get_filename(self, filename):
+        # No longer used by tool tests - drop if isn't used else where.
+        return self.test_data_resolver.get_filename(filename)

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -1,6 +1,5 @@
 """Scripts for drivers of Galaxy functional tests."""
 
-import fcntl
 import logging
 import os
 import random
@@ -9,7 +8,6 @@ import shutil
 import signal
 import socket
 import string
-import struct
 import subprocess
 import sys
 import tempfile
@@ -41,7 +39,10 @@ from galaxy.util import asbool, download_to_file, galaxy_directory
 from galaxy.util.properties import load_app_properties
 from galaxy.web import buildapp
 from galaxy_test.base.api_util import get_master_api_key, get_user_api_key
-from galaxy_test.base.env import DEFAULT_WEB_HOST, target_url_parts
+from galaxy_test.base.env import (
+    DEFAULT_WEB_HOST,
+    target_url_parts,
+)
 from galaxy_test.base.instrument import StructuredTestDataPlugin
 from galaxy_test.base.nose_util import run
 from tool_shed.webapp.app import UniverseApplication as ToolshedUniverseApplication
@@ -612,24 +613,6 @@ def build_shed_app(simple_kwargs):
     tool_shed_context = app.model.context
 
     return app
-
-
-class classproperty(object):
-
-    def __init__(self, f):
-        self.f = f
-
-    def __get__(self, obj, owner):
-        return self.f(owner)
-
-
-def get_ip_address(ifname):
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    return socket.inet_ntoa(fcntl.ioctl(
-        s.fileno(),
-        0x8915,  # SIOCGIFADDR
-        struct.pack('256s', ifname[:15].encode('utf-8'))
-    )[20:24])
 
 
 def explicitly_configured_host_and_port(prefix, config_object):

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -11,7 +11,7 @@ import pytest
 
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.util.commands import which
-from .api import UsesApiTestCaseMixin
+from galaxy_test.base.api import UsesApiTestCaseMixin
 from .driver_util import GalaxyTestDriver
 
 NO_APP_MESSAGE = "test_case._app called though no Galaxy has been configured."

--- a/lib/galaxy_test/driver/testcase.py
+++ b/lib/galaxy_test/driver/testcase.py
@@ -1,40 +1,8 @@
-from __future__ import print_function
-
-import logging
-import os
-import unittest
-
-from galaxy.tool_util.verify.test_data import TestDataResolver
-from galaxy_test.base.env import setup_keep_outdir, target_url_parts
+from galaxy_test.base.testcase import FunctionalTestCase
 from .driver_util import GalaxyTestDriver
 
-log = logging.getLogger(__name__)
 
-
-class FunctionalTestCase(unittest.TestCase):
-
-    def setUp(self):
-
-        self.history_id = os.environ.get('GALAXY_TEST_HISTORY_ID', None)
-        self.host, self.port, self.url = target_url_parts()
-        self.test_data_resolver = TestDataResolver()
-        self.keepOutdir = setup_keep_outdir()
-
-    @classmethod
-    def setUpClass(cls):
-        """Configure and start Galaxy for a test."""
-        cls._test_driver = None
-
-        if not os.environ.get("GALAXY_TEST_ENVIRONMENT_CONFIGURED"):
-            cls._test_driver = GalaxyTestDriver()
-            cls._test_driver.setup(config_object=cls)
-
-    @classmethod
-    def tearDownClass(cls):
-        """Shutdown Galaxy server and cleanup temp directory."""
-        if cls._test_driver:
-            cls._test_driver.tear_down()
-
-    def get_filename(self, filename):
-        # No longer used by tool tests - drop if isn't used else where.
-        return self.test_data_resolver.get_filename(filename)
+class DrivenFunctionalTestCase(FunctionalTestCase):
+    """Variant of FunctionalTestCase that can launch Galaxy instances.
+    """
+    galaxy_driver_class = GalaxyTestDriver

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -27,11 +27,15 @@ from galaxy.selenium.navigates_galaxy import (
     NavigatesGalaxy,
     retry_during_transitions
 )
-from galaxy.util import asbool
+from galaxy.util import asbool, classproperty
 from galaxy_test.base import populators
-from galaxy_test.driver.api import UsesApiTestCaseMixin
-from galaxy_test.driver.driver_util import classproperty, DEFAULT_WEB_HOST, get_ip_address
-from galaxy_test.driver.testcase import FunctionalTestCase
+from galaxy_test.base.api import UsesApiTestCaseMixin
+from galaxy_test.base.env import DEFAULT_WEB_HOST, get_ip_address
+from galaxy_test.base.testcase import FunctionalTestCase
+try:
+    from galaxy_test.driver.driver_util import GalaxyTestDriver
+except ImportError:
+    GalaxyTestDriver = None
 
 DEFAULT_TIMEOUT_MULTIPLIER = 1
 DEFAULT_TEST_ERRORS_DIRECTORY = os.path.abspath("database/test_errors")
@@ -398,6 +402,7 @@ class TestWithSeleniumMixin(NavigatesGalaxy, UsesApiTestCaseMixin):
 
 
 class SeleniumTestCase(FunctionalTestCase, TestWithSeleniumMixin):
+    galaxy_driver_class = GalaxyTestDriver
 
     def setUp(self):
         super(SeleniumTestCase, self).setUp()

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -23,7 +23,7 @@ import galaxy.util
 from galaxy.security import idencoding
 from galaxy.util import smart_str, unicodify
 from galaxy_test.base.api_util import get_master_api_key
-from galaxy_test.driver.testcase import FunctionalTestCase
+from galaxy_test.driver.testcase import DrivenFunctionalTestCase
 from tool_shed.util import (
     hg_util,
     hgweb_config,
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
 tc.options['equiv_refresh_interval'] = 0
 
 
-class ShedTwillTestCase(FunctionalTestCase):
+class ShedTwillTestCase(DrivenFunctionalTestCase):
 
     def setUp(self):
         # Security helper

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -12,6 +12,7 @@ import sys
 galaxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir))
 sys.path[1:1] = [os.path.join(galaxy_root, "lib"), os.path.join(galaxy_root, "test")]
 
+from galaxy.util import classproperty
 from galaxy_test.base.api_util import get_master_api_key, get_user_api_key
 from galaxy_test.driver import driver_util
 
@@ -61,7 +62,7 @@ class SeleniumGalaxyTestDriver(driver_util.GalaxyTestDriver):
 
     framework_tool_and_types = True
 
-    @driver_util.classproperty
+    @classproperty
     def default_web_host(cls):
         from galaxy_test.selenium.framework import default_web_host_for_selenium_tests
         return default_web_host_for_selenium_tests()

--- a/test/functional/test_toolbox.py
+++ b/test/functional/test_toolbox.py
@@ -12,7 +12,7 @@ from galaxy.tool_util.verify.interactor import GalaxyInteractorApi, verify_tool
 from galaxy.tools import DataManagerTool
 from galaxy_test.base.env import setup_keep_outdir, target_url_parts
 from galaxy_test.base.instrument import register_job_data
-from galaxy_test.driver.testcase import FunctionalTestCase
+from galaxy_test.driver.testcase import DrivenFunctionalTestCase
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ toolbox = None
 TOOL_TYPES_NO_TEST = (DataManagerTool, )
 
 
-class ToolTestCase(FunctionalTestCase):
+class ToolTestCase(DrivenFunctionalTestCase):
     """Abstract test case that runs tests based on a `galaxy.tools.test.ToolTest`."""
 
     def do_it(self, tool_id=None, tool_version=None, test_index=0, resource_parameters={}):


### PR DESCRIPTION
This is in some ways the ultimate separation of launching and configuring Galaxy instances for tests (galaxy-test-driver) from being able to interact with a running Galaxy for tests (galaxy-test-base). The latter does not require the whole app - just galaxy-tool-util (the old galaxy-lib). Being able to pip install the API and Selenium tests without bringing in the whole app is important to make them usable outside the context of the app - for testing remote, running servers for instance.

If galaxy-test-driver is available the test cases will still spawn a Galaxy instance if needed, but this is not longer required for import or use.
