### PR TITLE
[20.05] Mulled packaging dependency fixes

### DIFF
--- a/packages/test.sh
+++ b/packages/test.sh
@@ -44,7 +44,7 @@ for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
     if [ "$package_dir" = "util" ]; then
         pip install -e '.[template,jstree]'
     fi
-    if [ "$package_dir" = "tool_util"]; then
+    if [ "$package_dir" = "tool_util" ]; then
         pip install -e '.[condatesting]'
     fi
 

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -45,7 +45,7 @@ for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
         pip install -e '.[template,jstree]'
     fi
     if [ "$package_dir" = "tool_util" ]; then
-        pip install -e '.[condatesting]'
+        pip install -e '.[mulled]'
     fi
 
     if [[ "$run_tests" == "1" ]]; then

--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -97,7 +97,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'condatesting': ['jinja2'],
+        'mulled': ['conda', 'cytoolz', 'jinja2', 'Whoosh'],
     },
     license="AFL",
     zip_safe=False,

--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -97,7 +97,12 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'mulled': ['conda', 'cytoolz', 'jinja2', 'Whoosh'],
+        'mulled': [
+            'conda',
+            'cytoolz',  # cytoolz is an undeclared dependency of the conda package on PyPI
+            'jinja2',
+            'Whoosh',
+        ],
     },
     license="AFL",
     zip_safe=False,

--- a/packages/tool_util/tests/sample_data.py
+++ b/packages/tool_util/tests/sample_data.py
@@ -1,1 +1,0 @@
-../../../test/unit/unittest_utils/sample_data.py

--- a/packages/tool_util/tests/test_conda_resolution.py
+++ b/packages/tool_util/tests/test_conda_resolution.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_conda_resolution.py

--- a/packages/tool_util/tests/test_output_checker.py
+++ b/packages/tool_util/tests/test_output_checker.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_output_checker.py

--- a/packages/tool_util/tests/test_parsing.py
+++ b/packages/tool_util/tests/test_parsing.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_parsing.py

--- a/packages/tool_util/tests/test_tool_deps.py
+++ b/packages/tool_util/tests/test_tool_deps.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_tool_deps.py

--- a/packages/tool_util/tests/test_tool_linters.py
+++ b/packages/tool_util/tests/test_tool_linters.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_tool_linters.py

--- a/packages/tool_util/tests/test_tool_loader.py
+++ b/packages/tool_util/tests/test_tool_loader.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_tool_loader.py

--- a/packages/tool_util/tests/test_util.py
+++ b/packages/tool_util/tests/test_util.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/test_util.py

--- a/packages/tool_util/tests/tool_util
+++ b/packages/tool_util/tests/tool_util
@@ -1,0 +1,1 @@
+../../../test/unit/tool_util/

--- a/packages/tool_util/tests/util.py
+++ b/packages/tool_util/tests/util.py
@@ -1,1 +1,0 @@
-../../../test/unit/tool_util/util.py


### PR DESCRIPTION
So `pip install galaxy-tool-util[mulled]` will give you functional mulled commands. xref https://github.com/galaxyproject/galaxy-lib/issues/156