### PR TITLE
[20.05] Fix ToolValidator get_list_of_copied_sample_files

### DIFF
--- a/lib/tool_shed/tools/tool_validator.py
+++ b/lib/tool_shed/tools/tool_validator.py
@@ -112,7 +112,8 @@ class ToolValidator(GalaxyToolValidator):
         for changeset in hg_util.reversed_upper_bounded_changelog(repo, changeset_revision):
             changeset_ctx = repo[changeset]
             for ctx_file in changeset_ctx.files():
-                ctx_file_name = basic_util.strip_path(unicodify(ctx_file))
+                ctx_file = unicodify(ctx_file)
+                ctx_file_name = basic_util.strip_path(ctx_file)
                 # If we decide in the future that files deleted later in the changelog should
                 # not be used, we can use the following if statement. if ctx_file_name.endswith( '.sample' )
                 # and ctx_file_name not in sample_files and ctx_file_name not in deleted_sample_files:
@@ -132,9 +133,8 @@ class ToolValidator(GalaxyToolValidator):
                     else:
                         sample_files.append(ctx_file_name)
                         tmp_ctx_file_name = os.path.join(dir, ctx_file_name.replace('.sample', ''))
-                        fh = open(tmp_ctx_file_name, 'wb')
-                        fh.write(fctx.data())
-                        fh.close()
+                        with open(tmp_ctx_file_name, 'wb') as fh:
+                            fh.write(fctx.data())
         return sample_files, deleted_sample_files
 
     def handle_sample_files_and_load_tool_from_disk(self, repo_files_dir, repository_id, tool_config_filepath, work_dir):


### PR DESCRIPTION
After updating the MTS to python 3 we saw this:
```
AttributeError: 'NoneType' object has no attribute 'data'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/srv/toolshed/main/venv/lib/python3.8/site-packages/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/srv/toolshed/main/venv/lib/python3.8/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "routes/middleware.py", line 141, in __call__
    response = self.app(environ, start_response)
  File "/srv/toolshed/main/venv/lib/python3.8/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 145, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 224, in handle_request
    body = method(trans, **kwargs)
  File "tool_shed/webapp/controllers/repository.py", line 880, in display_tool
    repository, tool, valid, message = tv.load_tool_from_changeset_revision(repository_id,
  File "tool_shed/tools/tool_validator.py", line 216, in load_tool_from_changeset_revision
    self.handle_sample_files_and_load_tool_from_tmp_config(repo,
  File "tool_shed/tools/tool_validator.py", line 164, in handle_sample_files_and_load_tool_from_tmp_config
    sample_files, deleted_sample_files = self.get_list_of_copied_sample_files(repo, changeset_revision, dir=work_dir)
  File "tool_shed/tools/tool_validator.py", line 136, in get_list_of_copied_sample_files
    fh.write(fctx.data())
```
in https://sentry.galaxyproject.org/sentry/toolshed/issues/903796/.
This should fix that.

`ctx_file` was a bytestring, so in `get_file_context_from_ctx` we'd never find the sample file we're looking for, because `if filename == ctx_file_name:` would fail since `filename` is a bytestring and ctx_file_name a unicode string.