### PR TITLE
[20.09] Don't use subquery to update workflow invocation step update time

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1158,10 +1158,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         ''', '''
             UPDATE workflow_invocation_step
             SET update_time = :update_time
-            WHERE id in (
-                SELECT workflow_invocation_step.id
-                FROM workflow_invocation_step wis
-                WHERE wis.job_id = :job_id
+            WHERE job_id = :job_id
             );
         ''']
         sa_session = object_session(self)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1158,8 +1158,7 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         ''', '''
             UPDATE workflow_invocation_step
             SET update_time = :update_time
-            WHERE job_id = :job_id
-            );
+            WHERE job_id = :job_id;
         ''']
         sa_session = object_session(self)
         params = {


### PR DESCRIPTION
Thanks Nate, I don't think the subquery was needed.