### PR TITLE
Fix and simplify built-in trim tool

### DIFF
--- a/tools/filters/trimmer.py
+++ b/tools/filters/trimmer.py
@@ -18,32 +18,29 @@ options (listed below) default to 'None' if omitted
 
     parser.add_option(
         '-a', '--ascii',
-        dest='ascii',
         action='store_true',
         default=False,
         help='Use ascii codes to defined ignored beginnings instead of raw characters')
 
     parser.add_option(
         '-q', '--fastq',
-        dest='fastq',
         action='store_true',
         default=False,
         help='The input data in fastq format. It selected the script skips every even line since they contain sequence ids')
 
     parser.add_option(
         '-i', '--ignore',
-        dest='ignore',
         help='A comma separated list on ignored beginnings (e.g., ">,@"), or its ascii codes (e.g., "60,42") if option -a is enabled')
 
     parser.add_option(
         '-s', '--start',
-        dest='start',
-        default='0',
+        type='int',
+        default=0,
         help='Trim from beginning to here (1-based)')
 
     parser.add_option(
         '-e', '--end',
-        dest='end',
+        type='int',
         default='0',
         help='Trim from here to the ned (1-based)')
 
@@ -55,6 +52,7 @@ options (listed below) default to 'None' if omitted
 
     parser.add_option(
         '-c', '--column',
+        type='int',
         dest='col',
         default='0',
         help='Column to chop. If 0 = chop the whole line')
@@ -68,13 +66,10 @@ options (listed below) default to 'None' if omitted
         infile = sys.stdin
 
     if options.ignore and options.ignore != "None":
-        invalid_starts = options.ignore.split(',')
-
-    if options.ascii and options.ignore and options.ignore != "None":
-        for i, item in enumerate(invalid_starts):
-            invalid_starts[i] = chr(int(item))
-
-    col = int(options.col)
+        invalid_starts = set(
+            chr(int(c)) if options.ascii else c
+            for c in options.ignore.split(',')
+        )
 
     for i, line in enumerate(infile):
         line = line.rstrip('\r\n')
@@ -84,26 +79,20 @@ options (listed below) default to 'None' if omitted
                 continue
 
             if line[0] not in invalid_starts:
-                if col == 0:
-                    if int(options.end) > 0:
-                        line = line[int(options.start) - 1:int(options.end)]
-                    elif int(options.end) < 0:
-                        endposition = len(line) + int(options.end)
-                        line = line[int(options.start) - 1:endposition]
+                if options.col == 0:
+                    if options.end == 0:
+                        line = line[options.start - 1:]
                     else:
-                        line = line[int(options.start) - 1:]
+                        line = line[options.start - 1:options.end]
                 else:
                     fields = line.split('\t')
-                    if col - 1 > len(fields):
-                        stop_err('Column %d does not exist. Check input parameters\n' % col)
+                    if options.col > len(fields):
+                        stop_err('Column %d does not exist. Check input parameters\n' % options.col)
 
-                    if int(options.end) > 0:
-                        fields[col - 1] = fields[col - 1][int(options.start) - 1:int(options.end)]
-                    elif int(options.end) < 0:
-                        endposition = len(fields[col - 1]) + int(options.end)
-                        fields[col - 1] = fields[col - 1][int(options.start) - 1:endposition]
+                    if options.end == 0:
+                        fields[options.col - 1] = fields[options.col - 1][options.start - 1:]
                     else:
-                        fields[col - 1] = fields[col - 1][int(options.start) - 1:]
+                        fields[options.col - 1] = fields[options.col - 1][options.start - 1:options.end]
                     line = '\t'.join(fields)
             print(line)
 

--- a/tools/filters/trimmer.xml
+++ b/tools/filters/trimmer.xml
@@ -1,5 +1,8 @@
-<tool id="trimmer" name="Trim" version="0.0.1">
+<tool id="trimmer" name="Trim" version="0.0.2">
     <description>leading or trailing characters</description>
+    <requirements>
+        <requirement type="package" version="3.8">python</requirement>
+    </requirements>
     <command detect_errors="exit_code">
 <![CDATA[
 python '$__tool_directory__/trimmer.py' -a -f '$input1' -c $col -s $start -e $end -i '$ignore' $fastq > '$out_file1'
@@ -8,7 +11,7 @@ python '$__tool_directory__/trimmer.py' -a -f '$input1' -c $col -s $start -e $en
     <inputs>
         <param name="input1" type="data" format="tabular,txt" label="Input dataset" />
         <param name="col" type="integer" value="0" label="Trim this column only" help="0 = process entire line" />
-        <param name="start" type="integer" value="1" label="Trim from the beginning up to this position" help="Only positive positions allowed. 1 = do not trim the beginning"/>
+        <param name="start" type="integer" value="1" min="1" label="Trim from the beginning up to this position" help="Only positive positions allowed. 1 = do not trim the beginning"/>
         <param name="end" type="integer" value="0" label="Remove everything from this position to the end" help="Use negative position to indicate position starting from the end. 0 = do not trim the end"/>
         <param name="fastq" type="select" label="Is input dataset in FASTQ format?" help="If set to 'Yes', the tool will not trim evenly numbered lines (0, 2, 4, etc...). This allows for trimming the seq and qual lines, only if they are not spread over multiple lines (see warning below)">
             <option value="" selected="true">No</option>
@@ -69,7 +72,7 @@ python '$__tool_directory__/trimmer.py' -a -f '$input1' -c $col -s $start -e $en
     <help>
 **What it does**
 
-Trims specified number of characters from a dataset or its field (if dataset is tab-delimited).
+Trims specified number of characters from a dataset or a given column (if dataset is tab-delimited).
 
 -----
 
@@ -124,7 +127,7 @@ This tool can be used to trim sequences and quality strings in FASTQ datasets. T
   +
   II#IIIIIII$5+.(9IIIIIII$%*$G$A31I&amp;&amp;B
 
-cab done by setting **Remove everything from this position to the end** to 31::
+can be done by setting **Remove everything from this position to the end** to 31::
 
   @081017-and-081020:1:1:1715:1759
   GGACTCAGATAGTAATCCACGCTCCTTTAAA


### PR DESCRIPTION
In the previous version, specifying a negative end position would cause
a "rotating" behavior of the slice when the reverse index was larger
than the length of the string.
The fixed version also detects out of range column specifications
correctly and should be faster since it uses a set instead of a list
lookup and does int conversions up front instead of inside the loop.