### PR TITLE
Galaxy schema rendering script

### DIFF
--- a/scripts/galaxy_schemadisp.py
+++ b/scripts/galaxy_schemadisp.py
@@ -1,0 +1,44 @@
+import os
+import sys
+from db_shell import *  # noqa
+
+gxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+sys.path.insert(1, os.path.abspath(os.path.join(gxy_root, 'lib')))
+
+from galaxy import model
+from sqlalchemy import MetaData
+from sqlalchemy.orm import class_mapper
+from sqlalchemy_schemadisplay import create_schema_graph, create_uml_graph
+
+if __name__ == "__main__":
+    gxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    sqlitedb = os.path.join(gxy_root, 'database/universe.sqlite')
+    # Try to build a representation of what's in the sqlite database
+    if os.path.exists(sqlitedb):
+        graph = create_schema_graph(metadata=MetaData('sqlite:///' + sqlitedb),
+                                    show_datatypes=False,
+                                    show_indexes=False,
+                                    rankdir='LR',
+                                    concentrate=False)
+        print(f"Writing galaxy_universe.png, built from {sqlitedb}")
+        graph.write_png('galaxy_universe.png')
+    else:
+        print(f"No sqlitedb available at {sqlitedb}, skipping rendering")
+
+    # Build UML graph from loaded mapper
+    mappers = []
+    for attr in dir(model):
+        if attr[0] == '_':
+            continue
+        try:
+            cls = getattr(model, attr)
+            mappers.append(class_mapper(cls))
+        except Exception:
+            pass
+
+    graph = create_uml_graph(
+        mappers,
+        show_operations=False,
+    )
+    print("Writing galaxy_uml.png")
+    graph.write_png('galaxy_uml.png')  # write out the file

--- a/scripts/galaxy_schemadisp.py
+++ b/scripts/galaxy_schemadisp.py
@@ -1,14 +1,16 @@
 import os
 import sys
+
 from db_shell import *  # noqa
 
 gxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 sys.path.insert(1, os.path.abspath(os.path.join(gxy_root, 'lib')))
 
-from galaxy import model
 from sqlalchemy import MetaData
 from sqlalchemy.orm import class_mapper
 from sqlalchemy_schemadisplay import create_schema_graph, create_uml_graph
+
+from galaxy import model
 
 if __name__ == "__main__":
     gxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))

--- a/scripts/galaxy_schemadisp.py
+++ b/scripts/galaxy_schemadisp.py
@@ -2,13 +2,17 @@ import os
 import sys
 
 from db_shell import *  # noqa
+from sqlalchemy import MetaData
+from sqlalchemy.orm import class_mapper
+try:
+    from sqlalchemy_schemadisplay import create_schema_graph, create_uml_graph
+except ImportError:
+    print("please install sqlalchemy_schemadisplay to use this script (pip install sqlalchemy_schemadisplay)")
+    raise
+
 
 gxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 sys.path.insert(1, os.path.abspath(os.path.join(gxy_root, 'lib')))
-
-from sqlalchemy import MetaData
-from sqlalchemy.orm import class_mapper
-from sqlalchemy_schemadisplay import create_schema_graph, create_uml_graph
 
 from galaxy import model
 


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/10338

Uses sqlite_schemadisp to generate schema images like the old one at https://galaxyproject.org/admin/internals/data-model/

It's on my list to swap this to, for the UML where we have this info,  generate SVG and make a browser-viewable graph display instead with clickable links to code, docs, etc. eventually, but there was some interest this morning in the dev channel so I figured I'd go ahead and add this starting point.