### PR TITLE
[20.01] Pin latex-to-unicode js module

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "jquery.complexify": "^0.5.2",
     "jquery.cookie": "^1.4.1",
     "latex-parser": "^0.6.2",
-    "latex-to-unicode-converter": "^0.5.2",
+    "latex-to-unicode-converter": "0.5.2",
     "markdown-it": "^8.4.2",
     "moment": "2.20.1",
     "popper.js": "^1.14.7",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8068,7 +8068,7 @@ latex-parser@^0.6.2:
   dependencies:
     parsimmon "^1.6.2"
 
-latex-to-unicode-converter@^0.5.2:
+latex-to-unicode-converter@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/latex-to-unicode-converter/-/latex-to-unicode-converter-0.5.2.tgz#6c3702f66ab7362fb6ec3dcfeb8bbbf28cf3b945"
   integrity sha512-hpVh9tYWikQINRbIU0uUwTZypKOMYYi1p7qwypHpKdknxbdaBhKl7tRj0VzgbrV4jBW2XzbxV/QT/TcWcG84kw==


### PR DESCRIPTION
Which is now deprecated, and no longer used in future versions of Galaxy, but attempting to build with supposedly compatible recently released versions does not work.

Usually the `^` version matching is fine to use, but in this case compatibility was broken between 0.5.2 and 0.5.4.

Fixes #10149. 