### PR TITLE
Improve job error logging

### DIFF
--- a/lib/galaxy/tool_util/output_checker.py
+++ b/lib/galaxy/tool_util/output_checker.py
@@ -96,7 +96,6 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
                             'code_desc': code_desc,
                             'error_level': stdio_exit_code.error_level,
                         }
-                        log.info("Job {}: {}".format(job_id_tag, reason))
                         job_messages.append(reason)
                         max_error_level = max(max_error_level,
                                               stdio_exit_code.error_level)
@@ -133,7 +132,10 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
             if max_error_level == StdioErrorLevel.FATAL_OOM:
                 state = DETECTED_JOB_STATE.OUT_OF_MEMORY_ERROR
             elif max_error_level >= StdioErrorLevel.FATAL:
-                log.debug("Tool exit code indicates an error, failing job.")
+                reason = ''
+                if job_messages:
+                    reason = " Reasons are {}".format(job_messages)
+                log.debug("Job error detected, failing job.{}".format(reason))
                 state = DETECTED_JOB_STATE.GENERIC_ERROR
 
         # When there are no regular expressions and no exit codes to check,
@@ -145,10 +147,8 @@ def check_output(stdio_regexes, stdio_exit_codes, stdout, stderr, tool_exit_code
             #          + "checking stderr for success" )
             if stderr:
                 state = DETECTED_JOB_STATE.GENERIC_ERROR
-
-        if state != DETECTED_JOB_STATE.OK:
-            peak = stderr[0:ERROR_PEAK] if stderr else ""
-            log.debug("job failed, detected state {}, standard error is - [{}]".format(state, peak))
+                peak = stderr[0:ERROR_PEAK] if stderr else ""
+                log.debug("Job failed because of contents in the standard error stream: [{}]".format(peak))
     except Exception:
         log.exception("Job state check encountered unexpected exception; assuming execution successful")
 


### PR DESCRIPTION
If available, report the failure reason.
Also deduplicates redundant log messages.

With these changes there will be just one log message reporting why the job has failed.
For an exit code condition that will look like this:
```
galaxy.tool_util.output_checker DEBUG 2020-09-15 17:24:12,236 Job error detected, failing job. Reasons are [{'type': 'exit_code', 'desc': 'Fatal error: Exit code 127 (Failing exit code.)', 'exit_code': 127, 'code_desc': 'Failing exit code.', 'error_level': 3}]
```
For a match on stdout this is
```
galaxy.tool_util.output_checker DEBUG 2020-09-15 17:43:14,133 Job error detected, failing job. Reasons are [{'type': 'regex', 'stream': 'stdout', 'desc': 'Fatal error: ', 'code_desc': '', 'match': 'ERROR:', 'error_level': 3}]
```
