### PR TITLE
[20.09] Don't flush for each individual collection element when copying colle…

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4416,6 +4416,7 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         collection_copy = self.collection.copy(
             destination=hdca,
             element_destination=element_destination,
+            flush=False,
         )
         hdca.collection = collection_copy
         object_session(self).add(hdca)


### PR DESCRIPTION
…ctions

This is a minor change, but should result in in large speedups the bigger the collection to copy is (if we don't need the HDA id to copy the metadata file, but I think we can work around that as well.).