### PR TITLE
Selenium: Library Dataset Download Zip

### DIFF
--- a/client/src/mvc/library/library-folderrow-view.js
+++ b/client/src/mvc/library/library-folderrow-view.js
@@ -267,13 +267,13 @@ var FolderRowView = Backbone.View.extend({
                         <% if( content_item.get("description").length > 40 ) { %>
                             <td data-toggle="tooltip" data-placement="auto"
                                 title='<%= _.escape(content_item.get("description")) %>'>
-                                <%= _.escape(content_item.get("description")).substring(0, 40) + "..." %>
+                                <div class="description-field"><%= _.escape(content_item.get("description")).substring(0, 40) + "..." %></div>
                             </td>
                         <% } else { %>
-                            <td><%= _.escape(content_item.get("description"))%></td>
+                            <td><div class="description-field"><%= _.escape(content_item.get("description"))%></div></td>
                         <% } %>
                     <% } else { %>
-                        <td></td>
+                        <td> <div class="description-field"></div></td>
                     <% } %>
                 <% } else if(edit_mode){ %>
                     <td>
@@ -342,10 +342,12 @@ var FolderRowView = Backbone.View.extend({
                     <% if( content_item.get("message").length > 40 ) { %>
                         <td data-toggle="tooltip" data-placement="auto"
                             title='<%= _.escape(content_item.get("message")) %>'>
-                            <%= _.escape(content_item.get("message")).substring(0, 40) + "..." %>
+                            <div class="description-field">                            <%= _.escape(content_item.get("message")).substring(0, 40) + "..." %>
+</div>
                         </td>
                     <% } else { %>
-                        <td><%= _.escape(content_item.get("message"))%></td>
+                    <td><div class="description-field"> 
+                        <%= _.escape(content_item.get("message"))%></div></td>
                     <% } %>
                 <% } %>
                 <td><div class="nametags"><!-- Nametags mount here --></div></td>

--- a/client/src/mvc/library/library-folderrow-view.js
+++ b/client/src/mvc/library/library-folderrow-view.js
@@ -329,7 +329,7 @@ var FolderRowView = Backbone.View.extend({
                 <td class="mid">
                     <span title="Dataset" class="fa fa-file-o"></span>
                 </td>
-                <td class="mid">
+                <td class="mid lib-folder-checkbox">
                     <input style="margin: 0;" type="checkbox">
                 </td>
                 <td>
@@ -342,8 +342,7 @@ var FolderRowView = Backbone.View.extend({
                     <% if( content_item.get("message").length > 40 ) { %>
                         <td data-toggle="tooltip" data-placement="auto"
                             title='<%= _.escape(content_item.get("message")) %>'>
-                            <div class="description-field">                            <%= _.escape(content_item.get("message")).substring(0, 40) + "..." %>
-</div>
+                            <%= _.escape(content_item.get("message")).substring(0, 40) + "..." %>
                         </td>
                     <% } else { %>
                     <td><div class="description-field"> 

--- a/client/src/mvc/library/library-folderrow-view.js
+++ b/client/src/mvc/library/library-folderrow-view.js
@@ -267,13 +267,13 @@ var FolderRowView = Backbone.View.extend({
                         <% if( content_item.get("description").length > 40 ) { %>
                             <td data-toggle="tooltip" data-placement="auto"
                                 title='<%= _.escape(content_item.get("description")) %>'>
-                                <div class="description-field"><%= _.escape(content_item.get("description")).substring(0, 40) + "..." %></div>
+                                <%= _.escape(content_item.get("description")).substring(0, 40) + "..." %>
                             </td>
                         <% } else { %>
-                            <td><div class="description-field"><%= _.escape(content_item.get("description"))%></div></td>
+                            <td><%= _.escape(content_item.get("description"))%></td>
                         <% } %>
                     <% } else { %>
-                        <td> <div class="description-field"></div></td>
+                        <td></td>
                     <% } %>
                 <% } else if(edit_mode){ %>
                     <td>
@@ -345,8 +345,7 @@ var FolderRowView = Backbone.View.extend({
                             <%= _.escape(content_item.get("message")).substring(0, 40) + "..." %>
                         </td>
                     <% } else { %>
-                    <td><div class="description-field"> 
-                        <%= _.escape(content_item.get("message"))%></div></td>
+                        <td><%= _.escape(content_item.get("message"))%></td>
                     <% } %>
                 <% } %>
                 <td><div class="nametags"><!-- Nametags mount here --></div></td>

--- a/client/src/mvc/library/library-foldertoolbar-view.js
+++ b/client/src/mvc/library/library-foldertoolbar-view.js
@@ -1486,7 +1486,7 @@ var FolderToolbarView = Backbone.View.extend({
                             </div>
                             <div title="Download items as archive"
                                 class="dropdown dataset-manipulation mr-1" style="display:none; ">
-                                <button type="button" class="primary-button dropdown-toggle" data-toggle="dropdown">
+                                <button id="download-dropdown-btn" type="button" class="primary-button dropdown-toggle" data-toggle="dropdown">
                                     <span class="fa fa-save"></span> Download <span class="caret"></span>
                                 </button>
                                 <div class="dropdown-menu" role="menu">

--- a/lib/galaxy/selenium/driver_factory.py
+++ b/lib/galaxy/selenium/driver_factory.py
@@ -21,7 +21,7 @@ def get_local_browser(browser):
     if browser == "auto":
         if _which("chromedriver"):
             return "CHROME"
-        if _which("geckodriver"):
+        elif _which("geckodriver"):
             return "FIREFOX"
         else:
             raise Exception("Selenium browser is 'auto' but neither geckodriver or chromedriver are found on PATH.")
@@ -39,7 +39,8 @@ def get_local_driver(browser=DEFAULT_BROWSER, headless=False):
     driver_class = driver_to_class[browser]
     if browser == 'CHROME':
         options = ChromeOptions()
-        # options.add_argument('--headless')
+        if headless:
+            options.add_argument('--headless')
         prefs = {'download.default_directory': DEFAULT_DOWNLOAD_PATH}
         options.add_experimental_option('prefs', prefs)
         return driver_class(desired_capabilities={"loggingPrefs": LOGGING_PREFS}, chrome_options=options)

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -467,6 +467,11 @@ libraries:
       import_history_contents_items: '.library_selected_history_content tbody > tr'
       import_from_path_textarea: '#import_paths'
       select_all: '#select-all-checkboxes'
+      select_one: '.description-field'
+      download_dropdown: '#download-dropdown-btn'
+      download_zip:
+        type: xpath
+        selector: '//a[contains(text(), ".zip")]'
 
     labels:
       from_history: 'from History'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -467,7 +467,7 @@ libraries:
       import_history_contents_items: '.library_selected_history_content tbody > tr'
       import_from_path_textarea: '#import_paths'
       select_all: '#select-all-checkboxes'
-      select_one: '.description-field'
+      select_one: '.lib-folder-checkbox'
       download_dropdown: '#download-dropdown-btn'
       download_zip:
         type: xpath

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -44,6 +44,8 @@ DEFAULT_SELENIUM_REMOTE_HOST = "127.0.0.1"
 DEFAULT_SELENIUM_HEADLESS = "auto"
 DEFAULT_ADMIN_USER = "test@bx.psu.edu"
 DEFAULT_ADMIN_PASSWORD = "testpass"
+DEFAULT_DOWNLOAD_PATH = driver_factory.DEFAULT_DOWNLOAD_PATH
+
 
 TIMEOUT_MULTIPLIER = float(os.environ.get("GALAXY_TEST_TIMEOUT_MULTIPLIER", DEFAULT_TIMEOUT_MULTIPLIER))
 GALAXY_TEST_ERRORS_DIRECTORY = os.environ.get("GALAXY_TEST_ERRORS_DIRECTORY", DEFAULT_TEST_ERRORS_DIRECTORY)
@@ -260,6 +262,11 @@ class TestWithSeleniumMixin(NavigatesGalaxy, UsesApiTestCaseMixin):
             return
 
         self.driver.save_screenshot(target)
+
+    def get_download_path(self):
+        """Returns default download path
+        """
+        return DEFAULT_DOWNLOAD_PATH
 
     def api_interactor_for_logged_in_user(self):
         api_key = self.get_api_key(force=True)

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -1,6 +1,6 @@
-from selenium.webdriver.support.ui import Select
-
 import os
+
+from selenium.webdriver.support.ui import Select
 
 from .framework import (
     retry_assertion_during_transitions,
@@ -59,7 +59,6 @@ class LibraryContentsTestCase(SeleniumTestCase):
 
         expected_filename = "selected_dataset_files.zip"
         assert expected_filename in folder_files
-
 
     # Fine test locally but the upload doesn't work in Docker compose. I'd think
     # Galaxy must be running so that test-data/1.txt would work but it just doesn't

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -1,5 +1,7 @@
 from selenium.webdriver.support.ui import Select
 
+import os
+
 from .framework import (
     retry_assertion_during_transitions,
     retry_during_transitions,
@@ -44,6 +46,20 @@ class LibraryContentsTestCase(SeleniumTestCase):
         self.screenshot("libraries_dataset_import")
         self.libraries_dataset_import_from_history_click_ok()
         self._assert_num_displayed_items_is(1)
+
+    @selenium_test
+    def download_dataset_from_library(self):
+        self.test_import_dataset_from_history()
+
+        self.components.libraries.folder.select_one.wait_for_and_click()
+        self.components.libraries.folder.download_dropdown.wait_for_and_click()
+        self.components.libraries.folder.download_zip.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        folder_files = os.listdir(self.get_download_path())
+
+        expected_filename = "selected_dataset_files.zip"
+        assert expected_filename in folder_files
+
 
     # Fine test locally but the upload doesn't work in Docker compose. I'd think
     # Galaxy must be running so that test-data/1.txt would work but it just doesn't


### PR DESCRIPTION
This PR introduces new Selenium feature. It defines default download directory in gecko and chrome driver before we run selenium test.
 It allows us to check downloading dataset from Library-Folder (zip format). This has been recently fixed in https://github.com/galaxyproject/galaxy/pull/10072 and hopefully implemented test prevents us to break this functionality again. 

The idea is quite straightforward, we download selected dataset and verify its presence in download dir (`/tmp` by default)

This Test is already compatible with new major library folder re-write in https://github.com/galaxyproject/galaxy/pull/9905 and probably should be merged before 9905.