### PR TITLE
Don't fail to complete the job fail method if job outputs cannot be updated

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1290,7 +1290,7 @@ class JobWrapper(HasResourceParameters):
                     dataset.extension = 'data'
                 try:
                     self.__update_output(job, dataset)
-                except:
+                except Exception:
                     # Failure to update the output of a failed job should not prevent completion of the failure method
                     log.exception("(%s) fail(): Failed to update job output dataset with id: %s", self.get_id_tag(),
                                   dataset.dataset.id)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1288,7 +1288,12 @@ class JobWrapper(HasResourceParameters):
                 dataset.mark_unhidden()
                 if dataset.ext == 'auto':
                     dataset.extension = 'data'
-                self.__update_output(job, dataset)
+                try:
+                    self.__update_output(job, dataset)
+                except:
+                    # Failure to update the output of a failed job should not prevent completion of the failure method
+                    log.exception("(%s) fail(): Failed to update job output dataset with id: %s", self.get_id_tag(),
+                                  dataset.dataset.id)
                 # Pause any dependent jobs (and those jobs' outputs)
                 for dep_job_assoc in dataset.dependent_jobs:
                     self.pause(dep_job_assoc.job, "Execution of this dataset's job is paused because its input datasets are in an error state.")


### PR DESCRIPTION
They're failed outputs anyway. Otherwise this exception bubbles up and the handler will attempt to call `fail()` repeatedly forever until it works.