### PR TITLE
[20.09] Fix composite archive download one more time

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -346,7 +346,7 @@ class Data(metaclass=DataMeta):
     def _serve_raw(self, trans, dataset, to_ext, **kwd):
         trans.response.headers['Content-Length'] = int(os.stat(dataset.file_name).st_size)
         trans.response.set_content_type("application/octet-stream")  # force octet-stream so Safari doesn't append mime extensions to filename
-        filename = self._download_filename(dataset, to_ext, hdca=kwd.get("hdca", None), element_identifier=kwd.get("element_identifier", None))
+        filename = self._download_filename(dataset, to_ext, hdca=kwd.get("hdca"), element_identifier=kwd.get("element_identifier"))
         trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
         return open(dataset.file_name, mode='rb')
 
@@ -435,10 +435,10 @@ class Data(metaclass=DataMeta):
         from galaxy import datatypes  # DBTODO REMOVE THIS AT REFACTOR
         if to_ext or isinstance(data.datatype, datatypes.binary.Binary):  # Saving the file, or binary file
             if data.extension in composite_extensions:
-                return self._archive_composite_dataset(trans, data, do_action=kwd.get('do_action'))
+                return self._archive_composite_dataset(trans, data, do_action=kwd.get('do_action', 'zip'))
             else:
                 trans.response.headers['Content-Length'] = int(os.stat(data.file_name).st_size)
-                filename = self._download_filename(data, to_ext, hdca=kwd.get("hdca", None), element_identifier=kwd.get("element_identifier", None))
+                filename = self._download_filename(data, to_ext, hdca=kwd.get("hdca"), element_identifier=kwd.get("element_identifier"))
                 trans.response.set_content_type("application/octet-stream")  # force octet-stream so Safari doesn't append mime extensions to filename
                 trans.response.headers["Content-Disposition"] = 'attachment; filename="%s"' % filename
                 return open(data.file_name, 'rb')


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/10330

Fixes:
```
UnboundLocalError: local variable 'archive' referenced before assignment
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 33, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 141, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 220, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 186, in display
    return data.datatype.display_data(trans, data, preview, filename, to_ext, offset=offset, ck_size=ck_size, **kwd)
  File "galaxy/datatypes/data.py", line 438, in display_data
    return self._archive_composite_dataset(trans, data, do_action=kwd.get('do_action'))
  File "galaxy/datatypes/data.py", line 308, in _archive_composite_dataset
    error, msg = self._archive_main_file(archive, display_name, path)[:2]
```

which happens because we pass in an explicit `None` as the do_action argument.