### PR TITLE
Add Anndata peek capability

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -998,7 +998,7 @@ class Anndata(H5):
                     if hasattr(tmp, 'dtype'):
                         layers = [util.unicodify(x) for x in tmp.dtype.names]
                         count = len(tmp.dtype)
-                        size = tmp.size
+                        size = int(tmp.size)
                     else:
                         layers = [util.unicodify(x) for x in list(tmp.keys())]
                         count = len(layers)

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -941,6 +941,33 @@ class Anndata(H5):
     """
     file_ext = 'h5ad'
 
+    MetadataElement(name="title", default="", desc="title", readonly=True, visible=True, no_value="")
+    MetadataElement(name="description", default="", desc="description", readonly=True, visible=True, no_value="")
+    MetadataElement(name="url", default="", desc="url", readonly=True, visible=True, no_value="")
+    MetadataElement(name="doi", default="", desc="doi", readonly=True, visible=True, no_value="")
+    #MetadataElement(name="loom_spec_version", default="", desc="loom_spec_version", readonly=True, visible=True, no_value="")
+    MetadataElement(name="creation_date", default=None, desc="creation_date", readonly=True, visible=True, no_value=None)
+    MetadataElement(name="shape", default=(), desc="shape", param=metadata.ListParameter, readonly=True, visible=True, no_value=())
+    MetadataElement(name="layers_count", default=0, desc="layers_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="layers_names", desc="layers_names", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="row_attrs_count", default=0, desc="row_attrs_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="obs_names", desc="obs_names", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="obs_layers", desc="obs_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="obs_count", default=0, desc="obs_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="obs_size", default=0, desc="obs_size", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="obsm_layers", desc="obsm_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="obsm_count", default=0, desc="obsm_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="raw_var_layers", desc="raw_var_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="raw_var_count", default=0, desc="raw_var_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="raw_var_size", default=0, desc="raw_var_size", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="var_layers", desc="var_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="var_count", default=0, desc="var_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="var_size", default=0, desc="var_size", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="varm_layers", desc="varm_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="varm_count", default=0, desc="varm_count", readonly=True, visible=True, no_value=0)
+    MetadataElement(name="uns_layers", desc="uns_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
+    MetadataElement(name="uns_count", default=0, desc="uns_count", readonly=True, visible=True, no_value=0)
+
     def sniff(self, filename):
         if super(Anndata, self).sniff(filename):
             try:
@@ -962,21 +989,22 @@ class Anndata(H5):
                 # the above appear to be completely empty
                 dataset.metadata.shape = tuple(anndata_file['X'].shape)
                 # all possible keys
-                dataset.metadata.layers = tuple(anndata_file)
+                dataset.metadata.layers_count = len(anndata_file)
+                dataset.metadata.layers_names = tuple(anndata_file)
 
-                if 'obs' in dataset.metadata.layers:
+                if 'obs' in dataset.metadata.layers_names:
                     tmp = anndata_file["obs"]
                     dataset.metadata.obs_names = tmp["index"]
                     dataset.metadata.obs_layers = tmp.dtype.names
                     dataset.metadata.obs_count = len(tmp.dtype)
                     dataset.metadata.obs_size = tmp.size
 
-                if 'obsm' in dataset.metadata.layers:
+                if 'obsm' in dataset.metadata.layers_names:
                     tmp = anndata_file["obsm"]
                     dataset.metadata.obsm_layers = tuple(tmp)
                     dataset.metadata.obsm_count = len(tmp)
 
-                if 'raw.var' in dataset.metadata.layers:
+                if 'raw.var' in dataset.metadata.layers_names:
                     tmp = anndata_file["raw.var"]
                     # full set of genes would never need to be previewed
                     #dataset.metadata.raw_var_names = tmp["index"]
@@ -984,7 +1012,7 @@ class Anndata(H5):
                     dataset.metadata.raw_var_count = len(tmp.dtype)
                     dataset.metadata.raw_var_size = tmp.size
 
-                if 'var' in dataset.metadata.layers:
+                if 'var' in dataset.metadata.layers_names:
                     tmp = anndata_file["var"]
                     # row names are not used in preview windows
                     #dataset.metadata.var_names = tmp["index"]
@@ -992,12 +1020,12 @@ class Anndata(H5):
                     dataset.metadata.var_count = len(tmp.dtype)
                     dataset.metadata.var_size = tmp.size
 
-                if 'varm' in dataset.metadata.layers:
+                if 'varm' in dataset.metadata.layers_names:
                     tmp = anndata_file["varm"]
                     dataset.metadata.varm_layers = tuple(tmp)
                     dataset.metadata.varm_count = len(tmp)
 
-                if 'uns' in dataset.metadata.layers:
+                if 'uns' in dataset.metadata.layers_names:
                     tmp = anndata_file["uns"]
                     dataset.metadata.uns_layers = tuple(tmp)
                     dataset.metadata.uns_count = len(tmp)

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1001,7 +1001,7 @@ class Anndata(H5):
 
                 if 'obsm' in dataset.metadata.layers_names:
                     tmp = anndata_file["obsm"]
-                    dataset.metadata.obsm_layers = [util.unicodify(x) for x in tmp.keys()]
+                    dataset.metadata.obsm_layers = [util.unicodify(x) for x in list(tmp.keys())]
                     dataset.metadata.obsm_count = len(tmp)
 
                 if 'raw.var' in dataset.metadata.layers_names:
@@ -1022,12 +1022,12 @@ class Anndata(H5):
 
                 if 'varm' in dataset.metadata.layers_names:
                     tmp = anndata_file["varm"]
-                    dataset.metadata.varm_layers = [util.unicodify(x) for x in tmp.keys()]
+                    dataset.metadata.varm_layers = [util.unicodify(x) for x in list(tmp.keys())]
                     dataset.metadata.varm_count = len(tmp)
 
                 if 'uns' in dataset.metadata.layers_names:
                     tmp = anndata_file["uns"]
-                    dataset.metadata.uns_layers = [util.unicodify(x) for x in tmp.keys()]
+                    dataset.metadata.uns_layers = [util.unicodify(x) for x in list(tmp.keys())]
                     dataset.metadata.uns_count = len(tmp)
 
                 # Shape we determine here due to the non-standard representation of 'X'
@@ -1042,27 +1042,24 @@ class Anndata(H5):
     def set_peek(self, dataset, is_multi_byte=False):
         if not dataset.dataset.purged:
             tmp = dataset.metadata
-            peekstr = "[n_obs x n_vars]" ##\n    %d x %d" % tmp.shape
-            #if 'obs' in tmp.layers_names:
-            #    peekstr += "\n[obs]: %d layer(s)\n    %s" % (
-            #        tmp.obs_count, " " ##str(list(tmp.obs_layers))
-            #    )
-            # if 'var' in tmp.layers_names:
-            #     peekstr += "\n[var]: %d layer(s)\n    %s" % (
-            #         tmp.var_count, " " ##' '.join(tmp.var_names)
-            #     )
-            # if 'obsm' in tmp.layers_names:
-            #     peekstr += "\n[obsm]: %d layer(s)\n    %s" % (
-            #         tmp.obsm_count, " " ##' '.join(tmp.obsm_names)
-            #     )
-            # if 'varm' in tmp.layers_names:
-            #     peekstr += "\n[varm]: %d layer(s)\n    %s" % (
-            #         tmp.varm_count, " " ##' '.join(tmp.varm_names)
-            #     )
-            # if 'uns' in tmp.layers_names:
-            #     peekstr += "\n[uns]: %d layer(s)\n    %s" % (
-            #         tmp.uns_count, " " ##' '.join(tmp.uns_names)
-            #     )
+
+            def _makelayerstrings (layer, count, names):
+                if layer in tmp.layers_names:
+                    return "\n[%s]: %d %s\n    %s" % (
+                        layer,
+                        count,
+                        "layer" if count == 1 else "layers",
+                        ', '.join(sorted(names))
+                    )
+                return ""
+
+            peekstr = "[n_obs x n_vars]\n    %d x %d" % tmp.shape
+            peekstr += _makelayerstrings("obs", tmp.obs_count, tmp.obs_layers)
+            peekstr += _makelayerstrings("var", tmp.var_count, tmp.var_layers)
+            peekstr += _makelayerstrings("obsm", tmp.obsm_count, tmp.obsm_layers)
+            peekstr += _makelayerstrings("varm", tmp.varm_count, tmp.varm_layers)
+            peekstr += _makelayerstrings("uns", tmp.uns_count, tmp.uns_layers)
+
             dataset.peek = peekstr
             dataset.blurb = "Anndata file (%s)" % nice_size(dataset.get_size())
         else:

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1004,6 +1004,42 @@ class Anndata(H5):
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)
 
+    def set_peek(self, dataset, is_multi_byte=False):
+        if not dataset.dataset.purged:
+            tmp = dataset.metadata
+            peekstr = "[n_obs x n_vars]\n    %d x %d" % tmp.shape
+            if 'obs' in tmp.layers:
+                peekstr += "\n[obs]: %d layer(s)\n    %s" % (
+                    tmp.obs_count, ' '.join(tmp.obs_names)
+                )
+            if 'var' in tmp.layers:
+                peekstr += "\n[var]: %d layer(s)\n    %s" % (
+                    tmp.var_count, ' '.join(tmp.var_names)
+                )
+            if 'obsm' in tmp.layers:
+                peekstr += "\n[obsm]: %d layer(s)\n    %s" % (
+                    tmp.obsm_count, ' '.join(tmp.obsm_names)
+                )
+            if 'varm' in tmp.layers:
+                peekstr += "\n[varm]: %d layer(s)\n    %s" % (
+                    tmp.varm_count, ' '.join(tmp.varm_names)
+                )
+            if 'uns' in tmp.layers:
+                peekstr += "\n[uns]: %d layer(s)\n    %s" % (
+                    tmp.uns_count, ' '.join(tmp.uns_names)
+                )
+            dataset.peek = peekstr
+            dataset.blurb = "Anndata file (%s)" % nice_size(dataset.get_size())
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def display_peek(self, dataset):
+        try:
+            return dataset.peek
+        except Exception:
+            return "Binary Anndata file (%s)" % (nice_size(dataset.get_size()))
+
 class GmxBinary(Binary):
     """
     Base class for GROMACS binary files - xtc, trr, cpt

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1040,37 +1040,37 @@ class Anndata(H5):
         except Exception:
             return "Binary Anndata file (%s)" % (nice_size(dataset.get_size()))
 
