### PR TITLE
Toolbox refactoring, styling, and a couple bugfixes

### DIFF
--- a/client/src/components/Panels/Common/ToolSection.test.js
+++ b/client/src/components/Panels/Common/ToolSection.test.js
@@ -40,7 +40,7 @@ describe("ToolSection", () => {
         await Vue.nextTick();
         const $names = wrapper.findAll(".name");
         expect($names.at(1).text()).to.equal("name");
-        const $label = wrapper.find(".label");
+        const $label = wrapper.find(".tool-panel-label");
         expect($label.text()).to.equal("text");
         $sectionName.trigger("click");
         await Vue.nextTick();

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -130,20 +130,21 @@ export default {
 @import "scss/theme/blue.scss";
 
 .tool-panel-label {
-    font-weight: 600;
-    font-size: $h5-font-size;
-    text-transform: uppercase;
-}
-
-div.tool-panel-label {
     background: darken($panel-bg-color, 5%);
     border-left: 0.25rem solid darken($panel-bg-color, 25%);
+    font-size: $h5-font-size;
+    font-weight: 600;
     padding-left: 0.75rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    text-transform: uppercase;
 }
 
 .tool-panel-section .tool-panel-label {
     /* labels within subsections */
     margin-left: 1.5rem;
+    padding-top: 0.125rem;
+    padding-bottom: 0.125rem;
 }
 
 .slide-enter-active {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -131,7 +131,7 @@ export default {
 
 .tool-panel-label {
     font-weight: 600;
-    font-size: $h4-font-size;
+    font-size: $h5-font-size;
     text-transform: uppercase;
 }
 

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -126,7 +126,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import "scss/theme/blue.scss";
 
 .tool-panel-label {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -126,7 +126,26 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/utilities/spacing";
+
+@import "scss/theme/blue.scss";
+@import "scss/mixins";
+
+.toolPanelLabel {
+    @extend .pb-3;
+    @extend .pt-3;
+    @extend .px-3;
+    font-weight: bold;
+    font-size: $h5-font-size;
+    color: $text-light;
+    text-transform: uppercase;
+    text-decoration: underline;
+}
+
 .slide-enter-active {
     -moz-transition-duration: 0.2s;
     -webkit-transition-duration: 0.2s;

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -65,6 +65,7 @@ export default {
         },
         queryFilter: {
             type: String,
+            default: "",
         },
         disableFilter: {
             type: Boolean,
@@ -74,12 +75,15 @@ export default {
         },
         operationTitle: {
             type: String,
+            default: "",
         },
         operationIcon: {
             type: String,
+            default: "",
         },
         toolKey: {
             type: String,
+            default: ""
         },
         sectionName: {
             type: String,

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -12,9 +12,9 @@
                 <transition name="slide">
                     <div v-if="opened">
                         <template v-for="[key, el] in category.elems.entries()">
-                            <span v-if="el.text" class="label toolPanelLabel ml-2" :key="key">
+                            <div v-if="el.text" class="tool-panel-label ml-3" :key="key">
                                 {{ el.text }}
-                            </span>
+                            </div>
                             <tool
                                 v-else
                                 class="ml-2"
@@ -33,9 +33,9 @@
             </div>
         </div>
         <div v-else>
-            <span v-if="category.text" class="label toolPanelLabel">
+            <div v-if="category.text" class="tool-panel-label px-3">
                 {{ category.text }}
-            </span>
+            </div>
             <tool
                 v-else
                 :tool="category"
@@ -130,24 +130,22 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
-@import "~bootstrap/scss/functions";
-@import "~bootstrap/scss/variables";
-@import "~bootstrap/scss/mixins";
-@import "~bootstrap/scss/utilities/spacing";
-
+<style lang="scss">
 @import "scss/theme/blue.scss";
-@import "scss/mixins";
 
-.toolPanelLabel {
-    @extend .pb-3;
-    @extend .pt-3;
-    @extend .px-3;
-    font-weight: bold;
-    font-size: $h5-font-size;
-    color: $text-light;
+.tool-panel-label {
+    font-weight: 600;
+    font-size: $h4-font-size;
     text-transform: uppercase;
-    text-decoration: underline;
+}
+
+div.tool-panel-label {
+    background: darken($panel-bg-color, 10%);
+}
+
+span.tool-panel-label {
+    padding-left: 1rem;
+    background: darken($panel-bg-color, 5%);
 }
 
 .slide-enter-active {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="isSection && hasElements">
+    <div v-if="isSection && hasElements" class="tool-panel-section">
         <div :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]">
             <a @click="toggleMenu" href="javascript:void(0)" role="button">
                 <span class="name">
@@ -10,7 +10,7 @@
         <transition name="slide">
             <div v-if="opened">
                 <template v-for="[key, el] in category.elems.entries()">
-                    <div v-if="el.text" class="tool-panel-label ml-3" :key="key">
+                    <div v-if="el.text" class="tool-panel-label" :key="key">
                         {{ el.text }}
                     </div>
                     <tool
@@ -30,7 +30,7 @@
         </transition>
     </div>
     <div v-else>
-        <div v-if="category.text" class="tool-panel-label px-3">
+        <div v-if="category.text" class="tool-panel-label">
             {{ category.text }}
         </div>
         <tool
@@ -136,12 +136,14 @@ export default {
 }
 
 div.tool-panel-label {
-    background: darken($panel-bg-color, 10%);
+    background: darken($panel-bg-color, 5%);
+    border-left: 0.25rem solid darken($panel-bg-color, 25%);
+    padding-left: 0.75rem;
 }
 
-span.tool-panel-label {
-    padding-left: 1rem;
-    background: darken($panel-bg-color, 5%);
+.tool-panel-section .tool-panel-label {
+    /* labels within subsections */
+    margin-left: 1.5rem;
 }
 
 .slide-enter-active {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -1,51 +1,47 @@
 <template>
-    <div>
-        <div v-if="isSection">
-            <div v-if="hasElements">
-                <div :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]">
-                    <a @click="toggleMenu" href="javascript:void(0)" role="button">
-                        <span class="name">
-                            {{ this.name }}
-                        </span>
-                    </a>
-                </div>
-                <transition name="slide">
-                    <div v-if="opened">
-                        <template v-for="[key, el] in category.elems.entries()">
-                            <div v-if="el.text" class="tool-panel-label ml-3" :key="key">
-                                {{ el.text }}
-                            </div>
-                            <tool
-                                v-else
-                                class="ml-2"
-                                :tool="el"
-                                :key="key"
-                                :tool-key="toolKey"
-                                :hide-name="hideName"
-                                :operation-title="operationTitle"
-                                :operation-icon="operationIcon"
-                                @onOperation="onOperation"
-                                @onClick="onClick"
-                            />
-                        </template>
+    <div v-if="isSection && hasElements">
+        <div :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]">
+            <a @click="toggleMenu" href="javascript:void(0)" role="button">
+                <span class="name">
+                    {{ this.name }}
+                </span>
+            </a>
+        </div>
+        <transition name="slide">
+            <div v-if="opened">
+                <template v-for="[key, el] in category.elems.entries()">
+                    <div v-if="el.text" class="tool-panel-label ml-3" :key="key">
+                        {{ el.text }}
                     </div>
-                </transition>
+                    <tool
+                        v-else
+                        class="ml-2"
+                        :tool="el"
+                        :key="key"
+                        :tool-key="toolKey"
+                        :hide-name="hideName"
+                        :operation-title="operationTitle"
+                        :operation-icon="operationIcon"
+                        @onOperation="onOperation"
+                        @onClick="onClick"
+                    />
+                </template>
             </div>
+        </transition>
+    </div>
+    <div v-else>
+        <div v-if="category.text" class="tool-panel-label px-3">
+            {{ category.text }}
         </div>
-        <div v-else>
-            <div v-if="category.text" class="tool-panel-label px-3">
-                {{ category.text }}
-            </div>
-            <tool
-                v-else
-                :tool="category"
-                :hide-name="hideName"
-                :operation-title="operationTitle"
-                :operation-icon="operationIcon"
-                @onOperation="onOperation"
-                @onClick="onClick"
-            />
-        </div>
+        <tool
+            v-else
+            :tool="category"
+            :hide-name="hideName"
+            :operation-title="operationTitle"
+            :operation-icon="operationIcon"
+            @onOperation="onOperation"
+            @onClick="onClick"
+        />
     </div>
 </template>
 
@@ -83,7 +79,7 @@ export default {
         },
         toolKey: {
             type: String,
-            default: ""
+            default: "",
         },
         sectionName: {
             type: String,

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -33,9 +33,9 @@
                         @onClick="onOpen"
                     />
                 </div>
-                <div class="toolPanelLabel" id="title_XXinternalXXworkflow">
-                    <a>{{ workflowTitle }}</a>
-                </div>
+
+                <tool-section :category="{ text: workflowTitle }" />
+
                 <div id="internal-workflows" class="toolSectionBody">
                     <div class="toolSectionBg" />
                     <div class="toolTitle" v-for="wf in workflows" :key="wf.id">

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -80,7 +80,7 @@ export default {
             type: Array,
             required: true,
         },
-        stored_workflow_menu_entries: {
+        storedWorkflowMenuEntries: {
             type: Array,
             required: true,
         },
@@ -108,7 +108,7 @@ export default {
                     href: `${getAppRoot()}workflows/list`,
                     id: "list",
                 },
-                ...this.stored_workflow_menu_entries.map((menuEntry) => {
+                ...this.storedWorkflowMenuEntries.map((menuEntry) => {
                     return {
                         id: menuEntry.id,
                         title: menuEntry.name,

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -235,7 +235,7 @@ export const getAnalysisRouter = (Galaxy) =>
         },
 
         show_tools_view: function () {
-            this.page.toolPanel.getVueComponent().hide();
+            this.page.toolPanel?.component.hide();
             this.page.panels.right.hide();
             this._display_vue_helper(ToolsView);
         },
@@ -243,6 +243,7 @@ export const getAnalysisRouter = (Galaxy) =>
         show_tools_json: function () {
             this._display_vue_helper(ToolsJson);
         },
+
         show_histories_permissions: function () {
             this.page.display(
                 new FormWrapper.View({

--- a/client/src/entry/panels/tool-panel.js
+++ b/client/src/entry/panels/tool-panel.js
@@ -34,26 +34,17 @@ const ToolPanel = Backbone.View.extend({
 
     mountVueComponent: function (el) {
         const Galaxy = getGalaxyInstance();
-        return mountVueComponent(SidePanel)(
+        return this.component = mountVueComponent(SidePanel)(
             {
                 side: "left",
                 currentPanel: ToolBox,
-                currentPanelProperties: Galaxy.config,
+                currentPanelProperties: {
+                    storedWorkflowMenuEntries: Galaxy.config.stored_workflow_menu_entries,
+                    toolbox: Galaxy.config.toolbox,
+                },
             },
             el
         );
-    },
-
-    getVueComponent: function () {
-        const Galaxy = getGalaxyInstance();
-        const SidePanelClass = Vue.extend(SidePanel);
-        return new SidePanelClass({
-            propsData: {
-                side: "left",
-                currentPanel: ToolBox,
-                currentPanelProperties: Galaxy.config,
-            },
-        });
     },
 
     toString: function () {

--- a/client/src/entry/panels/tool-panel.js
+++ b/client/src/entry/panels/tool-panel.js
@@ -34,7 +34,7 @@ const ToolPanel = Backbone.View.extend({
 
     mountVueComponent: function (el) {
         const Galaxy = getGalaxyInstance();
-        return this.component = mountVueComponent(SidePanel)(
+        return (this.component = mountVueComponent(SidePanel)(
             {
                 side: "left",
                 currentPanel: ToolBox,
@@ -44,7 +44,7 @@ const ToolPanel = Backbone.View.extend({
                 },
             },
             el
-        );
+        ));
     },
 
     toString: function () {

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -152,11 +152,13 @@ body {
     @extend .unified-panel;
     left: 0px;
     width: $panel-width;
+    overflow: unset !important;
 }
 #right {
     @extend .unified-panel;
     right: 0px;
     width: $panel-width;
+    overflow: unset !important;
 }
 #right > .unified-panel-footer {
     .drag {

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -1266,16 +1266,6 @@ div.toolSectionTitle {
     font-size: $h4-font-size;
 }
 
-.toolPanelLabel {
-    @extend .pb-1;
-    @extend .pt-2;
-    @extend .px-3;
-    font-weight: bold;
-    font-size: $h5-font-size;
-    color: $text-light;
-    text-transform: uppercase;
-}
-
 div.toolTitle,
 div.toolSectionTitle {
     display: block;

--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -19,13 +19,13 @@ $brand-masthead-text-hover: $brand-toggle;
 $text-color: $brand-dark;
 $text-muted: lighten($text-color, 10%);
 $text-light: lighten($text-color, 20%);
-$border-color: lighten($text-color, 60%);
 
 // Light grays for backgrounds
 $white: lighten($brand-light, 15%); // body background
 $gray-100: $brand-light;
 $gray-200: darken($brand-light, 5%); // welcome background
 $gray-300: darken($brand-light, 10%);
+$border-color: darken($brand-light, 20%);
 
 // Dark grays for foregrounds
 $gray-900: $text-color;

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -70,16 +70,16 @@ steps:
       intro: "This is your ToolBox. All tools available in your Galaxy instance you can find here."
       position: "right"
 
+    - title: "Tool categories"
+      element: '.toolSectionTitle'
+      intro: "Tools are grouped into categories to make them easier to find."
+      position: "right"
+
     - title: "Tool search bar"
       element: '.search-query'
       intro: "You can search for tools by keywords."
       position: "right"
       textinsert: 'filter'
-
-    - title: "Tool categories"
-      element: '.toolSectionTitle'
-      intro: "Tools are grouped into categories to make them easier to find."
-      position: "right"
 
     - title: "Select a tool"
       element: 'a[href$="tool_runner?tool_id=Filter1"]'

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -592,6 +592,13 @@ def build_galaxy_app(simple_kwargs):
     galaxy_context = app.model.context
     install_context = app.install_model.context
 
+    # Toolbox indexing happens via the work queue out of band recently, and,
+    # beyond potentially running async after tests execute doesn't execute
+    # without building a uwsgi app (app.is_webapp = False for this test kit).
+    # We need to ensure to build an index for the test galaxy app -- this is
+    # pretty fast with the limited toolset
+    app.reindex_tool_search()
+
     return app
 
 


### PR DESCRIPTION
- Swaps to explicit panel property configuration instead of inheriting entire global configuration blob.
- Fixes a bug where tools view was actually rendering the toolbox twice, unnecessarily.
- Fixes a 'double scroller' bug where in some situations you'd get two scrollers in the panels.
- Adjusts basis for border color to be aligned with panels instead of text -- this is an issue I ran into when styling for the anvil branch.
- Relocates tool section label styles to be scoped and specific, not global
- Removes a few extraneous divs that served no purpose.

Updates tool section label styling (toplevel and subsection) to be more easily visually parsed.  -- I'm definitely looking for more feedback on the section label styling.  It's a bit of a pickle because it'd almost be nicer to standardize towards a third tier of section (or a drawer with toolSections in it -- something we've talked about specifically in the context of data ingress recently) instead of having a mix of labels and sections, but this is an option.

After:
![image](https://user-images.githubusercontent.com/155398/91861571-00457900-ec3b-11ea-8a49-f9f6329741fd.png)

