### PR TITLE
[20.05] Restore preview rendering of bam files

### DIFF
--- a/client/galaxy/scripts/mvc/dataset/data.js
+++ b/client/galaxy/scripts/mvc/dataset/data.js
@@ -316,7 +316,7 @@ var TabularDatasetChunkedView = Backbone.View.extend({
         _.each(
             chunk.ck_data.split("\n"),
             function (line, index) {
-                if (line !== "" && index >= chunk.data_line_offset) {
+                if (line !== "" && index >= (chunk.data_line_offset || 0)) {
                     data_table.append(this._renderRow(line));
                 }
             },


### PR DESCRIPTION
Broken in
https://github.com/galaxyproject/galaxy/commit/52138db431c4a234f8bc91e4cbfceefae953b33f, where I introduced `data_line_offset`, so that datatypes can skip rendering headers.