### PR TITLE
[20.01] Fix get_output_path when HDA identity changes

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1910,13 +1910,14 @@ class JobWrapper(HasResourceParameters):
         return self.output_paths
 
     def get_output_path(self, dataset):
+        if getattr(dataset, "fake_dataset_association", False):
+            return dataset.file_name
+        assert dataset.id is not None, "{} needs to be flushed to find output path".format(dataset)
         if self.output_paths is None:
             self.compute_outputs()
         for (hda, dataset_path) in self.output_hdas_and_paths.values():
-            if hda == dataset:
+            if hda.id == dataset.id:
                 return dataset_path
-        if getattr(dataset, "fake_dataset_association", False):
-            return dataset.file_name
         raise KeyError("Couldn't find job output for [%s] in [%s]" % (dataset, self.output_hdas_and_paths.values()))
 
     def get_mutable_output_fnames(self):


### PR DESCRIPTION
@RJMW  reported this on gitter:
```
galaxy.jobs.runners ERROR 2020-10-13 09:34:24,937 [p:23472,w:1,m:0] [SlurmRunner.monitor_thread] (442471) Failure preparing job
Traceback (most recent call last):
  File "lib/galaxy/jobs/runners/__init__.py", line 236, in prepare_job
    job_wrapper.prepare()
  File "lib/galaxy/jobs/__init__.py", line 1077, in prepare
    tool_evaluator.set_compute_environment(compute_environment, get_special=get_special)
  File "lib/galaxy/tools/evaluation.py", line 110, in set_compute_environment
    output_collections=out_collections,
  File "lib/galaxy/tools/evaluation.py", line 149, in build_param_dict
    self.__populate_output_dataset_wrappers(param_dict, output_datasets, job_working_directory)
  File "lib/galaxy/tools/evaluation.py", line 341, in __populate_output_dataset_wrappers
    param_dict[name] = DatasetFilenameWrapper(hda, compute_environment=self.compute_environment, io_type="output")
  File "lib/galaxy/tools/wrappers.py", line 289, in __init__
    path_rewrite = compute_environment and compute_environment.output_path_rewrite(dataset)
  File "lib/galaxy/jobs/__init__.py", line 2546, in output_path_rewrite
    dataset_path = self.job_wrapper.get_output_path(dataset)
  File "lib/galaxy/jobs/__init__.py", line 1912, in get_output_path
    raise KeyError("Couldn't find job output for [%s] in [%s]" % (dataset, self.output_hdas_and_paths.values()))
KeyError: "Couldn't find job output for [<galaxy.model.HistoryDatasetAssociation(714739) at 0x7f59c5d269b0>] in [dict_values([(<galaxy.model.HistoryDatasetAssociation(714739) at 0x7f5976dd5be0>, <galaxy.job_execution.datasets.DatasetPath object at 0x7f59783efc18>)])]"
```
The HDA with the id 714739 is present in the outputs, but the identity
is not the same. I don't know why that happened (~~maybe a flush?~~ not a flush as far as I can tell) but in
this case it should be safe to compare HDAs by database id.