### PR TITLE
API + UI for importing workflows from a GA4GH TRS server.

### DIFF
--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -1,0 +1,143 @@
+<template>
+    <b-card title="TRS Import">
+        <b-alert :show="hasErrorMessage" variant="danger">{{ errorMessage }}</b-alert>
+        <div>
+            <b>TRS Server:</b>
+
+            <TrsServerSelection
+                :selection="trsSelection"
+                :trs-servers="trsServers"
+                :loading="trsServersLoading"
+                @onTrsSelection="onTrsSelection"
+            />
+        </div>
+        <div>
+            <b>TRS ID:</b>
+            <b-form-input v-model="toolId" />
+        </div>
+
+        <trs-tool :trs-tool="trsTool" v-if="trsTool != null" @onImport="importVersion" />
+    </b-card>
+</template>
+
+<script>
+import { getAppRoot } from "onload/loadConfig";
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import TrsServerSelection from "./TrsServerSelection";
+import TrsTool from "./TrsTool";
+import { Services } from "./services";
+import QueryStringParsing from "utils/query-string-parsing";
+
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        TrsServerSelection,
+        TrsTool,
+    },
+    created() {
+        this.services = new Services();
+        this.queryTrsServer = QueryStringParsing.get("trs_server");
+        this.queryTrsId = QueryStringParsing.get("trs_id");
+        this.toolId = this.queryTrsId;
+        this.configureTrsServers();
+    },
+    data() {
+        return {
+            trsSelection: null,
+            trsServers: [],
+            trsServersLoading: true,
+            toolId: null,
+            trsTool: null,
+            errorMessage: null,
+            queryTrsServer: null,
+            queryTrsId: null,
+        };
+    },
+    computed: {
+        hasErrorMessage() {
+            return this.errorMessage != null;
+        },
+    },
+    watch: {
+        toolId: function () {
+            this.onToolId();
+        },
+    },
+    methods: {
+        configureTrsServers() {
+            this.services.getTrsServers().then((servers) => {
+                this.trsServers = servers;
+                const queryTrsServer = this.queryTrsServer;
+                let trsSelection = null;
+                if (queryTrsServer) {
+                    for (const server of servers) {
+                        if (server.id == queryTrsServer) {
+                            trsSelection = server;
+                            break;
+                        }
+                        if (possibleServeUrlsMatch(server.api_url, queryTrsServer)) {
+                            trsSelection = server;
+                            break;
+                        }
+                        if (possibleServeUrlsMatch(server.link_url, queryTrsServer)) {
+                            trsSelection = server;
+                            break;
+                        }
+                    }
+                }
+                if (trsSelection === null) {
+                    if (queryTrsServer) {
+                        this.errorMessage = "Failed to find requested TRS server " + queryTrsServer;
+                    }
+                    trsSelection = servers[0];
+                }
+                this.trsSelection = trsSelection;
+                this.trsServersLoading = false;
+                if (this.toolId) {
+                    this.onToolId();
+                }
+            });
+        },
+        onTrsSelection(selection) {
+            this.trsSelection = selection;
+        },
+        onToolId() {
+            if (!this.trsSelection) {
+                return;
+            }
+            this.services
+                .getTrsTool(this.trsSelection.id, this.toolId)
+                .then((tool) => {
+                    this.trsTool = tool;
+                    this.errorMessage = null;
+                })
+                .catch((errorMessage) => {
+                    this.trsTool = null;
+                    this.errorMessage = errorMessage;
+                });
+        },
+        importVersion(version) {
+            this.services
+                .importTrsTool(this.trsSelection.id, this.toolId, version.name)
+                .then((response_data) => {
+                    // copied from the WorkflowImport, de-duplicate somehow
+                    window.location = `${getAppRoot()}workflows/list?message=${response_data.message}&status=success`;
+                })
+                .catch((errorMessage) => {
+                    this.errorMessage = errorMessage || "Import failed for an unknown reason.";
+                });
+        },
+    },
+};
+
+function possibleServeUrlsMatch(a, b) {
+    // let http://trs_server.org/ match with https://trs_server.org for instance,
+    // we'll only use the one configured on the backend for making actual calls, but
+    // allow some robustness in matching it
+    a = a.replace(/^https?:\/\//, "").replace(/\/$/, "");
+    b = b.replace(/^https?:\/\//, "").replace(/\/$/, "");
+    return a == b;
+}
+</script>

--- a/client/src/components/Workflow/TrsServerSelection.vue
+++ b/client/src/components/Workflow/TrsServerSelection.vue
@@ -19,7 +19,7 @@
                     class="dropdown-item"
                     href="javascript:void(0)"
                     role="button"
-                    @click.prevent="onUrlSelection(selection)"
+                    @click.prevent="onTrsSelection(selection)"
                     >{{ selection.label }}</a
                 >
             </div>

--- a/client/src/components/Workflow/TrsServerSelection.vue
+++ b/client/src/components/Workflow/TrsServerSelection.vue
@@ -1,0 +1,68 @@
+<!-- Modelled after Sam's ToolShed ServerSelection.vue -->
+<template>
+    <span v-if="!loading" class="m-1 text-muted">
+        <span v-if="showDropdown" class="dropdown">
+            <b-link
+                id="dropdownTrsServer"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+                class="font-weight-bold"
+            >
+                {{ selection.label }}
+                <span class="fa fa-caret-down" />
+            </b-link>
+            <div class="dropdown-menu" aria-labelledby="dropdownTrsServer">
+                <a
+                    v-for="selection in trsServers"
+                    :key="selection.id"
+                    class="dropdown-item"
+                    href="javascript:void(0)"
+                    role="button"
+                    @click.prevent="onUrlSelection(selection)"
+                    >{{ selection.label }}</a
+                >
+            </div>
+        </span>
+        <span v-else>
+            <b-link :href="selection.link_url" target="_blank" class="font-weight-bold" :title="selection.doc">
+                {{ selection.label }}
+            </b-link>
+        </span>
+    </span>
+</template>
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        selection: {
+            type: Object,
+        },
+        trsServers: {
+            type: Array,
+        },
+        loading: {
+            type: Boolean,
+        },
+    },
+    computed: {
+        showDropdown() {
+            return this.trsServers.length > 1;
+        },
+    },
+    methods: {
+        onTrsSelection(selection) {
+            this.$emit("onTrsSelection", selection);
+        },
+    },
+};
+</script>
+<style scoped>
+span.dropdown {
+    display: inline-block;
+}
+</style>

