### PR TITLE
[20.09] Allow 'planemo run' to stage in existing datasets without reuploading

### DIFF
--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -200,15 +200,6 @@ class StagingInterace(object):
                 payload["files_0|url_paste"] = content
                 return self._tools_post(payload)
 
-        # To be used when datasets are already available and can be copied instead of uploaded
-        def copy_func(dataset_id):
-            copy_payload = {
-                'content': dataset_id,
-                'source': 'hda',
-                'type': 'dataset'
-            }
-            return self._post('histories/{}/contents'.format(history_id), payload=copy_payload)
-
         def create_collection_func(element_identifiers, collection_type):
             payload = {
                 "name": "dataset collection",
@@ -239,7 +230,6 @@ class StagingInterace(object):
             job,
             job_dir,
             upload,
-            copy_func,
             create_collection_func,
             tool_or_workflow,
         )

--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -200,6 +200,15 @@ class StagingInterace(object):
                 payload["files_0|url_paste"] = content
                 return self._tools_post(payload)
 
+        # To be used when datasets are already available and can be copied instead of uploaded
+        def copy_func(dataset_id):
+            copy_payload = {
+                'content': dataset_id,
+                'source': 'hda',
+                'type': 'dataset'
+            }
+            return self._post('histories/{}/contents'.format(history_id), payload=copy_payload)
+
         def create_collection_func(element_identifiers, collection_type):
             payload = {
                 "name": "dataset collection",
@@ -230,6 +239,7 @@ class StagingInterace(object):
             job,
             job_dir,
             upload,
+            copy_func,
             create_collection_func,
             tool_or_workflow,
         )

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -84,7 +84,7 @@ def path_or_uri_to_uri(path_or_uri):
 
 
 def galactic_job_json(
-    job, test_data_directory, upload_func, copy_func, collection_create_func, tool_or_workflow="workflow"
+    job, test_data_directory, upload_func, collection_create_func, tool_or_workflow="workflow"
 ):
     """Adapt a CWL job object to the Galaxy API.
 
@@ -145,7 +145,7 @@ def galactic_job_json(
         is_file = item_class == "File"
         is_directory = item_class == "Directory"
         is_collection = item_class == "Collection"  # Galaxy extension.
-        is_galaxy_id = item_class == "GalaxyID"  # Galaxy dataset/collection ID.
+        # is_galaxy_id = item_class == "GalaxyID"  # Galaxy dataset/collection ID.
 
         if force_to_file:
             if is_file:
@@ -168,12 +168,14 @@ def galactic_job_json(
             return replacement_directory(value)
         elif is_collection:
             return replacement_collection(value)
-        elif is_galaxy_id:
-            return replacement_galaxy_id(value)
+        # elif is_galaxy_id:
+        #     return replacement_galaxy_id(value)
         else:
             return replacement_record(value)
 
     def replacement_file(value):
+        if value.get('galaxy_id'):
+            return replacement_galaxy_id(value)
         file_path = value.get("location", None) or value.get("path", None)
         # format to match output definitions in tool, where did filetype come from?
         filetype = value.get("filetype", None) or value.get("format", None)
@@ -281,6 +283,8 @@ def galactic_job_json(
         return collection_element_identifiers
 
     def replacement_collection(value):
+        if value.get('galaxy_id'):
+            return replacement_galaxy_id(value)
         assert "collection_type" in value
         collection_type = value["collection_type"]
         elements = to_elements(value, collection_type)
@@ -291,10 +295,7 @@ def galactic_job_json(
         return {"src": "hdca", "id": hdca_id}
 
     def replacement_galaxy_id(value):
-        response = copy_func(value['location'])
-        target = FileLiteralTarget(contents=None)
-        datasets.append((response, target))
-        return {"src": "hda", "id": value['location']}
+        return {"src": "hda", "id": value['galaxy_id']}
 
     def replacement_record(value):
         collection_element_identifiers = []

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -145,7 +145,6 @@ def galactic_job_json(
         is_file = item_class == "File"
         is_directory = item_class == "Directory"
         is_collection = item_class == "Collection"  # Galaxy extension.
-        # is_galaxy_id = item_class == "GalaxyID"  # Galaxy dataset/collection ID.
 
         if force_to_file:
             if is_file:
@@ -168,14 +167,12 @@ def galactic_job_json(
             return replacement_directory(value)
         elif is_collection:
             return replacement_collection(value)
-        # elif is_galaxy_id:
-        #     return replacement_galaxy_id(value)
         else:
             return replacement_record(value)
 
     def replacement_file(value):
         if value.get('galaxy_id'):
-            return replacement_galaxy_id(value)
+            return {"src": "hda", "id": value['galaxy_id']}
         file_path = value.get("location", None) or value.get("path", None)
         # format to match output definitions in tool, where did filetype come from?
         filetype = value.get("filetype", None) or value.get("format", None)
@@ -284,7 +281,7 @@ def galactic_job_json(
 
     def replacement_collection(value):
         if value.get('galaxy_id'):
-            return replacement_galaxy_id(value)
+            return {"src": "hdca", "id": value['galaxy_id']}
         assert "collection_type" in value
         collection_type = value["collection_type"]
         elements = to_elements(value, collection_type)
@@ -293,9 +290,6 @@ def galactic_job_json(
         dataset_collections.append(collection)
         hdca_id = collection["id"]
         return {"src": "hdca", "id": hdca_id}
-
-    def replacement_galaxy_id(value):
-        return {"src": "hda", "id": value['galaxy_id']}
 
     def replacement_record(value):
         collection_element_identifiers = []

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -332,13 +332,12 @@ def _ensure_file_exists(file_path):
 
 class FileLiteralTarget:
 
-    def __init__(self, contents, path=None, **kwargs):
+    def __init__(self, contents, **kwargs):
         self.contents = contents
         self.properties = kwargs
-        self.path = path
 
     def __str__(self):
-        return "FileLiteralTarget[path={}] with {}".format(self.path, self.properties)
+        return "FileLiteralTarget[contents={}] with {}".format(self.contents, self.properties)
 
 
 class FileUploadTarget:


### PR DESCRIPTION
It would be great to get https://github.com/galaxyproject/galaxy/pull/10334 into the 20.09 release as well, so it's available in the next version of galaxy-tool-util. Thanks!