### PR TITLE
[20.09] bugfix: external login component fetching idps when it should not

### DIFF
--- a/client/src/components/User/ExternalIdentities/ExternalLogin.vue
+++ b/client/src/components/User/ExternalIdentities/ExternalLogin.vue
@@ -226,7 +226,10 @@ export default {
     },
     created() {
         this.rememberIdp = this.getIdpPreference() !== null;
-        this.getCILogonIdps();
+        /* Only fetch CILogonIDPs if custos/cilogon configured */
+        if (this.cilogonListShow) {
+            this.getCILogonIdps();
+        }
     },
 };
 </script>


### PR DESCRIPTION
external login component should not bother fetching idplists if custos/cilogon are not configured

followup to https://github.com/galaxyproject/galaxy/pull/10567