### PR TITLE
Add script to diff two release config files.

### DIFF
--- a/doc/source/releases/20.09-config.rst
+++ b/doc/source/releases/20.09-config.rst
@@ -1,0 +1,30 @@
+Configuration Changes
+=====================
+
+Changed
+-------
+
+The following configuration options have been changed
+
+config/tool_shed.yml.sample
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  uwsgi.static-safe has changed from ``client/galaxy/images`` to ``client/src/assets``
+
+config/galaxy.yml.sample
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  uwsgi.static-safe has changed from ``client/galaxy/images`` to ``client/src/assets``
+
+config/reports.yml.sample
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  uwsgi.static-safe has changed from ``client/galaxy/images`` to ``client/src/assets``
+
+
+New Configuration Files
+-----------------------
+
+The following files are new, or recently converted to yaml
+
+-  ``config/trs_servers_conf.yml.sample``

--- a/scripts/release-diff.py
+++ b/scripts/release-diff.py
@@ -80,7 +80,7 @@ def report_diff(added, changed, removed, new_files):
             "Added",
             "The following configuration options are new",
             added,
-            lambda x: f"-  {x}",
+            lambda x: f"-  {x}"
         )
 
     if changed:
@@ -88,7 +88,7 @@ def report_diff(added, changed, removed, new_files):
             "Changed",
             "The following configuration options have been changed",
             changed,
-            lambda x: f"-  {x[0]} has changed from ``{x[1]}`` to ``{x[2]}``",
+            lambda x: f"-  {x[0]} has changed from ``{x[1]}`` to ``{x[2]}``"
         )
 
     if removed:
@@ -96,7 +96,7 @@ def report_diff(added, changed, removed, new_files):
             "Removed",
             "The following configuration options have been completely removed",
             removed,
-            lambda x: f"-  {x}",
+            lambda x: f"-  {x}"
         )
 
     if new_files:

--- a/scripts/release-diff.py
+++ b/scripts/release-diff.py
@@ -63,11 +63,12 @@ files_to_diff = glob.glob('config/*.yml.sample')
 added = {}
 removed = {}
 changed = {}
+new_files = []
 
 for file in files_to_diff:
     real_path = Path(file).resolve().relative_to(Path.cwd())
     try:
-        contents = subprocess.check_output(['git', 'show', f'{old_version}:{real_path}'])
+        contents = subprocess.check_output(['git', 'show', f'{old_version}:{real_path}'], stderr=subprocess.STDOUT)
         old = yaml.load(contents, Loader=MockOrderedLoader)
         with open(real_path, 'r') as handle:
             new = yaml.load(handle, Loader=MockOrderedLoader)
@@ -83,7 +84,7 @@ for file in files_to_diff:
             changed[file] = c
 
     except subprocess.CalledProcessError:
-        print(f"{file} did not exist in that revision.")
+        new_files.append(file)
 
 # Print out report
 if added or changed or removed:
@@ -135,3 +136,12 @@ if removed:
             print(f"-  {k}")
         print()
     print()
+
+if new_files:
+    print("New Configuration Files")
+    print("-----------------------")
+    print()
+    print(f"The following files are new, or recently converted to yaml since the {old_version}")
+    print()
+    for k in new_files:
+        print(f"-  ``{k}``")

--- a/scripts/release-diff.py
+++ b/scripts/release-diff.py
@@ -134,7 +134,7 @@ def main(old_revision, new_revision=None):
         except subprocess.CalledProcessError:
             new_files.append(file)
 
-    report_diff(added, removed, changed, new_files)
+    report_diff(added, changed, removed, new_files)
 
 
 if __name__ == '__main__':

