### PR TITLE
[20.01] Cookie names to work with PR #9921 and py3 Exception printing

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -16,8 +16,8 @@ from galaxy.model import CustosAuthnzToken, User
 from ..authnz import IdentityProvider
 
 log = logging.getLogger(__name__)
-STATE_COOKIE_NAME = 'custos-state'
-NONCE_COOKIE_NAME = 'custos-nonce'
+STATE_COOKIE_NAME = 'galaxy-oidc-state'
+NONCE_COOKIE_NAME = 'galaxy-oidc-nonce'
 
 
 class CustosAuthnz(IdentityProvider):

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -260,7 +260,7 @@ class AuthnzManager(object):
             return True, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
         except Exception as e:
             msg = 'The following error occurred when handling callback from `{}` identity provider: ' \
-                  '{}'.format(provider, e.message)
+                  '{}'.format(provider, str(e))
             log.exception(msg)
             return False, msg, (None, None)
 
@@ -289,7 +289,7 @@ class AuthnzManager(object):
             return True, message, backend.logout(trans, post_logout_redirect_url)
         except Exception as e:
             msg = 'The following error occurred when logging out from `{}` identity provider: ' \
-                  '{}'.format(provider, e.message)
+                  '{}'.format(provider, str(e))
             log.exception(msg)
             return False, msg, None
 


### PR DESCRIPTION
`Nonce mismatch` error was occurring when logging in with OIDC (Keycloak). Noticed that the `nonce` cookie was returning `None`, and then Dannon informed me that `galaxy-` prefix is needed for cookie names after https://github.com/galaxyproject/galaxy/pull/9921.
Also, when the error was occurring, a subsequent error was happening when trying to print `e.message` because of changes to `Exception` in py3, so changed that as well.

This should also be ported to 20.05