### PR TITLE
[WIP][20.09] Restore exception handling for item accessibility problems.

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1654,7 +1654,7 @@ class Tool(Dictifiable):
             if len(rval) == 4:
                 execution_slice.datasets_to_persist = rval[2]
                 execution_slice.history = rval[3]
-        except (webob.exc.HTTPFound, exceptions.MessageException) as e:
+        except webob.exc.HTTPFound as e:
             # if it's a webob redirect exception, pass it up the stack
             raise e
         except ToolInputsNotReadyException as e:


### PR DESCRIPTION
Shouldn't this fix https://github.com/galaxyproject/galaxy/issues/10309? This way the exception falls through the object collecting exceptions and reporting them back instead of short circuiting the workflow scheduling stuff.

This was added in https://github.com/galaxyproject/galaxy/commit/f5c3478ad42102dd5f14879830ba60519e07de98#diff-17974c8048767aa536063088ba97dbc9c4475e7589002c3b2335f9e8490fc920R1600 but it seems unrelated to the rest of that commit?