### PR TITLE
Filter duplicate workflow output labels when initializing workflow step outputs

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -266,6 +266,7 @@ export default {
             Object.values(this.outputTerminals).forEach((t) => {
                 t.destroy();
             });
+            this.activeOutputs.filterOutputs({});
             this.$emit("onRemove", this);
         },
         onRedraw() {
@@ -397,7 +398,7 @@ export default {
             });
 
             // removes output from list of workflow outputs
-            this.activeOutputs.updateOutputs(outputNames);
+            this.activeOutputs.filterOutputs(outputNames);
 
             // trigger legacy events
             Vue.nextTick(() => {

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -409,14 +409,13 @@ export default {
             this.showLoading = false;
             this.$emit("onChange");
         },
-        labelOutput(output, label) {
-            return this.activeOutputs.labelOutput(output, label);
+        labelOutput(outputName, label) {
+            return this.activeOutputs.labelOutput(outputName, label);
         },
-        changeOutputDatatype(output, datatype) {
+        changeOutputDatatype(outputName, datatype) {
             if (datatype === "__empty__") {
                 datatype = null;
             }
-            const outputName = output.name;
             const outputTerminal = this.outputTerminals[outputName];
             if (datatype) {
                 this.postJobActions["ChangeDatatypeAction" + outputName] = {

--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -245,7 +245,7 @@ function _makeSection(self, node, output) {
                 fixed: true,
                 onchange: (newLabel) => {
                     self.form.data.create();
-                    const oldLabel = node.labelOutput(output, newLabel);
+                    const oldLabel = node.labelOutput(output.name, newLabel);
                     const input_id = self.form.data.match(`__label__${output.name}`);
                     const input_element = self.form.element_list[input_id];
                     if (oldLabel) {
@@ -276,7 +276,7 @@ function _makeSection(self, node, output) {
                 options: extensions,
                 help: "This action will change the datatype of the output to the indicated datatype.",
                 onchange: function (datatype) {
-                    node.changeOutputDatatype(output, datatype);
+                    node.changeOutputDatatype(output.name, datatype);
                 },
             },
             {

--- a/client/src/components/Workflow/Editor/modules/outputs.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.js
@@ -124,8 +124,9 @@ export class ActiveOutputs {
     /** Refreshes dictionary of outputs */
     _refreshIndex() {
         this.outputsIndex = {};
-        this.outputs.forEach((o) => {
-            this.outputsIndex[o.name] = o;
-        });
+        this.outputs &&
+            this.outputs.forEach((o) => {
+                this.outputsIndex[o.name] = o;
+            });
     }
 }

--- a/client/src/components/Workflow/Editor/modules/outputs.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.js
@@ -13,6 +13,9 @@ export class ActiveOutputs {
         this._refreshIndex();
         incoming &&
             incoming.forEach((entry) => {
+                if (entry.label && allLabels[entry.label]) {
+                    entry.label = null;
+                }
                 this.add(entry.output_name, entry.label);
                 if (entry.label) {
                     allLabels[entry.label] = true;

--- a/client/src/components/Workflow/Editor/modules/outputs.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.js
@@ -1,6 +1,6 @@
 import Vue from "vue";
 
-const allLabels = {};
+export const allLabels = {};
 
 export class ActiveOutputs {
     constructor() {
@@ -42,9 +42,9 @@ export class ActiveOutputs {
     }
 
     /** Change label for an output */
-    labelOutput(output, newLabel) {
-        if (!allLabels[newLabel]) {
-            const oldLabel = this.update(output.name, newLabel);
+    labelOutput(outputName, newLabel) {
+        if (this.outputsIndex[outputName] && !allLabels[newLabel]) {
+            const oldLabel = this.update(outputName, newLabel);
             if (oldLabel && allLabels[oldLabel]) {
                 delete allLabels[oldLabel];
             }
@@ -53,7 +53,7 @@ export class ActiveOutputs {
             }
             return null;
         } else {
-            const activeOutput = this.get(output.name);
+            const activeOutput = this.get(outputName);
             return activeOutput && activeOutput.label;
         }
     }

--- a/client/src/components/Workflow/Editor/modules/outputs.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.js
@@ -34,11 +34,6 @@ export class ActiveOutputs {
 
     /** Toggle an entry */
     toggle(name) {
-        const activeOutput = this.get(name);
-        const activeLabel = activeOutput && activeOutput.label;
-        if (activeLabel && allLabels[activeLabel]) {
-            delete allLabels[activeLabel];
-        }
         if (this.exists(name)) {
             this.remove(name);
         } else {
@@ -80,6 +75,11 @@ export class ActiveOutputs {
 
     /** Remove an entry given its name */
     remove(name) {
+        const activeOutput = this.get(name);
+        const activeLabel = activeOutput && activeOutput.label;
+        if (activeLabel && allLabels[activeLabel]) {
+            delete allLabels[activeLabel];
+        }
         delete this.entries[name];
         this._updateOutput(name);
     }
@@ -91,7 +91,7 @@ export class ActiveOutputs {
 
     /** Update an active outputs label */
     update(name, label) {
-        const activeOutput = this.entries[name];
+        const activeOutput = this.get(name);
         const oldLabel = activeOutput && activeOutput.label;
         this.entries[name] = {
             output_name: name,
@@ -102,7 +102,7 @@ export class ActiveOutputs {
     }
 
     /** Removes all entries which are not in the parsed dictionary of names */
-    updateOutputs(names) {
+    filterOutputs(names) {
         this.getAll().forEach((wf_output) => {
             if (!names[wf_output.output_name]) {
                 this.remove(wf_output.output_name);

--- a/client/src/components/Workflow/Editor/modules/outputs.test.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.test.js
@@ -1,0 +1,69 @@
+import { allLabels, ActiveOutputs } from "./outputs";
+
+describe("Workflow Outputs", () => {
+    it("test output label handling", () => {
+        // Test adding initial node
+        const activeOutputs = new ActiveOutputs();
+        const outputs = [{ name: "output_0" }, { name: "output_1" }, { name: "output_2" }];
+        const incoming = [
+            { output_name: "output_0", label: "label_0" },
+            { output_name: "output_1", label: "label_0" },
+            { output_name: "output_2", label: "label_1" },
+        ];
+        activeOutputs.initialize(outputs, incoming);
+        expect(Object.keys(allLabels).length).toBe(2);
+        expect(allLabels["label_0"]).toBe(true);
+        expect(allLabels["label_1"]).toBe(true);
+        expect(activeOutputs.count()).toBe(3);
+        expect(activeOutputs.entries["output_0"].label).toBe("label_0");
+        expect(activeOutputs.entries["output_1"].label).toBe(null);
+        expect(activeOutputs.entries["output_2"].label).toBe("label_1");
+
+        // Test adding additional node
+        const activeOutputs_1 = new ActiveOutputs();
+        const outputs_1 = [{ name: "output_0" }, { name: "output_1" }, { name: "output_2" }];
+        const incoming_1 = [
+            { output_name: "output_0", label: "label_0" },
+            { output_name: "output_1", label: "label_0" },
+            { output_name: "output_2", label: "label_2" },
+        ];
+        activeOutputs_1.initialize(outputs_1, incoming_1);
+        expect(Object.keys(allLabels).length).toBe(3);
+        expect(allLabels["label_0"]).toBe(true);
+        expect(allLabels["label_1"]).toBe(true);
+        expect(allLabels["label_2"]).toBe(true);
+        expect(activeOutputs_1.count()).toBe(3);
+        expect(activeOutputs_1.entries["output_0"].label).toBe(null);
+        expect(activeOutputs_1.entries["output_1"].label).toBe(null);
+        expect(activeOutputs_1.entries["output_2"].label).toBe("label_2");
+
+        // Test toggle / removal
+        activeOutputs_1.toggle("output_0");
+        expect(activeOutputs_1.count()).toBe(2);
+        activeOutputs_1.toggle("output_1");
+        expect(activeOutputs_1.count()).toBe(1);
+        activeOutputs_1.toggle("output_0");
+        expect(activeOutputs_1.count()).toBe(2);
+        activeOutputs_1.toggle("output_1");
+        expect(activeOutputs_1.count()).toBe(3);
+
+        // Test output filtering
+        activeOutputs.filterOutputs({ output_0: true, output_2: true });
+        expect(activeOutputs.count()).toBe(2);
+        expect(activeOutputs.entries["output_0"].label).toBe("label_0");
+        expect(activeOutputs.entries["output_1"]).toBe(undefined);
+        expect(activeOutputs.entries["output_2"].label).toBe("label_1");
+
+        // Update output label
+        const response = activeOutputs.labelOutput("output_0", "label_3");
+        expect(response).toBe(null);
+        expect(activeOutputs.entries["output_0"].label).toBe("label_3");
+        const response_1 = activeOutputs.labelOutput("output_0", "label_1");
+        expect(response_1).toBe("label_3");
+        expect(activeOutputs.entries["output_0"].label).toBe("label_3");
+
+        // Test output removal
+        activeOutputs.filterOutputs({});
+        expect(Object.keys(allLabels).length).toBe(1);
+    });
+});

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -815,7 +815,7 @@ class WorkflowContentsManager(UsesAnnotations):
                     if output_label is not None:
                         if output_label in output_label_index:
                             if output_label not in output_label_duplicate:
-                                output_label_duplicate.append(output_label)
+                                output_label_duplicate.add(output_label)
                         else:
                             output_label_index[output_label] = True
             step_dict['workflow_outputs'] = outputs

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -817,7 +817,7 @@ class WorkflowContentsManager(UsesAnnotations):
                             if output_label not in output_label_duplicate:
                                 output_label_duplicate.add(output_label)
                         else:
-                            output_label_index[output_label] = True
+                            output_label_index.add(output_label)
             step_dict['workflow_outputs'] = outputs
             if len(output_label_duplicate) > 0:
                 output_label_duplicate_string = ", ".join(output_label_duplicate)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -749,10 +749,7 @@ class WorkflowContentsManager(UsesAnnotations):
             # Load label from state of data input modules, necessary for backward compatibility
             self.__set_default_label(step, module, step.tool_inputs)
             # Fix any missing parameters
-            upgrade_message_dict = {}
-            check_and_update_messages = module.check_and_update_state()
-            if check_and_update_messages:
-                upgrade_message_dict = check_and_update_messages
+            upgrade_message_dict = module.check_and_update_state() or {}
             if hasattr(module, "version_changes") and module.version_changes:
                 upgrade_message_dict[module.tool.name] = "\n".join(module.version_changes)
             # Get user annotation.

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -803,7 +803,7 @@ class WorkflowContentsManager(UsesAnnotations):
 
             # workflow outputs
             outputs = []
-            output_label_duplicate = []
+            output_label_duplicate = set()
             for output in step.unique_workflow_outputs:
                 if output.workflow_step.type not in input_step_types:
                     output_label = output.label

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -738,7 +738,7 @@ class WorkflowContentsManager(UsesAnnotations):
         log.info("creator_metadata is %s" % workflow.creator_metadata)
         data['creator'] = workflow.creator_metadata
 
-        output_label_index = {}
+        output_label_index = set()
         input_step_types = set(workflow.input_step_types)
         # For each step, rebuild the form and encode the state
         for step in workflow.steps:


### PR DESCRIPTION
This PR introduces an additional condition to prevent the insertion of duplicate output labels when inserting workflow nodes in the workflow editor. To reproduce this, open the workflow editor and insert a tool with explicitly labeled workflow outputs multiple times. You will notice that the label displayed in the `Outputs` subsection of the corresponding workflow step forms are duplicates. Additionally this PR adds a call to properly cleanup output labels when removing workflow steps. Overall these changes improve the workflow label handling.