### PR TITLE
[20.01] Fix running workflows with parameters restricted on connections...

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -992,7 +992,7 @@ class InputParameterModule(WorkflowModule):
                 options = None
                 if static_options and len(static_options) == 1:
                     # If we are connected to a single option, just use it as is so order is preserved cleanly and such.
-                    options = [{"value": o[0], "label": o[1]} for o in static_options[0]]
+                    options = [{"value": o[1], "label": o[0]} for o in static_options[0]]
                 elif static_options:
                     # Intersection based on values of multiple option connections.
                     intxn_vals = set.intersection(*({option[1] for option in options} for options in static_options))

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -992,7 +992,7 @@ class InputParameterModule(WorkflowModule):
                 options = None
                 if static_options and len(static_options) == 1:
                     # If we are connected to a single option, just use it as is so order is preserved cleanly and such.
-                    options = [{"value": o[1], "label": o[0]} for o in static_options[0]]
+                    options = [{"label": o[0], "value": o[1]} for o in static_options[0]]
                 elif static_options:
                     # Intersection based on values of multiple option connections.
                     intxn_vals = set.intersection(*({option[1] for option in options} for options in static_options))


### PR DESCRIPTION
... when they are copied from a single tool source.

This is a runtime problem so these workflows were probably very broken when they tried to execute but nothing in the database or representation should need to change - making the fix somewhat clean at least.