-    def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, offset=None, ck_size=None, **kwd):
-        preview = util.string_as_bool(preview)
-        if offset is not None:
-            return self.get_chunk(trans, dataset, offset, ck_size)
-        elif to_ext or not preview:
-            to_ext = to_ext or dataset.extension
-            return self._serve_raw(trans, dataset, to_ext, **kwd)
-        elif dataset.metadata.columns > 50:
-            # Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
-            # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
-            # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
-            max_peek_size = 1000000  # 1 MB
-            if os.stat(dataset.file_name).st_size < max_peek_size:
-                self._clean_and_set_mime_type(trans, dataset.get_mime())
-                return open(dataset.file_name, mode='rb')
-            else:
-                trans.response.set_content_type("text/html")
-                return trans.stream_template_mako("/dataset/large_file.mako",
-                                                  truncated_data=open(dataset.file_name, mode='r').read(max_peek_size),
-                                                  data=dataset)
-        else:
-            column_names = 'null'
-            if dataset.metadata.obs_names
-                column_names = dataset.metadata.obs_names
-            return trans.fill_template("/dataset/tabular_chunked.mako",
-                                       ## TODO: how to get the "X" slot?
-                                       dataset=dataset,
-                                       chunk=self.get_chunk(trans, dataset, 0),
-                                       column_number=column_number,
-                                       column_names=column_names,
-                                       column_types=column_types)
+    # def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, offset=None, ck_size=None, **kwd):
+    #     preview = util.string_as_bool(preview)
+    #     if offset is not None:
+    #         return self.get_chunk(trans, dataset, offset, ck_size)
+    #     elif to_ext or not preview:
+    #         to_ext = to_ext or dataset.extension
+    #         return self._serve_raw(trans, dataset, to_ext, **kwd)
+    #     elif dataset.metadata.columns > 50:
+    #         # Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
+    #         # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
+    #         # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
+    #         max_peek_size = 1000000  # 1 MB
+    #         if os.stat(dataset.file_name).st_size < max_peek_size:
+    #             self._clean_and_set_mime_type(trans, dataset.get_mime())
+    #             return open(dataset.file_name, mode='rb')
+    #         else:
+    #             trans.response.set_content_type("text/html")
+    #             return trans.stream_template_mako("/dataset/large_file.mako",
+    #                                               truncated_data=open(dataset.file_name, mode='r').read(max_peek_size),
+    #                                               data=dataset)
+    #     else:
+    #         column_names = 'null'
+    #         if dataset.metadata.obs_names:
+    #             column_names = dataset.metadata.obs_names
+    #         return trans.fill_template("/dataset/tabular_chunked.mako",
+    #                                    ## TODO: how to get the "X" slot?
+    #                                    dataset=dataset,
+    #                                    chunk=self.get_chunk(trans, dataset, 0),
+    #                                    column_number=column_number,
+    #                                    column_names=column_names,
+    #                                    column_types=column_types)
 
 class GmxBinary(Binary):
     """

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -966,7 +966,7 @@ class Anndata(H5):
     MetadataElement(name="varm_count", default=0, desc="varm_count", readonly=True, visible=True, no_value=0)
     MetadataElement(name="uns_layers", desc="uns_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
     MetadataElement(name="uns_count", default=0, desc="uns_count", readonly=True, visible=True, no_value=0)
-    MetadataElement(name="shape", default=(), desc="shape", param=metadata.ListParameter, readonly=True, visible=True, no_value=())
+    MetadataElement(name="shape", default=(0,0), desc="shape", param=metadata.ListParameter, readonly=True, visible=True, no_value=(0,0))
 
     def sniff(self, filename):
         if super(Anndata, self).sniff(filename):
@@ -1047,7 +1047,7 @@ class Anndata(H5):
                     elif hasattr(anndata_file['X'], 'shape'):
                         dataset.metadata.shape = tuple(anndata_file['X'].shape)
                     else:
-                        dataset.metadata.shape = (dataset.metadata.obs_size, dataset.metadata.var_size)
+                        dataset.metadata.shape = (int(dataset.metadata.obs_size), int(dataset.metadata.var_size))
 
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -941,12 +941,12 @@ class Anndata(H5):
     """
     file_ext = 'h5ad'
 
