### PR TITLE
[20.01] Fix wiggle estimated_display_viewport

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1089,7 +1089,7 @@ class Wiggle(Tabular, _RemoteCallMixin):
                 span = 1
                 step = None
                 with open(dataset.file_name) as fh:
-                    for line in util.iter_readline_count(fh, VIEWPORT_READLINE_BUFFER_SIZE):
+                    for line in util.iter_start_of_line(fh, VIEWPORT_READLINE_BUFFER_SIZE):
                         try:
                             if line.startswith("browser"):
                                 chr_info = line.rstrip('\n\r').split()[-1]


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/9415, where I
used the wrong function name.
Fixes https://sentry.galaxyproject.org/sentry/main/issues/568813/:
```
AttributeError: module 'galaxy.util' has no attribute 'iter_readline_count'
  File "galaxy/datatypes/interval.py", line 1092, in get_estimated_display_viewport
    for line in util.iter_readline_count(fh, VIEWPORT_READLINE_BUFFER_SIZE):
```