### PR TITLE
Use optimized path of setting dataset size during output discovery

### DIFF
--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -261,22 +261,12 @@ class ModelPersistenceContext(object):
                 name,
                 create_dataset_timer,
             )
-            dataset.set_size(no_extra_files=True)
             element_datasets['element_identifiers'].append(element_identifiers)
             element_datasets['datasets'].append(dataset)
             element_datasets['tag_lists'].append(discovered_file.match.tag_list)
             element_datasets['paths'].append(filename)
 
-        add_datasets_timer = ExecutionTimer()
-        self.add_datasets_to_history(element_datasets['datasets'])
         self.add_tags_to_datasets(datasets=element_datasets['datasets'], tag_lists=element_datasets['tag_lists'])
-        log.debug(
-            "(%s) Add dynamic collection datasets to history for output [%s] %s",
-            self.job_id(),
-            name,
-            add_datasets_timer,
-        )
-
         for (element_identifiers, dataset) in zip(element_datasets['element_identifiers'], element_datasets['datasets']):
             current_builder = root_collection_builder
             for element_identifier in element_identifiers[:-1]:
@@ -290,6 +280,14 @@ class ModelPersistenceContext(object):
 
         self.flush()
         self.update_object_store_with_datasets(datasets=element_datasets['datasets'], paths=element_datasets['paths'])
+        add_datasets_timer = ExecutionTimer()
+        self.add_datasets_to_history(element_datasets['datasets'])
+        log.debug(
+            "(%s) Add dynamic collection datasets to history for output [%s] %s",
+            self.job_id(),
+            name,
+            add_datasets_timer,
+        )
         self.set_datasets_metadata(datasets=element_datasets['datasets'])
 
     def add_tags_to_datasets(self, datasets, tag_lists):
@@ -305,6 +303,7 @@ class ModelPersistenceContext(object):
     def update_object_store_with_datasets(self, datasets, paths):
         for dataset, path in zip(datasets, paths):
             self.object_store.update_from_file(dataset.dataset, file_name=path, create=True)
+            dataset.set_size(no_extra_files=True)
 
     @abc.abstractproperty
     def tag_handler(self):

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -261,6 +261,7 @@ class ModelPersistenceContext(object):
                 name,
                 create_dataset_timer,
             )
+            dataset.set_size(no_extra_files=True)
             element_datasets['element_identifiers'].append(element_identifiers)
             element_datasets['datasets'].append(dataset)
             element_datasets['tag_lists'].append(discovered_file.match.tag_list)
@@ -304,7 +305,6 @@ class ModelPersistenceContext(object):
     def update_object_store_with_datasets(self, datasets, paths):
         for dataset, path in zip(datasets, paths):
             self.object_store.update_from_file(dataset.dataset, file_name=path, create=True)
-            dataset.set_size(no_extra_files=True)
 
     @abc.abstractproperty
     def tag_handler(self):


### PR DESCRIPTION
Lost this optimization by moving update_object_store_with_datasets
after add_datasets_to_history in https://github.com/galaxyproject/galaxy/pull/9926.

Before (collection_creates_dynamic_nested):