--- a/scripts/release-diff.py
+++ b/scripts/release-diff.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+import sys
+import yaml
+from yaml import SafeLoader
+
+
+def flatten(d, path):
+    """
+    Flatten a dictionary into ('some/path/to/key', value)
+
+    >>> flatten({'a': {'b': 2}, 'q': 3}, [])
+    [('a.b', 2), ('q', 3)]
+    """
+
+    if isinstance(d, dict):
+        for k, v in d.items():
+            yield from flatten(v, path + [k])
+    elif isinstance(d, list):
+        for x in d:
+            yield from flatten(x, path + [x])
+    else:
+        yield (".".join(path), d)
+
+
+def flat_dict(d):
+    return dict(flatten(d, []))
+
+
+# Load without the includes since we can't follow those across git revisions.
+class MockOrderedLoader(SafeLoader):
+    def include(self, node):
+        return {}
+
+
+MockOrderedLoader.add_constructor("!include", MockOrderedLoader.include)
+
+# Load our two files
+with open(sys.argv[1], "r") as handle:
+    old = yaml.load(handle, Loader=MockOrderedLoader)
+
+with open(sys.argv[2], "r") as handle:
+    new = yaml.load(handle, Loader=MockOrderedLoader)
+
+
+# Flatten them
+old_kv = flat_dict(old)
+new_kv = flat_dict(new)
+
+# Compare them
+old_k = set(old_kv.keys())
+new_k = set(new_kv.keys())
+
+added = new_k - old_k
+removed = old_k - new_k
+shared = old_k & new_k
+changed = [(k, old_kv[k], new_kv[k]) for k in shared if old_kv[k] != new_kv[k]]
+
+# Print out report
+if added or changed or removed:
+    print("Configuration Changes")
+    print("=====================")
+    print()
+
+if added:
+    print("Added")
+    print("-----")
+    print()
+    print("The following configuration options are new")
+    print()
+    for k in added:
+        print(f"-  {k}")
+    print()
+
+if changed:
+    print("Changed")
+    print("-------")
+    print()
+    print("The following configuration options have been changed")
+    print()
+    for (k, o, n) in changed:
+        print(f"-  {k} has changed from ``{o}`` to ``{n}``")
+    print()
+
+if removed:
+    print("Removed")
+    print("-------")
+    print()
+    print("The following configuration options have been completely removed")
+    print()
+    for k in removed:
+        print(f"-  {k}")
+    print()

--- a/scripts/release-diff.py
+++ b/scripts/release-diff.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 import subprocess
+import argparse
 import sys
 from pathlib import Path
 import glob
 import yaml
 from yaml import SafeLoader
 
