### PR TITLE
Handle unschedulable jobs in k8s runner

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -2,12 +2,11 @@
 Offload jobs to a Kubernetes cluster.
 """
 
+from datetime import datetime
 import logging
 import math
 import os
 import re
-
-from datetime import datetime
 
 import yaml
 
@@ -586,7 +585,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             return True
 
         return False
-    
+
     def __job_pending_due_to_unschedulable_pod(self, job_state):
         """
         checks the state of the pod to see if it is unschedulable.

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -597,7 +597,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             return False
 
         pod = Pod(self._pykube_api, pods.response['items'][0])
-        is_unschedulable = bool(len([c in pod.obj['status']['conditions'] if c.get("reason") == "Unschedulable"]))
+        is_unschedulable = bool(len([c for c in pod.obj['status']['conditions'] if c.get("reason") == "Unschedulable"]))
         if pod.obj['status']['phase'] == "Pending" and is_unschedulable:
             return True
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -527,10 +527,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
     def _handle_unschedulable_job(self, job, job_state):
         # Handle unschedulable job that exceeded deadline
-        with open(job_state.error_file, 'a') as error_file:
-            error_file.write("UnschedulableDeadlineExceeded")
-            job_state.fail_message = "Job was unschedulable longer than specified deadline"
-            job_state.runner_state = JobState.runner_states.WALLTIME_REACHED
+        job_state.fail_message = "Job was unschedulable longer than specified deadline"
+        job_state.runner_state = JobState.runner_states.WALLTIME_REACHED
         job_state.running = False
         self.mark_as_failed(job_state)
         try:

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -2,11 +2,11 @@
 Offload jobs to a Kubernetes cluster.
 """
 
-from datetime import datetime
 import logging
 import math
 import os
 import re
+from datetime import datetime
 
 import yaml
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -7,6 +7,8 @@ import math
 import os
 import re
 
+from datetime import datetime
+
 import yaml
 
 from galaxy import model
@@ -70,7 +72,8 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             k8s_fs_group_id=dict(map=int),
             k8s_cleanup_job=dict(map=str, valid=lambda s: s in {"onsuccess", "always", "never"}, default="always"),
             k8s_pod_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=3),
-            k8s_walltime_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=172800))
+            k8s_walltime_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=172800),
+            k8s_unschedulable_walltime_limit=dict(map=int, valid=lambda x: int(x) >= 0, default=1800),)
 
         if 'runner_param_specs' not in kwargs:
             kwargs['runner_param_specs'] = dict()
@@ -484,8 +487,15 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 return None
             elif active > 0 and failed <= max_pod_retries:
                 if not job_state.running:
-                    job_state.running = True
-                    job_state.job_wrapper.change_state(model.Job.states.RUNNING)
+                    if self.__job_pending_due_to_unschedulable_pod(job_state):
+                        creation_time_str = job.obj['metadata'].get('creationTimestamp')
+                        creation_time = datetime.strptime(creation_time_str, '%Y-%m-%dT%H:%M:%SZ')
+                        elapsed_seconds = (datetime.utcnow() - creation_time).total_seconds()
+                        if elapsed_seconds > self.runner_params['k8s_unschedulable_walltime_limit']:
+                            return self._handle_unschedulable_job(job, job_state)
+                    else:
+                        job_state.running = True
+                        job_state.job_wrapper.change_state(model.Job.states.RUNNING)
                 return job_state
             elif job_persisted_state == model.Job.states.DELETED:
                 # Job has been deleted via stop_job and job has not been deleted,
@@ -514,6 +524,20 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             self.mark_as_failed(job_state)
             # job is no longer viable - remove from watched jobs
             return None
+
+    def _handle_unschedulable_job(self, job, job_state):
+        # Handle unschedulable job that exceeded deadline
+        with open(job_state.error_file, 'a') as error_file:
+            error_file.write("UnschedulableDeadlineExceeded")
+            job_state.fail_message = "Job was unschedulable longer than specified deadline"
+            job_state.runner_state = JobState.runner_states.WALLTIME_REACHED
+        job_state.running = False
+        self.mark_as_failed(job_state)
+        try:
+            self.__cleanup_k8s_job(job)
+        except Exception:
+            log.exception("Could not clean up k8s batch job. Ignoring...")
+        return None
 
     def _handle_job_failure(self, job, job_state):
         # Figure out why job has failed
@@ -559,6 +583,22 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         pod = Pod(self._pykube_api, pods.response['items'][0])
         if pod.obj['status']['phase'] == "Failed" and \
                 pod.obj['status']['containerStatuses'][0]['state']['terminated']['reason'] == "OOMKilled":
+            return True
+
+        return False
+    
+    def __job_pending_due_to_unschedulable_pod(self, job_state):
+        """
+        checks the state of the pod to see if it is unschedulable.
+        """
+
+        pods = find_pod_object_by_name(self._pykube_api, job_state.job_id, self.runner_params['k8s_namespace'])
+        if not pods.response['items']:
+            return False
+
+        pod = Pod(self._pykube_api, pods.response['items'][0])
+        is_unschedulable = bool(len([c in pod.obj['status']['conditions'] if c.get("reason") == "Unschedulable"]))
+        if pod.obj['status']['phase'] == "Pending" and is_unschedulable:
             return True
 
         return False

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -68,6 +68,14 @@ def find_pod_object_by_name(pykube_api, job_name, namespace=None):
     return Pod.objects(pykube_api).filter(selector="job-name=" + job_name, namespace=namespace)
 
 
+def is_pod_unschedulable(pykube_api, pod, namespace=None):
+    is_unschedulable = bool(len([c for c in pod.obj['status']['conditions'] if c.get("reason") == "Unschedulable"]))
+    if pod.obj['status']['phase'] == "Pending" and is_unschedulable:
+        return True
+
+    return False
+
+
 def stop_job(job, cleanup="always"):
     job_failed = (job.obj['status']['failed'] > 0
                   if 'failed' in job.obj['status'] else False)
@@ -126,6 +134,7 @@ __all__ = (
     "find_job_object_by_name",
     "find_pod_object_by_name",
     "galaxy_instance_id",
+    "is_pod_unschedulable",
     "Job",
     "job_object_dict",
     "Pod",


### PR DESCRIPTION
Addresses https://github.com/galaxyproject/galaxy/issues/10480

- [x] Adds `k8s_unschedulable_walltime_limit` which specifies the time limit for a job to wait while pods are unschedulable.
- [x] Makes job not be marked as running in Galaxy if Job is dispatched but job is still unschedulable
- [x] Handles marking the job as failed with a reasonable message and cleaning up the job when unschedulable past the specified limit

Testing everything together:
- [x] Job is not marked as running if the pod is unschedulable
- [x] Specified time limit is respected (tested with 30 seconds, defaulted to 30 mins)
- [x] Job error is properly reported
![image](https://user-images.githubusercontent.com/14061824/96759556-3800af80-13a6-11eb-9204-5078c3d6f3d2.png)
- [x] Job resource is cleaned up in k8s
- [x] Schedulable jobs still run unaffected