### PR TITLE
Fix history sharing link (ref. #10040)

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1132,7 +1132,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         url = url_for(controller='history', action="export_archive", id=id, qualified=True)
         return trans.show_message("Exporting History '%(n)s'. You will need to <a href='%(share)s' target='_top'>make this history 'accessible'</a> in order to import this to another galaxy sever. <br/>"
                                   "Use this link to download the archive or import it to another Galaxy server: "
-                                  "<a href='%(u)s'>%(u)s</a>" % ({'share': url_for(controller='', action='histories/sharing', id=id), 'n': history.name, 'u': url}))
+                                  "<a href='%(u)s'>%(u)s</a>" % ({'share': url_for('/histories/sharing', id=id), 'n': history.name, 'u': url}))
         # TODO: used in this file and index.mako
 
     @web.expose

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1130,9 +1130,9 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
                                           % ({'n': history.name, 's': url_for(controller='history', action="export_archive", id=id, qualified=True)}))
         self.queue_history_export(trans, history, gzip=gzip, include_hidden=include_hidden, include_deleted=include_deleted)
         url = url_for(controller='history', action="export_archive", id=id, qualified=True)
-        return trans.show_message("Exporting History '%(n)s'. You will need to <a href='%(share)s'>make this history 'accessible'</a> in order to import this to another galaxy sever. <br/>"
+        return trans.show_message("Exporting History '%(n)s'. You will need to <a href='%(share)s' target='_top'>make this history 'accessible'</a> in order to import this to another galaxy sever. <br/>"
                                   "Use this link to download the archive or import it to another Galaxy server: "
-                                  "<a href='%(u)s'>%(u)s</a>" % ({'share': url_for(controller='history', action='sharing'), 'n': history.name, 'u': url}))
+                                  "<a href='%(u)s'>%(u)s</a>" % ({'share': url_for(controller='', action='histories/sharing', id=id), 'n': history.name, 'u': url}))
         # TODO: used in this file and index.mako
 
     @web.expose


### PR DESCRIPTION
Fixes #10040.
I'm not sure whether this is the correct approach here. (ping @dannon)

**Tangent/discovered issue:** both `api.histories.HistoriesController` and `controllers.history.HistoryController` share `SharableMixin`. The mixin's `sharing()` method references `self.manager` and `self.serializer`, which exist only on `HistoriesConstoller`; `HistoryController` has `history_manager` and `history_serializer`. I haven't looked further into this (rabbit hole), but if we need both controllers, it will need to be addressed. 