### PR TITLE
Flush once for enqueue / workflow handler assignment

### DIFF
--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -49,7 +49,7 @@ class JobManager(object):
     def _message_callback(self, job):
         return JobHandlerMessage(task='setup', job_id=job.id)
 
-    def enqueue(self, job, tool=None):
+    def enqueue(self, job, tool=None, flush=True):
         """Queue a job for execution.
 
         Due to the nature of some handler assignment methods which are wholly DB-based, the enqueue method will flush
@@ -76,7 +76,7 @@ class JobManager(object):
         message_callback = partial(self._message_callback, job)
         try:
             return self.app.job_config.assign_handler(
-                job, configured=configured_handler, queue_callback=queue_callback, message_callback=message_callback)
+                job, configured=configured_handler, queue_callback=queue_callback, message_callback=message_callback, flush=flush)
         except HandlerAssignmentError as exc:
             raise ToolExecutionError(exc.args[0], job=exc.obj)
 

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -112,8 +112,9 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
         trans.sa_session.flush()
     for job in execution_tracker.successful_jobs:
         # Put the job in the queue if tracking in memory
-        tool.app.job_manager.enqueue(job, tool=tool)
+        tool.app.job_manager.enqueue(job, tool=tool, flush=False)
         trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
+    trans.sa_session.flush()
 
     if has_remaining_jobs:
         raise PartialJobExecution(execution_tracker)

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -422,9 +422,7 @@ class WorkflowStepExecutionTracker(ExecutionTracker):
 
     def record_success(self, execution_slice, job, outputs):
         super(WorkflowStepExecutionTracker, self).record_success(execution_slice, job, outputs)
-        if self.collection_info:
-            self.invocation_step.implicit_collection_jobs = self.implicit_collection_jobs
-        else:
+        if not self.collection_info:
             self.invocation_step.job = job
         self.job_callback(job)
 
@@ -453,6 +451,7 @@ class WorkflowStepExecutionTracker(ExecutionTracker):
                 assert hasattr(implicit_collection, "history_content_type")  # make sure it is an HDCA and not a DC
                 collections[output_assoc.output_name] = output_assoc.dataset_collection
             self.implicit_collections = collections
+        self.invocation_step.implicit_collection_jobs = self.implicit_collection_jobs
 
 
 __all__ = ('execute', )

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -379,7 +379,7 @@ class ConfiguresHandlers(object):
             _timed_flush_obj(obj)
         return handler_id
 
-    def _assign_db_tag(self, obj, method, configured, **kwargs):
+    def _assign_db_tag(self, obj, method, configured, flush=True, **kwargs):
         """Assign object to a handler by setting its ``handler`` column in the database to either the configured handler
         ID or tag, or to the default tag (or ``_default_``)
 
@@ -393,10 +393,11 @@ class ConfiguresHandlers(object):
         if handler is None:
             handler = self.default_handler_id or self.DEFAULT_HANDLER_TAG
         obj.set_handler(handler)
-        _timed_flush_obj(obj)
+        if flush:
+            _timed_flush_obj(obj)
         return handler
 
-    def _assign_uwsgi_mule_message_handler(self, obj, method, configured, message_callback=None, **kwargs):
+    def _assign_uwsgi_mule_message_handler(self, obj, method, configured, message_callback=None, flush=True, **kwargs):
         """Assign object to a handler by sending a setup message to the appropriate handler pool (farm), where a handler
         (mule) will receive the message and assign itself.
 
@@ -419,7 +420,8 @@ class ConfiguresHandlers(object):
             log.debug("(%s) No handler pool (uWSGI farm) for '%s' found", obj.log_str(), tag)
             raise HandlerAssignmentSkip()
         else:
-            _timed_flush_obj(obj)
+            if flush:
+                _timed_flush_obj(obj)
             message = message_callback()
             self.app.application_stack.send_message(pool, message)
         return pool

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -280,7 +280,7 @@ class ConfiguresHandlers(object):
 
     # If these get to be any more complex we should probably modularize them, or at least move to a separate class
 
-    def _assign_handler_direct(self, obj, configured):
+    def _assign_handler_direct(self, obj, configured, flush=True):
         """Directly assign a handler if the object has been preconfigured to a known single static handler.
 
         :param obj:             Same as :method:`ConfiguresHandlers.assign_handler()`.
@@ -295,11 +295,12 @@ class ConfiguresHandlers(object):
                 handlers = None
             if handlers == (configured,):
                 obj.set_handler(configured)
-                _timed_flush_obj(obj)
+                if flush:
+                    _timed_flush_obj(obj)
                 return configured
         return False
 
