### PR TITLE
[20.09] Fix progress bar floating text

### DIFF
--- a/client/src/components/JobStates/CollectionJobStates.vue
+++ b/client/src/components/JobStates/CollectionJobStates.vue
@@ -36,7 +36,7 @@ export default {
     mixins: [mixin],
     computed: {
         loadingNote() {
-            return `Loading job data for ${this.collectionTypeDescription}}`;
+            return `Loading job data for ${this.collectionTypeDescription}`;
         },
         generatingNote() {
             return `${this.jobsStr} generating a ${this.collectionTypeDescription}`;

--- a/client/src/components/ProgressBar.vue
+++ b/client/src/components/ProgressBar.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="my-1">
-        <small class="position-absolute text-center w-100" v-if="note">
+    <div class="my-1 progressContainer">
+        <small v-if="note" class="progressNote">
             {{ note }}<span v-if="loading">.<span class="blinking">..</span></span>
         </small>
         <b-progress :max="total">
@@ -46,3 +46,13 @@ export default {
     },
 };
 </script>
+<style lang="css" scoped>
+.progressNote {
+    position: absolute;
+    text-align: center;
+    width: 100%;
+}
+.progressContainer {
+    position: relative;
+}
+</style>


### PR DESCRIPTION
This fixes the collection summary display mentioned in #10553 

Bonus bugfix of a random dangling `}` that flashed in default text while status was loading.