### PR TITLE
Improve workflow layout algorithm

### DIFF
--- a/client/galaxy/scripts/components/Workflow/Editor/Index.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Index.vue
@@ -273,11 +273,9 @@ export default {
         onLayout() {
             this.canvasManager.drawOverview();
             this.canvasManager.scrollToNodes();
-            return import(/* webpackChunkName: "workflowLayout" */ "components/Workflow/Editor/modules/layout.js").then(
-                (layout) => {
-                    layout.default(this);
-                }
-            );
+            return import(/* webpackChunkName: "workflowLayout" */ "./modules/layout.js").then((layout) => {
+                layout.autoLayout(this);
+            });
         },
         onAttributes() {
             showAttributes();

--- a/client/galaxy/scripts/components/Workflow/Editor/Index.vue
+++ b/client/galaxy/scripts/components/Workflow/Editor/Index.vue
@@ -106,7 +106,6 @@ import {
     showForm,
     saveAs,
 } from "./modules/utilities";
-import { autoLayout } from "./modules/layout";
 import WorkflowCanvas from "./modules/canvas";
 import WorkflowOptions from "./Options";
 import MarkdownEditor from "components/Markdown/MarkdownEditor";
@@ -274,7 +273,11 @@ export default {
         onLayout() {
             this.canvasManager.drawOverview();
             this.canvasManager.scrollToNodes();
-            autoLayout(this);
+            return import(/* webpackChunkName: "workflowLayout" */ "components/Workflow/Editor/modules/layout.js").then(
+                (layout) => {
+                    layout.default(this);
+                }
+            );
         },
         onAttributes() {
             showAttributes();

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -8,7 +8,11 @@ export function autoLayout(workflow) {
     // Convert this to ELK compat.
     var newgraph = {
         id: "",
-        layoutOptions: { "elk.algorithm": "layered" },
+        layoutOptions: {
+            "elk.algorithm": "layered",
+            "crossingMinimization.semiInteractive": true,
+            "nodePlacement.strategy": "NETWORK_SIMPLEX",
+        },
         children: [],
         edges: [],
     };

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -24,7 +24,7 @@ export function autoLayout(workflow) {
                 properties: {
                     "port.side": "WEST",
                     "port.index": idx,
-                }
+                },
             };
         });
 
@@ -34,7 +34,7 @@ export function autoLayout(workflow) {
                 properties: {
                     "port.side": "EAST",
                     "port.index": idx,
-                }
+                },
             };
         });
 

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -1,86 +1,54 @@
 import $ from "jquery";