--- a/client/src/components/Workflow/TrsTool.vue
+++ b/client/src/components/Workflow/TrsTool.vue
@@ -1,0 +1,55 @@
+<template>
+    <div>
+        <div>
+            <b>Name:</b>
+            <span>{{ trsTool.name }}</span>
+        </div>
+        <div>
+            <b>Description:</b>
+            <span>{{ trsTool.description }}</span>
+        </div>
+        <div>
+            <b>Organization</b>
+            <span>{{ trsTool.organization }}</span>
+        </div>
+        <div>
+            <b>Versions</b>
+            <ul>
+                <li v-for="version in trsTool.versions" :key="version.id">
+                    <b-link>{{ version.name }}</b-link>
+                    <b-button id="workflow-import" class="m-1" @click="importVersion(version)">
+                        <font-awesome-icon icon="upload" />
+                    </b-button>
+                </li>
+            </ul>
+        </div>
+    </div>
+</template>
+
+<script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
+
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+library.add(faUpload);
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        FontAwesomeIcon,
+    },
+    props: {
+        trsTool: {
+            type: Object,
+        },
+    },
+    methods: {
+        importVersion(version) {
+            this.$emit("onImport", version);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/services.js
+++ b/client/src/components/Workflow/services.js
@@ -76,4 +76,46 @@ export class Services {
             }
         }
     }
+
+    async getTrsServers() {
+        const url = `${this.root}api/trs_consume/servers`;
+        try {
+            const response = await axios.get(url);
+            return response.data;
+        } catch (e) {
+            rethrowSimple(e);
+        }
+    }
+
+    async getTrsTool(trsServer, toolId) {
+        // Due to the slashes in the toolId, WSGI doesn't work with
+        // encodeURIComponent. I verified the framework is converting
+        // the information and we're losing it. As ugly as Base64 is, it is
+        // better than the alternatives IMO. -John
+        // https://github.com/pallets/flask/issues/900
+        toolId = btoa(toolId);
+        const url = `${this.root}api/trs_consume/${trsServer}/tools/${toolId}?tool_id_b64_encoded=true`;
+        try {
+            const response = await axios.get(url);
+            return response.data;
+        } catch (e) {
+            rethrowSimple(e);
+        }
+    }
+
+    async importTrsTool(trsServer, toolId, versionId) {
+        const data = {
+            archive_source: "trs_tool",
+            trs_server: trsServer,
+            trs_tool_id: toolId,
+            trs_version_id: versionId,
+        };
+        const url = `${this.root}api/workflows`;
+        try {
+            const response = await axios.post(url, data);
+            return response.data;
+        } catch (e) {
+            rethrowSimple(e);
+        }
+    }
 }

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -26,6 +26,7 @@ import Tours from "mvc/tours";
 import GridView from "mvc/grid/grid-view";
 import GridShared from "mvc/grid/grid-shared";
 import WorkflowImport from "components/Workflow/WorkflowImport.vue";
