### PR TITLE
[20.09] Fix - allow working around tool tests we expect to fail.

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -824,6 +824,39 @@ def _verify_extra_files_content(extra_files, hda_id, dataset_fetcher, test_data_
             shutil.rmtree(path)
 
 
+class NullClientTestConfig:
+
+    def get_test_config(self, job_data):
+        return None
+
+
+class DictClientTestConfig:
+
+    def __init__(self, tools):
+        self._tools = tools or {}
+
+    def get_test_config(self, job_data):
+        # TODO: allow short ids, allow versions below outer id instead of key concatenation.
+        tool_id = job_data.get("tool_id")
+        tool_test_config = None
+        if tool_id in self._tools:
+            tool_test_config = self._tools[tool_id]
+        if tool_test_config is None:
+            tool_version = job_data.get("tool_version")
+            tool_id = "%s/%s" % (tool_id, tool_version)
+            if tool_id in self._tools:
+                tool_test_config = self._tools[tool_id]
+        if tool_test_config:
+            test_index = job_data.get("test_index")
+            if test_index in tool_test_config:
+                return tool_test_config[test_index]
+            elif str(test_index) in tool_test_config:
+                return tool_test_config[str(test_index)]
+            if 'default' in tool_test_config:
+                return tool_test_config['default']
+        return None
+
+
 def verify_tool(tool_id,
                 galaxy_interactor,
                 resource_parameters=None,
@@ -835,15 +868,35 @@ def verify_tool(tool_id,
                 force_path_paste=False,
                 maxseconds=DEFAULT_TOOL_TEST_WAIT,
                 tool_test_dicts=None,
+                client_test_config=None,
                 skip_on_dynamic_param_errors=False):
     if resource_parameters is None:
         resource_parameters = {}
+    if client_test_config is None:
+        client_test_config = NullClientTestConfig()
     tool_test_dicts = tool_test_dicts or galaxy_interactor.get_tool_tests(tool_id, tool_version=tool_version)
     tool_test_dict = tool_test_dicts[test_index]
     if "test_index" not in tool_test_dict:
         tool_test_dict["test_index"] = test_index
     if "tool_id" not in tool_test_dict:
         tool_test_dict["tool_id"] = tool_id
+    if tool_version is None and "tool_version" in tool_test_dict:
+        tool_version = tool_test_dict.get("tool_version")
+
+    job_data = {
+        "tool_id": tool_id,
+        "tool_version": tool_version,
+        "test_index": test_index,
+    }
+    client_config = client_test_config.get_test_config(job_data)
+    if client_config is not None:
+        job_data.update(client_config)
+        skip_message = job_data.get("skip")
+        if skip_message:
+            job_data["status"] = "skip"
+            register_job_data(job_data)
+            return
+
     tool_test_dict.setdefault('maxseconds', maxseconds)
     testdef = ToolTestDescription(tool_test_dict)
     _handle_def_errors(testdef)
@@ -898,12 +951,7 @@ def verify_tool(tool_id,
     finally:
         if register_job_data is not None:
             end_time = time.time()
-            job_data = {
-                "tool_id": tool_id,
-                "tool_version": tool_version,
-                "test_index": test_index,
-                "time_seconds": end_time - begin_time,
-            }
+            job_data["time_seconds"] = end_time - begin_time
             if tool_inputs is not None:
                 job_data["inputs"] = tool_inputs
             if job_stdio is not None:
@@ -1107,6 +1155,7 @@ class ToolTestDescription:
         self.test_index = test_index
         assert "tool_id" in processed_test_dict, "Invalid processed test description, must have a 'tool_id' for naming, etc.."
         self.tool_id = processed_test_dict["tool_id"]
+        self.tool_version = processed_test_dict.get("tool_version")
         self.name = name
         self.maxseconds = maxseconds
         self.required_files = processed_test_dict.get("required_files", [])
@@ -1162,6 +1211,7 @@ class ToolTestDescription:
             "name": self.name,
             "test_index": self.test_index,
             "tool_id": self.tool_id,
+            "tool_version": self.tool_version,
             "required_files": self.required_files,
             "error": self.error,
             "exception": self.exception,

--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -6,7 +6,8 @@ import sys
 
 import yaml
 
-from .interactor import (
+from galaxy.tool_util.verify.interactor import (
+    DictClientTestConfig,
     GalaxyInteractorApi,
     verify_tool,
 )
@@ -24,6 +25,8 @@ def main(argv=None):
     if client_test_config_path is not None:
         with open(client_test_config_path, "r") as f:
             client_test_config = yaml.full_load(f)
+    else:
+        client_test_config = {}
 
     def get_option(key):
         arg_val = getattr(args, key, None)
@@ -42,6 +45,7 @@ def main(argv=None):
     }
     tool_id = args.tool_id
     tool_version = args.tool_version
+    tools_client_test_config = DictClientTestConfig(client_test_config.get("tools"))
 
     galaxy_interactor = GalaxyInteractorApi(**galaxy_interactor_kwds)
     raw_test_index = args.test_index
@@ -79,7 +83,8 @@ def main(argv=None):
         try:
             verify_tool(
                 tool_id, galaxy_interactor, test_index=test_index, tool_version=tool_version,
-                register_job_data=register, quiet=not verbose, force_path_paste=args.force_path_paste
+                register_job_data=register, quiet=not verbose, force_path_paste=args.force_path_paste,
+                client_test_config=tools_client_test_config,
             )
 
             if verbose:

--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -4,6 +4,8 @@ import argparse
 import json
 import sys
 
+import yaml
+
 from .interactor import (
     GalaxyInteractorApi,
     verify_tool,
@@ -18,10 +20,24 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     args = _arg_parser().parse_args(argv)
+    client_test_config_path = args.client_test_config
+    if client_test_config_path is not None:
+        with open(client_test_config_path, "r") as f:
+            client_test_config = yaml.full_load(f)
+
+    def get_option(key):
+        arg_val = getattr(args, key, None)
+        if arg_val is None and key in client_test_config:
+            val = client_test_config.get(key)
+        else:
+            val = arg_val
+        return val
+
+    output_json_path = get_option("output_json")
     galaxy_interactor_kwds = {
-        "galaxy_url": args.galaxy_url,
-        "master_api_key": args.admin_key,
-        "api_key": args.key,
+        "galaxy_url": get_option("galaxy_url"),
+        "master_api_key": get_option("admin_key"),
+        "api_key": get_option("key"),
         "keep_outputs_dir": args.output,
     }
     tool_id = args.tool_id
@@ -38,7 +54,8 @@ def main(argv=None):
     test_results = []
 
     if args.append:
-        with open(args.output_json) as f:
+        assert output_json_path != "-"
+        with open(output_json_path) as f:
             previous_results = json.load(f)
             test_results = previous_results["tests"]
 
@@ -77,13 +94,11 @@ def main(argv=None):
         'version': '0.1',
         'tests': test_results,
     }
-    output_json = args.output_json
-    if output_json:
-        if args.output_json == "-":
-            assert not args.append
+    if output_json_path:
+        if output_json_path == "-":
             print(json.dumps(report_obj))
         else:
-            with open(args.output_json, "w") as f:
+            with open(output_json_path, "w") as f:
                 json.dump(report_obj, f)
 
     if exceptions:
@@ -103,6 +118,7 @@ def _arg_parser():
     parser.add_argument('--append', default=False, action="store_true", help="Extend a test record json (created with --output-json) with additional tests.")
     parser.add_argument('-j', '--output-json', default=None, help='output metadata json')
     parser.add_argument('--verbose', default=False, action="store_true", help="Verbose logging.")
+    parser.add_argument('-c', '--client-test-config', default=None, help="Test config YAML to help with client testing")
     return parser
 
 

--- a/lib/galaxy/tool_util/verify/test_config.sample.yml
+++ b/lib/galaxy/tool_util/verify/test_config.sample.yml
@@ -1,0 +1,25 @@
+# Set Galaxy URL to test (command-line overrides this).
+galaxy_url: http://localhost:8080
+
+# User API key to test with.
+#key:
+
+# Admin API key to test with.
+#admin_key:
+
+# Path to accumulate output metadata into.
+#output_json:
+
+# Allow skipping tools and annotating test reports with notes and other metadata.
+tools:
+  'tool_id_0':
+    2:  # test index based at 0
+      skip: 'This test will never work on our servers.'
+  'tool_id_1/version':
+    0:
+      note: 'Add this note to the final report - maybe indicate flakey test or test important to check.'
+    1:
+      note: 'Or maybe note issue being tracked - fix open at https://github.com/bgruening/galaxytools/pull/1041'
+  'tool_id_2':
+    default:
+      skip: 'skip all tests for this tool+version'

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -56,6 +56,7 @@ def description_from_tool_object(tool, test_index, raw_test_dict):
             "expect_failure": raw_test_dict.get("expect_failure", False),
             "required_files": required_files,
             "tool_id": tool.id,
+            "tool_version": tool.version,
             "test_index": test_index,
             "error": False,
         }
@@ -63,6 +64,7 @@ def description_from_tool_object(tool, test_index, raw_test_dict):
         log.exception("Failed to load tool test number [%d] for %s" % (test_index, tool.id))
         processed_test_dict = {
             "tool_id": tool.id,
+            "tool_version": tool.version,
             "test_index": test_index,
             "inputs": {},
             "error": True,

--- a/packages/tool_util/MANIFEST.in
+++ b/packages/tool_util/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.rst *.txt LICENSE
 include galaxy/tool_util/deps/mulled/invfile.lua
 include galaxy/tool_util/deps/resolvers/default_conda_mapping.yml
+include galaxy/tool_util/verify/test_config.sample.yml
 include galaxy/tool_util/xsd/*


### PR DESCRIPTION
- Create a YAML file for specifying tool test options.
- Allow skipping tests with a message in that file.
- Allow annotating other metadata about tests (issues/PRs tracked, notes for collaborators, etc..).

Idea would be to check this file into a version control and track the effort of getting tool sets working on a server -or- architecture. I looked at @almahmoud's list of failing AnVIL tests and the first thing I noticed is a set of tests that I knew indicated the tool was working even though one test passed.

If we like the syntax and this gets merged, I'll open a Planemo PR to add display of this metadata to the generated reports.
