### PR TITLE
[20.05] Respect ``use_shared_home="false"`` when running tools in container

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -177,13 +177,6 @@ class XmlToolSource(ToolSource):
         # break or modify any configurations by default.
         return "job_tmp_if_explicit"
 
-    def parse_docker_env_pass_through(self):
-        if self.parse_profile() < "18.01":
-            return ["GALAXY_SLOTS"]
-        else:
-            # Pass home, etc...
-            return super(XmlToolSource, self).parse_docker_env_pass_through()
-
     def parse_interpreter(self):
         interpreter = None
         command_el = self._command_el

--- a/test/functional/tools/job_environment_explicit_isolated_home.xml
+++ b/test/functional/tools/job_environment_explicit_isolated_home.xml
@@ -1,0 +1,25 @@
+<tool id="job_environment_explicit_isolated_home" name="job_environment_explicit_isolated_home" version="0.1.0">
+    <requirements>
+        <container type="docker">busybox:ubuntu-14.04</container>
+    </requirements>
+    <command use_shared_home="false"><![CDATA[
+echo `id -u` > '$user_id';
+echo `id -g` > '$group_id';
+echo `pwd` > '$pwd';
+echo "\$HOME" > '$home';
+echo "\$TMP"  > '$tmp';
+echo "\$SOME_ENV_VAR" > '$some_env_var';
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="user_id" format="txt" label="user_id" />
+        <data name="group_id" format="txt" label="group_id" />
+        <data name="pwd" format="txt" label="pwd" />
+        <data name="home" format="txt" label="home" />
+        <data name="tmp" format="txt" label="tmp" />
+        <data name="some_env_var" format="txt" label="env_var" />
+    </outputs>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -68,6 +68,7 @@
   <tool file="job_environment_default.xml" />
   <tool file="job_environment_default_legacy.xml" />
   <tool file="job_environment_explicit_shared_home.xml" />
+  <tool file="job_environment_explicit_isolated_home.xml" />
   <tool file="galaxy_slots_and_memory.xml" />
   <tool file="version_command_plain.xml" />
   <tool file="version_command_interpreter.xml" />

--- a/test/integration/test_containerized_jobs.py
+++ b/test/integration/test_containerized_jobs.py
@@ -109,9 +109,21 @@ class DockerizedJobsIntegrationTestCase(integration_util.IntegrationTestCase, Ru
         assert job_env.group_id == str(egid), job_env.group_id
         assert job_env.pwd.startswith(self.jobs_directory)
         assert job_env.pwd.endswith("/working")
-        # Should we change env_pass_through to just always include TMP and HOME for docker?
-        # I'm not sure, if yes this would change.
         assert not job_env.home.endswith('/home')
+
+    def test_container_job_environment_explicit_shared_home(self):
+        job_env = self._run_and_get_environment_properties("job_environment_explicit_shared_home")
+
+        assert job_env.pwd.startswith(self.jobs_directory)
+        assert job_env.pwd.endswith("/working")
+        assert not job_env.home.endswith('/home')
+
+    def test_container_job_environment_explicit_isolated_home(self):
+        job_env = self._run_and_get_environment_properties("job_environment_explicit_isolated_home")
+
+        assert job_env.pwd.startswith(self.jobs_directory)
+        assert job_env.pwd.endswith("/working")
+        assert job_env.home.endswith('/home')
 
     def test_build_mulled(self):
         if not which('docker'):

--- a/test/integration/test_job_environments.py
+++ b/test/integration/test_job_environments.py
@@ -77,7 +77,7 @@ class DefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTest
         assert job_env.pwd.startswith(self.jobs_directory)
         assert job_env.pwd.endswith("/working")
 
-        # Newer tools have isolated home directories in job_directory/home
+        # Newer tools get isolated home directories in job_directory/home
         job_directory = os.path.dirname(job_env.pwd)
         assert job_env.home == os.path.join(job_directory, "home"), job_env.home
 
@@ -98,11 +98,21 @@ class DefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTest
 
     @skip_without_tool("job_environment_explicit_shared_home")
     def test_default_environment_force_legacy_home(self):
-        # Home should not overridden because we haven't set legacy_home_dir in job_conf
-        # or app, so it should just HOME.
+        # Home should not be overridden because we haven't set legacy_home_dir in job_conf
+        # or app, so it should just be HOME.
         job_env = self._run_and_get_environment_properties("job_environment_explicit_shared_home")
         home = os.getenv("HOME")
         assert job_env.home == home, job_env.home
+
+    @skip_without_tool("job_environment_explicit_isolated_home")
+    def test_default_environment_explicit_isolated_home(self):
+        # A tool with no profile but setting `use_shared_home="false"` must get
+        # an isolated home directory in job_directory/home
+        job_env = self._run_and_get_environment_properties("job_environment_explicit_isolated_home")
+        assert job_env.pwd.startswith(self.jobs_directory)
+        assert job_env.pwd.endswith("/working")
+        job_directory = os.path.dirname(job_env.pwd)
+        assert job_env.home == os.path.join(job_directory, "home"), job_env.home
 
 
 class TmpDirToTrueJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
@@ -169,6 +179,13 @@ class SharedHomeJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationT
         # shared_home_dir used for newer tools if forced in tool XML
         job_env = self._run_and_get_environment_properties("job_environment_explicit_shared_home")
         assert job_env.home == self.shared_home_directory, job_env.home
+
+    @skip_without_tool("job_environment_explicit_isolated_home")
+    def test_default_environment_explicit_isolated_home(self):
+        # shared_home_dir ignored for tools setting `use_shared_home="false"`
+        job_env = self._run_and_get_environment_properties("job_environment_explicit_isolated_home")
+        job_directory = os.path.dirname(job_env.pwd)
+        assert job_env.home == os.path.join(job_directory, "home"), job_env.home
 
 
 class JobIOEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):


### PR DESCRIPTION
When a tool doesn't specify a `profile` (or sets a `profile` < 18.01) but use ``use_shared_home="false"`` to ask to set a HOME within the job's directory (normally because the underlying tool writes to the home directory), this works as expected when resolving dependencies with conda.
But when running the same tool in a Docker container (e.g. via `planemo test --biocontainers`), the job script didn't export a temporary HOME into the container (which instead setting `profile="18.01"` correctly does).

Also add several integration tests for `use_shared_home`, of which `DockerizedJobsIntegrationTestCase.test_container_job_environment_explicit_isolated_home` would fail without this fix.