### PR TITLE
Pass user to ObjectStorePopulator.

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1456,7 +1456,7 @@ class JobWrapper(HasResourceParameters):
             # jobs may have this set. Skip this following code if that is the case.
             return
 
-        object_store_populator = ObjectStorePopulator(self.app)
+        object_store_populator = ObjectStorePopulator(self.app, job.user)
         object_store_id = self.get_destination_configuration("object_store_id", None)
         if object_store_id:
             object_store_populator.object_store_id = object_store_id

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1070,9 +1070,10 @@ class ObjectStorePopulator:
     datasets from a job end up with the same object_store_id.
     """
 
-    def __init__(self, app):
+    def __init__(self, app, user):
         self.object_store = app.object_store
         self.object_store_id = None
+        self.user = user
 
     def set_object_store_id(self, data):
         # Create an empty file immediately.  The first dataset will be

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -360,7 +360,7 @@ class DefaultToolAction:
         # datasets first, then create the associations
         parent_to_child_pairs = []
         child_dataset_names = set()
-        object_store_populator = ObjectStorePopulator(app)
+        object_store_populator = ObjectStorePopulator(app, trans.user)
         async_tool = tool.tool_type == 'data_source_async'
 
         def handle_output(name, output, hidden=None):

--- a/test/unit/tools/test_metadata.py
+++ b/test/unit/tools/test_metadata.py
@@ -169,7 +169,7 @@ class MetadataTestCase(unittest.TestCase, tools_support.UsesApp, tools_support.U
             **kwd
         )
         self.history.add_dataset(output_dataset)
-        ObjectStorePopulator(self.app).set_object_store_id(output_dataset)
+        ObjectStorePopulator(self.app, user=self.job.user).set_object_store_id(output_dataset)
         return output_dataset
 
     def _write_work_dir_file(self, filename, contents):


### PR DESCRIPTION
Not used yet in Galaxy core yet, but useful for applications where you want object store selection to be based on user in some way. This code was taken from https://github.com/galaxyproject/galaxy/pull/4840. Part of this is trying to reduce the number of files that branch touches to make review easier - but I'm confident this extension point is good regardless. Also it makes it clear we need to keep the user object in the picture when assigning the object store ID in the future.