### PR TITLE
Improve performance of copying HDAs and HDCAs

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -302,6 +302,7 @@ class DatasetCollectionManager:
         if copy_elements:
             copy_kwds["element_destination"] = parent
         new_hdca = source_hdca.copy(**copy_kwds)
+        new_hdca.copy_tags_from(target_user=trans.get_user(), source=source_hdca)
         if not copy_elements:
             parent.add_dataset_collection(new_hdca)
         trans.sa_session.flush()

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -302,10 +302,8 @@ class DatasetCollectionManager:
         if copy_elements:
             copy_kwds["element_destination"] = parent
         new_hdca = source_hdca.copy(**copy_kwds)
-        tags_str = self.tag_handler.get_tags_str(source_hdca.tags)
-        self.tag_handler.apply_item_tags(trans.get_user(), new_hdca, tags_str)
-        parent.add_dataset_collection(new_hdca)
-        trans.sa_session.add(new_hdca)
+        if not copy_elements:
+            parent.add_dataset_collection(new_hdca)
         trans.sa_session.flush()
         return new_hdca
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4470,6 +4470,7 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         collection_copy = self.collection.copy(
             destination=hdca,
             element_destination=element_destination,
+            flush=False,
         )
         hdca.collection = collection_copy
         object_session(self).add(hdca)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1779,7 +1779,7 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
     def empty(self):
         return self.hid_counter == 1
 
-    def add_pending_datasets(self, set_output_hid=True):
+    def add_pending_items(self, set_output_hid=True):
         # These are assumed to be either copies of existing datasets or new, empty datasets,
         # so we don't need to set the quota.
         self.add_datasets(object_session(self), self._pending_additions, set_hid=set_output_hid, quota=False, flush=False)
@@ -4478,7 +4478,7 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
         hdca.copy_tags_from(self.history.user, self)
         if element_destination:
             element_destination.stage_addition(hdca)
-            element_destination.add_pending_datasets()
+            element_destination.add_pending_items()
         else:
             object_session(self).flush()
         return hdca

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -527,7 +527,10 @@ class FileParameter(MetadataParameter):
             return None
         if isinstance(value, galaxy.model.MetadataFile) or isinstance(value, MetadataTempFile):
             return value
-        return session.query(galaxy.model.MetadataFile).get(value)
+        if isinstance(value, int):
+            return session.query(galaxy.model.MetadataFile).get(value)
+        else:
+            return session.query(galaxy.model.MetadataFile).filter_by(uuid=value).one()
 
     def make_copy(self, value, target_context, source_context):
         value = self.wrap(value, object_session(target_context.parent))
@@ -538,8 +541,11 @@ class FileParameter(MetadataParameter):
             # so this would ultimately get overwritten anyway.
             new_value = galaxy.model.MetadataFile(dataset=target_context.parent, name=self.spec.name)
             object_session(target_context.parent).add(new_value)
-            object_session(target_context.parent).flush()
-            shutil.copy(value.file_name, new_value.file_name)
+            try:
+                shutil.copy(value.file_name, new_value.file_name)
+            except AssertionError:
+                object_session(target_context.parent).flush()
+                shutil.copy(value.file_name, new_value.file_name)
             return self.unwrap(new_value)
         return None
 
@@ -550,6 +556,8 @@ class FileParameter(MetadataParameter):
             # as in extended_metadata mode, so there we just accept MetadataFile.
             # We will only serialize MetadataFile in this mode and not push to the database, so this is OK.
             value = value.id or value
+            if not isinstance(value, int) and object_session(value):
+                value = str(value.uuid)
         return value
 
     def from_external_value(self, value, parent, path_rewriter=None):

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -554,7 +554,7 @@ class DefaultToolAction:
         if app.config.track_jobs_in_database and rerun_remap_job_id is not None:
             # We need a flush here and get hids in order to rewrite jobs parameter,
             # but remapping jobs should only affect single jobs anyway, so this is not too costly.
