### PR TITLE
[20.09] Don't pass resources as job params when reading job config as a dict

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -467,7 +467,7 @@ class JobConfiguration(ConfiguresHandlers):
             if params is None:
                 params = {}
                 for key, value in tool.items():
-                    if key in ["environment", "handler", "id"]:
+                    if key in ["environment", "handler", "id", "resources"]:
                         continue
                     params[key] = value
                 tool["params"] = params

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -379,6 +379,7 @@ class AdvancedJobConfXmlParserTestCase(BaseJobConfXmlParserTestCase):
         assert self.job_config.tools["foo"][-1].params["source"] == "trackster"
         assert self.job_config.tools["longbar"][-1].destination == "dynamic"
         assert self.job_config.tools["longbar"][-1].resources == "all"
+        assert "resources" not in self.job_config.tools["longbar"][-1].params
 
     def test_handler_runner_plugins(self):
         self._with_advanced_config()


### PR DESCRIPTION
This basically prevented the use of resource params with handler/environment mappings since resources was set as a job param, meaning no JobToolConfiguration would match the tool being executed. Only applies to the YAML job config.