### PR TITLE
Use compression_utils to safely peek in compressed datasets

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -855,7 +855,6 @@ class Text(Data):
             sample_lines = dataset_read.count('\n')
             est_lines = int(sample_lines * (float(dataset.get_size()) / float(sample_size)))
         except UnicodeDecodeError:
-            # encoding error - this *should not happen* 
             log.error('Unable to estimate lines in file {}'.format(dataset.file_name))
             est_lines = None
         return est_lines

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -849,10 +849,15 @@ class Text(Data):
         Perform a rough estimate by extrapolating number of lines from a small read.
         """
         sample_size = 1048576
-        with open(dataset.file_name) as dataset_fh:
-            dataset_read = dataset_fh.read(sample_size)
-        sample_lines = dataset_read.count('\n')
-        est_lines = int(sample_lines * (float(dataset.get_size()) / float(sample_size)))
+        try:
+            with compression_utils.get_fileobj(dataset.file_name) as dataset_fh:
+                dataset_read = dataset_fh.read(sample_size)
+            sample_lines = dataset_read.count('\n')
+            est_lines = int(sample_lines * (float(dataset.get_size()) / float(sample_size)))
+        except UnicodeDecodeError:
+            # encoding error - this *should not happen* 
+            log.error('Unable to estimate lines in file {}'.format(dataset.file_name))
+            est_lines = None
         return est_lines
 
     def count_data_lines(self, dataset):
@@ -874,8 +879,9 @@ class Text(Data):
                     line = line.strip()
                     if line and not line.startswith('#'):
                         data_lines += 1
-            except Exception:
-                pass
+            except UnicodeDecodeError:
+                log.error('Unable to count lines in file {}'.format(dataset.file_name))
+                data_lines = None
         return data_lines
 
     def set_peek(self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=None, line_wrap=True):
@@ -896,11 +902,17 @@ class Text(Data):
                     if int(dataset.get_size()) <= 1048576:
                         # Small dataset, recount all lines and reset peek afterward.
                         lc = self.count_data_lines(dataset)
-                        dataset.metadata.data_lines = lc
-                        dataset.blurb = "%s %s" % (util.commaify(str(lc)), inflector.cond_plural(lc, self.line_class))
+                        if lc is not None:
+                            dataset.metadata.data_lines = lc
+                            dataset.blurb = "%s %s" % (util.commaify(str(lc)), inflector.cond_plural(lc, self.line_class))
+                        else:
+                            dataset.blurb = "Error: Cannot count lines in dataset"
                     else:
                         est_lines = self.estimate_file_lines(dataset)
-                        dataset.blurb = "~%s %s" % (util.commaify(util.roundify(str(est_lines))), inflector.cond_plural(est_lines, self.line_class))
+                        if est_lines is not None:
+                            dataset.blurb = "~%s %s" % (util.commaify(util.roundify(str(est_lines))), inflector.cond_plural(est_lines, self.line_class))
+                        else:
+                            dataset.blurb = "Error: Cannot estimate lines in dataset"
             else:
                 dataset.blurb = "%s %s" % (util.commaify(str(line_count)), inflector.cond_plural(line_count, self.line_class))
         else:

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2752,8 +2752,8 @@ class DatasetInstance(object):
             # extension is None
             return 'data'
 
-    def set_peek(self):
-        return self.datatype.set_peek(self)
+    def set_peek(self, **kwd):
+        return self.datatype.set_peek(self, **kwd)
 
     def init_meta(self, copy_from=None):
         return self.datatype.init_meta(self, copy_from=copy_from)


### PR DESCRIPTION
When uploading a compress GFF3 file I encountered this error:

```
uwsgi[24497]: TypeError: set_peek() got an unexpected keyword argument 'line_count'
uwsgi[24497]: During handling of the above exception, another exception occurred:
uwsgi[24497]: Traceback (most recent call last):
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/jobs/runners/__init__.py", line 540, in _finish_or_resubmit_job
uwsgi[24497]:     job_wrapper.finish(tool_stdout, tool_stderr, exit_code, check_output_detected_state=check_output_detected_state, job_stdout=job_stdout, job_stderr=job_stderr)
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/jobs/__init__.py", line 1687, in finish
uwsgi[24497]:     output_name, dataset, job, context, final_job_state, remote_metadata_directory
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/jobs/__init__.py", line 1555, in _finish_dataset
uwsgi[24497]:     dataset.set_peek()
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/model/__init__.py", line 2644, in set_peek
uwsgi[24497]:     return self.datatype.set_peek(self)
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/datatypes/tabular.py", line 60, in set_peek
uwsgi[24497]:     super(TabularData, self).set_peek(dataset, line_count=line_count, WIDTH=WIDTH, skipchars=skipchars, line_wrap=False)
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/datatypes/data.py", line 902, in set_peek
uwsgi[24497]:     est_lines = self.estimate_file_lines(dataset)
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/server/lib/galaxy/datatypes/data.py", line 853, in estimate_file_lines
uwsgi[24497]:     dataset_read = dataset_fh.read(sample_size)
uwsgi[24497]:   File "/projects/galaxy/pvh_masters_galaxy1/venv/lib/python3.6/codecs.py", line 321, in decode
uwsgi[24497]:     (result, consumed) = self._buffer_decode(data, self.errors, final)
uwsgi[24497]: UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte
```
This is caused by an attempt to read binary data and in the process encountering a data that can not be decoded in the default codec. This patch:

1) Uses compression_utils to access the dataset and thus deal with compressed files in a safer way
2) Catches UnicodeDecodeError (in `estimate_file_lines` and `count_data_lines`) to ensure that binary data does not trip up the peek operation.
