### PR TITLE
Test setting of all config values; uniformly process config files

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -737,8 +737,6 @@
     installation, these entries are automatically added to the
     following file, which is parsed and applied to the
     ToolDataTableManager at server start up.
-    The value of this option will be resolved with respect to
-    <managed_config_dir>.
 :Default: ``shed_tool_data_table_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1137,8 +1137,6 @@
 :Description:
     Configuration file for the object store If this is set and exists,
     it overrides any other objectstore settings.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``object_store_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3198,8 +3198,6 @@
 
 :Description:
     Sets the path to OIDC backends configuration file.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``oidc_backends_config.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3186,8 +3186,6 @@
 
 :Description:
     Sets the path to OIDC configuration file.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``oidc_config.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3954,8 +3954,6 @@
     definition. These fields will be presented to users in the tool
     forms and allow them to overwrite default job resources such as
     number of processors, memory and walltime.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``job_resource_params_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3484,8 +3484,6 @@
 :Description:
     File where Tool Shed based Data Managers are configured. This file
     will be created automatically upon data manager installation.
-    The value of this option will be resolved with respect to
-    <managed_config_dir>.
 :Default: ``shed_data_manager_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -528,8 +528,6 @@
     File containing the Galaxy Tool Sheds that should be made
     available to install from in the admin interface (.sample used if
     default does not exist).
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``tool_sheds_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1555,8 +1555,6 @@
 :Description:
     Location of the configuration file containing extra user
     preferences.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``user_preferences_extra_conf.yml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3218,8 +3218,6 @@
     XML config file that allows the use of different authentication
     providers (e.g. LDAP) instead or in addition to local
     authentication (.sample is used if default does not exist).
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``auth_conf.xml``
 :Type: str
 
@@ -3294,6 +3292,47 @@
     the workflow.
 :Default: ``false``
 :Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``simplified_workflow_run_ui``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    If set to 'off' by default, always use the traditional workflow
+    form that renders all steps in the GUI and serializes the tool
+    state of all steps during invocation. Set to 'prefer' to default
+    to a simplified workflow UI that only renders the inputs if
+    possible (the workflow must have no disconnected runtime inputs
+    and not replacement parameters within tool steps). In the future
+    'force' may be added an option for Galaskio-style servers that
+    should only render simplified workflows.
+:Default: ``prefer``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``simplified_workflow_run_ui_target_history``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    When the simplified workflow run form is rendered, should the
+    invocation outputs be sent to the 'current' history or a 'new'
+    history.
+:Default: ``current``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``simplified_workflow_run_ui_job_cache``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    When the simplified workflow run form is rendered, should the
+    invocation use job caching. This isn't a boolean so an option for
+    'show-selection' can be added later.
+:Default: ``off``
+:Type: str
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3954,8 +3954,6 @@
     requires both a description of the fields available (which
     defaults to the definitions in job_resource_params_file if not
     set).
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``workflow_resource_params_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -615,8 +615,6 @@
 
 :Description:
     Configured FileSource plugins.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``file_sources_conf.yml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -316,8 +316,6 @@
     migration scripts to install tools that have been migrated to the
     tool shed upon a new release, they will be added to this tool
     config file.
-    The value of this option will be resolved with respect to
-    <managed_config_dir>.
 :Default: ``migrated_tools_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3985,8 +3985,6 @@
 :Description:
     Optional configuration file similar to `job_config_file` to
     specify which Galaxy processes should schedule workflows.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``workflow_schedulers_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -381,8 +381,6 @@
     then use Conda if available. See
     https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/dependency_resolvers.rst
     for more information on these options.
-    The value of this option will be resolved with respect to
-    <config_dir>.
 :Default: ``dependency_resolvers_conf.xml``
 :Type: str
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3463,7 +3463,7 @@
 :Description:
     File where Data Managers are configured (.sample used if default
     does not exist).
-:Default: ``config/data_manager_conf.xml``
+:Default: ``data_manager_conf.xml``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1542,6 +1542,21 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``trs_servers_config_file``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Allow import of workflows from the TRS servers configured in the
+    specified YAML or JSON file. The file should be a list with 'id',
+    'label', and 'api_url' for each entry. Optionally, 'link_url' and
+    'doc' may be be specified as well for each entry.
+    If this is null (the default), a simple configuration containing
+    just Dockstore will be used.
+:Default: ``trs_servers_conf.yml``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``user_preferences_extra_conf_path``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3524,7 +3524,7 @@
     Jobs are run locally on the system on which Galaxy is started.
     Advanced job running capabilities can be configured through the
     job configuration file.
-:Default: ``config/job_conf.xml``
+:Default: ``job_conf.xml``
 :Type: str
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -285,8 +285,6 @@
     this option is preferable. This file will be created automatically
     upon tool installation, whereas Galaxy will fail to start if any
     files in tool_config_file cannot be read.
-    The value of this option will be resolved with respect to
-    <managed_config_dir>.
 :Default: ``shed_tool_conf.xml``
 :Type: str
 

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -200,7 +200,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
             from galaxy.authnz import managers
             self.authnz_manager = managers.AuthnzManager(self,
                                                          self.config.oidc_config,
-                                                         self.config.oidc_backends_config)
+                                                         self.config.oidc_backends_config_file)
 
         self.sentry_client = None
         if self.config.sentry_dsn:

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -199,7 +199,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
         if self.config.enable_oidc:
             from galaxy.authnz import managers
             self.authnz_manager = managers.AuthnzManager(self,
-                                                         self.config.oidc_config,
+                                                         self.config.oidc_config_file,
                                                          self.config.oidc_backends_config_file)
 
         self.sentry_client = None

--- a/lib/galaxy/auth/__init__.py
+++ b/lib/galaxy/auth/__init__.py
@@ -15,7 +15,7 @@ class AuthManager:
     def __init__(self, app):
         self.__app = app
         self.redact_username_in_logs = app.config.redact_username_in_logs
-        self.authenticators = get_authenticators(app.config.auth_config_file, app.config.auth_config_file_set)
+        self.authenticators = get_authenticators(app.config.auth_config_file, app.config.is_set('auth_config_file'))
 
     def check_registration_allowed(self, email, username, password):
         """Checks if the provided email/username is allowed to register."""

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -676,7 +676,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             with open(self.user_preferences_extra_conf_path) as stream:
                 self.user_preferences_extra = yaml.safe_load(stream)
         except Exception:
-            if self.user_preferences_extra_conf_path_set:
+            if self.is_set('user_preferences_extra_conf_path'):
                 log.warning('Config file (%s) could not be found or is malformed.' % self.user_preferences_extra_conf_path)
             self.user_preferences_extra = {'preferences': {}}
 
@@ -797,7 +797,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
-            user_preferences_extra_conf_path=[self._in_config_dir('user_preferences_extra_conf.yml')],
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],
             # self.file_path set to self._in_data_dir('objects') by schema

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -797,8 +797,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
-            tool_sheds_config_file=[self._in_config_dir('tool_sheds_conf.xml')],
-            trs_servers_config_file=[self._in_config_dir('trs_servers_conf.yml')],
             user_preferences_extra_conf_path=[self._in_config_dir('user_preferences_extra_conf.yml')],
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -793,7 +793,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
-            shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
             # self.file_path set to self._in_data_dir('objects') by schema

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -797,7 +797,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
-            workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],
             # self.file_path set to self._in_data_dir('objects') by schema
             file_path=[self._in_data_dir('files'), self.file_path],
         )

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -549,7 +549,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
                     break
         self.sanitize_allowlist_file = _sanitize_allowlist_path
 
-        self.allowed_origin_hostnames = self._parse_allowed_origin_hostnames(kwargs)
+        self.allowed_origin_hostnames = self._parse_allowed_origin_hostnames(self.allowed_origin_hostnames)
         if "trust_jupyter_notebook_conversion" not in kwargs:
             # if option not set, check IPython-named alternative, falling back to schema default if not set either
             _default = self.trust_jupyter_notebook_conversion
@@ -853,13 +853,13 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
                 log.warning("Config option '%s' is deprecated and will be removed in a future release.  Please consult the latest version of the sample configuration file." % key)
 
     @staticmethod
-    def _parse_allowed_origin_hostnames(kwargs):
+    def _parse_allowed_origin_hostnames(allowed_origin_hostnames):
         """
         Parse a CSV list of strings/regexp of hostnames that should be allowed
         to use CORS and will be sent the Access-Control-Allow-Origin header.
         """
-        allowed_origin_hostnames = listify(kwargs.get('allowed_origin_hostnames'))
-        if not allowed_origin_hostnames:
+        allowed_origin_hostnames_list = listify(allowed_origin_hostnames)
+        if not allowed_origin_hostnames_list:
             return None
 
         def parse(string):
@@ -869,7 +869,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
                 return re.compile(string, flags=(re.UNICODE))
             return string
 
-        return [parse(v) for v in allowed_origin_hostnames if v]
+        return [parse(v) for v in allowed_origin_hostnames_list if v]
 
 
 # legacy naming

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -793,7 +793,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
-            shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
             # self.file_path set to self._in_data_dir('objects') by schema
             file_path=[self._in_data_dir('files'), self.file_path],
@@ -1080,7 +1079,7 @@ class ConfiguresGalaxyMixin:
                                                         from_shed_config=from_shed_config)
         except OSError as exc:
             # Missing shed_tool_data_table_config is okay if it's the default
