### PR TITLE
Disable dataset edit button after the dataset has been deleted

### DIFF
--- a/client/src/mvc/dataset/dataset-li-edit.js
+++ b/client/src/mvc/dataset/dataset-li-edit.js
@@ -63,13 +63,15 @@ var DatasetListItemEdit = _super.extend(
                 faIcon: "fa-pencil",
                 classes: "edit-btn",
                 onclick: function (ev) {
-                    const Galaxy = getGalaxyInstance();
-                    if (Galaxy.router) {
-                        ev.preventDefault();
-                        const identifier = self.model.get("element_id") || self.model.get("id");
-                        Galaxy.router.push("datasets/edit", {
-                            dataset_id: identifier,
-                        });
+                    if (!disabled) {
+                        const Galaxy = getGalaxyInstance();
+                        if (Galaxy.router) {
+                            ev.preventDefault();
+                            const identifier = self.model.get("element_id") || self.model.get("id");
+                            Galaxy.router.push("datasets/edit", {
+                                dataset_id: identifier,
+                            });
+                        }
                     }
                 },
             };

--- a/client/src/mvc/dataset/dataset-li-edit.js
+++ b/client/src/mvc/dataset/dataset-li-edit.js
@@ -63,7 +63,7 @@ var DatasetListItemEdit = _super.extend(
                 faIcon: "fa-pencil",
                 classes: "edit-btn",
                 onclick: function (ev) {
-                    if (!disabled) {
+                    if (!deleted && !purged) {
                         const Galaxy = getGalaxyInstance();
                         if (Galaxy.router) {
                             ev.preventDefault();


### PR DESCRIPTION
Really trivial bug, but currently, although the edit button ('pencil') is greyed out after deletion and shows the mouseover text `Cannot edit attributes of datasets removed from disk`, you can still click on it and edit the dataset metadata.