### PR TITLE
Simplify workflow invocations grid, remove drop down, add workflow execution option

### DIFF
--- a/client/galaxy/scripts/components/User/RecentInvocations.vue
+++ b/client/galaxy/scripts/components/User/RecentInvocations.vue
@@ -2,8 +2,7 @@
     <invocations
         :invocation-items="invocationItems"
         :loading="loading"
-        header-message="Your most recent workflow invocations are displayed on this page."
-        no-invocations-message="There are no workflow invocations to show."
+        no-invocations-message="There are no invocations to be shown."
     >
     </invocations>
 </template>

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -6,11 +6,9 @@
         <b-alert variant="info" show v-if="headerMessage">
             {{ headerMessage }}
         </b-alert>
-        <b-alert v-if="loading" variant="info" show>
-            <loading-span message="Loading workflow invocation job data" />
-        </b-alert>
+        <loading-span v-if="loading" message="Loading workflow invocations" />
         <div v-else>
-            <b-alert v-if="!invocationItemsComputed.length" variant="secondary" show>
+            <b-alert v-if="!invocationItemsComputed.length" variant="info" show>
                 {{ noInvocationsMessage }}
             </b-alert>
             <b-table
@@ -23,10 +21,6 @@
                 caption-top
                 :busy="loading"
             >
-                <template v-slot:table-caption>
-                    These invocations are not finished scheduling - one or more steps are waiting on others steps to be
-                    complete before the full structure of the jobs in the workflow can be determined.
-                </template>
                 <template v-slot:row-details="row">
                     <b-card>
                         <workflow-invocation-state :invocation-id="row.item.id" />
