### PR TITLE
Datatypes refactoring

### DIFF
--- a/doc/source/dev/data_types.md
+++ b/doc/source/dev/data_types.md
@@ -457,7 +457,6 @@ class Lped(Text):
 
     composite_type = 'auto_primary_file'
     file_ext="lped"
-    allow_datatype_change = False
 
 
     def __init__(self, **kwd):
@@ -481,7 +480,7 @@ The file specified as `%s.ped` is found at `${os.path.join($input1.extra_files_p
 
 It should be noted that changing the datatype of datasets which use this substitution method will cause an error if the metadata parameter 'base_name' does not exist in a datatype that the dataset is set to. This is because the value within 'base_name' will be lost -- if the datatype is set back to the original datatype, the default metadata value will be used and the filenames might not match the basename.
 
-To prevent this from occurring, set `allow_datatype_change` to `False`. The dataset's datatype will not be able to be changed.
+For this reason, users are not allowed to change the datatype of dataset between a composite datatype and any other datatype. This can be enforced by setting the `allow_datatype_change` attribute of a datatype class to `False`.
 
 ## Galaxy Tool Shed - Data Types
 

--- a/lib/galaxy/datatypes/anvio.py
+++ b/lib/galaxy/datatypes/anvio.py
@@ -82,8 +82,6 @@ class AnvioDB(AnvioComposite):
     _anvio_basename = None
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def __init__(self, *args, **kwd):
         super().__init__(*args, **kwd)
@@ -113,8 +111,6 @@ class AnvioStructureDB(AnvioDB):
     _anvio_basename = 'STRUCTURE.db'
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_structure_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
 
 class AnvioGenomesDB(AnvioDB):
@@ -122,8 +118,6 @@ class AnvioGenomesDB(AnvioDB):
     _anvio_basename = '-GENOMES.db'
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_genomes_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
 
 class AnvioContigsDB(AnvioDB):
@@ -131,8 +125,6 @@ class AnvioContigsDB(AnvioDB):
     _anvio_basename = 'CONTIGS.db'
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_contigs_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def __init__(self, *args, **kwd):
         super().__init__(*args, **kwd)
@@ -144,8 +136,6 @@ class AnvioProfileDB(AnvioDB):
     _anvio_basename = 'PROFILE.db'
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_profile_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def __init__(self, *args, **kwd):
         super().__init__(*args, **kwd)
@@ -160,8 +150,6 @@ class AnvioPanDB(AnvioDB):
     _anvio_basename = 'PAN.db'
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_pan_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
 
 class AnvioSamplesDB(AnvioDB):
@@ -169,8 +157,6 @@ class AnvioSamplesDB(AnvioDB):
     _anvio_basename = 'SAMPLES.db'
     MetadataElement(name="anvio_basename", default=_anvio_basename, desc="Basename", readonly=True)
     file_ext = 'anvio_samples_db'
-    composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
 
 if __name__ == '__main__':

--- a/lib/galaxy/datatypes/assembly.py
+++ b/lib/galaxy/datatypes/assembly.py
@@ -139,7 +139,7 @@ class Velvet(Html):
     file_ext = 'velvet'
 
     def __init__(self, **kwd):
-        Html.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('Sequences', mimetype='text/html', description='Sequences', substitute_name_with_metadata=None, is_binary=False)
         self.add_composite_file('Roadmaps', mimetype='text/html', description='Roadmaps', substitute_name_with_metadata=None, is_binary=False)
         self.add_composite_file('Log', mimetype='text/html', description='Log', optional='True', substitute_name_with_metadata=None, is_binary=False)

--- a/lib/galaxy/datatypes/assembly.py
+++ b/lib/galaxy/datatypes/assembly.py
@@ -136,7 +136,6 @@ class Velvet(Html):
     MetadataElement(name="long_reads", desc="has long reads", default="False", readonly=False, set_in_upload=True)
     MetadataElement(name="short2_reads", desc="has 2nd short reads", default="False", readonly=False, set_in_upload=True)
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
     file_ext = 'velvet'
 
     def __init__(self, **kwd):

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -802,7 +802,7 @@ class H5(Binary):
     edam_format = "format_3590"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic = binascii.unhexlify("894844460d0a1a0a")
 
     def sniff(self, filename):
@@ -1446,7 +1446,7 @@ class BigWig(Binary):
     data_sources = {"data_standalone": "bigwig"}
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic = 0x888FFC26
         self._name = "BigWig"
 
@@ -2577,7 +2577,7 @@ class Dcd(Binary):
     edam_data = "data_3842"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic_number = b'CORD'
 
     def sniff(self, filename):
@@ -2628,7 +2628,7 @@ class Vel(Binary):
     file_ext = "vel"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic_number = b'VELD'
 
     def sniff(self, filename):
@@ -2678,7 +2678,7 @@ class DAA(Binary):
     file_ext = "daa"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic = binascii.unhexlify("6be33e6d47530e3c")
 
     def sniff(self, filename):
@@ -2701,7 +2701,7 @@ class RMA6(Binary):
     file_ext = "rma6"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic = binascii.unhexlify("000003f600000006")
 
     def sniff(self, filename):
@@ -2724,7 +2724,7 @@ class DMND(Binary):
     file_ext = "dmnd"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self._magic = binascii.unhexlify("6d18ee15a4f84a02")
 
     def sniff(self, filename):

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -236,13 +236,13 @@ class _BlastDb(Data):
         raise NotImplementedError("Can't split BLAST databases")
 
 
-class BlastNucDb(_BlastDb, Data):
+class BlastNucDb(_BlastDb):
     """Class for nucleotide BLAST database files."""
     file_ext = 'blastdbn'
     composite_type = 'basic'
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('blastdb.nhr', is_binary=True)  # sequence headers
         self.add_composite_file('blastdb.nin', is_binary=True)  # index file
         self.add_composite_file('blastdb.nsq', is_binary=True)  # nucleotide sequences
@@ -263,13 +263,13 @@ class BlastNucDb(_BlastDb, Data):
 # The previous 3 lines should be repeated for each WriteDB column, with filename extensions like ('.nba', '.nbb', '.nbc'), ('.nca', '.ncb', '.ncc'), etc.
 
 
-class BlastProtDb(_BlastDb, Data):
+class BlastProtDb(_BlastDb):
     """Class for protein BLAST database files."""
     file_ext = 'blastdbp'
     composite_type = 'basic'
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
 # Component file comments are as in BlastNucDb except where noted
         self.add_composite_file('blastdb.phr', is_binary=True)
         self.add_composite_file('blastdb.pin', is_binary=True)
@@ -287,13 +287,13 @@ class BlastProtDb(_BlastDb, Data):
 # The last 3 lines should be repeated for each WriteDB column, with filename extensions like ('.pba', '.pbb', '.pbc'), ('.pca', '.pcb', '.pcc'), etc.
 
 
-class BlastDomainDb(_BlastDb, Data):
+class BlastDomainDb(_BlastDb):
     """Class for domain BLAST database files."""
     file_ext = 'blastdbd'
     composite_type = 'basic'
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('blastdb.phr', is_binary=True)
         self.add_composite_file('blastdb.pin', is_binary=True)
         self.add_composite_file('blastdb.psq', is_binary=True)
@@ -327,7 +327,7 @@ class LastDb(Data):
             return "LAST database (multiple files)"
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('lastdb.bck', is_binary=True)
         self.add_composite_file('lastdb.des', description="Description file", is_binary=False)
         self.add_composite_file('lastdb.prj', description="Project resume file", is_binary=False)
@@ -337,13 +337,13 @@ class LastDb(Data):
         self.add_composite_file('lastdb.tis', is_binary=True)
 
 
-class BlastNucDb5(_BlastDb, Data):
+class BlastNucDb5(_BlastDb):
     """Class for nucleotide BLAST database files."""
     file_ext = 'blastdbn5'
     composite_type = 'basic'
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('blastdb.nhr', is_binary=True)  # sequence headers
         self.add_composite_file('blastdb.nin', is_binary=True)  # index file
         self.add_composite_file('blastdb.nsq', is_binary=True)  # nucleotide sequences
@@ -364,13 +364,13 @@ class BlastNucDb5(_BlastDb, Data):
 # The previous 3 lines should be repeated for each WriteDB column, with filename extensions like ('.nba', '.nbb', '.nbc'), ('.nca', '.ncb', '.ncc'), etc.
 
 
-class BlastProtDb5(_BlastDb, Data):
+class BlastProtDb5(_BlastDb):
     """Class for protein BLAST database files."""
     file_ext = 'blastdbp5'
     composite_type = 'basic'
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
 # Component file comments are as in BlastNucDb except where noted
         self.add_composite_file('blastdb.phr', is_binary=True)
         self.add_composite_file('blastdb.pin', is_binary=True)
@@ -388,13 +388,13 @@ class BlastProtDb5(_BlastDb, Data):
 # The last 3 lines should be repeated for each WriteDB column, with filename extensions like ('.pba', '.pbb', '.pbc'), ('.pca', '.pcb', '.pcc'), etc.
 
 
-class BlastDomainDb5(_BlastDb, Data):
+class BlastDomainDb5(_BlastDb):
     """Class for domain BLAST database files."""
     file_ext = 'blastdbd5'
     composite_type = 'basic'
 
     def __init__(self, **kwd):
-        Data.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('blastdb.phr', is_binary=True)
         self.add_composite_file('blastdb.pin', is_binary=True)
         self.add_composite_file('blastdb.psq', is_binary=True)

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -239,7 +239,6 @@ class _BlastDb(Data):
 class BlastNucDb(_BlastDb, Data):
     """Class for nucleotide BLAST database files."""
     file_ext = 'blastdbn'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def __init__(self, **kwd):
@@ -267,7 +266,6 @@ class BlastNucDb(_BlastDb, Data):
 class BlastProtDb(_BlastDb, Data):
     """Class for protein BLAST database files."""
     file_ext = 'blastdbp'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def __init__(self, **kwd):
@@ -292,7 +290,6 @@ class BlastProtDb(_BlastDb, Data):
 class BlastDomainDb(_BlastDb, Data):
     """Class for domain BLAST database files."""
     file_ext = 'blastdbd'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def __init__(self, **kwd):
@@ -311,7 +308,6 @@ class BlastDomainDb(_BlastDb, Data):
 class LastDb(Data):
     """Class for LAST database files."""
     file_ext = 'lastdb'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def set_peek(self, dataset, is_multi_byte=False):
@@ -344,7 +340,6 @@ class LastDb(Data):
 class BlastNucDb5(_BlastDb, Data):
     """Class for nucleotide BLAST database files."""
     file_ext = 'blastdbn5'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def __init__(self, **kwd):
@@ -372,7 +367,6 @@ class BlastNucDb5(_BlastDb, Data):
 class BlastProtDb5(_BlastDb, Data):
     """Class for protein BLAST database files."""
     file_ext = 'blastdbp5'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def __init__(self, **kwd):
@@ -397,7 +391,6 @@ class BlastProtDb5(_BlastDb, Data):
 class BlastDomainDb5(_BlastDb, Data):
     """Class for domain BLAST database files."""
     file_ext = 'blastdbd5'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def __init__(self, **kwd):

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -122,13 +122,13 @@ class Data(metaclass=DataMeta):
     # The dataset contains binary data --> do not space_to_tab or convert newlines, etc.
     # Allow binary file uploads of this type when True.
     is_binary = True
-    # Allow user to change between this datatype and others. If False, this datatype
-    # cannot be changed from or into.
-    allow_datatype_change = True
     # Composite datatypes
     composite_type = None
     composite_files = OrderedDict()
     primary_file_name = 'index'
+    # Allow user to change between this datatype and others. If left to None,
+    # datatype change is allowed if the datatype is not composite.
+    allow_datatype_change = None
     # A per datatype setting (inherited): max file size (in bytes) for setting optional metadata
     _max_optional_metadata_filesize = None
 
@@ -144,6 +144,16 @@ class Data(metaclass=DataMeta):
         self.supported_display_apps = self.supported_display_apps.copy()
         self.composite_files = self.composite_files.copy()
         self.display_applications = OrderedDict()
+
+    @classmethod
+    def is_datatype_change_allowed(cls):
+        """
+        Returns the value of the `allow_datatype_change` class attribute if set
+        in a subclass, or True iff the datatype is not composite.
+        """
+        if cls.allow_datatype_change is not None:
+            return cls.allow_datatype_change
+        return cls.composite_type is None
 
     def get_raw_data(self, dataset):
         """Returns the full data. To stream it open the file_name and read/write as needed"""

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -1042,13 +1042,6 @@ class Newick(Text):
     edam_format = "format_1910"
     file_ext = "newick"
 
-    def __init__(self, **kwd):
-        """Initialize foobar datatype"""
-        Text.__init__(self, **kwd)
-
-    def init_meta(self, dataset, copy_from=None):
-        Text.init_meta(self, dataset, copy_from=copy_from)
-
     def sniff(self, filename):
         """ Returning false as the newick format is too general and cannot be sniffed."""
         return False
@@ -1057,7 +1050,6 @@ class Newick(Text):
         """
         Returns a list of visualizations for datatype.
         """
-
         return ['phyloviz']
 
 
@@ -1068,13 +1060,6 @@ class Nexus(Text):
     edam_format = "format_1912"
     file_ext = "nex"
 
-    def __init__(self, **kwd):
-        """Initialize foobar datatype"""
-        Text.__init__(self, **kwd)
-
-    def init_meta(self, dataset, copy_from=None):
-        Text.init_meta(self, dataset, copy_from=copy_from)
-
     def sniff_prefix(self, file_prefix):
         """All Nexus Files Simply puts a '#NEXUS' in its first line"""
         return file_prefix.string_io().read(6).upper() == "#NEXUS"
@@ -1083,7 +1068,6 @@ class Nexus(Text):
         """
         Returns a list of visualizations for datatype.
         """
-
         return ['phyloviz']
 
 

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -273,7 +273,6 @@ class Rgenetics(Html):
                     readonly=True, set_in_upload=True)
 
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
     file_ext = 'rgenetics'
 
     def generate_primary_file(self, dataset=None):
@@ -528,7 +527,6 @@ class IdeasPre(Html):
     MetadataElement(name="tmp_archive", desc="Compressed archive of compressed bed files", default=None, readonly=True)
 
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
     file_ext = 'ideaspre'
 
     def __init__(self, **kwd):
@@ -597,7 +595,6 @@ class RexpBase(Html):
     file_ext = 'rexpbase'
     html_table = None
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def __init__(self, **kwd):
         Html.__init__(self, **kwd)

--- a/lib/galaxy/datatypes/genetics.py
+++ b/lib/galaxy/datatypes/genetics.py
@@ -56,11 +56,11 @@ class GenomeGraphs(Tabular):
         """
         Initialize gg datatype, by adding UCSC display apps
         """
-        Tabular.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_display_app('ucsc', 'Genome Graph', 'as_ucsc_display_file', 'ucsc_links')
 
     def set_meta(self, dataset, **kwd):
-        Tabular.set_meta(self, dataset, **kwd)
+        super().set_meta(dataset, **kwd)
         dataset.metadata.markerCol = 1
         header = open(dataset.file_name).readlines()[0].strip().split('\t')
         dataset.metadata.columns = len(header)
@@ -121,7 +121,7 @@ class GenomeGraphs(Tabular):
                     ret_val.append((site_name, link))
         return ret_val
 
-    def make_html_table(self, dataset, skipchars=[]):
+    def make_html_table(self, dataset):
         """
         Create HTML table, used for displaying peek
         """
@@ -160,9 +160,9 @@ class GenomeGraphs(Tabular):
         """
         with open(dataset.file_name) as infile:
             next(infile)  # header
-            for i, row in enumerate(infile):
+            for row in infile:
                 ll = row.strip().split('\t')[1:]  # first is alpha feature identifier
-                for j, x in enumerate(ll):
+                for x in ll:
                     x = float(x)
         return DatatypeValidation.validated()
 
@@ -214,7 +214,7 @@ class rgTabList(Tabular):
         """
         Initialize featurelistt datatype
         """
-        Tabular.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.column_names = []
 
     def display_peek(self, dataset):
@@ -240,7 +240,7 @@ class rgSampleList(rgTabList):
         """
         Initialize samplelist datatype
         """
-        rgTabList.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.column_names[0] = 'FID'
         self.column_names[1] = 'IID'
         # this is what Plink wants as at 2009
@@ -257,7 +257,7 @@ class rgFeatureList(rgTabList):
 
     def __init__(self, **kwd):
         """Initialize featurelist datatype"""
-        rgTabList.__init__(self, **kwd)
+        super().__init__(**kwd)
         for i, s in enumerate(['#FeatureId', 'Chr', 'Genpos', 'Mappos']):
             self.column_names[i] = s
 
@@ -297,7 +297,7 @@ class Rgenetics(Html):
         efp = dataset.extra_files_path
         flist = os.listdir(efp)
         rval = ['<html><head><title>Files for Composite Dataset {}</title></head><body><p/>Composite {} contains:<p/><ul>'.format(dataset.name, dataset.name)]
-        for i, fname in enumerate(flist):
+        for fname in flist:
             sfname = os.path.split(fname)[-1]
             f, e = os.path.splitext(fname)
             rval.append('<li><a href="{}">{}</a></li>'.format(sfname, sfname))
@@ -315,7 +315,7 @@ class Rgenetics(Html):
         for lped/pbed eg
 
         """
-        Html.set_meta(self, dataset, **kwd)
+        super().set_meta(dataset, **kwd)
         if not kwd.get('overwrite'):
             if verbose:
                 gal_Log.debug('@@@ rgenetics set_meta called with overwrite = False')
@@ -361,8 +361,8 @@ class SNPMatrix(Rgenetics):
     def sniff(self, filename):
         """ need to check the file header hex code
         """
-        infile = open(filename, "b")
-        head = infile.read(16)
+        with open(filename, "b") as infile:
+            head = infile.read(16)
         head = [hex(x) for x in head]
         if head != '':
             return False
@@ -377,7 +377,7 @@ class Lped(Rgenetics):
     file_ext = "lped"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.ped',
                                 description='Pedigree File',
                                 substitute_name_with_metadata='base_name',
@@ -395,7 +395,7 @@ class Pphe(Rgenetics):
     file_ext = "pphe"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.pphe',
                                 description='Plink Phenotype File',
                                 substitute_name_with_metadata='base_name',
@@ -410,7 +410,7 @@ class Fphe(Rgenetics):
     file_ext = "fphe"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.fphe',
                                 description='FBAT Phenotype File',
                                 substitute_name_with_metadata='base_name')
@@ -423,7 +423,7 @@ class Phe(Rgenetics):
     file_ext = "phe"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.phe',
                                 description='Phenotype File',
                                 substitute_name_with_metadata='base_name',
@@ -438,7 +438,7 @@ class Fped(Rgenetics):
     file_ext = "fped"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.fped', description='FBAT format pedfile',
                                 substitute_name_with_metadata='base_name',
                                 is_binary=False)
@@ -451,7 +451,7 @@ class Pbed(Rgenetics):
     file_ext = "pbed"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.bim', substitute_name_with_metadata='base_name', is_binary=False)
         self.add_composite_file('%s.bed', substitute_name_with_metadata='base_name', is_binary=True)
         self.add_composite_file('%s.fam', substitute_name_with_metadata='base_name', is_binary=False)
@@ -466,7 +466,7 @@ class ldIndep(Rgenetics):
     file_ext = "ldreduced"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.bim', substitute_name_with_metadata='base_name', is_binary=False)
         self.add_composite_file('%s.bed', substitute_name_with_metadata='base_name', is_binary=True)
         self.add_composite_file('%s.fam', substitute_name_with_metadata='base_name', is_binary=False)
@@ -481,7 +481,7 @@ class Eigenstratgeno(Rgenetics):
     file_ext = "eigenstratgeno"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.eigenstratgeno', substitute_name_with_metadata='base_name', is_binary=False)
         self.add_composite_file('%s.ind', substitute_name_with_metadata='base_name', is_binary=False)
         self.add_composite_file('%s.map', substitute_name_with_metadata='base_name', is_binary=False)
@@ -495,7 +495,7 @@ class Eigenstratpca(Rgenetics):
     file_ext = "eigenstratpca"
 
     def __init__(self, **kwd):
-        Rgenetics.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.eigenstratpca',
                                 description='Eigenstrat PCA file', substitute_name_with_metadata='base_name')
 
@@ -530,14 +530,14 @@ class IdeasPre(Html):
     file_ext = 'ideaspre'
 
     def __init__(self, **kwd):
-        Html.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('chromosome_windows.txt', description='Chromosome window positions', is_binary=False, optional=True)
         self.add_composite_file('chromosomes.bed', description='Bed file specifying window positions', is_binary=False, optional=True)
         self.add_composite_file('IDEAS_input_config.txt', description='IDEAS input config', is_binary=False)
         self.add_composite_file('tmp.tar.gz', description='Compressed archive of compressed bed files', is_binary=True)
 
     def set_meta(self, dataset, **kwd):
-        Html.set_meta(self, dataset, **kwd)
+        super().set_meta(dataset, **kwd)
         for fname in os.listdir(dataset.extra_files_path):
             if fname.startswith("chromosomes"):
                 dataset.metadata.chrom_bed = os.path.join(dataset.extra_files_path, fname)
@@ -553,7 +553,7 @@ class IdeasPre(Html):
         rval = ['<html><head></head><body>']
         rval.append('<h3>Files prepared for IDEAS</h3>')
         rval.append('<ul>')
-        for composite_name, composite_file in self.get_composite_files(dataset=dataset).items():
+        for composite_name in self.get_composite_files(dataset=dataset).keys():
             fn = composite_name
             rval.append('<li><a href="{}>{}</a></li>'.format(fn, fn))
         rval.append('</ul></body></html>\n')
@@ -597,7 +597,7 @@ class RexpBase(Html):
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
-        Html.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.pheno', description='Phenodata tab text file',
                                 substitute_name_with_metadata='base_name', is_binary=False)
 
@@ -612,7 +612,7 @@ class RexpBase(Html):
         """Returns the mime type of the datatype"""
         return 'text/html'
 
-    def get_phecols(self, phenolist=[], maxConc=20):
+    def get_phecols(self, phenolist, maxConc=20):
         """
         sept 2009: cannot use whitespace to split - make a more complex structure here
         and adjust the methods that rely on this structure
@@ -750,7 +750,7 @@ class RexpBase(Html):
         bn = dataset.metadata.base_name
         flist = os.listdir(dataset.extra_files_path)
         rval = ['<html><head><title>Files for Composite Dataset %s</title></head><p/>Comprises the following files:<p/><ul>' % (bn)]
-        for i, fname in enumerate(flist):
+        for fname in flist:
             sfname = os.path.split(fname)[-1]
             rval.append('<li><a href="{}">{}</a>'.format(sfname, sfname))
         rval.append('</ul></html>')
@@ -768,7 +768,7 @@ class RexpBase(Html):
         from a BioC eSet or affybatch.
 
         """
-        Html.set_meta(self, dataset, **kwd)
+        super().set_meta(dataset, **kwd)
         try:
             flist = os.listdir(dataset.extra_files_path)
         except Exception:
@@ -854,7 +854,7 @@ class Affybatch(RexpBase):
     file_ext = "affybatch"
 
     def __init__(self, **kwd):
-        RexpBase.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.affybatch',
                                 description='AffyBatch R object saved to file',
                                 substitute_name_with_metadata='base_name', is_binary=True)
@@ -867,7 +867,7 @@ class Eset(RexpBase):
     file_ext = "eset"
 
     def __init__(self, **kwd):
-        RexpBase.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.eset',
                                 description='ESet R object saved to file',
                                 substitute_name_with_metadata='base_name', is_binary=True)
@@ -880,7 +880,7 @@ class MAlist(RexpBase):
     file_ext = "malist"
 
     def __init__(self, **kwd):
-        RexpBase.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.malist',
                                 description='MAlist R object saved to file',
                                 substitute_name_with_metadata='base_name', is_binary=True)
@@ -896,7 +896,7 @@ class LinkageStudies(Text):
     ]
 
     def __init__(self, **kwd):
-        Text.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.max_lines = 10
 
 

--- a/lib/galaxy/datatypes/gis.py
+++ b/lib/galaxy/datatypes/gis.py
@@ -12,7 +12,6 @@ class Shapefile(Binary):
 
     composite_type = 'auto_primary_file'
     file_ext = "shp"
-    allow_datatype_change = False
 
     def __init__(self, **kwd):
         Binary.__init__(self, **kwd)

--- a/lib/galaxy/datatypes/gis.py
+++ b/lib/galaxy/datatypes/gis.py
@@ -14,7 +14,7 @@ class Shapefile(Binary):
     file_ext = "shp"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('shapefile.shp', description='Geometry File (shp)', is_binary=True, optional=False)
         self.add_composite_file('shapefile.shx', description='Geometry index File (shx)', is_binary=True, optional=False)
         self.add_composite_file('shapefile.dbf', description='Columnar attributes for each shape (dbf)', is_binary=True, optional=False)

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -62,7 +62,6 @@ def utf8_text_file_open(path):
 class _Isa(data.Data):
     """ Base class for implementing ISA datatypes """
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
     is_binary = True
     _main_file_regex = None
 

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -2,12 +2,12 @@ import logging
 import os
 import re
 
-from galaxy.datatypes import (
-    data,
-    metadata
-)
+from galaxy.datatypes import metadata
 from galaxy.datatypes.binary import Binary
-from galaxy.datatypes.data import get_file_peek
+from galaxy.datatypes.data import (
+    get_file_peek,
+    Text,
+)
 from galaxy.datatypes.metadata import MetadataElement
 from galaxy.datatypes.sniff import (
     build_sniff_from_prefix,
@@ -41,7 +41,7 @@ def count_lines(filename, non_empty=False):
     return int(out.split()[0])
 
 
-class GenericMolFile(data.Text):
+class GenericMolFile(Text):
     """
     Abstract class for most of the molecule files.
     """
@@ -347,7 +347,7 @@ class FPS(GenericMolFile):
         """
         if len(split_files) == 1:
             # For one file only, use base class method (move/copy)
-            return data.Text.merge(split_files, output_file)
+            return Text.merge(split_files, output_file)
         if not split_files:
             raise ValueError("No fps files given, %r, to merge into %s"
                              % (split_files, output_file))
@@ -379,7 +379,7 @@ class OBFS(Binary):
             A Fastsearch Index consists of a binary file with the fingerprints
             and a pointer the actual molecule file.
         """
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('molecule.fs', is_binary=True,
                                 description='OpenBabel Fastsearch Index')
         self.add_composite_file('molecule.sdf', optional=True,
@@ -673,7 +673,7 @@ class PQR(GenericMolFile):
             dataset.blurb = 'file purged from disk'
 
 
-class grd(data.Text):
+class grd(Text):
     file_ext = "grd"
 
     def set_peek(self, dataset, is_multi_byte=False):
@@ -910,7 +910,7 @@ class CML(GenericXml):
         """
         if len(split_files) == 1:
             # For one file only, use base class method (move/copy)
-            return data.Text.merge(split_files, output_file)
+            return Text.merge(split_files, output_file)
         if not split_files:
             raise ValueError("Given no CML files, %r, to merge into %s"
                              % (split_files, output_file))

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -370,7 +370,6 @@ class OBFS(Binary):
     """OpenBabel Fastsearch format (fs)."""
     file_ext = 'obfs'
     composite_type = 'basic'
-    allow_datatype_change = False
 
     MetadataElement(name="base_name", default='OpenBabel Fastsearch Index',
                     readonly=True, visible=True, optional=True,)

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -129,7 +129,7 @@ class HmmerPress(Binary):
             return "HMMER3 database (multiple files)"
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
         # Binary model
         self.add_composite_file('model.hmm.h3m', is_binary=True)
         # SSI index for binary model

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -110,7 +110,6 @@ class Hmmer3(Hmmer):
 class HmmerPress(Binary):
     """Class for hmmpress database files."""
     file_ext = 'hmmpress'
-    allow_datatype_change = False
     composite_type = 'basic'
 
     def set_peek(self, dataset, is_multi_byte=False):

--- a/lib/galaxy/datatypes/neo4j.py
+++ b/lib/galaxy/datatypes/neo4j.py
@@ -63,7 +63,6 @@ class Neo4jDB(Neo4j, Data):
     """Class for neo4jDB database files."""
     file_ext = 'neostore'
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def __init__(self, **kwd):
         Data.__init__(self, **kwd)
@@ -129,7 +128,6 @@ class Neo4jDBzip(Neo4j, Data):
 
     file_ext = "neostore.zip"
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def __init__(self, **kwd):
         Data.__init__(self, **kwd)

--- a/lib/galaxy/datatypes/ngsindex.py
+++ b/lib/galaxy/datatypes/ngsindex.py
@@ -34,7 +34,7 @@ class BowtieIndex(Html):
         bn = dataset.metadata.base_name
         flist = os.listdir(dataset.extra_files_path)
         rval = ['<html><head><title>Files for Composite Dataset %s</title></head><p/>Comprises the following files:<p/><ul>' % (bn)]
-        for i, fname in enumerate(flist):
+        for fname in flist:
             sfname = os.path.split(fname)[-1]
             rval.append('<li><a href="{}">{}</a>'.format(sfname, sfname))
         rval.append('</ul></html>')

--- a/lib/galaxy/datatypes/ngsindex.py
+++ b/lib/galaxy/datatypes/ngsindex.py
@@ -19,7 +19,6 @@ class BowtieIndex(Html):
     MetadataElement(name="sequence_space", desc="sequence_space for this index set", default='unknown', set_in_upload=True, readonly=True)
 
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
 
     def generate_primary_file(self, dataset=None):
         """

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -25,7 +25,7 @@ class Wiff(Binary):
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
 
         self.add_composite_file(
             'wiff',
@@ -322,7 +322,7 @@ class Dta(TabularData):
         data_lines = 0
         if dataset.has_data():
             with open(dataset.file_name) as dtafile:
-                for line in dtafile:
+                for _ in dtafile:
                     data_lines += 1
 
         # Guess column types
@@ -880,7 +880,7 @@ class SPLib(Msp):
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
-        Msp.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('library.splib',
                                 description='Spectral Library. Contains actual library spectra',
                                 is_binary=False)
@@ -972,7 +972,7 @@ class ImzML(Binary):
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
 
         """The metadata"""
         self.add_composite_file(
@@ -1009,7 +1009,7 @@ class Analyze75(Binary):
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
-        Binary.__init__(self, **kwd)
+        super().__init__(**kwd)
 
         """The header file. Provides information about dimensions, identification, and processing history."""
         self.add_composite_file(

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -22,7 +22,6 @@ class Wiff(Binary):
     edam_data = "data_2536"
     edam_format = "format_3710"
     file_ext = 'wiff'
-    allow_datatype_change = False
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
@@ -970,7 +969,6 @@ class ImzML(Binary):
     """
     edam_format = "format_3682"
     file_ext = 'imzml'
-    allow_datatype_change = False
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):
@@ -1008,7 +1006,6 @@ class Analyze75(Binary):
         http://www.imzml.org
     """
     file_ext = 'analyze75'
-    allow_datatype_change = False
     composite_type = 'auto_primary_file'
 
     def __init__(self, **kwd):

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -224,7 +224,7 @@ class Registry:
                             if ok:
                                 datatype_class = None
                                 if proprietary_path and proprietary_datatype_module and datatype_class_name:
-                                    # TODO: previously comments suggested this needs to be locked because it modifys
+                                    # TODO: previously comments suggested this needs to be locked because it modifies
                                     # the sys.path, probably true but the previous lock wasn't doing that.
                                     try:
                                         imported_module = __import_module(proprietary_path,
@@ -556,7 +556,7 @@ class Registry:
             return images.Image
 
         # TODO: too inefficient - would be better to generate this once as a map and store in this object
-        for ext, datatype_obj in self.datatypes_by_extension.items():
+        for datatype_obj in self.datatypes_by_extension.values():
             datatype_obj_class = datatype_obj.__class__
             datatype_obj_class_str = str(datatype_obj_class)
             if name in datatype_obj_class_str:

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -14,7 +14,6 @@ verbose = True
 
 
 class _SpalnDb(Data):
-    allow_datatype_change = False
     composite_type = "auto_primary_file"
 
     MetadataElement(

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -630,7 +630,6 @@ class SnpSiftDbNSFP(Text):
     MetadataElement(name="annotation", default=[], desc="Annotation Names", readonly=True, visible=True, no_value=[])
     file_ext = "snpsiftdbnsfp"
     composite_type = 'auto_primary_file'
-    allow_datatype_change = False
     """
     ## The dbNSFP file is a tabular file with 1 header line
     ## The first 4 columns are required to be: chrom	pos	ref	alt

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -561,7 +561,7 @@ class SnpEffDb(Text):
     MetadataElement(name="annotation", default=[], desc="Annotation Names", readonly=True, visible=True, no_value=[], optional=True)
 
     def __init__(self, **kwd):
-        Text.__init__(self, **kwd)
+        super().__init__(**kwd)
 
     # The SnpEff version line was added in SnpEff version 4.1
     def getSnpeffVersionFromFile(self, path):
@@ -578,7 +578,7 @@ class SnpEffDb(Text):
         return snpeff_version
 
     def set_meta(self, dataset, **kwd):
-        Text.set_meta(self, dataset, **kwd)
+        super().set_meta(dataset, **kwd)
         data_dir = dataset.extra_files_path
         # search data_dir/genome_version for files
         regulation_pattern = 'regulation_(.+).bin'
@@ -643,12 +643,9 @@ class SnpSiftDbNSFP(Text):
     """
 
     def __init__(self, **kwd):
-        Text.__init__(self, **kwd)
+        super().__init__(**kwd)
         self.add_composite_file('%s.gz', description='dbNSFP bgzip', substitute_name_with_metadata='reference_name', is_binary=True)
         self.add_composite_file('%s.gz.tbi', description='Tabix Index File', substitute_name_with_metadata='reference_name', is_binary=True)
-
-    def init_meta(self, dataset, copy_from=None):
-        Text.init_meta(self, dataset, copy_from=copy_from)
 
     def generate_primary_file(self, dataset=None):
         """

--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -16,9 +16,6 @@ class GeneTrack(binary.Binary):
     edam_format = "format_2919"
     file_ext = "genetrack"
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
 
 class UCSCTrackHub(Html):
     """
@@ -27,9 +24,6 @@ class UCSCTrackHub(Html):
 
     file_ext = 'trackhub'
     composite_type = 'auto_primary_file'
-
-    def __init__(self, **kwd):
-        Html.__init__(self, **kwd)
 
     def generate_primary_file(self, dataset=None):
         """

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -179,7 +179,7 @@ class DatasetsController(BaseAPIController, UsesVisualizationMixin):
         """
         Return True if dataset is currently used as an input or output. False otherwise.
         """
-        return not self.hda_manager.ok_to_edit_metadata(dataset.id)
+        return not dataset.ok_to_edit_metadata()
 
     def _dataset_state(self, trans, dataset, **kwargs):
         """

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -47,6 +47,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         super().__init__(app)
         self.history_manager = managers.histories.HistoryManager(app)
         self.hda_manager = managers.hdas.HDAManager(app)
+        self.hda_deserializer = managers.hdas.HDADeserializer(app)
 
     def _get_job_for_dataset(self, trans, dataset_id):
         '''
@@ -198,7 +199,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 return self.message_exception(trans, 'Please wait until this dataset finishes uploading before attempting to edit its metadata.')
             # let's not overwrite the imported datatypes module with the variable datatypes?
             # the built-in 'id' is overwritten in lots of places as well
-            ldatatypes = [(dtype_name, dtype_name) for dtype_name, dtype_value in trans.app.datatypes_registry.datatypes_by_extension.items() if dtype_value.allow_datatype_change]
+            ldatatypes = [(dtype_name, dtype_name) for dtype_name, dtype_value in trans.app.datatypes_registry.datatypes_by_extension.items() if dtype_value.is_datatype_change_allowed()]
             ldatatypes.sort()
             all_roles = [(r.name, trans.security.encode_id(r.id)) for r in trans.app.security_agent.get_legitimate_roles(trans, data.dataset, 'root')]
             data_metadata = [(name, spec) for name, spec in data.metadata.spec.items()]
@@ -258,7 +259,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 'help'      : 'This will create a new dataset with the contents of this dataset converted to a new format.',
                 'options'   : conversion_options
             }]
-            # datatype changeing
+            # datatype changing
             datatype_options = [(ext_name, ext_id) for ext_id, ext_name in ldatatypes]
             datatype_disable = len(datatype_options) == 0
             datatype_inputs = [{
@@ -362,20 +363,14 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         elif operation == 'datatype':
             # The user clicked the Save button on the 'Change data type' form
             datatype = payload.get('datatype')
-            if data.datatype.allow_datatype_change and trans.app.datatypes_registry.get_datatype_by_extension(datatype).allow_datatype_change:
-                # prevent modifying datatype when dataset is queued or running as input/output
-                if not __ok_to_edit_metadata(data.id):
-                    return self.message_exception(trans, 'This dataset is currently being used as input or output.  You cannot change datatype until the jobs have completed or you have canceled them.')
-                else:
-                    trans.app.datatypes_registry.change_datatype(data, datatype)
-                    trans.sa_session.flush()
-                    trans.app.datatypes_registry.set_external_metadata_tool.tool_action.execute(trans.app.datatypes_registry.set_external_metadata_tool, trans, incoming={'input1': data}, overwrite=False)  # overwrite is False as per existing behavior
-                    message = 'Changed the type to %s.' % datatype
-            else:
-                return self.message_exception(trans, 'You are unable to change datatypes in this manner. Changing {} to {} is not allowed.'.format(data.extension, datatype))
+            try:
+                self.hda_deserializer.deserialize(data, {'datatype': datatype}, trans=trans)
+                message = 'Changed the type to %s.' % datatype
+            except Exception as e:
+                return self.message_exception(trans, util.unicodify(e))
         elif operation == 'datatype_detect':
             # The user clicked the 'Detect datatype' button on the 'Change data type' form
-            if data.datatype.allow_datatype_change:
+            if data.datatype.is_datatype_change_allowed():
                 # prevent modifying datatype when dataset is queued or running as input/output
                 if not __ok_to_edit_metadata(data.id):
                     return self.message_exception(trans, 'This dataset is currently being used as input or output.  You cannot change datatype until the jobs have completed or you have canceled them.')

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -328,9 +328,6 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
     @web.legacy_expose_api_anonymous
     def set_edit(self, trans, payload=None, **kwd):
         """Allows user to modify parameters of an HDA."""
-        def __ok_to_edit_metadata(dataset_id):
-            return self.hda_manager.ok_to_edit_metadata(dataset_id)
-
         status = 'success'
         operation = payload.get('operation')
         dataset_id = payload.get('dataset_id')
@@ -342,7 +339,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             # The user clicked the Save button on the 'Edit Attributes' form
             data.name = payload.get('name')
             data.info = payload.get('info')
-            if __ok_to_edit_metadata(data.id):
+            if data.ok_to_edit_metadata():
                 # The following for loop will save all metadata_spec items
                 for name, spec in data.datatype.metadata_spec.items():
                     if not spec.get('readonly'):
@@ -372,7 +369,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             # The user clicked the 'Detect datatype' button on the 'Change data type' form
             if data.datatype.is_datatype_change_allowed():
                 # prevent modifying datatype when dataset is queued or running as input/output
-                if not __ok_to_edit_metadata(data.id):
+                if not data.ok_to_edit_metadata():
                     return self.message_exception(trans, 'This dataset is currently being used as input or output.  You cannot change datatype until the jobs have completed or you have canceled them.')
                 else:
                     path = data.dataset.file_name

--- a/test/unit/data/datatypes/test_data.py
+++ b/test/unit/data/datatypes/test_data.py
@@ -4,10 +4,28 @@ Unit tests for base DataTypes.
 """
 import os
 
-from galaxy.datatypes.data import get_file_peek
+from galaxy.datatypes.anvio import AnvioStructureDB
+from galaxy.datatypes.data import (
+    Data,
+    get_file_peek,
+)
+from galaxy.datatypes.interval import (
+    Bed,
+    BedStrict
+)
 from galaxy.util import galaxy_directory
 
 
 def test_get_file_peek():
     # should get the first 5 lines of the file without a trailing newline character
     assert get_file_peek(os.path.join(galaxy_directory(), 'test-data/1.tabular'), line_wrap=False) == 'chr22\t1000\tNM_17\nchr22\t2000\tNM_18\nchr10\t2200\tNM_10\nchr10\thap\ttest\nchr10\t1200\tNM_11\n'
+
+
+def test_is_datatype_change_allowed():
+    # By default is_datatype_change_allowed() is True if the datatype is not composite
+    assert Data.is_datatype_change_allowed()
+    assert Bed.is_datatype_change_allowed()
+    # AnvioStructureDB is a subclass of a composite datatype
+    assert AnvioStructureDB.is_datatype_change_allowed() is False
+    # BedStrict explictly disallows datatype change with `allow_datatype_change = False`
+    assert BedStrict.is_datatype_change_allowed() is False


### PR DESCRIPTION
- Don't allow datatype change by default if it's composite
- Re-use the HDA deserializer to change datatype in the dataset controller
- Make ``ok_to_edit_metadata()`` a method of ``DatasetInstance``
- Use `super()` to invoke parent class methods in all datatypes
- Remove unnecessarily overridden methods
- Fix issues reported by flake8-bugbear