### PR TITLE
Update authnz to include Azure as IDP

### DIFF
--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -23,14 +23,16 @@ BACKENDS = {
     'google': 'social_core.backends.google_openidconnect.GoogleOpenIdConnect',
     'globus': 'social_core.backends.globus.GlobusOpenIdConnect',
     'elixir': 'social_core.backends.elixir.ElixirOpenIdConnect',
-    'okta': 'social_core.backends.okta_openidconnect.OktaOpenIdConnect'
+    'okta': 'social_core.backends.okta_openidconnect.OktaOpenIdConnect',
+    'azure': 'social_core.backends.azuread_tenant.AzureADTenantOAuth2'
 }
 
 BACKENDS_NAME = {
     'google': 'google-openidconnect',
     'globus': 'globus',
     'elixir': 'elixir',
-    'okta': 'okta-openidconnect'
+    'okta': 'okta-openidconnect',
+    'azure': 'azuread-tenant-oauth2'
 }
 
 AUTH_PIPELINE = (

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -170,4 +170,16 @@ Please mind `http` and `https`.
         <api_url> ... </api_url>
     </provider>
 
+    <provider name="azure">
+        <client_id> ... </client_id>
+        <client_secret> ... </client_secret>
+        <redirect_uri>http://localhost:8080/authnz/azure/callback</redirect_uri>
+        <!-- Azure client_id, client_secret, and api_url can be obtained by folowing the instructions at 
+        https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
+
+        The api_url will typiclly be https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize
+         -->
+        <api_url> ... </api_url>
+    </provider>
+
 </OIDC>


### PR DESCRIPTION
Updated the psa_authz.py with azure backend to enable Azure as an IDP which is already supported by the used python-social-core components. Updated the oidc_backend sample config to document how to configure Azure as IDP. Very simple change. Only required two lines to pass configuration info to the python-social-auth mechanism galaxy uses. 