### PR TITLE
[20.05] Hyphyvision visualization dependency fix

### DIFF
--- a/config/plugins/visualizations/hyphyvision/package.json
+++ b/config/plugins/visualizations/hyphyvision/package.json
@@ -1,23 +1,30 @@
 {
-  "devDependencies": {
-    "css-loader": "^3.4.2",
-    "file-loader": "^5.0.2",
-    "mini-css-extract-plugin": "^0.9.0",
-    "style-loader": "^1.1.3",
-    "webpack": "^4.41.6",
-    "webpack-cli": "^3.3.11"
-  },
-  "dependencies": {
-    "d3": "3.x",
-    "expose-loader": "^0.7.5",
-    "hyphy-vision": "2.6.3",
-    "jquery": "1.x"
-  },
-  "name": "galaxy-hyphy",
-  "version": "1.1.0",
-  "main": "index.js",
-  "license": "MIT",
-  "scripts": {
-    "build": "webpack --mode production"
-  }
+    "resolutions": {
+        "**/phylotree": "0.1.6",
+        "**/react-phylotree": "0.1.0",
+        "**/react": "16.12.0",
+        "**/alignment.js": "0.1.1",
+        "**/underscore": "1.9.2"
+    },
+    "devDependencies": {
+        "css-loader": "^3.4.2",
+        "d3": "3.x",
+        "expose-loader": "^0.7.5",
+        "file-loader": "^5.0.2",
+        "hyphy-vision": "2.6.3",
+        "jquery": "1.x",
+        "mini-css-extract-plugin": "^0.9.0",
+        "phylotree": "0.1.6",
+        "style-loader": "^1.1.3",
+        "underscore": "1.9",
+        "webpack": "^4.41.6",
+        "webpack-cli": "^3.3.11"
+    },
+    "name": "galaxy-hyphy",
+    "version": "1.1.0",
+    "main": "index.js",
+    "license": "MIT",
+    "scripts": {
+        "build": "webpack --mode development"
+    }
 }

