### PR TITLE
Improve database operation job submission performance

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -40,6 +40,7 @@ from sqlalchemy.orm import (
     joinedload,
     object_session,
     Query,
+    reconstructor,
 )
 from sqlalchemy.schema import UniqueConstraint
 
@@ -1757,10 +1758,32 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
         self.datasets = []
         self.galaxy_sessions = []
         self.tags = []
+        # Objects to eventually add to history
+        self._pending_additions = []
+
+    @reconstructor
+    def init_on_load(self):
+        # Restores properties that are not tracked in the database
+        self._pending_additions = []
+
+    def stage_addition(self, items):
+        history_id = self.id
+        for item in listify(items):
+            if history_id:
+                item.history_id = history_id
+            else:
+                item.history = self
+            self._pending_additions.append(item)
 
     @property
     def empty(self):
         return self.hid_counter == 1
+
+    def add_pending_datasets(self, set_output_hid=True):
+        # These are assumed to be either copies of existing datasets or new, empty datasets,
+        # so we don't need to set the quota.
+        self.add_datasets(object_session(self), self._pending_additions, set_hid=set_output_hid, quota=False, flush=False)
+        self._pending_additions = []
 
     def _next_hid(self, n=1):
         # this is overriden in mapping.py db_next_hid() method

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4109,14 +4109,36 @@ class DatasetCollection(Dictifiable, UsesAnnotations, RepresentById):
 
     @property
     def dataset_instances(self):
-        instances = []
-        for element in self.elements:
-            if element.is_collection:
-                instances.extend(element.child_collection.dataset_instances)
-            else:
-                instance = element.dataset_instance
-                instances.append(instance)
-        return instances
+        db_session = object_session(self)
+        if db_session and self.id:
+            dc = alias(DatasetCollection.table)
+            de = alias(DatasetCollectionElement.table)
+            hda = alias(HistoryDatasetAssociation.table)
+
+            depth_collection_type = self.collection_type
+            select_from = dc.outerjoin(de, de.c.dataset_collection_id == dc.c.id)
+
+            while ":" in depth_collection_type:
+                child_collection = alias(DatasetCollection.table)
+                child_collection_element = alias(DatasetCollectionElement.table)
+                select_from = select_from.outerjoin(child_collection, child_collection.c.id == de.c.child_collection_id)
+                select_from = select_from.outerjoin(child_collection_element, child_collection_element.c.dataset_collection_id == child_collection.c.id)
+
+                de = child_collection_element
+                depth_collection_type = depth_collection_type.split(":", 1)[1]
+            select_from = select_from.outerjoin(hda, hda.c.id == de.c.hda_id)
+            select_stmt = select([hda]).select_from(select_from).where(dc.c.id == self.id).distinct()
+            return db_session.query(HistoryDatasetAssociation).select_entity_from(select_stmt).all()
+        else:
+            # Sessionless context
+            instances = []
+            for element in self.elements:
+                if element.is_collection:
+                    instances.extend(element.child_collection.dataset_instances)
+                else:
+                    instance = element.dataset_instance
+                    instances.append(instance)
+            return instances
 
     @property
     def dataset_elements(self):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2307,6 +2307,11 @@ class StorableObject:
         else:
             self.uuid = UUID(str(uuid))
 
