### PR TITLE
[20.05] Fix outputs_to_working_directory with extended metadata

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -919,7 +919,7 @@ class JobWrapper(HasResourceParameters):
             metadata_strategy_override = None
         if job.tasks:
             metadata_strategy_override = "directory"
-        self.external_output_metadata = get_metadata_compute_strategy(self.app.config, job.id, metadata_strategy_override=metadata_strategy_override)
+        self.external_output_metadata = get_metadata_compute_strategy(self.app.config, job.id, metadata_strategy_override=metadata_strategy_override, tool_id=job.tool_id)
 
         self.__commands_in_new_shell = True
         self.__user_system_pwent = None

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -22,11 +22,11 @@ log = getLogger(__name__)
 SET_METADATA_SCRIPT = 'from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()'
 
 
-def get_metadata_compute_strategy(config, job_id, metadata_strategy_override=None):
+def get_metadata_compute_strategy(config, job_id, metadata_strategy_override=None, tool_id=None):
     metadata_strategy = metadata_strategy_override or config.metadata_strategy
     if metadata_strategy == "legacy":
         return JobExternalOutputMetadataWrapper(job_id)
-    elif metadata_strategy == "extended":
+    elif metadata_strategy == "extended" and tool_id != "__SET_METADATA__":
         return ExtendedDirectoryMetadataGenerator(job_id)
     else:
         return PortableDirectoryMetadataGenerator(job_id)

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -237,7 +237,7 @@ def set_metadata_portable():
                 dataset.set_size()
                 if 'uuid' in context:
                     dataset.dataset.uuid = context['uuid']
-                object_store.update_from_file(dataset.dataset, create=True)
+                object_store.update_from_file(dataset.dataset, file_name=dataset_filename_override, create=True)
                 from galaxy.job_execution.output_collect import collect_extra_files
                 collect_extra_files(object_store, dataset, ".")
                 if galaxy.model.Job.states.ERROR == final_job_state:
@@ -265,11 +265,8 @@ def set_metadata_portable():
                     if context_key in context:
                         context_value = context[context_key]
                         setattr(dataset, context_key, context_value)
-
-                if extended_metadata_collection:
-                    export_store.add_dataset(dataset)
-                else:
-                    cPickle.dump(dataset, open(filename_out, 'wb+'))
+                dataset.dataset.external_filename = None
+                export_store.add_dataset(dataset)
             else:
                 dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta
 

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -372,7 +372,7 @@ class DiskObjectStore(ConcreteObjectStore):
         :param extra_dirs: Keys are string, values are directory paths.
         """
         super(DiskObjectStore, self).__init__(config, config_dict)
-        self.file_path = config_dict.get("files_dir") or config.file_path
+        self.file_path = os.path.abspath(config_dict.get("files_dir") or config.file_path)
 
     @classmethod
     def parse_xml(clazz, config_xml):

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2538,7 +2538,7 @@ class SetMetadataTool(Tool):
             job, base_dir='job_work', dir_only=True, obj_dir=True
         )
         for name, dataset in inp_data.items():
-            external_metadata = get_metadata_compute_strategy(app.config, job.id)
+            external_metadata = get_metadata_compute_strategy(app.config, job.id, tool_id=self.id)
             sa_session = app.model.context
             metadata_set_successfully = external_metadata.external_metadata_set_successfully(dataset, name, sa_session, working_directory=working_directory)
             if metadata_set_successfully:

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -85,7 +85,7 @@ class SetMetadataToolAction(ToolAction):
         job_working_dir = app.object_store.get_filename(job, base_dir='job_work', dir_only=True, extra_dir=str(job.id))
         datatypes_config = os.path.join(job_working_dir, 'registry.xml')
         app.datatypes_registry.to_xml_file(path=datatypes_config)
-        external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id)
+        external_metadata_wrapper = get_metadata_compute_strategy(app.config, job.id, tool_id=tool.id)
         output_datatasets_dict = {
             dataset_name: dataset,
         }

--- a/test/integration/objectstore/test_objectstore_datatype_upload.py
+++ b/test/integration/objectstore/test_objectstore_datatype_upload.py
@@ -112,8 +112,7 @@ class BaseObjectstoreUploadTest(UploadTestDatatypeDataTestCase):
         temp_directory = cls._test_driver.mkdtemp()
         cls.object_stores_parent = temp_directory
         cls.object_store_config_path = os.path.join(temp_directory, "object_store_conf.xml")
-        # This doesn't quite work yet, fails with extra_files_path
-        # config["metadata_strategy"] = "extended"
+        config["metadata_strategy"] = "extended"
         config["outpus_to_working_dir"] = True
         config["retry_metadata_internally"] = False
         config["object_store_store_by"] = "uuid"

--- a/test/integration/objectstore/test_selection.py
+++ b/test/integration/objectstore/test_selection.py
@@ -44,6 +44,9 @@ class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
         config["job_config_file"] = JOB_CONFIG_FILE
         config["job_resource_params_file"] = JOB_RESOURCE_PARAMETERS_CONFIG_FILE
+        config["object_store_store_by"] = "uuid"
+        config["metadata_strategy"] = "extended"
+        config["outputs_to_working_directory"] = True
 
     def _object_store_counts(self):
         files_default_count = files_count(self.files_default_path)
@@ -60,6 +63,11 @@ class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase
         assert static == files_static_count
         assert dynamic_ebs == files_dynamic_ebs_count
         assert dynamic_s3 == files_dynamic_s3_count
+
+    def _assert_no_external_filename(self):
+        # Should maybe be its own test case ...
+        for external_filename_tuple in self._app.model.session.query(self._app.model.Dataset.external_filename).all():
+            assert external_filename_tuple[0] is None
 
     def test_tool_simple_constructs(self):
         with self.dataset_populator.test_history() as history_id:
@@ -103,3 +111,4 @@ class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase
             }
             _run_tool("create_10", create_10_inputs)
             self._assert_file_counts(1, 2, 10, 10)
+            self._assert_no_external_filename()

--- a/test/integration/objectstore/test_swift_objectstore.py
+++ b/test/integration/objectstore/test_swift_objectstore.py
@@ -89,8 +89,7 @@ class SwiftObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
         cls.object_stores_parent = temp_directory
         config_path = os.path.join(temp_directory, "object_store_conf.xml")
         config["object_store_store_by"] = "uuid"
-        # This doesn't quite work yet, fails with extra_files_path
-        # config["metadata_strategy"] = "extended"
+        config["metadata_strategy"] = "extended"
         config["outpus_to_working_dir"] = True
         config["retry_metadata_internally"] = False
         with open(config_path, "w") as f:

--- a/test/unit/jobs/test_job_wrapper.py
+++ b/test/unit/jobs/test_job_wrapper.py
@@ -163,6 +163,7 @@ class MockTool(object):
         self.tool_dir = "/path/to/tools"
         self.dependencies = []
         self.requires_galaxy_python_environment = False
+        self.id = 'mock_id'
 
     def build_dependency_shell_commands(self, job_directory):
         return TEST_DEPENDENCIES_COMMANDS


### PR DESCRIPTION
And avoids populating `external_filename`. Also uses `directory` metadata strategy instead of `extended` when re-setting metadata on existing files (setting up `extended` was broken, but even if we fix it would be wrong, as we'd overwrite job attributes, at least in the current setup).
Fixes  #9968