-    #MetadataElement(name="title", default="", desc="title", readonly=True, visible=True, no_value="")
-    #MetadataElement(name="description", default="", desc="description", readonly=True, visible=True, no_value="")
-    #MetadataElement(name="url", default="", desc="url", readonly=True, visible=True, no_value="")
-    #MetadataElement(name="doi", default="", desc="doi", readonly=True, visible=True, no_value="")
-    #MetadataElement(name="anndata_spec_version", default="", desc="loom_spec_version", readonly=True, visible=True, no_value="")
-    #MetadataElement(name="creation_date", default=None, desc="creation_date", readonly=True, visible=True, no_value=None)
+    MetadataElement(name="title", default="", desc="title", readonly=True, visible=True, no_value="")
+    MetadataElement(name="description", default="", desc="description", readonly=True, visible=True, no_value="")
+    MetadataElement(name="url", default="", desc="url", readonly=True, visible=True, no_value="")
+    MetadataElement(name="doi", default="", desc="doi", readonly=True, visible=True, no_value="")
+    MetadataElement(name="anndata_spec_version", default="", desc="anndata_spec_version", readonly=True, visible=True, no_value="")
+    MetadataElement(name="creation_date", default=None, desc="creation_date", readonly=True, visible=True, no_value=None)
     MetadataElement(name="layers_count", default=0, desc="layers_count", readonly=True, visible=True, no_value=0)
     MetadataElement(name="layers_names", desc="layers_names", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
     MetadataElement(name="row_attrs_count", default=0, desc="row_attrs_count", readonly=True, visible=True, no_value=0)
@@ -966,7 +966,7 @@ class Anndata(H5):
     MetadataElement(name="varm_count", default=0, desc="varm_count", readonly=True, visible=True, no_value=0)
     MetadataElement(name="uns_layers", desc="uns_layers", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
     MetadataElement(name="uns_count", default=0, desc="uns_count", readonly=True, visible=True, no_value=0)
-    MetadataElement(name="shape", default=(0,0), desc="shape", param=metadata.ListParameter, readonly=True, visible=True, no_value=(0,0))
+    MetadataElement(name="shape", default=(), desc="shape", param=metadata.ListParameter, readonly=True, visible=True, no_value=(0,0))
 
     def sniff(self, filename):
         if super(Anndata, self).sniff(filename):
@@ -986,13 +986,14 @@ class Anndata(H5):
                 dataset.metadata.url = util.unicodify(anndata_file.attrs.get('url'))
                 dataset.metadata.doi = util.unicodify(anndata_file.attrs.get('doi'))
                 dataset.creation_date = util.unicodify(anndata_file.attrs.get('creation_date'))
-                # none of the above appear to work, taken from LOOM datatype
+                # none of the above appear to work in any dataset tested, but could be useful for future
+                # AnnData datasets
 
                 # all possible keys
                 dataset.metadata.layers_count = len(anndata_file)
                 dataset.metadata.layers_names = list(anndata_file.keys())
 
-                def _layercountsize (tmp, lennames=None):
+                def _layercountsize (tmp, lennames=0):
                     "From TMP and LENNAMES, return layers, their number, and the length of one of the layers (all equal)."
                     if hasattr(tmp, 'dtype'):
                         layers = [util.unicodify(x) for x in tmp.dtype.names]
@@ -1047,7 +1048,7 @@ class Anndata(H5):
                     elif hasattr(anndata_file['X'], 'shape'):
                         dataset.metadata.shape = tuple(anndata_file['X'].shape)
                     else:
-                        dataset.metadata.shape = (int(dataset.metadata.obs_size), int(dataset.metadata.var_size))
+                        dataset.metadata.shape = tuple(int(dataset.metadata.obs_size), int(dataset.metadata.var_size))
 
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)
@@ -1067,7 +1068,7 @@ class Anndata(H5):
                     )
                 return ""
 
