### PR TITLE
[20.09] Fix submission via UI of workflows with optional inputs

### DIFF
--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -288,6 +288,8 @@ def build_workflow_run_configs(trans, workflow, payload):
         steps_by_id = workflow.steps_by_id
         # Set workflow inputs.
         for key, input_dict in normalized_inputs.items():
+            if input_dict is None:
+                continue
             step = steps_by_id[key]
             if step.type == 'parameter_input':
                 continue


### PR DESCRIPTION
A typical payload from the UI looks like this:
```
{'0': None, '1': {'hid': 56, 'id': '0fe36ab5a28e309f', 'keep': False, 'name': 'Select first on data 55', 'src': 'hda', 'tags': [...]}}
```
where '0' is an optional data input step.
Just skipping `None` inputs should be fine here.