### PR TITLE
[20.05] Encoding issue fix for hmac_new

### DIFF
--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -18,25 +18,6 @@ class GeneTrack(binary.Binary):
 
     def __init__(self, **kwargs):
         super(GeneTrack, self).__init__(**kwargs)
-        # self.add_display_app( 'genetrack', 'View in', '', 'genetrack_link' )
-    # def get_display_links( self, dataset, type, app, base_url, target_frame='galaxy_main', **kwd ): #Force target_frame to be 'galaxy_main'
-    #     return binary.Binary.get_display_links( self, dataset, type, app, base_url, target_frame=target_frame, **kwd )
-    # def genetrack_link( self, hda, type, app, base_url ):
-    #     ret_val = []
-    #     if hda.dataset.has_data():
-    # Get the disk file name and data id
-    #         file_name = hda.dataset.get_file_name()
-    #         data_id  = quote_plus( str( hda.id ) )
-    #         galaxy_url = quote_plus( "%s%s" % ( base_url, url_for( controller = 'tool_runner', tool_id='predict2genetrack' ) ) )
-    # Make it secure
-    #         hashkey = quote_plus( hmac_new( app.config.tool_secret, file_name ) )
-    #         encoded = quote_plus( binascii.hexlify( file_name ) )
-    #         for name, url in util.get_genetrack_sites():
-    #             if name.lower() in app.config.genetrack_display_sites:
-    # send both  parameters filename and hashkey
-    #                 link = "%s?filename=%s&hashkey=%s&input=%s&GALAXY_URL=%s" % ( url, encoded, hashkey, data_id, galaxy_url )
-    #                 ret_val.append( ( name, link ) )
-    #         return ret_val
 
 
 class UCSCTrackHub(Html):

--- a/lib/galaxy/util/hash_util.py
+++ b/lib/galaxy/util/hash_util.py
@@ -74,7 +74,7 @@ def new_secure_hash(text_type):
 
 
 def hmac_new(key, value):
-    return hmac.new(key, value, sha).hexdigest()
+    return hmac.new(smart_str(key), smart_str(value), sha).hexdigest()
 
 
 def is_hashable(value):

--- a/lib/galaxy/util/tool_shed/encoding_util.py
+++ b/lib/galaxy/util/tool_shed/encoding_util.py
@@ -36,6 +36,6 @@ def tool_shed_encode(val):
         value = json.dumps(val)
     else:
         value = val
-    a = hmac_new(b'ToolShedAndGalaxyMustHaveThisSameKey', smart_str(value))
+    a = hmac_new(b'ToolShedAndGalaxyMustHaveThisSameKey', value)
     b = unicodify(binascii.hexlify(smart_str(value)))
     return "%s:%s" % (a, b)


### PR DESCRIPTION
We need to ensure both arguments to hmac_new are bytes objects.

When grepping, came across commented cruft in genetrack datatype that used hmac_new; that's why that's in here too.