### PR TITLE
[20.09] Move more non-dns compliant labels to annotations

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -42,6 +42,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
     """
     runner_name = "KubernetesRunner"
 
+    LABEL_REGEX = re.compile("[^-A-Za-z0-9_.]")
+
     def __init__(self, app, nworkers, **kwargs):
         # Check if pykube was importable, fail if not
         ensure_pykube()
@@ -205,19 +207,19 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         k8s_spec_template = {
             "metadata": {
                 "labels": {
-                    "app.kubernetes.io/name": ajs.job_wrapper.tool.old_id,
+                    "app.kubernetes.io/name": self.LABEL_REGEX.sub("_", ajs.job_wrapper.tool.old_id),
                     "app.kubernetes.io/instance": self.__produce_k8s_job_prefix(),
-                    "app.kubernetes.io/version": ajs.job_wrapper.tool.version,
+                    "app.kubernetes.io/version": self.LABEL_REGEX.sub("_", str(ajs.job_wrapper.tool.version)),
                     "app.kubernetes.io/component": "tool",
                     "app.kubernetes.io/part-of": "galaxy",
                     "app.kubernetes.io/managed-by": "galaxy",
-                    "app.galaxyproject.org/job_id": ajs.job_wrapper.get_id_tag(),
-                    "app.galaxyproject.org/instance": self._galaxy_instance_id or "",
-                    "app.galaxyproject.org/handler": self.app.config.server_name,
-                    "app.galaxyproject.org/destination": ajs.job_wrapper.job_destination.id,
+                    "app.galaxyproject.org/job_id": self.LABEL_REGEX.sub("_", ajs.job_wrapper.get_id_tag()),
+                    "app.galaxyproject.org/handler": self.LABEL_REGEX.sub("_", self.app.config.server_name),
+                    "app.galaxyproject.org/destination": self.LABEL_REGEX.sub(
+                        "_", str(ajs.job_wrapper.job_destination.id))
                 },
                 "annotations": {
-                    "app.galaxyproject.org/tool_id": ajs.job_wrapper.tool.id,
+                    "app.galaxyproject.org/tool_id": ajs.job_wrapper.tool.id
                 }
             },
             "spec": {


### PR DESCRIPTION
There are more labels which are not necessarily dns compliant. Have moved more into annotations.

Fixes: https://github.com/galaxyproject/galaxy/issues/10469