### PR TITLE
[20.05] Handle python2-related syntax errors in Cheetah code

### DIFF
--- a/lib/galaxy/util/template.py
+++ b/lib/galaxy/util/template.py
@@ -1,13 +1,13 @@
 """Entry point for the usage of Cheetah templating within Galaxy."""
 from __future__ import absolute_import
 
-import sys
 import traceback
 from lib2to3.refactor import RefactoringTool
 
 import packaging.version
 from Cheetah.Compiler import Compiler
 from Cheetah.NameMapper import NotFound
+from Cheetah.Parser import ParseError
 from Cheetah.Template import Template
 from past.translation import myfixes
 
@@ -15,11 +15,8 @@ from . import unicodify
 
 # Skip libpasteurize fixers, which make sure code is py2 and py3 compatible.
 # This is not needed, we only translate code on py3.
-if sys.version_info.major > 2:
-    myfixes = [f for f in myfixes if not f.startswith('libpasteurize')]
-    refactoring_tool = RefactoringTool(myfixes, {'print_function': True})
-else:
-    myfixes = refactoring_tool = None
+myfixes = [f for f in myfixes if not f.startswith('libpasteurize')]
+refactoring_tool = RefactoringTool(myfixes, {'print_function': True})
 
 
 class FixedModuleCodeCompiler(Compiler):
@@ -61,14 +58,32 @@ def fill_template(template_text,
         context = kwargs
     if isinstance(python_template_version, str):
         python_template_version = packaging.version.parse(python_template_version)
-    klass = Template.compile(source=template_text, compilerClass=compiler_class)
+    try:
+        klass = Template.compile(source=template_text, compilerClass=compiler_class)
+    except ParseError as e:
+        # Might happen on invalid syntax within a cheetah statement, like `#if $smxsize <> 128.0`
+        if first_exception is None:
+            first_exception = e
+        if python_template_version.release[0] < 3 and retry > 0:
+            module_code = Template.compile(source=template_text, compilerClass=compiler_class, returnAClass=False).decode('utf-8')
+            module_code = futurize_preprocessor(module_code)
+            compiler_class = create_compiler_class(module_code)
+            return fill_template(
+                template_text=template_text,
+                context=context,
+                retry=retry - 1,
+                compiler_class=compiler_class,
+                first_exception=first_exception,
+                python_template_version=python_template_version,
+            )
+        raise first_exception or e
     t = klass(searchList=[context])
     try:
         return unicodify(t)
     except NotFound as e:
         if first_exception is None:
             first_exception = e
-        if refactoring_tool and python_template_version.release[0] < 3 and retry > 0:
+        if python_template_version.release[0] < 3 and retry > 0:
             tb = e.__traceback__
             last_stack = traceback.extract_tb(tb)[-1]
             if last_stack.name == '<listcomp>':
@@ -95,7 +110,7 @@ def fill_template(template_text,
     except Exception as e:
         if first_exception is None:
             first_exception = e
-        if sys.version_info.major > 2 and python_template_version.release[0] < 3 and not futurized:
+        if python_template_version.release[0] < 3 and not futurized:
             # Possibly an error caused by attempting to run python 2
             # template code on python 3. Run the generated module code
             # through futurize and hope for the best.

--- a/test/unit/tools/test_fill_template.py
+++ b/test/unit/tools/test_fill_template.py
@@ -37,6 +37,12 @@ TWO_TO_THREE_TEMPLATE = """#set $a = [x for x in {'a': '1'}.iterkeys()][0]
 #set $c = [x for x in {'a': '1'}.itervalues()][0]
 $a $b $c"""
 
+INVALID_CHEETAH_SYNTAX = """#if 1 <> 1
+1 is not 1
+#else
+1 is 1
+#end if"""
+
 
 def test_fill_simple_template():
     template_str = str(fill_template(SIMPLE_TEMPLATE, {'a_list': [1, 2]}))
@@ -75,3 +81,8 @@ def test_gen_expr():
 def test_fix_template_two_to_three():
     template_str = fill_template(TWO_TO_THREE_TEMPLATE, python_template_version='2', retry=1)
     assert template_str == 'a a 1'
+
+
+def test_fix_template_invalid_cheetah():
+    template_str = fill_template(INVALID_CHEETAH_SYNTAX, python_template_version='2', retry=1)
+    assert template_str == "1 is 1\n"


### PR DESCRIPTION
Also drops conditional behavior on Python 2, sice we don't support that
anymore. Fixes cmsearch and cmscan, reported by @mmiladi on gitter.
Without this you'd see the following traceback:
```
Error in the Python code which Cheetah generated for this template:
================================================================================

invalid syntax (cheetah_DynamicallyCompiledCheetahTemplate_1597222728_2079988_77368.py, line 130)

Line

Job Traceback

Traceback (most recent call last):
  File "/opt/galaxy/venv3/lib64/python3.6/site-packages/Cheetah/Template.py", line 823, in compile
    co = compile(generatedModuleCode, __file__, 'exec')
  File "cheetah_DynamicallyCompiledCheetahTemplate_1597222728_2079988_77368.py", line 130
    if VFFSL(SL,"smxsize",True) <> 128.0: # generated from line 17, col 13
                                 ^
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 236, in prepare_job
    job_wrapper.prepare()
  File "/opt/galaxy/server/lib/galaxy/jobs/__init__.py", line 1107, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 475, in build
    raise e
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 471, in build
    self.__build_command_line()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 496, in __build_command_line
    command_line = fill_template(command, context=param_dict, python_template_version=self.tool.python_template_version)
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 64, in fill_template
    klass = Template.compile(source=template_text, compilerClass=compiler_class)
  File "/opt/galaxy/venv3/lib64/python3.6/site-packages/Cheetah/Template.py", line 834, in compile
    raise parseError
Cheetah.Parser.ParseError:

Error in the Python code which Cheetah generated for this template:
================================================================================

invalid syntax (cheetah_DynamicallyCompiledCheetahTemplate_1597222728_2079988_77368.py, line 130)

Line|Python Code
----|-------------------------------------------------------------
128 |        write('''
129 |''')
130 |        if VFFSL(SL,"smxsize",True) <> 128.0: # generated from line 17, col 13
                                         ^
131 |            _v = VFFSL(SL,"smxsize",True) # '$smxsize' on line 18, col 27
132 |            if _v is not None: write(_filter(_v, rawExpr='$smxsize')) # from line 18, col 27.
133 |            write('''

================================================================================

Here is the corresponding Cheetah code:

Line 17, column 13

Line|Cheetah Code
----|-------------------------------------------------------------
14  |            $notrunc
15  |            $anytrunc
16  |            $nonull3
17  |            #if $smxsize <> 128.0
                 ^
18  |                --smxsize $smxsize
19  |            #end if
20  |            #if $mxsize <> 128.0
```