### PR TITLE
Progressively render conditional as they are being displayed

### DIFF
--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -24,6 +24,7 @@ export var View = Backbone.View.extend({
                 onchange_title: null,
             }).set(options);
         this.setElement(this._template());
+        this.section = options.section;
 
         // link all dom elements
         this.$body = this.$(".portlet-body");
@@ -184,6 +185,9 @@ export var View = Backbone.View.extend({
     /** Expand portlet */
     expand: function () {
         this.collapsed = false;
+        if (this.section) {
+            this.section.renderOnce();
+        }
         this.$content.show();
         this.collapsible_button.setIcon("fa-eye");
     },


### PR DESCRIPTION
This reduces the time to render https://github.com/hepcat72/tools-iuc/tree/xml2json/tools/ncbi_entrez_eutils from ~ 90 seconds to immediate. I think this approach should also work for other elements that hide things, like repeats and sections. Might also fix https://github.com/galaxyproject/galaxy/issues/9615 ?