### PR TITLE
[20.09]Quickfix for workflow testing

### DIFF
--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -352,7 +352,8 @@ def _has_src_to_path(upload_config, item, is_dataset=False):
             name = "Pasted Entry"
     else:
         assert src == "path"
-        path = item["path"]
+        path = item.get("path", item.get("name"))
+        assert path
         if name is None:
             name = os.path.basename(path)
     return name, path

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -352,8 +352,7 @@ def _has_src_to_path(upload_config, item, is_dataset=False):
             name = "Pasted Entry"
     else:
         assert src == "path"
-        path = item.get("path", item.get("name"))
-        assert path
+        path = item["path"]
         if name is None:
             name = os.path.basename(path)
     return name, path

--- a/lib/galaxy/webapps/galaxy/api/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/api/_fetch_util.py
@@ -82,7 +82,7 @@ def validate_and_normalize_targets(trans, payload):
         if item["src"] == "url" and item["url"].startswith("file://"):
             item["src"] = "path"
             item["path"] = item["url"][len("file://"):]
-            del item["path"]
+            del item["url"]
 
         if "in_place" in item:
             raise RequestParameterInvalidException("in_place cannot be set in the upload request")


### PR DESCRIPTION
Seen this while testing workflows against 20.09
```
Traceback (most recent call last):
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 465, in <module>
    main()
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 40, in main
    galaxy_json = _request_to_galaxy_json(upload_config, request)
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 50, in _request_to_galaxy_json
    fetched_target = _fetch_target(upload_config, target)
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 278, in _fetch_target
    elements = elements_tree_map(_resolve_item, items)
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 311, in elements_tree_map
    new_items.append(f(item))
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 175, in _resolve_item
    return _resolve_item_with_primary(item)
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 180, in _resolve_item_with_primary
    name, path = _has_src_to_path(upload_config, item, is_dataset=True)
  File "/tmp/tmppeg91oi2/galaxy-dev/lib/galaxy/tools/data_fetch.py", line 355, in _has_src_to_path
    path = item["path"]
KeyError: 'path'
```