### PR TITLE
Allow numbers as filenames while adding datasets to library folder

### DIFF
--- a/client/src/mvc/library/library-foldertoolbar-view.js
+++ b/client/src/mvc/library/library-foldertoolbar-view.js
@@ -666,7 +666,8 @@ var FolderToolbarView = Backbone.View.extend({
             this.modal.disableButton("Import");
             for (let i = selected_nodes.length - 1; i >= 0; i--) {
                 if (selected_nodes[i].li_attr.full_path !== undefined) {
-                    paths.push(selected_nodes[i].li_attr.full_path);
+                    // should be always String
+                    paths.push(`"${selected_nodes[i].li_attr.full_path}"`);
                 }
             }
             this.initChainCallControl({

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -396,9 +396,10 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         path = kwd.get('path', None)
         if path is None:
             raise exceptions.RequestParameterMissingException('The required attribute path is missing.')
-        folder = self.folder_manager.get(trans, folder_id)
         if isinstance(path, int):
-            path = str(path)
+            raise exceptions.RequestParameterInvalidException('The required attribute path is Integer.')
+
+        folder = self.folder_manager.get(trans, folder_id)
 
         source = kwd.get('source', None)
         if source not in ['userdir_file', 'userdir_folder', 'importdir_file', 'importdir_folder', 'admin_path']:

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -396,8 +396,8 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         path = kwd.get('path', None)
         if path is None:
             raise exceptions.RequestParameterMissingException('The required attribute path is missing.')
-        if isinstance(path, int):
-            raise exceptions.RequestParameterInvalidException('The required attribute path is Integer.')
+        if not isinstance(path, str):
+            raise exceptions.RequestParameterInvalidException('The required attribute path is not String.')
 
         folder = self.folder_manager.get(trans, folder_id)
 

--- a/lib/galaxy/webapps/galaxy/api/library_datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/library_datasets.py
@@ -397,6 +397,8 @@ class LibraryDatasetsController(BaseAPIController, UsesVisualizationMixin, Libra
         if path is None:
             raise exceptions.RequestParameterMissingException('The required attribute path is missing.')
         folder = self.folder_manager.get(trans, folder_id)
+        if isinstance(path, int):
+            path = str(path)
 
         source = kwd.get('source', None)
         if source not in ['userdir_file', 'userdir_folder', 'importdir_file', 'importdir_folder', 'admin_path']:


### PR DESCRIPTION
If the filename of dataset is a number, it will raise an exception. This PR allows filenames to be numbers 