### PR TITLE
Flush once per mapped over execution

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -91,7 +91,8 @@ class DatasetCollectionManager(object):
 
     def create(self, trans, parent, name, collection_type, element_identifiers=None,
                elements=None, implicit_collection_info=None, trusted_identifiers=None,
-               hide_source_items=False, tags=None, copy_elements=False, history=None):
+               hide_source_items=False, tags=None, copy_elements=False, history=None,
+               set_hid=True, flush=True):
         """
         PRECONDITION: security checks on ability to add to parent
         occurred during load.
@@ -122,10 +123,10 @@ class DatasetCollectionManager(object):
             implicit_output_name = implicit_collection_info["implicit_output_name"]
 
         return self._create_instance_for_collection(
-            trans, parent, name, dataset_collection, implicit_inputs=implicit_inputs, implicit_output_name=implicit_output_name, tags=tags
+            trans, parent, name, dataset_collection, implicit_inputs=implicit_inputs, implicit_output_name=implicit_output_name, tags=tags, set_hid=set_hid, flush=flush,
         )
 
-    def _create_instance_for_collection(self, trans, parent, name, dataset_collection, implicit_output_name=None, implicit_inputs=None, tags=None, flush=True):
+    def _create_instance_for_collection(self, trans, parent, name, dataset_collection, implicit_output_name=None, implicit_inputs=None, tags=None, set_hid=True, flush=True):
         if isinstance(parent, model.History):
             dataset_collection_instance = self.model.HistoryDatasetCollectionAssociation(
                 collection=dataset_collection,
@@ -139,8 +140,9 @@ class DatasetCollectionManager(object):
                 dataset_collection_instance.implicit_output_name = implicit_output_name
 
             log.debug("Created collection with %d elements" % (len(dataset_collection_instance.collection.elements)))
-            # Handle setting hid
-            parent.add_dataset_collection(dataset_collection_instance)
+
+            if set_hid:
+                parent.add_dataset_collection(dataset_collection_instance)
 
         elif isinstance(parent, model.LibraryFolder):
             dataset_collection_instance = self.model.LibraryDatasetCollectionAssociation(

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5300,6 +5300,8 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             for step in self.steps:
                 if step.workflow_step.type == 'tool':
                     for job in step.jobs:
+                        if job is None:
+                            continue
                         for step_input in step.workflow_step.input_connections:
                             output_step_type = step_input.output_step.type
                             if output_step_type in ['data_input', 'data_collection_input']:

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -132,7 +132,9 @@ class TagHandler(object):
         """Delete tags from an item."""
         # Delete item-tag associations.
         for tag in item.tags:
-            self.sa_session.delete(tag)
+            if tag.id:
+                # Only can and need to delete tag if tag is persisted
+                self.sa_session.delete(tag)
         # Delete tags from item.
         del item.tags[:]
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1590,7 +1590,7 @@ class Tool(Dictifiable):
         resulting output data or an error message indicating the problem.
         """
         try:
-            job, out_data = self.execute(
+            rval = self.execute(
                 trans,
                 incoming=execution_slice.param_combination,
                 history=history,
@@ -1601,6 +1601,10 @@ class Tool(Dictifiable):
                 collection_info=collection_info,
                 flush_job=flush_job,
             )
+            job = rval[0]
+            out_data = rval[1]
+            if len(rval) == 3:
+                execution_slice.datasets_to_persist = rval[2]
         except (webob.exc.HTTPFound, exceptions.MessageException) as e:
             # if it's a webob redirect exception, pass it up the stack
             raise e

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1603,8 +1603,9 @@ class Tool(Dictifiable):
             )
             job = rval[0]
             out_data = rval[1]
-            if len(rval) == 3:
+            if len(rval) == 4:
                 execution_slice.datasets_to_persist = rval[2]
+                execution_slice.history = rval[3]
         except (webob.exc.HTTPFound, exceptions.MessageException) as e:
             # if it's a webob redirect exception, pass it up the stack
             raise e

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1584,7 +1584,7 @@ class Tool(Dictifiable):
                         output_collections=execution_tracker.output_collections,
                         implicit_collections=execution_tracker.implicit_collections)
 