-            history.add_pending_datasets(set_output_hid=set_output_hid)
+            history.add_pending_items(set_output_hid=set_output_hid)
             trans.sa_session.flush()
             self._remap_job_on_rerun(trans=trans,
                                      galaxy_session=galaxy_session,
@@ -586,7 +586,7 @@ class DefaultToolAction:
         else:
             if flush_job:
                 # Set HID and add to history.
-                history.add_pending_datasets(set_output_hid=set_output_hid)
+                history.add_pending_items(set_output_hid=set_output_hid)
                 job_flush_timer = ExecutionTimer()
                 trans.sa_session.flush()
                 log.info(f"Flushed transaction for job {job.log_str()} {job_flush_timer}")

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -103,7 +103,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
 
     if execution_slice:
         # a side effect of adding datasets to a history is a commit within db_next_hid (even with flush=False).
-        history.add_pending_datasets()
+        history.add_pending_items()
     else:
         # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
         trans.sa_session.flush()

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -1029,20 +1029,17 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                     else:
                         for hist in target_histories:
                             if content.history_content_type == "dataset":
-                                copy = content.copy()
-                                hist.add_dataset(copy)
+                                copy = content.copy(flush=False)
+                                hist.stage_addition(copy)
                             else:
-                                copy_collected_datasets = True
-                                copy_kwds = {}
-                                if copy_collected_datasets:
-                                    copy_kwds["element_destination"] = hist
-                                copy = content.copy(**copy_kwds)
-                                hist.add_dataset_collection(copy)
+                                copy = content.copy(element_destination=hist)
                             if user:
                                 copy.copy_tags_from(user, content)
+                        for hist in target_histories:
+                            hist.add_pending_datasets()
+                trans.sa_session.flush()
                 if current_history in target_histories:
                     refresh_frames = ['history']
-                trans.sa_session.flush()
                 hist_names_str = ", ".join('<a href="%s" target="_top">%s</a>' %
                                            (url_for(controller="history", action="switch_to_history",
                                                     hist_id=trans.security.encode_id(hist.id)), escape(hist.name))

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -1036,7 +1036,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                             if user:
                                 copy.copy_tags_from(user, content)
                         for hist in target_histories:
-                            hist.add_pending_datasets()
+                            hist.add_pending_items()
                 trans.sa_session.flush()
                 if current_history in target_histories:
                     refresh_frames = ['history']

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -477,7 +477,7 @@ def test_export_copied_collection():
     sa_session.flush()
 
     hc2 = hc1.copy(element_destination=h)
-    h.add_dataset_collection(hc2)
+    h.add_pending_datasets()
     assert h.hid_counter == 7
 
     sa_session.add(hc2)
@@ -513,7 +513,6 @@ def test_export_copied_objects_copied_outside_history():
     sa_session.flush()
 
     hc2 = hc1.copy(element_destination=h)
-    h.add_dataset_collection(hc2)
 
     sa_session.add(hc2)
 
@@ -521,13 +520,11 @@ def test_export_copied_objects_copied_outside_history():
     sa_session.add(other_h)
 
     hc3 = hc2.copy(element_destination=other_h)
-    other_h.add_dataset_collection(hc3)
-    sa_session.add(hc3)
-    sa_session.flush()
+    other_h.add_pending_datasets()
 
     hc4 = hc3.copy(element_destination=h)
-    h.add_dataset_collection(hc4)
     sa_session.add(hc4)
+    h.add_pending_datasets()
     sa_session.flush()
 
     assert h.hid_counter == 10

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -477,7 +477,7 @@ def test_export_copied_collection():
     sa_session.flush()
 
     hc2 = hc1.copy(element_destination=h)
-    h.add_pending_datasets()
+    h.add_pending_items()
     assert h.hid_counter == 7
 
     sa_session.add(hc2)
@@ -520,11 +520,11 @@ def test_export_copied_objects_copied_outside_history():
     sa_session.add(other_h)
 
     hc3 = hc2.copy(element_destination=other_h)
-    other_h.add_pending_datasets()
+    other_h.add_pending_items()
 
     hc4 = hc3.copy(element_destination=h)
     sa_session.add(hc4)
-    h.add_pending_datasets()
+    h.add_pending_items()
     sa_session.flush()
 
     assert h.hid_counter == 10


### PR DESCRIPTION
This builds on #10543. The most important idea is to eliminate flushes and commits (both of which require refreshing attributes from the database due to our use of `expire_on_commit`) for collection elements. The speedup is about 2 fold for 10 elements, 2.5 fold for 100 elements and 25 fold for 1000 elements.
The 2 core changes are :
- referencing `MetadataFile` objects by uuid when copying them, which means we don't need to flush before making the HDA <-> Metadata association. Note that that requires `store_by: uuid` to be able to construct the path to the new MetadataFile object.
- Adding new datasets and collections to the containing history in one batch.

Before:
```
*** PROFILER RESULTS ***
create (/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/history_contents.py:319)
function called 1 times

         312836458 function calls (306888451 primitive calls) in 281.464 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 1400 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.003    0.003  281.553  281.553 decorators.py:240(decorator)
        1    0.004    0.004  281.526  281.526 history_contents.py:319(create)
        1    0.000    0.000  281.515  281.515 history_contents.py:480(__create_dataset_collection)
        1    0.000    0.000  278.277  278.277 collections.py:294(copy)
        1    0.000    0.000  278.258  278.258 __init__.py:4409(copy)
        1    0.003    0.003  278.249  278.249 __init__.py:4159(copy)
     1000    0.014    0.000  277.791    0.278 __init__.py:4585(copy_to_collection)
     1000    0.018    0.000  208.748    0.209 __init__.py:1782(add_dataset)
284748/284746    0.155    0.000  192.031    0.001 attributes.py:279(__get__)
137583/122557    0.133    0.000  191.968    0.002 attributes.py:699(get)
    23032    0.086    0.000  183.646    0.008 strategies.py:665(_load_for_state)
     1000    0.011    0.000  177.264    0.177 __init__.py:3288(quota_amount)
     6025    0.012    0.000  175.134    0.029 <string>:1(<lambda>)
     6025    0.064    0.000  175.123    0.029 strategies.py:772(_emit_lazyload)
d d5a854b304 Minor optimization
     3005    1.980    0.001  172.050    0.057 baked.py:539(all)
  4369561    0.541    0.000  160.889    0.000 loading.py:35(instances)
    15033    1.722    0.000  134.289    0.009 loading.py:81(<listcomp>)
8695029/4354528   33.690    0.000  132.567    0.000 loading.py:509(_instance)
     3004    0.077    0.000   79.370    0.026 session.py:2489(flush)
     3003    0.062    0.000   79.274    0.026 session.py:2542(_flush)
     3004    0.034    0.000   73.549    0.024 session.py:501(commit)
     3004   11.587    0.004   71.736    0.024 session.py:386(_remove_snapshot)
     1000    0.019    0.000   63.832    0.064 __init__.py:3156(copy)
3853029/3853027   20.183    0.000   62.052    0.000 loading.py:710(_populate_full)
  8362541   18.449    0.000   51.592    0.000 state.py:567(_expire)
  4340501    3.626    0.000   45.183    0.000 strategies.py:2052(load_scalar_from_joined_new_row)
  9188501   17.616    0.000   35.373    0.000 state.py:677(unloaded)
     1001    0.034    0.000   28.452    0.028 mapping.py:2811(db_next_hid)
    23036    0.034    0.000   27.267    0.001 base.py:952(execute)
    23036    0.026    0.000   27.226    0.001 elements.py:296(_execute_on_connection)
    23036    0.137    0.000   27.199    0.001 base.py:1088(_execute_clauseelement)
  4351509    2.804    0.000   24.650    0.000 attr.py:316(__call__)
    23036    0.217    0.000   23.478    0.001 base.py:1195(_execute_context)
    15033    0.051    0.000   22.942    0.002 query.py:3501(_execute_and_instances)
    15033    0.047    0.000   22.008    0.001 result.py:1268(fetchall)
  4346501    4.299    0.000   21.838    0.000 custom_types.py:143(load)
    23036    0.020    0.000   20.225    0.001 default.py:589(do_execute)
    23036   19.985    0.001   20.206    0.001 {method 'execute' of 'psycopg2.extensions.cursor' objects}
8419603/8410606    3.893    0.000   19.207    0.000 attr.py:257(__call__)
    15033    0.087    0.000   18.648    0.001 result.py:1228(_fetchall_impl)
```

After:
```
*** PROFILER RESULTS ***
create (/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/history_contents.py:319)
function called 2 times

         12207614 function calls (11589074 primitive calls) in 11.322 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 1454 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        2    0.003    0.002   11.349    5.675 decorators.py:240(decorator)
        2    0.004    0.002   11.324    5.662 history_contents.py:319(create)
        2    0.000    0.000   11.310    5.655 history_contents.py:480(__create_dataset_collection)
        1    0.000    0.000    8.016    8.016 collections.py:294(copy)
218392/218389    0.096    0.000    7.095    0.000 attributes.py:279(__get__)
96298/86262    0.072    0.000    7.059    0.000 attributes.py:699(get)
        1    0.000    0.000    4.982    4.982 __init__.py:4440(copy)
     9064    0.012    0.000    4.923    0.001 base.py:952(execute)
     9064    0.009    0.000    4.908    0.001 elements.py:296(_execute_on_connection)
     9064    0.047    0.000    4.899    0.001 base.py:1088(_execute_clauseelement)
        7    0.011    0.002    4.445    0.635 session.py:2489(flush)
        7    0.005    0.001    4.430    0.633 session.py:2542(_flush)
     9064    0.075    0.000    4.061    0.000 base.py:1195(_execute_context)
        1    0.001    0.001    3.502    3.502 __init__.py:4189(copy)
     1000    0.006    0.000    3.458    0.003 __init__.py:4624(copy_to_collection)
    18056    0.040    0.000    3.434    0.000 strategies.py:665(_load_for_state)
     6047    0.018    0.000    3.430    0.001 query.py:3501(_execute_and_instances)
     3018    0.006    0.000    3.407    0.001 loading.py:190(load_on_ident)
     3019    0.018    0.000    3.403    0.001 loading.py:211(load_on_pk_identity)
     3023    0.002    0.000    3.382    0.001 query.py:3417(one)
     3023    0.039    0.000    3.379    0.001 query.py:3381(one_or_none)
     3023    0.005    0.000    3.295    0.001 <string>:1(<lambda>)
     3023    0.024    0.000    3.290    0.001 strategies.py:772(_emit_lazyload)
        2    0.000    0.000    3.192    1.596 history_contents.py:130(__collection_dict)
        2    0.000    0.000    3.185    1.593 collections_util.py:106(dictify_dataset_collection_instance)
       10    0.000    0.000    3.051    0.305 scoping.py:162(do)
        2    0.001    0.000    3.025    1.513 collections_util.py:128(<listcomp>)
     1001    0.004    0.000    3.025    0.003 collections_util.py:168(dictify_element)
     9063    0.007    0.000    2.673    0.000 default.py:589(do_execute)
     9063    2.580    0.000    2.666    0.000 {method 'execute' of 'psycopg2.extensions.cursor' objects}
     3002    0.003    0.000    2.625    0.001 __init__.py:4587(element_object)
    13620    0.054    0.000    2.509    0.000 loading.py:35(instances)
     2010    0.042    0.000    2.509    0.001 baked.py:557(_load_on_pk_identity)
        7    0.001    0.000    2.360    0.337 unitofwork.py:402(execute)
     3024    0.004    0.000    2.314    0.001 query.py:3476(__iter__)
24754/21745    0.007    0.000    1.962    0.000 attr.py:257(__call__)
        7    0.001    0.000    1.948    0.278 base.py:59(before_flush)
     1003    0.028    0.000    1.945    0.002 __init__.py:3139(__create_version__)
       35    0.002    0.000    1.933    0.055 persistence.py:184(save_obj)
     3005    0.010    0.000    1.886    0.001 __init__.py:2732(get_dbkey)
```