### PR TITLE
Add API endpoint for current history

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -200,6 +200,8 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
             return the history with ``id``
         * GET /api/histories/deleted/{id}:
             return the deleted history with ``id``
+        * GET /api/histories/current:
+            return the current history
         * GET /api/histories/most_recently_used:
             return the most recently used history
 
@@ -217,7 +219,9 @@ class HistoriesController(BaseAPIController, ExportsHistoryMixin, ImportsHistory
         history_id = id
         deleted = string_as_bool(deleted)
 
-        if history_id == "most_recently_used":
+        if history_id == "current":
+            history = self.manager.get_current(trans)
+        elif history_id == "most_recently_used":
             history = self.manager.most_recent(trans.user,
                 filters=(self.app.model.History.deleted == false()), current_history=trans.history)
         else:


### PR DESCRIPTION
Another paper cut - the bioblend method `get_current_history` somewhat misleadingly points to the `most_recently_used` endpoint. It should point at this instead (and optionally a new `get_most_recently_used_history` method could be added as well).