### PR TITLE
[20.09] Bugfix: include an index link in visualization base 

### DIFF
--- a/config/plugins/visualizations/common/templates/visualization_base.mako
+++ b/config/plugins/visualizations/common/templates/visualization_base.mako
@@ -20,6 +20,7 @@
 <html>
     <head>
         <title>${self.title()}</title>
+        <link rel="index" href="${ h.url_for( '/' ) }"/>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         ${self.metas()}
         ${self.stylesheets()}


### PR DESCRIPTION
to allow the app to derive baseUrl.  This fixes charts-framework-based visualizations served at a mount (proxy prefix) as they are on AnVIL.