### PR TITLE
Filtering.py failing all expressions

### DIFF
--- a/tools/stats/filtering.py
+++ b/tools/stats/filtering.py
@@ -13,7 +13,7 @@ AST_NODE_TYPE_WHITELIST = [
     'Or', 'GtE', 'LtE', 'Lt', 'Gt', 'BinOp', 'Add', 'Div', 'Sub', 'Mult', 'Mod',
     'Pow', 'LShift', 'GShift', 'BitAnd', 'BitOr', 'BitXor', 'UnaryOp', 'Invert',
     'Not', 'UAdd', 'USub', 'NotIn', 'In', 'Is', 'IsNot', 'List', 'Index',
-    'Subscript',
+    'Subscript', 'Constant',
     # Further checks
     'Name', 'Call', 'Attribute',
 ]


### PR DESCRIPTION
I am not entirely sure that this is the right fix, but with the newest version, all expressions were failing (including the ones in the examples, and the default one). I put print statements around and figured out that they were always failing because of hitting here: https://github.com/almahmoud/galaxy/blob/da860b09c829b804f5efef509882c7b42caa6f2a/tools/stats/filtering.py#L112 with type 'Constant' which was not in the list. This makes it work, but I am not entirely sure of any possible implications of adding 'Constant' to the whitelist if there are any.