### PR TITLE
[20.05] Update amqp, needed by kombu 4.6.11

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -1,7 +1,7 @@
 -i https://wheels.galaxyproject.org/simple
 --extra-index-url https://pypi.python.org/simple
 adal==1.2.3
-amqp==2.5.2
+amqp==2.6.0
 appdirs==1.4.3
 attmap==0.12.11
 attrs==19.3.0


### PR DESCRIPTION
This should fix the following error encountered after the merge of https://github.com/galaxyproject/galaxy/pull/10219:

` kombu 4.6.11 requires amqp<2.7,>=2.6.0, but you'll have amqp 2.5.2 which is incompatible.`