@@ -108,7 +102,6 @@ export default {
                 return {
                     id: invocation["id"],
                     create_time: invocation["create_time"],
-                    update_time: invocation["update_time"],
                     workflow_id: invocation["workflow_id"],
                     history_id: invocation["history_id"],
                     state: invocation["state"],
@@ -118,9 +111,6 @@ export default {
         },
         swapRowDetails(row) {
             row.toggleDetails();
-        },
-        handleError(error) {
-            console.error(error);
         },
         executeWorkflow: function (workflow_id) {
             window.location = `${getAppRoot()}workflows/run?id=${workflow_id}`;

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -27,12 +27,19 @@
                     </b-card>
                 </template>
                 <template v-slot:cell(workflow_id)="data">
-                    <b-link href="#" @click.stop="swapRowDetails(data)">
+                    <b-link v-b-tooltip title="Show Invocation details" href="#" @click.stop="swapRowDetails(data)">
                         <b>{{ getWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
                     </b-link>
                 </template>
                 <template v-slot:cell(history_id)="data">
-                    {{ getHistoryNameById(data.item.history_id) }}
+                    <b-link
+                        v-b-tooltip
+                        title="Switch to History"
+                        href="#"
+                        @click.stop="switchHistory(data.item.history_id)"
+                    >
+                        <b>{{ getHistoryNameById(data.item.history_id) }}</b>
+                    </b-link>
                 </template>
                 <template v-slot:cell(create_time)="data">
                     <UtcDate :date="data.value" mode="elapsed" />
@@ -52,6 +59,7 @@
 
 <script>
 import { getAppRoot } from "onload/loadConfig";
+import { getGalaxyInstance } from "app";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import UtcDate from "components/UtcDate";
 import LoadingSpan from "components/LoadingSpan";
@@ -112,8 +120,12 @@ export default {
         swapRowDetails(row) {
             row.toggleDetails();
         },
-        executeWorkflow: function (workflow_id) {
-            window.location = `${getAppRoot()}workflows/run?id=${workflow_id}`;
+        executeWorkflow: function (workflowId) {
+            window.location = `${getAppRoot()}workflows/run?id=${workflowId}`;
+        },
+        switchHistory(historyId) {
+            const Galaxy = getGalaxyInstance();
+            Galaxy.currHistoryPanel.switchToHistory(historyId);
         },
     },
 };

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -65,6 +65,9 @@
                         <history-dropdown :history="getHistoryById(data.item.history_id)" />
                     </div>
                 </template>
+                <template v-slot:cell(create_time)="data">
+                    <UtcDate :date="data.value" mode="elapsed" />
+                </template>
             </b-table>
         </div>
     </div>
@@ -73,6 +76,7 @@
 <script>
 import { getRootFromIndexLink } from "onload";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
+import UtcDate from "components/UtcDate";
 import LoadingSpan from "components/LoadingSpan";
 import WorkflowDropdown from "components/Workflow/WorkflowDropdown";
 import HistoryDropdown from "components/History/HistoryDropdown";
@@ -81,6 +85,7 @@ import { mapGetters } from "vuex";
 
 export default {
     components: {
+        UtcDate,
         WorkflowInvocationState,
         LoadingSpan,
         WorkflowDropdown,
@@ -98,10 +103,8 @@ export default {
             { key: "details", label: "" },
             { key: "workflow_id", label: "Workflow" },
             { key: "history_id", label: "History" },
-            { key: "id", label: "Invocation ID" },
+            { key: "create_time", label: "Invoked" },
             { key: "state" },
-            { key: "update_time", label: "Last Update" },
-            { key: "create_time", label: "Invocation Time" },
         ];
         return {
             invocationItemsModel: [],

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -23,6 +23,9 @@
             >
                 <template v-slot:row-details="row">
                     <b-card>
+                        <small class="float-right">
+                            <b>Invocation: {{ row.item.id }}</b>
+                        </small>
                         <workflow-invocation-state :invocation-id="row.item.id" />
                     </b-card>
                 </template>
@@ -44,10 +47,13 @@
                 <template v-slot:cell(create_time)="data">
                     <UtcDate :date="data.value" mode="elapsed" />
                 </template>
+                <template v-slot:cell(update_time)="data">
+                    <UtcDate :date="data.value" mode="elapsed" />
+                </template>
                 <template v-slot:cell(execute)="data">
                     <b-button
                         v-b-tooltip.hover.bottom
-                        title="Rerun Workflow"
+                        title="Run Workflow"
                         class="workflow-run btn-sm btn-primary fa fa-play"
                         @click.stop="executeWorkflow(getWorkflowByInstanceId(data.item.workflow_id).id)"
                     />
@@ -84,6 +90,7 @@ export default {
             { key: "workflow_id", label: "Workflow" },
             { key: "history_id", label: "History" },
             { key: "create_time", label: "Invoked" },
+            { key: "update_time", label: "Updated" },
             { key: "state" },
             { key: "execute", label: "" },
         ];
@@ -110,6 +117,7 @@ export default {
                 return {
                     id: invocation["id"],
                     create_time: invocation["create_time"],
+                    update_time: invocation["update_time"],
                     workflow_id: invocation["workflow_id"],
                     history_id: invocation["history_id"],
                     state: invocation["state"],

--- a/client/galaxy/scripts/components/Workflow/Invocations.vue
+++ b/client/galaxy/scripts/components/Workflow/Invocations.vue
@@ -29,44 +29,27 @@
                 </template>
                 <template v-slot:row-details="row">
                     <b-card>
-                        <!-- set provideContext to false, since the table itself provides this information -->
-                        <workflow-invocation-state :invocation-id="row.item.id" :provide-context="false" />
+                        <workflow-invocation-state :invocation-id="row.item.id" />
                     </b-card>
                 </template>
-                <template v-slot:cell(details)="data">
-                    <b-button
-                        v-b-tooltip.hover.bottom
-                        title="Show Invocation Details"
-                        class="btn-sm fa fa-chevron-down"
-                        v-if="!data.detailsShowing"
-                        @click.stop="swapRowDetails(data)"
-                    />
-                    <b-button
-                        v-b-tooltip.hover.bottom
-                        title="Hide Invocation Details"
-                        class="btn-sm fa fa-chevron-up"
-                        v-if="data.detailsShowing"
-                        @click.stop="swapRowDetails(data)"
-                    />
-                </template>
                 <template v-slot:cell(workflow_id)="data">
-                    <div v-if="!ownerGrid || !getWorkflowByInstanceId(data.item.workflow_id)">
-                        {{ data.item.workflow_id }}
-                    </div>
-                    <div v-else>
-                        <workflow-dropdown :workflow="getWorkflowByInstanceId(data.item.workflow_id)" />
-                    </div>
+                    <b-link href="#" @click.stop="swapRowDetails(data)">
+                        <b>{{ getWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
+                    </b-link>
                 </template>
                 <template v-slot:cell(history_id)="data">
-                    <div v-if="!ownerGrid || !getHistoryById(data.item.history_id)">
-                        {{ data.item.history_id }}
-                    </div>
-                    <div v-else>
-                        <history-dropdown :history="getHistoryById(data.item.history_id)" />
-                    </div>
+                    {{ getHistoryNameById(data.item.history_id) }}
                 </template>
                 <template v-slot:cell(create_time)="data">
                     <UtcDate :date="data.value" mode="elapsed" />
+                </template>
+                <template v-slot:cell(execute)="data">
+                    <b-button
+                        v-b-tooltip.hover.bottom
+                        title="Rerun Workflow"
+                        class="workflow-run btn-sm btn-primary fa fa-play"
+                        @click.stop="executeWorkflow(getWorkflowByInstanceId(data.item.workflow_id).id)"
+                    />
                 </template>
             </b-table>
         </div>
@@ -74,12 +57,10 @@
 </template>
 
 <script>
-import { getRootFromIndexLink } from "onload";
+import { getAppRoot } from "onload/loadConfig";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import UtcDate from "components/UtcDate";
 import LoadingSpan from "components/LoadingSpan";
-import WorkflowDropdown from "components/Workflow/WorkflowDropdown";
-import HistoryDropdown from "components/History/HistoryDropdown";
 import { mapCacheActions } from "vuex-cache";
 import { mapGetters } from "vuex";
 
@@ -88,23 +69,21 @@ export default {
         UtcDate,
         WorkflowInvocationState,
         LoadingSpan,
-        WorkflowDropdown,
-        HistoryDropdown,
     },
     props: {
         invocationItems: { type: Array, default: () => [] },
         loading: { type: Boolean, default: true },
-        noInvocationsMessage: { type: String },
+        noInvocationsMessage: { type: String, default: "" },
         headerMessage: { type: String, default: "" },
         ownerGrid: { type: Boolean, default: true },
     },
     data() {
         const fields = [
-            { key: "details", label: "" },
             { key: "workflow_id", label: "Workflow" },
             { key: "history_id", label: "History" },
             { key: "create_time", label: "Invoked" },
             { key: "state" },
+            { key: "execute", label: "" },
         ];
         return {
             invocationItemsModel: [],
@@ -113,16 +92,13 @@ export default {
         };
     },
     computed: {
-        ...mapGetters(["getWorkflowByInstanceId", "getHistoryById"]),
+        ...mapGetters(["getWorkflowNameByInstanceId", "getWorkflowByInstanceId", "getHistoryNameById"]),
         invocationItemsComputed() {
             return this.computeItems(this.invocationItems);
         },
     },
     methods: {
         ...mapCacheActions(["fetchWorkflowForInstanceId", "fetchHistoryForId"]),
-        editLink(workflowId) {
-            return getRootFromIndexLink() + "workflow/editor?id=" + this.getWorkflowByInstanceId(workflowId).id;
-        },
         computeItems(items) {
             return items.map((invocation) => {
                 if (this.ownerGrid) {
@@ -145,6 +121,9 @@ export default {
         },
         handleError(error) {
             console.error(error);
+        },
+        executeWorkflow: function (workflow_id) {
+            window.location = `${getAppRoot()}workflows/run?id=${workflow_id}`;
         },
     },
 };

--- a/client/galaxy/scripts/store/historyStore.js
+++ b/client/galaxy/scripts/store/historyStore.js
@@ -12,11 +12,11 @@ const getters = {
         return state.historyById[historyId];
     },
     getHistoryNameById: (state) => (historyId) => {
-        const details = state.historyDetailsById[historyId];
+        const details = state.historyById[historyId];
         if (details && details.name) {
             return details.name;
         } else {
-            return "Unavailable";
+            return "...";
         }
     },
 };

--- a/client/galaxy/scripts/store/workflowStore.js
+++ b/client/galaxy/scripts/store/workflowStore.js
@@ -10,6 +10,14 @@ const getters = {
     getWorkflowByInstanceId: (state) => (workflowId) => {
         return state.workflowsByInstanceId[workflowId];
     },
+    getWorkflowNameByInstanceId: (state) => (workflowId) => {
+        const details = state.workflowsByInstanceId[workflowId];
+        if (details && details.name) {
+            return details.name;
+        } else {
+            return "...";
+        }
+    },
 };
 
 const actions = {


### PR DESCRIPTION
This PR revises the workflow invocations grid. The grid currently has a series of options and dropdowns which might be misleading and overcrowd the interface. Some operation should not be made available like e.g. the workflow `deletion` and `renaming` options. These options do not return any confirmation of the action taken. Instead a user might assume that `deletion` deletes the invocation not the entire workflow.

<img width="830" alt="Screen Shot 2020-07-24 at 1 23 23 PM" src="https://user-images.githubusercontent.com/2105447/88418032-efd6ee80-cdb0-11ea-93ab-6a5be39db53e.png">
