### PR TITLE
Add hidden column, attach StoredWorkflow to subworkflows

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -52,8 +52,13 @@ import galaxy.util
 from galaxy.model.item_attrs import get_item_annotation_str, UsesAnnotations
 from galaxy.security import get_permitted_actions
 from galaxy.security.validate_user_input import validate_password_str
-from galaxy.util import (directory_hash_id, ready_name_for_url,
-                         unicodify, unique_id)
+from galaxy.util import (
+    directory_hash_id,
+    listify,
+    ready_name_for_url,
+    unicodify,
+    unique_id,
+)
 from galaxy.util.bunch import Bunch
 from galaxy.util.dictifiable import dict_for, Dictifiable
 from galaxy.util.form_builder import (AddressField, CheckboxField, HistoryField,
@@ -4655,19 +4660,21 @@ class UCI:
 
 class StoredWorkflow(HasTags, Dictifiable, RepresentById):
 
-    dict_collection_visible_keys = ['id', 'name', 'create_time', 'update_time', 'published', 'deleted']
-    dict_element_visible_keys = ['id', 'name', 'create_time', 'update_time', 'published', 'deleted']
+    dict_collection_visible_keys = ['id', 'name', 'create_time', 'update_time', 'published', 'deleted', 'hidden']
+    dict_element_visible_keys = ['id', 'name', 'create_time', 'update_time', 'published', 'deleted', 'hidden']
 
-    def __init__(self):
+    def __init__(self, user=None, name=None, slug=None, create_time=None, update_time=None, published=False, latest_workflow_id=None, workflow=None, hidden=False):
         self.id = None
-        self.user = None
-        self.name = None
-        self.slug = None
-        self.create_time = None
-        self.update_time = None
-        self.published = False
+        self.user = user
+        self.name = name
+        self.slug = slug
+        self.create_time = create_time
+        self.update_time = update_time
+        self.published = published
         self.latest_workflow_id = None
-        self.workflows = []
+        self.latest_workflow = workflow
+        self.workflows = listify(workflow)
+        self.hidden = hidden
 
     def get_internal_version(self, version):
         if version is None:

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -987,6 +987,7 @@ model.StoredWorkflow.table = Table(
         ForeignKey("workflow.id", use_alter=True, name='stored_workflow_latest_workflow_id_fk'), index=True),
     Column("name", TEXT),
     Column("deleted", Boolean, default=False),
+    Column("hidden", Boolean, default=False),
     Column("importable", Boolean, default=False),
     Column("slug", TEXT),
     Column("from_path", TEXT),

--- a/lib/galaxy/model/migrate/versions/0168_stored_workflow_hidden_col.py
+++ b/lib/galaxy/model/migrate/versions/0168_stored_workflow_hidden_col.py
@@ -1,0 +1,30 @@
+"""
+Migration script to add a 'hidden' column to the 'StoredWorkflow' table.
+"""
+
+import logging
+
+from sqlalchemy import Boolean, Column, MetaData
+
+from galaxy.model.migrate.versions.util import add_column, drop_column
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+# Column to add.
+hidden_col = Column("hidden", Boolean, default=False)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    add_column(hidden_col, 'stored_workflow', metadata)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    drop_column('hidden', 'stored_workflow', metadata)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -70,7 +70,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         """
         GET /api/workflows
         """
-        return self.get_workflows_list(trans, kwd)
+        return self.get_workflows_list(trans, **kwd)
 
     @expose_api
     def get_workflow_menu(self, trans, **kwd):
@@ -82,7 +82,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         ids_in_menu = [x.stored_workflow_id for x in user.stored_workflow_menu_entries]
         return {
             'ids_in_menu': ids_in_menu,
-            'workflows': self.get_workflows_list(trans, kwd)
+            'workflows': self.get_workflows_list(trans, **kwd)
         }
 
     @expose_api
@@ -124,31 +124,31 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         trans.set_message(message)
         return {'message': message, 'status': 'done'}
 
-    def get_workflows_list(self, trans, kwd):
+    def get_workflows_list(self, trans, missing_tools=False, show_published=None, show_hidden=False, show_deleted=False, **kwd):
         """
         Displays a collection of workflows.
 
         :param  show_published:      if True, show also published workflows
         :type   show_published:      boolean
+        :param  show_hidden:         if True, show hidden workflows
+        :type   show_hidden:         boolean
+        :param  show_deleted:        if True, show deleted workflows
+        :type   show_deleted:        boolean
         :param  missing_tools:       if True, include a list of missing tools per workflow
         :type   missing_tools:       boolean
         """
-        missing_tools = util.string_as_bool(kwd.get('missing_tools', 'False'))
         rval = []
-        filter1 = (trans.app.model.StoredWorkflow.user == trans.user)
+        filter1 = trans.app.model.StoredWorkflow.user == trans.user
         user = trans.get_user()
-        if user is None:
-            show_published = util.string_as_bool(kwd.get('show_published', 'True'))
-        else :
-            show_published = util.string_as_bool(kwd.get('show_published', 'False'))
-        if show_published:
+        if show_published or user is None and show_published is None:
             filter1 = or_(filter1, (trans.app.model.StoredWorkflow.published == true()))
-        for wf in trans.sa_session.query(trans.app.model.StoredWorkflow).options(
-                joinedload("annotations")).options(
-                joinedload("latest_workflow").undefer("step_count").lazyload("steps")).options(
-                joinedload("tags")).filter(
-                    filter1, trans.app.model.StoredWorkflow.table.c.deleted == false()).order_by(
-                    desc(trans.app.model.StoredWorkflow.table.c.update_time)).all():
+        query = trans.sa_session.query(trans.app.model.StoredWorkflow).options(
+            joinedload("annotations")).options(
+            joinedload("latest_workflow").undefer("step_count").lazyload("steps")).options(
+            joinedload("tags")
+        ).filter(filter1)
+        query = query.filter_by(hidden=true() if show_hidden else false(), deleted=true() if show_deleted else false())
+        for wf in query.order_by(desc(trans.app.model.StoredWorkflow.table.c.update_time)).all():
             item = wf.to_dict(value_mapper={'id': trans.security.encode_id})
             encoded_id = trans.security.encode_id(wf.id)
             item['annotations'] = [x.annotation for x in wf.annotations]
@@ -576,6 +576,10 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                 stored_workflow.name = sanitized_name
                 stored_workflow.latest_workflow = workflow
                 trans.sa_session.add(workflow, stored_workflow)
+                trans.sa_session.flush()
+
+            if 'hidden' in workflow_dict and stored_workflow.hidden != workflow_dict['hidden']:
+                stored_workflow.hidden = workflow_dict['hidden']
                 trans.sa_session.flush()
 
             if 'annotation' in workflow_dict:


### PR DESCRIPTION
and created hidden StoredWorkflow instances for subworkflows at import
time.

When importing workflows that include subworkflows we don't create
StoredWorkflow associations for the emebedded subworkflows. To be able
to serialize these workflows we now create a StoredWorkflow association
when serializing these workflows. This commit also introduces the hidden
column, so that these embedded workflows don't just appear out of
no-where in the workflow list.  This commit also filters out these new
hidden StoredWorkflows from the `api/workflows` endpoint by default, but
2 new options, `show_deleted` and `show_hidden`, allow displaying hidden
resp. deleted workflows, and adds the possibility to update the
`hidden` column via the API.

Includes API tests for the show_hidden / show_deleted options as well
as fetching an embedded imported subworkflow.

This fixes the `...` in the workflow name column for invocations with imported subworkflows.