### PR TITLE
Revise workflow invocation status page

### DIFF
--- a/client/galaxy/scripts/components/JobStates/mixin.js
+++ b/client/galaxy/scripts/components/JobStates/mixin.js
@@ -26,17 +26,8 @@ export default {
         errorCount() {
             return this.countStates(["error"]);
         },
-        runningPercent() {
-            return this.runningCount / (this.jobCount * 1.0);
-        },
-        okPercent() {
-            return this.okCount / (this.jobCount * 1.0);
-        },
-        errorPercent() {
-            return this.errorCount / (this.jobCount * 1.0);
-        },
-        otherPercent() {
-            return 1.0 - this.okPercent - this.runningPercent - this.errorPercent;
+        newCount() {
+            return this.jobCount - this.okCount - this.runningCount - this.errorCount;
         },
     },
     methods: {

--- a/client/galaxy/scripts/components/ProgressBar.vue
+++ b/client/galaxy/scripts/components/ProgressBar.vue
@@ -3,12 +3,12 @@
         <span class="note" v-if="note">
             {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
         </span>
-        <b-progress>
-            <b-progress-bar variant="secondary" :value="infoProgress * 100" :label="infoMessage"/>
-            <b-progress-bar variant="info" :value="runningProgress * 100" :label="runningMessage"/>
-            <b-progress-bar variant="success" :value="okProgress * 100" :label="okMessage"/>
-            <b-progress-bar variant="warning" :value="newProgress * 100" :label="newMessage"/>
-            <b-progress-bar variant="danger" :value="errorProgress * 100" :label="errorMessage"/>
+        <b-progress :max="total">
+            <b-progress-bar variant="warning" :value="infoCount" show-value/>
+            <b-progress-bar variant="warning" :value="runningCount" show-value/>
+            <b-progress-bar variant="success" :value="okCount" show-value/>
+            <b-progress-bar variant="warning" :value="newCount" show-value/>
+            <b-progress-bar variant="danger" :value="errorCount" show-value/>
         </b-progress>
     </div>
 </template>
@@ -16,18 +16,14 @@
 // Not really a very generic ProgressBar - consider renaming to StateProgressBar.
 export default {
     props: {
+        total: { type: Number, default: 1 },
         note: { type: String, default: null },
         loading: { type: Boolean, default: false },
-        infoProgress: { type: Number, default: 0.0 },
-        infoMessage: { type: String, default: null },
-        okProgress: { type: Number, default: 0.0 },
-        okMessage: { type: String, default: null },
-        runningProgress: { type: Number, default: 0.0 },
-        runningMessage: { type: String, default: null },
-        newProgress: { type: Number, default: 0.0 },
-        newMessage: { type: String, default: null },
-        errorProgress: { type: Number, default: 0.0 },
-        errorMessage: { type: String, default: null },
+        infoCount: { type: Number, default: 0 },
+        okCount: { type: Number, default: 0 },
+        runningCount: { type: Number, default: 0 },
+        newCount: { type: Number, default: 0 },
+        errorCount: { type: Number, default: 0 },
     }
 };
 </script>

--- a/client/galaxy/scripts/components/ProgressBar.vue
+++ b/client/galaxy/scripts/components/ProgressBar.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <span class="note" v-if="note">
+        <small class="note" v-if="note">
             {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
-        </span>
+        </small>
         <b-progress :max="total">
             <b-progress-bar variant="warning" :value="infoCount" show-value />
             <b-progress-bar variant="warning" :value="runningCount" show-value />

--- a/client/galaxy/scripts/components/ProgressBar.vue
+++ b/client/galaxy/scripts/components/ProgressBar.vue
@@ -1,14 +1,13 @@
 <template>
-    <div>
-        <small class="note" v-if="note">
-            {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
-        </small>
+    <div class="my-1">
         <b-progress :max="total">
-            <b-progress-bar variant="warning" :value="infoCount" show-value />
-            <b-progress-bar variant="warning" :value="runningCount" show-value />
-            <b-progress-bar variant="success" :value="okCount" show-value />
-            <b-progress-bar variant="warning" :value="newCount" show-value />
-            <b-progress-bar variant="danger" :value="errorCount" show-value />
+            <span class="position-absolute text-center w-100 mt-2" v-if="note">
+                {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
+            </span>
+            <b-progress-bar variant="success" :value="okCount" />
+            <b-progress-bar variant="danger" :value="errorCount" />
+            <b-progress-bar variant="warning" :value="runningCount" />
+            <b-progress-bar variant="warning" :value="newCount" />
         </b-progress>
     </div>
 </template>
@@ -27,10 +26,6 @@ export default {
         loading: {
             type: Boolean,
             default: false,
-        },
-        infoCount: {
-            type: Number,
-            default: 0,
         },
         okCount: {
             type: Number,

--- a/client/galaxy/scripts/components/ProgressBar.vue
+++ b/client/galaxy/scripts/components/ProgressBar.vue
@@ -1,13 +1,15 @@
 <template>
-    <div class="progress state-progress">
+    <div>
         <span class="note" v-if="note">
-            {{ note }}<span v-if="loading">.<span class="blinking">..</span> </span>
+            {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
         </span>
-        <div class="progress-bar info" :style="styleFromProgress(infoProgress)" :title="infoMessage"></div>
-        <div class="progress-bar ok" :style="styleFromProgress(okProgress)" :title="okMessage"></div>
-        <div class="progress-bar running" :style="styleFromProgress(runningProgress)" :title="runningMessage"></div>
-        <div class="progress-bar new" :style="styleFromProgress(newProgress)" :title="newMessage"></div>
-        <div class="progress-bar error" :style="styleFromProgress(errorProgress)" :title="errorMessage"></div>
+        <b-progress>
+            <b-progress-bar variant="secondary" :value="infoProgress * 100" :label="infoMessage"/>
+            <b-progress-bar variant="info" :value="runningProgress * 100" :label="runningMessage"/>
+            <b-progress-bar variant="success" :value="okProgress * 100" :label="okMessage"/>
+            <b-progress-bar variant="warning" :value="newProgress * 100" :label="newMessage"/>
+            <b-progress-bar variant="danger" :value="errorProgress * 100" :label="errorMessage"/>
+        </b-progress>
     </div>
 </template>
 <script>
@@ -26,11 +28,6 @@ export default {
         newMessage: { type: String, default: null },
         errorProgress: { type: Number, default: 0.0 },
         errorMessage: { type: String, default: null },
-    },
-    methods: {
-        styleFromProgress: function (progress) {
-            return { width: `${progress * 100}%` };
-        },
-    },
+    }
 };
 </script>

--- a/client/galaxy/scripts/components/ProgressBar.vue
+++ b/client/galaxy/scripts/components/ProgressBar.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="my-1">
+        <small class="position-absolute text-center w-100" v-if="note">
+            {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
+        </small>
         <b-progress :max="total">
-            <span class="position-absolute text-center w-100 mt-2" v-if="note">
-                {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
-            </span>
             <b-progress-bar variant="success" :value="okCount" />
             <b-progress-bar variant="danger" :value="errorCount" />
             <b-progress-bar variant="warning" :value="runningCount" />

--- a/client/galaxy/scripts/components/ProgressBar.vue
+++ b/client/galaxy/scripts/components/ProgressBar.vue
@@ -4,11 +4,11 @@
             {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
         </span>
         <b-progress :max="total">
-            <b-progress-bar variant="warning" :value="infoCount" show-value/>
-            <b-progress-bar variant="warning" :value="runningCount" show-value/>
-            <b-progress-bar variant="success" :value="okCount" show-value/>
-            <b-progress-bar variant="warning" :value="newCount" show-value/>
-            <b-progress-bar variant="danger" :value="errorCount" show-value/>
+            <b-progress-bar variant="warning" :value="infoCount" show-value />
+            <b-progress-bar variant="warning" :value="runningCount" show-value />
+            <b-progress-bar variant="success" :value="okCount" show-value />
+            <b-progress-bar variant="warning" :value="newCount" show-value />
+            <b-progress-bar variant="danger" :value="errorCount" show-value />
         </b-progress>
     </div>
 </template>
@@ -16,14 +16,38 @@
 // Not really a very generic ProgressBar - consider renaming to StateProgressBar.
 export default {
     props: {
-        total: { type: Number, default: 1 },
-        note: { type: String, default: null },
-        loading: { type: Boolean, default: false },
-        infoCount: { type: Number, default: 0 },
-        okCount: { type: Number, default: 0 },
-        runningCount: { type: Number, default: 0 },
-        newCount: { type: Number, default: 0 },
-        errorCount: { type: Number, default: 0 },
-    }
+        total: {
+            type: Number,
+            default: 1,
+        },
+        note: {
+            type: String,
+            default: null,
+        },
+        loading: {
+            type: Boolean,
+            default: false,
+        },
+        infoCount: {
+            type: Number,
+            default: 0,
+        },
+        okCount: {
+            type: Number,
+            default: 0,
+        },
+        runningCount: {
+            type: Number,
+            default: 0,
+        },
+        newCount: {
+            type: Number,
+            default: 0,
+        },
+        errorCount: {
+            type: Number,
+            default: 0,
+        },
+    },
 };
 </script>

--- a/client/galaxy/scripts/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/galaxy/scripts/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -19,11 +19,11 @@
             </p>
         </div>
         <workflow-invocation-state
-            v-for="invocation in invocations"
+            v-for="(invocation, index) in invocations"
             :key="invocation.id"
+            :index="index"
             :invocation-id="invocation.id"
-        >
-        </workflow-invocation-state>
+        />
         <div id="webhook-view"></div>
     </div>
 </template>

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -1,60 +1,57 @@
 <template>
     <div>
-        <div :class="{ 'context-wrapped': provideContext }">
-            <div>
-                Step Scheduling
-                <span
-                    v-if="stepCount && !invocationSchedulingTerminal"
-                    v-b-tooltip.hover
-                    title="Cancel scheduling of workflow invocation"
-                    class="fa fa-times"
-                    @click="cancelWorkflowScheduling"
-                ></span>
-                <div v-if="!stepCount">
-                    <progress-bar
-                        note="Loading step state summary" :loading="true" :info-count="1" />
-                </div>
-                <div v-else-if="invocationState == 'cancelled'">
-                    <progress-bar
-                        note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
-                        :error-count="1"
-                    />
-                </div>
-                <div v-else-if="invocationState == 'failed'">
-                    <progress-bar
-                        note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
-                        :error-count="1"
-                    />
-                </div>
-                <div v-else>
-                    <progress-bar
-                        :note="stepStatesStr"
-                        :total="stepCount"
-                        :ok-count="stepStates.scheduled"
-                        :new-count="stepCount - stepStates.scheduled"
-                    />
-                </div>
+        <div>
+            <b>Step Scheduling</b>
+            <span
+                v-if="stepCount && !invocationSchedulingTerminal"
+                v-b-tooltip.hover
+                title="Cancel scheduling of workflow invocation"
+                class="fa fa-times"
+                @click="cancelWorkflowScheduling"
+            ></span>
+            <div v-if="!stepCount">
+                <progress-bar note="Loading step state summary" :loading="true" :info-count="1" />
             </div>
-            <div>
-                <div v-if="jobCount">
-                    <progress-bar
-                        :note="jobStatesStr"
-                        :total="jobCount"
-                        :ok-count="okCount"
-                        :running-count="runningCount"
-                        :new-count="newCount"
-                        :error-count="errorCount"
-                    />
-                </div>
-                <div v-else>
-                    <progress-bar note="Loading job summary" :loading="true" :info-count="1" />
-                </div>
+            <div v-else-if="invocationState == 'cancelled'">
+                <progress-bar
+                    note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
+                    :error-count="1"
+                />
             </div>
-            <span v-if="invocationSchedulingTerminal && jobStatesTerminal">
-                <a :href="invocationLink">View Invocation Report</a>
-                <a class="fa fa-print" :href="invocationPdfLink"></a>
-            </span>
+            <div v-else-if="invocationState == 'failed'">
+                <progress-bar
+                    note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
+                    :error-count="1"
+                />
+            </div>
+            <div v-else>
+                <progress-bar
+                    :note="stepStatesStr"
+                    :total="stepCount"
+                    :ok-count="stepStates.scheduled"
+                    :new-count="stepCount - stepStates.scheduled"
+                />
+            </div>
         </div>
+        <div>
+            <div v-if="jobCount">
+                <progress-bar
+                    :note="jobStatesStr"
+                    :total="jobCount"
+                    :ok-count="okCount"
+                    :running-count="runningCount"
+                    :new-count="newCount"
+                    :error-count="errorCount"
+                />
+            </div>
+            <div v-else>
+                <progress-bar note="Loading job summary" :loading="true" :info-count="1" />
+            </div>
+        </div>
+        <span v-if="invocationSchedulingTerminal && jobStatesTerminal">
+            <a :href="invocationLink">View Invocation Report</a>
+            <a class="fa fa-print" :href="invocationPdfLink"></a>
+        </span>
     </div>
 </template>
 <script>
@@ -82,10 +79,6 @@ export default {
         invocationId: {
             type: String,
             required: true,
-        },
-        provideContext: {
-            type: Boolean,
-            default: true,
         },
     },
     data() {
@@ -149,7 +142,7 @@ export default {
             return this.jobStatesSummary && this.jobStatesSummary.terminal();
         },
         stepStatesStr: function () {
-            return `${this.stepStates["scheduled"] || 0} of ${this.stepCount} steps successfully scheduled`;
+            return `${this.stepStates.scheduled || 0} of ${this.stepCount} steps successfully scheduled`;
         },
         jobStatesStr: function () {
             let jobStr = `${this.jobStatesSummary.states()["ok"] || 0} of ${this.jobCount} jobs complete`;
@@ -192,9 +185,3 @@ export default {
     },
 };
 </script>
-<style scoped>
-.context-wrapped {
-    border-left: 1px solid black;
-    padding-left: 10px;
-}
-</style>

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -2,7 +2,6 @@
     <div>
         <span v-if="provideContext">
             <b>Workflow Invocation State</b>
-            <span v-if="createdTime"> (invoked at {{ createdTime }})</span>
         </span>
         <div :class="{ 'context-wrapped': provideContext }">
             <div>
@@ -67,7 +66,6 @@ import BootstrapVue from "bootstrap-vue";
 import Vue from "vue";
 
 import { cancelWorkflowScheduling } from "./services";
-
 import { getRootFromIndexLink } from "onload";
 import JOB_STATES_MODEL from "mvc/history/job-states-model";
 import mixin from "components/JobStates/mixin";

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -20,7 +20,7 @@
                 class="fa fa-times"
                 @click="cancelWorkflowScheduling"
             ></span>
-            <progress-bar v-if="!stepCount" note="Loading step state summary" :loading="true" :info-count="1" />
+            <progress-bar v-if="!stepCount" note="Loading step state summary" :loading="true" />
             <progress-bar
                 v-else-if="invocationState == 'cancelled'"
                 note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
@@ -36,7 +36,6 @@
                 :note="stepStatesStr"
                 :total="stepCount"
                 :ok-count="stepStates.scheduled"
-                :new-count="stepCount - stepStates.scheduled"
             />
         </div>
         <div>
@@ -49,7 +48,7 @@
                 :new-count="newCount"
                 :error-count="errorCount"
             />
-            <progress-bar v-else note="Loading job summary" :loading="true" :info-count="1" />
+            <progress-bar v-else note="Loading job summary" :loading="true" />
         </div>
     </div>
 </template>

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
-        <div>
-            <b>Step Scheduling</b>
+        <div class="mt-2">
+            <b>Invocation</b>
             <span
                 v-if="stepCount && !invocationSchedulingTerminal"
                 v-b-tooltip.hover
@@ -9,49 +9,49 @@
                 class="fa fa-times"
                 @click="cancelWorkflowScheduling"
             ></span>
-            <div v-if="!stepCount">
-                <progress-bar note="Loading step state summary" :loading="true" :info-count="1" />
-            </div>
-            <div v-else-if="invocationState == 'cancelled'">
-                <progress-bar
-                    note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
-                    :error-count="1"
-                />
-            </div>
-            <div v-else-if="invocationState == 'failed'">
-                <progress-bar
-                    note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
-                    :error-count="1"
-                />
-            </div>
-            <div v-else>
-                <progress-bar
-                    :note="stepStatesStr"
-                    :total="stepCount"
-                    :ok-count="stepStates.scheduled"
-                    :new-count="stepCount - stepStates.scheduled"
-                />
-            </div>
+            <progress-bar v-if="!stepCount" note="Loading step state summary" :loading="true" :info-count="1" />
+            <progress-bar
+                v-else-if="invocationState == 'cancelled'"
+                note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
+                :error-count="1"
+            />
+            <progress-bar
+                v-else-if="invocationState == 'failed'"
+                note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
+                :error-count="1"
+            />
+            <progress-bar
+                v-else
+                :note="stepStatesStr"
+                :total="stepCount"
+                :ok-count="stepStates.scheduled"
+                :new-count="stepCount - stepStates.scheduled"
+            />
         </div>
         <div>
-            <div v-if="jobCount">
-                <progress-bar
-                    :note="jobStatesStr"
-                    :total="jobCount"
-                    :ok-count="okCount"
-                    :running-count="runningCount"
-                    :new-count="newCount"
-                    :error-count="errorCount"
-                />
+            <progress-bar
+                v-if="jobCount"
+                :note="jobStatesStr"
+                :total="jobCount"
+                :ok-count="okCount"
+                :running-count="runningCount"
+                :new-count="newCount"
+                :error-count="errorCount"
+            />
+            <progress-bar v-else note="Loading job summary" :loading="true" :info-count="1" />
+        </div>
+        <div class="mt-1">
+            <div v-if="invocationSchedulingTerminal && jobStatesTerminal">
+                <a :href="invocationLink">
+                    <a class="fa fa-print mr-1" :href="invocationPdfLink"/>
+                    <span>View Report</span>
+                </a>
             </div>
             <div v-else>
-                <progress-bar note="Loading job summary" :loading="true" :info-count="1" />
+                <span class="fa fa-spinner fa-spin" />
+                <span>Processing...</span>
             </div>
         </div>
-        <span v-if="invocationSchedulingTerminal && jobStatesTerminal">
-            <a :href="invocationLink">View Invocation Report</a>
-            <a class="fa fa-print" :href="invocationPdfLink"></a>
-        </span>
     </div>
 </template>
 <script>

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -1,7 +1,18 @@
 <template>
     <div>
         <div class="mt-2">
-            <b>Invocation</b>
+            <div class="mt-1">
+                <div v-if="invocationSchedulingTerminal && jobStatesTerminal">
+                    <a :href="invocationLink">
+                        <a class="fa fa-print mr-1" :href="invocationPdfLink"/>
+                        <span>View Report</span>
+                    </a>
+                </div>
+                <div v-else>
+                    <span class="fa fa-spinner fa-spin" />
+                    <span>Invocation...</span>
+                </div>
+            </div>
             <span
                 v-if="stepCount && !invocationSchedulingTerminal"
                 v-b-tooltip.hover
@@ -39,18 +50,6 @@
                 :error-count="errorCount"
             />
             <progress-bar v-else note="Loading job summary" :loading="true" :info-count="1" />
-        </div>
-        <div class="mt-1">
-            <div v-if="invocationSchedulingTerminal && jobStatesTerminal">
-                <a :href="invocationLink">
-                    <a class="fa fa-print mr-1" :href="invocationPdfLink"/>
-                    <span>View Report</span>
-                </a>
-            </div>
-            <div v-else>
-                <span class="fa fa-spinner fa-spin" />
-                <span>Processing...</span>
-            </div>
         </div>
     </div>
 </template>

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -1,55 +1,46 @@
 <template>
-    <div>
-        <div class="mt-2">
-            <div class="mt-1">
-                <div v-if="invocationSchedulingTerminal && jobStatesTerminal">
-                    <a :href="invocationLink">
-                        <a class="fa fa-print mr-1" :href="invocationPdfLink"/>
-                        <span>View Report</span>
-                    </a>
-                </div>
-                <div v-else>
-                    <span class="fa fa-spinner fa-spin" />
-                    <span>Invocation...</span>
-                </div>
-            </div>
-            <span
-                v-if="stepCount && !invocationSchedulingTerminal"
-                v-b-tooltip.hover
-                title="Cancel scheduling of workflow invocation"
-                class="fa fa-times"
-                @click="cancelWorkflowScheduling"
-            ></span>
-            <progress-bar v-if="!stepCount" note="Loading step state summary" :loading="true" />
-            <progress-bar
-                v-else-if="invocationState == 'cancelled'"
-                note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
-                :error-count="1"
-            />
-            <progress-bar
-                v-else-if="invocationState == 'failed'"
-                note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
-                :error-count="1"
-            />
-            <progress-bar
-                v-else
-                :note="stepStatesStr"
-                :total="stepCount"
-                :ok-count="stepStates.scheduled"
-            />
+    <div class="mb-3">
+        <div v-if="invocationSchedulingTerminal && jobStatesTerminal">
+            <span>
+                <a :href="invocationLink"
+                    ><b>View Report {{ index + 1 }}</b></a
+                >
+                <a class="fa fa-print ml-1" :href="invocationPdfLink" v-b-tooltip title="Download PDF" />
+            </span>
         </div>
-        <div>
-            <progress-bar
-                v-if="jobCount"
-                :note="jobStatesStr"
-                :total="jobCount"
-                :ok-count="okCount"
-                :running-count="runningCount"
-                :new-count="newCount"
-                :error-count="errorCount"
-            />
-            <progress-bar v-else note="Loading job summary" :loading="true" />
+        <div v-else>
+            <span class="fa fa-spinner fa-spin" />
+            <span>Invocation {{ index + 1 }}...</span>
         </div>
+        <span
+            v-if="stepCount && !invocationSchedulingTerminal"
+            v-b-tooltip.hover
+            title="Cancel scheduling of workflow invocation"
+            class="fa fa-times"
+            @click="cancelWorkflowScheduling"
+        ></span>
+        <progress-bar v-if="!stepCount" note="Loading step state summary" :loading="true" />
+        <progress-bar
+            v-else-if="invocationState == 'cancelled'"
+            note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
+            :error-count="1"
+        />
+        <progress-bar
+            v-else-if="invocationState == 'failed'"
+            note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
+            :error-count="1"
+        />
+        <progress-bar v-else :note="stepStatesStr" :total="stepCount" :ok-count="stepStates.scheduled" />
+        <progress-bar
+            v-if="jobCount"
+            :note="jobStatesStr"
+            :total="jobCount"
+            :ok-count="okCount"
+            :running-count="runningCount"
+            :new-count="newCount"
+            :error-count="errorCount"
+        />
+        <progress-bar v-else note="Loading job summary" :loading="true" />
     </div>
 </template>
 <script>
@@ -77,6 +68,10 @@ export default {
         invocationId: {
             type: String,
             required: true,
+        },
+        index: {
+            type: Number,
+            default: 0,
         },
     },
     data() {

--- a/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/galaxy/scripts/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -11,23 +11,23 @@
         <div v-else>
             <span class="fa fa-spinner fa-spin" />
             <span>Invocation {{ index + 1 }}...</span>
+            <span
+                v-if="stepCount && !invocationSchedulingTerminal"
+                v-b-tooltip.hover
+                title="Cancel scheduling of workflow invocation"
+                class="fa fa-times"
+                @click="cancelWorkflowScheduling"
+            ></span>
         </div>
-        <span
-            v-if="stepCount && !invocationSchedulingTerminal"
-            v-b-tooltip.hover
-            title="Cancel scheduling of workflow invocation"
-            class="fa fa-times"
-            @click="cancelWorkflowScheduling"
-        ></span>
-        <progress-bar v-if="!stepCount" note="Loading step state summary" :loading="true" />
+        <progress-bar v-if="!stepCount" note="Loading step state summary..." :loading="true" />
         <progress-bar
             v-else-if="invocationState == 'cancelled'"
-            note="Invocation scheduling cancelled - expected jobs and outputs may not be generated"
+            note="Invocation scheduling cancelled - expected jobs and outputs may not be generated."
             :error-count="1"
         />
         <progress-bar
             v-else-if="invocationState == 'failed'"
-            note="Invocation scheduling failed - Galaxy administrator may have additional details in logs"
+            note="Invocation scheduling failed - Galaxy administrator may have additional details in logs."
             :error-count="1"
         />
         <progress-bar v-else :note="stepStatesStr" :total="stepCount" :ok-count="stepStates.scheduled" />
@@ -40,7 +40,7 @@
             :new-count="newCount"
             :error-count="errorCount"
         />
-        <progress-bar v-else note="Loading job summary" :loading="true" />
+        <progress-bar v-else note="Loading job summary..." :loading="true" />
     </div>
 </template>
 <script>
@@ -135,14 +135,14 @@ export default {
             return this.jobStatesSummary && this.jobStatesSummary.terminal();
         },
         stepStatesStr: function () {
-            return `${this.stepStates.scheduled || 0} of ${this.stepCount} steps successfully scheduled`;
+            return `${this.stepStates.scheduled || 0} of ${this.stepCount} steps successfully scheduled.`;
         },
         jobStatesStr: function () {
             let jobStr = `${this.jobStatesSummary.states()["ok"] || 0} of ${this.jobCount} jobs complete`;
             if (!this.invocationSchedulingTerminal) {
                 jobStr += " (total number of jobs will change until all steps fully scheduled)";
             }
-            return jobStr;
+            return `${jobStr}.`;
         },
         jobStatesSummary() {
             const jobsSummary = this.getInvocationJobsSummaryById(this.invocationId);

--- a/client/galaxy/scripts/layout/page.js
+++ b/client/galaxy/scripts/layout/page.js
@@ -114,10 +114,13 @@ const View = Backbone.View.extend({
         if (this.config.message_box_visible) {
             const content = this.config.message_box_content || "";
             const level = this.config.message_box_class || "info";
-            this.$el.addClass("has-message-box");
-            this.$messagebox.attr("class", `panel-${level}-message`).html(content).toggle(!!content).show();
+            this.$messagebox
+                .attr("class", `alert alert-${level} rounded-0 m-0 p-2`)
+                .append($("<div/>").attr("class", "fa fa-fw mr-1 fa-exclamation"))
+                .append(content)
+                .toggle(!!content)
+                .show();
         } else {
-            this.$el.removeClass("has-message-box");
             this.$messagebox.hide();
         }
         return this;
@@ -128,12 +131,16 @@ const View = Backbone.View.extend({
         if (this.config.show_inactivity_warning) {
             const content = this.config.inactivity_box_content || "";
             const verificationLink = $("<a/>")
+                .attr("class", "ml-1")
                 .attr("href", `${getAppRoot()}user/resend_verification`)
                 .text("Resend verification");
-            this.$el.addClass("has-inactivity-box");
-            this.$inactivebox.html(`${content} `).append(verificationLink).toggle(!!content).show();
+            this.$inactivebox
+                .append($("<div/>").attr("class", "fa fa-fw mr-1 fa-exclamation-triangle"))
+                .append(content)
+                .append(verificationLink)
+                .toggle(!!content)
+                .show();
         } else {
-            this.$el.removeClass("has-inactivity-box");
             this.$inactivebox.hide();
         }
         return this;
@@ -159,8 +166,8 @@ const View = Backbone.View.extend({
             `<div id="everything">
                 <div id="background"/>
                 <div id="masthead"/>
-                <div id="messagebox" class="full-message"/>
-                <div id="inactivebox" class="full-message panel-warning-message" />
+                <small id="messagebox"/>
+                <small id="inactivebox" class="alert rounded-0 m-0 p-2 alert-warning" />
                 <div id="columns">
                     <div id="left" class="unified-panel"/>
                     <div id="center" />

--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -316,43 +316,7 @@ body {
     }
 }
 
-// Messages for message box, slightly different style
-
-.panel-error-message,
-.panel-warning-message,
-.panel-done-message,
-.panel-info-message {
-    height: $panel-message-height;
-    line-height: $panel-message-height;
-    padding: 0px;
-    padding-left: 2.5rem;
-    background-color: $state-danger-bg;
-    background-image: url(../../images/error_small.png);
-    background-repeat: no-repeat;
-    background-position: 0.5rem 50%;
-}
-
-.panel-warning-message {
-    background-image: url(../../images/warn_small.png);
-    background-color: $state-warning-bg;
-}
-
-.panel-done-message {
-    background-image: url(../../images/ok_small.png);
-    background-color: $state-success-bg;
-}
-
-.panel-info-message {
-    background-image: url(../../images/info_icon.svg);
-    background-size: 1.5rem;
-    background-color: $state-info-bg;
-    svg:path {
-        fill: black;
-    }
-}
-
 // ==== Masthead ====
-
 #masthead {
     @extend .p-0;
     @extend .mb-0;
@@ -961,34 +925,7 @@ ul.manage-table-actions li {
     margin-left: 0.5em;
 }
 
-.state-progress {
-    @extend .position-relative;
-    @extend .m-1;
-    border: $border-default;
-    .info {
-        color: $text-color;
-        background: $body-bg;
-    }
-    .new {
-        background: $state-default-bg;
-    }
-    .running {
-        background: $state-running-bg;
-    }
-    .ok {
-        background: $state-success-bg;
-    }
-    .error {
-        background: $state-danger-bg;
-    }
-    .note {
-        @extend .position-absolute;
-        @extend .ml-2;
-    }
-}
-
 // State colors
-
 .state-color-new {
     border-color: $state-default-border;
     background: $state-default-bg;

--- a/client/galaxy/style/scss/overrides.scss
+++ b/client/galaxy/style/scss/overrides.scss
@@ -147,3 +147,14 @@ pre.code {
     padding: 0.5rem 1.5rem 0.5rem 1rem;
     font-weight: bold;
 }
+
+// progress bar
+.progress-bar.bg-success {
+    background: $state-success-bg !important;
+}
+.progress-bar.bg-danger {
+    background: $state-danger-bg !important;
+}
+.progress-bar.bg-warning {
+    background: $state-warning-bg !important;
+}

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1414,13 +1414,15 @@ class NavigatesGalaxy(HasDriver):
         assert text == expected, "Tooltip text [%s] was not expected text [%s]." % (text, expected)
 
     def assert_error_message(self, contains=None):
-        return self._assert_message("error", contains=contains)
+        element = self.components._.messages["error"]
+        return self.assert_message(element, contains=contains)
 
     def assert_warning_message(self, contains=None):
-        return self._assert_message("warning", contains=contains)
+        element = self.components._.messages["warning"]
+        return self.assert_message(element, contains=contains)
 
-    def _assert_message(self, message_type, contains=None):
-        element = self.components._.messages[message_type].wait_for_visible()
+    def assert_message(self, element, contains=None):
+        element = element.wait_for_visible()
         assert element, "No error message found, one expected."
         if contains is not None:
             text = element.text

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -326,6 +326,7 @@ workflows:
 workflow_run:
 
   selectors:
+    warning: ".ui-form-composite .alert-warning"
     input_div: "[step-label='${label}']"
     input_data_div: "[step-label='${label}'] .select2-container"
     # TODO: put step labels in the DOM ideally
@@ -415,6 +416,7 @@ admin:
       allowlist: '#admin-link-allowlist'
 
   selectors:
+    warning: '#center .alert-warning'
     # TODO: place betters IDS or something on this in these grids in the DOM
     datatypes_grid: '#data-types-grid'
     data_tables_grid: '#data-tables-grid'

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -84,7 +84,7 @@ class AdminAppTestCase(SeleniumTestCase):
         self.screenshot("admin_data_tables")
 
         admin_component.index.display_applications.wait_for_and_click()
-        self.assert_warning_message("No display applications available.")
+        self.assert_message(self.components.admin.warning, "No display applications available.")
         self.screenshot("admin_display_applications")
 
         admin_component.index.jobs.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -153,7 +153,7 @@ steps:
         self.workflow_run_with_name(name)
         self.sleep_for(self.wait_types.UX_TRANSITION)
         # Check that this tool form contains a warning about different versions.
-        self.assert_warning_message(contains="different versions")
+        self.assert_message(self.components.workflow_run.warning, contains="different versions")
         self.screenshot("workflow_run_tool_upgrade")
 
     @selenium_test

--- a/templates/base/base_panels.mako
+++ b/templates/base/base_panels.mako
@@ -174,13 +174,13 @@
             </div>
             
             %if self.message_box_visible:
-                <div id="messagebox" class="panel-${app.config.message_box_class}-message" style="display:block">
+                <div id="messagebox" class="alert alert-${app.config.message_box_class} rounded-0 m-0 p-2">
                     ${app.config.message_box_content}
                 </div>
             %endif
             
             %if self.show_inactivity_warning:
-                <div id="inactivebox" class="panel-warning-message">
+                <div id="inactivebox" class="alert alert-warning rounded-0 m-0 p-2">
                     ${app.config.inactivity_box_content} <a href="${h.url_for( controller='user', action='resend_verification' )}">Resend verification.</a>
                 </div>
             %endif


### PR DESCRIPTION
This PR revises the invocation status page which appears after executing a workflow. It fixes some UI glitches e.g. progress bar animates from left to right now, label overlap has been fixed. The PR replaces the custom use of Bootstrap classes with the corresponding Bootstrap-Vue component. Additionally the PR restructures the appearance of results by removing some unnecessary content and improving the visibility and highlighting of the `Report link`. This PR also removes unused styles and replaces the styles used for the masthead message and warning with regular bootstrap classes. Fixes #9901.

<img width="500" alt="Screen Shot 2020-07-10 at 12 23 57 PM" src="https://user-images.githubusercontent.com/2105447/87176596-52f05d80-c2a8-11ea-9e0c-80ad10ed33f8.png">