+import ELK from 'elkjs/lib/elk.bundled.js';
+const elk = new ELK();
+
 
 export function autoLayout(workflow) {
     workflow.hasChanges = true;
-    // Prepare predecessor / successor tracking
-    const n_pred = {};
-    const successors = {};
-    // First pass to initialize arrays even for nodes with no connections
-    Object.keys(workflow.nodes).forEach((id) => {
-        if (n_pred[id] === undefined) {
-            n_pred[id] = 0;
+
+    // Convert this to ELK compat.
+    var newgraph = {
+        id: '',
+        layoutOptions: { 'elk.algorithm': 'layered' },
+        children: [],
+        edges: [],
+    }
+
+    newgraph.children = Object.values(workflow.nodes).map((node) => {
+        return {
+            id: node._uid,
+            height: $(node.element).height() + 80,
+            width: $(node.element).width() + 30,
         }
-        if (successors[id] === undefined) {
-            successors[id] = [];
-        }
-    });
-    // Second pass to count predecessors and successors
+    })
+
     Object.values(workflow.nodes).forEach((node) => {
         Object.values(node.inputTerminals).forEach((t) => {
             t.connectors.forEach((c) => {
-                // A connection exists from `other` to `node`
-                const other = c.outputHandle.node;
-                // node gains a predecessor
-                n_pred[node.id] += 1;
-                // other gains a successor
-                successors[other.id].push(node.id);
+
+                newgraph.edges.push({
+                    id: `e_${node._uid}_${c.outputHandle.node._uid}`,
+                    sources: [c.outputHandle.node._uid],
+                    targets: [node._uid],
+                })
+
+            })
+        })
+    })
+
+    elk.layout(newgraph)
+        .then((x) => {
+            // Reapply positions to galaxy graph from our relayed out graph.
+            x.children.forEach((q) => {
+                var node = Object.values(workflow.nodes).filter((x) => {return x._uid === q.id })[0];
+                const element = $(node.element);
+                $(element).css({ top: q.y, left: q.x });
+            })
+
+            Object.values(all_nodes).forEach((node) => {
+                node.onRedraw();
             });
-        });
-    });
-    // Assemble order, tracking levels
-    const node_ids_by_level = [];
-    for (;;) {
-        // Everything without a predecessor
-        const level_parents = [];
-        for (const pred_k in n_pred) {
-            if (n_pred[pred_k] === 0) {
-                level_parents.push(pred_k);
-            }
-        }
-        if (level_parents.length === 0) {
-            break;
-        }
-        node_ids_by_level.push(level_parents);
-        // Remove the parents from this level, and decrement the number
-        // of predecessors for each successor
-        for (const k in level_parents) {
-            const v = level_parents[k];
-            delete n_pred[v];
-            for (const sk in successors[v]) {
-                n_pred[successors[v][sk]] -= 1;
-            }
-        }
-    }
-    if (n_pred.length) {
-        // ERROR: CYCLE! Currently we do nothing
-        return;
-    }
-    // Layout each level
-    const all_nodes = workflow.nodes;
-    const h_pad = 80;
-    const v_pad = 30;
-    let left = h_pad;
-    node_ids_by_level.forEach((ids) => {
-        // We keep nodes in the same order in a level to give the user
-        // some control over ordering
-        ids.sort(
-            (a, b) =>
-                all_nodes[a].element.getBoundingClientRect().top - all_nodes[b].element.getBoundingClientRect().top
-        );
-        // Position each node
-        let max_width = 0;
-        let top = v_pad;
-        ids.forEach((id) => {
-            const node = all_nodes[id];
-            const element = $(node.element);
-            $(element).css({ top: top, left: left });
-            max_width = Math.max(max_width, $(element).width());
-            top += $(element).height() + v_pad;
-        });
-        left += max_width + h_pad;
-    });
-    // Need to redraw all connectors
-    Object.values(all_nodes).forEach((node) => {
-        node.onRedraw();
-    });
+        })
+       .catch(console.error)
+
 }

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -18,10 +18,31 @@ export function autoLayout(workflow) {
     };
 
     newgraph.children = Object.values(workflow.nodes).map((node) => {
+        var inputs = Object.keys(node.inputTerminals).map((t, idx) => {
+            return {
+                id: `${node._uid}/in/${t}`,
+                properties: {
+                    "port.side": "WEST",
+                    "port.index": idx,
+                }
+            };
+        });
+
+        var outputs = Object.keys(node.outputTerminals).map((t, idx) => {
+            return {
+                id: `${node._uid}/out/${t}`,
+                properties: {
+                    "port.side": "EAST",
+                    "port.index": idx,
+                }
+            };
+        });
+
         return {
             id: node._uid,
-            height: $(node.element).height() + 80,
-            width: $(node.element).width() + 30,
+            height: $(node.element).height() + 20,
+            width: $(node.element).width() + 60,
+            ports: inputs.concat(outputs),
         };
     });
 
@@ -30,8 +51,8 @@ export function autoLayout(workflow) {
             t.connectors.forEach((c) => {
                 newgraph.edges.push({
                     id: `e_${node._uid}_${c.outputHandle.node._uid}`,
-                    sources: [c.outputHandle.node._uid],
-                    targets: [node._uid],
+                    sources: [`${c.outputHandle.node._uid}/out/${c.outputHandle.name}`],
+                    targets: [`${c.inputHandle.node._uid}/in/${c.inputHandle.name}`],
                 });
             });
         });

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 import ELK from "elkjs/lib/elk.bundled.js";
 const elk = new ELK();
 
