### PR TITLE
[20.05] Don't display download link for optional, non-existant metadata files

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -523,12 +523,13 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer,
         """
         meta_files = []
         for meta_type in dataset_assoc.metadata_file_types:
-            meta_files.append(
-                dict(file_type=meta_type,
-                     download_url=self.url_for('history_contents_metadata_file',
-                                               history_id=self.app.security.encode_id(dataset_assoc.history_id),
-                                               history_content_id=self.app.security.encode_id(dataset_assoc.id),
-                                               metadata_file=meta_type)))
+            if getattr(dataset_assoc.metadata, meta_type, None):
+                meta_files.append(
+                    dict(file_type=meta_type,
+                         download_url=self.url_for('history_contents_metadata_file',
+                                                   history_id=self.app.security.encode_id(dataset_assoc.history_id),
+                                                   history_content_id=self.app.security.encode_id(dataset_assoc.id),
+                                                   metadata_file=meta_type)))
         return meta_files
 
     def serialize_metadata(self, dataset_assoc, key, excluded=None, **context):
@@ -554,6 +555,8 @@ class _UnflattenedMetadataDatasetAssociationSerializer(base.ModelSerializer,
             # If no value for metadata, look in datatype for metadata.
             elif val is None and hasattr(dataset_assoc.datatype, name):
                 val = getattr(dataset_assoc.datatype, name)
+            if val is None and spec.get("optional"):
+                continue
             metadata[name] = val
 
         return metadata


### PR DESCRIPTION
This became an issue when we added optional MetadaFile elements (the csi index) to Bam files in 20.05.