-    def _assign_mem_self_handler(self, obj, method, configured, queue_callback=None, **kwargs):
+    def _assign_mem_self_handler(self, obj, method, configured, queue_callback=None, flush=True, **kwargs):
         """Assign object to this handler using this process's in-memory queue.
 
         This method ignores all handler configuration.
@@ -319,11 +320,12 @@ class ConfiguresHandlers(object):
             log.warning("(%s) Ignoring handler assignment to '%s' because configured handler assignment method"
                         " '' overrides per-tool handler assignment", obj.log_str(),
                         HANDLER_ASSIGNMENT_METHODS.MEM_SELF, configured)
-        _timed_flush_obj(obj)
+        if flush():
+            _timed_flush_obj(obj)
         queue_callback()
         return self.app.config.server_name
 
-    def _assign_db_self_handler(self, obj, method, configured, **kwargs):
+    def _assign_db_self_handler(self, obj, method, configured, flush=True, **kwargs):
         """Assign object to this process by setting its ``handler`` column in the database to this process.
 
         This only occurs if there is not an explicitly configured handler assignment for the object. Otherwise, it is
@@ -340,10 +342,11 @@ class ConfiguresHandlers(object):
                 obj, method, configured, **kwargs
             )
         obj.set_handler(self.app.config.server_name)
-        _timed_flush_obj(obj)
+        if flush:
+            _timed_flush_obj(obj)
         return self.app.config.server_name
 