+    def flush(self):
+        sa_session = object_session(self)
+        if sa_session:
+            sa_session.flush()
+
 
 class Dataset(StorableObject, RepresentById):
     states = Bunch(NEW='new',

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -283,7 +283,6 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
             association_name = f'__new_primary_file_{name}|{element_identifier_str}__'
             self.add_output_dataset_association(association_name, dataset)
 
-        self.flush()
         self.update_object_store_with_datasets(datasets=element_datasets['datasets'], paths=element_datasets['paths'], extra_files=element_datasets['extra_files'])
         add_datasets_timer = ExecutionTimer()
         self.add_datasets_to_history(element_datasets['datasets'])

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -256,7 +256,11 @@ class BaseObjectStore(ObjectStore):
 
     def _get_object_id(self, obj):
         if hasattr(obj, self.store_by):
-            return getattr(obj, self.store_by)
+            obj_id = getattr(obj, self.store_by)
+            if obj_id is None:
+                obj.flush()
+                return obj.id
+            return obj_id
         else:
             # job's don't have uuids, so always use ID in this case when creating
             # job working directories.

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2773,7 +2773,7 @@ class DatabaseOperationTool(Tool):
                 if not input_dataset_collection.collection.populated_optimized:
                     raise ToolInputsNotReadyException("An input collection is not populated.")
 
-            states, _  = input_dataset_collection.collection.dataset_states_and_extensions_summary
+            states, _ = input_dataset_collection.collection.dataset_states_and_extensions_summary
             for state in states:
                 check_dataset_state(state)
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -27,7 +27,6 @@ from galaxy import (
 from galaxy.job_execution import output_collect
 from galaxy.managers.jobs import JobSearch
 from galaxy.metadata import get_metadata_compute_strategy
-from galaxy.model.tags import GalaxyTagHandler
 from galaxy.tool_shed.util.repository_util import get_installed_repository
 from galaxy.tool_shed.util.shed_util_common import set_image_paths
 from galaxy.tool_util.deps import (
@@ -2787,7 +2786,7 @@ class DatabaseOperationTool(Tool):
         if datasets:
             history.add_datasets(self.sa_session, datasets, set_hid=True)
 
-    def produce_outputs(self, trans, out_data, output_collections, incoming, history):
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
         return self._outputs_dict()
 
     def _outputs_dict(self):
@@ -2797,7 +2796,7 @@ class DatabaseOperationTool(Tool):
 class UnzipCollectionTool(DatabaseOperationTool):
     tool_type = 'unzip_collection'
 
-    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tags=None):
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tags=None, **kwds):
         has_collection = incoming["input"]
         if hasattr(has_collection, "element_type"):
             # It is a DCE
@@ -2835,7 +2834,7 @@ class ZipCollectionTool(DatabaseOperationTool):
 class BuildListCollectionTool(DatabaseOperationTool):
     tool_type = 'build_list'
 
-    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tags=None):
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tags=None, **kwds):
         new_elements = OrderedDict()
 
         for i, incoming_repeat in enumerate(incoming["datasets"]):
@@ -2851,7 +2850,7 @@ class BuildListCollectionTool(DatabaseOperationTool):
 class ExtractDatasetCollectionTool(DatabaseOperationTool):
     tool_type = 'extract_dataset'
 
-    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tags=None):
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tags=None, **kwds):
         has_collection = incoming["input"]
         if hasattr(has_collection, "element_type"):
             # It is a DCE
@@ -3154,36 +3153,38 @@ class RelabelFromFileTool(DatabaseOperationTool):
 class ApplyRulesTool(DatabaseOperationTool):
     tool_type = 'apply_rules'
 
-    def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tag_handler, **kwds):
         hdca = incoming["input"]
         rule_set = RuleSet(incoming["rules"])
-        copied_datasets = []
+        datasets_to_persist = []
 
         def copy_dataset(dataset, tags):
             copied_dataset = dataset.copy(flush=False)
-            copied_datasets.append(copied_dataset)
             if tags is not None:
-                self.app.tag_handler.set_tags_from_list(trans.get_user(), copied_dataset, tags)
+                tag_handler.set_tags_from_list(trans.get_user(), copied_dataset, tags, flush=False)
+            copied_dataset.history_id = history.id
+            datasets_to_persist.append(copied_dataset)
             return copied_dataset
 
         new_elements = self.app.dataset_collections_service.apply_rules(
             hdca, rule_set, copy_dataset
         )
-        self._add_datasets_to_history(history, copied_datasets)
-        output_collections.create_collection(
-            next(iter(self.outputs.values())), "output", collection_type=rule_set.collection_type, elements=new_elements
+        hdca = output_collections.create_collection(
+            next(iter(self.outputs.values())), "output", collection_type=rule_set.collection_type, elements=new_elements, flush=False, set_hid=False,
         )
+        if hdca:
+            datasets_to_persist.append(hdca)
+        return datasets_to_persist
 
 
 class TagFromFileTool(DatabaseOperationTool):
     tool_type = 'tag_from_file'
 
-    def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, tag_handler, **kwds):
         hdca = incoming["input"]
         how = incoming['how']
         new_tags_dataset_assoc = incoming["tags"]
         new_elements = OrderedDict()
