### PR TITLE
Fix change_datatype

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -587,7 +587,7 @@ class Registry:
         # initialization.
         if data.has_data():
             data.set_size()
-        data.init_meta(copy_from=data)
+            data.init_meta(copy_from=data)
         return data
 
     def load_datatype_converters(self, toolbox, installed_repository_dict=None, deactivate=False, use_cached=False):


### PR DESCRIPTION
Broken in #10087.

If the dataset is new we can't copy Metadata, it fails with
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/metadata.py", line 145, in make_dict_copy
    rval[key] = self.spec[key].param.make_copy(value, target_context=self, source_context=to_copy)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/metadata.py", line 265, in make_copy
    return copy.deepcopy(value)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/custom_types.py", line 232, in __deepcopy__
    return MutationList(MutationObj.coerce(self._key, copy.deepcopy(self[:])))
AttributeError: 'MutationList' object has no attribute '_key'
```

I guess that's also not necessary, since `copy_from` in handle_outputs
would take care of this (and this restores the logic from #10087)