-            if exc.errno != errno.ENOENT or self.config.shed_tool_data_table_config_set:
+            if exc.errno != errno.ENOENT or self.config.is_set('shed_tool_data_table_config'):
                 raise
 
     def _configure_datatypes_registry(self, installed_repository_manager=None):

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -794,7 +794,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
-            shed_data_manager_config_file=[self._in_managed_config_dir('shed_data_manager_conf.xml')],
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -787,7 +787,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         defaults = dict(
             build_sites_config_file=[self._in_config_dir('build_sites.yml'), self._in_sample_dir('build_sites.yml.sample')],
             containers_config_file=[self._in_config_dir('containers_conf.yml')],
-            data_manager_config_file=[self._in_config_dir('data_manager_conf.xml')],
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
             error_report_file=[self._in_config_dir('error_report.yml')],
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -793,7 +793,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
             error_report_file=[self._in_config_dir('error_report.yml')],
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
-            job_resource_params_file=[self._in_config_dir('job_resource_params_conf.xml')],
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             migrated_tools_config=[self._in_managed_config_dir('migrated_tools_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -443,7 +443,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.len_file_path = os.path.join(self.tool_data_path, self.len_file_path)
         # Galaxy OIDC settings.
         self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
-        self.oidc_backends_config = kwargs.get("oidc_backends_config_file", self.oidc_backends_config_file)
         self.oidc = {}
         self.integrated_tool_panel_config = self._in_managed_config_dir(self.integrated_tool_panel_config)
         integrated_tool_panel_tracking_directory = kwargs.get('integrated_tool_panel_tracking_directory')
@@ -796,7 +795,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
-            oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.xml')],
             oidc_config_file=[self._in_config_dir('oidc_config.xml')],
             shed_data_manager_config_file=[self._in_managed_config_dir('shed_data_manager_conf.xml')],
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -164,7 +164,11 @@ class BaseAppConfiguration:
                 self.config_dir = os.path.abspath(self.config_dir)
 
             self.data_dir = config_kwargs.get('data_dir')
+            if self.data_dir:
+                self.data_dir = os.path.abspath(self.data_dir)
+
             self.sample_config_dir = os.path.join(os.path.dirname(__file__), 'sample')
+
             self.managed_config_dir = config_kwargs.get('managed_config_dir')
             if self.managed_config_dir:
                 self.managed_config_dir = os.path.abspath(self.managed_config_dir)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -791,7 +791,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
             error_report_file=[self._in_config_dir('error_report.yml')],
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
-            file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -808,7 +808,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             user_preferences_extra_conf_path=[self._in_config_dir('user_preferences_extra_conf.yml')],
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],
-            markdown_export_css=[self._in_config_dir('markdown_export.css')],
             markdown_export_css_pages=[self._in_config_dir('markdown_export_pages.css')],
             markdown_export_css_invocation_reports=[self._in_config_dir('markdown_export_invocation_reports.css')],
             # self.file_path set to self._in_data_dir('objects') by schema

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -132,6 +132,11 @@ class BaseAppConfiguration:
                 if old in kwargs and new not in kwargs:
                     kwargs[new] = kwargs[old]
 
+    def is_set(self, key):
+        if property not in self._raw_config:
+            log.warning("Configuration option does not exist: '%s'" % key)
+        return self._raw_config[key] != self.schema.defaults.get(key)
+
     def resolve_path(self, path):
         """Resolve a path relative to Galaxy's root."""
         return self._in_root_dir(path)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -442,7 +442,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.builds_file_path = os.path.join(self.tool_data_path, self.builds_file_path)
         self.len_file_path = os.path.join(self.tool_data_path, self.len_file_path)
         # Galaxy OIDC settings.
-        self.oidc_config = kwargs.get("oidc_config_file", self.oidc_config_file)
         self.oidc = {}
         self.integrated_tool_panel_config = self._in_managed_config_dir(self.integrated_tool_panel_config)
         integrated_tool_panel_tracking_directory = kwargs.get('integrated_tool_panel_tracking_directory')
@@ -795,7 +794,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
-            oidc_config_file=[self._in_config_dir('oidc_config.xml')],
             shed_data_manager_config_file=[self._in_managed_config_dir('shed_data_manager_conf.xml')],
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -113,6 +113,7 @@ class BaseAppConfiguration:
 
     def __init__(self, **kwargs):
         self._process_renamed_options(kwargs)
+        self._kwargs = kwargs  # Save these as a record of explicitly set options
         self.config_dict = kwargs
         self.root = find_root(kwargs)
         self._set_config_base(kwargs)
@@ -133,9 +134,12 @@ class BaseAppConfiguration:
                     kwargs[new] = kwargs[old]
 
     def is_set(self, key):
-        if property not in self._raw_config:
+        """Check if a configuration option has been explicitly set."""
+        # NOTE: This will check all supplied keyword arguments, including those not in the schema.
+        # To check only schema options, change the line below to `if property not in self._raw_config:`
+        if property not in self._kwargs:
             log.warning("Configuration option does not exist: '%s'" % key)
-        return self._raw_config.get(key) != self.schema.defaults.get(key)
+        return key in self._kwargs
 
     def resolve_path(self, path):
         """Resolve a path relative to Galaxy's root."""

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -796,7 +796,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
-            object_store_config_file=[self._in_config_dir('object_store_conf.xml')],
             oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.xml')],
             oidc_config_file=[self._in_config_dir('oidc_config.xml')],
             shed_data_manager_config_file=[self._in_managed_config_dir('shed_data_manager_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -797,7 +797,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             shed_tool_config_file=[self._in_managed_config_dir('shed_tool_conf.xml')],
             shed_tool_data_table_config=[self._in_managed_config_dir('shed_tool_data_table_conf.xml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
-            workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],
             # self.file_path set to self._in_data_dir('objects') by schema
             file_path=[self._in_data_dir('files'), self.file_path],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -605,7 +605,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         self.object_store_cache_path = self._in_root_dir(kwargs.get("object_store_cache_path", self._in_data_dir("object_store_cache")))
         if self.object_store_store_by is None:
             self.object_store_store_by = 'id'
-            if not self.file_path_set and self.file_path.endswith('objects'):
+            if not self.is_set('file_path') and self.file_path.endswith('objects'):
                 self.object_store_store_by = 'uuid'
         assert self.object_store_store_by in ['id', 'uuid'], "Invalid value for object_store_store_by [%s]" % self.object_store_store_by
         # Handle AWS-specific config options for backward compatibility
@@ -793,8 +793,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
             tool_destinations_config_file=[self._in_config_dir('tool_destinations.yml')],
-            # self.file_path set to self._in_data_dir('objects') by schema
-            file_path=[self._in_data_dir('files'), self.file_path],
         )
         listify_defaults = {
             'tool_data_table_config_path': [

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -137,7 +137,7 @@ class BaseAppConfiguration:
         """Check if a configuration option has been explicitly set."""
         # NOTE: This will check all supplied keyword arguments, including those not in the schema.
         # To check only schema options, change the line below to `if property not in self._raw_config:`
-        if property not in self._kwargs:
+        if key not in self._raw_config:
             log.warning("Configuration option does not exist: '%s'" % key)
         return key in self._kwargs
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -808,7 +808,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             user_preferences_extra_conf_path=[self._in_config_dir('user_preferences_extra_conf.yml')],
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],
-            markdown_export_css_pages=[self._in_config_dir('markdown_export_pages.css')],
             # self.file_path set to self._in_data_dir('objects') by schema
             file_path=[self._in_data_dir('files'), self.file_path],
         )

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -135,7 +135,7 @@ class BaseAppConfiguration:
     def is_set(self, key):
         if property not in self._raw_config:
             log.warning("Configuration option does not exist: '%s'" % key)
-        return self._raw_config[key] != self.schema.defaults.get(key)
+        return self._raw_config.get(key) != self.schema.defaults.get(key)
 
     def resolve_path(self, path):
         """Resolve a path relative to Galaxy's root."""
@@ -783,7 +783,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     def parse_config_file_options(self, kwargs):
         """Backwards compatibility for config files moved to the config/ dir."""
         defaults = dict(
-            auth_config_file=[self._in_config_dir('auth_conf.xml')],
             build_sites_config_file=[self._in_config_dir('build_sites.yml'), self._in_sample_dir('build_sites.yml.sample')],
             containers_config_file=[self._in_config_dir('containers_conf.yml')],
             data_manager_config_file=[self._in_config_dir('data_manager_conf.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -809,7 +809,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             workflow_resource_params_file=[self._in_config_dir('workflow_resource_params_conf.xml')],
             workflow_schedulers_config_file=[self._in_config_dir('workflow_schedulers_conf.xml')],
             markdown_export_css_pages=[self._in_config_dir('markdown_export_pages.css')],
-            markdown_export_css_invocation_reports=[self._in_config_dir('markdown_export_invocation_reports.css')],
             # self.file_path set to self._in_data_dir('objects') by schema
             file_path=[self._in_data_dir('files'), self.file_path],
         )

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -795,7 +795,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],
             local_conda_mapping_file=[self._in_config_dir('local_conda_mapping.yml')],
-            migrated_tools_config=[self._in_managed_config_dir('migrated_tools_conf.xml')],
             modules_mapping_files=[self._in_config_dir('environment_modules_mapping.yml')],
             object_store_config_file=[self._in_config_dir('object_store_conf.xml')],
             oidc_backends_config_file=[self._in_config_dir('oidc_backends_config.xml')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -787,7 +787,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             containers_config_file=[self._in_config_dir('containers_conf.yml')],
             data_manager_config_file=[self._in_config_dir('data_manager_conf.xml')],
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
-            dependency_resolvers_config_file=[self._in_config_dir('dependency_resolvers_conf.xml')],
             error_report_file=[self._in_config_dir('error_report.yml')],
             job_config_file=[self._in_config_dir('job_conf.xml')],
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -792,7 +792,6 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             data_manager_config_file=[self._in_config_dir('data_manager_conf.xml')],
             datatypes_config_file=[self._in_config_dir('datatypes_conf.xml'), self._in_sample_dir('datatypes_conf.xml.sample')],
             error_report_file=[self._in_config_dir('error_report.yml')],
-            job_config_file=[self._in_config_dir('job_conf.xml')],
             job_metrics_config_file=[self._in_config_dir('job_metrics_conf.xml'), self._in_sample_dir('job_metrics_conf.xml.sample')],
             job_resource_params_file=[self._in_config_dir('job_resource_params_conf.xml')],
             file_sources_config_file=[self._in_config_dir('file_sources_conf.yml')],

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1685,7 +1685,7 @@ galaxy:
 
   # File where Data Managers are configured (.sample used if default
   # does not exist).
-  #data_manager_config_file: config/data_manager_conf.xml
+  #data_manager_config_file: data_manager_conf.xml
 
   # File where Tool Shed based Data Managers are configured. This file
   # will be created automatically upon data manager installation.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -641,8 +641,6 @@ galaxy:
 
   # Configuration file for the object store If this is set and exists,
   # it overrides any other objectstore settings.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #object_store_config_file: object_store_conf.xml
 
   # What Dataset attribute is used to reference files in an ObjectStore

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1928,8 +1928,6 @@ galaxy:
   # used to influence scheduling of jobs within the workflow. This
   # requires both a description of the fields available (which defaults
   # to the definitions in job_resource_params_file if not set).
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #workflow_resource_params_file: workflow_resource_params_conf.xml
 
   # This parameter describes how to map users and workflows to a set of

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1581,8 +1581,6 @@ galaxy:
   #oidc_config_file: oidc_config.xml
 
   # Sets the path to OIDC backends configuration file.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #oidc_backends_config_file: oidc_backends_config.xml
 
   # XML config file that allows the use of different authentication

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -399,8 +399,6 @@ galaxy:
   #legacy_eager_objectstore_initialization: false
 
   # Configured FileSource plugins.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #file_sources_config_file: file_sources_conf.yml
 
   # Enable Galaxy to fetch containers registered with quay.io generated

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1576,8 +1576,6 @@ galaxy:
   #enable_oidc: false
 
   # Sets the path to OIDC configuration file.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #oidc_config_file: oidc_config.xml
 
   # Sets the path to OIDC backends configuration file.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -828,8 +828,6 @@ galaxy:
 
   # Location of the configuration file containing extra user
   # preferences.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #user_preferences_extra_conf_path: user_preferences_extra_conf.yml
 
   # Default localization for Galaxy UI. Allowed values are listed at the

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -292,8 +292,6 @@ galaxy:
   # Conda if available. See
   # https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/dependency_resolvers.rst
   # for more information on these options.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #dependency_resolvers_config_file: dependency_resolvers_conf.xml
 
   # conda_prefix is the location on the filesystem where Conda packages

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -354,8 +354,6 @@ galaxy:
   # File containing the Galaxy Tool Sheds that should be made available
   # to install from in the admin interface (.sample used if default does
   # not exist).
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #tool_sheds_config_file: tool_sheds_conf.xml
 
   # Monitor the tools and tool directories listed in any tool config

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -239,8 +239,6 @@ galaxy:
   # preferable. This file will be created automatically upon tool
   # installation, whereas Galaxy will fail to start if any files in
   # tool_config_file cannot be read.
-  # The value of this option will be resolved with respect to
-  # <managed_config_dir>.
   #shed_tool_config_file: shed_tool_conf.xml
 
   # Enable / disable checking if any tools defined in the above non-shed

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -255,8 +255,6 @@ galaxy:
   # migration scripts to install tools that have been migrated to the
   # tool shed upon a new release, they will be added to this tool config
   # file.
-  # The value of this option will be resolved with respect to
-  # <managed_config_dir>.
   #migrated_tools_config: migrated_tools_conf.xml
 
   # File that contains the XML section and tool tags from all tool panel

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1725,7 +1725,7 @@ galaxy:
   # are run locally on the system on which Galaxy is started.  Advanced
   # job running capabilities can be configured through the job
   # configuration file.
-  #job_config_file: config/job_conf.xml
+  #job_config_file: job_conf.xml
 
   # Description of job running configuration, can be embedded into
   # Galaxy configuration or loaded from an additional file with the

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1936,8 +1936,6 @@ galaxy:
   # These fields will be presented to users in the tool forms and allow
   # them to overwrite default job resources such as number of
   # processors, memory and walltime.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #job_resource_params_file: job_resource_params_conf.xml
 
   # Similar to the above parameter, workflows can describe parameters

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1594,8 +1594,6 @@ galaxy:
   # XML config file that allows the use of different authentication
   # providers (e.g. LDAP) instead or in addition to local authentication
   # (.sample is used if default does not exist).
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #auth_config_file: auth_conf.xml
 
   # Optional list of email addresses of API users who can make calls on
@@ -1627,6 +1625,26 @@ galaxy:
   # for each "Set at Runtime" input, independent of others in the
   # workflow.
   #enable_unique_workflow_defaults: false
+
+  # If set to 'off' by default, always use the traditional workflow form
+  # that renders all steps in the GUI and serializes the tool state of
+  # all steps during invocation. Set to 'prefer' to default to a
+  # simplified workflow UI that only renders the inputs if possible (the
+  # workflow must have no disconnected runtime inputs and not
+  # replacement parameters within tool steps). In the future 'force' may
+  # be added an option for Galaskio-style servers that should only
+  # render simplified workflows.
+  #simplified_workflow_run_ui: prefer
+
+  # When the simplified workflow run form is rendered, should the
+  # invocation outputs be sent to the 'current' history or a 'new'
+  # history.
+  #simplified_workflow_run_ui_target_history: current
+
+  # When the simplified workflow run form is rendered, should the
+  # invocation use job caching. This isn't a boolean so an option for
+  # 'show-selection' can be added later.
+  #simplified_workflow_run_ui_job_cache: 'off'
 
   # The URL to the myExperiment instance being used (omit scheme but
   # include port).

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -458,8 +458,6 @@ galaxy:
   # these entries are automatically added to the following file, which
   # is parsed and applied to the ToolDataTableManager at server start
   # up.
-  # The value of this option will be resolved with respect to
-  # <managed_config_dir>.
   #shed_tool_data_table_config: shed_tool_data_table_conf.xml
 
   # Directory where data used by tools is located.  See the samples in

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -820,6 +820,14 @@ galaxy:
   # format string as specified by ISO 8601 international   standard).
   #pretty_datetime_format: $locale (UTC)
 
+  # Allow import of workflows from the TRS servers configured in the
+  # specified YAML or JSON file. The file should be a list with 'id',
+  # 'label', and 'api_url' for each entry. Optionally, 'link_url' and
+  # 'doc' may be be specified as well for each entry.
+  # If this is null (the default), a simple configuration containing
+  # just Dockstore will be used.
+  #trs_servers_config_file: trs_servers_conf.yml
+
   # Location of the configuration file containing extra user
   # preferences.
   #user_preferences_extra_conf_path: user_preferences_extra_conf.yml

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1699,8 +1699,6 @@ galaxy:
 
   # File where Tool Shed based Data Managers are configured. This file
   # will be created automatically upon data manager installation.
-  # The value of this option will be resolved with respect to
-  # <managed_config_dir>.
   #shed_data_manager_config_file: shed_data_manager_conf.xml
 
   # Directory to store Data Manager based tool-data. Defaults to the

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1945,8 +1945,6 @@ galaxy:
 
   # Optional configuration file similar to `job_config_file` to specify
   # which Galaxy processes should schedule workflows.
-  # The value of this option will be resolved with respect to
-  # <config_dir>.
   #workflow_schedulers_config_file: workflow_schedulers_conf.xml
 
   # If using job concurrency limits (configured in job_config_file),

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -262,7 +262,7 @@ class ToolBox(BaseGalaxyToolBox):
         )
 
     def can_load_config_file(self, config_filename):
-        if config_filename == self.app.config.shed_tool_config_file and not self.app.config.shed_tool_config_file_set:
+        if config_filename == self.app.config.shed_tool_config_file and not self.app.config.is_set('shed_tool_config_file'):
             if self.dynamic_confs():
                 # Do not load or create a default shed_tool_config_file if another shed_tool_config file has already been loaded
                 return False

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -39,7 +39,7 @@ class DataManagers:
         try:
             tree = util.parse_xml(xml_filename)
         except OSError as e:
-            if e.errno != errno.ENOENT or self.app.config.data_manager_config_file_set:
+            if e.errno != errno.ENOENT or self.app.config.is_set('data_manager_config_file'):
                 raise
             return  # default config option and it doesn't exist, which is fine
         except Exception as e:

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -32,7 +32,7 @@ class DataManagers:
             try:
                 self.load_from_xml(self.app.config.shed_data_manager_config_file, store_tool_path=True)
             except OSError as exc:
-                if exc.errno != errno.ENOENT or self.app.config.shed_data_manager_config_file_set:
+                if exc.errno != errno.ENOENT or self.app.config.is_set('shed_data_manager_config_file'):
                     raise
 
     def load_from_xml(self, xml_filename, store_tool_path=True):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2878,6 +2878,7 @@ mapping:
       markdown_export_css_pages:
         type: str
         default: markdown_export_pages.css
+        path_resolves_to: config_dir
         required: false
         desc: |
           CSS file to apply to "Galaxy Page" exports to PDF. Generally prefer

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -406,12 +406,11 @@ mapping:
       tool_sheds_config_file:
         type: str
         default: tool_sheds_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           File containing the Galaxy Tool Sheds that should be made available to
           install from in the admin interface (.sample used if default does not exist).
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       watch_tools:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2378,10 +2378,9 @@ mapping:
         type: str
         default: oidc_backends_config.xml
         required: false
+        path_resolves_to: config_dir
         desc: |
           Sets the path to OIDC backends configuration file.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       auth_config_file:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2887,6 +2887,7 @@ mapping:
       markdown_export_css_invocation_reports:
         type: str
         default: markdown_export_invocation_reports.css
+        path_resolves_to: config_dir
         required: false
         desc: |
           CSS file to apply to invocation report exports to PDF. Generally prefer

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -845,12 +845,11 @@ mapping:
       object_store_config_file:
         type: str
         default: object_store_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           Configuration file for the object store
           If this is set and exists, it overrides any other objectstore settings.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       object_store_store_by:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2570,7 +2570,8 @@ mapping:
 
       data_manager_config_file:
         type: str
-        default: config/data_manager_conf.xml
+        default: data_manager_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           File where Data Managers are configured (.sample used if default does not

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -553,6 +553,7 @@ mapping:
       shed_tool_data_table_config:
         type: str
         default: shed_tool_data_table_conf.xml
+        path_resolves_to: managed_config_dir
         required: false
         desc: |
           XML config file that contains additional data table entries for the
@@ -561,8 +562,6 @@ mapping:
           tool_data_table_conf.xml.sample files.  At the time of installation, these
           entries are automatically added to the following file, which is parsed and
           applied to the ToolDataTableManager at server start up.
-
-          The value of this option will be resolved with respect to <managed_config_dir>.
 
       tool_data_path:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2938,14 +2938,13 @@ mapping:
       job_resource_params_file:
         type: str
         default: job_resource_params_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           Optional file containing job resource data entry fields definition.
           These fields will be presented to users in the tool forms and allow them to
           overwrite default job resources such as number of processors, memory and
           walltime.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       workflow_resource_params_file:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -248,13 +248,12 @@ mapping:
       migrated_tools_config:
         type: str
         default: migrated_tools_conf.xml
+        path_resolves_to: managed_config_dir
         required: false
         desc: |
           Tool config maintained by tool migration scripts.  If you use the migration
           scripts to install tools that have been migrated to the tool shed upon a new
           release, they will be added to this tool config file.
-
-          The value of this option will be resolved with respect to <managed_config_dir>.
 
       integrated_tool_panel_config:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2869,6 +2869,7 @@ mapping:
       markdown_export_css:
         type: str
         default: markdown_export.css
+        path_resolves_to: config_dir
         required: false
         desc: |
           CSS file to apply to all Markdown exports to PDF - currently used by

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -220,6 +220,7 @@ mapping:
       shed_tool_config_file:
         type: str
         default: shed_tool_conf.xml
+        path_resolves_to: managed_config_dir
         required: false
         desc: |
           Tool config file for tools installed from the Galaxy Tool Shed. Must
@@ -231,8 +232,6 @@ mapping:
           preferable. This file will be created automatically upon tool
           installation, whereas Galaxy will fail to start if any files in
           tool_config_file cannot be read.
-
-          The value of this option will be resolved with respect to <managed_config_dir>.
 
       check_migrate_tools:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2967,12 +2967,11 @@ mapping:
       workflow_schedulers_config_file:
         type: str
         default: workflow_schedulers_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           Optional configuration file similar to `job_config_file` to specify
           which Galaxy processes should schedule workflows.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       cache_user_job_count:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -295,6 +295,7 @@ mapping:
       dependency_resolvers_config_file:
         type: str
         default: dependency_resolvers_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           The dependency resolvers config file specifies an ordering and options for how
@@ -303,8 +304,6 @@ mapping:
           Galaxy packages, and then use Conda if available.
           See https://github.com/galaxyproject/galaxy/blob/dev/doc/source/admin/dependency_resolvers.rst
           for more information on these options.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       conda_prefix:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2389,13 +2389,12 @@ mapping:
       auth_config_file:
         type: str
         default: auth_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           XML config file that allows the use of different authentication providers
           (e.g. LDAP) instead or in addition to local authentication (.sample is used
           if default does not exist).
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       api_allow_run_as:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2368,11 +2368,10 @@ mapping:
       oidc_config_file:
         type: str
         default: oidc_config.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           Sets the path to OIDC configuration file.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       oidc_backends_config_file:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1151,6 +1151,7 @@ mapping:
       trs_servers_config_file:
         type: str
         default: 'trs_servers_conf.yml'
+        path_resolves_to: config_dir
         required: false
         desc: |
           Allow import of workflows from the TRS servers configured in

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -469,11 +469,10 @@ mapping:
       file_sources_config_file:
         type: str
         default: file_sources_conf.yml        
+        path_resolves_to: config_dir
         required: false
         desc: |
           Configured FileSource plugins.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       enable_mulled_containers:
         type: bool

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1167,11 +1167,10 @@ mapping:
       user_preferences_extra_conf_path:
         type: str
         default: 'user_preferences_extra_conf.yml'
+        path_resolves_to: config_dir
         required: false
         desc: |
           Location of the configuration file containing extra user preferences.
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       default_locale:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2604,7 +2604,8 @@ mapping:
 
       job_config_file:
         type: str
-        default: config/job_conf.xml
+        default: job_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           To increase performance of job execution and the web interface, you can

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2584,12 +2584,11 @@ mapping:
       shed_data_manager_config_file:
         type: str
         default: shed_data_manager_conf.xml
+        path_resolves_to: managed_config_dir
         required: false
         desc: |
           File where Tool Shed based Data Managers are configured. This file will be created
           automatically upon data manager installation.
-
-          The value of this option will be resolved with respect to <managed_config_dir>.
 
       galaxy_data_manager_data_path:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2942,14 +2942,13 @@ mapping:
       workflow_resource_params_file:
         type: str
         default: workflow_resource_params_conf.xml
+        path_resolves_to: config_dir
         required: false
         desc: |
           Similar to the above parameter, workflows can describe parameters used to
           influence scheduling of jobs within the workflow. This requires both a description
           of the fields available (which defaults to the definitions in
           job_resource_params_file if not set).
-
-          The value of this option will be resolved with respect to <config_dir>.
 
       workflow_resource_params_mapper:
         type: str

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -178,7 +178,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
     def __init_schedulers(self):
         config_file = self.app.config.workflow_schedulers_config_file
         use_default_scheduler = False
-        if not config_file or (not os.path.exists(config_file) and not self.app.config.workflow_schedulers_config_file_set):
+        if not config_file or (not os.path.exists(config_file) and not self.app.config.is_set('workflow_schedulers_config_file')):
             log.info("No workflow schedulers plugin config file defined, using default scheduler.")
             use_default_scheduler = True
         elif not os.path.exists(config_file):

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -186,7 +186,9 @@ def setup_galaxy_config(
     for data_manager_config in ['config/data_manager_conf.xml', 'data_manager_conf.xml']:
         if os.path.exists(data_manager_config):
             default_data_manager_config = data_manager_config
-    data_manager_config_file = "test/functional/tools/sample_data_manager_conf.xml"
+    # Make this abspath: otherwise config will resolve it w.r.t. config_dir)
+    data_manager_config_file = os.path.abspath("test/functional/tools/sample_data_manager_conf.xml")
+
     if default_data_manager_config is not None:
         data_manager_config_file = "{},{}".format(default_data_manager_config, data_manager_config_file)
     master_api_key = get_master_api_key()

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -208,8 +208,6 @@ def setup_galaxy_config(
     if shed_tool_conf is not None:
         tool_conf = "{},{}".format(tool_conf, shed_tool_conf)
 
-    shed_tool_data_table_config = default_shed_tool_data_table_config
-
     config = dict(
         admin_users='test@bx.psu.edu',
         allow_library_path_paste=True,
@@ -239,7 +237,6 @@ def setup_galaxy_config(
         override_tempdir=False,
         master_api_key=master_api_key,
         running_functional_tests=True,
-        shed_tool_data_table_config=shed_tool_data_table_config,
         template_cache_path=template_cache_path,
         template_path='templates',
         tool_config_file=tool_conf,
@@ -256,6 +253,8 @@ def setup_galaxy_config(
         object_store_store_by="uuid",
         simplified_workflow_run_ui="off",
     )
+    if default_shed_tool_data_table_config:
+        config["shed_tool_data_table_config"] = default_shed_tool_data_table_config
     if not use_shared_connection_for_amqp:
         config["amqp_internal_connection"] = "sqlalchemy+sqlite:///%s?isolation_level=IMMEDIATE" % os.path.join(tmpdir, "control.sqlite")
 

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -163,7 +163,7 @@ DO_NOT_TEST = [
     'conda_auto_init',  # broken: default overridden
     'config_dir',  # value overridden for testing
     'data_dir',  # value overridden for testing
-    'data_manager_config_file',  # broken: remove 'config/' prefix from schema
+    'data_manager_config_file',  # value overidden for testing
     'database_connection',  # untestable; refactor config/__init__ to test
     'database_engine_option_max_overflow',  # overridden for tests running on non-sqlite databases
     'database_engine_option_pool_size',  # overridden for tests runnign on non-sqlite databases

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -187,11 +187,7 @@ DO_NOT_TEST = [
     'library_import_dir',  # broken: default overridden
     'logging',  # mapping loaded in config/
     'managed_config_dir',  # depends on config_dir: see note above
-    'markdown_export_css',  # default not used?
-    'markdown_export_css_pages',  # default not used?
-    'markdown_export_css_invocation_reports',  # default not used?
     'master_api_key',  # broken: default value assigned outside of config/
-    'migrated_tools_config',  # needs more work (should work)
     'monitor_thread_join_timeout',  # broken: default overridden
     'new_file_path',  # value overridden for testing
     'object_store_store_by',  # broken: default overridden

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -26,6 +26,10 @@ def appconfig():
 
 @pytest.fixture
 def mock_config_file(monkeypatch):
+    # Patch this; otherwise tempfile.tempdir will be set, which is a global variable that
+    # defines the value of the default `dir` argument to the functions in Python's
+    # tempfile module - which breaks multiple tests.
+    monkeypatch.setattr(config.GalaxyAppConfiguration, '_override_tempdir', lambda a, b: None)
     # Set this to return None to force the creation of base config directories
     # in _set_config_directories(). Used to test the values of these directories only.
     monkeypatch.setattr(config, 'find_config_file', lambda x: None)

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -341,7 +341,6 @@ SET_CONFIG = {
     # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
     # 'tool_test_data_directories': 'test-data_new',
     # 'use_remote_user': True,
-    # 'user_preferences_extra_conf_path': 'user_preferences_extra_conf.yml',  # cause: parse_config_file_options
     # 'workflow_resource_params_file': 'workflow_resource_params_conf.xml',  # cause: parse_config_file_options
     # 'workflow_resource_params_mapper': 'new',
     # 'workflow_schedulers_config_file': 'workflow_schedulers_conf.xml',  # cause: parse_config_file_options
@@ -623,6 +622,7 @@ SET_CONFIG = {
     'user_library_import_dir': 'user_library_import_dir_new',
     'user_library_import_dir_auto_creation': True,
     'user_library_import_symlink_allowlist': 'user_library_import_symlink_allowlist_new',
+    'user_preferences_extra_conf_path': 'user_preferences_extra_conf.yml_new',
     'user_tool_filters': 'examples:restrict_upload_to_admins, examples:restrict_encode_new',
     'user_tool_label_filters': 'examples:restrict_upload_to_admins, examples:restrict_encode_new',
     'user_tool_section_filters': 'examples:restrict_text_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -335,7 +335,6 @@ SET_CONFIG = {
     # 'job_config_file': 'config/job_conf.xml',  # cause: parse_config_file_options
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
-    # 'markdown_export_css': 'markdown_export.css',  # cause: parse_config_file_options
     # 'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css_new',
     # 'markdown_export_css_pages': 'markdown_export_pages.css_new',  # cause: parse_config_file_options
     # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
@@ -505,6 +504,7 @@ SET_CONFIG = {
     'mailing_join_addr': 'mailing_join_addr_new',
     'mailing_lists_url': 'https://galaxyproject.org/mailing-lists/new',
     'managed_config_dir': 'managed_config_new',
+    'markdown_export_css': 'markdown_export.css_new',
     'markdown_export_epilogue': 'markdown_export_epilogue_new',
     'markdown_export_epilogue_invocation_reports': 'markdown_export_epilogue_invocation_reports_new',
     'markdown_export_epilogue_pages': 'markdown_export_epilogue_pages_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -307,6 +307,8 @@ def test_default_config(test_data):
 
 @pytest.mark.parametrize('test_data', get_test_data_with_set_values(), ids=get_key)
 def test_set_config(test_data):
+    if test_data.key == 'data_dir':
+        print(test_data)
     assert test_data.expected == test_data.loaded
 
 
@@ -317,67 +319,44 @@ def test_set_config(test_data):
 # Commented values indicate failing tests and require fixing. In many cases it's a bug
 # (i.e., a property is not correctly set). Ideally, none should be commented out.
 SET_CONFIG = {
-    # 'amqp_internal_connection': 'sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE_new', TODO
-    # 'auth_config_file': 'auth_conf_new.xml',  # cause: parse_config_file_options TODO
+    # 'amqp_internal_connection': 'sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE_new',
+    # 'auth_config_file': 'auth_conf_new.xml',  # cause: parse_config_file_options
     # 'build_sites_config_file': 'build_sites.yml_new',  # cause: parse_config_file_options
-    # 'builds_file_path': 'shared/ucsc/builds.txt',
-    # 'citation_cache_data_dir': 'citations/data',
-    # 'citation_cache_lock_dir': 'citations/locks',
-    # 'cluster_files_directory': 'pbs',
     # 'containers_resolvers_config_file': 'None',  # cause: parse_config_file_options
-    # 'data_dir': 'data_new', TODO
     # 'data_manager_config_file': 'config/data_manager_conf.xml',  # cause: parse_config_file_options
     # 'database_connection': 'database_connection',
     # 'dependency_resolvers_config_file': 'dependency_resolvers_conf.xml',  # cause: parse_config_file_options
     # 'disable_library_comptypes': 'None',
-    # 'dynamic_proxy_session_map': 'session_map.sqlite',
-    # 'enable_beta_gdpr': True,  TODO
+    # 'enable_beta_gdpr': True,
     # 'file_path': 'objects',  # cause: parse_config_file_options
     # 'ftp_upload_dir_template': 'None',
-    # 'galaxy_data_manager_data_path': 'None',
-    # 'integrated_tool_panel_config': 'integrated_tool_panel.xml',
-    # 'interactive_environment_plugins_directory': 'None',
-    # 'interactivetools_map': 'interactivetools_map.sqlite',
-    # 'interactivetools_proxy_host': 'None',
-    # 'involucro_path': 'involucro',
+    # 'interactive_environment_plugins_directory': 'new',
+    # 'interactivetools_map': 'interactivetools_map.sqlite_new',
+    # 'interactivetools_proxy_host': 'new',
     # 'job_config_file': 'config/job_conf.xml',  # cause: parse_config_file_options
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
-    # 'len_file_path': 'shared/ucsc/chrom',
     # 'markdown_export_css': 'markdown_export.css',  # cause: parse_config_file_options
-    # 'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css',
-    # 'markdown_export_css_pages': 'markdown_export_pages.css',  # cause: parse_config_file_options
+    # 'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css_new',
+    # 'markdown_export_css_pages': 'markdown_export_pages.css_new',  # cause: parse_config_file_options
     # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
-    # 'mulled_resolution_cache_data_dir': 'mulled/data',
-    # 'mulled_resolution_cache_lock_dir': 'mulled/locks',
-    # 'new_file_path': 'tmp',
-    # 'nginx_upload_store': 'None',
+    # 'nginx_upload_store': 'new',
     # 'object_store_config_file': 'object_store_conf.xml',  # cause: parse_config_file_options
-    # 'object_store_store_by': 'None',
+    # 'object_store_store_by': 'new',
     # 'oidc_backends_config_file': 'oidc_backends_config.xml',  # cause: parse_config_file_options
     # 'oidc_config_file': 'oidc_config.xml',  # cause: parse_config_file_options
-    # 'openid_consumer_cache_path': 'openid_consumer_cache',
-    # 'sanitize_allowlist_file': 'sanitize_allowlist.txt',
     # 'shed_data_manager_config_file': 'shed_data_manager_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_config_file': 'shed_tool_conf.xml',  # cause: parse_config_file_options
-    # 'shed_tool_data_path': 'None',
     # 'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml',  # cause: parse_config_file_options
-    # 'single_user': 'single_user_new',
     # 'statsd_host': 'None',
-    # 'template_cache_path': 'compiled_templates',
-    # 'tool_cache_data_dir': 'tool_cache',
     # 'tool_config_file': config/tool_conf.xml,
-    # 'tool_data_path': 'tool-data',
     # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
-    # 'tool_path': 'tools',
-    # 'tool_search_index_dir': 'tool_search_index',
     # 'tool_sheds_config_file': 'tool_sheds_conf.xml',  # cause: parse_config_file_options
-    # 'tool_test_data_directories': 'test-data',
+    # 'tool_test_data_directories': 'test-data_new',
     # 'use_remote_user': True,
-    # 'user_library_import_dir_auto_creation': True,
     # 'user_preferences_extra_conf_path': 'user_preferences_extra_conf.yml',  # cause: parse_config_file_options
     # 'workflow_resource_params_file': 'workflow_resource_params_conf.xml',  # cause: parse_config_file_options
-    # 'workflow_resource_params_mapper': 'None',
+    # 'workflow_resource_params_mapper': 'new',
     # 'workflow_schedulers_config_file': 'workflow_schedulers_conf.xml',  # cause: parse_config_file_options
     'activation_grace_period': 2,
     'admin_tool_recommendations_path': 'tool_recommendations_overwrite_new.yml',
@@ -393,15 +372,19 @@ SET_CONFIG = {
     'auto_configure_logging': False,
     'aws_estimate': True,
     'brand': 'brand_new',
+    'builds_file_path': 'shared/ucsc/builds.txt_new',
     'cache_user_job_count': True,
     'check_job_script_integrity': False,
     'check_job_script_integrity_count': 34,
     'check_job_script_integrity_sleep': 0.24,
     'check_migrate_tools': True,
     'chunk_upload_size': 104857601,
+    'citation_cache_data_dir': 'citations/data_new',
+    'citation_cache_lock_dir': 'citations/locks_new',
     'citation_cache_type': 'file_new',
     'citation_url': 'https://galaxyproject.org/citing-galaxy/new',
     'cleanup_job': 'never',
+    'cluster_files_directory': 'pbs_new',
     'communication_server_host': 'http://localhost_new',
     'communication_server_port': 7071,
     'conda_auto_init': False,
@@ -414,6 +397,7 @@ SET_CONFIG = {
     'conda_use_local': True,
     'config_dir': 'config_new',
     'cookie_domain': 'cookie_domain_new',
+    'data_dir': 'data_new',
     'database_auto_migrate': True,
     'database_engine_option_echo': True,
     'database_engine_option_echo_pool': True,
@@ -453,6 +437,7 @@ SET_CONFIG = {
     'dynamic_proxy_golang_noaccess': 61,
     'dynamic_proxy_manage': False,
     'dynamic_proxy_prefix': 'gie_proxy_new',
+    'dynamic_proxy_session_map': 'session_map.sqlite_new',
     'email_domain_allowlist_file': 'None',
     'email_domain_blocklist_file': 'None',
     'email_from': 'email_from_new',
@@ -490,6 +475,7 @@ SET_CONFIG = {
     'ftp_upload_purge': False,
     'ftp_upload_site': 'ftp_upload_site_new',
     'ga_code': 'ga_code_new',
+    'galaxy_data_manager_data_path': 'new',
     'galaxy_infrastructure_url': 'http://localhost:8081',
     'galaxy_infrastructure_web_port': 8082,
     'heartbeat_interval': 21,
@@ -501,11 +487,14 @@ SET_CONFIG = {
     'inactivity_box_content': 'inactivity_box_content_new',
     'install_database_connection': 'install_database_connection_new',
     'instance_resource_url': 'instance_resource_url_new',
+    'integrated_tool_panel_config': 'integrated_tool_panel.xml_new',
     'interactivetools_enable': True,
     'involucro_auto_init': False,
+    'involucro_path': 'involucro_new',
     'job_config': 'job_config_new',
     'job_working_directory': 'jobs_directory_new',
     'legacy_eager_objectstore_initialization': True,
+    'len_file_path': 'shared/ucsc/chrom_new',
     'library_import_dir': 'library_import_dir_new',
     'local_task_queue_workers': 3,
     'log_actions': True,
@@ -531,14 +520,18 @@ SET_CONFIG = {
     'message_box_visible': True,
     'monitor_thread_join_timeout': 31,
     'mulled_channels': 'conda-forge,bioconda_new',
+    'mulled_resolution_cache_data_dir': 'mulled/data_new',
+    'mulled_resolution_cache_lock_dir': 'mulled/locks_new',
     'mulled_resolution_cache_type': 'file_new',
     'myexperiment_target_url': 'www.myexperiment.org:81',
+    'new_file_path': 'tmp_new',
     'new_user_dataset_access_role_default_private': True,
     'nginx_upload_job_files_path': 'nginx_upload_job_files_path_new',
     'nginx_upload_job_files_store': 'nginx_upload_job_files_store_new',
     'nginx_upload_path': 'nginx_upload_path_new',
     'nginx_x_accel_redirect_base': 'nginx_x_accel_redirect_base_new',
     'normalize_remote_user_email': True,
+    'openid_consumer_cache_path': 'openid_consumer_cache_new',
     'outputs_to_working_directory': True,
     'overwrite_model_recommendations': True,
     'parallelize_workflow_scheduling_within_histories': True,
@@ -559,6 +552,7 @@ SET_CONFIG = {
     'retry_job_output_collection': 1,
     'retry_metadata_internally': False,
     'sanitize_all_html': False,
+    'sanitize_allowlist_file': 'sanitize_allowlist.txt_new',
     'screencasts_url': 'https://vimeo.com/galaxyproject/new',
     'search_url': 'https://galaxyproject.org/search/new',
     'select_type_workflow_threshold': 0,
@@ -566,8 +560,10 @@ SET_CONFIG = {
     'sentry_sloreq_threshold': 0.1,
     'serve_xss_vulnerable_mimetypes': True,
     'session_duration': 1,
+    'shed_tool_data_path': 'new',
     'show_user_prepopulate_form': True,
     'show_welcome_with_login': True,
+    'single_user': 'single_user_new',
     'slow_query_log_threshold': 0.1,
     'smtp_password': 'smtp_password_new',
     'smtp_server': 'smtp_server_new',
@@ -586,7 +582,10 @@ SET_CONFIG = {
     'statsd_port': 8126,
     'statsd_prefix': 'galaxy_new',
     'support_url': 'https://galaxyproject.org/support/new',
+    'template_cache_path': 'compiled_templates_new',
     'terms_url': 'terms_url_new',
+    'tool_cache_data_dir': 'tool_cache_new',
+    'tool_data_path': 'tool-data_new',
     'tool_dependency_cache_dir': 'tool_dependency_cache_dir_new',
     'tool_dependency_dir': 'dependencies_new',
     'tool_description_boost': 2.1,
@@ -598,7 +597,9 @@ SET_CONFIG = {
     'tool_name_boost': 9.1,
     'tool_ngram_maxsize': 5,
     'tool_ngram_minsize': 4,
+    'tool_path': 'tools_new',
     'tool_recommendation_model_path': 'tool_recommendation_model_path_new',
+    'tool_search_index_dir': 'tool_search_index_new',
     'tool_search_limit': 21,
     'tool_section_boost': 3.1,
     'tool_section_filters': 'tool_section_filters_new',
@@ -620,6 +621,7 @@ SET_CONFIG = {
     'user_activation_on': True,
     'user_library_import_check_permissions': True,
     'user_library_import_dir': 'user_library_import_dir_new',
+    'user_library_import_dir_auto_creation': True,
     'user_library_import_symlink_allowlist': 'user_library_import_symlink_allowlist_new',
     'user_tool_filters': 'examples:restrict_upload_to_admins, examples:restrict_encode_new',
     'user_tool_label_filters': 'examples:restrict_upload_to_admins, examples:restrict_encode_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -331,7 +331,6 @@ SET_CONFIG = {
     # 'interactive_environment_plugins_directory': 'new',
     # 'interactivetools_map': 'interactivetools_map.sqlite_new',
     # 'interactivetools_proxy_host': 'new',
-    # 'job_config_file': 'config/job_conf.xml',  # cause: parse_config_file_options
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
     # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
@@ -489,6 +488,7 @@ SET_CONFIG = {
     'involucro_auto_init': False,
     'involucro_path': 'involucro_new',
     'job_config': 'job_config_new',
+    'job_config_file': 'config/job_conf.xml_new',
     'job_working_directory': 'jobs_directory_new',
     'legacy_eager_objectstore_initialization': True,
     'len_file_path': 'shared/ucsc/chrom_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -329,7 +329,6 @@ SET_CONFIG = {
     # 'database_connection': 'database_connection',
     # 'disable_library_comptypes': 'None',
     # 'enable_beta_gdpr': True,
-    # 'file_path': 'objects',  # cause: parse_config_file_options
     # 'ftp_upload_dir_template': 'None',
     # 'interactive_environment_plugins_directory': 'new',
     # 'interactivetools_map': 'interactivetools_map.sqlite_new',
@@ -452,6 +451,7 @@ SET_CONFIG = {
     'expose_user_name': True,
     'external_chown_script': 'external_chown_script_new',
     'fetch_url_allowlist': '10.10.10.10',
+    'file_path': 'objects_new',
     'fluent_host': 'localhost_new',
     'fluent_log': True,
     'fluent_port': 24225,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -1,6 +1,7 @@
 import os
 from collections import namedtuple
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 
@@ -280,9 +281,10 @@ def get_test_data_with_default_values():
 
 def get_test_data_with_set_values():
     """GalaxyAppConfiguration loaded with user-set values."""
-    appconfig = config.GalaxyAppConfiguration(**SET_CONFIG)
+    # Prevent GalaxyAppConfiguration from trying to load a nonexistant file
+    with patch.object(config.GalaxyAppConfiguration, '_load_list_from_file'):
+        appconfig = config.GalaxyAppConfiguration(**SET_CONFIG)
     evp = ExpectedValuesProvider(appconfig)
-
     for key, data in appconfig.schema.app_schema.items():
         if key not in DO_NOT_TEST and key in SET_CONFIG:
             set_value = SET_CONFIG.get(key)
@@ -329,8 +331,6 @@ SET_CONFIG = {
     # 'dependency_resolvers_config_file': 'dependency_resolvers_conf.xml',  # cause: parse_config_file_options
     # 'disable_library_comptypes': 'None',
     # 'dynamic_proxy_session_map': 'session_map.sqlite',
-    # 'email_domain_allowlist_file': 'None',
-    # 'email_domain_blocklist_file': 'None',
     # 'enable_beta_gdpr': True,  TODO
     # 'file_path': 'objects',  # cause: parse_config_file_options
     # 'ftp_upload_dir_template': 'None',
@@ -453,6 +453,8 @@ SET_CONFIG = {
     'dynamic_proxy_golang_noaccess': 61,
     'dynamic_proxy_manage': False,
     'dynamic_proxy_prefix': 'gie_proxy_new',
+    'email_domain_allowlist_file': 'None',
+    'email_domain_blocklist_file': 'None',
     'email_from': 'email_from_new',
     'enable_beta_containers_interface': True,
     'enable_beta_markdown_export': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -15,8 +15,8 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 DO_NOT_TEST = {
     'allowed_origin_hostnames',
     'data_manager_config_file',     # fix schema
-    'datatypes_config_file',        # fix schema
-    'job_config_file',              # fix schema
+    'datatypes_config_file',        # fix schema  TODO!!!!!!!!!!
+    'job_config_file',              # fix schema  TODO!!!!!!!!!!
     'tool_config_file',             # fix schema
     'tool_data_table_config_path',  # fix schema
 }
@@ -334,7 +334,6 @@ SET_CONFIG = {
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_store_by': 'new',
-    # 'shed_data_manager_config_file': 'shed_data_manager_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_config_file': 'shed_tool_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml',  # cause: parse_config_file_options
     # 'statsd_host': 'None',
@@ -560,6 +559,7 @@ SET_CONFIG = {
     'sentry_sloreq_threshold': 0.1,
     'serve_xss_vulnerable_mimetypes': True,
     'session_duration': 1,
+    'shed_data_manager_config_file': 'shed_data_manager_conf.xml_new',
     'shed_tool_data_path': 'new',
     'show_user_prepopulate_form': True,
     'show_welcome_with_login': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -339,7 +339,6 @@ SET_CONFIG = {
     # 'statsd_host': 'None',
     # 'tool_config_file': config/tool_conf.xml,
     # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
-    # 'tool_sheds_config_file': 'tool_sheds_conf.xml',  # cause: parse_config_file_options
     # 'tool_test_data_directories': 'test-data_new',
     # 'use_remote_user': True,
     # 'user_preferences_extra_conf_path': 'user_preferences_extra_conf.yml',  # cause: parse_config_file_options
@@ -603,6 +602,7 @@ SET_CONFIG = {
     'tool_search_limit': 21,
     'tool_section_boost': 3.1,
     'tool_section_filters': 'tool_section_filters_new',
+    'tool_sheds_config_file': 'tool_sheds_conf.xml_new',
     'tool_stub_boost': 5.1,
     'toolbox_filter_base_modules': 'galaxy.tools.filters,galaxy.tools.toolbox.filters_new',
     'topk_recommendations': 11,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -324,7 +324,6 @@ SET_CONFIG = {
     # 'containers_resolvers_config_file': 'None',  # cause: parse_config_file_options
     # 'data_manager_config_file': 'config/data_manager_conf.xml',  # cause: parse_config_file_options
     # 'database_connection': 'database_connection',
-    # 'dependency_resolvers_config_file': 'dependency_resolvers_conf.xml',  # cause: parse_config_file_options
     # 'disable_library_comptypes': 'None',
     # 'enable_beta_gdpr': True,
     # 'file_path': 'objects',  # cause: parse_config_file_options
@@ -418,6 +417,7 @@ SET_CONFIG = {
     'delay_tool_initialization': True,
     'dependency_resolution': 'dependency_resolution_new',
     'dependency_resolvers': 'dependency_resolvers_new',
+    'dependency_resolvers_config_file': 'dependency_resolvers_conf.xml_new',
     'display_chunk_size': 65537,
     'display_galaxy_brand': False,
     'display_servers': 'display_servers_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -13,7 +13,6 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 
 DO_NOT_TEST = {
-    'data_manager_config_file',     # fix schema+
     'datatypes_config_file',        # fix schema; parse_config_files
     'tool_config_file',             # fix schema; parse_config_files
     'tool_data_table_config_path',  # fix schema; parse_config_files
@@ -115,6 +114,7 @@ class ExpectedValuesProvider:
                 'cluster_files_directory': self._in_data_dir,
                 'config_dir': self._resolve_config_dir,
                 'data_dir': self._resolve_data_dir,
+                'data_manager_config_file': self._in_config_dir, 
                 'database_connection': self._resolve_database_connection,
                 'dependency_resolvers_config_file': self._in_config_dir,
                 'dynamic_proxy_session_map': self._in_data_dir,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -335,7 +335,6 @@ SET_CONFIG = {
     # 'job_config_file': 'config/job_conf.xml',  # cause: parse_config_file_options
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
-    # 'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css_new',
     # 'markdown_export_css_pages': 'markdown_export_pages.css_new',  # cause: parse_config_file_options
     # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
@@ -505,6 +504,7 @@ SET_CONFIG = {
     'mailing_lists_url': 'https://galaxyproject.org/mailing-lists/new',
     'managed_config_dir': 'managed_config_new',
     'markdown_export_css': 'markdown_export.css_new',
+    'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css_new',
     'markdown_export_epilogue': 'markdown_export_epilogue_new',
     'markdown_export_epilogue_invocation_reports': 'markdown_export_epilogue_invocation_reports_new',
     'markdown_export_epilogue_pages': 'markdown_export_epilogue_pages_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -338,7 +338,6 @@ SET_CONFIG = {
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_store_by': 'new',
-    # 'shed_tool_config_file': 'shed_tool_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml',  # cause: parse_config_file_options
     # 'statsd_host': 'None',
     # 'tool_config_file': config/tool_conf.xml,
@@ -559,6 +558,7 @@ SET_CONFIG = {
     'serve_xss_vulnerable_mimetypes': True,
     'session_duration': 1,
     'shed_data_manager_config_file': 'shed_data_manager_conf.xml_new',
+    'shed_tool_config_file': 'shed_tool_conf.xml_new',
     'shed_tool_data_path': 'new',
     'show_user_prepopulate_form': True,
     'show_welcome_with_login': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -322,7 +322,7 @@ SET_CONFIG = {
     # 'amqp_internal_connection': 'sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE_new',
     # 'build_sites_config_file': 'build_sites.yml_new',  # cause: parse_config_file_options
     # 'containers_resolvers_config_file': 'None',  # cause: parse_config_file_options
-    # 'data_manager_config_file': 'config/data_manager_conf.xml',  # cause: parse_config_file_options
+    # 'data_manager_config_file': 'config/data_manager_conf.xml',  # TODO: driver_util causes further errors
     # 'database_connection': 'database_connection',
     # 'disable_library_comptypes': 'None',
     # 'enable_beta_gdpr': True,
@@ -332,7 +332,6 @@ SET_CONFIG = {
     # 'interactivetools_map': 'interactivetools_map.sqlite_new',
     # 'interactivetools_proxy_host': 'new',
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
-    # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
     # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_config_file': 'object_store_conf.xml',  # cause: parse_config_file_options
@@ -489,6 +488,7 @@ SET_CONFIG = {
     'involucro_path': 'involucro_new',
     'job_config': 'job_config_new',
     'job_config_file': 'config/job_conf.xml_new',
+    'job_resource_params_file': 'job_resource_params_conf.xml_new',
     'job_working_directory': 'jobs_directory_new',
     'legacy_eager_objectstore_initialization': True,
     'len_file_path': 'shared/ucsc/chrom_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -333,7 +333,6 @@ SET_CONFIG = {
     # 'interactivetools_proxy_host': 'new',
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
-    # 'object_store_config_file': 'object_store_conf.xml',  # cause: parse_config_file_options
     # 'object_store_store_by': 'new',
     # 'oidc_backends_config_file': 'oidc_backends_config.xml',  # cause: parse_config_file_options
     # 'oidc_config_file': 'oidc_config.xml',  # cause: parse_config_file_options
@@ -531,6 +530,7 @@ SET_CONFIG = {
     'nginx_upload_path': 'nginx_upload_path_new',
     'nginx_x_accel_redirect_base': 'nginx_x_accel_redirect_base_new',
     'normalize_remote_user_email': True,
+    'object_store_config_file': 'object_store_conf.xml_new',
     'openid_consumer_cache_path': 'openid_consumer_cache_new',
     'outputs_to_working_directory': True,
     'overwrite_model_recommendations': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -13,7 +13,6 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 
 DO_NOT_TEST = {
-    'allowed_origin_hostnames',
     'data_manager_config_file',     # fix schema
     'datatypes_config_file',        # fix schema  TODO!!!!!!!!!!
     'job_config_file',              # fix schema  TODO!!!!!!!!!!
@@ -108,6 +107,7 @@ class ExpectedValuesProvider:
             """
             self._resolvers_callables = {
                 'admin_tool_recommendations_path': self._in_config_dir,
+                'allowed_origin_hostnames': config.GalaxyAppConfiguration._parse_allowed_origin_hostnames,
                 'amqp_internal_connection': self._resolve_amqp_internal_connection,
                 'auth_config_file': self._in_config_dir,
                 'builds_file_path': self._in_tool_data_dir,
@@ -349,7 +349,7 @@ SET_CONFIG = {
     'allow_user_dataset_purge': False,
     'allow_user_deletion': True,
     'allow_user_impersonation': True,
-    'allowed_origin_hostnames': 'allowed_origin_hostnames_new',
+    'allowed_origin_hostnames': 'allowed_origin_hostnames_new1, allowed_origin_hostnames_new2',
     'apache_xsendfile': True,
     'api_allow_run_as': 'api_allow_run_as_new',
     'auth_config_file': 'auth_conf_new.xml',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -11,6 +11,16 @@ from galaxy.web.formatting import expand_pretty_datetime_format
 TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 
+DO_NOT_TEST = {
+    'allowed_origin_hostnames',
+    'data_manager_config_file',     # fix schema
+    'datatypes_config_file',        # fix schema
+    'job_config_file',              # fix schema
+    'tool_config_file',             # fix schema
+    'tool_data_table_config_path',  # fix schema
+}
+
+
 @pytest.fixture(scope='module')
 def appconfig():
     return config.GalaxyAppConfiguration()
@@ -56,164 +66,571 @@ def listify_strip(value):
     return listify(value, do_strip=True)
 
 
-class ExpectedValues:
-
-    def __init__(self, config):
-        self._config = config
+class ExpectedValuesProvider:
+    """
+    The purpose of this class is to calculate expected values for config options
+    based on their key, default value, set value (default is overwritten if the
+    value is set), and any processing logic specified in the schema or the
+    config module. For example, a path may be resolved with respect to a parent
+    directory specified in the schema (via `path_resolves_to`), or a function
+    may be applied to the value (e.g., `listify` in the config module).
+    """
+    def __init__(self, appconfig):
+        self.schema_defaults = appconfig.schema.defaults
+        self._root_dir = appconfig.root
+        self._config_dir = appconfig.config_dir
+        self._data_dir = appconfig.data_dir
+        self._managed_config_dir = appconfig.managed_config_dir
+        self._sample_config_dir = appconfig.sample_config_dir
+        self._tool_data_path = appconfig.tool_data_path
         self._load_resolvers()
-        self._load_paths()
 
     def _load_resolvers(self):
-        self._resolvers = {
-            'amqp_internal_connection': self.get_expected_amqp_internal_connection,
-            'database_connection': self.get_expected_database_connection,
-            'disable_library_comptypes': [''],  # TODO: we can do better
-            'ftp_upload_dir_template': self.get_expected_ftp_upload_dir_template,
-            'mulled_channels': listify_strip,
-            'object_store_store_by': 'uuid',
-            'password_expiration_period': timedelta,
-            'persistent_communication_rooms': listify_strip,
-            'pretty_datetime_format': expand_pretty_datetime_format,
-            'statsd_host': '',  # TODO: do we need '' as the default?
-            'tool_config_file': listify_strip,
-            'tool_data_table_config_path': listify_strip,
-            'tool_filters': listify_strip,
-            'tool_label_filters': listify_strip,
-            'tool_section_filters': listify_strip,
-            'toolbox_filter_base_modules': listify_strip,
-            'use_remote_user': None,  # TODO: should be False (config logic incorrect)
-            'user_library_import_symlink_allowlist': listify_strip,
-            'user_tool_filters': listify_strip,
-            'user_tool_label_filters': listify_strip,
-            'user_tool_section_filters': listify_strip,
-        }
-        # _resolvers provides expected values for config options.
-        # - key: config option
-        # - value: expected value or a callable. The callable will be called with a
-        #   single argument, which is the default value of the config option.
+        """
+        A resolver is used to transform an initial value to the final expected
+        value. A resolver can be (1) a constant, (2) a callable that takes
+        one argument, (3) a callable that takes 2 arguments. A key can be
+        mapped to one resolver at most.
+        """
+        def load_constants():
+            """Dictionary mapping keys to constants."""
+            self._resolvers_constants = {
+                'disable_library_comptypes': [''],  # TODO: we can do better
+                'object_store_store_by': 'uuid',
+                'statsd_host': '',  # TODO: do we need '' as the default?
+                'use_remote_user': None,  # TODO: should be False (config logic incorrect)
+            }
 
-    def _load_paths(self):
-        self._expected_paths = {
-            'admin_tool_recommendations_path': self._in_config_dir('tool_recommendations_overwrite.yml'),
-            'auth_config_file': self._in_config_dir('auth_conf.xml'),
-            'build_sites_config_file': self._in_sample_dir('build_sites.yml.sample'),
-            'builds_file_path': self._in_root_dir('tool-data/shared/ucsc/builds.txt'),
-            'citation_cache_data_dir': self._in_data_dir('citations/data'),
-            'citation_cache_lock_dir': self._in_data_dir('citations/locks'),
-            'cluster_files_directory': self._in_data_dir('pbs'),
-            'config_dir': self._in_config_dir(),
-            'data_dir': self._in_data_dir(),
-            'data_manager_config_file': self._in_config_dir('data_manager_conf.xml'),
-            'datatypes_config_file': self._in_sample_dir('datatypes_conf.xml.sample'),
-            'dependency_resolvers_config_file': self._in_config_dir('dependency_resolvers_conf.xml'),
-            'dynamic_proxy_session_map': self._in_data_dir('session_map.sqlite'),
-            'file_path': self._in_data_dir('objects'),
-            'file_sources_config_file': self._in_config_dir('file_sources_conf.yml'),
-            'galaxy_data_manager_data_path': self._in_root_dir('tool-data'),
-            'integrated_tool_panel_config': self._in_managed_config_dir('integrated_tool_panel.xml'),
-            'interactivetools_map': self._in_data_dir('interactivetools_map.sqlite'),
-            'involucro_path': self._in_root_dir('involucro'),
-            'job_config_file': self._in_config_dir('job_conf.xml'),
-            'job_metrics_config_file': self._in_sample_dir('job_metrics_conf.xml.sample'),
-            'job_resource_params_file': self._in_config_dir('job_resource_params_conf.xml'),
-            'len_file_path': self._in_root_dir('tool-data/shared/ucsc/chrom'),
-            'managed_config_dir': self._in_managed_config_dir(),
-            'markdown_export_css': self._in_config_dir('markdown_export.css'),
-            'markdown_export_css_invocation_reports': self._in_config_dir('markdown_export_invocation_reports.css'),
-            'markdown_export_css_pages': self._in_config_dir('markdown_export_pages.css'),
-            'migrated_tools_config': self._in_managed_config_dir('migrated_tools_conf.xml'),
-            'mulled_resolution_cache_data_dir': self._in_data_dir('mulled/data'),
-            'mulled_resolution_cache_lock_dir': self._in_data_dir('mulled/locks'),
-            'new_file_path': self._in_data_dir('tmp'),
-            'object_store_config_file': self._in_config_dir('object_store_conf.xml'),
-            'oidc_backends_config_file': self._in_config_dir('oidc_backends_config.xml'),
-            'oidc_config_file': self._in_config_dir('oidc_config.xml'),
-            'openid_consumer_cache_path': self._in_data_dir('openid_consumer_cache'),
-            'sanitize_allowlist_file': self._in_managed_config_dir('sanitize_allowlist.txt'),
-            'shed_data_manager_config_file': self._in_managed_config_dir('shed_data_manager_conf.xml'),
-            'shed_tool_config_file': self._in_managed_config_dir('shed_tool_conf.xml'),
-            'shed_tool_data_path': self._in_root_dir('tool-data'),
-            'shed_tool_data_table_config': self._in_managed_config_dir('shed_tool_data_table_conf.xml'),
-            'template_cache_path': self._in_data_dir('compiled_templates'),
-            'tool_cache_data_dir': self._in_data_dir('tool_cache'),
-            'tool_config_file': self._in_sample_dir('tool_conf.xml.sample'),
-            'tool_data_path': self._in_root_dir('tool-data'),
-            'tool_data_table_config_path': self._in_sample_dir('tool_data_table_conf.xml.sample'),
-            'tool_path': self._in_root_dir('tools'),
-            'tool_search_index_dir': self._in_data_dir('tool_search_index'),
-            'tool_sheds_config_file': self._in_config_dir('tool_sheds_conf.xml'),
-            'tool_test_data_directories': self._in_root_dir('test-data'),
-            'trs_servers_config_file': self._in_config_dir('trs_servers_conf.yml'),
-            'user_preferences_extra_conf_path': self._in_config_dir('user_preferences_extra_conf.yml'),
-            'workflow_resource_params_file': self._in_config_dir('workflow_resource_params_conf.xml'),
-            'workflow_schedulers_config_file': self._in_config_dir('workflow_schedulers_conf.xml'),
-        }
-        # _expected_paths provides expected values for config options that are paths. Each value is
-        # wrapped in a function that ensures that the path (a) is resolved w.r.t. its parent as per
-        # schema and/or config module; and (b) is an absolute path. The base config paths used by
-        # each function are tested separately (see tests of base config properties in this module).
-        # The values are hardcoded intentionally for the sake of keeping the test readable and
-        # simple. They correspond to schema defaults, and should be adjusted if the schema is
-        # modified.
+        def load_callables_one_arg():
+            """
+            Dictionary mapping keys to callables that take one argument: the value to be resolved.
+            """
+            self._resolvers_callables = {
+                'admin_tool_recommendations_path': self._in_config_dir,
+                'amqp_internal_connection': self._resolve_amqp_internal_connection,
+                'auth_config_file': self._in_config_dir,
+                'builds_file_path': self._in_tool_data_dir,
+                'citation_cache_data_dir': self._in_data_dir,
+                'citation_cache_lock_dir': self._in_data_dir,
+                'cluster_files_directory': self._in_data_dir,
+                'config_dir': self._resolve_config_dir,
+                'data_dir': self._resolve_data_dir,
+                'database_connection': self._resolve_database_connection,
+                'dependency_resolvers_config_file': self._in_config_dir,
+                'dynamic_proxy_session_map': self._in_data_dir,
+                'file_path': self._in_data_dir,
+                'file_sources_config_file': self._in_config_dir,
+                'ftp_upload_dir_template': self._resolve_ftp_upload_dir_template,
+                'galaxy_data_manager_data_path': self._resolve_galaxy_data_manager_data_path,
+                'integrated_tool_panel_config': self._in_managed_config_dir,
+                'interactivetools_map': self._in_data_dir,
+                'involucro_path': self._in_root_dir,
+                'job_resource_params_file': self._in_config_dir,
+                'len_file_path': self._in_tool_data_dir,
+                'managed_config_dir': self._resolve_managed_config_dir,
+                'markdown_export_css': self._in_config_dir,
+                'markdown_export_css_invocation_reports': self._in_config_dir,
+                'markdown_export_css_pages': self._in_config_dir,
+                'migrated_tools_config': self._in_managed_config_dir,
+                'mulled_channels': listify_strip,
+                'mulled_resolution_cache_data_dir': self._in_data_dir,
+                'mulled_resolution_cache_lock_dir': self._in_data_dir,
+                'new_file_path': self._in_data_dir,
+                'object_store_config_file': self._in_config_dir,
+                'oidc_backends_config_file': self._in_config_dir,
+                'oidc_config_file': self._in_config_dir,
+                'openid_consumer_cache_path': self._in_data_dir,
+                'password_expiration_period': timedelta,
+                'persistent_communication_rooms': listify_strip,
+                'pretty_datetime_format': expand_pretty_datetime_format,
+                'sanitize_allowlist_file': self._in_managed_config_dir,
+                'shed_data_manager_config_file': self._in_managed_config_dir,
+                'shed_tool_config_file': self._in_managed_config_dir,
+                'shed_tool_data_path': self._resolve_shed_tool_data_path,
+                'shed_tool_data_table_config': self._in_managed_config_dir,
+                'template_cache_path': self._in_data_dir,
+                'tool_cache_data_dir': self._in_data_dir,
+                'tool_data_path': self._in_root_dir,
+                'tool_filters': listify_strip,
+                'tool_label_filters': listify_strip,
+                'tool_path': self._in_root_dir,
+                'tool_search_index_dir': self._in_data_dir,
+                'tool_section_filters': listify_strip,
+                'tool_sheds_config_file': self._in_config_dir,
+                'tool_test_data_directories': self._in_root_dir,
+                'toolbox_filter_base_modules': listify_strip,
+                'trs_servers_config_file': self._in_config_dir,
+                'user_library_import_symlink_allowlist': listify_strip,
+                'user_preferences_extra_conf_path': self._in_config_dir,
+                'user_tool_filters': listify_strip,
+                'user_tool_label_filters': listify_strip,
+                'user_tool_section_filters': listify_strip,
+                'workflow_resource_params_file': self._in_config_dir,
+                'workflow_schedulers_config_file': self._in_config_dir,
+            }
+
+        def load_callables_two_args():
+            """
+            Dictionary mapping keys to callables that take two arguments: (1) the value
+            to be resolved, and (2) the schema default.
+            """
+            self._resolvers_callables_two_args = {
+                'build_sites_config_file': self._in_config_or_sample_dir,
+                'job_metrics_config_file': self._in_config_or_sample_dir,
+            }
+
+        def ensure_one_resolver_per_key():
+            a = set(self._resolvers_constants)
+            b = set(self._resolvers_callables)
+            c = set(self._resolvers_callables_two_args)
+            if a & b or b & c or a & c:
+                raise Exception('A key can be mapped to one resolver at most')
+
+        load_constants()
+        load_callables_one_arg()
+        load_callables_two_args()
+        ensure_one_resolver_per_key()
 
     def _in_root_dir(self, path=None):
-        return self._in_dir(self._config.root, path)
+        return self._in_dir(self._root_dir, path)
 
     def _in_config_dir(self, path=None):
-        return self._in_dir(self._config.config_dir, path)
+        return self._in_dir(self._config_dir, path)
 
     def _in_data_dir(self, path=None):
-        return self._in_dir(self._config.data_dir, path)
+        return self._in_dir(self._data_dir, path)
 
     def _in_managed_config_dir(self, path=None):
-        return self._in_dir(self._config.managed_config_dir, path)
+        return self._in_dir(self._managed_config_dir, path)
 
-    def _in_sample_dir(self, path=None):
-        return self._in_dir(self._config.sample_config_dir, path)
+    def _in_tool_data_dir(self, path=None):
+        return self._in_dir(self._tool_data_path, path)
+
+    def _in_config_or_sample_dir(self, set_path, default_path):
+        if set_path:
+            return self._in_dir(self._config_dir, set_path)
+        else:
+            path = '%s.sample' % default_path
+            return self._in_dir(self._sample_config_dir, path)
 
     def _in_dir(self, _dir, path):
         return os.path.join(_dir, path) if path else _dir
 
-    def get_value(self, key, data):
-        value = data.get('default')
-        # 1. If this is a path, resolve it
-        if key in self._expected_paths:
-            value = self._expected_paths[key]
-        # 2. AFTER resolving paths, apply resolver, if one exists
-        if key in self._resolvers:
-            resolver = self._resolvers[key]
-            if callable(resolver):
-                value = resolver(value)
-            else:
-                value = resolver
-        return value
+    def _resolve_config_dir(self, path=None):
+        if path:
+            return self._in_root_dir(path)
+        return self._config_dir
 
-    def get_expected_database_connection(self, value):
-        return 'sqlite:///{}/universe.sqlite?isolation_level=IMMEDIATE'.format(self._config.data_dir)
+    def _resolve_data_dir(self, path=None):
+        if path:
+            return self._in_root_dir(path)
+        return self._data_dir
 
-    def get_expected_ftp_upload_dir_template(self, value):
+    def _resolve_managed_config_dir(self, path=None):
+        if path:
+            return self._in_root_dir(path)
+        return self._managed_config_dir
+
+    def _resolve_galaxy_data_manager_data_path(self, path=None):
+        return path or self._tool_data_path
+
+    def _resolve_database_connection(self, value):
+        return 'sqlite:///{}/universe.sqlite?isolation_level=IMMEDIATE'.format(self._data_dir)
+
+    def _resolve_ftp_upload_dir_template(self, value):
         return '${ftp_upload_dir}%s${ftp_upload_dir_identifier}' % os.path.sep
 
-    def get_expected_amqp_internal_connection(self, value):
-        return 'sqlalchemy+sqlite:///{}/control.sqlite?isolation_level=IMMEDIATE'.format(self._config.data_dir)
+    def _resolve_amqp_internal_connection(self, value):
+        return 'sqlalchemy+sqlite:///{}/control.sqlite?isolation_level=IMMEDIATE'.format(self._data_dir)
+
+    def _resolve_shed_tool_data_path(self, path=None):
+        if path:
+            return self._in_root_dir(path)
+        return self._tool_data_path
+
+    def get_expected_value(self, key, set_value=None):
+        default_value = self.schema_defaults.get(key)
+        # If value not set, use schema default
+        value = default_value
+        if set_value is not None:  # value can be falsy, so compare to None
+            value = set_value
+        # Use resolver if one exists; otherwise return value unchanged
+        if key in self._resolvers_constants:
+            return self._resolvers_constants[key]
+        elif key in self._resolvers_callables:
+            return self._resolvers_callables[key](value)
+        elif key in self._resolvers_callables_two_args:
+            f = self._resolvers_callables_two_args[key]
+            return f(set_value, default_value)
+        else:
+            return value
 
 
-def get_config_data():
-    config.GalaxyAppConfiguration._override_tempdir = lambda a, b: None  # method must be mocked
-    configuration = config.GalaxyAppConfiguration()
-    ev = ExpectedValues(configuration)
-    items = ((k, v) for k, v in configuration.schema.app_schema.items())
-    for key, data in items:
-        expected = ev.get_value(key, data)
-        loaded = getattr(configuration, key)
-        test_data = TestData(key=key, expected=expected, loaded=loaded)
-        yield pytest.param(test_data)
+def get_test_data_with_default_values():
+    """GalaxyAppConfiguration loaded with schema defaults."""
+    appconfig = config.GalaxyAppConfiguration()
+    evp = ExpectedValuesProvider(appconfig)
+    for key, data in appconfig.schema.app_schema.items():
+        if key not in DO_NOT_TEST:
+            expected_value = evp.get_expected_value(key)
+            loaded_value = getattr(appconfig, key)
+            test_data = TestData(key, expected_value, loaded_value)
+            yield pytest.param(test_data)
+
+
+def get_test_data_with_set_values():
+    """GalaxyAppConfiguration loaded with user-set values."""
+    appconfig = config.GalaxyAppConfiguration(**SET_CONFIG)
+    evp = ExpectedValuesProvider(appconfig)
+
+    for key, data in appconfig.schema.app_schema.items():
+        if key not in DO_NOT_TEST and key in SET_CONFIG:
+            set_value = SET_CONFIG.get(key)
+            if set_value == evp.schema_defaults.get(key):
+                raise Exception('New value for %s set to schema default: use a different value' % key)
+            expected_value = evp.get_expected_value(key, set_value)
+            loaded_value = getattr(appconfig, key)
+            test_data = TestData(key, expected_value, loaded_value)
+            yield pytest.param(test_data)
 
 
 def get_key(test_data):
     return test_data.key
 
 
-@pytest.mark.parametrize('test_data', get_config_data(), ids=get_key)
-def test_config_defaults(test_data):
+@pytest.mark.parametrize('test_data', get_test_data_with_default_values(), ids=get_key)
+def test_default_config(test_data):
     assert test_data.expected == test_data.loaded
+
+
+@pytest.mark.parametrize('test_data', get_test_data_with_set_values(), ids=get_key)
+def test_set_config(test_data):
+    assert test_data.expected == test_data.loaded
+
+
+# These are all the configuration options defined in the schema (main schema file only)
+# with values that differ from schema defaults. The values carry no meaning; they serve
+# the purpose of testing whether a config option can be set.
+#
+# Commented values indicate failing tests and require fixing. In many cases it's a bug
+# (i.e., a property is not correctly set). Ideally, none should be commented out.
+SET_CONFIG = {
+    # 'amqp_internal_connection': 'sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE_new', TODO
+    # 'auth_config_file': 'auth_conf_new.xml',  # cause: parse_config_file_options TODO
+    # 'build_sites_config_file': 'build_sites.yml_new',  # cause: parse_config_file_options
+    # 'builds_file_path': 'shared/ucsc/builds.txt',
+    # 'citation_cache_data_dir': 'citations/data',
+    # 'citation_cache_lock_dir': 'citations/locks',
+    # 'cluster_files_directory': 'pbs',
+    # 'containers_resolvers_config_file': 'None',  # cause: parse_config_file_options
+    # 'data_dir': 'data_new', TODO
+    # 'data_manager_config_file': 'config/data_manager_conf.xml',  # cause: parse_config_file_options
+    # 'database_connection': 'database_connection',
+    # 'dependency_resolvers_config_file': 'dependency_resolvers_conf.xml',  # cause: parse_config_file_options
+    # 'disable_library_comptypes': 'None',
+    # 'dynamic_proxy_session_map': 'session_map.sqlite',
+    # 'email_domain_allowlist_file': 'None',
+    # 'email_domain_blocklist_file': 'None',
+    # 'enable_beta_gdpr': True,  TODO
+    # 'file_path': 'objects',  # cause: parse_config_file_options
+    # 'ftp_upload_dir_template': 'None',
+    # 'galaxy_data_manager_data_path': 'None',
+    # 'integrated_tool_panel_config': 'integrated_tool_panel.xml',
+    # 'interactive_environment_plugins_directory': 'None',
+    # 'interactivetools_map': 'interactivetools_map.sqlite',
+    # 'interactivetools_proxy_host': 'None',
+    # 'involucro_path': 'involucro',
+    # 'job_config_file': 'config/job_conf.xml',  # cause: parse_config_file_options
+    # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
+    # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
+    # 'len_file_path': 'shared/ucsc/chrom',
+    # 'markdown_export_css': 'markdown_export.css',  # cause: parse_config_file_options
+    # 'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css',
+    # 'markdown_export_css_pages': 'markdown_export_pages.css',  # cause: parse_config_file_options
+    # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
+    # 'mulled_resolution_cache_data_dir': 'mulled/data',
+    # 'mulled_resolution_cache_lock_dir': 'mulled/locks',
+    # 'new_file_path': 'tmp',
+    # 'nginx_upload_store': 'None',
+    # 'object_store_config_file': 'object_store_conf.xml',  # cause: parse_config_file_options
+    # 'object_store_store_by': 'None',
+    # 'oidc_backends_config_file': 'oidc_backends_config.xml',  # cause: parse_config_file_options
+    # 'oidc_config_file': 'oidc_config.xml',  # cause: parse_config_file_options
+    # 'openid_consumer_cache_path': 'openid_consumer_cache',
+    # 'sanitize_allowlist_file': 'sanitize_allowlist.txt',
+    # 'shed_data_manager_config_file': 'shed_data_manager_conf.xml',  # cause: parse_config_file_options
+    # 'shed_tool_config_file': 'shed_tool_conf.xml',  # cause: parse_config_file_options
+    # 'shed_tool_data_path': 'None',
+    # 'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml',  # cause: parse_config_file_options
+    # 'single_user': 'single_user_new',
+    # 'statsd_host': 'None',
+    # 'template_cache_path': 'compiled_templates',
+    # 'tool_cache_data_dir': 'tool_cache',
+    # 'tool_config_file': config/tool_conf.xml,
+    # 'tool_data_path': 'tool-data',
+    # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
+    # 'tool_path': 'tools',
+    # 'tool_search_index_dir': 'tool_search_index',
+    # 'tool_sheds_config_file': 'tool_sheds_conf.xml',  # cause: parse_config_file_options
+    # 'tool_test_data_directories': 'test-data',
+    # 'use_remote_user': True,
+    # 'user_library_import_dir_auto_creation': True,
+    # 'user_preferences_extra_conf_path': 'user_preferences_extra_conf.yml',  # cause: parse_config_file_options
+    # 'workflow_resource_params_file': 'workflow_resource_params_conf.xml',  # cause: parse_config_file_options
+    # 'workflow_resource_params_mapper': 'None',
+    # 'workflow_schedulers_config_file': 'workflow_schedulers_conf.xml',  # cause: parse_config_file_options
+    'activation_grace_period': 2,
+    'admin_tool_recommendations_path': 'tool_recommendations_overwrite_new.yml',
+    'admin_users': 'admin_users_new',
+    'allow_path_paste': True,
+    'allow_user_creation': False,
+    'allow_user_dataset_purge': False,
+    'allow_user_deletion': True,
+    'allow_user_impersonation': True,
+    'allowed_origin_hostnames': 'allowed_origin_hostnames_new',
+    'apache_xsendfile': True,
+    'api_allow_run_as': 'api_allow_run_as_new',
+    'auto_configure_logging': False,
+    'aws_estimate': True,
+    'brand': 'brand_new',
+    'cache_user_job_count': True,
+    'check_job_script_integrity': False,
+    'check_job_script_integrity_count': 34,
+    'check_job_script_integrity_sleep': 0.24,
+    'check_migrate_tools': True,
+    'chunk_upload_size': 104857601,
+    'citation_cache_type': 'file_new',
+    'citation_url': 'https://galaxyproject.org/citing-galaxy/new',
+    'cleanup_job': 'never',
+    'communication_server_host': 'http://localhost_new',
+    'communication_server_port': 7071,
+    'conda_auto_init': False,
+    'conda_auto_install': True,
+    'conda_copy_dependencies': True,
+    'conda_debug': True,
+    'conda_ensure_channels': 'conda_ensure_channels_new',
+    'conda_exec': 'conda_exec_new',
+    'conda_prefix': 'conda_prefix_new',
+    'conda_use_local': True,
+    'config_dir': 'config_new',
+    'cookie_domain': 'cookie_domain_new',
+    'database_auto_migrate': True,
+    'database_engine_option_echo': True,
+    'database_engine_option_echo_pool': True,
+    'database_engine_option_max_overflow': 9,
+    'database_engine_option_pool_recycle': 0,
+    'database_engine_option_pool_size': 4,
+    'database_engine_option_server_side_cursors': True,
+    'database_log_query_counts': True,
+    'database_query_profiling_proxy': True,
+    'database_template': 'database_template_new',
+    'database_wait': True,
+    'database_wait_attempts': 61,
+    'database_wait_sleep': 1.1,
+    'datatypes_config_file': 'datatypes_conf.xml_new',  # cause: parse_config_file_options
+    'datatypes_disable_auto': True,
+    'debug': True,
+    'default_job_resubmission_condition': 'default_job_resubmission_condition_new',
+    'default_job_shell': '/bin/bash_new',
+    'default_locale': 'auto_new',
+    'default_workflow_export_format': 'ga_new',
+    'delay_tool_initialization': True,
+    'dependency_resolution': 'dependency_resolution_new',
+    'dependency_resolvers': 'dependency_resolvers_new',
+    'display_chunk_size': 65537,
+    'display_galaxy_brand': False,
+    'display_servers': 'display_servers_new',
+    'drmaa_external_killjob_script': 'drmaa_external_killjob_script_new',
+    'drmaa_external_runjob_script': 'drmaa_external_runjob_script_new',
+    'dynamic_proxy': 'node_new',
+    'dynamic_proxy_bind_ip': '0.0.0.1',
+    'dynamic_proxy_bind_port': 8801,
+    'dynamic_proxy_debug': True,
+    'dynamic_proxy_external_proxy': True,
+    'dynamic_proxy_golang_api_key': 'dynamic_proxy_golang_api_key_new',
+    'dynamic_proxy_golang_clean_interval': 11,
+    'dynamic_proxy_golang_docker_address': 'unix:///var/run/docker.sock_new',
+    'dynamic_proxy_golang_noaccess': 61,
+    'dynamic_proxy_manage': False,
+    'dynamic_proxy_prefix': 'gie_proxy_new',
+    'email_from': 'email_from_new',
+    'enable_beta_containers_interface': True,
+    'enable_beta_markdown_export': True,
+    'enable_beta_workflow_modules': True,
+    'enable_communication_server': True,
+    'enable_data_manager_user_view': True,
+    'enable_job_recovery': False,
+    'enable_legacy_sample_tracking_api': True,
+    'enable_mulled_containers': False,
+    'enable_oidc': True,
+    'enable_old_display_applications': False,
+    'enable_openid': True,
+    'enable_per_request_sql_debugging': True,
+    'enable_quotas': True,
+    'enable_tool_recommendations': True,
+    'enable_tool_shed_check': True,
+    'enable_tool_tags': True,
+    'enable_unique_workflow_defaults': True,
+    'environment_setup_file': 'environment_setup_file_new',
+    'error_email_to': 'error_email_to_new',
+    'expose_dataset_path': True,
+    'expose_potentially_sensitive_job_metrics': True,
+    'expose_user_name': True,
+    'external_chown_script': 'external_chown_script_new',
+    'fetch_url_allowlist': '10.10.10.10',
+    'fluent_host': 'localhost_new',
+    'fluent_log': True,
+    'fluent_port': 24225,
+    'force_beta_workflow_scheduled_for_collections': True,
+    'force_beta_workflow_scheduled_min_steps': 251,
+    'ftp_upload_dir': 'ftp_upload_dir_new',
+    'ftp_upload_dir_identifier': 'ftp_upload_dir_identifier_new',
+    'ftp_upload_purge': False,
+    'ftp_upload_site': 'ftp_upload_site_new',
+    'ga_code': 'ga_code_new',
+    'galaxy_infrastructure_url': 'http://localhost:8081',
+    'galaxy_infrastructure_web_port': 8082,
+    'heartbeat_interval': 21,
+    'heartbeat_log': 'heartbeat_{server_name}.log_new',
+    'helpsite_url': 'helpsite_url_new',
+    'history_local_serial_workflow_scheduling': True,
+    'hours_between_check': 11,
+    'id_secret': 'id_secret_new',
+    'inactivity_box_content': 'inactivity_box_content_new',
+    'install_database_connection': 'install_database_connection_new',
+    'instance_resource_url': 'instance_resource_url_new',
+    'interactivetools_enable': True,
+    'involucro_auto_init': False,
+    'job_config': 'job_config_new',
+    'job_working_directory': 'jobs_directory_new',
+    'legacy_eager_objectstore_initialization': True,
+    'library_import_dir': 'library_import_dir_new',
+    'local_task_queue_workers': 3,
+    'log_actions': True,
+    'log_events': True,
+    'log_level': 'INFO',
+    'logging': 'loggin_new',
+    'logo_url': '/new',
+    'mailing_join_addr': 'mailing_join_addr_new',
+    'mailing_lists_url': 'https://galaxyproject.org/mailing-lists/new',
+    'managed_config_dir': 'managed_config_new',
+    'markdown_export_epilogue': 'markdown_export_epilogue_new',
+    'markdown_export_epilogue_invocation_reports': 'markdown_export_epilogue_invocation_reports_new',
+    'markdown_export_epilogue_pages': 'markdown_export_epilogue_pages_new',
+    'markdown_export_prologue': 'markdown_export_prologue_new',
+    'markdown_export_prologue_invocation_reports': 'markdown_export_prologue_invocation_reports_new',
+    'markdown_export_prologue_pages': 'markdown_export_prologue_pages_new',
+    'master_api_key': 'master_api_key_new',
+    'max_metadata_value_size': 5242881,
+    'maximum_workflow_invocation_duration': 2678401,
+    'maximum_workflow_jobs_per_scheduling_iteration': 0,
+    'message_box_class': 'message_box_class_new',
+    'message_box_content': 'message_box_content_new',
+    'message_box_visible': True,
+    'monitor_thread_join_timeout': 31,
+    'mulled_channels': 'conda-forge,bioconda_new',
+    'mulled_resolution_cache_type': 'file_new',
+    'myexperiment_target_url': 'www.myexperiment.org:81',
+    'new_user_dataset_access_role_default_private': True,
+    'nginx_upload_job_files_path': 'nginx_upload_job_files_path_new',
+    'nginx_upload_job_files_store': 'nginx_upload_job_files_store_new',
+    'nginx_upload_path': 'nginx_upload_path_new',
+    'nginx_x_accel_redirect_base': 'nginx_x_accel_redirect_base_new',
+    'normalize_remote_user_email': True,
+    'outputs_to_working_directory': True,
+    'overwrite_model_recommendations': True,
+    'parallelize_workflow_scheduling_within_histories': True,
+    'password_expiration_period': 1,
+    'persistent_communication_rooms': 'persistent_communication_rooms_new',
+    'precache_dependencies': False,
+    'preserve_python_environment': 'always',
+    'pretty_datetime_format': '$locale (UTC)_new',
+    'qa_url': 'qa_url_new',
+    'real_system_username': 'user_email_new',
+    'refgenie_config_file': 'refgenie_config_file_new',
+    'registration_warning_message': 'registration_warning_message_new',
+    'remote_user_header': 'HTTP_REMOTE_USER_new',
+    'remote_user_logout_href': 'remote_user_logout_href_new',
+    'remote_user_maildomain': 'remote_user_maildomain_new',
+    'remote_user_secret': 'remote_user_secret_new',
+    'require_login': True,
+    'retry_job_output_collection': 1,
+    'retry_metadata_internally': False,
+    'sanitize_all_html': False,
+    'screencasts_url': 'https://vimeo.com/galaxyproject/new',
+    'search_url': 'https://galaxyproject.org/search/new',
+    'select_type_workflow_threshold': 0,
+    'sentry_dsn': 'sentry_dsn_new',
+    'sentry_sloreq_threshold': 0.1,
+    'serve_xss_vulnerable_mimetypes': True,
+    'session_duration': 1,
+    'show_user_prepopulate_form': True,
+    'show_welcome_with_login': True,
+    'slow_query_log_threshold': 0.1,
+    'smtp_password': 'smtp_password_new',
+    'smtp_server': 'smtp_server_new',
+    'smtp_ssl': True,
+    'smtp_username': 'smtp_username_new',
+    'sniff_compressed_dynamic_datatypes_default': False,
+    'static_cache_time': 361,
+    'static_dir': 'static/_new',
+    'static_enabled': False,
+    'static_favicon_dir': 'static/favicon.ico_new',
+    'static_images_dir': 'static/images_new',
+    'static_robots_txt': 'static/robots.txt_new',
+    'static_scripts_dir': 'static/scripts/_new',
+    'static_style_dir': 'static/style_new',
+    'statsd_influxdb': True,
+    'statsd_port': 8126,
+    'statsd_prefix': 'galaxy_new',
+    'support_url': 'https://galaxyproject.org/support/new',
+    'terms_url': 'terms_url_new',
+    'tool_dependency_cache_dir': 'tool_dependency_cache_dir_new',
+    'tool_dependency_dir': 'dependencies_new',
+    'tool_description_boost': 2.1,
+    'tool_enable_ngram_search': True,
+    'tool_filters': 'tool_filters_new',
+    'tool_help_boost': 0.6,
+    'tool_label_boost': 1.1,
+    'tool_label_filters': 'tool_label_filters_new',
+    'tool_name_boost': 9.1,
+    'tool_ngram_maxsize': 5,
+    'tool_ngram_minsize': 4,
+    'tool_recommendation_model_path': 'tool_recommendation_model_path_new',
+    'tool_search_limit': 21,
+    'tool_section_boost': 3.1,
+    'tool_section_filters': 'tool_section_filters_new',
+    'tool_stub_boost': 5.1,
+    'toolbox_filter_base_modules': 'galaxy.tools.filters,galaxy.tools.toolbox.filters_new',
+    'topk_recommendations': 11,
+    'tour_config_dir': 'config/plugins/tours_new',
+    'track_jobs_in_database': False,
+    'transfer_manager_port': 8164,
+    'trust_jupyter_notebook_conversion': True,
+    'upstream_gzip': True,
+    'use_cached_dependency_manager': True,
+    'use_heartbeat': True,
+    'use_lint': True,
+    'use_pbkdf2': False,
+    'use_printdebug': False,
+    'use_profile': True,
+    'use_tasked_jobs': True,
+    'user_activation_on': True,
+    'user_library_import_check_permissions': True,
+    'user_library_import_dir': 'user_library_import_dir_new',
+    'user_library_import_symlink_allowlist': 'user_library_import_symlink_allowlist_new',
+    'user_tool_filters': 'examples:restrict_upload_to_admins, examples:restrict_encode_new',
+    'user_tool_label_filters': 'examples:restrict_upload_to_admins, examples:restrict_encode_new',
+    'user_tool_section_filters': 'examples:restrict_text_new',
+    'visualization_plugins_directory': 'config/plugins/visualizations_new',
+    'visualizations_visible': False,
+    'watch_core_config': 'auto',
+    'watch_job_rules': 'auto',
+    'watch_tool_data_dir': 'auto',
+    'watch_tools': 'auto',
+    'watch_tours': 'auto',
+    'webhooks_dir': 'config/plugins/webhooks_new',
+    'welcome_url': '/static/welcome_new.html',
+    'wiki_url': 'https://galaxyproject.org/new',
+    'x_frame_options': 'SAMEORIGIN_new',
+}

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -114,7 +114,7 @@ class ExpectedValuesProvider:
                 'cluster_files_directory': self._in_data_dir,
                 'config_dir': self._resolve_config_dir,
                 'data_dir': self._resolve_data_dir,
-                'data_manager_config_file': self._in_config_dir, 
+                'data_manager_config_file': self._in_config_dir,
                 'database_connection': self._resolve_database_connection,
                 'dependency_resolvers_config_file': self._in_config_dir,
                 'dynamic_proxy_session_map': self._in_data_dir,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -334,7 +334,6 @@ SET_CONFIG = {
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_store_by': 'new',
-    # 'oidc_backends_config_file': 'oidc_backends_config.xml',  # cause: parse_config_file_options
     # 'oidc_config_file': 'oidc_config.xml',  # cause: parse_config_file_options
     # 'shed_data_manager_config_file': 'shed_data_manager_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_config_file': 'shed_tool_conf.xml',  # cause: parse_config_file_options
@@ -531,6 +530,7 @@ SET_CONFIG = {
     'nginx_x_accel_redirect_base': 'nginx_x_accel_redirect_base_new',
     'normalize_remote_user_email': True,
     'object_store_config_file': 'object_store_conf.xml_new',
+    'oidc_backends_config_file': 'oidc_backends_config.xml_new',
     'openid_consumer_cache_path': 'openid_consumer_cache_new',
     'outputs_to_working_directory': True,
     'overwrite_model_recommendations': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -13,11 +13,10 @@ TestData = namedtuple('TestData', ('key', 'expected', 'loaded'))
 
 
 DO_NOT_TEST = {
-    'data_manager_config_file',     # fix schema
-    'datatypes_config_file',        # fix schema  TODO!!!!!!!!!!
-    'job_config_file',              # fix schema  TODO!!!!!!!!!!
-    'tool_config_file',             # fix schema
-    'tool_data_table_config_path',  # fix schema
+    'data_manager_config_file',     # fix schema+
+    'datatypes_config_file',        # fix schema; parse_config_files
+    'tool_config_file',             # fix schema; parse_config_files
+    'tool_data_table_config_path',  # fix schema; parse_config_files
 }
 
 
@@ -126,6 +125,7 @@ class ExpectedValuesProvider:
                 'integrated_tool_panel_config': self._in_managed_config_dir,
                 'interactivetools_map': self._in_data_dir,
                 'involucro_path': self._in_root_dir,
+                'job_config_file': self._in_config_dir,
                 'job_resource_params_file': self._in_config_dir,
                 'len_file_path': self._in_tool_data_dir,
                 'managed_config_dir': self._resolve_managed_config_dir,
@@ -479,7 +479,7 @@ SET_CONFIG = {
     'involucro_auto_init': False,
     'involucro_path': 'involucro_new',
     'job_config': 'job_config_new',
-    'job_config_file': 'config/job_conf.xml_new',
+    'job_config_file': 'job_conf.xml_new',
     'job_resource_params_file': 'job_resource_params_conf.xml_new',
     'job_working_directory': 'jobs_directory_new',
     'legacy_eager_objectstore_initialization': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -332,7 +332,6 @@ SET_CONFIG = {
     # 'interactivetools_map': 'interactivetools_map.sqlite_new',
     # 'interactivetools_proxy_host': 'new',
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
-    # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_config_file': 'object_store_conf.xml',  # cause: parse_config_file_options
     # 'object_store_store_by': 'new',
@@ -518,6 +517,7 @@ SET_CONFIG = {
     'message_box_class': 'message_box_class_new',
     'message_box_content': 'message_box_content_new',
     'message_box_visible': True,
+    'migrated_tools_config': 'migrated_tools_conf.xml_new',
     'monitor_thread_join_timeout': 31,
     'mulled_channels': 'conda-forge,bioconda_new',
     'mulled_resolution_cache_data_dir': 'mulled/data_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -334,7 +334,6 @@ SET_CONFIG = {
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_store_by': 'new',
-    # 'oidc_config_file': 'oidc_config.xml',  # cause: parse_config_file_options
     # 'shed_data_manager_config_file': 'shed_data_manager_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_config_file': 'shed_tool_conf.xml',  # cause: parse_config_file_options
     # 'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml',  # cause: parse_config_file_options
@@ -531,6 +530,7 @@ SET_CONFIG = {
     'normalize_remote_user_email': True,
     'object_store_config_file': 'object_store_conf.xml_new',
     'oidc_backends_config_file': 'oidc_backends_config.xml_new',
+    'oidc_config_file': 'oidc_config.xml_new',
     'openid_consumer_cache_path': 'openid_consumer_cache_new',
     'outputs_to_working_directory': True,
     'overwrite_model_recommendations': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -166,6 +166,7 @@ class ExpectedValuesProvider:
                 'user_tool_filters': listify_strip,
                 'user_tool_label_filters': listify_strip,
                 'user_tool_section_filters': listify_strip,
+                'workflow_resource_params_mapper': self._resolve_workflow_resource_params_mapper,
                 'workflow_resource_params_file': self._in_config_dir,
                 'workflow_schedulers_config_file': self._in_config_dir,
             }
@@ -249,6 +250,11 @@ class ExpectedValuesProvider:
             return self._in_root_dir(path)
         return self._tool_data_path
 
+    def _resolve_workflow_resource_params_mapper(self, value=None):
+        if value:
+            return self._in_root_dir(value)
+        return None
+
     def get_expected_value(self, key, set_value=None):
         default_value = self.schema_defaults.get(key)
         # If value not set, use schema default
@@ -307,8 +313,6 @@ def test_default_config(test_data):
 
 @pytest.mark.parametrize('test_data', get_test_data_with_set_values(), ids=get_key)
 def test_set_config(test_data):
-    if test_data.key == 'data_dir':
-        print(test_data)
     assert test_data.expected == test_data.loaded
 
 
@@ -341,7 +345,6 @@ SET_CONFIG = {
     # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
     # 'tool_test_data_directories': 'test-data_new',
     # 'use_remote_user': True,
-    # 'workflow_resource_params_mapper': 'new',
     'activation_grace_period': 2,
     'admin_tool_recommendations_path': 'tool_recommendations_overwrite_new.yml',
     'admin_users': 'admin_users_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -326,7 +326,6 @@ SET_CONFIG = {
     # 'amqp_internal_connection': 'sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE_new',
     # 'build_sites_config_file': 'build_sites.yml_new',  # cause: parse_config_file_options
     # 'containers_resolvers_config_file': 'None',  # cause: parse_config_file_options
-    # 'data_manager_config_file': 'config/data_manager_conf.xml',  # TODO: driver_util causes further errors
     # 'database_connection': 'database_connection',
     # 'disable_library_comptypes': 'None',
     # 'enable_beta_gdpr': True,
@@ -384,6 +383,7 @@ SET_CONFIG = {
     'config_dir': 'config_new',
     'cookie_domain': 'cookie_domain_new',
     'data_dir': 'data_new',
+    'data_manager_config_file': 'data_manager_conf.xml_new',
     'database_auto_migrate': True,
     'database_engine_option_echo': True,
     'database_engine_option_echo_pool': True,

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -320,7 +320,6 @@ def test_set_config(test_data):
 # (i.e., a property is not correctly set). Ideally, none should be commented out.
 SET_CONFIG = {
     # 'amqp_internal_connection': 'sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE_new',
-    # 'auth_config_file': 'auth_conf_new.xml',  # cause: parse_config_file_options
     # 'build_sites_config_file': 'build_sites.yml_new',  # cause: parse_config_file_options
     # 'containers_resolvers_config_file': 'None',  # cause: parse_config_file_options
     # 'data_manager_config_file': 'config/data_manager_conf.xml',  # cause: parse_config_file_options
@@ -369,6 +368,7 @@ SET_CONFIG = {
     'allowed_origin_hostnames': 'allowed_origin_hostnames_new',
     'apache_xsendfile': True,
     'api_allow_run_as': 'api_allow_run_as_new',
+    'auth_config_file': 'auth_conf_new.xml',
     'auto_configure_logging': False,
     'aws_estimate': True,
     'brand': 'brand_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -341,7 +341,6 @@ SET_CONFIG = {
     # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
     # 'tool_test_data_directories': 'test-data_new',
     # 'use_remote_user': True,
-    # 'workflow_resource_params_file': 'workflow_resource_params_conf.xml',  # cause: parse_config_file_options
     # 'workflow_resource_params_mapper': 'new',
     # 'workflow_schedulers_config_file': 'workflow_schedulers_conf.xml',  # cause: parse_config_file_options
     'activation_grace_period': 2,
@@ -636,5 +635,6 @@ SET_CONFIG = {
     'webhooks_dir': 'config/plugins/webhooks_new',
     'welcome_url': '/static/welcome_new.html',
     'wiki_url': 'https://galaxyproject.org/new',
+    'workflow_resource_params_file': 'workflow_resource_params_conf.xml_new',
     'x_frame_options': 'SAMEORIGIN_new',
 }

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -342,7 +342,6 @@ SET_CONFIG = {
     # 'tool_test_data_directories': 'test-data_new',
     # 'use_remote_user': True,
     # 'workflow_resource_params_mapper': 'new',
-    # 'workflow_schedulers_config_file': 'workflow_schedulers_conf.xml',  # cause: parse_config_file_options
     'activation_grace_period': 2,
     'admin_tool_recommendations_path': 'tool_recommendations_overwrite_new.yml',
     'admin_users': 'admin_users_new',
@@ -636,5 +635,6 @@ SET_CONFIG = {
     'welcome_url': '/static/welcome_new.html',
     'wiki_url': 'https://galaxyproject.org/new',
     'workflow_resource_params_file': 'workflow_resource_params_conf.xml_new',
+    'workflow_schedulers_config_file': 'workflow_schedulers_conf.xml_new',
     'x_frame_options': 'SAMEORIGIN_new',
 }

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -338,7 +338,6 @@ SET_CONFIG = {
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_store_by': 'new',
-    # 'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml',  # cause: parse_config_file_options
     # 'statsd_host': 'None',
     # 'tool_config_file': config/tool_conf.xml,
     # 'tool_data_table_config_path': 'config/tool_data_table_conf.xml',
@@ -560,6 +559,7 @@ SET_CONFIG = {
     'shed_data_manager_config_file': 'shed_data_manager_conf.xml_new',
     'shed_tool_config_file': 'shed_tool_conf.xml_new',
     'shed_tool_data_path': 'new',
+    'shed_tool_data_table_config': 'shed_tool_data_table_conf.xml_new',
     'show_user_prepopulate_form': True,
     'show_welcome_with_login': True,
     'single_user': 'single_user_new',

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -335,7 +335,6 @@ SET_CONFIG = {
     # 'job_config_file': 'config/job_conf.xml',  # cause: parse_config_file_options
     # 'job_metrics_config_file': 'job_metrics_conf.xml',  # cause: parse_config_file_options
     # 'job_resource_params_file': 'job_resource_params_conf.xml',  # cause: parse_config_file_options
-    # 'markdown_export_css_pages': 'markdown_export_pages.css_new',  # cause: parse_config_file_options
     # 'migrated_tools_config': 'migrated_tools_conf.xml',  # cause: parse_config_file_options
     # 'nginx_upload_store': 'new',
     # 'object_store_config_file': 'object_store_conf.xml',  # cause: parse_config_file_options
@@ -505,6 +504,7 @@ SET_CONFIG = {
     'managed_config_dir': 'managed_config_new',
     'markdown_export_css': 'markdown_export.css_new',
     'markdown_export_css_invocation_reports': 'markdown_export_invocation_reports.css_new',
+    'markdown_export_css_pages': 'markdown_export_pages.css_new',
     'markdown_export_epilogue': 'markdown_export_epilogue_new',
     'markdown_export_epilogue_invocation_reports': 'markdown_export_epilogue_invocation_reports_new',
     'markdown_export_epilogue_pages': 'markdown_export_epilogue_pages_new',

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -117,19 +117,30 @@ def test_set_renamed_option_not_overridden_by_old_option(mock_init):
 
 def test_is_set(mock_init):
     # if an option is set from kwargs, is_set() returns True, otherwise False
-    # Note: is_set() here means 'value is set by user', which includes setting to None.
-    config = GalaxyAppConfiguration(property1='b', property2=None, property4=False, property6=None)
+    # Note: is_set() here means 'value is set by user', which includes setting
+    # to None or setting to the same value as the schema default.
 
-    assert len(config._raw_config) == 6
+    # First, test that none are set
+    config = GalaxyAppConfiguration()
+    assert not config.is_set('property1')
+    assert not config.is_set('property2')
+    assert not config.is_set('property3')
+    assert not config.is_set('property4')
+    assert not config.is_set('property5')
+    assert not config.is_set('property6')
 
-    assert config._raw_config['property1'] == 'b'
-    assert config._raw_config['property2'] is None
-    assert config._raw_config['property3'] == 1.0
-    assert config._raw_config['property4'] is False
-    assert config._raw_config['property6'] is None
+    # Now set all values, including setting to None and setting to the schema default
+    config = GalaxyAppConfiguration(
+        property1='b',    # default = 'a'  (overwrites default w/'a')
+        property2=None,   # default = 1    (overwrites default w/None)
+        property3=1.0,    # default = 1.0  (same as default: 1.0)
+        property4=True,   # default = True (same as default: True)
+        property5=None,   # default = None (same as default: None)
+        property6=1)      # default = None (overwrites default w/None)
 
-    assert config.is_set('property1')  # 'b' overwrites 'a'
-    assert config.is_set('property2')  # None overwrites 1
-    assert not config.is_set('property3')  # default 1.0 preserved
-    assert config.is_set('property4')  # False overwrites True
-    assert not config.is_set('property6')  # supplied value is same as default (None)
+    assert config.is_set('property1')
+    assert config.is_set('property2')
+    assert config.is_set('property3')
+    assert config.is_set('property4')
+    assert config.is_set('property4')
+    assert config.is_set('property6')

--- a/test/unit/config/test_load_config.py
+++ b/test/unit/config/test_load_config.py
@@ -113,3 +113,23 @@ def test_set_renamed_option_not_overridden_by_old_option(mock_init):
     config = GalaxyAppConfiguration(old_property1='b', property1='c')
 
     assert config._raw_config['property1'] == 'c'
+
+
+def test_is_set(mock_init):
+    # if an option is set from kwargs, is_set() returns True, otherwise False
+    # Note: is_set() here means 'value is set by user', which includes setting to None.
+    config = GalaxyAppConfiguration(property1='b', property2=None, property4=False, property6=None)
+
+    assert len(config._raw_config) == 6
+
+    assert config._raw_config['property1'] == 'b'
+    assert config._raw_config['property2'] is None
+    assert config._raw_config['property3'] == 1.0
+    assert config._raw_config['property4'] is False
+    assert config._raw_config['property6'] is None
+
+    assert config.is_set('property1')  # 'b' overwrites 'a'
+    assert config.is_set('property2')  # None overwrites 1
+    assert not config.is_set('property3')  # default 1.0 preserved
+    assert config.is_set('property4')  # False overwrites True
+    assert not config.is_set('property6')  # supplied value is same as default (None)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -180,6 +180,9 @@ class MockAppConfig(Bunch):
         return self.dict()
 
     def __getattr__(self, name):
+        # Handle the automatic [option]_set options: for tests, assume none are set
+        if name == 'is_set':
+            return lambda x: False
         # Handle the automatic config file _set options
         if name.endswith('_file_set'):
             return False

--- a/test/unit/webapps/test_webapp_base.py
+++ b/test/unit/webapps/test_webapp_base.py
@@ -24,7 +24,8 @@ class CORSParsingMockConfig(galaxy_mock.MockAppConfig):
 
     @staticmethod
     def _parse_allowed_origin_hostnames(kwargs):
-        return galaxy.config.Configuration._parse_allowed_origin_hostnames(kwargs)
+        hostnames = kwargs.get('allowed_origin_hostnames')
+        return galaxy.config.Configuration._parse_allowed_origin_hostnames(hostnames)
 
 
 class GalaxyWebTransaction_Headers_TestCase(unittest.TestCase):


### PR DESCRIPTION
[This is close to done.]

Fixes #9973 (here's the description of a specific bug: https://github.com/galaxyproject/galaxy/issues/9973#issuecomment-655792443)

**Overall problem.** We had tests (both integration and unit) for testing *default* values of configuration options. We did *not* test overriding those defaults. Which is why we were not catching at least one type of bugs (9973 shows one that surfaced). The issues are due to non-uniform processing of config options: we load them uniformly ([using defaults from the schema, adding some processing steps, etc.](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/config/__init__.py#L114)). But then we reload some of them in `parse_config_file_options` - which overrides not only the schema defaults, but also any processing steps previously executed. User-set relative config file paths being resolved with respect to the root directory instead of their correct location is one example of a bug. Not being able to set any of the options that pass through `parse_config_file_options` to `None` is another unintended consequence (currently, the user *can* explicitly set all other config options to `None`; if we want to disallow this for these options, we can do that explicitly, and not as an implicit side-effect).

**What this PR contains:** 
- Tests for loading config option defaults (326 out of 329) + overriding defaults (302 out of 329). Tests for default values have been partially rewritten (they should be simpler now, much easier to read)
- Changes to config module, config schema + minor edits to a few other modules (those that made use of `app.config.foo_set`: this has been replaced with `app.config.is_set('foo')`)
- Minor edits to the testing infrastructure enabling testing of these options (mostly different handling of loading values into the mock config)
The config schema has been changed to make use of `path_resolves_to` instead of hardcoding prefixes (`config/`, `data/`, etc.).

The PR consists of many commits - that's intentional. Each commit is focused on one change; the commit message contains details about what was done and why. The "Refactor processing of ..." commit messages are not all the same.

This PR will be ready for final review in a few more commits: my goal is to remove `parse_config_file_options` and enable tests for the few remaining config options. Meanwhile, any feedback is, as always, very much appreciated.

When this is done, I'll write a "How-to" entry on configuration edits for the documentation.