```
*** PROFILER RESULTS ***
discover_outputs (/Users/mvandenb/src/galaxy/lib/galaxy/jobs/__init__.py:1755)
function called 1 times

         135669 function calls (133089 primitive calls) in 1.094 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 1329 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    1.095    1.095 __init__.py:1755(discover_outputs)
        1    0.000    0.000    1.095    1.095 __init__.py:1858(discover_outputs)
        1    0.000    0.000    1.082    1.082 output_collect.py:87(collect_dynamic_outputs)
        1    0.000    0.000    1.022    1.022 discover.py:210(populate_collection_elements)
  778/735    0.001    0.000    0.521    0.001 attributes.py:699(get)
      111    0.000    0.000    0.512    0.005 base.py:952(execute)
      111    0.000    0.000    0.511    0.005 elements.py:296(_execute_on_connection)
      111    0.001    0.000    0.511    0.005 base.py:1088(_execute_clauseelement)
      111    0.002    0.000    0.473    0.004 base.py:1195(_execute_context)
        1    0.000    0.000    0.448    0.448 output_collect.py:266(add_datasets_to_history)
        1    0.000    0.000    0.448    0.448 __init__.py:1790(add_datasets)
      608    0.001    0.000    0.448    0.001 attributes.py:279(__get__)
      110    0.000    0.000    0.429    0.004 default.py:589(do_execute)
      110    0.427    0.004    0.429    0.004 {method 'execute' of 'psycopg2.extensions.cursor' objects}
      139    0.001    0.000    0.367    0.003 strategies.py:665(_load_for_state)
       72    0.000    0.000    0.366    0.005 query.py:3501(_execute_and_instances)
        1    0.000    0.000    0.339    0.339 __init__.py:1799(<listcomp>)
        6    0.000    0.000    0.339    0.056 __init__.py:2723(get_total_size)
        9    0.000    0.000    0.321    0.036 session.py:2489(flush)
        9    0.000    0.000    0.321    0.036 session.py:2542(_flush)
      163    0.000    0.000    0.316    0.002 state.py:640(_load_expired)
       37    0.000    0.000    0.315    0.009 loading.py:938(load_scalar_attributes)
       37    0.000    0.000    0.313    0.008 loading.py:190(load_on_ident)
       37    0.000    0.000    0.312    0.008 loading.py:211(load_on_pk_identity)
       37    0.000    0.000    0.312    0.008 query.py:3417(one)
       37    0.001    0.000    0.311    0.008 query.py:3381(one_or_none)
        1    0.000    0.000    0.274    0.274 discover.py:304(update_object_store_with_datasets)
        6    0.000    0.000    0.254    0.042 __init__.py:2430(get_total_size)
       37    0.000    0.000    0.238    0.006 query.py:3476(__iter__)
       54    0.000    0.000    0.223    0.004 __init__.py:269(_invoke)
        9    0.000    0.000    0.220    0.024 unitofwork.py:402(execute)
       35    0.000    0.000    0.211    0.006 <string>:1(<lambda>)
       35    0.001    0.000    0.211    0.006 strategies.py:772(_emit_lazyload)
        6    0.000    0.000    0.186    0.031 __init__.py:293(update_from_file)
        6    0.001    0.000    0.186    0.031 __init__.py:570(_update_from_file)
        1    0.000    0.000    0.175    0.175 discover.py:177(set_datasets_metadata)
       24    0.000    0.000    0.154    0.006 persistence.py:184(save_obj)
       37    0.000    0.000    0.153    0.004 mapper.py:2822(_get_state_attr_by_column)
       35    0.001    0.000    0.144    0.004 baked.py:421(__iter__)
       29    0.000    0.000    0.144    0.005 strategies.py:753(_get_ident_for_use_get)
```
After:
```
*** PROFILER RESULTS ***
discover_outputs (/Users/mvandenb/src/galaxy/lib/galaxy/jobs/__init__.py:1755)
function called 1 times

         97638 function calls (96017 primitive calls) in 0.840 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 1314 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.840    0.840 __init__.py:1755(discover_outputs)
        1    0.000    0.000    0.840    0.840 __init__.py:1858(discover_outputs)
        1    0.000    0.000    0.830    0.830 output_collect.py:87(collect_dynamic_outputs)
        1    0.001    0.001    0.813    0.813 discover.py:210(populate_collection_elements)
  563/526    0.001    0.000    0.328    0.001 attributes.py:699(get)
      578    0.001    0.000    0.324    0.001 attributes.py:279(__get__)
       81    0.000    0.000    0.317    0.004 base.py:952(execute)
       81    0.000    0.000    0.317    0.004 elements.py:296(_execute_on_connection)
       81    0.001    0.000    0.317    0.004 base.py:1088(_execute_clauseelement)
      133    0.000    0.000    0.309    0.002 strategies.py:665(_load_for_state)
       81    0.001    0.000    0.293    0.004 base.py:1195(_execute_context)
        1    0.000    0.000    0.264    0.264 discover.py:305(update_object_store_with_datasets)
       80    0.000    0.000    0.260    0.003 default.py:589(do_execute)
       80    0.259    0.003    0.260    0.003 {method 'execute' of 'psycopg2.extensions.cursor' objects}
       48    0.000    0.000    0.226    0.005 __init__.py:269(_invoke)
       48    0.000    0.000    0.194    0.004 query.py:3501(_execute_and_instances)
       30    0.000    0.000    0.192    0.006 <string>:1(<lambda>)
       30    0.001    0.000    0.192    0.006 strategies.py:772(_emit_lazyload)
        1    0.000    0.000    0.188    0.188 discover.py:177(set_datasets_metadata)
        6    0.000    0.000    0.171    0.029 __init__.py:293(update_from_file)
        6    0.000    0.000    0.171    0.029 __init__.py:570(_update_from_file)
        1    0.000    0.000    0.155    0.155 output_collect.py:266(add_datasets_to_history)
        1    0.000    0.000    0.155    0.155 __init__.py:1790(add_datasets)
        3    0.000    0.000    0.154    0.051 session.py:2489(flush)
        3    0.000    0.000    0.153    0.051 session.py:2542(_flush)
        3    0.000    0.000    0.146    0.049 unitofwork.py:402(execute)
       24    0.000    0.000    0.135    0.006 state.py:640(_load_expired)
       18    0.000    0.000    0.134    0.007 loading.py:938(load_scalar_attributes)
       18    0.000    0.000    0.134    0.007 persistence.py:184(save_obj)
       18    0.000    0.000    0.133    0.007 loading.py:190(load_on_ident)
       18    0.000    0.000    0.133    0.007 loading.py:211(load_on_pk_identity)
       18    0.000    0.000    0.133    0.007 query.py:3417(one)
       18    0.001    0.000    0.133    0.007 query.py:3381(one_or_none)
        6    0.000    0.000    0.132    0.022 __init__.py:2761(set_meta)
       30    0.000    0.000    0.126    0.004 baked.py:421(__iter__)
       66    0.125    0.002    0.125    0.002 {built-in method io.open}
       31    0.000    0.000    0.116    0.004 mapper.py:2822(_get_state_attr_by_column)
       23    0.000    0.000    0.114    0.005 strategies.py:753(_get_ident_for_use_get)
       23    0.000    0.000    0.114    0.005 strategies.py:763(<listcomp>)
       83    0.001    0.000    0.114    0.001 loading.py:35(instances)
```