-    def _assign_db_preassign_handler(self, obj, method, configured, index=None, **kwargs):
+    def _assign_db_preassign_handler(self, obj, method, configured, index=None, flush=True, **kwargs):
         """Assign object to a handler by setting its ``handler`` column in the database to a handler selected at random
         from the known handlers in the appropriate tag.
 
@@ -372,7 +375,8 @@ class ConfiguresHandlers(object):
             log.debug("(%s) Selected handler '%s' by random choice from handler tag '%s'", obj.log_str(),
                       handler_id, handler)
         obj.set_handler(handler_id)
-        _timed_flush_obj(obj)
+        if flush:
+            _timed_flush_obj(obj)
         return handler_id
 
     def _assign_db_tag(self, obj, method, configured, **kwargs):
@@ -438,8 +442,8 @@ class ConfiguresHandlers(object):
         # that's currently the best place for it. It's worth noting that this method is also part of the
         # WorkflowSchedulingManager, which acts like a combined JobConfiguration and JobManager. Combining those two
         # classes would probably be reasonable (and would remove the need for the queue callback).
-        if self._assign_handler_direct(obj, configured):
-            log.info("(%s) Skipped handler assignment logic due to explicit configuration to a single handler: %s",
+        if self._assign_handler_direct(obj, configured, flush=kwargs.get('flush', True)):
+            log.info("(%s) Skipped handler assignment logic due to explicit configuration` to a single handler: %s",
                      obj.log_str(), configured)
             return True
         for method in self.handler_assignment_methods:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -813,10 +813,13 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                 trans=trans,
                 workflow=workflow,
                 workflow_run_config=run_config,
-                request_params=work_request_params
+                request_params=work_request_params,
+                flush=False,
             )
-            invocation = self.encode_all_ids(trans, workflow_invocation.to_dict(), recursive=True)
-            invocations.append(invocation)
+            invocations.append(workflow_invocation)
+
+        trans.sa_session.flush()
+        invocations = [self.encode_all_ids(trans, invocation.to_dict(), recursive=True) for invocation in invocations]
 
         if is_batch:
             return invocations

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -106,12 +106,12 @@ def __invoke(trans, workflow, workflow_run_config, workflow_invocation=None, pop
     return outputs, invoker.workflow_invocation
 
 
-def queue_invoke(trans, workflow, workflow_run_config, request_params={}, populate_state=True):
+def queue_invoke(trans, workflow, workflow_run_config, request_params={}, populate_state=True, flush=True):
     if populate_state:
         modules.populate_module_and_state(trans, workflow, workflow_run_config.param_map, allow_tool_state_corrections=workflow_run_config.allow_tool_state_corrections)
     workflow_invocation = workflow_run_config_to_request(trans, workflow_run_config, workflow)
     workflow_invocation.workflow = workflow
-    return trans.app.workflow_scheduling_manager.queue(workflow_invocation, request_params)
+    return trans.app.workflow_scheduling_manager.queue(workflow_invocation, request_params, flush=flush)
 
 
 class WorkflowInvoker(object):

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -118,7 +118,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
     def _message_callback(self, workflow_invocation):
         return WorkflowSchedulingMessage(task='setup', workflow_invocation_id=workflow_invocation.id)
 
-    def _assign_handler(self, workflow_invocation):
+    def _assign_handler(self, workflow_invocation, flush=True):
         # Use random-ish integer history_id to produce a consistent index to pick
         # job handler with.
         random_index = workflow_invocation.history.id
@@ -128,7 +128,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
             random_index = None
         return self.__handlers_config.assign_handler(
             workflow_invocation, configured=None, index=random_index, queue_callback=queue_callback,
-            message_callback=message_callback)
+            message_callback=message_callback, flush=flush)
 
     def shutdown(self):
         exception = None
@@ -148,15 +148,15 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         if exception:
             raise exception
 
-    def queue(self, workflow_invocation, request_params):
+    def queue(self, workflow_invocation, request_params, flush=True):
         workflow_invocation.state = model.WorkflowInvocation.states.NEW
         workflow_invocation.scheduler = request_params.get("scheduler", None) or self.default_scheduler_id
         sa_session = self.app.model.context
         sa_session.add(workflow_invocation)
 
-        # Assign handler (also performs the flush)
+        # Assign handler
         try:
-            self._assign_handler(workflow_invocation)
+            self._assign_handler(workflow_invocation, flush=flush)
         except HandlerAssignmentError:
             raise RuntimeError("Unable to set a handler for workflow invocation '%s'" % workflow_invocation.id)
 


### PR DESCRIPTION
That's the last bit of optimization I've been working on.

1000 fastp jobs (paired collection, mapping over list:pair input):
Before:
```
*** PROFILER RESULTS ***
execute (/Users/mvandenb/src/galaxy/lib/galaxy/tools/execute.py:33)
function called 1 times

         145266132 function calls (144357020 primitive calls) in 156.053 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 1968 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.016    0.016  156.275  156.275 execute.py:33(execute)
     1005    0.175    0.000  115.135    0.115 session.py:2489(flush)
     1004    0.404    0.000  114.873    0.114 session.py:2542(_flush)
     1000    0.017    0.000  105.944    0.106 manager.py:52(enqueue)
     1000    0.005    0.000  101.476    0.101 handlers.py:423(assign_handler)
     1000    0.006    0.000  101.359    0.101 handlers.py:283(_assign_handler_direct)
     1000    0.013    0.000  101.332    0.101 handlers.py:463(_timed_flush_obj)
     1007    0.018    0.000   75.595    0.075 session.py:501(commit)
     1007    8.511    0.008   74.676    0.074 session.py:386(_remove_snapshot)
  8103262   22.495    0.000   60.200    0.000 state.py:567(_expire)
8478432/8472432    4.785    0.000   30.670    0.000 attr.py:257(__call__)
    56047    0.087    0.000   30.483    0.001 base.py:952(execute)
    56047    0.067    0.000   30.377    0.001 elements.py:296(_execute_on_connection)
    56047    0.357    0.000   30.310    0.001 base.py:1088(_execute_clauseelement)
3210069/3210063    1.839    0.000   30.085    0.000 attributes.py:279(__get__)
     1000    0.015    0.000   29.793    0.030 execute.py:54(execute_single_job)
     1000    0.011    0.000   29.185    0.029 __init__.py:1587(handle_single_execution)
     1000    0.018    0.000   29.173    0.029 __init__.py:1681(execute)
     1000    0.129    0.000   29.155    0.029 __init__.py:280(execute)
580205/555189    0.523    0.000   28.900    0.000 attributes.py:699(get)
    56047    0.497    0.000   23.370    0.000 base.py:1195(_execute_context)
     1004    0.010    0.000   21.085    0.021 unitofwork.py:402(execute)
        3    0.000    0.000   18.307    6.102 mapping.py:2827(db_next_hid)
1007/1005    0.003    0.000   18.226    0.018 session.py:899(begin)
1007/1005    0.006    0.000   18.223    0.018 session.py:221(__init__)
1007/1005    0.005    0.000   18.216    0.018 session.py:338(_take_snapshot)
        1    0.000    0.000   18.200   18.200 __init__.py:1791(add_datasets)
        1    0.006    0.006   18.019   18.019 __init__.py:1811(__add_datasets_optimized)
    18031    0.077    0.000   16.787    0.001 query.py:3501(_execute_and_instances)
     7013    0.021    0.000   16.542    0.002 loading.py:190(load_on_ident)
     7013    0.068    0.000   16.521    0.002 loading.py:211(load_on_pk_identity)
     7014    0.010    0.000   16.415    0.002 query.py:3417(one)
     7014    0.182    0.000   16.405    0.002 query.py:3381(one_or_none)
    56042    0.044    0.000   15.741    0.000 default.py:589(do_execute)
    56042   15.352    0.000   15.697    0.000 {method 'execute' of 'psycopg2.extensions.cursor' objects}
     1037    0.038    0.000   15.221    0.015 persistence.py:184(save_obj)
    80013    0.046    0.000   14.735    0.000 state.py:640(_load_expired)
     5013    0.047    0.000   14.640    0.003 loading.py:938(load_scalar_attributes)
  8103262   13.742    0.000   13.742    0.000 state.py:584(<listcomp>)
     7015    0.016    0.000   13.376    0.002 query.py:3476(__iter__)
```
after:
```
*** PROFILER RESULTS ***
execute (/Users/mvandenb/src/galaxy/lib/galaxy/tools/execute.py:33)
function called 1 times

         52239273 function calls (51684556 primitive calls) in 60.087 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 1981 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.012    0.012   60.281   60.281 execute.py:33(execute)
        6    0.139    0.023   27.886    4.648 session.py:2489(flush)
        5    0.052    0.010   27.662    5.532 session.py:2542(_flush)
     1000    0.014    0.000   26.734    0.027 execute.py:54(execute_single_job)
     1000    0.009    0.000   26.180    0.026 __init__.py:1587(handle_single_execution)
     1000    0.015    0.000   26.170    0.026 __init__.py:1681(execute)
     1000    0.109    0.000   26.155    0.026 __init__.py:280(execute)
    54048    0.077    0.000   23.137    0.000 base.py:952(execute)
    54048    0.058    0.000   23.046    0.000 elements.py:296(_execute_on_connection)
    54048    0.299    0.000   22.989    0.000 base.py:1088(_execute_clauseelement)
3208071/3208065    1.694    0.000   22.316    0.000 attributes.py:279(__get__)
579205/554189    0.472    0.000   21.223    0.000 attributes.py:699(get)
    54048    0.427    0.000   18.368    0.000 base.py:1195(_execute_context)
        5    0.003    0.001   18.153    3.631 unitofwork.py:402(execute)
        3    0.000    0.000   17.253    5.751 mapping.py:2827(db_next_hid)
        1    0.000    0.000   17.192   17.192 __init__.py:1791(add_datasets)
      8/6    0.000    0.000   17.151    2.858 session.py:899(begin)
      8/6    0.000    0.000   17.151    2.858 session.py:221(__init__)
      8/6    0.000    0.000   17.151    2.858 session.py:338(_take_snapshot)
        1    0.005    0.005   17.025   17.025 __init__.py:1811(__add_datasets_optimized)
       38    0.020    0.001   12.771    0.336 persistence.py:184(save_obj)
    54042    0.037    0.000   12.115    0.000 default.py:589(do_execute)
    54042   11.783    0.000   12.078    0.000 {method 'execute' of 'psycopg2.extensions.cursor' objects}
    11012    0.022    0.000   12.033    0.001 scoping.py:162(do)
    17031    0.065    0.000   11.452    0.001 query.py:3501(_execute_and_instances)
     1000    0.013    0.000   10.593    0.011 __init__.py:247(_collect_inputs)
       35    0.002    0.000   10.576    0.302 unitofwork.py:585(execute)
     6013    0.015    0.000   10.351    0.002 loading.py:190(load_on_ident)
     6013    0.048    0.000   10.336    0.002 loading.py:211(load_on_pk_identity)
      168    0.000    0.000   10.266    0.061 unitofwork.py:520(execute_aggregate)
     6014    0.006    0.000   10.263    0.002 query.py:3417(one)
     6014    0.126    0.000   10.256    0.002 query.py:3381(one_or_none)
       38    0.339    0.009   10.251    0.270 persistence.py:1039(_emit_insert_statements)
   109036    0.174    0.000    9.750    0.000 strategies.py:665(_load_for_state)
    11016    0.022    0.000    9.315    0.001 <string>:1(<lambda>)
    11016    0.118    0.000    9.293    0.001 strategies.py:772(_emit_lazyload)
     2000    0.004    0.000    8.955    0.004 __init__.py:1477(visit_inputs)
32000/2000    0.204    0.000    8.951    0.004 __init__.py:22(visit_input_values)
    79013    0.032    0.000    8.683    0.000 state.py:640(_load_expired)
     1000    0.003    0.000    8.663    0.009 __init__.py:66(_collect_input_datasets)
```