+import TrsImport from "components/Workflow/TrsImport.vue";
 import InteractiveTools from "components/InteractiveTools/InteractiveTools.vue";
 import WorkflowList from "components/Workflow/WorkflowList.vue";
 import HistoryImport from "components/HistoryImport.vue";
@@ -69,6 +70,7 @@ export const getAnalysisRouter = (Galaxy) =>
             "(/)visualizations(/)sharing(/)": "show_visualizations_sharing",
             "(/)visualizations/(:action_id)": "show_visualizations",
             "(/)workflows/import": "show_workflows_import",
+            "(/)workflows/trs_import": "show_workflows_trs_import",
             "(/)workflows/run(/)": "show_workflows_run",
             "(/)workflows(/)list": "show_workflows",
             "(/)workflows/invocations": "show_workflow_invocations",
@@ -318,6 +320,10 @@ export const getAnalysisRouter = (Galaxy) =>
 
         show_workflows_import: function () {
             this._display_vue_helper(WorkflowImport);
+        },
+
+        show_workflows_trs_import: function () {
+            this._display_vue_helper(TrsImport);
         },
 
         show_custom_builds: function () {

--- a/config/trs_servers_conf.yml.sample
+++ b/config/trs_servers_conf.yml.sample
@@ -1,0 +1,20 @@
+# List GA4GH Tool Registry Services to connect Galaxy with.
+# 'id' is used to key API interactions and should be unique, the backend uses 'api_url'
+# to build requests. The remaining fields 'label', 'link_url', and 'doc' are used to render
+# information in the user interface.
+
+# By default only dockstore is configured.
+- id: dockstore
+  api_url: https://dockstore.org/api
+  link_url: https://dockstore.org
+  label: Dockstore
+  doc: |
+    Dockstore is an open platform used by the GA4GH for sharing Docker-based tools and workflows.
+
+# Staging variant of dockstore can be configured.
+#- id: staging_dockstore
+#  api_url: https://staging.dockstore.org/api
+#  link_url: https://staging.dockstore.org
+#  label: Staging Dockstore
+#  doc: |
+#    Staging variant of Dockstore for testing.

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -51,6 +51,7 @@ from galaxy.web import url_for
 from galaxy.web.proxy import ProxyManager
 from galaxy.web_stack import application_stack_instance
 from galaxy.webhooks import WebhooksRegistry
+from galaxy.workflow.trs_proxy import TrsProxy
 
 log = logging.getLogger(__name__)
 app = None
@@ -224,6 +225,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         # Must be initialized after job_config.
         self.workflow_scheduling_manager = scheduling_manager.WorkflowSchedulingManager(self)
 
+        self.trs_proxy = TrsProxy(self.config)
         # Must be initialized after any component that might make use of stack messaging is configured. Alternatively if
         # it becomes more commonly needed we could create a prefork function registration method like we do with
         # postfork functions.

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -796,6 +796,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
             tool_sheds_config_file=[self._in_config_dir('tool_sheds_conf.xml')],
+            trs_servers_config_file=[self._in_config_dir('trs_servers_conf.yml')],
             user_preferences_extra_conf_path=[self._in_config_dir('user_preferences_extra_conf.yml')],
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -31,6 +31,15 @@ class MessageException(Exception):
         self.type = type
         self.extra_error_info = extra_error_info
 
+    @staticmethod
+    def from_code(status_code, message):
+        exception_class = MessageException
+        if status_code == 404:
+            exception_class = ObjectNotFound
+        elif status_code / 100 == 5:
+            exception_class = InternalServerError
+        return exception_class(message)
+
     def __str__(self):
         return self.err_msg
 

--- a/lib/galaxy/webapps/galaxy/api/trs_consumer.py
+++ b/lib/galaxy/webapps/galaxy/api/trs_consumer.py
@@ -1,0 +1,31 @@
+"""Proxy requests to GA4GH TRS servers (e.g. Dockstore).
+
+Information on TRS can be found at https://github.com/ga4gh/tool-registry-service-schemas.
+"""
+from galaxy.web import expose_api
+from galaxy.webapps.base.controller import (
+    BaseAPIController
+)
+
+
+class TrsConsumeAPIController(BaseAPIController):
+    """Controller for TRS proxying."""
+
+    def __init__(self, app):
+        self._trs_proxy = app.trs_proxy
+
+    @expose_api
+    def get_servers(self, trans, *args, **kwd):
+        return self._trs_proxy.get_servers()
+
+    @expose_api
+    def get_tool(self, trans, *args, **kwd):
+        return self._trs_proxy.get_tool(*args, **kwd)
+
+    @expose_api
+    def get_versions(self, trans, *args, **kwd):
+        return self._trs_proxy.get_versions(*args, **kwd)
+
+    @expose_api
+    def get_version(self, trans, *args, **kwd):
+        return self._trs_proxy.get_version(*args, **kwd)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -345,6 +345,11 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                     workflow_src = {"src": "from_path", "path": archive_source[len("file://"):]}
                     payload["workflow"] = workflow_src
                     return self.__api_import_new_workflow(trans, payload, **kwd)
+                elif archive_source == "trs_tool":
+                    trs_server = payload.get("trs_server")
+                    trs_tool_id = payload.get("trs_tool_id")
+                    trs_version_id = payload.get("trs_version_id")
+                    archive_data = self.app.trs_proxy.get_version_descriptor(trs_server, trs_tool_id, trs_version_id)
                 else:
                     try:
                         archive_data = requests.get(archive_source).text

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -158,6 +158,7 @@ def app_factory(global_conf, load_app_kwds={}, **kwargs):
     webapp.add_client_route('/workflows/create')
     webapp.add_client_route('/workflows/run')
     webapp.add_client_route('/workflows/import')
+    webapp.add_client_route('/workflows/trs_import')
     webapp.add_client_route('/workflows/invocations')
     webapp.add_client_route('/workflows/invocations/report')
     webapp.add_client_route('/custom_builds')
@@ -549,6 +550,42 @@ def populate_api_routes(webapp, app):
                           controller='workflows',
                           action='import_shared_workflow_deprecated',
                           conditions=dict(method=['POST']))
