### PR TITLE
[20.05] Make cached container resolver pick newest build

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -154,7 +154,7 @@ def find_best_matching_cached_image(targets, cached_images, hash_func):
     image = None
     if len(targets) == 1:
         target = targets[0]
-        for cached_image in cached_images:
+        for cached_image in reversed(cached_images):
             if cached_image.multi_target:
                 continue
             if not cached_image.package_name == target.package_name:
@@ -169,7 +169,7 @@ def find_best_matching_cached_image(targets, cached_images, hash_func):
         else:
             package_hash, version_hash = name, None
 
-        for cached_image in cached_images:
+        for cached_image in reversed(cached_images):
             if cached_image.multi_target != "v2":
                 continue
 
@@ -186,7 +186,7 @@ def find_best_matching_cached_image(targets, cached_images, hash_func):
 
     elif hash_func == "v1":
         name = v1_image_name(targets)
-        for cached_image in cached_images:
+        for cached_image in reversed(cached_images):
             if cached_image.multi_target != "v1":
                 continue
 

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -118,14 +118,22 @@ def split_tag(tag):
 
 def parse_tag(tag):
     """Decompose tag of mulled images into version, build string and build number."""
-    version = tag
+    version = tag.rsplit(':')[-1]
     build_string = "-1"
+    build_number = -1
+    match = BUILD_NUMBER_REGEX.search(version)
+    if match:
+        build_number = int(match.group(0))
     if '--' in tag:
-        version, build_string = tag.rsplit('--', 1)
+        version, build_string = version.rsplit('--', 1)
     elif '-' in tag:
         # Should be mulled multi-container image tag
-        version, build_string = tag.rsplit('-', 1)
-    build_number = int(BUILD_NUMBER_REGEX.search(tag).group(0))
+        version, build_string = version.rsplit('-', 1)
+    else:
+        # We don't have a build number, and the BUILD_NUMBER_REGEX above is only accurate for build strings,
+        # so set build number to -1. Any matching image:version combination with a build number
+        # will be considered newer.
+        build_number = -1
     return PARSED_TAG(tag=tag,
                       version=packaging.version.parse(version),
                       build_string=packaging.version.parse(build_string),
@@ -137,7 +145,7 @@ def version_sorted(elements):
     elements = (parse_tag(tag) for tag in elements)
     elements = sorted(elements, key=lambda tag: tag.build_string, reverse=True)
     elements = sorted(elements, key=lambda tag: tag.build_number, reverse=True)
-    elements = sorted(elements, key=lambda tag: tag.version)
+    elements = sorted(elements, key=lambda tag: tag.version, reverse=True)
     return [e.tag for e in elements]
 
 

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -124,9 +124,9 @@ def parse_tag(tag):
     match = BUILD_NUMBER_REGEX.search(version)
     if match:
         build_number = int(match.group(0))
-    if '--' in tag:
+    if '--' in version:
         version, build_string = version.rsplit('--', 1)
-    elif '-' in tag:
+    elif '-' in version:
         # Should be mulled multi-container image tag
         version, build_string = version.rsplit('-', 1)
     else:

--- a/test/unit/tool_util/mulled/test_mulled_util.py
+++ b/test/unit/tool_util/mulled/test_mulled_util.py
@@ -6,7 +6,8 @@ from galaxy.tool_util.deps.mulled.util import version_sorted
 @pytest.mark.parametrize("tags,tag", [
     (["2.22--he941832_1", "2.22--he860b03_2", "2.22--hdbcaa40_3"], "2.22--hdbcaa40_3"),
     (["1.1.2--py27_0", "1.1.2--py36_0", "1.1.2--py35_0"], "1.1.2--py36_0"),
-    (["6725cda82000b8e514baddcbf8c2dce054e3f797-1", "6725cda82000b8e514baddcbf8c2dce054e3f797-0"], "6725cda82000b8e514baddcbf8c2dce054e3f797-1")
+    (["6725cda82000b8e514baddcbf8c2dce054e3f797-1", "6725cda82000b8e514baddcbf8c2dce054e3f797-0"], "6725cda82000b8e514baddcbf8c2dce054e3f797-1"),
+    (["python:3.5", "python:3.7", "python:3.7--2"], "python:3.7--2")
 ])
 def test_version_sorted(tags, tag):
     assert version_sorted(tags)[0] == tag


### PR DESCRIPTION
Traversing the cached container list in reverse should pick up the latest version. Resolves https://github.com/galaxyproject/galaxy/issues/10235.