### PR TITLE
[20.05] Fix hg_repo path handling in shed_index.py

### DIFF
--- a/lib/tool_shed/util/shed_index.py
+++ b/lib/tool_shed/util/shed_index.py
@@ -116,7 +116,7 @@ def get_repos(sa_session, file_path, hgweb_config_dir, **kwargs):
         full_last_updated = repo.update_time.strftime("%Y-%m-%d %I:%M %p")
 
         # Load all changesets of the repo for lineage.
-        repo_path = os.path.join(hgweb_config_dir, hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name)))
+        repo_path = os.path.join(file_path, hgwcm.get_entry(os.path.join("repos", repo.user.username, repo.name)))
         hg_repo = hg.repository(ui.ui(), repo_path.encode('utf-8'))
         lineage = []
         for changeset in hg_repo.changelog:


### PR DESCRIPTION
Entries are absolute paths anyway (at least since 20.05),
and all paths on the main toolshed and test toolshed are absolute.
This only worked for us because os.path.join does this:
```
Signature: os.path.join(a, *p)
Docstring:
Join two or more pathname components, inserting '/' as needed.
If any component is an absolute path, all previous path components
will be discarded.  An empty last part will result in a path that
ends with a separator.
```

Fixes https://github.com/galaxyproject/galaxy/issues/10271.