### PR TITLE
Strip deprecated dir from all paths in comma-separated option values

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -276,14 +276,17 @@ class BaseAppConfiguration:
         def strip_deprecated_dir(key, value):
             resolves_to = self.schema.paths_to_resolve.get(key)
             if resolves_to:  # value is a path that will be resolved
-                first_dir = value.split(os.sep)[0]  # get first directory component
-                if first_dir == self.deprecated_dirs.get(resolves_to):  # first_dir is deprecated for this option
-                    ignore = first_dir + os.sep
-                    log.warning(
-                        "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
-                        "to suppress this warning: %s", key, resolves_to, ignore, value
-                    )
-                    return value[len(ignore):]
+                paths = value.split(',')
+                for i, path in enumerate(paths):
+                    first_dir = path.split(os.sep)[0]  # get first directory component
+                    if first_dir == self.deprecated_dirs.get(resolves_to):  # first_dir is deprecated for this option
+                        ignore = first_dir + os.sep
+                        log.warning(
+                            "Paths for the '%s' option are now relative to '%s', remove the leading '%s' "
+                            "to suppress this warning: %s", key, resolves_to, ignore, path
+                        )
+                        paths[i] = path[len(ignore):]
+                return ','.join(paths)
             return value
 
         type_converters = {'bool': string_as_bool, 'int': int, 'float': float, 'str': str}

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -275,8 +275,8 @@ class BaseAppConfiguration:
 
         def strip_deprecated_dir(key, value):
             resolves_to = self.schema.paths_to_resolve.get(key)
-            if resolves_to:  # value is a path that will be resolved
-                paths = value.split(',')
+            if resolves_to:  # value contains paths that will be resolved
+                paths = [path.strip() for path in value.split(',')]
                 for i, path in enumerate(paths):
                     first_dir = path.split(os.sep)[0]  # get first directory component
                     if first_dir == self.deprecated_dirs.get(resolves_to):  # first_dir is deprecated for this option

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -85,7 +85,7 @@ def test_kwargs_relative_path(mock_init):
     assert config.path3 == 'my-other-files'  # no change
 
 
-def test_kwargs_ablsolute_path(mock_init):
+def test_kwargs_absolute_path(mock_init):
     # Expected: use value from kwargs, do NOT resolve
     new_path1 = '/foo1/bar'
     new_path2 = '/foo2/bar'
@@ -105,6 +105,13 @@ def test_kwargs_relative_path_old_prefix(mock_init):
     assert config.path1 == 'my-config/foo1/bar'  # stripped of old prefix, resolved
     assert config.path2 == 'my-data/foo2/bar'  # stripped of old prefix, resolved
     assert config.path3 == 'my-other-files'  # no change
+
+
+def test_kwargs_relative_path_old_prefix_csv_value(mock_init):
+    # Expect: use value from kwargs, split at commas, then for each path strip
+    # spaces, strip old prefix if needed, and resolve if needed
+    config = BaseAppConfiguration(path4='old-config/foo/file1 , /foo1/bar,  foo/file3')
+    assert config.path4 == ['my-config/foo/file1', '/foo1/bar', 'my-config/foo/file3']
 
 
 def test_kwargs_relative_path_old_prefix_for_other_option(mock_init):
@@ -198,7 +205,7 @@ def test_kwargs_listify(mock_init, monkeypatch):
     new_path4 = 'new1, new2'
     config = BaseAppConfiguration(path4=new_path4)
 
-    assert config._raw_config['path4'] == 'new1, new2'
+    assert config._raw_config['path4'] == 'new1,new2'
     assert config.path4 == ['my-config/new1', 'my-config/new2']
 
 


### PR DESCRIPTION
Fix the following traceback in BioBlend testing:

```
WARNING:galaxy.config:Paths for the 'tool_config_file' option are now relative to 'config_dir', remove the leading 'config/' to suppress this warning: config/tool_conf.xml.sample,config/shed_tool_conf.xml,test/functional/tools/samples_tool_conf.xml
WARNING:galaxy.config:Paths for the 'tool_config_file' option should be relative to 'config_dir'. To suppress this warning, move 'tool_config_file' into 'config_dir', or set it's value to an absolute path.
Traceback (most recent call last):
  File "/home/travis/galaxy-dev/lib/galaxy/webapps/galaxy/buildapp.py", line 48, in app_factory
    app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
  File "/home/travis/galaxy-dev/lib/galaxy/app.py", line 77, in __init__
    self.config.check()
  File "/home/travis/galaxy-dev/lib/galaxy/config/__init__.py", line 920, in check
    raise ConfigurationError("Tool config file not found: %s" % path)
galaxy.exceptions.ConfigurationError: Tool config file not found: /home/travis/galaxy-dev/config/config/shed_tool_conf.xml
```

See https://travis-ci.org/github/galaxyproject/bioblend/jobs/726994011#L1249