### PR TITLE
[WIP] Implement get_quota in SQL

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -6,7 +6,6 @@ import time
 import galaxy.model
 import galaxy.model.security
 import galaxy.queues
-import galaxy.quota
 import galaxy.security
 from galaxy import config, job_metrics, jobs
 from galaxy.config_watchers import ConfigWatchers
@@ -27,6 +26,7 @@ from galaxy.queue_worker import (
     GalaxyQueueWorker,
     send_local_control_task,
 )
+from galaxy.quota import get_quota_agent
 from galaxy.tool_shed.galaxy_install.installed_repository_manager import InstalledRepositoryManager
 from galaxy.tool_shed.galaxy_install.update_repository_manager import UpdateRepositoryManager
 from galaxy.tool_util.deps.views import DependencyResolversView
@@ -175,10 +175,7 @@ class UniverseApplication(config.ConfiguresGalaxyMixin):
             model=self.security_agent.model,
             permitted_actions=self.security_agent.permitted_actions)
         # Load quota management.
-        if self.config.enable_quotas:
-            self.quota_agent = galaxy.quota.QuotaAgent(self.model)
-        else:
-            self.quota_agent = galaxy.quota.NoQuotaAgent(self.model)
+        self.quota_agent = get_quota_agent(self.config, self.model)
         # Heartbeat for thread profiling
         self.heartbeat = None
         from galaxy import auth

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -558,15 +558,8 @@ class JobHandlerQueue(Monitors):
 
         if state == JOB_READY:
             state = self.__check_user_jobs(job, job_wrapper)
-        if state == JOB_READY and self.app.config.enable_quotas:
-            quota = self.app.quota_agent.get_quota(job.user)
-            if quota is not None:
-                try:
-                    usage = self.app.quota_agent.get_usage(user=job.user, history=job.history)
-                    if usage > quota:
-                        return JOB_USER_OVER_QUOTA, job_destination
-                except AssertionError:
-                    pass  # No history, should not happen with an anon user
+        if state == JOB_READY and self.app.quota_agent.is_over_quota(job, job_destination):
+            return JOB_USER_OVER_QUOTA, job_destination
         # Check total walltime limits
         if (state == JOB_READY and
                 "delta" in self.app.job_config.limits.total_walltime):

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -332,7 +332,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
 
     def quota(self, user, total=False):
         if total:
-            return self.app.quota_agent.get_quota(user, nice_size=True)
+            return self.app.quota_agent.get_quota_nice_size(user)
         return self.app.quota_agent.get_percent(user=user)
 
     def tags_used(self, user, tag_models=None):

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -50,6 +50,14 @@ class QuotaAgent(metaclass=abc.ABCMeta):
             usage = user.total_disk_usage
         return usage
 
+    def is_over_quota(self, job, job_destination):
+        """Return True if the user or history is over quota for specified job.
+
+        job_destination unused currently but an important future application will
+        be admins and/or users dynamically specifying which object stores to use
+        and that will likely come in through the job destination.
+        """
+
 
 class NoQuotaAgent(QuotaAgent):
     """Base quota agent, always returns no quota"""
@@ -66,6 +74,9 @@ class NoQuotaAgent(QuotaAgent):
 
     def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
         return None
+
+    def is_over_quota(self, job, job_destination):
+        return False
 
 
 class DatabaseQuotaAgent(QuotaAgent):
@@ -204,6 +215,17 @@ class DatabaseQuotaAgent(QuotaAgent):
                 gqa = self.model.GroupQuotaAssociation(group, quota)
                 self.sa_session.add(gqa)
             self.sa_session.flush()
+
+    def is_over_quota(self, job, job_destination):
+        quota = self.get_quota(job.user)
+        if quota is not None:
+            try:
+                usage = self.get_usage(user=job.user, history=job.history)
+                if usage > quota:
+                    return True
+            except AssertionError:
+                pass  # No history, should not happen with an anon user
+        return False
 
 
 def get_quota_agent(config, model):

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -1,6 +1,5 @@
-"""
-Galaxy Quotas
-"""
+"""Galaxy Quotas"""
+import abc
 import logging
 
 import galaxy.util