-export default function autoLayout(workflow) {
+export function autoLayout(workflow) {
     workflow.hasChanges = true;
 
     // Convert this to ELK compat.

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -45,7 +45,7 @@ export function autoLayout(workflow) {
                 $(element).css({ top: q.y, left: q.x });
             })
 
-            Object.values(all_nodes).forEach((node) => {
+            Object.values(workflow.nodes).forEach((node) => {
                 node.onRedraw();
             });
         })

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 import ELK from "elkjs/lib/elk.bundled.js";
 const elk = new ELK();
 
-export function autoLayout(workflow) {
+export default function autoLayout(workflow) {
     workflow.hasChanges = true;
 
     // Convert this to ELK compat.

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/layout.js
@@ -1,54 +1,52 @@
 import $ from "jquery";
-import ELK from 'elkjs/lib/elk.bundled.js';
+import ELK from "elkjs/lib/elk.bundled.js";
 const elk = new ELK();
-
 
 export function autoLayout(workflow) {
     workflow.hasChanges = true;
 
     // Convert this to ELK compat.
     var newgraph = {
-        id: '',
-        layoutOptions: { 'elk.algorithm': 'layered' },
+        id: "",
+        layoutOptions: { "elk.algorithm": "layered" },
         children: [],
         edges: [],
-    }
+    };
 
     newgraph.children = Object.values(workflow.nodes).map((node) => {
         return {
             id: node._uid,
             height: $(node.element).height() + 80,
             width: $(node.element).width() + 30,
-        }
-    })
+        };
+    });
 
     Object.values(workflow.nodes).forEach((node) => {
         Object.values(node.inputTerminals).forEach((t) => {
             t.connectors.forEach((c) => {
-
                 newgraph.edges.push({
                     id: `e_${node._uid}_${c.outputHandle.node._uid}`,
                     sources: [c.outputHandle.node._uid],
                     targets: [node._uid],
-                })
-
-            })
-        })
-    })
+                });
+            });
+        });
+    });
 
     elk.layout(newgraph)
         .then((x) => {
             // Reapply positions to galaxy graph from our relayed out graph.
             x.children.forEach((q) => {
-                var node = Object.values(workflow.nodes).filter((x) => {return x._uid === q.id })[0];
+                var node = Object.values(workflow.nodes).filter((x) => {
+                    return x._uid === q.id;
+                })[0];
                 const element = $(node.element);
                 $(element).css({ top: q.y, left: q.x });
-            })
+            });
 
             Object.values(workflow.nodes).forEach((node) => {
                 node.onRedraw();
             });
         })
-       .catch(console.error)
-
+        .catch(console.error);
 }

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "citation-js": "^0.5.0-alpha.5",
     "d3": "3",
     "decode-uri-component": "^0.2.0",
+    "elkjs": "^0.6.2",
     "flush-promises": "^1.0.2",
     "glob": "^7.1.6",
     "handsontable": "^2.0.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -20,13 +20,13 @@ module.exports = (env = {}, argv = {}) => {
             login: ["polyfills", "bundleEntries", "entry/login"],
             analysis: ["polyfills", "bundleEntries", "entry/analysis"],
             admin: ["polyfills", "bundleEntries", "entry/admin"],
