### PR TITLE
[20.09] Make package names lowercase for mulled dependency resolving

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build_tool.py
@@ -15,9 +15,9 @@ from .mulled_build import (
     add_build_arguments,
     add_single_image_arguments,
     args_to_mull_targets_kwds,
-    build_target,
     mull_targets,
 )
+from .util import build_target
 
 
 def main(argv=None):

--- a/lib/galaxy/tool_util/deps/mulled/util.py
+++ b/lib/galaxy/tool_util/deps/mulled/util.py
@@ -83,7 +83,7 @@ def mulled_tags_for(namespace, image, tag_prefix=None, resolution_cache=None):
         # Following check is pretty expensive against biocontainers... don't even bother doing it
         # if can't cache the response.
         if not _namespace_has_repo_name(namespace, image, resolution_cache):
-            log.debug("skipping mulled_tags_for [%s] no repository" % image)
+            log.info("skipping mulled_tags_for [%s] no repository" % image)
             return []
 
     cache_key = "galaxy.tool_util.deps.container_resolvers.mulled.util:tag_cache"
@@ -158,7 +158,8 @@ def build_target(package_name, version=None, build=None, tag=None):
         assert build is None
         version, build = split_tag(tag)
 
-    return Target(package_name, version, build, package_name)
+    # conda package and quay image names are lowercase
+    return Target(package_name.lower(), version, build, package_name)
 
 
 def conda_build_target_str(target):


### PR DESCRIPTION
Fix `planemo test --biocontainers --no_dependency_resolution --no_conda_auto_init ~/tools-devteam/tools/sicer/` where the requirement

```xml
<requirement type="package" version="1.1">SICER</requirement>
```

was not being resolved by `CachedMulledDockerContainerResolver` since commit f0a55a3 , while on 20.05 is
correctly resolved to `quay.io/biocontainers/sicer:1.1--4` .