-            peekstr = "[n_obs x n_vars]\n    %d x %d" % tmp.shape
+            peekstr = "[n_obs x n_vars]\n    %d x %d" % tuple(tmp.shape)
             peekstr += _makelayerstrings("obs", tmp.obs_count, tmp.obs_layers)
             peekstr += _makelayerstrings("var", tmp.var_count, tmp.var_layers)
             peekstr += _makelayerstrings("obsm", tmp.obsm_count, tmp.obsm_layers)

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1040,6 +1040,38 @@ class Anndata(H5):
         except Exception:
             return "Binary Anndata file (%s)" % (nice_size(dataset.get_size()))
 
+    def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, offset=None, ck_size=None, **kwd):
+        preview = util.string_as_bool(preview)
+        if offset is not None:
+            return self.get_chunk(trans, dataset, offset, ck_size)
+        elif to_ext or not preview:
+            to_ext = to_ext or dataset.extension
+            return self._serve_raw(trans, dataset, to_ext, **kwd)
+        elif dataset.metadata.columns > 50:
+            # Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
+            # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
+            # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
+            max_peek_size = 1000000  # 1 MB
+            if os.stat(dataset.file_name).st_size < max_peek_size:
+                self._clean_and_set_mime_type(trans, dataset.get_mime())
+                return open(dataset.file_name, mode='rb')
+            else:
+                trans.response.set_content_type("text/html")
+                return trans.stream_template_mako("/dataset/large_file.mako",
+                                                  truncated_data=open(dataset.file_name, mode='r').read(max_peek_size),
+                                                  data=dataset)
+        else:
+            column_names = 'null'
+            if dataset.metadata.obs_names
+                column_names = dataset.metadata.obs_names
+            return trans.fill_template("/dataset/tabular_chunked.mako",
+                                       ## TODO: how to get the "X" slot?
+                                       dataset=dataset,
+                                       chunk=self.get_chunk(trans, dataset, 0),
+                                       column_number=column_number,
+                                       column_names=column_names,
+                                       column_types=column_types)
+
 class GmxBinary(Binary):
     """
     Base class for GROMACS binary files - xtc, trr, cpt

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1087,37 +1087,6 @@ class Anndata(H5):
         except Exception:
             return "Binary Anndata file (%s)" % (nice_size(dataset.get_size()))
 
-    # def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, offset=None, ck_size=None, **kwd):
-    #     preview = util.string_as_bool(preview)
-    #     if offset is not None:
-    #         return self.get_chunk(trans, dataset, offset, ck_size)
-    #     elif to_ext or not preview:
-    #         to_ext = to_ext or dataset.extension
-    #         return self._serve_raw(trans, dataset, to_ext, **kwd)
-    #     elif dataset.metadata.columns > 50:
-    #         # Fancy tabular display is only suitable for datasets without an incredibly large number of columns.
-    #         # We should add a new datatype 'matrix', with its own draw method, suitable for this kind of data.
-    #         # For now, default to the old behavior, ugly as it is.  Remove this after adding 'matrix'.
-    #         max_peek_size = 1000000  # 1 MB
-    #         if os.stat(dataset.file_name).st_size < max_peek_size:
-    #             self._clean_and_set_mime_type(trans, dataset.get_mime())
-    #             return open(dataset.file_name, mode='rb')
-    #         else:
-    #             trans.response.set_content_type("text/html")
-    #             return trans.stream_template_mako("/dataset/large_file.mako",
-    #                                               truncated_data=open(dataset.file_name, mode='r').read(max_peek_size),
-    #                                               data=dataset)
-    #     else:
-    #         column_names = 'null'
-    #         if dataset.metadata.obs_names:
-    #             column_names = dataset.metadata.obs_names
-    #         return trans.fill_template("/dataset/tabular_chunked.mako",
-    #                                    ## TODO: how to get the "X" slot?
-    #                                    dataset=dataset,
-    #                                    chunk=self.get_chunk(trans, dataset, 0),
-    #                                    column_number=column_number,
-    #                                    column_names=column_names,
-    #                                    column_types=column_types)
 
 class GmxBinary(Binary):
     """


### PR DESCRIPTION
This is an attempt to add peek and display functionality to the AnnData type. Targets the `release_20.01` branch.
 It is part of the GCC 2020 collaboration fest.

TODO:

* [X] Extract relevant metadata
  * [x] Passing local upload tests
* [X] Format a peek string
  * [x] Passing local upload tests
* [ ] Display a data matrix
* [x] Passing all tests