### PR TITLE
use GalaxyTagHandlerSession for data library uploads

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -232,14 +232,13 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state
                                                             user=trans.user,
                                                             create_dataset=True,
                                                             sa_session=trans.sa_session)
+    tag_manager = tags.GalaxyTagHandlerSession(trans.sa_session)
     if uploaded_dataset.get('tag_using_filenames', False):
         tag_from_filename = os.path.splitext(os.path.basename(uploaded_dataset.name))[0]
-        tag_manager = tags.GalaxyTagHandlerSession(trans.sa_session)
         tag_manager.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag_from_filename)
 
     tags_list = uploaded_dataset.get('tags', False)
     if tags_list:
-        tag_manager = tags.GalaxyTagHandlerSession(trans.sa_session)
         for tag in tags_list:
             tag_manager.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag)
 

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -234,12 +234,12 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, state
                                                             sa_session=trans.sa_session)
     if uploaded_dataset.get('tag_using_filenames', False):
         tag_from_filename = os.path.splitext(os.path.basename(uploaded_dataset.name))[0]
-        tag_manager = tags.GalaxyTagHandler(trans.sa_session)
+        tag_manager = tags.GalaxyTagHandlerSession(trans.sa_session)
         tag_manager.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag_from_filename)
 
     tags_list = uploaded_dataset.get('tags', False)
     if tags_list:
-        tag_manager = tags.GalaxyTagHandler(trans.sa_session)
+        tag_manager = tags.GalaxyTagHandlerSession(trans.sa_session)
         for tag in tags_list:
             tag_manager.apply_item_tag(item=ldda, user=trans.user, name='name', value=tag)
 


### PR DESCRIPTION
Without the `GalaxyTagHandlerSession` I receive integrity errors about tag key 'name' already existing when uploading a dataset with multiple tags.