### PR TITLE
Add pwd when overriding tool_config_file in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ setup_python
 
 if [ ! -z "$GALAXY_RUN_WITH_TEST_TOOLS" ];
 then
-    export GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE="test/functional/tools/samples_tool_conf.xml"
+    export GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE="$(pwd)/test/functional/tools/samples_tool_conf.xml"
     export GALAXY_CONFIG_ENABLE_BETA_WORKFLOW_MODULES="true"
     export GALAXY_CONFIG_OVERRIDE_ENABLE_BETA_TOOL_FORMATS="true"
     export GALAXY_CONFIG_INTERACTIVETOOLS_ENABLE="true"


### PR DESCRIPTION
~~This is a temporary fix; to be removed after fix applied to config path resolution in the config module.
(so that dev is not broken)~~
EDIT: I think we can keep this along with the other fix (#10201)
Note: config system resolves paths as per schema (fix applied today, see #10187 for context). However, the value of `tool_config_file` is overwritten in `run.sh` when the `GALAXY_CONFIG_OVERRIDE_TOOL_CONFIG_FILE` env var is set. 
ping @jmchilton 