-        tags_manager = GalaxyTagHandler(trans.app.model.context)
         new_datasets = []
 
         def add_copied_value_to_new_elements(new_tags_dict, dce):
@@ -3196,13 +3197,13 @@ class TagFromFileTool(DatabaseOperationTool):
                 if new_tags:
                     if how in ('add', 'remove') and dce.element_object.tags:
                         # We need get the original tags and update them with the new tags
-                        old_tags = {tag for tag in tags_manager.get_tags_str(dce.element_object.tags).split(',') if tag}
+                        old_tags = {tag for tag in tag_handler.get_tags_str(dce.element_object.tags).split(',') if tag}
                         if how == 'add':
                             old_tags.update(set(new_tags))
                         elif how == 'remove':
                             old_tags = old_tags - set(new_tags)
                         new_tags = old_tags
-                    tags_manager.add_tags_from_list(user=history.user, item=copied_value, new_tags_list=new_tags)
+                    tag_handler.add_tags_from_list(user=history.user, item=copied_value, new_tags_list=new_tags, flush=False)
             else:
                 # We have a collection, and we copy the elements so that we don't manipulate the original tags
                 copied_value = dce.element_object.copy(element_destination=history)
@@ -3212,14 +3213,14 @@ class TagFromFileTool(DatabaseOperationTool):
                     new_element.element_object.visible = False
                     new_tags = new_tags_dict.get(new_element.element_identifier)
                     if how in ('add', 'remove'):
-                        old_tags = {tag for tag in tags_manager.get_tags_str(old_element.element_object.tags).split(',') if tag}
+                        old_tags = {tag for tag in tag_handler.get_tags_str(old_element.element_object.tags).split(',') if tag}
                         if new_tags:
                             if how == 'add':
                                 old_tags.update(set(new_tags))
                             elif how == 'remove':
                                 old_tags = old_tags - set(new_tags)
                         new_tags = old_tags
-                    tags_manager.add_tags_from_list(user=history.user, item=new_element.element_object, new_tags_list=new_tags)
+                    tag_handler.add_tags_from_list(user=history.user, item=new_element.element_object, new_tags_list=new_tags, flush=False)
             new_elements[dce.element_identifier] = copied_value
 
         new_tags_path = new_tags_dataset_assoc.file_name

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2757,24 +2757,25 @@ class DatabaseOperationTool(Tool):
         return not self.require_dataset_ok
 
     def check_inputs_ready(self, input_datasets, input_dataset_collections):
-        def check_dataset_instance(input_dataset):
-            if input_dataset.is_pending:
+        def check_dataset_state(state):
+            if state in model.Dataset.non_ready_states:
                 raise ToolInputsNotReadyException("An input dataset is pending.")
 
             if self.require_dataset_ok:
-                if input_dataset.state != input_dataset.dataset.states.OK:
+                if state != model.Dataset.states.OK:
                     raise ValueError("Tool requires inputs to be in valid state.")
 
         for input_dataset in input_datasets.values():
-            check_dataset_instance(input_dataset)
+            check_dataset_state(input_dataset.state)
 
         for input_dataset_collection_pairs in input_dataset_collections.values():
             for input_dataset_collection, _ in input_dataset_collection_pairs:
-                if not input_dataset_collection.collection.populated:
+                if not input_dataset_collection.collection.populated_optimized:
                     raise ToolInputsNotReadyException("An input collection is not populated.")
 
-            for dataset_instance in input_dataset_collection.dataset_instances:
-                check_dataset_instance(dataset_instance)
+            states, _  = input_dataset_collection.collection.dataset_states_and_extensions_summary
+            for state in states:
+                check_dataset_state(state)
 
     def _add_datasets_to_history(self, history, elements, datasets_visible=False):
         datasets = []

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -252,12 +252,9 @@ class DefaultToolAction:
 
     def _collect_inputs(self, tool, trans, incoming, history, current_user_roles, collection_info):
         """ Collect history as well as input datasets and collections. """
-        app = trans.app
         # Set history.
         if not history:
             history = tool.get_default_history_by_trans(trans, create=True)
-        if history not in trans.sa_session:
-            history = trans.sa_session.query(app.model.History).get(history.id)
 
         # Track input dataset collections - but replace with simply lists so collect
         # input datasets can process these normally.

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -331,8 +331,7 @@ class DefaultToolAction:
 
         if not completed_job:
             # Determine output dataset permission/roles list
