### PR TITLE
[20.05] (backport) Bugfix: include an index link in visualization base to allow the app to derive baseUrl

### DIFF
--- a/config/plugins/visualizations/common/templates/visualization_base.mako
+++ b/config/plugins/visualizations/common/templates/visualization_base.mako
@@ -20,6 +20,7 @@
 <html>
     <head>
         <title>${self.title()}</title>
+        <link rel="index" href="${ h.url_for( '/' ) }"/>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         ${self.metas()}
         ${self.stylesheets()}


### PR DESCRIPTION
@gregvonkuster, @natefoo mentioned you ran into what is almost certainly this, in 20.05.  Try this backport out?