### PR TITLE
[20.09] Bugfix: chrome forgets scroll offset upon show/hide cycle of GTN in Galaxy webhook

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -1,11 +1,11 @@
 var gtnWebhookLoaded = false;
 
 function removeOverlay() {
-    document.getElementById("gtn-container").style.visibility = 'hidden';
+    document.getElementById("gtn-container").style.visibility = "hidden";
 }
 
 function showOverlay() {
-    document.getElementById("gtn-container").style.visibility = 'visible';
+    document.getElementById("gtn-container").style.visibility = "visible";
 }
 
 function addIframe() {

--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -1,7 +1,11 @@
 var gtnWebhookLoaded = false;
 
 function removeOverlay() {
-    document.getElementById("gtn-container").classList.add("d-none");
+    document.getElementById("gtn-container").style.visibility = 'hidden';
+}
+
+function showOverlay() {
+    document.getElementById("gtn-container").style.visibility = 'visible';
 }
 
 function addIframe() {
@@ -105,7 +109,7 @@ elementReady("#gtn a").then((el) => {
         if (!gtnWebhookLoaded) {
             addIframe();
         } else {
-            document.getElementById("gtn-container").classList.toggle("d-none");
+            showOverlay();
         }
     });
 });


### PR DESCRIPTION
Some of the discussion in https://stackoverflow.com/questions/4582669/scroll-returns-to-default-after-displaynone-in-chrome-ie indicates that when the display property changes to none and back, that chrome reflows content and scrolls to the top by default, contrary to how firefox behaves.

So this replaces d-none with `visibility: hidden` in order to make chrome based browsers work as well as firefox.