### PR TITLE
Revert "add putatively failing tool"

### DIFF
--- a/test/functional/tools/composite.xml
+++ b/test/functional/tools/composite.xml
@@ -1,5 +1,5 @@
 <tool id="composite" name="composite" version="1.0.0">
-  <command>cat '${os.path.join(input.extra_files_path, "Sequences")}' > $output</command>
+  <command>cat '$input.extra_files_path/Sequences' > $output</command>
   <inputs>
     <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
   </inputs>


### PR DESCRIPTION
Inadvertently merged an extra test commit that had been pushed in https://github.com/galaxyproject/galaxy/pull/10057#issuecomment-669252367, this backs it out.

This reverts commit e1080c82d97c399c33d4a2a64dc2e67fe8505c60.