+
+    webapp.mapper.connect(
+        'trs_consume_get_servers',
+        '/api/trs_consume/servers',
+        controller='trs_consumer',
+        action="get_servers",
+        conditions=dict(method=['GET'])
+    )
+    webapp.mapper.connect(
+        'trs_consume_get_tool',
+        '/api/trs_consume/{trs_server}/tools/{tool_id}',
+        controller='trs_consumer',
+        action="get_tool",
+        conditions=dict(method=['GET'])
+    )
+    webapp.mapper.connect(
+        'trs_consume_get_tool_versions',
+        '/api/trs_consume/{trs_server}/tools/{tool_id}/versions',
+        controller='trs_consumer',
+        action="get_tool_versions",
+        conditions=dict(method=['GET'])
+    )
+    webapp.mapper.connect(
+        'trs_consume_get_tool_version',
+        '/api/trs_consume/{trs_server}/tools/{tool_id}/versions/{version_id}',
+        controller='trs_consumer',
+        action="get_tool_version",
+        conditions=dict(method=['GET'])
+    )
+    webapp.mapper.connect(
+        'trs_consume_import_tool_version',
+        '/api/trs_consume/{trs_server}/tools/{tool_id}/versions/{version_id}/import',
+        controller='trs_consumer',
+        action="import_tool_version",
+        conditions=dict(method=['POST'])
+    )
 
     # route for creating/getting converted datasets
     webapp.mapper.connect('/api/datasets/{dataset_id}/converted', controller='datasets', action='converted', ext=None)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1162,7 +1162,7 @@ mapping:
         desc: |
           Allow import of workflows from the TRS servers configured in
           the specified YAML or JSON file. The file should be a list with
-          and 'id', 'label', and 'api_url' for each entry. Optionally,
+          'id', 'label', and 'api_url' for each entry. Optionally,
           'link_url' and 'doc' may be be specified as well for each entry.
 
           If this is null (the default), a simple configuration containing

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1155,6 +1155,19 @@ mapping:
           - $iso8601 (complete format string as specified by ISO 8601 international
             standard).
 
