### PR TITLE
Move Selenium to GitHub Actions

### DIFF
--- a/.ci/run_selenium.sh
+++ b/.ci/run_selenium.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Prepare
+python -m venv .venv
+
+source ".venv/bin/activate" # activate virtualenv
+pip install -r lib/galaxy/dependencies/dev-requirements.txt -r requirements.txt  &> /dev/null
+python test/manual/test_parser.py

--- a/.github/workflows/start-selenium-job.yaml
+++ b/.github/workflows/start-selenium-job.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
-      
+
     name: ${{ matrix.project }}
     steps:
       - name: Checkout code

--- a/.github/workflows/start-selenium-job.yaml
+++ b/.github/workflows/start-selenium-job.yaml
@@ -1,0 +1,60 @@
+name: Selenium Runner
+
+# Run this workflow every time a new commit pushed to your repository
+on: push
+
+jobs:
+  prepare:
+    name: Selenium Run
+    runs-on: ubuntu-20.04
+    strategy:
+          matrix:
+            python-version: [3.8]
+    outputs:
+      matrix: ${{ steps.prepare-tests.outputs.matrix }}
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+            galaxy/.venv/
+          key: ${{ runner.os }}-selenium
+
+      - id: prepare-tests
+        run: |
+          TEST_VAR=$(source .ci/run_selenium.sh)
+          VAR={\"include\":$(echo $TEST_VAR)}
+          echo $VAR
+          echo "::set-output name=matrix::$(echo $VAR)"
+
+  run-selenium-tests:
+    runs-on: ubuntu-20.04
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
+      
+    name: ${{ matrix.project }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Cache multiple paths
+        uses: actions/cache@v2
+        with:
+          path: |
+            galaxy/.venv/
+          key: ${{ runner.os }}-selenium
+
+      - name: run
+        run: |
+          echo "${{ matrix.test_path }}"
+          ./run_tests.sh -selenium ${{ matrix.test_path }}

--- a/test/manual/test_parser.py
+++ b/test/manual/test_parser.py
@@ -1,0 +1,57 @@
+import ast
+from os import listdir
+from os.path import isfile, join
+import pytest
+from io import StringIO
+import sys
+import json
+
+galaxy_root_dir = "./"
+selenium_test_dir = "lib/galaxy_test/selenium/"
+
+test_root_dir = galaxy_root_dir + selenium_test_dir
+
+
+# https://stackoverflow.com/a/44699395/4870846
+def is_admin(filename):
+    with open(filename) as file:
+        node = ast.parse(file.read())
+
+    classes = [n for n in node.body if isinstance(n, ast.ClassDef)]
+    for class_ in classes:
+        asssings = [n for n in class_.body if isinstance(n, ast.Assign)]
+        for var in asssings:
+            for target in var.targets:
+                if target.id == "requires_admin" and var.value.value == True:
+                    return True
+        return False
+
+
+def get_individual_tests(test_file_path):
+    old_stdout = sys.stdout
+    sys.stdout = mystdout = StringIO()
+
+    pytest.main(["--co", "-q", "--disable-pytest-warnings", test_file_path])
+
+    sys.stdout = old_stdout
+
+    current_available_tests = []
+    for line in mystdout.getvalue().splitlines():
+        if selenium_test_dir in line:
+            parts = line.split("::")
+            test_name = f'{parts[1]}.{parts[2]}'
+            test_path = f'{parts[0]}:{test_name}'
+
+            current_available_tests.append({"project": test_name, "test_path": test_path})
+
+    return current_available_tests
+
+
+test_files = [f for f in listdir(test_root_dir) if isfile(join(test_root_dir, f)) and f.startswith("test_")]
+
+selenium_tests = []
+for test_file in test_files:
+    path = test_root_dir + test_file
+    if not is_admin(path):
+        selenium_tests += get_individual_tests(path)
+print(json.dumps(selenium_tests))

--- a/test/manual/test_parser.py
+++ b/test/manual/test_parser.py
@@ -22,7 +22,7 @@ def is_admin(filename):
         asssings = [n for n in class_.body if isinstance(n, ast.Assign)]
         for var in asssings:
             for target in var.targets:
-                if target.id == "requires_admin" and var.value.value == True:
+                if target.id == "requires_admin" and var.value.value is True:
                     return True
         return False
 
@@ -52,6 +52,6 @@ test_files = [f for f in listdir(test_root_dir) if isfile(join(test_root_dir, f)
 selenium_tests = []
 for test_file in test_files:
     path = test_root_dir + test_file
-    if not is_admin(path):
-        selenium_tests += get_individual_tests(path)
+    # if not is_admin(path):
+    selenium_tests += get_individual_tests(path)
 print(json.dumps(selenium_tests))


### PR DESCRIPTION
It's pretty much an experimental PR and still a proof of concept. We dynamically create a separate job for each test and run them in parallel (github allows 20 parallel jobs at a time) 
Most probably there is a much better/less hacky way to derive list of  tests than my `test_parser.py`, if so please let me know. 
After it is done, we can harvest screenshots and upload them as artifacts (github stores it for 3 months). 
We will improve the performance dramatically, if we skip client build in every job (will add caching later)