### PR TITLE
Abstraction for purging the dataset quota usage from a user.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3252,6 +3252,12 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         """
         return self.dataset.get_access_roles(trans)
 
+    def purge_usage_from_quota(self, user):
+        """Remove this HDA's quota_amount from user's quota.
+        """
+        if user:
+            user.adjust_total_disk_usage(-self.quota_amount(user))
+
     def quota_amount(self, user):
         """
         Return the disk space used for this HDA relevant to user quotas.

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -834,8 +834,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             hda.deleted = True
             # HDA is purgeable
             # Decrease disk usage first
-            if user:
-                user.adjust_total_disk_usage(-hda.quota_amount(user))
+            hda.purge_usage_from_quota(user)
             # Mark purged
             hda.purged = True
             trans.sa_session.add(hda)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1055,8 +1055,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             for hda in trans.history.datasets:
                 if not hda.deleted or hda.purged:
                     continue
-                if trans.user:
-                    trans.user.adjust_total_disk_usage(-hda.quota_amount(trans.user))
+                hda.purge_usage_from_quota(trans.user)
                 hda.purged = True
                 trans.sa_session.add(hda)
                 trans.log_event("HDA id %s has been purged" % hda.id)


### PR DESCRIPTION
Deduplicates the if and the arg call - but the amount of de-duplicated code would be increased in https://github.com/galaxyproject/galaxy/pull/4840/files where there is a second if based on hda.dataset.has_active_storage_media.