### PR TITLE
Implement quota interface - with better logic isolation and unit tests.

### DIFF
--- a/client/src/layout/masthead.js
+++ b/client/src/layout/masthead.js
@@ -19,6 +19,7 @@ export class MastheadState {
         // add quota meter to masthead
         Galaxy.quotaMeter = this.quotaMeter = new QuotaMeter.UserQuotaMeter({
             model: Galaxy.user,
+            quotaUrl: Galaxy.config.quota_url,
         });
 
         // loop through beforeunload functions if the user attempts to unload the page

--- a/client/src/mvc/user/user-quotameter.js
+++ b/client/src/mvc/user/user-quotameter.js
@@ -129,22 +129,16 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
         },
 
         _templateQuotaMeter: function (data) {
-            return [
-                '<div id="quota-meter" class="quota-meter progress">',
-                '<div class="progress-bar" style="width: ',
-                data.quota_percent,
-                '%"></div>',
-                '<div class="quota-meter-text" data-placement="left"',
-                data.nice_total_disk_usage ? ` title="Using ${data.nice_total_disk_usage}. Click for details.">` : ">",
-                '<a href="https://galaxyproject.org/support/account-quotas/" target="_blank">',
-                _l("Using"),
-                " ",
-                data.quota_percent,
-                "%",
-                "</a>",
-                "</div>",
-                "</div>",
-            ].join("");
+            const title = data.nice_total_disk_usage
+                ? `title="Using ${data.nice_total_disk_usage}. Click for details."`
+                : "";
+            const using = `${_l("Using")} ${data.quota_percent}%`;
+            return `<div id="quota-meter" class="quota-meter progress">
+    <div class="progress-bar" style="width: ${data.quota_percent}%"></div>
+    <div class="quota-meter-text" data-placement="left" ${title}>
+        <a href="https://galaxyproject.org/support/account-quotas/" target="_blank">${using}</a>
+    </div>
+</div>`;
         },
 
         _templateUsage: function (data) {

--- a/client/src/mvc/user/user-quotameter.js
+++ b/client/src/mvc/user/user-quotameter.js
@@ -20,6 +20,7 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
         options: {
             warnAtPercent: 85,
             errorAtPercent: 100,
+            quotaUrl: "https://galaxyproject.org/support/account-quotas/",
         },
 
         /** Set up, accept options, and bind events */
@@ -133,10 +134,11 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
                 ? `title="Using ${data.nice_total_disk_usage}. Click for details."`
                 : "";
             const using = `${_l("Using")} ${data.quota_percent}%`;
+            const quotaUrl = this.options.quotaUrl;
             return `<div id="quota-meter" class="quota-meter progress">
     <div class="progress-bar" style="width: ${data.quota_percent}%"></div>
     <div class="quota-meter-text" data-placement="left" ${title}>
-        <a href="https://galaxyproject.org/support/account-quotas/" target="_blank">${using}</a>
+        <a href="${quotaUrl}" target="_blank">${using}</a>
     </div>
 </div>`;
         },

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -6,7 +6,6 @@ import time
 import galaxy.model
 import galaxy.model.security
 import galaxy.queues
-import galaxy.quota
 import galaxy.security
 from galaxy import config, job_metrics, jobs
 from galaxy.config_watchers import ConfigWatchers
@@ -27,6 +26,7 @@ from galaxy.queue_worker import (
     GalaxyQueueWorker,
     send_local_control_task,
 )
+from galaxy.quota import get_quota_agent
 from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
 from galaxy.tool_shed.galaxy_install.update_repository_manager import UpdateRepositoryManager
 from galaxy.tool_util.deps.views import DependencyResolversView
@@ -175,10 +175,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
             model=self.security_agent.model,
             permitted_actions=self.security_agent.permitted_actions)
         # Load quota management.
-        if self.config.enable_quotas:
-            self.quota_agent = galaxy.quota.QuotaAgent(self.model)
-        else:
-            self.quota_agent = galaxy.quota.NoQuotaAgent(self.model)
+        self.quota_agent = get_quota_agent(self.config, self.model)
         # Heartbeat for thread profiling
         self.heartbeat = None
         from galaxy import auth

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -578,15 +578,8 @@ class JobHandlerQueue(Monitors):
 
         if state == JOB_READY:
             state = self.__check_user_jobs(job, job_wrapper)
