### PR TITLE
actually `set -e` for non-legacy tools

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -488,12 +488,14 @@ class XmlToolSource(ToolSource):
 
     def parse_strict_shell(self):
         command_el = self._command_el
-        if command_el is not None:
-            return string_as_bool(command_el.get("strict", "False"))
-        elif self.legacy_defaults:
-            return False
+        if self.legacy_defaults:
+            default = "False"
         else:
-            return True
+            default = "True"
+        if command_el is not None:
+            return string_as_bool(command_el.get("strict", default))
+        else:
+            return string_as_bool(default)
 
     def parse_help(self):
         help_elem = self.root.find('help')

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -488,7 +488,7 @@ class XmlToolSource(ToolSource):
 
     def parse_strict_shell(self):
         command_el = self._command_el
-        if self.legacy_defaults:
+        if packaging.version.parse(self.parse_profile()) < packaging.version.parse('20.09'):
             default = "False"
         else:
             default = "True"

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2889,7 +2889,7 @@ Prior to Galaxy release 19.01 the stdio block has only been used for non-legacy 
         </xs:attribute>
         <xs:attribute name="strict" type="xs:boolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">This boolean forces the ``#set -e`` directive on in shell scripts - so that in a multi-part command if any part fails the job exits with a non-zero exit code. This is enabled by default for tools with ``profile>=16.04`` and disabled on legacy tools.</xs:documentation>
+            <xs:documentation xml:lang="en">This boolean forces the ``#set -e`` directive on in shell scripts - so that in a multi-part command if any part fails the job exits with a non-zero exit code. This is enabled by default for tools with ``profile>=20.09`` and disabled on legacy tools.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -57,6 +57,7 @@
   <tool file="metadata_column_names.xml" />
   <tool file="strict_shell.xml" />
   <tool file="strict_shell_default_off.xml" />
+  <tool file="strict_shell_profile.xml" />
   <tool file="detect_errors.xml" />
   <tool file="detect_errors_aggressive.xml" />
   <tool file="qc_stdout.xml" />

--- a/test/functional/tools/strict_shell_profile.xml
+++ b/test/functional/tools/strict_shell_profile.xml
@@ -1,0 +1,23 @@
+<tool id="strict_shell_profile" name="strict_shell_profile" version="1.0.0" profile="16.04">
+    <command detect_errors="exit_code">
+        echo "Hello" > $out_file1
+        ; sh -c "exit $exit_code"
+        ; sh -c "exit 0"
+    </command>
+    <inputs>
+        <param name="exit_code" type="integer" value="0" label="exit code"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test expect_exit_code="0" expect_failure="false">
+            <param name="exit_code" value="0" />
+        </test>
+        <test expect_exit_code="1" expect_failure="true">
+            <param name="exit_code" value="1" />
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/strict_shell_profile.xml
+++ b/test/functional/tools/strict_shell_profile.xml
@@ -1,4 +1,4 @@
-<tool id="strict_shell_profile" name="strict_shell_profile" version="1.0.0" profile="16.04">
+<tool id="strict_shell_profile" name="strict_shell_profile" version="1.0.0" profile="20.09">
     <command detect_errors="exit_code">
         echo "Hello" > $out_file1
         ; sh -c "exit $exit_code"


### PR DESCRIPTION
before the proper default strict mode was only used if the command block was absent