### PR TITLE
[20.09] Strip trailing ``/`` from tool_id for data source redirects

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -47,6 +47,9 @@ class ToolRunner(BaseUIController):
         # tool id not available, redirect to main page
         if tool_id is None:
             return trans.response.send_redirect(url_for(controller='root', action='welcome'))
+        if tool_id.endswith('/'):
+            # Probably caused by a redirect
+            tool_id = tool_id[:-1]
         tool = self.__get_tool(tool_id)
         # tool id is not matching, display an error
         if not tool:


### PR DESCRIPTION
Might be happening on redirect (that didn't happen for a quick test with
the ENA, but I don't think this hurts).
Fixes https://sentry.galaxyproject.org/sentry/main/issues/266808/:
```
data_source_redirect called with tool id 'ebi_sra_main/' but no such tool exists
```