### PR TITLE
Ensure data_dir path is absolute when set by user

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -162,8 +162,9 @@ class BaseAppConfiguration:
             # Make path absolute before using it as base for other paths
             if self.config_dir:
                 self.config_dir = os.path.abspath(self.config_dir)
-
             self.data_dir = config_kwargs.get('data_dir')
+            if self.data_dir:
+                self.data_dir = os.path.abspath(self.data_dir)
             self.sample_config_dir = os.path.join(os.path.dirname(__file__), 'sample')
             self.managed_config_dir = config_kwargs.get('managed_config_dir')
             if self.managed_config_dir:


### PR DESCRIPTION
Bug: if a user sets `data_dir` to a relative path, that path is never resolved.

Fix: same as `config_dir`, `managed_config_dir`

EDIT: tangent to #9973.
