### PR TITLE
[20.09] Handle resend_activation_email gracefully without session

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -200,7 +200,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
         """
         if email is None:  # User is coming from outside registration form, load email from trans
             if not trans.user:
-                trans.show_error_message("No session found, cannot send activation email.")
+                return "No session found, cannot send activation email.", None
             email = trans.user.email
         if username is None:  # User is coming from outside registration form, load email from trans
             username = trans.user.username


### PR DESCRIPTION
Bots keep hitting this and are causing
https://sentry.galaxyproject.org/sentry/main/issues/298051/:
```
AttributeError: 'NoneType' object has no attribute 'email'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 33, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 141, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 220, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/user.py", line 191, in resend_verification
    message, status = self.resend_activation_email(trans, None, None)
  File "galaxy/webapps/galaxy/controllers/user.py", line 204, in resend_activation_email
    email = trans.user.email
```