### PR TITLE
Truncate excessively long dataset names in the collection creator.

### DIFF
--- a/client/src/mvc/collection/list-of-pairs-collection-creator.js
+++ b/client/src/mvc/collection/list-of-pairs-collection-creator.js
@@ -37,11 +37,11 @@ var PairView = Backbone.View.extend(baseMVC.LoggableMixin).extend({
 
     template: _.template(
         [
-            '<span class="forward-dataset-name flex-column"><%- pair.forward.name %></span>',
+            '<span class="forward-dataset-name flex-column truncate"><%- pair.forward.name %></span>',
             '<span class="pair-name-column flex-column">',
-            '<span class="pair-name"><%- pair.name %></span>',
+            '<span class="pair-name truncate"><%- pair.name %></span>',
             "</span>",
-            '<span class="reverse-dataset-name flex-column"><%- pair.reverse.name %></span>',
+            '<span class="reverse-dataset-name flex-column truncate"><%- pair.reverse.name %></span>',
         ].join("")
     ),
 
@@ -796,7 +796,7 @@ var PairedCollectionCreator = Backbone.View.extend(baseMVC.LoggableMixin)
             return (
                 $("<li/>")
                     .attr("id", `dataset-${dataset.id}`)
-                    .addClass("dataset unpaired")
+                    .addClass("dataset unpaired truncate")
                     .attr("draggable", true)
                     .addClass(dataset.selected ? "selected" : "")
                     .append($("<span/>").addClass("dataset-name").text(dataset.name))


### PR DESCRIPTION
This was reported at a meeting some days ago by @nekrut.

Before and after screenshots:

![before](https://i.imgur.com/hBS97xN.jpg)

![after](https://i.imgur.com/JgbrK0s.jpg)
