### PR TITLE
[20.01] Pin pytest < 6.1

### DIFF
--- a/packages/test.sh
+++ b/packages/test.sh
@@ -14,7 +14,7 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 
 virtualenv -p "$TEST_PYTHON" "$TEST_ENV_DIR"
 . "${TEST_ENV_DIR}/bin/activate"
-pip install pytest
+pip install "pytest<6.1"
 
 # ensure ordered by dependency dag
 PACKAGE_DIRS=(


### PR DESCRIPTION
Backport-ish of #10320 

(merge as-is to 20.05, then drop for 20.09 and dev, using the method there instead)