### PR TITLE
[20.01] Backport webpack bundle prefix fix

### DIFF
--- a/client/galaxy/scripts/onload/index.js
+++ b/client/galaxy/scripts/onload/index.js
@@ -6,6 +6,10 @@ import "bootstrap-tour";
 // Galaxy core styles
 import "scss/base.scss";
 
+// Set up webpack's public path; nothing to import but the module has side
+// effects fixing webpack globals.
+import "./publicPath";
+
 // Module exports appear as objects on window.config in the browser
 export { standardInit } from "./standardInit";
 export { initializations$, addInitialization, prependInitialization, clearInitQueue } from "./initQueue";

--- a/client/galaxy/scripts/onload/publicPath.js
+++ b/client/galaxy/scripts/onload/publicPath.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /**
  * Set dynamically loaded webpack public path. (https://webpack.js.org/guides/public-path/#on-the-fly)
  * This is, by default, just `/static/dist/`, but if galaxy is being served at

--- a/client/galaxy/scripts/onload/publicPath.js
+++ b/client/galaxy/scripts/onload/publicPath.js
@@ -1,0 +1,12 @@
+/**
+ * Set dynamically loaded webpack public path. (https://webpack.js.org/guides/public-path/#on-the-fly)
+ * This is, by default, just `/static/dist/`, but if galaxy is being served at
+ * a prefix (e.g.  `<server>/galaxy/`), this must be accounted for before any
+ * dynamic bundle imports load, otherwise they will fail.
+ */
+
+/* global __webpack_public_path__:writable */
+
+import { getRootFromIndexLink } from "./getRootFromIndexLink";
+
+__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/static/dist/`;

--- a/client/galaxy/scripts/onload/publicPath.js
+++ b/client/galaxy/scripts/onload/publicPath.js
@@ -9,4 +9,4 @@
 
 import { getRootFromIndexLink } from "./getRootFromIndexLink";
 
-__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/static/dist/`;
+__webpack_public_path__ = `${getRootFromIndexLink().replace(/\/+$/, "")}/static/scripts/bundled/`;


### PR DESCRIPTION
Backports https://github.com/galaxyproject/galaxy/pull/9898, but please don't merge forward as-is.  I'll open a separate PR merging forward, since the dist paths have changed.  (specifically, the change in 2351898 needs to be undone in the forward merge)