### PR TITLE
[20.09] Fix double masthead in some spaces

### DIFF
--- a/templates/webapps/galaxy/galaxy.masthead.mako
+++ b/templates/webapps/galaxy/galaxy.masthead.mako
@@ -35,11 +35,17 @@
 
     ## load the frame manager
     <script type="text/javascript">
-        config.addInitialization(function(galaxy, config) {
-            console.log("galaxy.masthead.mako", "initialize masthead");
-            let options = ${h.dumps(masthead_config)};
-            let container = document.getElementById("masthead");
-            window.bundleEntries.initMasthead(options, container);
-        });
+        if (window.self === window.top) {
+            config.addInitialization(function (galaxy, config) {
+                console.log("galaxy.masthead.mako", "initialize masthead");
+                let options = ${h.dumps(masthead_config)};
+                const container = document.getElementById("masthead");
+                window.bundleEntries.initMasthead(options, container);
+            });
+        } else {
+            console.log("galaxy.masthead.mako", "Detected embedding, not initializing masthead");
+            const container = document.getElementById("masthead");
+            container.parentNode.removeChild(container);
+        }
     </script>
 </%def>


### PR DESCRIPTION
Fixes #10291 

Do we know of any context where Galaxy is legitimately stuffed into a child frame?  If so, I have another commit that checks against the parent having a live 'Galaxy' object and only prevents duplicate masthead load when within another Galaxy, but would allow other circumstances.  But there's more that can go weird there, and I don't want anything else touching a global `Galaxy` if I don't really need to.