### PR TITLE
Touch up of toolbox search adjustments and messages

### DIFF
--- a/client/galaxy/scripts/components/Panels/ToolBox.vue
+++ b/client/galaxy/scripts/components/Panels/ToolBox.vue
@@ -11,13 +11,12 @@
         </div>
         <div class="unified-panel-controls">
             <tool-search :query="query" placeholder="search tools" @onQuery="onQuery" @onResults="onResults" />
-
             <div class="py-2" v-if="hasResults">
                 <b-button @click="onToggle">{{ buttonText }}</b-button>
             </div>
             <div class="py-2" v-else-if="query">
-                <span v-if="query.length < 3" class="font-weight-bold">***Search string too short***</span>
-                <span v-else class="font-weight-bold">***No Results Found***</span>
+                <b-badge v-if="query.length < 3" class="w-100">Search string too short</b-badge>
+                <b-badge v-else class="w-100">No Results Found</b-badge>
             </div>
         </div>
         <div class="unified-panel-body">

--- a/client/galaxy/scripts/components/Panels/ToolBox.vue
+++ b/client/galaxy/scripts/components/Panels/ToolBox.vue
@@ -12,7 +12,10 @@
         <div class="unified-panel-controls">
             <tool-search :query="query" placeholder="search tools" @onQuery="onQuery" @onResults="onResults" />
             <div class="py-2" v-if="hasResults">
-                <b-button @click="onToggle">{{ buttonText }}</b-button>
+                <b-button @click="onToggle" size="sm" class="w-100">
+                    <span :class="buttonIcon" />
+                    <span class="mr-1">{{ buttonText }}</span>
+                </b-button>
             </div>
             <div class="py-2" v-else-if="query">
                 <b-badge v-if="query.length < 3" class="w-100">Search string too short</b-badge>
@@ -69,6 +72,7 @@ export default {
             queryFilter: null,
             showSections: false,
             buttonText: "",
+            buttonIcon: "",
         };
     },
     props: {
@@ -148,6 +152,7 @@ export default {
         },
         setButtonText() {
             this.buttonText = this.showSections ? "Hide Sections" : "Show Sections";
+            this.buttonIcon = this.showSections ? "fa fa-eye-slash" : "fa fa-eye";
         },
     },
 };

--- a/client/galaxy/scripts/components/Panels/ToolBox.vue
+++ b/client/galaxy/scripts/components/Panels/ToolBox.vue
@@ -18,8 +18,8 @@
                 </b-button>
             </div>
             <div class="py-2" v-else-if="query">
-                <b-badge v-if="query.length < 3" class="w-100">Search string too short</b-badge>
-                <b-badge v-else class="w-100">No Results Found</b-badge>
+                <b-badge v-if="query.length < 3" class="w-100">Search string too short!</b-badge>
+                <b-badge v-else class="w-100">No results found!</b-badge>
             </div>
         </div>
         <div class="unified-panel-body">

--- a/client/galaxy/scripts/components/Panels/utilities.js
+++ b/client/galaxy/scripts/components/Panels/utilities.js
@@ -9,7 +9,7 @@ export function filterToolSections(layout, results) {
                     }
                 });
             }
-            //Sorts tools in section by rank in results
+            // sort tools in section by rank in results
             toolRes.sort((tool1, tool2) => {
                 return results.indexOf(tool1.id) - results.indexOf(tool2.id);
             });
@@ -19,8 +19,7 @@ export function filterToolSections(layout, results) {
                 elems: toolRes,
             };
         });
-
-        //Filter out categories without tools in results
+        // filter out categories without tools in results
         return filteredLayout
             .filter((section) => {
                 const isSection = section.elems && section.elems.length > 0;
@@ -28,6 +27,9 @@ export function filterToolSections(layout, results) {
                 return isSection || isMatchedTool;
             })
             .sort((sect1, sect2) => {
+                if (sect1.elems.length == 0 || sect2.elems.length == 0) {
+                    return 0;
+                }
                 return results.indexOf(sect1.elems[0].id) - results.indexOf(sect2.elems[0].id);
             });
     } else {
@@ -36,17 +38,15 @@ export function filterToolSections(layout, results) {
 }
 
 export function filterTools(layout, results) {
-    // don't consider expression tools, unless it's workflow editor
+    // do not consider expression tools, unless requested by the workflow editor
     layout = layout.filter((section) => section.name !== "Expression Tools");
-
     if (results) {
         var toolsResults = [];
         if (results.length < 1) {
             return toolsResults;
         }
-
-        //Goes through each section and adds each tools that's in results to
-        //toolsResults, sorted by search ranking
+        // iterate through each section and add each tool that is in the results to
+        // toolsResults, sort by search ranking
         layout.map((section) => {
             if (section.elems) {
                 section.elems.forEach((el) => {
@@ -56,7 +56,6 @@ export function filterTools(layout, results) {
                 });
             }
         });
-
         return toolsResults.sort((tool1, tool2) => {
             return results.indexOf(tool1.id) - results.indexOf(tool2.id);
         });


### PR DESCRIPTION
This PR replaces the toolbox search hints by bootstrap badges, it also adjusts the appearance of the section toggle button by adding icons and aligning its appearance to the surrounding wrapper. Additionally this PR fixes a bug which is triggered when an empty section is attempted to be expanded. Currently this triggers a console error.