### PR TITLE
Count all terminal jobs when rendering job complete string

### DIFF
--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -147,7 +147,7 @@ export default {
             return `${this.stepStates.scheduled || 0} of ${this.stepCount} steps successfully scheduled.`;
         },
         jobStatesStr: function () {
-            let jobStr = `${this.jobStatesSummary.states()["ok"] || 0} of ${this.jobCount} jobs complete`;
+            let jobStr = `${this.jobStatesSummary.numTerminal()} of ${this.jobCount} jobs complete`;
             if (!this.invocationSchedulingTerminal) {
                 jobStr += " (total number of jobs will change until all steps fully scheduled)";
             }

--- a/client/src/mvc/history/job-states-model.js
+++ b/client/src/mvc/history/job-states-model.js
@@ -6,6 +6,7 @@ import AJAX_QUEUE from "utils/ajax-queue";
 var UPDATE_DELAY = 2000;
 var NON_TERMINAL_STATES = ["new", "queued", "running"];
 var ERROR_STATES = ["error", "deleted"];
+var TERMINAL_STATES = ["ok"].concat(ERROR_STATES);
 /** Fetch state on add or just wait for polling to start. */
 var FETCH_STATE_ON_ADD = false;
 var BATCH_FETCH_STATE = true;
@@ -58,6 +59,10 @@ var JobStatesSummary = Backbone.Model.extend({
 
     numInError: function () {
         return this.numWithStates(ERROR_STATES);
+    },
+
+    numTerminal: function () {
+        return this.numWithStates(TERMINAL_STATES);
     },
 
     running: function () {


### PR DESCRIPTION
This previously only counted OK states, which was very confusing if you're waiting for your jobs to run, but they've actually errored or were deleted. Maybe paused should also count as a terminal state, or maybe the progress bar should be colored based on the number of OK / RUNNING / PAUSED / ERROR / DELETED ?

I am planning to make this a dropdown with jobs per state in the future (to mirror what I've done in https://github.com/galaxyproject/planemo/pull/1048), but that's a nice first step that I think we should backport eventually.