### PR TITLE
Cache container resolution during job execution

### DIFF
--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -244,6 +244,7 @@ class ContainerRegistry:
         return None if resolved_container_description is None else resolved_container_description.container_description
 
     def resolve(self, enabled_container_types, tool_info, index=None, resolver_type=None, install=True, resolution_cache=None):
+        resolution_cache = resolution_cache or self.mulled_resolution_cache
         for i, container_resolver in enumerate(self.container_resolvers):
             if index is not None and i != index:
                 continue


### PR DESCRIPTION
That should be very useful when the Cached* container resolvers can't be used (e.g. on k8s).