### PR TITLE
Display proper clientside error

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -108,7 +108,7 @@ class CustosAuthnz(IdentityProvider):
                             len(trans.app.auth_manager.authenticators) == 0):
                         user = existing_user
                     else:
-                        message = 'There already exists a user this email.  To associate this external login, you must first be logged in as that existing account.'
+                        message = "There already exists a user with email %s.  To associate this external login, you must first be logged in as that existing account." % email
                         log.exception(message)
                         raise exceptions.AuthenticationFailed(message)
                 else:

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -287,7 +287,7 @@ class AuthnzManager:
             if success is False:
                 return False, message, (None, None)
             return success, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
-        except exceptions.AuthenticationFailed as e:
+        except exceptions.AuthenticationFailed:
             raise
         except Exception as e:
             msg = 'The following error occurred when handling callback from `{}` identity provider: ' \

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -288,8 +288,7 @@ class AuthnzManager:
                 return False, message, (None, None)
             return success, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
         except exceptions.AuthenticationFailed as e:
-            log.exception(e.message)
-            raise exceptions.AuthenticationFailed(e.message)
+            raise
         except Exception as e:
             msg = 'The following error occurred when handling callback from `{}` identity provider: ' \
                   '{}'.format(provider, str(e))

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -83,7 +83,7 @@ class OIDC(JSAppLauncher):
                                                                                 login_redirect_url=url_for('/'),
                                                                                 idphint=idphint)
         except exceptions.AuthenticationFailed as e:
-            return trans.response.send_redirect(trans.request.base + url_for('/') + 'root/login?message=' + (e.message or "Duplicate Email"))
+            raise
         if success is False:
             return trans.show_error_message(message)
         user = user if user is not None else trans.user

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -82,7 +82,7 @@ class OIDC(JSAppLauncher):
                                                                                 trans,
                                                                                 login_redirect_url=url_for('/'),
                                                                                 idphint=idphint)
-        except exceptions.AuthenticationFailed as e:
+        except exceptions.AuthenticationFailed:
             raise
         if success is False:
             return trans.show_error_message(message)


### PR DESCRIPTION
fixes part of #10075 - Uses b-alert to display error for using custos to log in when an email is already in use with another login method.