### PR TITLE
[20.05] Pass stdin to hg clone to fix planemo tests

### DIFF
--- a/lib/galaxy/tool_shed/util/hg_util.py
+++ b/lib/galaxy/tool_shed/util/hg_util.py
@@ -23,7 +23,7 @@ def clone_repository(repository_clone_url, repository_file_dir, ctx_rev=None):
     if not os.path.exists(repository_file_dir):
         os.makedirs(repository_file_dir)
     try:
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL)
         return True, None
     except Exception as e:
         error_message = 'Error cloning repository: %s' % unicodify(e)


### PR DESCRIPTION
This is super-weird, but is required if Galaxy is driven by planemo:
```
Status of installed repositories: [{'changeset_revision': 'ff9530579d1f', 'ctx_rev': '16', 'deleted': False, 'description': 'Read QC reports using FastQC', 'dist_to_shed': False, 'error_message': 'Error cloning repository: Command \'[\'hg\', \'clone\', \'-r\', \'16\', \'https://toolshed.g2.bx.psu.edu/repos/devteam/fastqc\', \'/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmp2pxuokji/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/ff9530579d1f/fastqc\']\' returned non-zero exit status 1.\nOutput was:\nTraceback (most recent call last):\n  File "/Users/mvandenb/src/galaxy/.venv/bin/hg", line 35, in <module>\n    from mercurial import dispatch\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/dispatch.py", line 22, in <module>\n    from .i18n import _\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/i18n.py", line 15, in <module>\n    from .pycompat import getattr\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/pycompat.py", line 133, in <module>\n    stdin = sys.stdin.buffer\nAttributeError: \'NoneType\' object has no attribute \'buffer\'\n', 'id': '5729865256bc2525', 'includes_datatypes': False, 'installed_changeset_revision': 'ff9530579d1f', 'name': 'fastqc', 'owner': 'devteam', 'status': 'Error', 'tool_shed': 'toolshed.g2.bx.psu.edu', 'tool_shed_status': None, 'uninstalled': False, 'url': '/api/tool_shed_repositories/5729865256bc2525'}, {'changeset_revision': '1ea4e668bf73', 'ctx_rev': '3', 'deleted': False, 'description': 'Query Tabular.', 'dist_to_shed': False, 'error_message': 'Error cloning repository: Command \'[\'hg\', \'clone\', \'-r\', \'3\', \'https://toolshed.g2.bx.psu.edu/repos/iuc/query_tabular\', \'/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmp2pxuokji/shed_tools/toolshed.g2.bx.psu.edu/repos/iuc/query_tabular/1ea4e668bf73/query_tabular\']\' returned non-zero exit status 1.\nOutput was:\nTraceback (most recent call last):\n  File "/Users/mvandenb/src/galaxy/.venv/bin/hg", line 35, in <module>\n    from mercurial import dispatch\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/dispatch.py", line 22, in <module>\n    from .i18n import _\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/i18n.py", line 15, in <module>\n    from .pycompat import getattr\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/pycompat.py", line 133, in <module>\n    stdin = sys.stdin.buffer\nAttributeError: \'NoneType\' object has no attribute \'buffer\'\n', 'id': '2891970512fa2d5a', 'includes_datatypes': False, 'installed_changeset_revision': '1ea4e668bf73', 'name': 'query_tabular', 'owner': 'iuc', 'status': 'Error', 'tool_shed': 'toolshed.g2.bx.psu.edu', 'tool_shed_status': None, 'uninstalled': False, 'url': '/api/tool_shed_repositories/2891970512fa2d5a'}, {'changeset_revision': '0a8c6b61f0f4', 'ctx_rev': '13', 'deleted': False, 'description': 'High performance text processing tools using the GNU coreutils, sed, awk and friends.', 'dist_to_shed': False, 'error_message': 'Error cloning repository: Command \'[\'hg\', \'clone\', \'-r\', \'13\', \'https://toolshed.g2.bx.psu.edu/repos/bgruening/text_processing\', \'/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmp2pxuokji/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/text_processing/0a8c6b61f0f4/text_processing\']\' returned non-zero exit status 1.\nOutput was:\nTraceback (most recent call last):\n  File "/Users/mvandenb/src/galaxy/.venv/bin/hg", line 35, in <module>\n    from mercurial import dispatch\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/dispatch.py", line 22, in <module>\n    from .i18n import _\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/i18n.py", line 15, in <module>\n    from .pycompat import getattr\n  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mercurial/pycompat.py", line 133, in <module>\n    stdin = sys.stdin.buffer\nAttributeError: \'NoneType\' object has no attribute \'buffer\'\n', 'id': '54f2a3a23292eb07', 'includes_datatypes': False, 'installed_changeset_revision': '0a8c6b61f0f4', 'name': 'text_processing', 'owner': 'bgruening', 'status': 'Error', 'tool_shed': 'toolshed.g2.bx.psu.edu', 'tool_shed_status': None, 'uninstalled': False, 'url': '/api/tool_shed_repositories/54f2a3a23292eb07'}]
```

Fixes `pytest -s  tests/test_training_tutorial.py -k get_hands_on_boxes_from_local_galaxy`