### PR TITLE
Implement quota tracking options per ObjectStore.

### DIFF
--- a/client/src/components/Quota/QuotaUsage.vue
+++ b/client/src/components/Quota/QuotaUsage.vue
@@ -1,0 +1,44 @@
+<template>
+    <div>
+        <b>{{ quotaUsage.name }}</b>
+        <progress-bar
+            :note="title"
+            :ok-count="quotaUsage.quota_percent"
+            :total="100"
+            v-if="quotaUsage.quota_percent < 99"
+        />
+        <progress-bar :note="title" :error-count="quotaUsage.quota_percent" :total="100" v-else />
+        <p>
+            <i>Using {{ quotaUsage.nice_total_disk_usage }} out of {{ quotaUsage.quota }}.</i>
+        </p>
+        <hr />
+    </div>
+</template>
+
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import ProgressBar from "components/ProgressBar";
+
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        ProgressBar,
+    },
+    props: {
+        quotaUsage: {
+            type: Object,
+        },
+    },
+    computed: {
+        title() {
+            if (this.quotaUsage.quota_percent == null) {
+                return `Unlimited`;
+            } else {
+                return `Using ${this.quotaUsage.quota_percent}%.`;
+            }
+        },
+    },
+};
+</script>

--- a/client/src/components/Quota/QuotaUsageDialog.vue
+++ b/client/src/components/Quota/QuotaUsageDialog.vue
@@ -1,0 +1,76 @@
+<template>
+    <b-modal visible ok-only ok-title="Close" hide-header>
+        <b-alert v-if="errorMessage" variant="danger" show v-html="errorMessage" />
+        <div v-else-if="usage == null">
+            <span class="fa fa-spinner fa-spin" />
+            <span>Please wait...</span>
+        </div>
+        <div class="d-block" style="overflow: hidden;" v-else>
+            <div v-for="item in effectiveQuotaSourceLabels" :key="item.id">
+                <quota-usage :quotaUsage="item" />
+            </div>
+        </div>
+    </b-modal>
+</template>
+
+<script>
+import axios from "axios";
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import { getAppRoot } from "onload/loadConfig";
+import { errorMessageAsString } from "utils/simple-error";
+import QuotaUsage from "./QuotaUsage";
+
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        QuotaUsage,
+    },
+    props: {
+        quotaSourceLabels: {
+            type: Array,
+        },
+    },
+    data() {
+        return {
+            usage: null,
+            errorMessage: null,
+        };
+    },
+    created() {
+        const url = `${getAppRoot()}api/users/current/usage`;
+        axios
+            .get(url)
+            .then((response) => {
+                this.usage = response.data;
+            })
+            .catch((error) => {
+                this.errorMessage = errorMessageAsString(error);
+            });
+    },
+    computed: {
+        effectiveQuotaSourceLabels() {
+            const labels = [];
+            const usageAsDict = this.usageAsDict;
+            labels.push({ id: "_default_", name: "Default Quota", ...usageAsDict["_default_"] });
+            for (const label of this.quotaSourceLabels) {
+                const usage = usageAsDict[label];
+                labels.push({ id: label, name: `Quota Source: ${label}`, ...usage });
+            }
+            return labels;
+        },
+        usageAsDict() {
+            const asDict = {};
+            for (const usage of this.usage) {
+                if (usage.quota_source_label == null) {
+                    asDict["_default_"] = usage;
+                } else {
+                    asDict[usage.quota_source_label] = usage;
+                }
+            }
+            return asDict;
+        },
+    },
+};
+</script>

--- a/client/src/components/Quota/index.js
+++ b/client/src/components/Quota/index.js
@@ -1,0 +1,1 @@
+export { showQuotaDialog } from "./show";

--- a/client/src/components/Quota/show.js
+++ b/client/src/components/Quota/show.js
@@ -1,0 +1,11 @@
+import Vue from "vue";
+import QuotaUsageDialog from "./QuotaUsageDialog";
+
+export function showQuotaDialog(options = {}) {
+    const instance = Vue.extend(QuotaUsageDialog);
+    const vm = document.createElement("div");
+    document.body.appendChild(vm);
+    new instance({
+        propsData: options,
+    }).$mount(vm);
+}

