### PR TITLE
Make extract wf action more visible

### DIFF
--- a/templates/webapps/galaxy/workflow/build_from_current_history.mako
+++ b/templates/webapps/galaxy/workflow/build_from_current_history.mako
@@ -90,7 +90,7 @@ into a workflow will be shown in gray.</p>
     <input name="workflow_name" type="text" value="Workflow constructed from history '${ util.unicodify( history.name )}'" size="60"/>
 </div>
 <p>
-    <input type="submit" value="${_('Create Workflow')}" />
+    <input type="submit" class="btn btn-primary" value="${_('Create Workflow')}" />
     <button id="checkall" style="display: none;">Check all</button>
     <button id="uncheckall" style="display: none;">Uncheck all</button>
 </p>


### PR DESCRIPTION
I was demoing this today and it took me a second to read the buttons so, making this the primary action makes things a lot clearer.

![image](https://user-images.githubusercontent.com/458683/97558073-e676a700-19db-11eb-86ab-6a5a5887b074.png)
