### PR TITLE
[20.09] Fix missing section values on tool re-run

### DIFF
--- a/client/src/mvc/form/form-section.js
+++ b/client/src/mvc/form/form-section.js
@@ -89,9 +89,11 @@ var View = Backbone.View.extend({
                             break;
                         }
                     }
-                    if (i == selectedCase && nonhidden) {
+                    if (i == selectedCase) {
                         const selectedView = self.elements[input_def.id + "_" + i];
                         selectedView.renderOnce();
+                    }
+                    if (i == selectedCase && nonhidden) {
                         section_row.fadeIn("fast");
                     } else {
                         section_row.hide();

--- a/client/src/mvc/form/form-section.js
+++ b/client/src/mvc/form/form-section.js
@@ -156,7 +156,7 @@ var View = Backbone.View.extend({
 
     /** Add a customized section */
     _addSection: function (input_def) {
-        const section = new View(this.app, { inputs: input_def.inputs, skip_render: true });
+        const section = new View(this.app, { inputs: input_def.inputs });
         var portlet = new Portlet.View({
             title: input_def.title || input_def.name,
             cls: "ui-portlet-section",


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/10083 optimized rendering of conditionals and sections so that rendering only happens when conditionals and sections are expanded. On job re-run unexpanded sections may contain non-default values. When submitting the job without expanding the section we'd lose those values and the default value would be submitted.

This reverses the optimization for sections and hidden conditional `</when>` items.