-        if state == JOB_READY and self.app.config.enable_quotas:
-            quota = self.app.quota_agent.get_quota(job.user)
-            if quota is not None:
-                try:
-                    usage = self.app.quota_agent.get_usage(user=job.user, history=job.history)
-                    if usage > quota:
-                        return JOB_USER_OVER_QUOTA, job_destination
-                except AssertionError:
-                    pass  # No history, should not happen with an anon user
+        if state == JOB_READY and self.app.quota_agent.is_over_quota(self.app, job, job_destination):
+            return JOB_USER_OVER_QUOTA, job_destination
         # Check total walltime limits
         if (state == JOB_READY and
                 "delta" in self.app.job_config.limits.total_walltime):

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -54,6 +54,7 @@ class ConfigSerializer(base.ModelSerializer):
             'screencasts_url'                   : _use_config,
             'citation_url'                      : _use_config,
             'support_url'                       : _use_config,
+            'quota_url'                         : _use_config,
             'helpsite_url'                      : _use_config,
             'lims_doc_url'                      : _defaults_to("https://usegalaxy.org/u/rkchak/p/sts"),
             'default_locale'                    : _use_config,

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -332,7 +332,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def quota(self, user, total=False):
         if total:
-            return self.app.quota_agent.get_quota(user, nice_size=True)
+            return self.app.quota_agent.get_quota_nice_size(user)
         return self.app.quota_agent.get_percent(user=user)
 
     def tags_used(self, user, tag_models=None):

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -1,6 +1,5 @@
-"""
-Galaxy Quotas
-"""
+"""Galaxy Quotas"""
+import abc
 import logging
 
 import galaxy.util
@@ -8,19 +7,36 @@ import galaxy.util
 log = logging.getLogger(__name__)
 
 
-class NoQuotaAgent:
-    """Base quota agent, always returns no quota"""
+class QuotaAgent(metaclass=abc.ABCMeta):
+    """Abstraction around querying Galaxy for quota available and used.
 
-    def __init__(self, model):
-        self.model = model
-        self.sa_session = model.context
+    Certain parts of the app that deal directly with modifying the quota assume more than
+    this interface - they assume the availability of the methods on DatabaseQuotaAgent that
+    implements this interface. But for read-only quota operations - such as checking available
+    quota or reporting it to users - methods defined on this interface should be sufficient
+    and the NoQuotaAgent should be a valid choice.
 
-    def get_quota(self, user, nice_size=False):
-        return None
+    Sticking to well annotated methods on this interface should make it clean and
+    possible to implement other backends for quota setting in the future such as managing
+    the quota in other apps (LDAP maybe?) or via configuration files.
+    """
 
-    @property
-    def default_quota(self):
-        return None
+    @abc.abstractmethod
+    def get_quota(self, user):
+        """Return quota in bytes or None if no quota is set."""
+
+    def get_quota_nice_size(self, user):
+        """Return quota as a human-readable string or 'unlimited' if no quota is set."""
+        quota_bytes = self.get_quota(user)
+        if quota_bytes is not None:
+            quota_str = galaxy.util.nice_size(quota_bytes)
+        else:
+            quota_str = 'unlimited'
+        return quota_str
+
+    @abc.abstractmethod
+    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
+        """Return the percentage of any storage quota applicable to the user/transaction."""
 
     def get_usage(self, trans=None, user=False, history=False):
         if trans:
@@ -34,17 +50,32 @@ class NoQuotaAgent:
             usage = user.total_disk_usage
         return usage
 
+
+class NoQuotaAgent(QuotaAgent):
+    """Base quota agent, always returns no quota"""
+
+    def __init__(self):
+        pass
+
+    def get_quota(self, user):
+        return None
+
+    @property
+    def default_quota(self):
+        return None
+
     def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
         return None
 
-    def get_user_quotas(self, user):
-        return []
 
-
-class QuotaAgent(NoQuotaAgent):
+class DatabaseQuotaAgent(QuotaAgent):
     """Class that handles galaxy quotas"""
 