@@ -8,19 +7,36 @@ import galaxy.util
 log = logging.getLogger(__name__)
 
 
-class NoQuotaAgent:
-    """Base quota agent, always returns no quota"""
+class QuotaAgent(metaclass=abc.ABCMeta):
+    """Abstraction around querying Galaxy for quota available and used.
 
-    def __init__(self, model):
-        self.model = model
-        self.sa_session = model.context
+    Certain parts of the app that deal directly with modifying the quota assume more than
+    this interface - they assume the availability of the methods on DatabaseQuotaAgent that
+    implements this interface. But for read-only quota operations - such as checking available
+    quota or reporting it to users - methods defined on this interface should be sufficient
+    and the NoQuotaAgent should be a valid choice.
 
-    def get_quota(self, user, nice_size=False):
-        return None
+    Sticking to well annotated methods on this interface should make it clean and
+    possible to implement other backends for quota setting in the future such as managing
+    the quota in other apps (LDAP maybe?) or via configuration files.
+    """
 
-    @property
-    def default_quota(self):
-        return None
+    @abc.abstractmethod
+    def get_quota(self, user):
+        """Return quota in bytes or None if no quota is set."""
+
+    def get_quota_nice_size(self, user):
+        """Return quota as a human-readable string or 'unlimited' if no quota is set."""
+        quota_bytes = self.get_quota(user)
+        if quota_bytes is not None:
+            quota_str = galaxy.util.nice_size(quota_bytes)
+        else:
+            quota_str = 'unlimited'
+        return quota_str
+
+    @abc.abstractmethod
+    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
+        """Return the percentage of any storage quota applicable to the user/transaction."""
 
     def get_usage(self, trans=None, user=False, history=False):
         if trans:
@@ -34,17 +50,32 @@ class NoQuotaAgent:
             usage = user.total_disk_usage
         return usage
 
+
+class NoQuotaAgent(QuotaAgent):
+    """Base quota agent, always returns no quota"""
+
+    def __init__(self):
+        pass
+
+    def get_quota(self, user):
+        return None
+
+    @property
+    def default_quota(self):
+        return None
+
     def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
         return None
 
-    def get_user_quotas(self, user):
-        return []
 
-
-class QuotaAgent(NoQuotaAgent):
+class DatabaseQuotaAgent(QuotaAgent):
     """Class that handles galaxy quotas"""
 
