### PR TITLE
Adding nodeSelector to K8S runner job pod spec

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -64,7 +64,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_run_as_group_id=dict(map=str, valid=lambda s: s == "$gid" or s.isdigit()),
             k8s_fs_group_id=dict(map=int),
             k8s_cleanup_job=dict(map=str, valid=lambda s: s in {"onsuccess", "always", "never"}, default="always"),
-            k8s_pod_retries=dict(map=int, valid=lambda x: int >= 0, default=3),
+            k8s_pod_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=3),
             k8s_walltime_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=172800))
 
         if 'runner_param_specs' not in kwargs:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -52,6 +52,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_namespace=dict(map=str, default="default"),
             k8s_pod_priority_class=dict(map=str, default=None),
             k8s_affinity=dict(map=str, default=None),
+            k8s_node_selector=dict(map=str, default=None),
             k8s_tolerations=dict(map=str, default=None),
             k8s_galaxy_instance_id=dict(map=str),
             k8s_timeout_seconds_job_deletion=dict(map=int, valid=lambda x: int > 0, default=30),
@@ -234,7 +235,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 "containers": self.__get_k8s_containers(ajs),
                 "priorityClassName": self.runner_params['k8s_pod_priority_class'],
                 "tolerations": yaml.safe_load(self.runner_params['k8s_tolerations'] or "[]"),
-                "affinity": yaml.safe_load(self.runner_params['k8s_affinity'] or "{}")
+                "affinity": yaml.safe_load(self.runner_params['k8s_affinity'] or "{}"),
+                "nodeSelector": yaml.safe_load(self.runner_params['k8s_node_selector'] or "{}")
             }
         }
         # TODO include other relevant elements that people might want to use from


### PR DESCRIPTION
Similar to `affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms` (which is already supported through `k8s_affinity` and could be a way to accomplish what we need), `nodeSelector` is used to determine which nodes the job can run on.
This is specifically needed in Anvil to restrict jobs run by a user to that user's nodepool(s).
