### PR TITLE
Do not let uWSGI remap stdin to /dev/null by default

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2636,6 +2636,19 @@
 :Type: float
 
 
+~~~~~~~~~~~~~~~~~
+``tool_id_boost``
+~~~~~~~~~~~~~~~~~
+
+:Description:
+    Boosts are used to customize this instance's toolbox search. The
+    higher the boost, the more importance the scoring algorithm gives
+    to the given field.  Section refers to the tool group in the tool
+    panel.  Rest of the fields are tool's attributes.
+:Default: ``9.0``
+:Type: float
+
+
 ~~~~~~~~~~~~~~~~~~~~~~
 ``tool_section_boost``
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -168,24 +168,11 @@ UWSGI_OPTIONS = OrderedDict([
         'default': '027',
         'type': 'str',
     }),
-    # ('route-uri', {
-    #     'default': '^/proxy/ goto:proxy'
-    # }),
-    # ('route', {
-    #     'default': '.* last:'
-    # }),
-    # ('route-label', {
-    #     'default': 'proxy'
-    # }),
-    # ('route-run', {
-    #     'default': 'rpcvar:TARGET_HOST galaxy_dynamic_proxy_mapper ${HTTP_HOST} ${cookie[galaxysession]}'
-    # }),
-    # ('route-run', {
-    #     'default': "['log:Proxy ${HTTP_HOST} to ${TARGET_HOST}', 'httpdumb:${TARGET_HOST}']",
-    # }),
-    # ('http-raw-body', {
-    #     'default': True
-    # }),
+    ('honour-stdin', {
+        'desc': """By default, uWSGI remapps stdin to /dev/null. Setting this option to `true` preserves stdin, which enables debugging with tools like pdb.""",
+        'default': True,
+        'type': 'bool',
+    }),
 ])
 
 SHED_ONLY_UWSGI_OPTIONS = [('cron', {

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -105,6 +105,10 @@ uwsgi:
   # to be in the same group as the Galaxy system user
   umask: 027
 
+  # By default, uWSGI remapps stdin to /dev/null. Setting this option to
+  # `true` preserves stdin, which enables debugging with tools like pdb.
+  honour-stdin: true
+
 galaxy:
 
   # The directory that will be prepended to relative paths in options

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -87,6 +87,10 @@ uwsgi:
   # to be in the same group as the Galaxy system user
   umask: 027
 
+  # By default, uWSGI remapps stdin to /dev/null. Setting this option to
+  # `true` preserves stdin, which enables debugging with tools like pdb.
+  honour-stdin: true
+
 reports:
 
   # Verbosity of console log messages.  Acceptable values can be found

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -87,6 +87,10 @@ uwsgi:
   # to be in the same group as the Galaxy system user
   umask: 027
 
+  # By default, uWSGI remapps stdin to /dev/null. Setting this option to
+  # `true` preserves stdin, which enables debugging with tools like pdb.
+  honour-stdin: true
+
   # Task for rebuilding Toolshed search indexes using the uWSGI
   # cron-like interface.
   cron: 0 -1 -1 -1 -1 python scripts/tool_shed/build_ts_whoosh_index.py -c config/tool_shed.yml --config-section tool_shed


### PR DESCRIPTION
Set this by default to allow using debugging tools like pdb. (as per suggestion by @nsoranzo)

From https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html#things-to-know-best-practices-and-issues-read-it:
> By default, stdin is remapped to /dev/null on uWSGI startup. If you need a valid stdin (for debugging, piping and so on) 
add --honour-stdin.
