### PR TITLE
Drop unused helpers in web.framework.helpers

### DIFF
--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -99,16 +99,7 @@ def dist_js(*args):
     return js_helper('static/dist/', *args)
 
 
-def templates(*args):
-    """
-    Take a list of template names (no extension) and return appropriate
-    string of script tags.
-    """
-    return js_helper('static/scripts/templates/compiled/', *args)
-
 # Hashes
-
-
 def md5(s):
     """
     Return hex encoded md5 hash of string s

--- a/lib/galaxy/web/framework/helpers/__init__.py
+++ b/lib/galaxy/web/framework/helpers/__init__.py
@@ -91,18 +91,10 @@ def js_helper(prefix, *args):
     return javascript_link(*urls)
 
 
-def js(*args):
+def dist_js(*args):
     """
     Take a prefix and list of javascript names and return appropriate
     string of script tags.
-    """
-    return js_helper('static/scripts/', *args)
-
-
-def dist_js(*args):
-    """
-    Transition function 'js' helper -- this is the modern way where all bundled
-    artifacts are in the unified 'dist'.
     """
     return js_helper('static/dist/', *args)
 


### PR DESCRIPTION
Followup to https://github.com/galaxyproject/galaxy/pull/10143#issuecomment-679205591

There's still quite a lot of static CSS in https://github.com/galaxyproject/galaxy/tree/dev/static/style, though, so we can't drop h.css yet.