### PR TITLE
[20.01] Try case-insensitive match on email also when it's lowercase

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -138,7 +138,8 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
             trans.app.model.User.table.c.email == login,
             trans.app.model.User.table.c.username == login
         )).first()
-        if not user and login.lower() != login:
+        if not user:
+            # Try a case-insensitive match on the email
             user = trans.sa_session.query(trans.app.model.User).filter(
                 func.lower(trans.app.model.User.table.c.email) == login.lower()
             ).first()


### PR DESCRIPTION
Fix login for a user whose registered email is mixed case which tries to login with lowercase.