### PR TITLE
[18.01] Add missing semicolon to uwsgi_pass directive in nginx docs

### DIFF
--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -125,7 +125,7 @@ http {
 
         # proxy all requests not matching other locations to uWSGI
         location / {
-            uwsgi_pass unix:///srv/galaxy/var/uwsgi.sock
+            uwsgi_pass unix:///srv/galaxy/var/uwsgi.sock;
             uwsgi_param UWSGI_SCHEME $scheme;
             include uwsgi_params;
         }


### PR DESCRIPTION
As reported by @smirarab on Gitter. I'll do the requisite merges forward, but wanted to go all the way back so there weren't incorrect docs online.