-            existing_datasets = [inp for inp in inp_data.values() if inp]
-            if existing_datasets:
+            if all_permissions:
                 output_permissions = app.security_agent.guess_derived_permissions(all_permissions)
             else:
                 # No valid inputs, we will use history defaults

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -57,21 +57,21 @@ class ModelOperationToolAction(DefaultToolAction):
         # Create job.
         #
         job, galaxy_session = self._new_job_for_session(trans, tool, history)
-        self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
+        datasets_to_persist = self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
         self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)
         job.state = job.states.OK
         trans.sa_session.add(job)
-        trans.sa_session.flush()  # ensure job.id are available
 
         # Queue the job for execution
         # trans.app.job_manager.job_queue.put( job.id, tool.id )
         # trans.log_event( "Added database job action to the job queue, id: %s" % str(job.id), tool_id=job.tool_id )
         log.info("Calling produce_outputs, tool is %s" % tool)
-        return job, out_data
+        return job, out_data, datasets_to_persist, history
 
     def _produce_outputs(self, trans, tool, out_data, output_collections, incoming, history, tags):
-        tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags)
+        tag_handler = trans.app.tag_handler.create_tag_handler_session()
+        datasets_to_persist = tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags, tag_handler=tag_handler)
         mapped_over_elements = output_collections.dataset_collection_elements
         if mapped_over_elements:
             for name, value in out_data.items():
@@ -80,4 +80,4 @@ class ModelOperationToolAction(DefaultToolAction):
                     mapped_over_elements[name].hda = value
 
         trans.sa_session.add_all(out_data.values())
-        trans.sa_session.flush()
+        return datasets_to_persist

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -57,7 +57,7 @@ class ModelOperationToolAction(DefaultToolAction):
         # Create job.
         #
         job, galaxy_session = self._new_job_for_session(trans, tool, history)
-        datasets_to_persist = self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
+        self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
         self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)
         job.state = job.states.OK
@@ -67,11 +67,11 @@ class ModelOperationToolAction(DefaultToolAction):
         # trans.app.job_manager.job_queue.put( job.id, tool.id )
         # trans.log_event( "Added database job action to the job queue, id: %s" % str(job.id), tool_id=job.tool_id )
         log.info("Calling produce_outputs, tool is %s" % tool)
-        return job, out_data, datasets_to_persist, history
+        return job, out_data, history
 
     def _produce_outputs(self, trans, tool, out_data, output_collections, incoming, history, tags):
         tag_handler = trans.app.tag_handler.create_tag_handler_session()
-        datasets_to_persist = tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags, tag_handler=tag_handler)
+        tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags, tag_handler=tag_handler)
         mapped_over_elements = output_collections.dataset_collection_elements
         if mapped_over_elements:
             for name, value in out_data.items():
@@ -80,4 +80,3 @@ class ModelOperationToolAction(DefaultToolAction):
                     mapped_over_elements[name].hda = value
 
         trans.sa_session.add_all(out_data.values())
-        return datasets_to_persist

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -90,7 +90,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
 
     jobs_executed = 0
     has_remaining_jobs = False
-    datasets_to_persist = []
+    execution_slice = None
 
     for i, execution_slice in enumerate(execution_tracker.new_execution_slices()):
         if max_num_jobs and jobs_executed >= max_num_jobs:
@@ -100,12 +100,10 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
             execute_single_job(execution_slice, completed_jobs[i])
             history = execution_slice.history or history
             jobs_executed += 1
-            if execution_slice.datasets_to_persist:
-                datasets_to_persist.extend(execution_slice.datasets_to_persist)
 
-    if datasets_to_persist:
-        history.add_datasets(trans.sa_session, datasets_to_persist, set_hid=True, quota=False, flush=False)
-        # a side effect of history.add_datasets is a commit within db_next_hid (even with flush=False).
+    if execution_slice:
+        # a side effect of adding datasets to a history is a commit within db_next_hid (even with flush=False).
+        history.add_pending_datasets()
     else:
         # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
         trans.sa_session.flush()
@@ -130,7 +128,6 @@ class ExecutionSlice:
         self.job_index = job_index
         self.param_combination = param_combination
         self.dataset_collection_elements = dataset_collection_elements