-            generic: ["polyfills", "bundleEntries", "entry/generic"]
+            generic: ["polyfills", "bundleEntries", "entry/generic"],
         },
         output: {
             path: path.join(__dirname, "../", "/static/dist"),
             publicPath: "/static/dist/",
             filename: "[name].bundled.js",
-            chunkFilename: "[name].chunk.js"
+            chunkFilename: "[name].chunk.js",
         },
         resolve: {
             extensions: ["*", ".js", ".json", ".vue", ".scss"],
@@ -39,8 +39,8 @@ module.exports = (env = {}, argv = {}) => {
                 moment: path.resolve(__dirname, "node_modules/moment"),
                 underscore: path.resolve(__dirname, "node_modules/underscore"),
                 // client-side application config
-                config$: path.join(__dirname, "galaxy", "config", targetEnv) + ".js"
-            }
+                config$: path.join(__dirname, "galaxy", "config", targetEnv) + ".js",
+            },
         },
         optimization: {
             splitChunks: {
@@ -48,23 +48,23 @@ module.exports = (env = {}, argv = {}) => {
                     styles: {
                         name: "base",
                         chunks: "all",
-                        test: m => m.constructor.name == "CssModule",
-                        priority: -5
+                        test: (m) => m.constructor.name == "CssModule",
+                        priority: -5,
                     },
                     libs: {
                         name: "libs",
-                        test: /node_modules[\\/](?!(handsontable|pikaday|moment)[\\/])|galaxy\/scripts\/libs/,
+                        test: /node_modules[\\/](?!(handsontable|pikaday|moment|elkjs)[\\/])|galaxy\/scripts\/libs/,
                         chunks: "all",
-                        priority: -10
-                    }
-                }
-            }
+                        priority: -10,
+                    },
+                },
+            },
         },
         module: {
             rules: [
                 {
                     test: /\.vue$/,
-                    loader: "vue-loader"
+                    loader: "vue-loader",
                 },
                 {
                     test: /\.js$/,
@@ -72,7 +72,7 @@ module.exports = (env = {}, argv = {}) => {
                      * Babel transpile excludes for:
                      * - all node_modules except for handsontable, bootstrap-vue
                      * - statically included libs (like old jquery plugins, etc.)
-                    */
+                     */
                     exclude: [/(node_modules\/(?!(handsontable|bootstrap-vue)\/))/, libsBase],
                     loader: "babel-loader",
                     options: {
@@ -80,34 +80,34 @@ module.exports = (env = {}, argv = {}) => {
                         cacheCompression: false,
                         presets: [["@babel/preset-env", { modules: false }]],
                         plugins: ["transform-vue-template", "@babel/plugin-syntax-dynamic-import"],
-                        ignore: ["i18n.js", "utils/localization.js", "nls/*"]
-                    }
+                        ignore: ["i18n.js", "utils/localization.js", "nls/*"],
+                    },
                 },
                 {
                     test: `${libsBase}/jquery.custom.js`,
                     use: [
                         {
                             loader: "expose-loader",
-                            options: "jQuery"
+                            options: "jQuery",
                         },
                         {
                             loader: "expose-loader",
-                            options: "$"
-                        }
-                    ]
+                            options: "$",
+                        },
+                    ],
                 },
                 {
                     test: require.resolve("underscore"),
                     use: [
                         {
                             loader: "expose-loader",
-                            options: "_"
+                            options: "_",
                         },
                         {
                             loader: "expose-loader",
-                            options: "underscore"
-                        }
-                    ]
+                            options: "underscore",
+                        },
+                    ],
                 },
                 {
                     test: /\.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)(\?.*$|$)/,
@@ -115,9 +115,9 @@ module.exports = (env = {}, argv = {}) => {
                         loader: "file-loader",
                         options: {
                             outputPath: "assets",
-                            publicPath: "../dist/assets/"
-                        }
-                    }
+                            publicPath: "../dist/assets/",
+                        },
+                    },
                 },
                 // Alternative to setting window.bundleEntries
                 // Just import "bundleEntries" in any endpoint that needs
@@ -128,18 +128,18 @@ module.exports = (env = {}, argv = {}) => {
                     use: [
                         {
                             loader: "expose-loader",
-                            options: "bundleEntries"
-                        }
-                    ]
+                            options: "bundleEntries",
+                        },
+                    ],
                 },
                 {
                     test: `${scriptsBase}/onload/loadConfig.js`,
                     use: [
                         {
                             loader: "expose-loader",
-                            options: "config"
-                        }
-                    ]
+                            options: "config",
+                        },
+                    ],
                 },
                 {
                     test: /\.(sa|sc|c)ss$/,
@@ -147,47 +147,47 @@ module.exports = (env = {}, argv = {}) => {
                         {
                             loader: MiniCssExtractPlugin.loader,
                             options: {
-                                hmr: process.env.NODE_ENV === "development"
-                            }
+                                hmr: process.env.NODE_ENV === "development",
+                            },
                         },
                         {
                             loader: "css-loader",
-                            options: { sourceMap: true }
+                            options: { sourceMap: true },
                         },
                         {
                             loader: "postcss-loader",
                             options: {
-                                plugins: function() {
+                                plugins: function () {
                                     return [require("autoprefixer")];
-                                }
-                            }
+                                },
+                            },
                         },
                         {
                             loader: "sass-loader",
                             options: {
                                 sourceMap: true,
                                 sassOptions: {
-                                    includePaths: ["galaxy/style/scss", path.resolve(__dirname, "./node_modules")]
-                                }
-                            }
-                        }
-                    ]
+                                    includePaths: ["galaxy/style/scss", path.resolve(__dirname, "./node_modules")],
+                                },
+                            },
+                        },
+                    ],
                 },
                 {
                     test: /\.(txt|tmpl)$/,
-                    loader: "raw-loader"
-                }
-            ]
+                    loader: "raw-loader",
+                },
+            ],
         },
         node: {
-            setImmediate: false
+            setImmediate: false,
         },
         resolveLoader: {
             alias: {
                 // since we support both requirejs i18n and non-requirejs and both use a similar syntax,
                 // use an alias so we can just use one file
-                i18n: "amdi18n-loader"
-            }
+                i18n: "amdi18n-loader",
+            },
         },
         plugins: [
             // this plugin allows using the following keys/globals in scripts (w/o req'ing them first)
@@ -197,27 +197,27 @@ module.exports = (env = {}, argv = {}) => {
                 jQuery: `${libsBase}/jquery.custom.js`,
                 _: "underscore",
                 Backbone: "backbone",
-                Galaxy: ["app", "monitor"]
+                Galaxy: ["app", "monitor"],
             }),
             new VueLoaderPlugin(),
             new MiniCssExtractPlugin({
                 filename: "[name].css",
-                sourceMap: true
+                sourceMap: true,
             }),
             // https://github.com/webpack-contrib/mini-css-extract-plugin/issues/141
             new OptimizeCssAssetsPlugin({
                 cssProcessorOptions: {
                     map: {
                         inline: false,
-                        annotation: true
-                    }
-                }
+                        annotation: true,
+                    },
+                },
             }),
