### PR TITLE
[20.09] Fix tuple assignment (fixes anndata, scanpy tool tests)

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -1048,7 +1048,7 @@ class Anndata(H5):
                     elif hasattr(anndata_file['X'], 'shape'):
                         dataset.metadata.shape = tuple(anndata_file['X'].shape)
                     else:
-                        dataset.metadata.shape = tuple(int(dataset.metadata.obs_size), int(dataset.metadata.var_size))
+                        dataset.metadata.shape = (int(dataset.metadata.obs_size), int(dataset.metadata.var_size))
 
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)


### PR DESCRIPTION
Fixes #10292 

`tuple()` expects iterable; just use values in parens instead.