-        self.datasets_to_persist = None
         self.history = None
 
 

--- a/test/unit/jobs/test_job_context.py
+++ b/test/unit/jobs/test_job_context.py
@@ -81,6 +81,7 @@ def test_job_context_discover_outputs_flushes_once(mocker):
         final_job_state=job_context.final_job_state,
     )
     collection_builder.populate()
-    assert spy.call_count == 1
+    assert spy.call_count == 0
+    sa_session.flush()
     assert len(collection.dataset_instances) == 10
     assert collection.dataset_instances[0].dataset.file_size == 1

--- a/test/unit/tools/test_actions.py
+++ b/test/unit/tools/test_actions.py
@@ -134,7 +134,7 @@ class DefaultToolActionTestCase(unittest.TestCase, tools_support.UsesApp, tools_
         if incoming is None:
             incoming = dict(param1="moo")
         self._init_tool(contents)
-        job, out_data, _, _ = self.action.execute(
+        job, out_data, _, = self.action.execute(
             tool=self.tool,
             trans=self.trans,
             history=self.history,


### PR DESCRIPTION
For a collection of 1000 text files:

Before:
```
*** PROFILER RESULTS ***
create (/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/tools.py:453)
function called 1 times

         60776745 function calls (59984285 primitive calls) in 59.550 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 2068 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.004    0.004   59.665   59.665 tools.py:453(create)
        1    0.000    0.000   59.656   59.656 tools.py:468(_create)
        1    0.000    0.000   56.251   56.251 __init__.py:1577(handle_input)
        1    0.000    0.000   56.236   56.236 execute.py:29(execute)
        1    0.000    0.000   50.151   50.151 execute.py:49(execute_single_job)
        1    0.000    0.000   50.138   50.138 __init__.py:1631(handle_single_execution)
        1    0.002    0.002   50.138   50.138 __init__.py:1725(execute)
        1    0.000    0.000   50.135   50.135 model_operations.py:25(execute)
        1    0.002    0.002   40.479   40.479 model_operations.py:73(_produce_outputs)
        1    0.000    0.000   40.476   40.476 __init__.py:3156(produce_outputs)
     3014    0.007    0.000   36.452    0.012 scoping.py:162(do)
     1008    0.049    0.000   34.890    0.035 session.py:2489(flush)
     1005    0.034    0.000   34.825    0.035 session.py:2542(_flush)
        1    0.001    0.001   30.724   30.724 collections.py:487(apply_rules)
        1    0.008    0.008   30.716   30.716 collections.py:500(_build_elements_from_rule_data)
     1000    0.008    0.000   30.708    0.031 __init__.py:3161(copy_dataset)
     1000    0.007    0.000   27.115    0.027 tags.py:61(set_tags_from_list)
186191/167181    0.169    0.000   23.861    0.000 attributes.py:699(get)
221127/211125    0.147    0.000   22.083    0.000 attributes.py:279(__get__)
     1007    0.011    0.000   19.813    0.020 session.py:501(commit)
     1007    2.182    0.002   19.284    0.019 session.py:386(_remove_snapshot)
    10007    0.022    0.000   18.620    0.002 loading.py:190(load_on_ident)
    10007    0.071    0.000   18.598    0.002 loading.py:211(load_on_pk_identity)
    10009    0.009    0.000   18.494    0.002 query.py:3417(one)
    10009    0.206    0.000   18.485    0.002 query.py:3381(one_or_none)
    28036    0.041    0.000   18.255    0.001 base.py:952(execute)
    28036    0.033    0.000   18.204    0.001 elements.py:296(_execute_on_connection)
    28036    0.163    0.000   18.171    0.001 base.py:1088(_execute_clauseelement)
    22017    0.073    0.000   16.509    0.001 query.py:3501(_execute_and_instances)
  2528561    5.820    0.000   15.965    0.000 state.py:567(_expire)
    10010    0.016    0.000   14.692    0.001 query.py:3476(__iter__)
    30034    0.097    0.000   14.578    0.000 strategies.py:665(_load_for_state)
    12007    0.025    0.000   12.657    0.001 <string>:1(<lambda>)
    12007    0.131    0.000   12.631    0.001 strategies.py:772(_emit_lazyload)
    28036    0.230    0.000   12.237    0.000 base.py:1195(_execute_context)
    57983    0.035    0.000   11.129    0.000 state.py:640(_load_expired)
     6007    0.041    0.000   11.050    0.002 loading.py:938(load_scalar_attributes)
2580931/2571931    1.237    0.000   10.786    0.000 attr.py:257(__call__)
        2    0.002    0.001   10.727    5.363 __init__.py:246(_collect_inputs)
        5    0.000    0.000    9.337    1.867 __init__.py:21(visit_input_values)
```

After:
```
*** PROFILER RESULTS ***
create (/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/tools.py:453)
function called 1 times

         9961471 function calls (9835656 primitive calls) in 12.098 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 2082 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.005    0.005   12.148   12.148 tools.py:453(create)
        1    0.000    0.000   12.139   12.139 tools.py:468(_create)
        1    0.000    0.000    9.259    9.259 __init__.py:1576(handle_input)
        1    0.002    0.002    9.240    9.240 execute.py:29(execute)
153131/153128    0.083    0.000    7.009    0.000 attributes.py:279(__get__)
120174/109167    0.091    0.000    6.996    0.000 attributes.py:699(get)
        3    0.017    0.006    6.286    2.095 session.py:2489(flush)
        2    0.007    0.004    6.261    3.131 session.py:2542(_flush)
    13031    0.018    0.000    5.376    0.000 base.py:952(execute)
    13031    0.014    0.000    5.356    0.000 elements.py:296(_execute_on_connection)
    13031    0.066    0.000    5.342    0.000 base.py:1088(_execute_clauseelement)
    13031    0.098    0.000    4.451    0.000 base.py:1195(_execute_context)
     8016    0.024    0.000    3.719    0.000 query.py:3501(_execute_and_instances)
    22032    0.043    0.000    3.700    0.000 strategies.py:665(_load_for_state)
     5005    0.008    0.000    3.574    0.001 <string>:1(<lambda>)
     5005    0.044    0.000    3.566    0.001 strategies.py:772(_emit_lazyload)
        7    0.000    0.000    3.405    0.486 scoping.py:162(do)
        2    0.001    0.001    3.323    1.662 unitofwork.py:402(execute)
        1    0.000    0.000    3.017    3.017 __init__.py:1773(add_pending_datasets)
        1    0.000    0.000    3.017    3.017 __init__.py:1824(add_datasets)
     3006    0.005    0.000    3.010    0.001 loading.py:190(load_on_ident)
     3006    0.018    0.000    3.005    0.001 loading.py:211(load_on_pk_identity)
     3008    0.003    0.000    2.992    0.001 query.py:3417(one)
     3008    0.038    0.000    2.990    0.001 query.py:3381(one_or_none)
    13029    0.008    0.000    2.978    0.000 default.py:589(do_execute)
    13029    2.887    0.000    2.970    0.000 {method 'execute' of 'psycopg2.extensions.cursor' objects}
        1    0.002    0.002    2.967    2.967 __init__.py:1844(__add_datasets_optimized)
        1    0.000    0.000    2.917    2.917 mapping.py:2811(db_next_hid)
      3/2    0.000    0.000    2.905    1.452 session.py:899(begin)
      3/2    0.000    0.000    2.905    1.452 session.py:221(__init__)
      3/2    0.000    0.000    2.905    1.452 session.py:338(_take_snapshot)
        1    0.000    0.000    2.870    2.870 collections_util.py:106(dictify_dataset_collection_instance)
42595/36595    0.012    0.000    2.785    0.000 attr.py:257(__call__)
        1    0.001    0.001    2.774    2.774 collections_util.py:128(<listcomp>)
     1000    0.004    0.000    2.773    0.003 collections_util.py:168(dictify_element)
        2    0.002    0.001    2.763    1.382 base.py:59(before_flush)
     2000    0.055    0.000    2.758    0.001 __init__.py:3144(__create_version__)
       22    0.004    0.000    2.298    0.104 persistence.py:184(save_obj)
     3011    0.005    0.000    2.262    0.001 query.py:3476(__iter__)
        1    0.000    0.000    2.149    2.149 execute.py:49(execute_single_job)
```

The larger the collection the more significant the speedup.