### PR TITLE
Allow unary plus and minus in filtering

### DIFF
--- a/tools/stats/filtering.py
+++ b/tools/stats/filtering.py
@@ -12,7 +12,8 @@ AST_NODE_TYPE_WHITELIST = [
     'Expr', 'Load', 'Str', 'Num', 'BoolOp', 'Compare', 'And', 'Eq', 'NotEq',
     'Or', 'GtE', 'LtE', 'Lt', 'Gt', 'BinOp', 'Add', 'Div', 'Sub', 'Mult', 'Mod',
     'Pow', 'LShift', 'GShift', 'BitAnd', 'BitOr', 'BitXor', 'UnaryOp', 'Invert',
-    'Not', 'NotIn', 'In', 'Is', 'IsNot', 'List', 'Index', 'Subscript',
+    'Not', 'UAdd', 'USub', 'NotIn', 'In', 'Is', 'IsNot', 'List', 'Index',
+    'Subscript',
     # Further checks
     'Name', 'Call', 'Attribute',
 ]

--- a/tools/stats/filtering.py
+++ b/tools/stats/filtering.py
@@ -74,6 +74,8 @@ def check_expression(text):
     True
     >>> check_expression("c3=='chr1' and c5>5")
     True
+    >>> check_expression("c3=='chr1' and c5>-5 and c5<+5")  # Unary +/-
+    True
     >>> check_expression("c3=='chr1' and d5>5")  # Invalid d5 reference
     False
     >>> check_expression("c3=='chr1' and c5>5 or exec")

--- a/tools/stats/filtering.xml
+++ b/tools/stats/filtering.xml
@@ -1,4 +1,4 @@
-<tool id="Filter1" name="Filter" version="1.1.0">
+<tool id="Filter1" name="Filter" version="1.1.1">
   <description>data on any column using simple expressions</description>
   <edam_operations>
     <edam_operation>operation_0335</edam_operation>


### PR DESCRIPTION
Adding `USub` to the list of allowed ast node types makes it possible to use filter expressions like `c1 >= -5` (which addresses a bug report received at usegalaxy.eu).
Allowing this type (and also `UAdd`) seems benign to me. Does anyone else see a problem with this?