### PR TITLE
[20.01] Fix regex replacement wrongly appearing in rule builder

### DIFF
--- a/client/galaxy/scripts/components/RuleCollectionBuilder.vue
+++ b/client/galaxy/scripts/components/RuleCollectionBuilder.vue
@@ -1962,7 +1962,7 @@ export default {
                 this.addColumnRegexGroupCount = 1;
             }
             if (val == "replacement") {
-                this.addColumnRegexReplacement = "\0";
+                this.addColumnRegexReplacement = null;
             }
         }
     },


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/10389.
This has been bugging me for a long time (and we also have some workarunds in place like https://github.com/galaxyproject/galaxy/pull/6572/commits/366701cfb23d8de31eac3c4312c6accca2e74ef1)