### PR TITLE
Disable upload option in default data dialog since history panel is not always available

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -23,7 +23,7 @@
                 <div class="fa fa-caret-left mr-1" />
                 Back
             </b-btn>
-            <b-btn size="sm" class="float-left mr-1" @click="onUpload">
+            <b-btn v-if="allowUpload" size="sm" class="float-left mr-1" @click="onUpload">
                 <div class="fa fa-upload ml-1" />
                 Upload
             </b-btn>
@@ -73,6 +73,10 @@ export default {
             required: true,
         },
         modalStatic: {
+            type: Boolean,
+            default: false,
+        },
+        allowUpload: {
             type: Boolean,
             default: false,
         },

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -360,6 +360,7 @@ const View = Backbone.View.extend({
                         multiple: cnf.multiple,
                         library: !!cnf.library,
                         format: null,
+                        allowUpload: true,
                     }
                 );
             },


### PR DESCRIPTION
Currently the upload option is shown by default when the data dialog is displayed. However at the moment this option is designed to work only with an existing history panel and for the content selector in the tool form. This PR adds a flag to the data dialog to avoid displaying the upload dialog by default.