### PR TITLE
[20.09] Allow username or email for authenticate API identity

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -21,7 +21,7 @@ from galaxy.managers import (
     deletable
 )
 from galaxy.security.validate_user_input import (
-    VALID_PUBLICNAME_RE,
+    VALID_EMAIL_RE,
     validate_email,
     validate_password,
     validate_publicname
@@ -282,17 +282,17 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
     def get_user_by_identity(self, identity):
         """Get user by username or email."""
         user = None
-        if VALID_PUBLICNAME_RE.match(identity):
-            # VALID_PUBLICNAME and VALID_EMAIL do not overlap, so 'identity' here is publicname
-            user = self.session().query(self.model_class).filter(
-                self.model_class.table.c.username == identity).first()
-        else:
+        if VALID_EMAIL_RE.match(identity):
+            # VALID_PUBLICNAME and VALID_EMAIL do not overlap, so 'identity' here is an email address
             user = self.session().query(self.model_class).filter(
                 self.model_class.table.c.email == identity).first()
             if not user:
                 # Try a case-insensitive match on the email
                 user = self.session().query(self.model_class).filter(
                     func.lower(self.model_class.table.c.email) == identity.lower()).first()
+        else:
+            user = self.session().query(self.model_class).filter(
+                self.model_class.table.c.username == identity).first()
         return user
 
     # ---- current

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -134,15 +134,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
         status = None
         if not login or not password:
             return self.message_exception(trans, "Please specify a username and password.")
-        user = trans.sa_session.query(trans.app.model.User).filter(or_(
-            trans.app.model.User.table.c.email == login,
-            trans.app.model.User.table.c.username == login
-        )).first()
-        if not user:
-            # Try a case-insensitive match on the email
-            user = trans.sa_session.query(trans.app.model.User).filter(
-                func.lower(trans.app.model.User.table.c.email) == login.lower()
-            ).first()
+        user = self.user_manager.get_user_by_identity(login)
         log.debug("trans.app.config.auth_config_file: %s" % trans.app.config.auth_config_file)
         if user is None:
             message, user = self.__autoregistration(trans, login, password)

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -7,10 +7,6 @@ from datetime import datetime, timedelta
 
 from markupsafe import escape
 from six.moves.urllib.parse import unquote
-from sqlalchemy import (
-    func,
-    or_
-)
 from sqlalchemy.orm.exc import NoResultFound
 
 from galaxy import (

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -25,6 +25,8 @@ changed_password = '654321'
 user2_data = dict(email='user2@user2.user2', username='user2', password=default_password)
 user3_data = dict(email='user3@user3.user3', username='user3', password=default_password)
 user4_data = dict(email='user4@user4.user4', username='user4', password=default_password)
+uppercase_email_user = dict(email='USER5@USER5.USER5', username='USER5', password=default_password)
+lowercase_email_user = dict(email='user5@user5.user5', username='user5', password=default_password)
 
 
 # =============================================================================
@@ -193,6 +195,28 @@ class UserManagerTestCase(BaseTestCase):
         # should not be able to login with a null or empty password
         self.assertFalse(check_password("", user.password))
         self.assertFalse(check_password(None, user.password))
+
+    def test_get_user_by_identity(self):
+        # return None if username/email not found
+        assert self.user_manager.get_user_by_identity('xyz') is None
+        uppercase_user = self.user_manager.create(**uppercase_email_user)
+        assert uppercase_user.email == uppercase_email_user['email']
+        assert uppercase_user.username == uppercase_email_user['username']
+        assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
+        assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
+        lowercase_user = self.user_manager.create(**lowercase_email_user)
+        assert lowercase_user.email == lowercase_email_user['email']
+        assert lowercase_user.username == lowercase_email_user['username']
+        assert self.user_manager.get_user_by_identity(lowercase_user.email) == lowercase_user
+        assert self.user_manager.get_user_by_identity(lowercase_user.username) == lowercase_user
+        # assert uppercase user can still be retrieved
+        assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
+        assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
+        # username matches need to be exact
+        assert self.user_manager.get_user_by_identity(uppercase_user.username.capitalize()) is None
+        # email matches can ignore capitalization
+        ignore_email_capitalization_user = self.user_manager.create(email='user123@nopassword.com', username='someusername123')
+        assert self.user_manager.get_user_by_identity(ignore_email_capitalization_user.email.capitalize()) == ignore_email_capitalization_user
 
 
 # =============================================================================

--- a/test/unit/managers/test_UserManager.py
+++ b/test/unit/managers/test_UserManager.py
@@ -204,6 +204,9 @@ class UserManagerTestCase(BaseTestCase):
         assert uppercase_user.username == uppercase_email_user['username']
         assert self.user_manager.get_user_by_identity(uppercase_user.email) == uppercase_user
         assert self.user_manager.get_user_by_identity(uppercase_user.username) == uppercase_user
+        # Create another user with the same email just differently capitalized.
+        # This is not normally allowed now, since registration goes through user_manager.register(),
+        # which checks for that, but was possible in earlier releases of Galaxy
         lowercase_user = self.user_manager.create(**lowercase_email_user)
         assert lowercase_user.email == lowercase_email_user['email']
         assert lowercase_user.username == lowercase_email_user['username']


### PR DESCRIPTION
The primary authentication mechanism behaves this way.

Fixes https://github.com/galaxyproject/galaxy/issues/10519