### PR TITLE
[20.05] Fix non-unique entries in tool search index

### DIFF
--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -50,7 +50,7 @@ class ToolBoxSearch(object):
     """
 
     def __init__(self, toolbox, index_dir=None, index_help=True):
-        self.schema = Schema(id=ID(stored=True),
+        self.schema = Schema(id=ID(stored=True, unique=True),
                              stub=KEYWORD,
                              name=TEXT(analyzer=analysis.SimpleAnalyzer()),
                              description=TEXT,
@@ -89,7 +89,7 @@ class ToolBoxSearch(object):
                 tool = tool_cache.get_tool_by_id(tool_id)
                 if tool and tool.is_latest_version:
                     add_doc_kwds = self._create_doc(tool_id=tool_id, tool=tool, index_help=index_help)
-                    writer.add_document(**add_doc_kwds)
+                    writer.update_document(**add_doc_kwds)
         log.debug("Toolbox index finished %s", execution_timer)
 
     def _create_doc(self, tool_id, tool, index_help=True):


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/10030, broken in 19c4ff42823638d51792a98486cb28e9b92a6923, where I made the assumption that we always start with a fully-populated index.

This resulted in somewhere between 1 and N (for N web handlers) entries in the search index.
Fixed this by using `update_document` and making ID unique in the Whoosh schema.

`update_document` behaves like `add_document` if the document id is not in the index:
https://whoosh.readthedocs.io/en/latest/indexing.html?highlight=unique#updating-documents