### PR TITLE
[20.09] Improve support for readonly tool caches

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -65,8 +65,8 @@ class ToolDocumentCache:
                 return None
         return tool_document
 
-    def make_writable(self):
-        if not self.writeable_cache_file and self.cache_file_is_writeable:
+    def _make_writable(self):
+        if not self.writeable_cache_file:
             self.writeable_cache_file = tempfile.NamedTemporaryFile(dir=self.cache_dir, suffix='cache.sqlite.tmp', delete=False)
             if os.path.exists(self.cache_file):
                 shutil.copy(self.cache_file, self.writeable_cache_file.name)
@@ -80,7 +80,7 @@ class ToolDocumentCache:
 
     def set(self, config_file, tool_source):
         if self.cache_file_is_writeable:
-            self.make_writable()
+            self._make_writable()
             to_persist = {
                 'document': tool_source.to_string(),
                 'macro_paths': tool_source.macro_paths,
@@ -91,7 +91,7 @@ class ToolDocumentCache:
 
     def delete(self, config_file):
         if self.cache_file_is_writeable:
-            self.make_writable()
+            self._make_writable()
             try:
                 del self._cache[config_file]
             except KeyError:

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -60,9 +60,10 @@ class ToolDocumentCache:
             return None
         if tool_document.get('tool_cache_version') != CURRENT_TOOL_CACHE_VERSION:
             return None
-        for path, modtime in tool_document['paths_and_modtimes'].items():
-            if self.cache_file_is_writeable and os.path.getmtime(path) != modtime:
-                return None
+        if self.cache_file_is_writeable:
+            for path, modtime in tool_document['paths_and_modtimes'].items():
+                if os.path.getmtime(path) != modtime:
+                    return None
         return tool_document
 
     def _make_writable(self):

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -46,6 +46,10 @@ class ToolDocumentCache:
     def close(self):
         self._cache.close()
 
+    @property
+    def cache_file_is_writeable(self):
+        return os.access(self.cache_file, os.W_OK)
+
     def reopen_ro(self):
         self._cache = SqliteDict(self.cache_file, flag='r', encode=encoder, decode=decoder, autocommit=False)
         self.writeable_cache_file = None
@@ -57,12 +61,12 @@ class ToolDocumentCache:
         if tool_document.get('tool_cache_version') != CURRENT_TOOL_CACHE_VERSION:
             return None
         for path, modtime in tool_document['paths_and_modtimes'].items():
-            if os.path.getmtime(path) != modtime:
+            if self.cache_file_is_writeable and os.path.getmtime(path) != modtime:
                 return None
         return tool_document
 
     def make_writable(self):
-        if not self.writeable_cache_file:
+        if not self.writeable_cache_file and self.cache_file_is_writeable:
             self.writeable_cache_file = tempfile.NamedTemporaryFile(dir=self.cache_dir, suffix='cache.sqlite.tmp', delete=False)
             if os.path.exists(self.cache_file):
                 shutil.copy(self.cache_file, self.writeable_cache_file.name)
@@ -75,21 +79,23 @@ class ToolDocumentCache:
             self.reopen_ro()
 
     def set(self, config_file, tool_source):
-        self.make_writable()
-        to_persist = {
-            'document': tool_source.to_string(),
-            'macro_paths': tool_source.macro_paths,
-            'paths_and_modtimes': tool_source.paths_and_modtimes(),
-            'tool_cache_version': CURRENT_TOOL_CACHE_VERSION,
-        }
-        self._cache[config_file] = to_persist
+        if self.cache_file_is_writeable:
+            self.make_writable()
+            to_persist = {
+                'document': tool_source.to_string(),
+                'macro_paths': tool_source.macro_paths,
+                'paths_and_modtimes': tool_source.paths_and_modtimes(),
+                'tool_cache_version': CURRENT_TOOL_CACHE_VERSION,
+            }
+            self._cache[config_file] = to_persist
 
     def delete(self, config_file):
-        self.make_writable()
-        try:
-            del self._cache[config_file]
-        except KeyError:
-            pass
+        if self.cache_file_is_writeable:
+            self.make_writable()
+            try:
+                del self._cache[config_file]
+            except KeyError:
+                pass
 
     def __del__(self):
         if self.writeable_cache_file:


### PR DESCRIPTION
Only create a writeable cache if the cache file is writeable,
and skip access time comparison if cache is read-only (since the cache
must be managed externally).
Fixes
```
/srv/galaxy/main/log/zergling0.log:galaxy.tools.toolbox.base ERROR 2020-10-13 08:36:53,186 [p:24887,w:7,m:0] [Thread-1] ("Error reading tool configuration file from path '%s': %s", 'toolshed.g2.bx.psu.edu/repos/mvdbeek/add_input_name_as_column/3284b72eef56/add_input_name_as_column/add_input_name_as_column.xml', "[Errno 30] Read-only file system: '/cvmfs/main.galaxyproject.org/var/tool_cache/tmpiyucza7dcache.sqlite.tmp'")
```