### PR TITLE
Make visualization unit tests independent

### DIFF
--- a/test/unit/visualizations/plugins/__init__.py
+++ b/test/unit/visualizations/plugins/__init__.py
@@ -1,10 +1,10 @@
 import unittest
 
-from galaxy.web.framework.base import WebApplication
+import routes
 
 
 class VisualizationsBase_TestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        WebApplication()
+        routes.Mapper()

--- a/test/unit/visualizations/plugins/__init__.py
+++ b/test/unit/visualizations/plugins/__init__.py
@@ -1,0 +1,10 @@
+import unittest
+
+from galaxy.web.framework.base import WebApplication
+
+
+class VisualizationsBase_TestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        WebApplication()

--- a/test/unit/visualizations/plugins/test_VisualizationPlugin.py
+++ b/test/unit/visualizations/plugins/test_VisualizationPlugin.py
@@ -11,10 +11,11 @@ from galaxy.visualization.plugins import (
     resource_parser,
     utils as vis_utils
 )
+from . import VisualizationsBase_TestCase
 from ...unittest_utils import galaxy_mock
 
 
-class VisualizationsPlugin_TestCase(unittest.TestCase):
+class VisualizationsPlugin_TestCase(VisualizationsBase_TestCase):
     plugin_class = vis_plugin.VisualizationPlugin
 
     def test_default_init(self):

--- a/test/unit/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/visualizations/plugins/test_VisualizationsRegistry.py
@@ -11,6 +11,7 @@ from galaxy import model
 from galaxy.util import clean_multiline_string
 from galaxy.visualization.plugins import plugin
 from galaxy.visualization.plugins.registry import VisualizationsRegistry
+from . import VisualizationsBase_TestCase
 from ...unittest_utils import galaxy_mock
 
 glx_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, os.pardir))
@@ -37,7 +38,7 @@ config1 = """\
 """
 
 
-class VisualizationsRegistry_TestCase(unittest.TestCase):
+class VisualizationsRegistry_TestCase(VisualizationsBase_TestCase):
 
     def test_plugin_load_from_repo(self):
         """should attempt load if criteria met"""


### PR DESCRIPTION
Solves #10161.

EDIT: the tests depended on running `test/unit/test_routes.py` (which runs *before* `visualization/`)
