### PR TITLE
[20.09] Persist tool_cache_data_dir tag if specified

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/tools/tool_panel_manager.py
@@ -34,6 +34,7 @@ class ToolPanelManager:
             return
         old_toolbox = self.app.toolbox
         shed_tool_conf = shed_tool_conf_dict['config_filename']
+        tool_cache_data_dir = shed_tool_conf_dict.get('tool_cache_data_dir')
         tool_path = shed_tool_conf_dict['tool_path']
         config_elems = []
         # Ideally shed_tool_conf.xml would be created before the repo is cloned and added to the DB, but this is called
@@ -57,7 +58,7 @@ class ToolPanelManager:
             for elem_entry in elem_list:
                 config_elems.append(elem_entry)
             # Persist the altered shed_tool_config file.
-            self.config_elems_to_xml_file(config_elems, shed_tool_conf, tool_path)
+            self.config_elems_to_xml_file(config_elems, shed_tool_conf, tool_path, tool_cache_data_dir)
             self.app.wait_for_toolbox_reload(old_toolbox)
         else:
             log.error(error_message)
@@ -94,13 +95,14 @@ class ToolPanelManager:
             self.app.toolbox.update_shed_config(shed_tool_conf_dict)
             self.add_to_shed_tool_config(shed_tool_conf_dict, elem_list)
 
-    def config_elems_to_xml_file(self, config_elems, config_filename, tool_path):
+    def config_elems_to_xml_file(self, config_elems, config_filename, tool_path, tool_cache_data_dir=None):
         """
         Persist the current in-memory list of config_elems to a file named by the
         value of config_filename.
         """
         try:
-            root = parse_xml_string('<?xml version="1.0"?>\n<toolbox tool_path="%s"></toolbox>' % str(tool_path))
+            tool_cache_data_dir = ' tool_cache_data_dir="{}"'.format(tool_cache_data_dir) if tool_cache_data_dir else ''
+            root = parse_xml_string('<?xml version="1.0"?>\n<toolbox tool_path="{}"{}></toolbox>'.format(tool_path, tool_cache_data_dir))
             for elem in config_elems:
                 root.append(elem)
             with RenamedTemporaryFile(config_filename, mode='w') as fh:

--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -218,6 +218,7 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
         if parsing_shed_tool_conf:
             shed_tool_conf_dict = dict(config_filename=config_filename,
                                        tool_path=tool_path,
+                                       tool_cache_data_dir=tool_cache_data_dir,
                                        config_elems=config_elems)
             self._dynamic_tool_confs.append(shed_tool_conf_dict)
 


### PR DESCRIPTION
We noticed that the tag was getting lost when installing new tools,
this fixes that.