### PR TITLE
Add generic CORS preflight options response

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -287,12 +287,17 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
             del self.response.headers['Access-Control-Allow-Origin']
 
     def set_cors_headers(self):
-        """Allow CORS requests if configured to do so by echoing back the request's
-        'Origin' header (if any) as the response header 'Access-Control-Allow-Origin'
+        """Allow CORS requests if configured to do so by echoing back the
+        request's 'Origin' header (if any) as the response header
+        'Access-Control-Allow-Origin'
+
+        Preflight OPTIONS requests to the API work by routing all OPTIONS
+        requests to a single method in the authenticate API (options method),
+        setting CORS headers, and responding OK.
+
+        NOTE: raising some errors (such as httpexceptions), will remove the
+        header (e.g. client will get both CORS error and 404 inside that)
         """
-        # TODO: in order to use these, we need preflight to work, and to do that we
-        # need the OPTIONS method on all api calls (or everywhere we can POST/PUT)
-        # ALLOWED_METHODS = ( 'POST', 'PUT' )
 
         # do not set any access control headers if not configured for it (common case)
         if not self.app.config.get('allowed_origin_hostnames', None):
@@ -324,11 +329,6 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
         # check against the list of allowed strings/regexp hostnames, echo original if cleared
         if is_allowed_origin(origin):
             self.set_cors_origin(origin=origin_header)
-            # TODO: see the to do on ALLOWED_METHODS above
-            # self.response.headers[ 'Access-Control-Allow-Methods' ] = ', '.join( ALLOWED_METHODS )
-
-        # NOTE: raising some errors (such as httpexceptions), will remove the header
-        # (e.g. client will get both cors error and 404 inside that)
 
     def get_user(self):
         """Return the current user if logged in or None."""

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -36,13 +36,16 @@ class AuthenticationController(BaseAPIController):
     @expose_api_anonymous_and_sessionless
     def options(self, trans, **kwd):
         """
-        A no-op endpoint to return generic OPTIONS for the API.  Right now this is solely to inform preflight CORS checks, which are API wide.
+        A no-op endpoint to return generic OPTIONS for the API.
+        Any OPTIONS request to /api/* maps here.
+        Right now this is solely to inform preflight CORS checks, which are API wide.
+        Might be better placed elsewhere, but for now this is the initial entrypoint for relevant consumers.
         """
         trans.response.headers['Access-Control-Allow-Headers'] = '*'
-        #Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
-        #Access-Control-Max-Age: 86400
-        print(trans.response.headers)
-        return
+        trans.response.headers['Access-Control-Max-Age'] = 600
+        # No need to set allow-methods for preflight cors check, I don't think.
+        # When this is actually granular, endpoints should *probably* respond appropriately.
+        # trans.response.headers['Access-Control-Allow-Methods'] = 'POST, PUT, GET, OPTIONS, DELETE'
 
     @expose_api_anonymous_and_sessionless
     def get_api_key(self, trans, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -34,6 +34,17 @@ class AuthenticationController(BaseAPIController):
         self.api_keys_manager = api_keys.ApiKeyManager(app)
 
     @expose_api_anonymous_and_sessionless
+    def options(self, trans, **kwd):
+        """
+        A no-op endpoint to return generic OPTIONS for the API.  Right now this is solely to inform preflight CORS checks, which are API wide.
+        """
+        trans.response.headers['Access-Control-Allow-Headers'] = '*'
+        #Access-Control-Allow-Methods: POST, GET, OPTIONS, DELETE
+        #Access-Control-Max-Age: 86400
+        print(trans.response.headers)
+        return
+
+    @expose_api_anonymous_and_sessionless
     def get_api_key(self, trans, **kwd):
         """
         def get_api_key( self, trans, **kwd )

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -627,6 +627,13 @@ def populate_api_routes(webapp, app):
                           action='get_api_key',
                           conditions=dict(method=["GET"]))
 
+    # API OPTIONS RESPONSE
+    webapp.mapper.connect('options',
+                          '/api/{path_info:.*?}',
+                          controller='authenticate',
+                          action='options',
+                          conditions={'method': ['OPTIONS']})
+
     # ======================================
     # ====== DISPLAY APPLICATIONS API ======
     # ======================================


### PR DESCRIPTION
This adds API support for CORS preflight requests.

@mvdbeek This is one reason we were having CORS issues when working on covid19.galaxyproject.org viz, for what it's worth, when the CORS headers were configured but weren't seemingly being set correctly for some requests.



Before:
```
curl -v 'http://192.168.0.101:8080/api/authenticate/baseauth' -X OPTIONS -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization' -H 'Origin: http://192.168.0.101:8083'
*   Trying 192.168.0.101...
* TCP_NODELAY set
* Connected to 192.168.0.101 (192.168.0.101) port 8080 (#0)
> OPTIONS /api/authenticate/baseauth HTTP/1.1
> Host: 192.168.0.101:8080
> User-Agent: curl/7.64.1
> Accept: */*
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: authorization
> Origin: http://192.168.0.101:8083
>
< HTTP/1.1 404 Not Found
< Content-Length: 193
< Content-Type: text/html; charset=UTF-8
<
<html>
 <head>
  <title>404 Not Found</title>
 </head>
 <body>
  <h1>404 Not Found</h1>
  The resource could not be found.<br /><br />
No route for /api/authenticate/baseauth


 </body>
* Connection #0 to host 192.168.0.101 left intact
</html>* Closing connection 0
```

After:
```
curl -v 'http://192.168.0.101:8080/api/authenticate/baseauth' -X OPTIONS -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: authorization' -H 'Origin: http://192.168.0.101:8083'
*   Trying 192.168.0.101...
* TCP_NODELAY set
* Connected to 192.168.0.101 (192.168.0.101) port 8080 (#0)
> OPTIONS /api/authenticate/baseauth HTTP/1.1
> Host: 192.168.0.101:8080
> User-Agent: curl/7.64.1
> Accept: */*
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: authorization
> Origin: http://192.168.0.101:8083
>
< HTTP/1.1 200 OK
< content-type: application/json; charset=UTF-8
< x-frame-options: SAMEORIGIN
< access-control-allow-origin: http://192.168.0.101:8083
< cache-control: max-age=0,no-cache,no-store
< access-control-allow-headers: *
< access-control-max-age: 600
* no chunk, no close, no size. Assume close to signal end
<
* Closing connection 0
```

The important part here is the response notating `access-control-allow-origin: http://192.168.0.101:8083`, reflecting my (whitelisted) origin back, along with the 200 OK.