### PR TITLE
[20.05] Fix pip error around markdown tables.

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -55,7 +55,7 @@ scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
 snowballstemmer==2.0.0
-sphinx-markdown-tables==0.0.12
+sphinx-markdown-tables==0.0.13
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -55,7 +55,7 @@ scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
 snowballstemmer==2.0.0
-sphinx-markdown-tables==0.0.13
+sphinx-markdown-tables==0.0.15
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2


### PR DESCRIPTION
```
ERROR: sphinx-markdown-tables 0.0.12 has requirement markdown==3.0.1, but you'll have markdown 3.1.1 which is incompatible.
```

xref: https://github.com/ryanfox/sphinx-markdown-tables/commit/25b922235a883d77204b705b14a30c9f7a40a24b