### PR TITLE
[20.01] Ensure that k8s job ids are unique

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -226,7 +226,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         (see pod selector) and an appropriate restart policy."""
         k8s_spec_template = {
             "metadata": {
-                "labels": {"app": self.__produce_unique_k8s_job_name(ajs.job_wrapper.get_id_tag())}
+                "labels": {"app": self.__produce_unique_k8s_job_name(ajs.job_wrapper.get_id_tag())[:-5]}
             },
             "spec": {
                 "volumes": self.runner_params['k8s_mountable_volumes'],
@@ -526,7 +526,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         """Attempts to delete a dispatched job to the k8s cluster"""
         job = job_wrapper.get_job()
         try:
-            name = self.__produce_unique_k8s_job_name(job.get_id_tag())
+            name = job.job_runner_external_id
             namespace = self.runner_params['k8s_namespace']
             job_to_delete = find_job_object_by_name(self._pykube_api, name, namespace)
             if job_to_delete:

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -1,9 +1,7 @@
 """Interface layer for pykube library shared between Galaxy and Pulsar."""
 import logging
 import os
-import random
 import re
-import string
 import uuid
 
 try:
@@ -59,9 +57,7 @@ def produce_unique_k8s_job_name(app_prefix=None, instance_id=None, job_id=None):
     if instance_id and len(instance_id) > 0:
         job_name += "%s-" % instance_id
 
-    unique_id = ''.join(random.choices(string.ascii_lowercase, k=4))
-
-    return job_name + job_id + "-" + unique_id
+    return "{}{}-{}".format(job_name, job_id, uuid.uuid4())
 
 
 def pull_policy(params):

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -1,7 +1,9 @@
 """Interface layer for pykube library shared between Galaxy and Pulsar."""
 import logging
 import os
+import random
 import re
+import string
 import uuid
 
 try:
@@ -57,7 +59,9 @@ def produce_unique_k8s_job_name(app_prefix=None, instance_id=None, job_id=None):
     if instance_id and len(instance_id) > 0:
         job_name += "%s-" % instance_id
 
-    return job_name + job_id
+    unique_id = ''.join(random.choices(string.ascii_lowercase, k=4))
+
+    return job_name + job_id + "-" + unique_id
 
 
 def pull_policy(params):


### PR DESCRIPTION
Currently, the k8s runner generates an external id for each job by appending the job id to a string of format:
galaxy-<instance_id>-<job_id>

However, when metadata jobs or datatype conversion jobs run, they are spawned with the same job id, which can cause conflicts when jobs are executing in quick succession. (e.g. the first job has not yet been cleaned up before the metadata job is spawned). This PR appends an additional unique id to each job so that the name is always unique.