--- a/config/plugins/visualizations/hyphyvision/package.json
+++ b/config/plugins/visualizations/hyphyvision/package.json
@@ -1,6 +1,6 @@
 {
     "name": "galaxy-hyphy",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "MIT",
     "main": "index.js",
     "scripts": {

--- a/config/plugins/visualizations/hyphyvision/package.json
+++ b/config/plugins/visualizations/hyphyvision/package.json
@@ -7,6 +7,7 @@
         "build": "webpack --mode development"
     },
     "dependencies": {
+        "fbjs": "^1.0.0",
         "underscore": "^1.9.2"
     },
     "devDependencies": {

--- a/config/plugins/visualizations/hyphyvision/package.json
+++ b/config/plugins/visualizations/hyphyvision/package.json
@@ -1,6 +1,14 @@
 {
-    "resolutions": {
-        "**/underscore": "1.9.2"
+    "name": "galaxy-hyphy",
+    "version": "1.1.0",
+    "license": "MIT",
+    "main": "index.js",
+    "scripts": {
+        "build": "webpack --mode development"
+    },
+    "dependencies": {
+        "underscore": "^1.9.2",
+        "jquery": "1.x"
     },
     "devDependencies": {
         "css-loader": "^3.4.2",
@@ -8,21 +16,13 @@
         "expose-loader": "^0.7.5",
         "file-loader": "^5.0.2",
         "hyphy-vision": "2.6.3",
-        "jquery": "1.x",
         "mini-css-extract-plugin": "^0.9.0",
         "phylotree": "0.1.6",
         "style-loader": "^1.1.3",
         "webpack": "^4.41.6",
         "webpack-cli": "^3.3.11"
     },
-    "name": "galaxy-hyphy",
-    "version": "1.1.0",
-    "main": "index.js",
-    "license": "MIT",
-    "scripts": {
-        "build": "webpack --mode development"
-    },
-    "dependencies": {
-        "underscore": "^1.9.2"
+    "resolutions": {
+        "**/underscore": "1.9.2"
     }
 }

--- a/config/plugins/visualizations/hyphyvision/package.json
+++ b/config/plugins/visualizations/hyphyvision/package.json
@@ -1,9 +1,5 @@
 {
     "resolutions": {
-        "**/phylotree": "0.1.6",
-        "**/react-phylotree": "0.1.0",
-        "**/react": "16.12.0",
-        "**/alignment.js": "0.1.1",
         "**/underscore": "1.9.2"
     },
     "devDependencies": {
@@ -16,7 +12,6 @@
         "mini-css-extract-plugin": "^0.9.0",
         "phylotree": "0.1.6",
         "style-loader": "^1.1.3",
-        "underscore": "1.9",
         "webpack": "^4.41.6",
         "webpack-cli": "^3.3.11"
     },
@@ -26,5 +21,8 @@
     "license": "MIT",
     "scripts": {
         "build": "webpack --mode development"
+    },
+    "dependencies": {
+        "underscore": "^1.9.2"
     }
 }

--- a/config/plugins/visualizations/hyphyvision/package.json
+++ b/config/plugins/visualizations/hyphyvision/package.json
@@ -7,12 +7,10 @@
         "build": "webpack --mode development"
     },
     "dependencies": {
-        "underscore": "^1.9.2",
-        "jquery": "1.x"
+        "underscore": "^1.9.2"
     },
     "devDependencies": {
         "css-loader": "^3.4.2",
-        "d3": "3.x",
         "expose-loader": "^0.7.5",
         "file-loader": "^5.0.2",
         "hyphy-vision": "2.6.3",

--- a/config/plugins/visualizations/hyphyvision/webpack.config.js
+++ b/config/plugins/visualizations/hyphyvision/webpack.config.js
@@ -15,7 +15,6 @@ module.exports = {
             $: "jquery",
             jQuery: "jquery",
             d3: "d3",
-            //datamonkey: "datamonkey",
             _: "underscore"
         })
     ],
@@ -25,22 +24,6 @@ module.exports = {
                 test: /\.css/,
                 use: [MiniCssExtractPlugin.loader, "css-loader"]
             },
-            {
-                test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/,
-                loader: "url-loader",
-                options: { limit: 10000, mimetype: "application/font-woff" }
-            },
-            {
-                test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
-                loader: "url-loader",
-                options: { limit: 10000, mimetype: "application/octet-stream" }
-            },
-            { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loaders: "file-loader" },
-            {
-                test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
-                loaders: "url-loader",
-                options: { limit: 10000, mimetype: "image/svg+xml" }
-            }
         ]
     },
     resolve: {

--- a/config/plugins/visualizations/hyphyvision/webpack.config.js
+++ b/config/plugins/visualizations/hyphyvision/webpack.config.js
@@ -77,7 +77,7 @@ module.exports = {
     resolve: {
         modules: ["node_modules"],
         alias: {
-            "phylotree.css": __dirname + "/node_modules/phylotree/build/phylotree.css",
+            "phylotree.css": __dirname + "/node_modules/phylotree/phylotree.css",
             "hyphy-vision.css": __dirname + "/node_modules/hyphy-vision/dist/hyphyvision.css"
         }
     }

--- a/config/plugins/visualizations/hyphyvision/webpack.config.js
+++ b/config/plugins/visualizations/hyphyvision/webpack.config.js
@@ -40,37 +40,6 @@ module.exports = {
                 test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
                 loaders: "url-loader",
                 options: { limit: 10000, mimetype: "image/svg+xml" }
-            },
-            {
-                test: require.resolve("jquery"),
-                use: [
-                    {
-                        loader: "expose-loader",
-                        query: "jQuery"
-                    },
-                    {
-                        loader: "expose-loader",
-                        query: "$"
-                    }
-                ]
-            },
-            {
-                test: require.resolve("d3"),
-                use: [
-                    {
-                        loader: "expose-loader",
-                        query: "d3"
-                    }
-                ]
-            },
-            {
-                test: require.resolve("underscore"),
-                use: [
-                    {
-                        loader: "expose-loader",
-                        query: "_"
-                    }
-                ]
             }
         ]
     },


### PR DESCRIPTION
Fixing and cleaning up hyphyvision plugin.  After a lot of debugging, it was actually an unpinned underscore.js combined with the new underscore.js release (since this was originally added, when it worked) that caused the core issue.

We need to get this to main when it is convenient, but I know we need to work around a few schedules with BCC going on right now.