### PR TITLE
[20.05] Don't close fds, dont pass subprocess cwd to mercurial calls

### DIFF
--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     services:
       postgres:
         image: postgres:11

--- a/lib/galaxy/tool_shed/util/hg_util.py
+++ b/lib/galaxy/tool_shed/util/hg_util.py
@@ -110,7 +110,7 @@ def get_file_context_from_ctx(ctx, filename):
 def pull_repository(repo_path, repository_clone_url, ctx_rev):
     """Pull changes from a remote repository to a local one."""
     try:
-        subprocess.check_output(['hg', 'pull', '-r', ctx_rev, repository_clone_url], stderr=subprocess.STDOUT, cwd=repo_path)
+        subprocess.check_output(['hg', 'pull', '--cwd', repo_path, '-r', ctx_rev, repository_clone_url], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error pulling revision '%s': %s" % (ctx_rev, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):

--- a/lib/galaxy/tool_shed/util/hg_util.py
+++ b/lib/galaxy/tool_shed/util/hg_util.py
@@ -3,11 +3,15 @@ import os
 import subprocess
 
 from galaxy.tool_shed.util import basic_util
-from galaxy.util import unicodify
+from galaxy.util import (
+    unicodify,
+    which,
+)
 
 log = logging.getLogger(__name__)
 
 INITIAL_CHANGELOG_HASH = '000000000000'
+HG_EXECUTABLE_PATH = which('hg') or 'hg'
 
 
 def clone_repository(repository_clone_url, repository_file_dir, ctx_rev=None):
@@ -15,7 +19,7 @@ def clone_repository(repository_clone_url, repository_file_dir, ctx_rev=None):
     Clone the repository up to the specified changeset_revision.  No subsequent revisions will be
     present in the cloned repository.
     """
-    cmd = ['hg', 'clone']
+    cmd = [HG_EXECUTABLE_PATH, 'clone']
     if ctx_rev:
         cmd.extend(['-r', str(ctx_rev)])
     cmd.extend([repository_clone_url, repository_file_dir])
@@ -110,7 +114,7 @@ def get_file_context_from_ctx(ctx, filename):
 def pull_repository(repo_path, repository_clone_url, ctx_rev):
     """Pull changes from a remote repository to a local one."""
     try:
-        subprocess.check_output(['hg', 'pull', '--cwd', repo_path, '-r', ctx_rev, repository_clone_url], stderr=subprocess.STDOUT, close_fds=False)
+        subprocess.check_output([HG_EXECUTABLE_PATH, 'pull', '--cwd', repo_path, '-r', ctx_rev, repository_clone_url], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error pulling revision '%s': %s" % (ctx_rev, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -168,7 +172,7 @@ def update_repository(repo_path, ctx_rev=None):
     # I = ignored
     # It would be nice if we could use mercurial's purge extension to remove untracked files.  The problem is that
     # purging is not supported by the mercurial API.
-    cmd = ['hg', 'update']
+    cmd = [HG_EXECUTABLE_PATH, 'update']
     if ctx_rev:
         cmd.extend(['-r', ctx_rev])
     try:

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -13,6 +13,7 @@ from galaxy.tool_shed.util.hg_util import (
     get_config_from_disk,
     get_ctx_file_path_from_manifest,
     get_file_context_from_ctx,
+    HG_EXECUTABLE_PATH,
     pull_repository,
     reversed_lower_upper_bounded_changelog,
     reversed_upper_bounded_changelog,
@@ -27,7 +28,7 @@ INITIAL_CHANGELOG_HASH = '000000000000'
 
 def add_changeset(repo_path, path_to_filename_in_archive):
     try:
-        subprocess.check_output(['hg', 'add', '--cwd', repo_path, path_to_filename_in_archive], stderr=subprocess.STDOUT, close_fds=False)
+        subprocess.check_output([HG_EXECUTABLE_PATH, 'add', '--cwd', repo_path, path_to_filename_in_archive], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error adding '%s' to repository: %s" % (path_to_filename_in_archive, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -39,7 +40,7 @@ def archive_repository_revision(app, repository, archive_dir, changeset_revision
     '''Create an un-versioned archive of a repository.'''
     repo_path = repository.repo_path(app)
     try:
-        subprocess.check_output(['hg', 'archive', '--cwd', repo_path, '-r', changeset_revision, archive_dir], stderr=subprocess.STDOUT, close_fds=False)
+        subprocess.check_output([HG_EXECUTABLE_PATH, 'archive', '--cwd', repo_path, '-r', changeset_revision, archive_dir], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error attempting to archive revision '%s' of repository '%s': %s" % (changeset_revision, repository.name, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -50,7 +51,7 @@ def archive_repository_revision(app, repository, archive_dir, changeset_revision
 
 def commit_changeset(repo_path, full_path_to_changeset, username, message):
     try:
-        subprocess.check_output(['hg', 'commit', '--cwd', repo_path, '-u', username, '-m', message, full_path_to_changeset], stderr=subprocess.STDOUT, close_fds=False)
+        subprocess.check_output([HG_EXECUTABLE_PATH, 'commit', '--cwd', repo_path, '-u', username, '-m', message, full_path_to_changeset], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error committing '%s' to repository: %s" % (full_path_to_changeset, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -210,7 +211,7 @@ def get_rev_label_from_changeset_revision(repo, changeset_revision, include_date
 
 
 def remove_file(repo_path, selected_file, force=True):
-    cmd = ['hg', 'remove', '--cwd', repo_path]
+    cmd = [HG_EXECUTABLE_PATH, 'remove', '--cwd', repo_path]
     if force:
         cmd.append('--force')
     cmd.append(selected_file)
@@ -228,7 +229,7 @@ def init_repository(repo_path):
     Create a new Mercurial repository in the given directory.
     """
     try:
-        subprocess.check_output(['hg', 'init', '--cwd', repo_path], stderr=subprocess.STDOUT, close_fds=False)
+        subprocess.check_output([HG_EXECUTABLE_PATH, 'init', '--cwd', repo_path], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = 'Error initializing repository: %s' % unicodify(e)
         if isinstance(e, subprocess.CalledProcessError):
@@ -241,7 +242,7 @@ def changeset2rev(repo_path, changeset_revision):
     Return the revision number (as an int) corresponding to a specified changeset revision.
     """
     try:
-        rev = subprocess.check_output(['hg', 'id', '--cwd', repo_path, '-r', changeset_revision, '-n'], stderr=subprocess.STDOUT, close_fds=False)
+        rev = subprocess.check_output([HG_EXECUTABLE_PATH, 'id', '--cwd', repo_path, '-r', changeset_revision, '-n'], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error looking for changeset '%s': %s" % (changeset_revision, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -27,7 +27,7 @@ INITIAL_CHANGELOG_HASH = '000000000000'
 
 def add_changeset(repo_path, path_to_filename_in_archive):
     try:
-        subprocess.check_output(['hg', 'add', path_to_filename_in_archive], stderr=subprocess.STDOUT, cwd=repo_path)
+        subprocess.check_output(['hg', 'add', '--cwd', repo_path, path_to_filename_in_archive], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error adding '%s' to repository: %s" % (path_to_filename_in_archive, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -39,7 +39,7 @@ def archive_repository_revision(app, repository, archive_dir, changeset_revision
     '''Create an un-versioned archive of a repository.'''
     repo_path = repository.repo_path(app)
     try:
-        subprocess.check_output(['hg', 'archive', '-r', changeset_revision, archive_dir], stderr=subprocess.STDOUT, cwd=repo_path)
+        subprocess.check_output(['hg', 'archive', '--cwd', repo_path, '-r', changeset_revision, archive_dir], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error attempting to archive revision '%s' of repository '%s': %s" % (changeset_revision, repository.name, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -50,7 +50,7 @@ def archive_repository_revision(app, repository, archive_dir, changeset_revision
 
 def commit_changeset(repo_path, full_path_to_changeset, username, message):
     try:
-        subprocess.check_output(['hg', 'commit', '-u', username, '-m', message, full_path_to_changeset], stderr=subprocess.STDOUT, cwd=repo_path)
+        subprocess.check_output(['hg', 'commit', '--cwd', repo_path, '-u', username, '-m', message, full_path_to_changeset], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error committing '%s' to repository: %s" % (full_path_to_changeset, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -210,12 +210,12 @@ def get_rev_label_from_changeset_revision(repo, changeset_revision, include_date
 
 
 def remove_file(repo_path, selected_file, force=True):
-    cmd = ['hg', 'remove']
+    cmd = ['hg', 'remove', '--cwd', repo_path]
     if force:
         cmd.append('--force')
     cmd.append(selected_file)
     try:
-        subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error removing file '%s': %s" % (selected_file, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):
@@ -228,7 +228,7 @@ def init_repository(repo_path):
     Create a new Mercurial repository in the given directory.
     """
     try:
-        subprocess.check_output(['hg', 'init'], stderr=subprocess.STDOUT, cwd=repo_path)
+        subprocess.check_output(['hg', 'init', '--cwd', repo_path], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = 'Error initializing repository: %s' % unicodify(e)
         if isinstance(e, subprocess.CalledProcessError):
@@ -241,7 +241,7 @@ def changeset2rev(repo_path, changeset_revision):
     Return the revision number (as an int) corresponding to a specified changeset revision.
     """
     try:
-        rev = subprocess.check_output(['hg', 'id', '-r', changeset_revision, '-n'], stderr=subprocess.STDOUT, cwd=repo_path)
+        rev = subprocess.check_output(['hg', 'id', '--cwd', repo_path, '-r', changeset_revision, '-n'], stderr=subprocess.STDOUT, close_fds=False)
     except Exception as e:
         error_message = "Error looking for changeset '%s': %s" % (changeset_revision, unicodify(e))
         if isinstance(e, subprocess.CalledProcessError):


### PR DESCRIPTION
Should allow using posix_spawn, which may get us around
```
OSError: [Errno 12] Cannot allocate memory
  File "galaxy/tool_shed/util/hg_util.py", line 175, in update_repository
    subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
  File "python3.8/subprocess.py", line 411, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "python3.8/subprocess.py", line 489, in run
    with Popen(*popenargs, **kwargs) as process:
  File "python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "python3.8/subprocess.py", line 1637, in _execute_child
    self.pid = _posixsubprocess.fork_exec(
Exception: Error updating repository: [Errno 12] Cannot allocate memory
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/srv/toolshed/main/venv/lib/python3.8/site-packages/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/srv/toolshed/main/venv/lib/python3.8/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "routes/middleware.py", line 141, in __call__
    response = self.app(environ, start_response)
  File "/srv/toolshed/main/venv/lib/python3.8/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 145, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 224, in handle_request
    body = method(trans, **kwargs)
  File "tool_shed/webapp/controllers/repository.py", line 439, in browse_repository
    hg_util.update_repository(repo_path)
  File "galaxy/tool_shed/util/hg_util.py", line 180, in update_repository
    raise Exception(error_message)
```
This occasionally also happens when we still have 2 out of 8GB free.
I don't know if this actually helps, but worst case this should
execute slightly faster.