### PR TITLE
[20.05] Fix MetadataFile handing with metadata_strategy: extended

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -174,7 +174,7 @@ def set_metadata_portable():
 
         # Load outputs.
         import_model_store = store.imported_store_for_metadata('metadata/outputs_new', object_store=object_store)
-        export_store = store.DirectoryModelExportStore('metadata/outputs_populated', serialize_dataset_objects=True, for_edit=True)
+        export_store = store.DirectoryModelExportStore('metadata/outputs_populated', serialize_dataset_objects=True, for_edit=True, strip_metadata_files=False)
 
     for output_name, output_dict in outputs.items():
         if extended_metadata_collection:

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -524,8 +524,7 @@ class FileParameter(MetadataParameter):
             return None
         if isinstance(value, galaxy.model.MetadataFile) or isinstance(value, MetadataTempFile):
             return value
-        mf = session.query(galaxy.model.MetadataFile).get(value)
-        return mf
+        return session.query(galaxy.model.MetadataFile).get(value)
 
     def make_copy(self, value, target_context, source_context):
         value = self.wrap(value, object_session(target_context.parent))
@@ -540,7 +539,10 @@ class FileParameter(MetadataParameter):
     @classmethod
     def marshal(cls, value):
         if isinstance(value, galaxy.model.MetadataFile):
-            value = value.id
+            # We want to push value.id to the database, but need to skip this when no session is available,
+            # as in extended_metadata mode, so there we just accept MetadataFile.
+            # We will only serialize MetadataFile in this mode and not push to the database, so this is OK.
+            value = value.id or value
         return value
 
     def from_external_value(self, value, parent, path_rewriter=None):

--- a/test/functional/tools/metadata_bam.xml
+++ b/test/functional/tools/metadata_bam.xml
@@ -1,6 +1,8 @@
 <tool id="metadata_bam" name="metadata BAM" version="1.0.0" profile="16.04">
-  <command><![CDATA[ #assert $input_bam.metadata.bam_index
-echo "${ref_names}" > "${output_of_input_metadata}"]]></command>
+  <command><![CDATA[
+#assert $input_bam.metadata.bam_index
+echo '${ref_names}' > '${output_of_input_metadata}'
+  ]]></command>
   <inputs>
     <param name="input_bam" type="data" format="bam" label="BAM File"/>
     <param name="ref_names" type="select" optional="False" label="Select references you would like to restrict bam to" multiple="True">

--- a/test/functional/tools/metadata_bam.xml
+++ b/test/functional/tools/metadata_bam.xml
@@ -1,5 +1,6 @@
-<tool id="metadata_bam" name="metadata BAM" version="1.0.0">
-  <command>echo "${ref_names}" &gt; "${output_of_input_metadata}"</command>
+<tool id="metadata_bam" name="metadata BAM" version="1.0.0" profile="16.04">
+  <command><![CDATA[ #assert $input_bam.metadata.bam_index
+echo "${ref_names}" > "${output_of_input_metadata}"]]></command>
   <inputs>
     <param name="input_bam" type="data" format="bam" label="BAM File"/>
     <param name="ref_names" type="select" optional="False" label="Select references you would like to restrict bam to" multiple="True">

--- a/test/integration/test_pulsar_embedded_metadata.py
+++ b/test/integration/test_pulsar_embedded_metadata.py
@@ -20,8 +20,9 @@ class EmbeddedMetadataPulsarIntegrationInstance(integration_util.IntegrationInst
         # We set the global metadata_strategy to `extended, but`metadata_strategy is
         # being overridden in embedded_pulsar_metadata_job_conf.yml, since extended_metadata does not yet work on pulsar
         config['metadata_strategy'] = 'extended'
+        config['retry_metadata_internally'] = False
 
 
 instance = integration_util.integration_module_instance(EmbeddedMetadataPulsarIntegrationInstance)
 
-test_tools = integration_util.integration_tool_runner(["simple_constructs"])
+test_tools = integration_util.integration_tool_runner(["simple_constructs", "metadata_bam"])


### PR DESCRIPTION
We used to skip the import of MetadaFile objects, despite them being generated and pushed to the
object store, this is fixed by adding `strip_metadata_files=False`. And we need to allow MetadataFile as a marshalled value
when there is no associated ID yet.

Includes a test case that fails when reverting the first commit, with the same traceback as in https://github.com/galaxyproject/galaxy/issues/9968#issue-653176276

```
0f8 HTTP/1.1" 200 None
INFO     galaxy.jobs.runners.pulsar:pulsar.py:1012 input_metadata_rewrite is /private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmptmaihrfu/tmp34xwtbm6/tmp4w4wz7zt/database/pulsar_staging/4/inputs/metadata_None from None
DEBUG    pulsar.client.client:client.py:595 Copying path [/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmptmaihrfu/tmp34xwtbm6/tmp4w4wz7zt/database/objects/2/7/9/dataset_279e9130-5f2e-473b-9305-480166228e44.dat] to [/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmptmaihrfu/tmp34xwtbm6/tmp4w4wz7zt/database/pulsar_staging/4/inputs/dataset_279e9130-5f2e-473b-9305-480166228e44.dat]
WARNING  pulsar.client.staging.up:up.py:517 __action_for_transfer called on non-existent file - [None]
DEBUG    galaxy.tools.error_reports:__init__.py:73 Bug report plugin <galaxy.tools.error_reports.plugins.sentry.SentryPlugin object at 0x129422f70> generated response None
ERROR    galaxy.jobs.runners.pulsar:pulsar.py:398 failure running job 4
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/jobs/runners/pulsar.py", line 390, in queue_job
    job_id = pulsar_submit_job(client, client_job_description, remote_job_config)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/pulsar/client/staging/up.py", line 27, in submit_job
    file_stager = FileStager(client, client_job_description, job_config)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/pulsar/client/staging/up.py", line 123, in __init__
    self.__upload_input_files()
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/pulsar/client/staging/up.py", line 236, in __upload_input_files
    self.__upload_input_metadata_file(client_input.action_source)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/pulsar/client/staging/up.py", line 255, in __upload_input_metadata_file
    self.transfer_tracker.handle_transfer_source(input_action_source, path_type.INPUT, name=remote_name)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/pulsar/client/staging/up.py", line 462, in handle_transfer_source
    action = self.__action_for_transfer(source, type, contents)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/pulsar/client/staging/up.py", line 518, in __action_for_transfer
    raise Exception(message)
Exception: __action_for_transfer called on non-existent file - [None]
```