### PR TITLE
[20.09] Fix ``maximum_workflow_jobs_per_scheduling_iteration`` and set 1000 as default value

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3181,8 +3181,8 @@
     associated with scheduling workflows at the expense of increased
     total DB traffic because model objects are expunged from the SQL
     alchemy session between workflow invocation scheduling iterations.
-    Set to -1 to disable any such maximum (the default).
-:Default: ``-1``
+    Set to -1 to disable any such maximum.
+:Default: ``1000``
 :Type: int
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1577,8 +1577,8 @@ galaxy:
   # scheduling workflows at the expense of increased total DB traffic
   # because model objects are expunged from the SQL alchemy session
   # between workflow invocation scheduling iterations. Set to -1 to
-  # disable any such maximum (the default).
-  #maximum_workflow_jobs_per_scheduling_iteration: -1
+  # disable any such maximum.
+  #maximum_workflow_jobs_per_scheduling_iteration: 1000
 
   # Force serial scheduling of workflows within the context of a
   # particular history

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -101,11 +101,13 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
             break
         else:
             execute_single_job(execution_slice, completed_jobs[i])
+            history = execution_slice.history or history
+            jobs_executed += 1
             if execution_slice.datasets_to_persist:
                 datasets_to_persist.extend(execution_slice.datasets_to_persist)
 
     if datasets_to_persist:
-        execution_slice.history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=True, quota=False, flush=False)
+        history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=True, quota=False, flush=False)
         # a side effect of history.add_datasets is a commit within db_next_hid (even with flush=False).
     else:
         # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2368,7 +2368,7 @@ mapping:
 
       maximum_workflow_jobs_per_scheduling_iteration:
         type: int
-        default: -1
+        default: 1000
         required: false
         desc: |
           Specify a maximum number of jobs that any given workflow scheduling iteration can create.
@@ -2376,7 +2376,7 @@ mapping:
           preventing other jobs from executing. This may also mitigate memory issues associated with
           scheduling workflows at the expense of increased total DB traffic because model objects
           are expunged from the SQL alchemy session between workflow invocation scheduling iterations.
-          Set to -1 to disable any such maximum (the default).
+          Set to -1 to disable any such maximum.
 
       history_local_serial_workflow_scheduling:
         type: bool

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -24,7 +24,7 @@ class MaximumWorkflowInvocationDurationTestCase(integration_util.IntegrationTest
     def handle_galaxy_config_kwds(cls, config):
         config["maximum_workflow_invocation_duration"] = 20
 
-    def do_test(self):
+    def test(self):
         workflow = self.workflow_populator.load_workflow_from_resource("test_workflow_pause")
         workflow_id = self.workflow_populator.create_workflow(workflow)
         history_id = self.dataset_populator.new_history()
@@ -61,7 +61,7 @@ class MaximumWorkflowJobsPerSchedulingIterationTestCase(integration_util.Integra
     def handle_galaxy_config_kwds(cls, config):
         config["maximum_workflow_jobs_per_scheduling_iteration"] = 1
 
-    def do_test(self):
+    def test(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
@@ -73,11 +73,11 @@ steps:
   - tool_id: collection_paired_test
     state:
       f1:
-        $link: 1#paired_output
+        $link: 1/paired_output
   - tool_id: cat_list
     state:
       input1:
-        $link: 2#out1
+        $link: 2/out1
 """)
         with self.dataset_populator.test_history() as history_id:
             hdca1 = self.dataset_collection_populator.create_list_in_history(history_id, contents=["a\nb\nc\nd\n", "e\nf\ng\nh\n"]).json()


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/10486 and should address the bulk of https://github.com/galaxyproject/galaxy/issues/10442 ?