### PR TITLE
Allow option to remember the previously used IDP for login

### DIFF
--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -38,7 +38,7 @@
                                         </multiselect>
                                     </b-form-group>
 
-                                    <input type="checkbox" id="remember-idp" v-model="rememberIdp">
+                                    <input type="checkbox" id="remember-idp" v-model="rememberIdp" />
                                     <label for="remember-idp"> Remember institution </label>
 
                                     <div>
@@ -229,8 +229,7 @@ export default {
         },
         submitCILogon(idp) {
             const rootUrl = getAppRoot();
-
-            this.setIdpCookie();          
+            this.setIdpCookie();
             axios
                 .post(`${rootUrl}authnz/${idp}/login/?idphint=${this.selected.EntityID}`)
                 .then((response) => {
@@ -270,14 +269,16 @@ export default {
         getCILogonIdps() {
             const rootUrl = getAppRoot();
 
-            axios.get(`${rootUrl}authnz/get_cilogon_idps`).then((response) => {
-                this.cilogon_idps = response.data;
-                //List is originally sorted by OrganizationName which can be different from DisplayName
-                this.cilogon_idps.sort((a, b) => (a.DisplayName > b.DisplayName ? 1 : -1));
-            })
-            .then(() => {
-                this.selected = this.cilogon_idps.find(idp => idp.EntityID === this.getIdpCookie());
-            });
+            axios
+                .get(`${rootUrl}authnz/get_cilogon_idps`)
+                .then((response) => {
+                    this.cilogon_idps = response.data;
+                    //List is originally sorted by OrganizationName which can be different from DisplayName
+                    this.cilogon_idps.sort((a, b) => (a.DisplayName > b.DisplayName ? 1 : -1));
+                })
+                .then(() => {
+                    this.selected = this.cilogon_idps.find((idp) => idp.EntityID === this.getIdpCookie());
+                });
         },
         setIdpCookie() {
             var expires = new Date();
@@ -286,10 +287,10 @@ export default {
         },
         getIdpCookie() {
             const idpCookie = document.cookie
-                                .split('; ')
-                                .find(row => row.startsWith('remembered-idp'))
-                                .split('=')[1];
-            
+                .split("; ")
+                .find((row) => row.startsWith("remembered-idp"))
+                .split("=")[1];
+
             return idpCookie;
         },
     },

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -38,24 +38,25 @@
                                         </multiselect>
                                     </b-form-group>
 
-                                    <input type="checkbox" id="remember-idp" v-model="rememberIdp" />
-                                    <label for="remember-idp"> Remember institution </label>
+                                    <b-form-group>
+                                        <b-form-checkbox id="remember-idp" v-model="rememberIdp">
+                                            Remember institution selection
+                                        </b-form-checkbox>
+                                    </b-form-group>
 
-                                    <div>
-                                        <b-button
-                                            v-if="Object.prototype.hasOwnProperty.call(oidc_idps, 'cilogon')"
-                                            @click="submitCILogon('cilogon')"
-                                            :disabled="selected === null"
-                                            >Sign in with Institutional Credentials*</b-button
-                                        >
-                                        <!--convert to v-else-if to allow only one or the other. if both enabled, put the one that should be default first-->
-                                        <b-button
-                                            v-if="Object.prototype.hasOwnProperty.call(oidc_idps, 'custos')"
-                                            @click="submitCILogon('custos')"
-                                            :disabled="selected === null"
-                                            >Sign in with Custos*</b-button
-                                        >
-                                    </div>
+                                    <b-button
+                                        v-if="Object.prototype.hasOwnProperty.call(oidc_idps, 'cilogon')"
+                                        @click="submitCILogon('cilogon')"
+                                        :disabled="selected === null"
+                                        >Sign in with Institutional Credentials*</b-button
+                                    >
+                                    <!--convert to v-else-if to allow only one or the other. if both enabled, put the one that should be default first-->
+                                    <b-button
+                                        v-if="Object.prototype.hasOwnProperty.call(oidc_idps, 'custos')"
+                                        @click="submitCILogon('custos')"
+                                        :disabled="selected === null"
+                                        >Sign in with Custos*</b-button
+                                    >
 
                                     <p class="mt-3">
                                         <small class="text-muted">

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -230,7 +230,7 @@ export default {
         },
         submitCILogon(idp) {
             const rootUrl = getAppRoot();
-            this.setIdpCookie();
+            this.setIdpPreference();
             axios
                 .post(`${rootUrl}authnz/${idp}/login/?idphint=${this.selected.EntityID}`)
                 .then((response) => {
@@ -269,7 +269,6 @@ export default {
         },
         getCILogonIdps() {
             const rootUrl = getAppRoot();
-
             axios
                 .get(`${rootUrl}authnz/get_cilogon_idps`)
                 .then((response) => {
@@ -278,21 +277,17 @@ export default {
                     this.cilogon_idps.sort((a, b) => (a.DisplayName > b.DisplayName ? 1 : -1));
                 })
                 .then(() => {
-                    this.selected = this.cilogon_idps.find((idp) => idp.EntityID === this.getIdpCookie());
+                    const preferredIdp = this.getIdpPreference();
+                    if (preferredIdp) {
+                        this.selected = this.cilogon_idps.find((idp) => idp.EntityID === preferredIdp);
+                    }
                 });
         },
-        setIdpCookie() {
-            var expires = new Date();
-            expires.setTime(expires.getTime() + 2628000000); //one month in milliseconds
-            document.cookie = "remembered-idp=" + this.selected.EntityID + "; expires=" + expires.toUTCString();
+        setIdpPreference() {
+            window.localStorage.setItem("galaxy-remembered-idp", this.selected.EntityID);
         },
-        getIdpCookie() {
-            const idpCookie = document.cookie
-                .split("; ")
-                .find((row) => row.startsWith("remembered-idp"))
-                .split("=")[1];
-
-            return idpCookie;
+        getIdpPreference() {
+            return window.localStorage.getItem("galaxy-remembered-idp");
         },
     },
     created() {

--- a/client/galaxy/scripts/components/login/Login.vue
+++ b/client/galaxy/scripts/components/login/Login.vue
@@ -284,13 +284,18 @@ export default {
                 });
         },
         setIdpPreference() {
-            window.localStorage.setItem("galaxy-remembered-idp", this.selected.EntityID);
+            if (this.rememberIdp) {
+                localStorage.setItem("galaxy-remembered-idp", this.selected.EntityID);
+            } else {
+                localStorage.removeItem("galaxy-remembered-idp");
+            }
         },
         getIdpPreference() {
-            return window.localStorage.getItem("galaxy-remembered-idp");
+            return localStorage.getItem("galaxy-remembered-idp");
         },
     },
     created() {
+        this.rememberIdp = this.getIdpPreference() !== null;
         this.getCILogonIdps();
     },
 };


### PR DESCRIPTION
- if user checks the "remember instutition" checkbox on login with custos/cilogon, that idp is pre-selected the next time they log in (until the cookie expires)