### PR TITLE
fix masthead dropdown

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -118,13 +118,13 @@ export default {
             return document.getElementById("galaxy_main");
         },
     },
-    mounted() {
-        if (this.galaxyIframe) {
+    updated() {
+        if (this.$refs.dropdown && this.galaxyIframe) {
             this.galaxyIframe.addEventListener("load", this.iframeListener);
         }
     },
     destroyed() {
-        if (this.galaxyIframe) {
+        if (this.$refs.dropdown && this.galaxyIframe) {
             this.galaxyIframe.removeEventListener("load", this.iframeListener);
         }
     },


### PR DESCRIPTION
This PR fixes https://github.com/galaxyproject/galaxy/issues/10092 . 

![Peek 2020-08-12 16-58](https://user-images.githubusercontent.com/15801412/90031265-51f28780-dcbd-11ea-94a3-26ebae082910.gif)


It took me a bit to understand why did it stop working. It was a race between Vue component and `galaxy_main` iframe. 

We added additional stuff to our home page and it slowed down the rendering, thus `document.getElementById("galaxy_main");` was returning null. Also we don't need this listener, if we don't have dropdown  `MastheadItem` component (added a check for that)

Thanks a lot @afgane for reporting!
