### PR TITLE
[20.05] Fix webless handler --attach-to-pool

### DIFF
--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -533,6 +533,9 @@ class WeblessApplicationStack(ApplicationStack):
         # isolation if it doesn't, or DB_PREASSIGN if the job_config doesn't allow either.
         conf_class_name = job_config.__class__.__name__
         remove_methods = [HANDLER_ASSIGNMENT_METHODS.DB_SELF]
+        with self.app.model.session.connection():
+            # Force a connection so dialect.server_version_info is populated
+            pass
         dialect = self.app.model.session.bind.dialect
         if ((dialect.name == 'postgresql' and dialect.server_version_info >= (9, 5))
                 or (dialect.name == 'mysql' and dialect.server_version_info >= (8, 0, 1))):


### PR DESCRIPTION
We need to create a connection before reading
dialect.server_version_info. See https://docs.sqlalchemy.org/en/13/core/internals.html#sqlalchemy.engine.interfaces.Dialect
Fixes https://github.com/galaxyproject/galaxy-helm/issues/160