### PR TITLE
[20.09] Fix 'Newer Version Available' tag in admin tool management section

### DIFF
--- a/client/src/components/Toolshed/InstalledList/Index.vue
+++ b/client/src/components/Toolshed/InstalledList/Index.vue
@@ -33,9 +33,7 @@
                     <template v-slot:cell(name)="row">
                         <b-link href="#" role="button" class="font-weight-bold" @click="row.toggleDetails">
                             <div v-if="!isLatest(row.item)">
-                                <b-badge variant="danger" class="mb-2">
-                                    Newer version available!
-                                </b-badge>
+                                <b-badge variant="danger" class="mb-2"> Newer version available! </b-badge>
                             </div>
                             <div class="name">{{ row.item.name }}</div>
                         </b-link>
@@ -49,9 +47,7 @@
                     No matching entries found for: <span class="font-weight-bold">{{ this.filter }}</span
                     >.
                 </div>
-                <div v-if="showNotAvailable">
-                    No installed repositories found.
-                </div>
+                <div v-if="showNotAvailable">No installed repositories found.</div>
             </div>
         </div>
     </div>
@@ -123,7 +119,7 @@ export default {
         load() {
             this.loading = true;
             this.services
-                .getInstalledRepositories()
+                .getInstalledRepositories({ selectLatest: true })
                 .then((repositories) => {
                     this.repositories = repositories;
                     this.nRepositories = repositories.length;

--- a/client/src/components/Toolshed/services.test.js
+++ b/client/src/components/Toolshed/services.test.js
@@ -8,6 +8,7 @@ describe("Toolshed service helpers", () => {
             status: "status_0_0",
             description: "description_0_0",
             tool_shed: "url_1",
+            ctx_rev: "1",
         },
         {
             name: "name_0",
@@ -15,6 +16,7 @@ describe("Toolshed service helpers", () => {
             status: "status_0_1",
             description: "description_0_1",
             tool_shed: "url_1",
+            ctx_rev: "3",
         },
         {
             name: "name_1",
@@ -22,6 +24,7 @@ describe("Toolshed service helpers", () => {
             status: "status_1",
             description: "description_1",
             tool_shed: "url_2",
+            ctx_rev: "42",
         },
         {
             name: "name_2",
@@ -29,6 +32,7 @@ describe("Toolshed service helpers", () => {
             status: "Installed",
             description: "description_2",
             tool_shed: "url_2",
+            ctx_rev: "1",
         },
     ];
     const urls = ["http://url_1.com", "http://url_2.com"];
@@ -36,11 +40,12 @@ describe("Toolshed service helpers", () => {
     it("test fix toolshed helper", () => {
         const services = new Services();
         const filter = (x) => x.status !== "Installed";
-        const grouped = services._groupByNameOwner(incoming, filter);
+        const grouped = services._groupByNameOwner(incoming, filter, true);
         services._fixToolshedUrls(grouped, urls);
         expect(grouped.length).toBe(2);
         expect(grouped[0].name).toBe("name_0");
         expect(grouped[0].tool_shed_url).toBe("http://url_1.com");
+        expect(grouped[0].ctx_rev).toBe("3");
         expect(grouped[1].name === "name_1");
         expect(grouped[1].tool_shed_url).toBe("http://url_2.com");
     });

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -6,7 +6,11 @@ from paste.httpexceptions import (
     HTTPBadRequest,
     HTTPForbidden
 )
-from sqlalchemy import and_
+from sqlalchemy import (
+    and_,
+    cast,
+    Integer,
+)
 
 from galaxy import (
     exceptions,
@@ -82,7 +86,8 @@ class ToolShedRepositoriesController(BaseAPIController):
             clause_list.append(self.app.install_model.ToolShedRepository.table.c.uninstalled == util.asbool(kwd.get('uninstalled')))
         tool_shed_repository_dicts = []
         query = trans.install_model.context.query(self.app.install_model.ToolShedRepository) \
-                                           .order_by(self.app.install_model.ToolShedRepository.table.c.name)
+                                           .order_by(self.app.install_model.ToolShedRepository.table.c.name) \
+                                           .order_by(cast(self.app.install_model.ToolShedRepository.ctx_rev, Integer).desc())
         if len(clause_list) > 0:
             query = query.filter(and_(*clause_list))
         for tool_shed_repository in query.all():


### PR DESCRIPTION
The 'Newer Version Available' tag often shows up for tools where the newest version actually is installed.  _groupByNameOwner currently returns one repository for each name-owner but this is not necessarily the newest from the list.  This is one possible solution.

This only works if `parseInt(repository.ctx_rev)` will never throw an exception.  If there is a chance that there would be a repository that has no ctx_rev or a ctx_rev value that cannot be parsed as an integer then I should be putting try/catch around this.