+      trs_servers_config_file:
+        type: str
+        default: 'trs_servers_conf.yml'
+        required: false
+        desc: |
+          Allow import of workflows from the TRS servers configured in
+          the specified YAML or JSON file. The file should be a list with
+          and 'id', 'label', and 'api_url' for each entry. Optionally,
+          'link_url' and 'doc' may be be specified as well for each entry.
+
+          If this is null (the default), a simple configuration containing
+          just Dockstore will be used.
+
       user_preferences_extra_conf_path:
         type: str
         default: 'user_preferences_extra_conf.yml'

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -1,0 +1,93 @@
+import logging
+import os
+import urllib.parse
+
+import requests
+import yaml
+
+from galaxy.exceptions import MessageException
+from galaxy.util import asbool
+
+log = logging.getLogger(__name__)
+
+# Make configurable via YAML,JSON
+DEFAULT_TRS_SERVERS = [
+    {
+        "id": "dockstore",
+        "api_url": "https://dockstore.org/api",
+        "link_url": "https://dockstore.org",
+        "label": "Dockstore",
+        "doc": "Dockstore is an open platform used by the GA4GH for sharing Docker-based tools and workflows.",
+    },
+]
+# Switch to "Galaxy" after Dockstore bug fixed, deployed:
+# https://github.com/dockstore/dockstore/issues/3670
+GA4GH_GALAXY_DESCRIPTOR = "GXFORMAT2"
+
+
+class TrsProxy(object):
+
+    def __init__(self, config=None):
+        config_file = getattr(config, "trs_servers_config_file", None)
+        if config_file and os.path.exists(config_file):
+            with open(config_file, "r") as f:
+                server_list = yaml.safe_load(f)
+        else:
+            server_list = DEFAULT_TRS_SERVERS
+        self._server_list = server_list
+        self._server_dict = {t["id"]: t for t in self._server_list}
+
+    def get_servers(self):
+        return self._server_list
+
+    def get_tools(self, trs_server, **kwd):
+        trs_api_url = self._get_api_endpoint(trs_server, **kwd)
+        return self._get(trs_api_url)
+
+    def get_tool(self, trs_server, tool_id, **kwd):
+        trs_api_url = self._get_tool_api_endpoint(trs_server, tool_id, **kwd)
+        return self._get(trs_api_url)
+
+    def get_versions(self, trs_server, tool_id, **kwd):
+        trs_api_url = self._get_tool_api_endpoint(trs_server, tool_id, **kwd) + "/versions"
+        return self._get(trs_api_url)
+
+    def get_version(self, trs_server, tool_id, version_id, **kwd):
+        trs_api_url = self._get_tool_api_endpoint(trs_server, tool_id, **kwd) + "/versions/" + version_id
+        return self._get(trs_api_url)
+
+    def get_version_descriptor(self, trs_server, tool_id, version_id, **kwd):
+        trs_api_url = self._get_tool_api_endpoint(trs_server, tool_id, **kwd) + "/versions/" + version_id + "/%s/descriptor" % GA4GH_GALAXY_DESCRIPTOR
+        return self._get(trs_api_url)["content"]
+
+    def _quote(self, tool_id, **kwd):
+        if asbool(kwd.get("tool_id_b64_encoded", False)):
+            import base64
+            tool_id = base64.b64decode(tool_id)
+        tool_id = urllib.parse.quote_plus(tool_id)
+        return tool_id
+
+    def _get(self, url):
+        response = requests.get(url)
+        if response.ok:
+            return response.json()
+        else:
+            code = response.status_code
+            message = response.text
+            try:
+                trs_error_dict = response.json()
+                code = int(trs_error_dict["code"])
+                message = trs_error_dict["message"]
+            except Exception:
+                pass
+            raise MessageException.from_code(code, message)
+
+    def _get_api_endpoint(self, trs_server, **kwd):
+        trs_url = self._server_dict[trs_server]["api_url"]
+        trs_api_endpoint = trs_url + "/" + "ga4gh/trs/v2/tools"
+        return trs_api_endpoint
+
+    def _get_tool_api_endpoint(self, trs_server, tool_id, **kwd):
+        tool_id = self._quote(tool_id, **kwd)
+        trs_api_url = self._get_api_endpoint(trs_server, **kwd) + "/" + tool_id
+        return trs_api_url

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -20,9 +20,7 @@ DEFAULT_TRS_SERVERS = [
         "doc": "Dockstore is an open platform used by the GA4GH for sharing Docker-based tools and workflows.",
     },
 ]