-    def get_quota(self, user, nice_size=False):
+    def __init__(self, model):
+        self.model = model
+        self.sa_session = model.context
+
+    def get_quota(self, user):
         """
         Calculated like so:
 
@@ -92,11 +123,6 @@ class QuotaAgent(NoQuotaAgent):
             rval = max + adjustment
             if rval <= 0:
                 rval = 0
-        if nice_size:
-            if rval is not None:
-                rval = galaxy.util.nice_size(rval)
-            else:
-                rval = 'unlimited'
         return rval
 
     @property
@@ -179,21 +205,13 @@ class QuotaAgent(NoQuotaAgent):
                 self.sa_session.add(gqa)
             self.sa_session.flush()
 
-    def get_user_quotas(self, user):
-        rval = []
-        if not user:
-            dqa = self.sa_session.query(self.model.DefaultQuotaAssociation) \
-                .filter(self.model.DefaultQuotaAssociation.table.c.type == self.model.DefaultQuotaAssociation.types.UNREGISTERED).first()
-            if dqa:
-                rval.append(dqa.quota)
-        else:
-            dqa = self.sa_session.query(self.model.DefaultQuotaAssociation) \
-                .filter(self.model.DefaultQuotaAssociation.table.c.type == self.model.DefaultQuotaAssociation.types.REGISTERED).first()
-            if dqa:
-                rval.append(dqa.quota)
-            for uqa in user.quotas:
-                rval.append(uqa.quota)
-            for group in [uga.group for uga in user.groups]:
-                for gqa in group.quotas:
-                    rval.append(gqa.quota)
-        return rval
+
+def get_quota_agent(config, model):
+    if config.enable_quotas:
+        quota_agent = galaxy.quota.DatabaseQuotaAgent(model)
+    else:
+        quota_agent = galaxy.quota.NoQuotaAgent()
+    return quota_agent
+
+
+__all__ = ('get_quota_agent', 'NoQuotaAgent')

--- a/lib/tool_shed/webapp/app.py
+++ b/lib/tool_shed/webapp/app.py
@@ -3,13 +3,13 @@ import sys
 import time
 
 import galaxy.datatypes.registry
-import galaxy.quota
 import galaxy.tools.data
 import tool_shed.repository_registry
 import tool_shed.repository_types.registry
 import tool_shed.webapp.model
 from galaxy.config import configure_logging
 from galaxy.model.tags import CommunityTagHandler
+from galaxy.quota import NoQuotaAgent
 from galaxy.security import idencoding
 from galaxy.util.dbkeys import GenomeBuilds
 from galaxy.web_stack import application_stack_instance
@@ -69,7 +69,7 @@ class UniverseApplication:
         # Initialize the Tool Shed security agent.
         self.security_agent = self.model.security_agent
         # The Tool Shed makes no use of a quota, but this attribute is still required.
-        self.quota_agent = galaxy.quota.NoQuotaAgent(self.model)
+        self.quota_agent = NoQuotaAgent()
         # Initialize the baseline Tool Shed statistics component.
         self.shed_counter = self.model.shed_counter
         # Let the Tool Shed's HgwebConfigManager know where the hgweb.config file is located.

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -14,7 +14,41 @@ datatypes_registry.load_datatypes()
 galaxy.model.set_datatypes_registry(datatypes_registry)
 
 
-class MappingTests(unittest.TestCase):
+class BaseModelTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # Start the database and connect the mapping
+        cls.model = mapping.init("/tmp", "sqlite:///:memory:", create_tables=True, object_store=MockObjectStore())
+        assert cls.model.engine is not None
+
+    @classmethod
+    def query(cls, type):
+        return cls.model.session.query(type)
+
+    @classmethod
+    def persist(cls, *args, **kwargs):
+        session = cls.session()
+        flush = kwargs.get('flush', True)
+        for arg in args:
+            session.add(arg)
+            if flush:
+                session.flush()
+        if kwargs.get('expunge', not flush):
+            cls.expunge()
+        return arg  # Return last or only arg.
+
+    @classmethod
+    def session(cls):
+        return cls.model.session
+
+    @classmethod
+    def expunge(cls):
+        cls.model.session.flush()
+        cls.model.session.expunge_all()
+
+
+class MappingTests(BaseModelTestCase):
 
     def test_annotations(self):
         model = self.model
@@ -546,37 +580,6 @@ class MappingTests(unittest.TestCase):
 
     def new_hda(self, history, **kwds):
         return history.add_dataset(self.model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds))
-
-    @classmethod
-    def setUpClass(cls):
-        # Start the database and connect the mapping
-        cls.model = mapping.init("/tmp", "sqlite:///:memory:", create_tables=True, object_store=MockObjectStore())
-        assert cls.model.engine is not None
-
-    @classmethod
-    def query(cls, type):
-        return cls.model.session.query(type)
-
-    @classmethod
-    def persist(cls, *args, **kwargs):
-        session = cls.session()
-        flush = kwargs.get('flush', True)
-        for arg in args:
-            session.add(arg)
-            if flush:
-                session.flush()
-        if kwargs.get('expunge', not flush):
-            cls.expunge()
-        return arg  # Return last or only arg.
-
-    @classmethod
-    def session(cls):
-        return cls.model.session
-
-    @classmethod
-    def expunge(cls):
-        cls.model.session.flush()
-        cls.model.session.expunge_all()
 
 
 class MockObjectStore(object):

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -1,0 +1,62 @@
+from galaxy.quota import DatabaseQuotaAgent
+from .test_galaxy_mapping import BaseModelTestCase
+
+
+class QuotaTestCase(BaseModelTestCase):
+
+    def setUp(self):
+        super().setUp()
+        model = self.model
+        self.quota_agent = DatabaseQuotaAgent(model)
+
+    def test_quota(self):
+        model = self.model
+        u = model.User(email="quota@example.com", password="password")
+        self.persist(u)
+
+        self._assert_user_quota_is(u, None)
+
+        quota = model.Quota(name="default registered", amount=20)
+        self.quota_agent.set_default_quota(
+            model.DefaultQuotaAssociation.types.REGISTERED,
+            quota,
+        )
+
+        self._assert_user_quota_is(u, 20)
+
+        quota = model.Quota(name="user quota add", amount=30, operation="+")
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 50)
+
+        quota = model.Quota(name="user quota bigger base", amount=70, operation="=")
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 100)
+
+        quota = model.Quota(name="user quota del", amount=10, operation="-")
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 90)
+
+        quota = model.Quota(name="group quota add", amount=7, operation="+")
+        self._add_group_quota(u, quota)
+        self._assert_user_quota_is(u, 97)
+
+        quota = model.Quota(name="quota quota bigger base", amount=100, operation="=")
+        self._add_group_quota(u, quota)
+        self._assert_user_quota_is(u, 127)
+
+    def _add_group_quota(self, user, quota):
+        group = self.model.Group()
+        uga = self.model.UserGroupAssociation(user, group)
+        gqa = self.model.GroupQuotaAssociation(group=group, quota=quota)
+        self.persist(group, uga, quota, gqa, user)
+
+    def _add_user_quota(self, user, quota):
+        uqa = self.model.UserQuotaAssociation(user=user, quota=quota)
+        user.quotas.append(uqa)
+        self.persist(quota, uqa, user)
+
+    def _assert_user_quota_is(self, user, amount):
+        assert amount == self.quota_agent.get_quota(user)

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -43,9 +43,17 @@ class QuotaTestCase(BaseModelTestCase):
         self._add_group_quota(u, quota)
         self._assert_user_quota_is(u, 97)
 
-        quota = model.Quota(name="quota quota bigger base", amount=100, operation="=")
+        quota = model.Quota(name="group quota bigger base", amount=100, operation="=")
         self._add_group_quota(u, quota)
         self._assert_user_quota_is(u, 127)
+
+        quota.deleted = True
+        self.persist(quota)
+        self._assert_user_quota_is(u, 97)
+
+        quota = model.Quota(name="group quota unlimited", amount=-1, operation="=")
+        self._add_group_quota(u, quota)
+        self._assert_user_quota_is(u, None)
 
     def _add_group_quota(self, user, quota):
         group = self.model.Group()

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -60,3 +60,15 @@ class QuotaTestCase(BaseModelTestCase):
 
     def _assert_user_quota_is(self, user, amount):
         assert amount == self.quota_agent.get_quota(user)
+        if amount is None:
+            user.total_disk_usage = 1000
+            job = self.model.Job()
+            job.user = user
+            assert not self.quota_agent.is_over_quota(job, None)
+        else:
+            job = self.model.Job()
+            job.user = user
+            user.total_disk_usage = amount - 1
+            assert not self.quota_agent.is_over_quota(job, None)
+            user.total_disk_usage = amount + 1
+            assert self.quota_agent.is_over_quota(job, None)

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -67,7 +67,8 @@ class QuotaTestCase(BaseModelTestCase):
         self.persist(quota, uqa, user)
 
     def _assert_user_quota_is(self, user, amount):
-        assert amount == self.quota_agent.get_quota(user)
+        actual_quota = self.quota_agent.get_quota(user)
+        assert amount == actual_quota, "Expected quota [%s], got [%s]" % (amount, actual_quota)
         if amount is None:
             user.total_disk_usage = 1000
             job = self.model.Job()

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -67,7 +67,7 @@ class MockApp(object):
         self.security_agent = self.model.security_agent
         self.visualizations_registry = MockVisualizationsRegistry()
         self.tag_handler = tags.GalaxyTagHandler(self.model.context)
-        self.quota_agent = quota.QuotaAgent(self.model)
+        self.quota_agent = quota.DatabaseQuotaAgent(self.model)
         self.init_datatypes()
         self.job_config = Bunch(
             dynamic_params=None,


### PR DESCRIPTION
Every iteration of every handled job calls this - seems needless to pull all the relevant objects down from the database and calculate this in Python.

Also I'd like to make some progress toward per-objectstore usage and quotas - that will make calculating quotas and usage more complicated along this critical path - so I want to make sure whatever is done can be done in database efficiently.

This PR builds on #10212 