### PR TITLE
Fix change_datatype PJA when dataset is not yet in object store

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -587,7 +587,7 @@ class Registry:
         # initialization.
         if data.has_data():
             data.set_size()
-            data.init_meta(copy_from=data)
+        data.init_meta(copy_from=data)
         return data
 
     def load_datatype_converters(self, toolbox, installed_repository_dict=None, deactivate=False, use_cached=False):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2324,6 +2324,10 @@ class Dataset(StorableObject, RepresentById):
         self.sources = []
         self.hashes = []
 
+    @property
+    def is_new(self):
+        return self.state == self.states.NEW
+
     def in_ready_state(self):
         return self.state in self.ready_states
 
@@ -2447,7 +2451,7 @@ class Dataset(StorableObject, RepresentById):
 
     def has_data(self):
         """Detects whether there is any data"""
-        return self.get_size() > 0
+        return not self.is_new and self.get_size() > 0
 
     def mark_deleted(self):
         self.deleted = True

--- a/test/integration/test_change_datatype_with_store_by_id.py
+++ b/test/integration/test_change_datatype_with_store_by_id.py
@@ -1,0 +1,22 @@
+from galaxy_test.api.test_workflows import ChangeDatatypeTestCase
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    WorkflowPopulator,
+)
+from galaxy_test.driver import integration_util
+
+
+class ChangeDatatypeStoreByIdIntegrationTestCase(integration_util.IntegrationTestCase, ChangeDatatypeTestCase):
+    """Test changing datatype with object_store_store_by: id."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["object_store_store_by"] = "id"
+        config["retry_metadata_internally"] = False
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)


### PR DESCRIPTION
Fixes a fallout from the recent flush optimizations. Should fix #10085 (@bgruening any chance you could try this ?).
- [x] Maybe we should push the is_new check into has_data?