### PR TITLE
[20.05] Force pagination on Valid Galaxy Tools -> Tools page

### DIFF
--- a/client/galaxy/scripts/legacy/grid/grid-template.js
+++ b/client/galaxy/scripts/legacy/grid/grid-template.js
@@ -202,6 +202,7 @@ export default {
             var num_page_links = options.num_page_links;
             var cur_page_num = options.cur_page_num;
             var num_pages = options.num_pages;
+            const allow_fetching_all_results = options.allow_fetching_all_results;
 
             // First pass on min page.
             var page_link_range = num_page_links / 2;
@@ -264,10 +265,12 @@ export default {
             tmpl += "</span>";
 
             // Show all link
-            tmpl += `
-                    <span class="page-link" id="show-all-link-span"> | <a href="javascript:void(0);" onclick="return false;" page_num="all">Show All</a></span>
-                    </td>
-                </tr>`;
+            if (allow_fetching_all_results) {
+                tmpl += `
+                        <span class="page-link" id="show-all-link-span"> | <a href="javascript:void(0);" onclick="return false;" page_num="all">Show All</a></span>
+                        </td>
+                    </tr>`;
+            }
         }
 
         // Grid operations for multiple items.

--- a/lib/galaxy/webapps/reports/framework/grids.py
+++ b/lib/galaxy/webapps/reports/framework/grids.py
@@ -37,6 +37,7 @@ class Grid(object):
     use_paging = False
     num_rows_per_page = 25
     num_page_links = 10
+    allow_fetching_all_results = True
     # Set preference names.
     cur_filter_pref_name = ".filter"
     cur_sort_key_pref_name = ".sort_key"
@@ -194,6 +195,11 @@ class Grid(object):
             if 'page' in kwargs:
                 if kwargs['page'] == 'all':
                     page_num = 0
+                    if self.allow_fetching_all_results:
+                        page_num = 0
+                    else:
+                        # Should make it harder to return all results at once
+                        page_num = 1
                 else:
                     page_num = int(kwargs['page'])
             else:
@@ -273,6 +279,7 @@ class Grid(object):
                                    cur_page_num=page_num,
                                    num_pages=num_pages,
                                    num_page_links=self.num_page_links,
+                                   allow_fetching_all_results=self.allow_fetching_all_results,
                                    default_filter_dict=self.default_filter,
                                    cur_filter_dict=cur_filter_dict,
                                    sort_key=sort_key,

--- a/lib/tool_shed/grids/repository_grids.py
+++ b/lib/tool_shed/grids/repository_grids.py
@@ -235,7 +235,8 @@ class RepositoryGrid(grids.Grid):
     standard_filters = []
     default_filter = dict(deleted="False")
     num_rows_per_page = 50
-    use_paging = False
+    use_paging = True
+    allow_fetching_all_results = False
 
     def build_initial_query(self, trans, **kwd):
         filter = trans.app.repository_grid_filter_manager.get_filter(trans)

--- a/lib/tool_shed/grids/repository_grids.py
+++ b/lib/tool_shed/grids/repository_grids.py
@@ -1188,6 +1188,10 @@ class ToolDependenciesGrid(RepositoryMetadataGrid):
 
 class ToolsGrid(RepositoryMetadataGrid):
 
+    allow_fetching_all_results = False
+    num_rows_per_page = 50
+    use_paging = True
+
     class ToolsColumn(grids.TextColumn):
 
         def get_value(self, trans, grid, repository_metadata):

--- a/lib/tool_shed/webapp/controllers/hg.py
+++ b/lib/tool_shed/webapp/controllers/hg.py
@@ -4,6 +4,7 @@ from mercurial.hgweb.hgwebdir_mod import hgwebdir
 from mercurial.hgweb.request import wsgiapplication
 
 from galaxy import web
+from galaxy.exceptions import ObjectNotFound
 from galaxy.webapps.base.controller import BaseUIController
 from tool_shed.util.repository_util import get_repository_by_name_and_owner
 
@@ -16,21 +17,25 @@ class HgController(BaseUIController):
         # The os command that results in this method being called will look something like:
         # hg clone http://test@127.0.0.1:9009/repos/test/convert_characters1
         hgweb_config = trans.app.hgweb_config_manager.hgweb_config
-        cmd = kwd.get('cmd', None)
 
         def make_web_app():
             hgwebapp = hgwebdir(hgweb_config.encode('utf-8'))
             return hgwebapp
+
         wsgi_app = wsgiapplication(make_web_app)
-        if cmd == 'getbundle':
-            path_info = kwd.get('path_info', None)
-            if path_info:
-                owner, name = path_info.split('/')
-                repository = get_repository_by_name_and_owner(trans.app, name, owner)
-                if repository:
-                    times_downloaded = repository.times_downloaded
-                    times_downloaded += 1
-                    repository.times_downloaded = times_downloaded
-                    trans.sa_session.add(repository)
-                    trans.sa_session.flush()
+        repository = None
+        path_info = kwd.get('path_info', None)
+        if path_info and len(path_info.split('/')) == 2:
+            owner, name = path_info.split('/')
+            repository = get_repository_by_name_and_owner(trans.app, name, owner)
+        if repository:
+            if repository.deprecated:
+                raise ObjectNotFound("Requested repository not found or deprecated.")
+            cmd = kwd.get('cmd', None)
+            if cmd == 'getbundle':
+                times_downloaded = repository.times_downloaded
+                times_downloaded += 1
+                repository.times_downloaded = times_downloaded
+                trans.sa_session.add(repository)
+                trans.sa_session.flush()
         return wsgi_app

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -75,6 +75,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
     matched_repository_grid = repository_grids.MatchedRepositoryGrid()
     my_writable_repositories_grid = repository_grids.MyWritableRepositoriesGrid()
     my_writable_repositories_missing_tool_test_components_grid = repository_grids.MyWritableRepositoriesMissingToolTestComponentsGrid()
+    my_writable_repositories_with_invalid_tools_grid = repository_grids.MyWritableRepositoriesWithInvalidToolsGrid()
     repositories_by_user_grid = repository_grids.RepositoriesByUserGrid()
     repositories_i_own_grid = repository_grids.RepositoriesIOwnGrid()
     repositories_i_can_administer_grid = repository_grids.RepositoriesICanAdministerGrid()

--- a/lib/tool_shed/webapp/templates/legacy/grid_base.mako
+++ b/lib/tool_shed/webapp/templates/legacy/grid_base.mako
@@ -80,6 +80,7 @@
         'cur_page_num'                  : cur_page_num,
         'num_pages'                     : num_pages,
         'num_page_links'                : num_page_links,
+        'allow_fetching_all_results'    : grid.allow_fetching_all_results,
         'status'                        : status,
         'message'                       : util.restore_text(message),
         'global_actions'                : [],


### PR DESCRIPTION
If fetching all tools at once this route is both slow and consumes a lot of memory, and we suspect it's one of the reason the TS runs out of memory regularly.