### PR TITLE
Tensorflow update to support python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ database/test_errors
 database/tmp
 database/tool_cache
 database/tool_search_index
+database/tool_recommendation_model.hdf5
 
 
 # Python bytecode

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -30,5 +30,4 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-keras==2.4.3
 tensorflow==2.3.0

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -30,5 +30,5 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-keras==2.2.4
-tensorflow==1.15.2
+keras==2.4.3
+tensorflow==2.3.0

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -57,15 +57,15 @@ class ToolRecommendations():
             # keras is not downloaded because of conditional requirement and Galaxy does not build
             try:
                 from keras.models import model_from_json
-                import tensorflow.compat.v1 as tf
-                tf.disable_v2_behavior()
+                import tensorflow as tf
+                tf.compat.v1.disable_v2_behavior()
             except Exception:
                 trans.response.status = 400
                 return False
             # set graph and session only once
             if self.graph is None:
                 self.graph = tf.Graph()
-                self.session = tf.Session(graph=self.graph)
+                self.session = tf.compat.v1.Session(graph=self.graph)
             model_weights = list()
             counter_layer_weights = 0
             self.tool_recommendation_model_path = self.__download_model(remote_model_url)

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -56,7 +56,6 @@ class ToolRecommendations():
             # import moves from the top of file: in case the tool recommendation feature is disabled,
             # keras is not downloaded because of conditional requirement and Galaxy does not build
             try:
-                from keras.models import model_from_json
                 import tensorflow as tf
                 tf.compat.v1.disable_v2_behavior()
             except Exception:
@@ -83,7 +82,7 @@ class ToolRecommendations():
                                 weight = trained_model["weight_" + str(counter_layer_weights)][()]
                                 model_weights.append(weight)
                                 counter_layer_weights += 1
-                        self.loaded_model = model_from_json(model_config)
+                        self.loaded_model = tf.keras.models.model_from_json(model_config)
                         self.loaded_model.set_weights(model_weights)
                     except Exception as e:
                         log.exception(e)

--- a/lib/galaxy/tools/recommendations.py
+++ b/lib/galaxy/tools/recommendations.py
@@ -57,7 +57,8 @@ class ToolRecommendations():
             # keras is not downloaded because of conditional requirement and Galaxy does not build
             try:
                 from keras.models import model_from_json
-                import tensorflow as tf
+                import tensorflow.compat.v1 as tf
+                tf.disable_v2_behavior()
             except Exception:
                 trans.response.status = 400
                 return False


### PR DESCRIPTION
```
Collecting keras==2.2.4
  Using cached Keras-2.2.4-py2.py3-none-any.whl (312 kB)
ERROR: Could not find a version that satisfies the requirement tensorflow==1.15.2 (from -r /dev/stdin (line 5)) (from versions: 2.2.0rc3, 2.2.0rc4, 2.2.0, 2.3.0rc0, 2.3.0rc1, 2.3.0rc2, 2.3.0)
ERROR: No matching distribution found for tensorflow==1.15.2 (from -r /dev/stdin (line 5))
```
Ran into the above trying to test tool recommendations against python 3.8.5.  This should make it work and will be compatible with previous versions  as well, I hope -- opening to run tests.