### PR TITLE
[20.09] Fix ``Wav`` datatype to inherit from ``Audio``

### DIFF
--- a/lib/galaxy/datatypes/media.py
+++ b/lib/galaxy/datatypes/media.py
@@ -128,7 +128,7 @@ class Mp3(Audio):
             return 'mp3' in metadata['format_name'].split(',')
 
 
-class Wav(Binary):
+class Wav(Audio):
     """Class that reads WAV audio file
     >>> from galaxy.datatypes.sniff import sniff_with_cls
     >>> sniff_with_cls(Wav, 'hello.wav')


### PR DESCRIPTION
Reported by @yingfeng-iu on Gitter: https://gitter.im/galaxyproject/Lobby?at=5f7200301c5b0d210ad82765