### PR TITLE
[WIP] Add the PSA-based backend of Fence

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -32,7 +32,7 @@ BACKENDS_NAME = {
     'globus': 'globus',
     'elixir': 'elixir',
     'okta': 'okta-openidconnect',
-    "fence": "fence"
+    'fence': 'fence'
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -24,7 +24,7 @@ BACKENDS = {
     'globus': 'social_core.backends.globus.GlobusOpenIdConnect',
     'elixir': 'social_core.backends.elixir.ElixirOpenIdConnect',
     'okta': 'social_core.backends.okta_openidconnect.OktaOpenIdConnect',
-    "fence": "social_core.backends.fence.Fence"
+    'fence': 'social_core.backends.fence.Fence'
 }
 
 BACKENDS_NAME = {

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -23,14 +23,16 @@ BACKENDS = {
     'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
     'globus': 'social_core.backends.globus.GlobusOpenIdConnect',
     'elixir': 'social_core.backends.elixir.ElixirOpenIdConnect',
-    'okta': 'social_core.backends.okta_openidconnect.OktaOpenIdConnect'
+    'okta': 'social_core.backends.okta_openidconnect.OktaOpenIdConnect',
+    "fence": "social_core.backends.fence.Fence"
 }
 
 BACKENDS_NAME = {
     'google': 'google-openidconnect',
     'globus': 'globus',
     'elixir': 'elixir',
-    'okta': 'okta-openidconnect'
+    'okta': 'okta-openidconnect',
+    "fence": "fence"
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -85,6 +85,15 @@ Please mind `http` and `https`.
         <prompt>consent</prompt>
     </provider>
 
+    <provider name="Fence">
+        <!-- Sets the URL where the Fence installation is accessible from. -->
+        <url>https://localhost/user/</url>
+
+        <client_id> ... </client_id>
+        <client_secret> ... </client_secret>
+        <redirect_uri>http://localhost:8080/authnz/fence/callback</redirect_uri>
+    </provider>
+
     <provider name="Custos">
         <url>https://custos.scigap.org/apiserver/identity-management/v1.0.0/</url>
         <client_id> ... </client_id>


### PR DESCRIPTION
Enables configuring a Fence-based AuthNZ through python social auth (PSA). 

It depends on https://github.com/python-social-auth/social-core/pull/505