### PR TITLE
[20.05] Fix admin data_types_list bug

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -590,8 +590,9 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         status = kwd.get('status', 'done')
         for dtype in sorted(trans.app.datatypes_registry.datatype_elems,
                            key=lambda dtype: dtype.get('extension')):
-            datatypes.append(dtype.attrib)
-            keys |= set(dtype.attrib)
+            attrib = dict(dtype.attrib)
+            datatypes.append(attrib)
+            keys |= set(attrib.keys())
         return {'keys': list(keys), 'data': datatypes, 'message': message, 'status': status}
 
     @web.expose


### PR DESCRIPTION
Issue #9977

The admin data types list is breaking because it tries to json dump an lxml _Attrib object.