-    def handle_single_execution(self, trans, rerun_remap_job_id, execution_slice, history, execution_cache=None, completed_job=None, collection_info=None):
+    def handle_single_execution(self, trans, rerun_remap_job_id, execution_slice, history, execution_cache=None, completed_job=None, collection_info=None, flush_job=True):
         """
         Return a pair with whether execution is successful as well as either
         resulting output data or an error message indicating the problem.
@@ -1599,6 +1599,7 @@ class Tool(Dictifiable):
                 dataset_collection_elements=execution_slice.dataset_collection_elements,
                 completed_job=completed_job,
                 collection_info=collection_info,
+                flush_job=flush_job,
             )
         except (webob.exc.HTTPFound, exceptions.MessageException) as e:
             # if it's a webob redirect exception, pass it up the stack

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -408,7 +408,7 @@ class DefaultToolAction(object):
                     dataset_collection_elements[name].hda = data
                 trans.sa_session.add(data)
                 if not completed_job:
-                    trans.app.security_agent.set_all_dataset_permissions(data.dataset, output_permissions, new=True)
+                    trans.app.security_agent.set_all_dataset_permissions(data.dataset, output_permissions, new=True, flush=False)
             data.copy_tags_to(preserved_tags)
 
             if not completed_job and trans.app.config.legacy_eager_objectstore_initialization:

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -549,16 +549,16 @@ class DefaultToolAction(object):
         # Now that we have a job id, we can remap any outputs if this is a rerun and the user chose to continue dependent jobs
         # This functionality requires tracking jobs in the database.
         if app.config.track_jobs_in_database and rerun_remap_job_id is not None:
-            # We need a flush here in order to rewrite jobs parameter,
+            # We need a flush here and get hids in order to rewrite jobs parameter,
             # but remapping jobs should only affect single jobs anyway, so this is not too costly.
             trans.sa_session.flush()
+            history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=set_output_hid, quota=False, flush=False)
             self._remap_job_on_rerun(trans=trans,
                                      galaxy_session=galaxy_session,
                                      rerun_remap_job_id=rerun_remap_job_id,
                                      current_job=job,
                                      out_data=out_data)
-            # remap_job_on_rerun may assign hids, only add datasets to history that don't have hid yet.
-            datasets_to_persist = [d for d in datasets_to_persist if d.hid is None]
+            datasets_to_persist = []
         log.info("Setup for job %s complete, ready to be enqueued %s" % (job.log_str(), job_setup_timer))
 
         # Some tools are not really executable, but jobs are still created for them ( for record keeping ).

--- a/lib/galaxy/tools/actions/data_manager.py
+++ b/lib/galaxy/tools/actions/data_manager.py
@@ -10,7 +10,7 @@ class DataManagerToolAction(DefaultToolAction):
 
     def execute(self, tool, trans, **kwds):
         rval = super(DataManagerToolAction, self).execute(tool, trans, **kwds)
-        if isinstance(rval, tuple) and len(rval) == 2 and isinstance(rval[0], trans.app.model.Job):
+        if isinstance(rval, tuple) and len(rval) >= 2 and isinstance(rval[0], trans.app.model.Job):
             assoc = trans.app.model.DataManagerJobAssociation(job=rval[0], data_manager_id=tool.data_manager_id)
             trans.sa_session.add(assoc)
             trans.sa_session.flush()

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -106,7 +106,10 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
 
     if datasets_to_persist:
         history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=True, quota=False, flush=False)
-    trans.sa_session.flush()
+        # a side effect of history.add_datasets is a commit within db_next_hid (even with flush=False).
+    else:
+        # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
+        trans.sa_session.flush()
     for job in execution_tracker.successful_jobs:
         # Put the job in the queue if tracking in memory
         tool.app.job_manager.enqueue(job, tool=tool)

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -101,11 +101,10 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
         else:
             execute_single_job(execution_slice, completed_jobs[i])
 
-    full_flush_timer = ExecutionTimer()
     trans.sa_session.flush()
     for job in execution_tracker.successful_jobs:
         # Put the job in the queue if tracking in memory
-        app.job_manager.enqueue(job, tool=tool)
+        tool.app.job_manager.enqueue(job, tool=tool)
         trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
 
     if has_remaining_jobs:

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -373,7 +373,7 @@ class ExecutionTracker(object):
             job_assoc = model.ImplicitCollectionJobsJobAssociation()
             job_assoc.order_index = execution_slice.job_index
             job_assoc.implicit_collection_jobs = implicit_collection_jobs
-            job_assoc.job_id = job.id
+            job_assoc.job = job
             self.trans.sa_session.add(job_assoc)
 
 

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -105,7 +105,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
                 datasets_to_persist.extend(execution_slice.datasets_to_persist)
 
     if datasets_to_persist:
-        history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=True, quota=False, flush=False)
+        execution_slice.history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=True, quota=False, flush=False)
         # a side effect of history.add_datasets is a commit within db_next_hid (even with flush=False).
     else:
         # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
@@ -131,6 +131,7 @@ class ExecutionSlice(object):
         self.param_combination = param_combination
         self.dataset_collection_elements = dataset_collection_elements
         self.datasets_to_persist = None
+        self.history = None
 
 
 class ExecutionTracker(object):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1802,17 +1802,16 @@ class ToolModule(WorkflowModule):
 
         # Combine workflow and runtime post job actions into the effective post
         # job actions for this execution.
-        flush_required = False
         effective_post_job_actions = self._effective_post_job_actions(step)
         for pja in effective_post_job_actions:
             if pja.action_type in ActionBox.immediate_actions or isinstance(self.tool, DatabaseOperationTool):
                 ActionBox.execute(self.trans.app, self.trans.sa_session, pja, job, replacement_dict)
             else:
-                pjaa = model.PostJobActionAssociation(pja, job_id=job.id)
+                if job.id:
+                    pjaa = model.PostJobActionAssociation(pja, job_id=job.id)
+                else:
+                    pjaa = model.PostJobActionAssociation(pja, job=job)
                 self.trans.sa_session.add(pjaa)
-                flush_required = True
-        if flush_required:
-            self.trans.sa_session.flush()
 
     def __restore_step_meta_runtime_state(self, step_runtime_state):
         if RUNTIME_POST_JOB_ACTIONS_KEY in step_runtime_state:

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -134,12 +134,13 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
         if incoming is None:
             incoming = dict(param1="moo")
         self._init_tool(contents)
-        return self.action.execute(
+        job, out_data, _, _ = self.action.execute(
             tool=self.tool,
             trans=self.trans,
             history=self.history,
             incoming=incoming,
         )
+        return job, out_data
 
 
 def test_determine_output_format():

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -211,6 +211,9 @@ class MockTrans(object):
     def get_current_user_roles(self):
         return []
 
+    def log_event(self, *args, **kwds):
+        pass
+
 
 class MockCollectionService(object):
 


### PR DESCRIPTION
Groundwork in the first commit by @jmchilton, originally in https://github.com/galaxyproject/galaxy/pull/6563.
The idea is to push flushes out until all jobs have been created in-memory, which should be much more efficient.