### PR TITLE
Add update time to workflow version selector in workflow editor

### DIFF
--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -25,6 +25,7 @@ export default {
         },
         customFormat: {
             type: String,
+            default: null,
         },
     },
     created() {

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -104,7 +104,7 @@ export default {
             for (let i = 0; i < this.versions.length; i++) {
                 const current_wf = this.versions[i];
                 const update_time = moment.utc(current_wf.update_time).format("MMM Do YYYY");
-                const label = `${current_wf.version}: ${update_time}, ${current_wf.steps} steps`;
+                const label = `${current_wf.version + 1}: ${update_time}, ${current_wf.steps} steps`;
                 versions.push({
                     version: i,
                     label: label,

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -43,6 +43,7 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
+import moment from "moment";
 import { Services } from "components/Workflow/services";
 import Tags from "components/Common/Tags";
 
@@ -102,10 +103,8 @@ export default {
             const versions = [];
             for (let i = 0; i < this.versions.length; i++) {
                 const current_wf = this.versions[i];
-                let label = `Version ${current_wf.version}, ${current_wf.steps} steps`;
-                if (i == this.version) {
-                    label = `${label} (active)`;
-                }
+                const update_time = moment.utc(current_wf.update_time).format("MMM Do YYYY");
+                const label = `${current_wf.version}: ${update_time}, ${current_wf.steps} steps`;
                 versions.push({
                     version: i,
                     label: label,


### PR DESCRIPTION
<img width="244" alt="image" src="https://user-images.githubusercontent.com/2105447/96752064-f66b0700-139b-11eb-84e8-743f3d733f01.png">

Additionally this PR displays the workflow version starting with `1` instead of `0`.

Resolves #10491.