-    def get_quota(self, user, nice_size=False):
+    def __init__(self, model):
+        self.model = model
+        self.sa_session = model.context
+
+    def get_quota(self, user):
         """
         Calculated like so:
 
@@ -92,11 +123,6 @@ class QuotaAgent(NoQuotaAgent):
             rval = max + adjustment
             if rval <= 0:
                 rval = 0
-        if nice_size:
-            if rval is not None:
-                rval = galaxy.util.nice_size(rval)
-            else:
-                rval = 'unlimited'
         return rval
 
     @property
@@ -179,21 +205,13 @@ class QuotaAgent(NoQuotaAgent):
                 self.sa_session.add(gqa)
             self.sa_session.flush()
 
-    def get_user_quotas(self, user):
-        rval = []
-        if not user:
-            dqa = self.sa_session.query(self.model.DefaultQuotaAssociation) \
-                .filter(self.model.DefaultQuotaAssociation.table.c.type == self.model.DefaultQuotaAssociation.types.UNREGISTERED).first()
-            if dqa:
-                rval.append(dqa.quota)
-        else:
-            dqa = self.sa_session.query(self.model.DefaultQuotaAssociation) \
-                .filter(self.model.DefaultQuotaAssociation.table.c.type == self.model.DefaultQuotaAssociation.types.REGISTERED).first()
-            if dqa:
-                rval.append(dqa.quota)
-            for uqa in user.quotas:
-                rval.append(uqa.quota)
-            for group in [uga.group for uga in user.groups]:
-                for gqa in group.quotas:
-                    rval.append(gqa.quota)
-        return rval
+
+def get_quota_agent(config, model):
+    if config.enable_quotas:
+        quota_agent = galaxy.quota.DatabaseQuotaAgent(model)
+    else:
+        quota_agent = galaxy.quota.NoQuotaAgent()
+    return quota_agent
+
+
+__all__ = ('get_quota_agent', 'NoQuotaAgent')

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1259,6 +1259,13 @@ mapping:
         desc: |
           The URL linked by the "Wiki" link in the "Help" menu.
 
+      quota_url:
+        type: str
+        default: https://galaxyproject.org/support/account-quotas/
+        required: false
+        desc: |
+          The URL linked for quota information in the UI.
+
       support_url:
         type: str
         default: https://galaxyproject.org/support/

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -547,6 +547,16 @@ class BaseDatasetPopulator:
         assert role_response.status_code == 200
         return role_response.json()[0]
 
+    def create_quota(self, quota_payload):
+        quota_response = self.galaxy_interactor.post("quotas", data=quota_payload, admin=True)
+        quota_response.raise_for_status()
+        return quota_response.json()
+
+    def get_quotas(self):
+        quota_response = self.galaxy_interactor.get("quotas", admin=True)
+        quota_response.raise_for_status()
+        return quota_response.json()
+
     def make_private(self, history_id, dataset_id):
         role_id = self.user_private_role_id()
         # Give manage permission to the user.

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -3,13 +3,13 @@ import sys
 import time
 
 import galaxy.datatypes.registry
-import galaxy.quota
 import galaxy.tools.data
 import tool_shed.repository_registry
 import tool_shed.repository_types.registry
 import tool_shed.webapp.model
 from galaxy.config import configure_logging
 from galaxy.model.tags import CommunityTagHandler
+from galaxy.quota import NoQuotaAgent
 from galaxy.security import idencoding
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.web_stack import application_stack_instance
@@ -69,7 +69,7 @@ class UniverseApplication:
         # Initialize the Tool Shed security agent.
         self.security_agent = self.model.security_agent
         # The Tool Shed makes no use of a quota, but this attribute is still required.
-        self.quota_agent = galaxy.quota.NoQuotaAgent(self.model)
+        self.quota_agent = NoQuotaAgent()
         # Initialize the baseline Tool Shed statistics component.
         self.shed_counter = self.model.shed_counter
         # Let the Tool Shed's HgwebConfigManager know where the hgweb.config file is located.

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -1,0 +1,32 @@
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+)
+from galaxy_test.driver import integration_util
+
+
+class QuotaIntegrationTestCase(integration_util.IntegrationTestCase):
+    require_admin_user = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["enable_quotas"] = True
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_quota_crud(self):
+        quotas = self.dataset_populator.get_quotas()
+        assert len(quotas) == 0
+
+        payload = {
+            'name': 'defaultquota1',
+            'description': 'first default quota',
+            'amount': '100MB',
+            'operation': '=',
+            'default': 'registered',
+        }
+        self.dataset_populator.create_quota(payload)
+
+        quotas = self.dataset_populator.get_quotas()
+        assert len(quotas) == 1

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -1,0 +1,62 @@
+from galaxy.quota import DatabaseQuotaAgent
+from .test_galaxy_mapping import BaseModelTestCase
+
+
+class QuotaTestCase(BaseModelTestCase):
+
+    def setUp(self):
+        super().setUp()
+        model = self.model
+        self.quota_agent = DatabaseQuotaAgent(model)
+
+    def test_quota(self):
+        model = self.model
+        u = model.User(email="quota@example.com", password="password")
+        self.persist(u)
+
+        self._assert_user_quota_is(u, None)
+
+        quota = model.Quota(name="default registered", amount=20)
+        self.quota_agent.set_default_quota(
+            model.DefaultQuotaAssociation.types.REGISTERED,
+            quota,
+        )
+
+        self._assert_user_quota_is(u, 20)
+
+        quota = model.Quota(name="user quota add", amount=30, operation="+")
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 50)
+
+        quota = model.Quota(name="user quota bigger base", amount=70, operation="=")
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 100)
+
+        quota = model.Quota(name="user quota del", amount=10, operation="-")
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 90)
+
+        quota = model.Quota(name="group quota add", amount=7, operation="+")
+        self._add_group_quota(u, quota)
+        self._assert_user_quota_is(u, 97)
+
+        quota = model.Quota(name="quota quota bigger base", amount=100, operation="=")
+        self._add_group_quota(u, quota)
+        self._assert_user_quota_is(u, 127)
+
+    def _add_group_quota(self, user, quota):
+        group = self.model.Group()
+        uga = self.model.UserGroupAssociation(user, group)
+        gqa = self.model.GroupQuotaAssociation(group=group, quota=quota)
+        self.persist(group, uga, quota, gqa, user)
+
+    def _add_user_quota(self, user, quota):
+        uqa = self.model.UserQuotaAssociation(user=user, quota=quota)
+        user.quotas.append(uqa)
+        self.persist(quota, uqa, user)
+
+    def _assert_user_quota_is(self, user, amount):
+        assert amount == self.quota_agent.get_quota(user)

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -43,9 +43,17 @@ class QuotaTestCase(BaseModelTestCase):
         self._add_group_quota(u, quota)
         self._assert_user_quota_is(u, 97)
 
-        quota = model.Quota(name="quota quota bigger base", amount=100, operation="=")
+        quota = model.Quota(name="group quota bigger base", amount=100, operation="=")
         self._add_group_quota(u, quota)
         self._assert_user_quota_is(u, 127)
+
+        quota.deleted = True
+        self.persist(quota)
+        self._assert_user_quota_is(u, 97)
+
+        quota = model.Quota(name="group quota unlimited", amount=-1, operation="=")
+        self._add_group_quota(u, quota)
+        self._assert_user_quota_is(u, None)
 
     def _add_group_quota(self, user, quota):
         group = self.model.Group()

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -60,3 +60,15 @@ class QuotaTestCase(BaseModelTestCase):
 
     def _assert_user_quota_is(self, user, amount):
         assert amount == self.quota_agent.get_quota(user)
+        if amount is None:
+            user.total_disk_usage = 1000
+            job = self.model.Job()
+            job.user = user
+            assert not self.quota_agent.is_over_quota(None, job, None)
+        else:
+            job = self.model.Job()
+            job.user = user
+            user.total_disk_usage = amount - 1
+            assert not self.quota_agent.is_over_quota(None, job, None)
+            user.total_disk_usage = amount + 1
+            assert self.quota_agent.is_over_quota(None, job, None)

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -67,7 +67,7 @@ class MockApp:
         self.security_agent = self.model.security_agent
         self.visualizations_registry = MockVisualizationsRegistry()
         self.tag_handler = tags.GalaxyTagHandler(self.model.context)
-        self.quota_agent = quota.QuotaAgent(self.model)
+        self.quota_agent = quota.DatabaseQuotaAgent(self.model)
         self.init_datatypes()
         self.job_config = Bunch(
             dynamic_params=None,


### PR DESCRIPTION
- Add 'interface' (abc) Quota agent with more documentation to define the interface jobs and user pieces have to quota management.
- Remove unused 'get_user_quotas' method from implementations of quota_agent.
- Add factory method to refactor logic for determining which quota agent to use out of galaxy/app and into galaxy.quota.
- Break get_quota into get_quota and get_quota_nice_size based on return type - I think return types varying so wildly based on input parameters is an anti-pattern.
- Unit tests that cover a lot of the complex get_quota logic.
- Integration test case for simple API testing of quotas.
- Refactor checking if quota is exceeded out of job.handler so it can be tested in isolation and so new functionality for quota calculation is extended in quota modules and not in job handler logic. I think this will make #4840 a little cleaner.
