### PR TITLE
Fix copy/paste in workflow editor

### DIFF
--- a/client/galaxy/scripts/components/Workflow/Editor/modules/canvas.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/canvas.js
@@ -9,6 +9,7 @@ export const zoomLevels = [0.25, 0.33, 0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 
 
 // Default zoome level
 export const defaultZoomLevel = 7;
+const inputElementTypes = ["input", "text", "textarea"];
 
 // FIXME: merge scroll panel into CanvasManager, clean up hardcoded stuff.
 class ScrollPanel {
@@ -221,11 +222,7 @@ class CanvasManager {
             logic so we don't interfere with standard copy/paste functionality.
         */
         document.addEventListener("copy", (e) => {
-            if (
-                document.activeElement &&
-                document.activeElement.type !== "text" &&
-                document.activeElement.type !== "textarea"
-            ) {
+            if (document.activeElement && inputElementTypes.indexOf(document.activeElement.type) === -1) {
                 if (this.app.activeNode && this.app.activeNode.type !== "subworkflow") {
                     e.clipboardData.setData(
                         "application/json",
@@ -238,11 +235,7 @@ class CanvasManager {
             }
         });
         document.addEventListener("paste", (e) => {
-            if (
-                document.activeElement &&
-                document.activeElement.type !== "textarea" &&
-                document.activeElement.type !== "text"
-            ) {
+            if (document.activeElement && inputElementTypes.indexOf(document.activeElement.type) === -1) {
                 let nodeId;
                 try {
                     nodeId = JSON.parse(e.clipboardData.getData("application/json")).nodeId;

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/canvas.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/canvas.js
@@ -222,7 +222,7 @@ class CanvasManager {
             logic so we don't interfere with standard copy/paste functionality.
         */
         document.addEventListener("copy", (e) => {
-            if (document.activeElement && inputElementTypes.indexOf(document.activeElement.type) === -1) {
+            if (document.activeElement && !inputElementTypes.includes(document.activeElement.type)) {
                 if (this.app.activeNode && this.app.activeNode.type !== "subworkflow") {
                     e.clipboardData.setData(
                         "application/json",
@@ -235,7 +235,7 @@ class CanvasManager {
             }
         });
         document.addEventListener("paste", (e) => {
-            if (document.activeElement && inputElementTypes.indexOf(document.activeElement.type) === -1) {
+            if (document.activeElement && !inputElementTypes.includes(document.activeElement.type)) {
                 let nodeId;
                 try {
                     nodeId = JSON.parse(e.clipboardData.getData("application/json")).nodeId;

--- a/client/galaxy/scripts/components/Workflow/Editor/modules/canvas.js
+++ b/client/galaxy/scripts/components/Workflow/Editor/modules/canvas.js
@@ -215,10 +215,17 @@ class CanvasManager {
         }
     }
     init_copy_paste() {
+        /*
+            Both of these copy/paste event bindings check the active element
+            and, if it's one of the text inputs, skip the workflow copy/paste
+            logic so we don't interfere with standard copy/paste functionality.
+        */
         document.addEventListener("copy", (e) => {
-            // If it appears that the user is trying to copy/paste text, we
-            // pass that through.
-            if (window.getSelection().toString() === "") {
+            if (
+                document.activeElement &&
+                document.activeElement.type !== "text" &&
+                document.activeElement.type !== "textarea"
+            ) {
                 if (this.app.activeNode && this.app.activeNode.type !== "subworkflow") {
                     e.clipboardData.setData(
                         "application/json",
@@ -231,8 +238,6 @@ class CanvasManager {
             }
         });
         document.addEventListener("paste", (e) => {
-            // If it appears that the user is trying to paste into a text box,
-            // pass that through and skip the workflow copy/paste logic.
             if (
                 document.activeElement &&
                 document.activeElement.type !== "textarea" &&


### PR DESCRIPTION
`window.getSelection().toString() === ""` is not reliably the text selection contents across all browsers; using an active element heuristic instead seems to be more robust.

(if this seems fine and works for folks, I'll backport it flattened to 20.05)