### PR TITLE
modified list-of-pairs to copy datasets as hidden

### DIFF
--- a/client/src/mvc/collection/list-of-pairs-collection-creator.js
+++ b/client/src/mvc/collection/list-of-pairs-collection-creator.js
@@ -635,12 +635,13 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
             var self = this;
 
             var url = `${getAppRoot()}api/histories/${this.historyId}/contents/dataset_collections`;
+            const hideSourceItems = !!self.hideOriginals;
 
             var ajaxData = {
                 type: "dataset_collection",
                 collection_type: "list:paired",
-                hide_source_items: self.hideOriginals || false,
-                copy_elements: self.copyElements,
+                hide_source_items: hideSourceItems,
+                copy_elements: !hideSourceItems,
                 name: _.escape(name || self.$(".collection-name").val()),
                 element_identifiers: self.paired.map((pair) => self._pairToJSON(pair)),
             };
@@ -1811,7 +1812,6 @@ function createListOfPairsCollection(collection, defaultHideSourceItems) {
     return pairedCollectionCreatorModal(elements, {
         historyId: collection.historyId,
         defaultHideSourceItems: defaultHideSourceItems,
-        copyElements: !defaultHideSourceItems,
     });
 }
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4593,6 +4593,7 @@ class DatasetCollectionElement(Dictifiable, RepresentById):
                 )
             else:
                 new_element_object = element_object.copy(flush=flush)
+                new_element_object.visible = False
                 if destination is not None and element_object.hidden_beneath_collection_instance:
                     new_element_object.hidden_beneath_collection_instance = destination
                 # Ideally we would not need to give the following

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -69,7 +69,7 @@ class CollectionBuildersTestCase(SeleniumTestCase):
         self.collection_builder_set_name("my awesome paired list")
         self.screenshot("collection_builder_paired_list")
         self.collection_builder_create()
-        self.history_panel_wait_for_hid_ok(3)
+        self.history_panel_wait_for_hid_ok(5)
 
     @selenium_test
     def test_build_paired_list_hide_original(self):


### PR DESCRIPTION
Fix for papercut issue #10229 

It only fixes new collections that are created using the updated collection creator. 

Thanks to much help from @jmchilton , @dannon , and @mvdbeek ! 