### PR TITLE
Add S3 plugin for remote files browser

### DIFF
--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -34,7 +34,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
                     res.extend(map(to_dict, files))
                 return res
             else:
-                res = h.scandir(path)
+                res = h.scandir(path, namespaces=['details'])
                 to_dict = functools.partial(self._resource_info_to_dict, path)
                 return list(map(to_dict, res))
 

--- a/lib/galaxy/files/sources/s3.py
+++ b/lib/galaxy/files/sources/s3.py
@@ -1,0 +1,20 @@
+try:
+    from fs_s3fs import S3FS
+except ImportError:
+    S3FS = None
+
+from ._pyfilesystem2 import PyFilesystem2FilesSource
+
+
+class S3FilesSource(PyFilesystem2FilesSource):
+    plugin_type = 's3'
+    required_module = S3FS
+    required_package = "fs-s3fs"
+
+    def _open_fs(self, user_context):
+        props = self._serialization_props(user_context)
+        handle = S3FS(**props)
+        return handle
+
+
+__all__ = ('S3FilesSource',)


### PR DESCRIPTION
Requires `fs-s3fs` package.

and the following in `file_sources_conf.yml` configuration:
```
- type: s3
  id: <Bucket label shown in the UI>
  doc: <Description for the bucket>
  bucket_name: <Bucket name>
  aws_access_key_id: <A_KEY>
  aws_secret_access_key: <S_KEY>
```