### PR TITLE
[20.09] Fixes data_source tools

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -372,6 +372,9 @@ class ToolBox(BaseGalaxyToolBox):
         # are now using only GALAXY_URL.
         tool_ids = listify(tool_id)
         for tool_id in tool_ids:
+            if tool_id.endswith('/'):
+                # Some data sources send back redirects ending with `/`, this takes care of that case
+                tool_id = tool_id[:-1]
             if get_loaded_tools_by_lineage:
                 tools = toolbox.get_loaded_tools_by_lineage(tool_id)
             else:

--- a/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
+++ b/lib/galaxy/webapps/galaxy/controllers/tool_runner.py
@@ -47,9 +47,6 @@ class ToolRunner(BaseUIController):
         # tool id not available, redirect to main page
         if tool_id is None:
             return trans.response.send_redirect(url_for(controller='root', action='welcome'))
-        if tool_id.endswith('/'):
-            # Probably caused by a redirect
-            tool_id = tool_id[:-1]
         tool = self.__get_tool(tool_id)
         # tool id is not matching, display an error
         if not tool:


### PR DESCRIPTION
tool_ids may be a list, so need to strip `'/'` in `get_tool_components`
instead.

Broken in https://github.com/galaxyproject/galaxy/pull/10332