### PR TITLE
[20.09] Fix listing idps

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -56,6 +56,7 @@ class AuthnzManager:
             file (e.g., oidc_backends_config.xml).
         """
         self.app = app
+        self.allowed_idps = None
         self._parse_oidc_config(oidc_config_file)
         self._parse_oidc_backends_config(oidc_backends_config_file)
 


### PR DESCRIPTION
Fixes
```
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: Traceback (most recent call last):
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/error.py", line 153, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: app_iter = self.application(environ, sr_checker)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "/opt/galaxy/venv/lib64/python3.6/site-packages/paste/recursive.py", line 85, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.application(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/statsd.py", line 33, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: req = self.application(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "/opt/galaxy/venv/lib64/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.application(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/base.py", line 141, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.handle_request(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/base.py", line 220, in handle_request
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: body = method(trans, **kwargs)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/decorators.py", line 56, in call_and_format
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: rval = func(self, trans, *args, **kwargs)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/webapps/galaxy/controllers/authnz.py", line 135, in get_cilogon_idps
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: allowed_idps = trans.app.authnz_manager.get_allowed_idps()
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/authnz/managers.py", line 170, in get_allowed_idps
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.allowed_idps
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: AttributeError: 'AuthnzManager' object has no attribute 'allowed_idps'
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: The above exception was the direct cause of the following exception:
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: Traceback (most recent call last):
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/batch.py", line 80, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.application(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/request_id.py", line 15, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.app(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/xforwardedhost.py", line 23, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.app(environ, start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/translogger.py", line 70, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return self.application(environ, replacement_start_response)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/error.py", line 163, in __call__
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: exc_info)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: File "lib/galaxy/web/framework/middleware/translogger.py", line 69, in replacement_start_response
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: return start_response(status, headers, exc_info)
Oct 28 09:59:55 sn04.bi.uni-freiburg.de uwsgi[2381694]: SystemError: <built-in function uwsgi_spit> returned a result with
```