### PR TITLE
Fix determining 'int', 'float' column type in Tabular

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -308,20 +308,20 @@ class Tabular(TabularData):
             raise ValueError("Tried to compare unknown column types: {} and {}".format(column_type1, column_type2))
 
         def is_int(column_text):
+            # Don't allow underscores in numeric literals (PEP 515)
+            if '_' in column_text:
+                return False
             try:
-                # Don't allow underscores in numeric literals (PEP 515)
-                if '_' in column_text:
-                    return False
                 int(column_text)
                 return True
             except ValueError:
                 return False
 
         def is_float(column_text):
+            # Don't allow underscores in numeric literals (PEP 515)
+            if '_' in column_text:
+                return False
             try:
-                # Don't allow underscores in numeric literals (PEP 515)
-                if '_' in column_text:
-                    return False
                 float(column_text)
                 return True
             except ValueError:
@@ -976,6 +976,9 @@ class BaseCSV(TabularData):
     big_peek_size = 10240  # Large File chunk used for sniffing CSV dialect
 
     def is_int(self, column_text):
+        # Don't allow underscores in numeric literals (PEP 515)
+        if '_' in column_text:
+            return False
         try:
             int(column_text)
             return True
@@ -983,6 +986,9 @@ class BaseCSV(TabularData):
             return False
 
     def is_float(self, column_text):
+        # Don't allow underscores in numeric literals (PEP 515)
+        if '_' in column_text:
+            return False
         try:
             float(column_text)
             return True

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -312,6 +312,7 @@ class Tabular(TabularData):
                 if any(c in ['_'] for c in column_text):
                     return False
                 int(column_text)
+                return True
             except ValueError:
                 return False
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -309,7 +309,8 @@ class Tabular(TabularData):
 
         def is_int(column_text):
             try:
-                if any(c in ['_'] for c in column_text):
+                # Don't allow underscores in numeric literals (PEP 515)
+                if '_' in column_text:
                     return False
                 int(column_text)
                 return True

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -319,7 +319,8 @@ class Tabular(TabularData):
 
         def is_float(column_text):
             try:
-                if any(c in ['_'] for c in column_text):
+                # Don't allow underscores in numeric literals (PEP 515)
+                if '_' in column_text:
                     return False
                 float(column_text)
                 return True

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -309,13 +309,16 @@ class Tabular(TabularData):
 
         def is_int(column_text):
             try:
+                if any(c in ['_'] for c in column_text):
+                    return False
                 int(column_text)
-                return True
             except ValueError:
                 return False
 
         def is_float(column_text):
             try:
+                if any(c in ['_'] for c in column_text):
+                    return False
                 float(column_text)
                 return True
             except ValueError:


### PR DESCRIPTION
If a `_` is present in an int or float, python 3 will still validate it as being int or float and remove the `_`.