-old_version = sys.argv[1]
 
 def flatten(d, path):
     """
@@ -58,90 +58,88 @@ def diff_files(old, new):
     return added, removed, changed
 
 
-
-files_to_diff = glob.glob('config/*.yml.sample')
-added = {}
-removed = {}
-changed = {}
-new_files = []
-
-for file in files_to_diff:
-    real_path = Path(file).resolve().relative_to(Path.cwd())
-    try:
-        contents = subprocess.check_output(['git', 'show', f'{old_version}:{real_path}'], stderr=subprocess.STDOUT)
-        old = yaml.load(contents, Loader=MockOrderedLoader)
-        with open(real_path, 'r') as handle:
-            new = yaml.load(handle, Loader=MockOrderedLoader)
-
-        (a, r, c) = diff_files(old, new)
-        if a:
-            added[file] = a
-
-        if r:
-            removed[file] = r
-
-        if c:
-            changed[file] = c
-
-    except subprocess.CalledProcessError:
-        new_files.append(file)
-
-# Print out report
-if added or changed or removed:
-    print("Configuration Changes")
-    print("=====================")
+def _report_dict(title, subheading, data, mapper):
+    print(title)
+    print("-" * len(title))
     print()
-
-if added:
-    print("Added")
-    print("-----")
+    print(subheading)
     print()
-    print("The following configuration options are new")
-    print()
-    for fn in added:
+    for fn in data:
         print(fn)
         print('~' * len(fn))
         print()
-        for k in added[fn]:
-            print(f"-  {k}")
+        for k in data[fn]:
+            print(mapper(k))
         print()
     print()
 
-if changed:
-    print("Changed")
-    print("-------")
-    print()
-    print("The following configuration options have been changed")
-    print()
-    for fn in changed:
-        print(fn)
-        print('~' * len(fn))
-        print()
-        for (k, o, n) in changed[fn]:
-            print(f"-  {k} has changed from ``{o}`` to ``{n}``")
-        print()
-    print()
 
-if removed:
-    print("Removed")
-    print("-------")
-    print()
-    print("The following configuration options have been completely removed")
-    print()
-    for fn in removed:
-        print(fn)
-        print('~' * len(fn))
+def report_diff(added, changed, removed, new_files):
+    # Print out report
+    if added or changed or removed:
+        print("Configuration Changes")
+        print("=====================")
         print()
-        for k in removed[fn]:
-            print(f"-  {k}")
-        print()
-    print()
 
-if new_files:
-    print("New Configuration Files")
-    print("-----------------------")
-    print()
-    print(f"The following files are new, or recently converted to yaml since the {old_version}")
-    print()
-    for k in new_files:
-        print(f"-  ``{k}``")
+    if added:
+        _report_dict("Added", "The following configuration options are new", added, lambda x: f'-  {x}')
+
+    if changed:
+        _report_dict("Changed", "The following configuration options have been changed", changed, lambda x: f'-  {x[0]} has changed from ``{x[1]}`` to ``{x[2]}``')
+
+    if removed:
+        _report_dict("Removed", "The following configuration options have been completely removed", removed, lambda x: f'-  {x}')
+
+    if new_files:
+        print("New Configuration Files")
+        print("-----------------------")
+        print()
+        print(f"The following files are new, or recently converted to yaml")
+        print()
+        for k in new_files:
+            print(f"-  ``{k}``")
+
+
+def load_at_time(path, revision=None):
+    if revision is not None:
+        return subprocess.check_output(['git', 'show', f'{revision}:{path}'], stderr=subprocess.STDOUT)
+    else:
+        with open(path, 'r') as handle:
+            return handle.read()
+
+
+def main(old_revision, new_revision=None):
+    files_to_diff = glob.glob('config/*.yml.sample')
+    added = {}
+    removed = {}
+    changed = {}
+    new_files = []
+
+    for file in files_to_diff:
+        real_path = Path(file).resolve().relative_to(Path.cwd())
+        try:
+            old_contents = yaml.load(load_at_time(real_path, old_revision), Loader=MockOrderedLoader)
+            new_contents = yaml.load(load_at_time(real_path, new_revision), Loader=MockOrderedLoader)
+
+            (a, r, c) = diff_files(old_contents, new_contents)
+            if a:
+                added[file] = a
+
+            if r:
+                removed[file] = r
+
+            if c:
+                changed[file] = c
+
+        except subprocess.CalledProcessError:
+            new_files.append(file)
+
+    report_diff(added, removed, changed, new_files)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Diff yaml configuration files between two points in time.')
+    parser.add_argument("old_revision", help="Old revision")
+    parser.add_argument("--new_revision", help="New revision (defaults to whatever is currently in tree)")
+    args = parser.parse_args()
+    main(args.old_revision, args.new_revision)


### PR DESCRIPTION
Per some discussion with @mvdbeek in gitter. Not integrated or used yet, but, it's a starting point and opening this for discussion.

```
$ .venv/bin/python scripts/release-diff.py v20.05 > doc/source/releases/20.09-config.rst
```

produces [this lovely diff](https://github.com/hexylena/galaxy/blob/release-diff/doc/source/releases/20.09-config.rst)


fyis:

- intentionally doesn't load `!includes` since those can't be followed to the old git revision.

some open questions

- which files should we diff and show? I've done all yml.sample in config.
- Doesn't parse newly added options which aren't added with default values to the config files. We'd have to parse the schemas for that. I didn't have a good feeling for if that would be significantly more useful?