--- a/client/src/layout/masthead.js
+++ b/client/src/layout/masthead.js
@@ -20,6 +20,7 @@ export class MastheadState {
         Galaxy.quotaMeter = this.quotaMeter = new QuotaMeter.UserQuotaMeter({
             model: Galaxy.user,
             quotaUrl: Galaxy.config.quota_url,
+            quotaSourceLabels: Galaxy.config.quota_source_labels,
         });
 
         // loop through beforeunload functions if the user attempts to unload the page

--- a/client/src/mvc/user/user-quotameter.js
+++ b/client/src/mvc/user/user-quotameter.js
@@ -4,6 +4,8 @@ import _ from "underscore";
 import baseMVC from "mvc/base-mvc";
 import _l from "utils/localization";
 
+import { showQuotaDialog } from "components/Quota";
+
 var logNamespace = "user";
 //==============================================================================
 /** @class View to display a user's disk/storage usage
@@ -27,6 +29,7 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
         initialize: function (options) {
             this.log(`${this}.initialize:`, options);
             _.extend(this.options, options);
+            this.useQuotaSourceLabels = options.quotaSourceLabels.length > 0;
 
             //this.bind( 'all', function( event, data ){ this.log( this + ' event:', event, data ); }, this );
             this.listenTo(this.model, "change:quota_percent change:total_disk_usage", this.render);
@@ -126,6 +129,16 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
 
             this.$el.html(meterHtml);
             this.$el.find(".quota-meter-text").tooltip();
+            const $link = this.$el.find(".quota-meter-link");
+            if (this.useQuotaSourceLabels) {
+                $link.click(() => {
+                    showQuotaDialog({
+                        quotaSourceLabels: this.options.quotaSourceLabels,
+                    });
+                });
+            } else {
+                $link.attr("href", "https://galaxyproject.org/support/account-quotas/");
+            }
             return this;
         },
 
@@ -138,7 +151,7 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
             return `<div id="quota-meter" class="quota-meter progress">
     <div class="progress-bar" style="width: ${data.quota_percent}%"></div>
     <div class="quota-meter-text" data-placement="left" ${title}>
-        <a href="${quotaUrl}" target="_blank">${using}</a>
+        <a href="${quotaUrl}" class="quota-meter-link" target="_blank">${using}</a>
     </div>
 </div>`;
         },

--- a/lib/galaxy/actions/admin.py
+++ b/lib/galaxy/actions/admin.py
@@ -40,7 +40,13 @@ class AdminActions:
             raise ActionInputError("Operation for an unlimited quota must be '='.")
         else:
             # Create the quota
-            quota = self.app.model.Quota(name=params.name, description=params.description, amount=create_amount, operation=params.operation)
+            quota = self.app.model.Quota(
+                name=params.name,
+                description=params.description,
+                amount=create_amount,
+                operation=params.operation,
+                quota_source_label=params.quota_source_label,
+            )
             self.sa_session.add(quota)
             # If this is a default quota, create the DefaultQuotaAssociation
             if params.default != 'no':

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -105,6 +105,7 @@ class ConfigSerializer(base.ModelSerializer):
             'python'                            : _defaults_to((sys.version_info.major, sys.version_info.minor)),
             'select_type_workflow_threshold'    : _use_config,
             'file_sources_configured'           : lambda config, key, **context: self.app.file_sources.custom_sources_configured,
+            'quota_source_labels'               : lambda config, key, **context: list(self.app.object_store.get_quota_source_map().get_quota_source_labels()),
             'upload_from_form_button'           : _use_config,
         }
 

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -143,8 +143,9 @@ class HDAManager(datasets.DatasetAssociationManager,
             quota_amount_reduction = hda.quota_amount(user)
         super().purge(hda, flush=flush)
         # decrease the user's space used
-        if quota_amount_reduction:
-            user.adjust_total_disk_usage(-quota_amount_reduction)
+        quota_source_info = hda.dataset.quota_source_info
+        if quota_amount_reduction and quota_source_info.use:
+            user.adjust_total_disk_usage(-quota_amount_reduction, quota_source_info.label)
         return hda
 
     # .... states

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -25,6 +25,7 @@ from social_core.storage import AssociationMixin, CodeMixin, NonceMixin, Partial
 from sqlalchemy import (
     alias,
     and_,
+    bindparam,
     func,
     inspect,
     join,
@@ -354,6 +355,102 @@ class JobLike:
         raise NotImplementedError("Attempt to set stdout, must set tool_stderr or job_stderr")
 
 
+UNIQUE_DATASET_USER_USAGE = """
+WITH per_user_histories AS
+(
+    SELECT id
+    FROM history
+    WHERE user_id = :id
+        AND NOT purged
+),
+per_hist_hdas AS (
+    SELECT DISTINCT dataset_id
+    FROM history_dataset_association
+    WHERE NOT purged
+        AND history_id IN (SELECT id FROM per_user_histories)
+)
+SELECT COALESCE(SUM(COALESCE(dataset.total_size, dataset.file_size, 0)), 0)
+FROM dataset
+LEFT OUTER JOIN library_dataset_dataset_association ON dataset.id = library_dataset_dataset_association.dataset_id
+WHERE dataset.id IN (SELECT dataset_id FROM per_hist_hdas)
+    AND library_dataset_dataset_association.id IS NULL
+    AND (
+        {dataset_condition}
+    )
+"""
+
+
+def calculate_user_disk_usage_statements(user_id, quota_source_map, for_sqlite=False):
+    """Standalone function so can be reused for postgres directly in pgcleanup.py."""
+    statements = []
+    default_quota_enabled = quota_source_map.default_quota_enabled
+    default_exclude_ids = quota_source_map.default_usage_excluded_ids()
+    default_cond = "dataset.object_store_id IS NULL" if default_quota_enabled else ""
+    exclude_cond = "dataset.object_store_id NOT IN :exclude_object_store_ids" if default_exclude_ids else ""
+    use_or = " OR " if (default_cond != "" and exclude_cond != "") else ""
+    default_usage_dataset_condition = "{default_cond} {use_or} {exclude_cond}".format(
+        default_cond=default_cond,
+        exclude_cond=exclude_cond,
+        use_or=use_or,
+    )
+    default_usage = UNIQUE_DATASET_USER_USAGE.format(
+        dataset_condition=default_usage_dataset_condition
+    )
+    default_usage = """
+UPDATE galaxy_user SET disk_usage = (%s)
+WHERE id = :id
+""" % default_usage
+    params = {"id": user_id}
+    if default_exclude_ids:
+        params["exclude_object_store_ids"] = default_exclude_ids
+    statements.append((default_usage, params))
+    source = quota_source_map.ids_per_quota_source()
+    # TODO: Merge a lot of these settings together by generating a temp table for
+    # the object_store_id to quota_source_label into a temp table of values
+    for (quota_source_label, object_store_ids) in source.items():
+        label_usage = UNIQUE_DATASET_USER_USAGE.format(
+            dataset_condition="dataset.object_store_id IN :include_object_store_ids"
+        )
+        if for_sqlite:
+            # hacky alternative for older sqlite
+            statement = """
+WITH new (user_id, quota_source_label, disk_usage) AS (
+    VALUES(:id, :label, ({label_usage}))
+)
+INSERT OR REPLACE INTO user_quota_source_usage (id, user_id, quota_source_label, disk_usage)
+SELECT old.id, new.user_id, new.quota_source_label, new.disk_usage
+FROM new
+    LEFT JOIN user_quota_source_usage AS old
+        ON new.user_id = old.user_id
+            AND new.quota_source_label = old.quota_source_label
+""".format(label_usage=label_usage)
+        else:
+            statement = """
+INSERT INTO user_quota_source_usage(user_id, quota_source_label, disk_usage)
+VALUES(:user_id, :label, ({label_usage}))
+ON CONFLICT
+ON constraint uqsu_unique_label_per_user
+DO UPDATE SET disk_usage = excluded.disk_usage
+""".format(label_usage=label_usage)
+        statements.append((statement, {"id": user_id, "label": quota_source_label, "include_object_store_ids": object_store_ids}))
+
+    params = {"id": user_id}
+    source_labels = list(source.keys())
+    if len(source_labels) > 0:
+        clean_old_statement = """
+DELETE FROM user_quota_source_usage
+WHERE user_id = :id AND quota_source_label NOT IN :labels
+"""
+        params["labels"] = source_labels
+    else:
+        clean_old_statement = """
+DELETE FROM user_quota_source_usage
+WHERE user_id = :id AND quota_source_label IS NOT NULL
+"""
+    statements.append((clean_old_statement, params))
+    return statements
+
+
 class User(Dictifiable, RepresentById):
     use_pbkdf2 = True
     """
@@ -482,14 +579,31 @@ class User(Dictifiable, RepresentById):
                     roles.append(role)
         return roles
 
-    def get_disk_usage(self, nice_size=False):
+    def get_disk_usage(self, nice_size=False, quota_source_label=None):
         """
         Return byte count of disk space used by user or a human-readable
         string if `nice_size` is `True`.
         """
-        rval = 0
-        if self.disk_usage is not None:
-            rval = self.disk_usage
+        if quota_source_label is None:
+            rval = 0
+            if self.disk_usage is not None:
+                rval = self.disk_usage
+        else:
+            statement = """
+SELECT DISK_USAGE
+FROM user_quota_source_usage
+WHERE user_id = :user_id and quota_source_label = :label
+"""
+            sa_session = object_session(self)
+            params = {
+                'user_id': self.id,
+                'label': quota_source_label,
+            }
+            row = sa_session.execute(statement, params).fetchone()
+            if row is not None:
+                rval = row[0]
+            else:
+                rval = 0
         if nice_size:
             rval = galaxy.util.nice_size(rval)
         return rval
@@ -502,9 +616,36 @@ class User(Dictifiable, RepresentById):
 
     total_disk_usage = property(get_disk_usage, set_disk_usage)
 
-    def adjust_total_disk_usage(self, amount):
+    def adjust_total_disk_usage(self, amount, quota_source_label):
+        assert amount is not None
         if amount != 0:
-            self.disk_usage = func.coalesce(self.table.c.disk_usage, 0) + amount
+            if quota_source_label is None:
+                self.disk_usage = func.coalesce(self.table.c.disk_usage, 0) + amount
+            else:
+                # else would work on newer sqlite - 3.24.0
+                sa_session = object_session(self)
+                if "sqlite" in sa_session.bind.dialect.name:
+                    # hacky alternative for older sqlite
+                    statement = """
+WITH new (user_id, quota_source_label) AS ( VALUES(:user_id, :label) )
+INSERT OR REPLACE INTO user_quota_source_usage (id, user_id, quota_source_label, disk_usage)
+SELECT old.id, new.user_id, new.quota_source_label, COALESCE(old.disk_usage + :amount, :amount)
+FROM new LEFT JOIN user_quota_source_usage AS old ON new.user_id = old.user_id AND NEW.quota_source_label = old.quota_source_label;
+"""
+                else:
+                    statement = """
+INSERT INTO user_quota_source_usage(user_id, disk_usage, quota_source_label)
+VALUES(:user_id, :amount, :label)
+ON CONFLICT
+    ON constraint uqsu_unique_label_per_user
+    DO UPDATE SET disk_usage = user_quota_source_usage.disk_usage + :amount
+"""
+                params = {
+                    'user_id': self.id,
+                    'amount': int(amount),
+                    'label': quota_source_label,
+                }
+                sa_session.execute(statement, params)
 
     @property
     def nice_total_disk_usage(self):
@@ -513,51 +654,57 @@ class User(Dictifiable, RepresentById):
         """
         return self.get_disk_usage(nice_size=True)
 
-    def calculate_disk_usage(self):
+    def calculate_disk_usage_default_source(self, object_store):
         """
         Return byte count total of disk space used by all non-purged, non-library
-        HDAs in non-purged histories.
+        HDAs in non-purged histories assigned to default quota source.
         """
-        # maintain a list so that we don't double count
-        return self._calculate_or_set_disk_usage(dryrun=True)
+        # only used in set_user_disk_usage.py
+        assert object_store is not None
+        quota_source_map = object_store.get_quota_source_map()
+        default_quota_enabled = quota_source_map.default_quota_enabled
+        default_cond = "dataset.object_store_id IS NULL OR" if default_quota_enabled else ""
+        default_usage_dataset_condition = "{default_cond} dataset.object_store_id NOT IN :exclude_object_store_ids".format(
+            default_cond=default_cond,
+        )
+        default_usage = UNIQUE_DATASET_USER_USAGE.format(
+            dataset_condition=default_usage_dataset_condition
+        )
+        sql_calc = text(default_usage)
+        sql_calc = sql_calc.bindparams(
+            bindparam("id"),
+            bindparam("exclude_object_store_ids", expanding=True)
+        )
+        params = {'id': self.id, "exclude_object_store_ids": quota_source_map.default_usage_excluded_ids()}
+        sa_session = object_session(self)
+        usage = sa_session.scalar(sql_calc, params)
+        return usage
 
-    def calculate_and_set_disk_usage(self):
+    def calculate_and_set_disk_usage(self, object_store):
         """
         Calculates and sets user disk usage.
         """
-        self._calculate_or_set_disk_usage(dryrun=False)
+        self._calculate_or_set_disk_usage(object_store=object_store)
 
-    def _calculate_or_set_disk_usage(self, dryrun=True):
+    def _calculate_or_set_disk_usage(self, object_store):
         """
         Utility to calculate and return the disk usage.  If dryrun is False,
         the new value is set immediately.
         """
-        sql_calc = """
-            WITH per_user_histories AS
-            (
-                SELECT id
-                FROM history
-                WHERE user_id = :id
-                    AND NOT purged
-            ),
-            per_hist_hdas AS (
-                SELECT DISTINCT dataset_id
-                FROM history_dataset_association
-                WHERE NOT purged
-                    AND history_id IN (SELECT id FROM per_user_histories)
-            )
-            SELECT SUM(COALESCE(dataset.total_size, dataset.file_size, 0))
-            FROM dataset
-            LEFT OUTER JOIN library_dataset_dataset_association ON dataset.id = library_dataset_dataset_association.dataset_id
-            WHERE dataset.id IN (SELECT dataset_id FROM per_hist_hdas)
-                AND library_dataset_dataset_association.id IS NULL
-        """
+        assert object_store is not None
+        quota_source_map = object_store.get_quota_source_map()
         sa_session = object_session(self)
-        usage = sa_session.scalar(sql_calc, {'id': self.id})
-        if not dryrun:
-            self.set_disk_usage(usage)
+        for_sqlite = "sqlite" in sa_session.bind.dialect.name
+        statements = calculate_user_disk_usage_statements(self.id, quota_source_map, for_sqlite)
+        for (sql, args) in statements:
+            statement = text(sql)
+            binds = []
+            for key, val in args.items():
+                expand_binding = key.endswith("s")
+                binds.append(bindparam(key, expanding=expand_binding))
+            statement = statement.bindparams(*binds)
+            sa_session.execute(statement, args)
             sa_session.flush()
-        return usage
 
     @staticmethod
     def user_template_environment(user):
@@ -621,6 +768,18 @@ class User(Dictifiable, RepresentById):
         assoc = UserRoleAssociation(self, role)
         session.add(assoc)
         session.flush()
+
+    def dictify_usage(self):
+        rval = [{
+            'quota_source_label': None,
+            'total_disk_usage': float(self.disk_usage or 0),
+        }]
+        for quota_source_usage in self.quota_source_usages:
+            rval.append({
+                'quota_source_label': quota_source_usage.quota_source_label,
+                'total_disk_usage': float(quota_source_usage.disk_usage),
+            })
+        return rval
 
 
 class PasswordResetToken:
@@ -1801,7 +1960,9 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
             if set_hid:
                 dataset.hid = self._next_hid()
         if quota and is_dataset and self.user:
-            self.user.adjust_total_disk_usage(dataset.quota_amount(self.user))
+            quota_source_info = dataset.dataset.quota_source_info
+            if quota_source_info.use:
+                self.user.adjust_total_disk_usage(dataset.quota_amount(self.user), quota_source_info.label)
         dataset.history = self
         if is_dataset and genome_build not in [None, '?']:
             self.genome_build = genome_build
@@ -1816,8 +1977,12 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
         if optimize:
             self.__add_datasets_optimized(datasets, genome_build=genome_build)
             if quota and self.user:
-                disk_usage = sum([d.get_total_size() for d in datasets if is_hda(d)])
-                self.user.adjust_total_disk_usage(disk_usage)
+                hdas = [d for d in datasets if is_hda(d)]
+                disk_usage = sum([d.get_total_size() for d in hdas])
+                if disk_usage:
+                    quota_source_info = hdas[0].dataset.quota_source_info
+                    if quota_source_info.use:
+                        self.user.adjust_total_disk_usage(disk_usage, quota_source_info.label)
             sa_session.add_all(datasets)
             if flush:
                 sa_session.flush()
@@ -2149,6 +2314,10 @@ class Role(Dictifiable, RepresentById):
         self.deleted = deleted
 
 
+class UserQuotaSourceUsage(Dictifiable, RepresentById):
+    dict_element_visible_keys = ['disk_usage', 'quota_source_label']
+
+
 class UserQuotaAssociation(Dictifiable, RepresentById):
     dict_element_visible_keys = ['user']
 
@@ -2166,11 +2335,11 @@ class GroupQuotaAssociation(Dictifiable, RepresentById):
 
 
 class Quota(Dictifiable, RepresentById):
-    dict_collection_visible_keys = ['id', 'name']
-    dict_element_visible_keys = ['id', 'name', 'description', 'bytes', 'operation', 'display_amount', 'default', 'users', 'groups']
+    dict_collection_visible_keys = ['id', 'name', 'quota_source_label']
+    dict_element_visible_keys = ['id', 'name', 'description', 'bytes', 'operation', 'display_amount', 'default', 'users', 'groups', 'quota_source_label']
     valid_operations = ('+', '-', '=')
 
-    def __init__(self, name="", description="", amount=0, operation="="):
+    def __init__(self, name="", description="", amount=0, operation="=", quota_source_label=None):
         self.name = name
         self.description = description
         if amount is None:
@@ -2178,6 +2347,7 @@ class Quota(Dictifiable, RepresentById):
         else:
             self.bytes = amount
         self.operation = operation
+        self.quota_source_label = quota_source_label
 
     def get_amount(self):
         if self.bytes == -1:
@@ -2369,6 +2539,16 @@ class Dataset(StorableObject, RepresentById):
             filename = self.external_filename
         # Make filename absolute
         return os.path.abspath(filename)
+
+    @property
+    def quota_source_label(self):
+        return self.get_quota_source_info(self.object_store_id).label
+
+    @property
+    def quota_source_info(self):
+        object_store_id = self.object_store_id
+        quota_source_map = self.object_store.get_quota_source_map()
+        return quota_source_map.get_quota_source_info(object_store_id)
 
     def set_file_name(self, filename):
         if not filename:
@@ -3298,11 +3478,11 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         """
         return self.dataset.get_access_roles(security_agent)
 
-    def purge_usage_from_quota(self, user):
+    def purge_usage_from_quota(self, user, quota_source_info):
         """Remove this HDA's quota_amount from user's quota.
         """
-        if user:
-            user.adjust_total_disk_usage(-self.quota_amount(user))
+        if user and quota_source_info.use:
+            user.adjust_total_disk_usage(-self.quota_amount(user), quota_source_info.label)
 
     def quota_amount(self, user):
         """

--- a/lib/galaxy/model/migrate/versions/0172_add_user_quota_source_usage.py
+++ b/lib/galaxy/model/migrate/versions/0172_add_user_quota_source_usage.py
@@ -1,0 +1,64 @@
+"""
+Migration script to add a new user_quota_source_usage table.
+"""
+
+import logging
+
+from migrate.changeset.constraint import UniqueConstraint as MigrateUniqueContraint
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, Numeric, String, Table, UniqueConstraint
+
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    add_index,
+    drop_column,
+    drop_index,
+)
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+user_quota_source_usage_table = Table(
+    "user_quota_source_usage", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("quota_source_label", String(32), index=True),
+    # user had an index on disk_usage - does that make any sense? -John
+    Column("disk_usage", Numeric(15, 0)),
+    UniqueConstraint('user_id', 'quota_source_label', name="uqsu_unique_label_per_user"),
+)
+# Column to add.
+quota_source_label_col = Column("quota_source_label", String(32), default=None, nullable=True)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    add_column(quota_source_label_col, 'quota', metadata)
+
+    try:
+        user_quota_source_usage_table.create()
+    except Exception:
+        log.exception("Creating user_quota_source_usage_table table failed")
+
+    try:
+        table = Table("default_quota_association", metadata, autoload=True)
+        MigrateUniqueContraint("type", table=table).drop()
+    except Exception:
+        log.exception("Dropping unique constraint on default_quota_association.type failed")
+
+    add_index("ix_quota_quota_source_label", "quota", "quota_source_label", metadata)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        user_quota_source_usage_table.drop()
+    except Exception:
+        log.exception("Dropping user_quota_source_usage_table table failed")
+
+    drop_index("ix_quota_quota_source_label", "quota", "quota_source_label", metadata)
+    drop_column(quota_source_label_col, 'quota', metadata)

--- a/lib/galaxy/web/params.py
+++ b/lib/galaxy/web/params.py
@@ -23,6 +23,7 @@ class QuotaParamParser(BaseParamParser):
                        amount=util.restore_text(params.get('amount', '').strip()),
                        operation=params.get('operation', ''),
                        default=params.get('default', ''),
+                       quota_source_label=params.get('quota_source_label', None),
                        in_users=util.listify(params.get('in_users', [])),
                        out_users=util.listify(params.get('out_users', [])),
                        in_groups=util.listify(params.get('in_groups', [])),

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -703,7 +703,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
                 # Increase the user's disk usage by the amount of the previous history's datasets if they didn't already
                 # own it.
                 for hda in history.datasets:
-                    user.adjust_total_disk_usage(hda.quota_amount(user))
+                    user.adjust_total_disk_usage(hda.quota_amount(user), hda.dataset.quota_source_info)
                 # Only set default history permissions if the history is from the previous session and anonymous
                 set_permissions = True
         elif self.galaxy_session.current_history:

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -62,21 +62,15 @@ class QuotaAPIController(BaseAPIController, AdminActions, UsesQuotaMixin, QuotaP
         return quota.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'total_disk_usage': float})
 
     @web.require_admin
-    @web.legacy_expose_api
+    @web.expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/quotas
         Creates a new quota.
         """
-        try:
-            self.validate_in_users_and_groups(trans, payload)
-        except Exception as e:
-            raise HTTPBadRequest(detail=util.unicodify(e))
+        self.validate_in_users_and_groups(trans, payload)
         params = self.get_quota_params(payload)
-        try:
-            quota, message = self._create_quota(params)
-        except ActionInputError as e:
-            raise HTTPBadRequest(detail=util.unicodify(e))
+        quota, message = self._create_quota(params)
         item = quota.to_dict(value_mapper={'id': trans.security.encode_id})
         item['url'] = url_for('quota', id=trans.security.encode_id(quota.id))
         item['message'] = message

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -427,6 +427,7 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('/api/container_resolvers/{index}/toolbox/install', action="resolve_toolbox_with_install", controller="container_resolution", conditions=dict(method=["POST"]))
     webapp.mapper.connect('/api/workflows/get_tool_predictions', action='get_tool_predictions', controller="workflows", conditions=dict(method=["POST"]))
 
+    webapp.mapper.connect('/api/users/{user_id}/usage', action='usage', controller="users", conditions=dict(method=["GET"]))
     webapp.mapper.resource_with_deleted('user', 'users', path_prefix='/api')
     webapp.mapper.resource('genome', 'genomes', path_prefix='/api')
     webapp.mapper.connect('/api/genomes/{id}/indexes', controller='genomes', action='indexes')

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -806,7 +806,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             hda.deleted = True
             # HDA is purgeable
             # Decrease disk usage first
-            hda.purge_usage_from_quota(user)
+            hda.purge_usage_from_quota(user, hda.dataset.quota_source_info)
             # Mark purged
             hda.purged = True
             trans.sa_session.add(hda)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1055,7 +1055,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             for hda in trans.history.datasets:
                 if not hda.deleted or hda.purged:
                     continue
-                hda.purge_usage_from_quota(trans.user)
+                hda.purge_usage_from_quota(trans.user, hda.dataset.quota_source_info)
                 hda.purged = True
                 trans.sa_session.add(hda)
                 trans.log_event("HDA id %s has been purged" % hda.id)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -548,6 +548,11 @@ class BaseDatasetPopulator:
         assert len(users_roles) == 1, f"Did not find exactly one role for email {user_email} - {users_roles}"
         return users_roles[0]["id"]
 
+    def get_usage(self):
+        usage_response = self.galaxy_interactor.get("users/current/usage")
+        usage_response.raise_for_status()
+        return usage_response.json()
+
     def create_role(self, user_ids, description=None):
         payload = {
             "name": self.get_random_name(prefix="testpop"),

--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -10,6 +10,7 @@ import datetime
 import inspect
 import logging
 import os
+import re
 import string
 import sys
 from collections import namedtuple
@@ -24,6 +25,7 @@ sys.path.insert(1, os.path.join(galaxy_root, 'lib'))
 
 import galaxy.config
 from galaxy.exceptions import ObjectNotFound
+from galaxy.model import calculate_user_disk_usage_statements
 from galaxy.objectstore import build_object_store_from_config
 from galaxy.util.script import app_properties_from_args, populate_config_args
 
@@ -69,6 +71,7 @@ class Action:
     Generally you should set at least ``_action_sql`` in subclasses (although it's possible to just override ``sql``
     directly.)
     """
+    requires_objectstore = True
     update_time_sql = ", update_time = NOW() AT TIME ZONE 'utc'"
     force_retry_sql = " AND NOT purged"
     primary_key = None
@@ -107,6 +110,9 @@ class Action:
         self.__row_methods = []
         self.__post_methods = []
         self.__exit_methods = []
+        if self.requires_objectstore:
+            self.object_store = build_object_store_from_config(self._config)
+            self._register_exit_method(self.object_store.shutdown)
         self._init()
 
     def __enter__(self):
@@ -235,13 +241,14 @@ class Action:
 class RemovesObjects:
     """Base class for mixins that remove objects from object stores.
     """
+    requires_objectstore = True
+
     def _init(self):
+        super()._init()
         self.objects_to_remove = set()
         log.info('Initializing object store for action %s', self.name)
-        self.object_store = build_object_store_from_config(self._config)
         self._register_row_method(self.collect_removed_object_info)
         self._register_post_method(self.remove_objects)
-        self._register_exit_method(self.object_store.shutdown)
 
     def collect_removed_object_info(self, row):
         object_id = getattr(row, self.id_column, None)
@@ -340,7 +347,10 @@ class RequiresDiskUsageRecalculation:
 
     To use, ensure your query returns a ``recalculate_disk_usage_user_id`` column.
     """
+    requires_objectstore = True
+
     def _init(self):
+        super()._init()
         self.__recalculate_disk_usage_user_ids = set()
         self._register_row_method(self.collect_recalculate_disk_usage_user_id)
         self._register_post_method(self.recalculate_disk_usage)
@@ -360,30 +370,21 @@ class RequiresDiskUsageRecalculation:
         """
         log.info('Recalculating disk usage for users whose data were purged')
         for user_id in sorted(self.__recalculate_disk_usage_user_ids):
-            # TODO: h.purged = false should be unnecessary once all hdas in purged histories are purged.
-            sql = """
-                   UPDATE galaxy_user
-                      SET disk_usage = (
-                            SELECT COALESCE(SUM(total_size), 0)
-                              FROM (  SELECT d.total_size
-                                        FROM history_dataset_association hda
-                                             JOIN history h ON h.id = hda.history_id
-                                             JOIN dataset d ON hda.dataset_id = d.id
-                                       WHERE h.user_id = %(user_id)s
-                                             AND h.purged = false
-                                             AND hda.purged = false
-                                             AND d.purged = false
-                                             AND d.id NOT IN (SELECT dataset_id
-                                                                FROM library_dataset_dataset_association)
-                                    GROUP BY d.id) AS sizes)
-                    WHERE id = %(user_id)s
-                RETURNING disk_usage;
-            """
-            args = {'user_id': user_id}
-            cur = self._update(sql, args, add_event=False)
-            for row in cur:
-                # disk_usage might be None (e.g. user has purged all data)
-                self.log.info('recalculate_disk_usage user_id %i to %s bytes' % (user_id, row.disk_usage))
+            quota_source_map = self.object_store.get_quota_source_map()
+            statements = calculate_user_disk_usage_statements(
+                user_id, quota_source_map
+            )
+
+            for (sql, args) in statements:
+                sql, _ = re.subn(r"\:([\w]+)", r"%(\1)s", sql)
+                new_args = {}
+                for key, val in args.items():
+                    if isinstance(val, list):
+                        val = tuple(val)
+                    new_args[key] = val
+                self._update(sql, new_args, add_event=False)
+
+            self.log.info('recalculate_disk_usage user_id %i' % user_id)
 
 
 class RemovesMetadataFiles(RemovesObjects):

--- a/scripts/set_user_disk_usage.py
+++ b/scripts/set_user_disk_usage.py
@@ -35,18 +35,18 @@ def init():
     return galaxy.config.init_models_from_config(config, object_store=object_store), object_store, engine
 
 
-def quotacheck(sa_session, users, engine):
+def quotacheck(sa_session, users, engine, object_store):
     sa_session.refresh(user)
     current = user.get_disk_usage()
     print(user.username, '<' + user.email + '>:', end=' ')
 
     if not args.dryrun:
         # Apply new disk usage
-        user.calculate_and_set_disk_usage()
+        user.calculate_and_set_disk_usage(object_store)
         # And fetch
         new = user.get_disk_usage()
     else:
-        new = user.calculate_disk_usage()
+        new = user.calculate_disk_usage_default_source(object_store)
 
     print('old usage:', nice_size(current), 'change:', end=' ')
     if new in (current, None):
@@ -68,7 +68,7 @@ if __name__ == '__main__':
         print('Processing %i users...' % user_count)
         for i, user in enumerate(sa_session.query(model.User).enable_eagerloads(False).yield_per(1000)):
             print('%3i%%' % int(float(i) / user_count * 100), end=' ')
-            quotacheck(sa_session, user, engine)
+            quotacheck(sa_session, user, engine, object_store)
         print('100% complete')
         object_store.shutdown()
         sys.exit(0)
@@ -79,5 +79,5 @@ if __name__ == '__main__':
     if not user:
         print('User not found')
         sys.exit(1)
+    quotacheck(sa_session, user, engine, object_store)
     object_store.shutdown()
-    quotacheck(sa_session, user, engine)

--- a/test/integration/objectstore/test_quota_limit.py
+++ b/test/integration/objectstore/test_quota_limit.py
@@ -1,0 +1,73 @@
+from ._base import BaseObjectStoreIntegrationTestCase
+from .test_selection import (
+    DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE,
+    JOB_CONFIG_FILE,
+    JOB_RESOURCE_PARAMETERS_CONFIG_FILE,
+)
+
+
+class QuotaIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
+        config["job_config_file"] = JOB_CONFIG_FILE
+        config["job_resource_params_file"] = JOB_RESOURCE_PARAMETERS_CONFIG_FILE
+        config["enable_quotas"] = True
+
+    def test_selection_limit(self):
+        with self.dataset_populator.test_history() as history_id:
+
+            hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3\n4 5 6\n7 8 9\n")
+            self.dataset_populator.wait_for_history(history_id)
+            hda1_input = {"src": "hda", "id": hda1["id"]}
+
+            quotas = self.dataset_populator.get_quotas()
+            assert len(quotas) == 0
+
+            payload = {
+                'name': 'defaultquota1',
+                'description': 'first default quota',
+                'amount': '1 bytes',
+                'operation': '=',
+                'default': 'registered',
+            }
+            self.dataset_populator.create_quota(payload)
+
+            payload = {
+                'name': 'ebsquota1',
+                'description': 'first ebs quota',
+                'amount': '100 MB',
+                'operation': '=',
+                'default': 'registered',
+                'quota_source_label': 'ebs',
+            }
+            self.dataset_populator.create_quota(payload)
+
+            quotas = self.dataset_populator.get_quotas()
+            assert len(quotas) == 2
+
+            hda2 = self.dataset_populator.new_dataset(history_id, content="1 2 3\n4 5 6\n7 8 9\n")
+            self.dataset_populator.wait_for_history(history_id)
+
+            hda2_now = self.dataset_populator.get_history_dataset_details(history_id, dataset=hda2, wait=False)
+            assert hda2_now["state"] == "paused"
+
+            create_10_inputs = {
+                "input1": hda1_input,
+                "input2": hda1_input,
+                "__job_resource|__job_resource__select": "yes",
+                "__job_resource|how_store": "slow",
+            }
+            create10_response = self.dataset_populator.run_tool(
+                "create_10",
+                create_10_inputs,
+                history_id,
+                assert_ok=False,
+            )
+            job_id = create10_response.json()["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(job_id)
+            job_details = self.dataset_populator.get_job_details(job_id).json()
+            # This job isn't paused, it goes through because we used a different
+            # objectstore using job parameters.
+            assert job_details["state"] == "ok"

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -30,3 +30,20 @@ class QuotaIntegrationTestCase(integration_util.IntegrationTestCase):
 
         quotas = self.dataset_populator.get_quotas()
         assert len(quotas) == 1
+
+        payload = {
+            'name': 'defaultmylabeledquota1',
+            'description': 'first default quota that is labeled',
+            'amount': '120MB',
+            'operation': '=',
+            'default': 'registered',
+            'quota_source_label': 'mylabel',
+        }
+        self.dataset_populator.create_quota(payload)
+
+        quotas = self.dataset_populator.get_quotas()
+        assert len(quotas) == 2
+
+        labels = [q["quota_source_label"] for q in quotas]
+        assert None in labels
+        assert 'mylabel' in labels

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -11,6 +11,7 @@ import galaxy.datatypes.registry
 import galaxy.model
 import galaxy.model.mapping as mapping
 from galaxy.model.security import GalaxyRBACAgent
+from galaxy.objectstore import QuotaSourceMap
 
 datatypes_registry = galaxy.datatypes.registry.Registry()
 datatypes_registry.load_datatypes()
@@ -324,7 +325,7 @@ class MappingTests(BaseModelTestCase):
 
         u = model.User(email="disk_default@test.com", password="password")
         self.persist(u)
-        u.adjust_total_disk_usage(1)
+        u.adjust_total_disk_usage(1, None)
         u_id = u.id
         self.expunge()
         user_reload = model.session.query(model.User).get(u_id)
@@ -780,8 +781,11 @@ class PostgresMappingTests(MappingTests):
 
 class MockObjectStore:
 
-    def __init__(self):
-        pass
+    def __init__(self, quota_source_map=None):
+        self._quota_source_map = quota_source_map or QuotaSourceMap()
+
+    def get_quota_source_map(self):
+        return self._quota_source_map
 
     def size(self, dataset):
         return 42

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -1,25 +1,94 @@
+import uuid
+
+from galaxy.objectstore import QuotaSourceInfo, QuotaSourceMap
 from galaxy.quota import DatabaseQuotaAgent
-from .test_galaxy_mapping import BaseModelTestCase
+from .test_galaxy_mapping import BaseModelTestCase, MockObjectStore
+
+
+class PurgeUsageTestCase(BaseModelTestCase):
+
+    def setUp(self):
+        super().setUp()
+        model = self.model
+        u = model.User(email="purge_usage@example.com", password="password")
+        u.disk_usage = 25
+        self.persist(u)
+
+        h = model.History(name="History for Purging", user=u)
+        self.persist(h)
+        self.u = u
+        self.h = h
+
+    def _setup_dataset(self):
+        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=self.h, create_dataset=True, sa_session=self.model.session)
+        d1.dataset.total_size = 10
+        self.persist(d1)
+        return d1
+
+    def test_calculate_usage(self):
+        d1 = self._setup_dataset()
+        quota_source_info = QuotaSourceInfo(None, True)
+        d1.purge_usage_from_quota(self.u, quota_source_info)
+        self.persist(self.u)
+        assert int(self.u.disk_usage) == 15
+
+    def test_calculate_usage_untracked(self):
+        # test quota tracking off on the objectstore
+        d1 = self._setup_dataset()
+        quota_source_info = QuotaSourceInfo(None, False)
+        d1.purge_usage_from_quota(self.u, quota_source_info)
+        self.persist(self.u)
+        assert int(self.u.disk_usage) == 25
+
+    def test_calculate_usage_per_source(self):
+        self.u.adjust_total_disk_usage(124, "myquotalabel")
+
+        # test quota tracking with a non-default quota label
+        d1 = self._setup_dataset()
+        quota_source_info = QuotaSourceInfo("myquotalabel", True)
+        d1.purge_usage_from_quota(self.u, quota_source_info)
+        self.persist(self.u)
+        assert int(self.u.disk_usage) == 25
+
+        usages = self.u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[1]["quota_source_label"] == "myquotalabel"
+        assert usages[1]["total_disk_usage"] == 114
 
 
 class CalculateUsageTestCase(BaseModelTestCase):
 
+    def setUp(self):
+        model = self.model
+        u = model.User(email="calc_usage%s@example.com" % str(uuid.uuid1()), password="password")
+        self.persist(u)
+        h = model.History(name="History for Calculated Usage", user=u)
+        self.persist(h)
+        self.u = u
+        self.h = h
+
+    def _add_dataset(self, total_size, object_store_id=None):
+        model = self.model
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=self.h, create_dataset=True, sa_session=self.model.session)
+        d1.dataset.total_size = total_size
+        d1.dataset.object_store_id = object_store_id
+        self.persist(d1)
+        return d1
+
     def test_calculate_usage(self):
         model = self.model
-        u = model.User(email="calc_usage@example.com", password="password")
-        self.persist(u)
+        u = self.u
+        h = self.h
 
-        h = model.History(name="History for Usage", user=u)
-        self.persist(h)
+        d1 = self._add_dataset(10)
 
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=model.session)
-        d1.dataset.total_size = 10
-        self.persist(d1)
-
-        assert u.calculate_disk_usage() == 10
+        object_store = MockObjectStore()
+        assert u.calculate_disk_usage_default_source(object_store) == 10
         assert u.disk_usage is None
-        u.calculate_and_set_disk_usage()
-        assert u.disk_usage == 10
+        u.calculate_and_set_disk_usage(object_store)
+        assert u.calculate_disk_usage_default_source(object_store) == 10
+        # method no longer updates user object
+        # assert u.disk_usage == 10
 
         # Test dataset being in another history doesn't duplicate usage cost.
         h2 = model.History(name="Second usage history", user=u)
@@ -31,7 +100,104 @@ class CalculateUsageTestCase(BaseModelTestCase):
         d3 = model.HistoryDatasetAssociation(extension="txt", history=h, dataset=d1.dataset)
         self.persist(d3)
 
-        assert u.calculate_disk_usage() == 10
+        assert u.calculate_disk_usage_default_source(object_store) == 10
+
+    def test_calculate_usage_disabled_quota(self):
+        u = self.u
+
+        self._add_dataset(10, "not_tracked")
+        self._add_dataset(15, "tracked")
+
+        quota_source_map = QuotaSourceMap()
+        not_tracked = QuotaSourceMap()
+        not_tracked.default_quota_enabled = False
+        quota_source_map.backends["not_tracked"] = not_tracked
+
+        object_store = MockObjectStore(quota_source_map)
+
+        assert u.calculate_disk_usage_default_source(object_store) == 15
+
+    def test_calculate_usage_alt_quota(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap()
+        alt_source = QuotaSourceMap()
+        alt_source.default_quota_source = "alt_source"
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        object_store = MockObjectStore(quota_source_map)
+
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 10
+
+        assert usages[1]["quota_source_label"] == "alt_source"
+        assert usages[1]["total_disk_usage"] == 15
+
+    def test_calculate_usage_removes_unused_quota_labels(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap()
+        alt_source = QuotaSourceMap()
+        alt_source.default_quota_source = "alt_source"
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        object_store = MockObjectStore(quota_source_map)
+
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 10
+
+        assert usages[1]["quota_source_label"] == "alt_source"
+        assert usages[1]["total_disk_usage"] == 15
+
+        alt_source.default_quota_source = "new_alt_source"
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 10
+
+        assert usages[1]["quota_source_label"] == "new_alt_source"
+        assert usages[1]["total_disk_usage"] == 15
+
+    def test_calculate_usage_default_storage_disabled(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap(None, False)
+        alt_source = QuotaSourceMap("alt_source", True)
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        object_store = MockObjectStore(quota_source_map)
+
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 0
+
+        assert usages[1]["quota_source_label"] == "alt_source"
+        assert usages[1]["total_disk_usage"] == 15
 
 
 class QuotaTestCase(BaseModelTestCase):
@@ -87,6 +253,27 @@ class QuotaTestCase(BaseModelTestCase):
         self._add_group_quota(u, quota)
         self._assert_user_quota_is(u, None)
 
+    def test_labeled_quota(self):
+        model = self.model
+        u = model.User(email="labeled_quota@example.com", password="password")
+        self.persist(u)
+
+        label1 = "coollabel1"
+        self._assert_user_quota_is(u, None, label1)
+
+        quota = model.Quota(name="default registered labeled", amount=21, quota_source_label=label1)
+        self.quota_agent.set_default_quota(
+            model.DefaultQuotaAssociation.types.REGISTERED,
+            quota,
+        )
+
+        self._assert_user_quota_is(u, 21, label1)
+
+        quota = model.Quota(name="user quota add labeled", amount=31, operation="+", quota_source_label=label1)
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 52, label1)
+
     def _add_group_quota(self, user, quota):
         group = self.model.Group()
         uga = self.model.UserGroupAssociation(user, group)
@@ -98,18 +285,57 @@ class QuotaTestCase(BaseModelTestCase):
         user.quotas.append(uqa)
         self.persist(quota, uqa, user)
 
-    def _assert_user_quota_is(self, user, amount):
-        actual_quota = self.quota_agent.get_quota(user)
+    def _assert_user_quota_is(self, user, amount, quota_source_label=None):
+        actual_quota = self.quota_agent.get_quota(user, quota_source_label=quota_source_label)
         assert amount == actual_quota, "Expected quota [%s], got [%s]" % (amount, actual_quota)
-        if amount is None:
-            user.total_disk_usage = 1000
-            job = self.model.Job()
-            job.user = user
-            assert not self.quota_agent.is_over_quota(None, job, None)
-        else:
-            job = self.model.Job()
-            job.user = user
-            user.total_disk_usage = amount - 1
-            assert not self.quota_agent.is_over_quota(None, job, None)
-            user.total_disk_usage = amount + 1
-            assert self.quota_agent.is_over_quota(None, job, None)
+        if quota_source_label is None:
+            if amount is None:
+                user.total_disk_usage = 1000
+                job = self.model.Job()
+                job.user = user
+                assert not self.quota_agent.is_over_quota(None, job, None)
+            else:
+                job = self.model.Job()
+                job.user = user
+                user.total_disk_usage = amount - 1
+                assert not self.quota_agent.is_over_quota(None, job, None)
+                user.total_disk_usage = amount + 1
+                assert self.quota_agent.is_over_quota(None, job, None)
+
+
+class UsageTestCase(BaseModelTestCase):
+
+    def test_usage(self):
+        model = self.model
+        u = model.User(email="usage@example.com", password="password")
+        self.persist(u)
+
+        u.adjust_total_disk_usage(123, None)
+        self.persist(u)
+
+        assert u.get_disk_usage() == 123
+
+    def test_labeled_usage(self):
+        model = self.model
+        u = model.User(email="labeled.usage@example.com", password="password")
+        self.persist(u)
+        assert len(u.quota_source_usages) == 0
+
+        u.adjust_total_disk_usage(123, "foobar")
+        usages = u.dictify_usage()
+        assert len(usages) == 1
+
+        assert u.get_disk_usage() == 0
+        assert u.get_disk_usage(quota_source_label="foobar") == 123
+        self.model.context.refresh(u)
+
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+
+        u.adjust_total_disk_usage(124, "foobar")
+        self.model.context.refresh(u)
+
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[1]["quota_source_label"] == "foobar"
+        assert usages[1]["total_disk_usage"] == 247

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -99,7 +99,8 @@ class QuotaTestCase(BaseModelTestCase):
         self.persist(quota, uqa, user)
 
     def _assert_user_quota_is(self, user, amount):
-        assert amount == self.quota_agent.get_quota(user)
+        actual_quota = self.quota_agent.get_quota(user)
+        assert amount == actual_quota, "Expected quota [%s], got [%s]" % (amount, actual_quota)
         if amount is None:
             user.total_disk_usage = 1000
             job = self.model.Job()

--- a/test/unit/test_routes.py
+++ b/test/unit/test_routes.py
@@ -106,6 +106,12 @@ def test_galaxy_routes():
         action="resolver_dependency"
     )
 
+    test_webapp.assert_maps(
+        "/api/users/current/usage",
+        controller="users",
+        action="usage"
+    )
+
 
 def assert_url_is(actual, expected):
     assert actual == expected, f"Expected URL [{expected}] but obtained [{actual}]"


### PR DESCRIPTION
Builds on https://github.com/galaxyproject/galaxy/pull/10212.

## Overview

#6552 implemented the ability for admins to assign job outputs to different object stores at runtime (this could take into account tool/workflow injected parameters or just be based on user, tool, destination, cluster state, etc..). But all the stored data would consume the same quota - regardless of the source selected.

This pull request allows different object stores or different groups of object stores to have different quotas or no quota at all. This enables uses cases such as sending job to cheaper data when a user's quota is getting near full or allowing admin to setup tool and/of workflow parameters to send job outputs higher quality, more redundant storage based on user selected options or user preferences.

This is a substantial step forward toward allowing scratch-space histories, while I suspect we want to implement some higher level convince functions and interface around that (per history preferences, object store preferences types) - I think that would all be based on these abstractions - abstractions that allow even more flexibility for admins who require it.

## Implementation

This adds the quota tag to XML/YAML object store declarations - that allow specifying a "quota source label" for each objectstore in a nested objectstore or disabling quota all together on objectstores.

The following quota block would assign all this storage to a quota source labelled with ``s3``.

```
        <backend id="dynamic_s3" type="disk" weight="0">
            <quota source="s3" />
            <files_dir path="${temp_directory}/files_dynamic_s3"/>
```

Whereas this would disable quota usage for this object store altogether. 

```
        <backend id="temp_disk" type="disk" weight="0">
            <quota enabled="false" />
            <files_dir path="${temp_directory}/files_cloud_scratch"/>
```

In order to implement this a new table/model has been added to track a user's usage per quota source label - namely ``UserQuotaSourceUsage``. Object stores that did not have a source label are still tracked using the User model's ``disk_usage`` attribute. I've updated all the scripts that recalculate user usage.

## UI + API

The quota dialog adds the option to pick a quota source label from those defined on the object stores, though this option only appears if quota source labels are configured.

<img width="1398" alt="Screen Shot 2020-09-28 at 8 45 33 PM" src="https://user-images.githubusercontent.com/216771/94499839-b5803800-01cb-11eb-8bfc-f033cad50917.png">

Likewise, by default the quota meter is unaffected but when multiple quota source labels are configured the meter becomes a link that shows the usage of each quota source.

<img width="776" alt="Screen Shot 2020-09-28 at 8 47 19 PM" src="https://user-images.githubusercontent.com/216771/94499923-e8c2c700-01cb-11eb-8b6d-b4ea44255027.png">

A new API ``/api/users/<user_id|current>/usage`` enables this.

## Abstractions for #4840

While this PR adds significant complexity related to recalculating a User's quota - it does reduce the duplication, adds tests (made more useful by having fewer paths through the quota recalculation code), and bring object store information into the calculation. I think this is all stuff that would be needed for #4840 and currently missing.

Part of this establishes a pattern for how to exclude certain datasets from usage calculation both when it is being added (included in #4840) and when re-calculdated (not included in #4840).

The API endpoints for disk usage across object stores and the UI entry point for displaying that information will hopefully both enable a more robust implementation of #4840.
