### PR TITLE
Fix error in get_open_tempfile()

### DIFF
--- a/lib/galaxy/datatypes/util/maf_utilities.py
+++ b/lib/galaxy/datatypes/util/maf_utilities.py
@@ -85,6 +85,7 @@ class TempFileHandler(object):
             if index is None:
                 index = len(self.files)
                 temp_kwds = dict(self.kwds)
+                temp_kwds['delete'] = False
                 temp_kwds.update(kwds)
                 # Being able to use delete=True here, would simplify a bit,
                 # but we support python2.4 in these tools
@@ -100,11 +101,11 @@ class TempFileHandler(object):
                         else:
                             raise e
                 tmp_file.close()
-                self.files.append(open(filename, 'w'))
+                self.files.append(open(filename, 'r+'))
             else:
                 while True:
                     try:
-                        self.files[index] = open(self.files[index].name, 'r')
+                        self.files[index] = open(self.files[index].name, 'r+')
                         break
                     except OSError as e:
                         if self.open_file_indexes and e.errno == EMFILE:


### PR DESCRIPTION
Without this change, the following error would be emitted:

```
Traceback (most recent call last):
  File "/home/dave/github-repos/galaxy/database/shed_tools/testtoolshed.g2.bx.psu.edu/repos/dave/genebed_maf_to_fasta/b5c3cb24e9de/genebed_maf_to_fasta/interval_maf_to_merged_fasta.py", line 203, in <module>
    __main__()
  File "/home/dave/github-repos/galaxy/database/shed_tools/testtoolshed.g2.bx.psu.edu/repos/dave/genebed_maf_to_fasta/b5c3cb24e9de/genebed_maf_to_fasta/interval_maf_to_merged_fasta.py", line 165, in __main__
    output.write(alignment.get_sequence_reverse_complement(primary_species))
  File "/home/dave/github-repos/galaxy/lib/galaxy/tools/util/maf_utilities.py", line 271, in get_sequence_reverse_complement
    complement = [base for base in self.get_sequence(species).translate(self.DNA_COMPLEMENT)]
  File "/home/dave/github-repos/galaxy/lib/galaxy/tools/util/maf_utilities.py", line 265, in get_sequence
    rval = fh.read()
io.UnsupportedOperation: not readable
````

And without `delete=False`, get_sequence() returns a different error.