### PR TITLE
[20.05] Fix container resolution when requirement version is not specified

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -269,21 +269,17 @@ def targets_to_mulled_name(targets, hash_func, namespace, resolution_cache=None)
         tags = mulled_tags_for(namespace, target.package_name, resolution_cache=resolution_cache)
 
         if tags:
-            if target_version:
-                for tag in tags:
-                    if '--' in tag:
-                        version, build = split_tag(tag)
-                    else:
-                        version = tag
-                        build = None
-                    if version == target_version:
-                        name = "%s:%s" % (target.package_name, version)
-                        if build:
-                            name = "%s--%s" % (name, build)
-                        break
-            else:
-                version, build = split_tag(tags[0])
-                name = "%s:%s--%s" % (target.package_name, version, build)
+            for tag in tags:
+                if '--' in tag:
+                    version, build = split_tag(tag)
+                else:
+                    version = tag
+                    build = None
+                if target_version and version == target_version:
+                    name = "%s:%s" % (target.package_name, version)
+                    if build:
+                        name = "%s--%s" % (name, build)
+                    break
 
     else:
         def first_tag_if_available(image_name):

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -271,14 +271,11 @@ def targets_to_mulled_name(targets, hash_func, namespace, resolution_cache=None)
         if tags:
             for tag in tags:
                 if '--' in tag:
-                    version, build = split_tag(tag)
+                    version, _ = split_tag(tag)
                 else:
                     version = tag
-                    build = None
                 if target_version and version == target_version:
-                    name = "%s:%s" % (target.package_name, version)
-                    if build:
-                        name = "%s--%s" % (name, build)
+                    name = "%s:%s" % (target.package_name, tag)
                     break
 
     else:


### PR DESCRIPTION
and no useful container is in the cache.

Fix the following traceback:

```
2020-09-27 01:11:44,352 INFO  [galaxy.tool_util.deps.containers] Checking with container resolver [ExplicitContainerResolver[]] found description [None]
2020-09-27 01:11:44,461 INFO  [galaxy.tool_util.deps.containers] Checking with container resolver [CachedMulledDockerContainerResolver[namespace=biocontainers]] found description [None]
2020-09-27 01:11:44,565 INFO  [galaxy.tool_util.deps.containers] Checking with container resolver [CachedMulledDockerContainerResolver[namespace=local]] found description [None]
2020-09-27 01:11:45,117 ERROR [galaxy.tool_util.deps.containers] Could not get container description for tool 'gstf_preparation'
Traceback (most recent call last):
  File "/tmp/tmpi_lg_ln2/galaxy-dev/lib/galaxy/tool_util/deps/containers.py", line 240, in find_best_container_description
    resolved_container_description = self.resolve(enabled_container_types, tool_info, **kwds)
  File "/tmp/tmpi_lg_ln2/galaxy-dev/lib/galaxy/tool_util/deps/containers.py", line 261, in resolve
    container_description = container_resolver.resolve(enabled_container_types, tool_info, resolution_cache=resolution_cache)
  File "/tmp/tmpi_lg_ln2/galaxy-dev/lib/galaxy/tool_util/deps/container_resolvers/mulled.py", line 411, in resolve
    name = targets_to_mulled_name(targets=targets, hash_func=self.hash_func, namespace=self.namespace, resolution_cache=resolution_cache)
  File "/tmp/tmpi_lg_ln2/galaxy-dev/lib/galaxy/tool_util/deps/container_resolvers/mulled.py", line 285, in targets_to_mulled_name
    version, build = split_tag(tags[0])
ValueError: not enough values to unpack (expected 2, got 1)
```