-# Switch to "Galaxy" after Dockstore bug fixed, deployed:
-# https://github.com/dockstore/dockstore/issues/3670
-GA4GH_GALAXY_DESCRIPTOR = "GXFORMAT2"
+GA4GH_GALAXY_DESCRIPTOR = "GALAXY"
 
 
 class TrsProxy(object):

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -89,6 +89,7 @@ PATH_CONFIG_PROPERTIES = [
     'tool_dependency_cache_dir',
     'tool_path',
     'tool_sheds_config_file',
+    'trs_servers_config_file',
     'user_preferences_extra_conf_path',
     'webhooks_dir',
     'workflow_resource_params_file',
@@ -117,6 +118,7 @@ RESOLVE = {
     'object_store_config_file': 'config_dir',
     'oidc_backends_config_file': 'config_dir',
     'oidc_config_file': 'config_dir',
+    'trs_servers_config_file': 'config_dir',
     'sanitize_allowlist_file': 'managed_config_dir',
     'shed_data_manager_config_file': 'managed_config_dir',
     'shed_tool_config_file': 'managed_config_dir',
@@ -201,6 +203,7 @@ DO_NOT_TEST = [
     'tool_config_file',  # default not used; may or may not be testable
     'tool_data_table_config_path',  # broken: remove 'config/' prefix from schema
     'tool_test_data_directories',  # untestable; refactor config/__init__ to test
+    'trs_servers_config_file',  # default not used?
     'use_remote_user',  # broken: default overridden
     'use_tasked_jobs',  # broken: default overridden
     'user_library_import_dir',  # broken: default overridden

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -102,6 +102,7 @@ class ExpectedValues:
             'tool_search_index_dir': self._in_data_dir('tool_search_index'),
             'tool_sheds_config_file': self._in_config_dir('tool_sheds_conf.xml'),
             'tool_test_data_directories': self._in_root_dir('test-data'),
+            'trs_servers_config_file': self._in_config_dir('trs_servers_conf.yml'),
             'user_preferences_extra_conf_path': self._in_config_dir('user_preferences_extra_conf.yml'),
             'workflow_resource_params_file': self._in_config_dir('workflow_resource_params_conf.xml'),
             'workflow_schedulers_config_file': self._in_config_dir('workflow_schedulers_conf.xml'),

--- a/test/unit/workflows/test_trs_proxy.py
+++ b/test/unit/workflows/test_trs_proxy.py
@@ -1,0 +1,35 @@
+import base64
+
+import yaml
+
+from galaxy.workflow.trs_proxy import (
+    GA4GH_GALAXY_DESCRIPTOR,
+    TrsProxy,
+)
+
+
+def test_proxy():
+    proxy = TrsProxy()
+
+    assert 'dockstore' == proxy.get_servers()[0]["id"]
+
+    tool_id = "#workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow"
+    tool = proxy.get_tool("dockstore", tool_id)
+    assert "description" in tool
+
+    b64_tool_id = base64.b64encode(tool_id.encode("UTF-8"))
+    tool = proxy.get_tool("dockstore", b64_tool_id, tool_id_b64_encoded=True)
+    assert "description" in tool
+
+    versions = proxy.get_versions("dockstore", tool_id)
+    assert isinstance(versions, list)
+    assert len(versions) >= 1
+
+    version_id = versions[0]["name"]
+    version = proxy.get_version("dockstore", tool_id, version_id)
+    assert "descriptor_type" in version
+    assert GA4GH_GALAXY_DESCRIPTOR in version["descriptor_type"]
+
+    descriptor = proxy.get_version_descriptor("dockstore", tool_id, version_id)
+    content = yaml.safe_load(descriptor)
+    assert "inputs" in content


### PR DESCRIPTION
Defaults to allowing import from Dockstore, which added Galaxy support with the latest release and has followed up with several bug fixes for us.

The UI and API are both roughly functional but there isn't a link to it yet in the analysis app. Once search is done that will make sense, but this is still something I think we want merged and ready to go for 20.09 because it provides a callback endpoint they can send us - (e.g. they should be able to link to https://usegalaxy.org/workflows/trs_import?trs_server=dockstore.org&trs_id=%23workflow%2Fgithub.com%2Fjmchilton%2Fgalaxy-workflow-dockstore-example-1%2Fmycoolworkflow and that seems to work in local testing). 

Check out the demo or an earlier version of this:

https://www.youtube.com/watch?v=D59ftjdme3o