-            new DuplicatePackageCheckerPlugin()
+            new DuplicatePackageCheckerPlugin(),
         ],
         devServer: {
-            hot: true
-        }
+            hot: true,
+        },
     };
 
     if (process.env.GXY_BUILD_SOURCEMAPS || process.env.NODE_ENV == "development") {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -4316,6 +4316,11 @@ electron-to-chromium@^1.3.79:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.80.tgz#e99ec7efe64c2c6a269d3885ff411ea88852fa53"
   integrity sha512-WClidEWEUNx7OfwXehB0qaxCuetjbKjev2SmXWgybWPLKAThBiMTF/2Pd8GSUDtoGOavxVzdkKwfFAPRSWlkLw==
 
+elkjs@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/elkjs/-/elkjs-0.6.2.tgz#b33ea52cd2e049abf921598e5106995865245bda"
+  integrity sha512-eAPWONv3c+eT+F1r5dvH/qbyBjPi21LPFlUFaQgB5fCguWTZvp4rjEbVX2iY8TjnprOq9cYXNME38J3Tqxby/w==
+
 elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"


### PR DESCRIPTION
I wrote [a rubbish workflow plotter](https://github.com/hexylena/galaxy-workflow-plotter) forever ago and someone asked about it today. I was annoyed I never added a better layout algorithm and so I went looking today for a better algorithm while my blast runs.

I found this: https://github.com/kieler/elkjs 

> [ELK] is a layer-based layout algorithm that is particularly suited for node-link diagrams with an inherent direction and ports (explicit attachment points on a node's border). It is based on the ideas originally introduced by Sugiyama et al.

So I tried my hand at replacing Galaxy's layout with it. What do y'all think? Personally I like it a lot better.

**Default**
![image](https://user-images.githubusercontent.com/458683/88927770-37112380-d278-11ea-9a7d-3c92d967f741.png)

**ELK**
![image](https://user-images.githubusercontent.com/458683/88927722-2365bd00-d278-11ea-9aae-ebbb300e7e94.png)

**Default**
![image](https://user-images.githubusercontent.com/458683/88929289-38dbe680-d27a-11ea-83b1-e768471126cf.png)

detail image (:musical_note: Where did you come from, where did you go? :notes:)

![image](https://user-images.githubusercontent.com/458683/88929322-46916c00-d27a-11ea-8840-42db7678336e.png)

**ELK**

![image](https://user-images.githubusercontent.com/458683/88930937-780b3700-d27c-11ea-90ac-a0398f1fd625.png)

Some admittedly imperfect things there, but, I'd argue an improvement. No longer noodle soup :ramen:!

For reference, the manual layout i'd been using, which only looks good on that version of galaxy due to the very different noodle bezier parameters.

![image](https://user-images.githubusercontent.com/458683/88932201-1055eb80-d27e-11ea-9606-49029e70986d.png)


- ~~Current bug: noodles bug out until you manually touch nodes. Dunno how to fix that sorry.~~ JK, old variable. Thanks CircleCI for catching it.
- This (somewhat intentionally) throws out the retaining of any user control over layout that the original considered.