### PR TITLE
[20.09] Mark test cases that use data tables or loc files

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1170,6 +1170,8 @@ class ToolTestDescription:
         self.name = name
         self.maxseconds = maxseconds
         self.required_files = processed_test_dict.get("required_files", [])
+        self.required_data_tables = processed_test_dict.get("required_data_tables", [])
+        self.required_loc_files = processed_test_dict.get("required_loc_files", [])
 
         inputs = processed_test_dict.get("inputs", {})
         loaded_inputs = {}
@@ -1224,6 +1226,8 @@ class ToolTestDescription:
             "tool_id": self.tool_id,
             "tool_version": self.tool_version,
             "required_files": self.required_files,
+            "required_data_tables": self.required_data_tables,
+            "required_loc_files": self.required_loc_files,
             "error": self.error,
             "exception": self.exception,
         }

--- a/lib/galaxy/tools/test.py
+++ b/lib/galaxy/tools/test.py
@@ -58,7 +58,7 @@ def description_from_tool_object(tool, test_index, raw_test_dict):
             "expect_failure": raw_test_dict.get("expect_failure", False),
             "required_files": required_files,
             "required_data_tables": required_data_tables,
-            "required_loc_files":  required_loc_files,
+            "required_loc_files": required_loc_files,
             "tool_id": tool.id,
             "tool_version": tool.version,
             "test_index": test_index,
@@ -158,7 +158,7 @@ def _process_raw_inputs(tool, tool_inputs, raw_inputs, required_files, required_
     return expanded_inputs
 
 
-def _process_simple_value(param, param_value, required_data_tables, required_loc_files, ):
+def _process_simple_value(param, param_value, required_data_tables, required_loc_files):
     if isinstance(param, galaxy.tools.parameters.basic.SelectToolParameter):
         # Tests may specify values as either raw value or the value
         # as they appear in the list - the API doesn't and shouldn't

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -295,6 +295,14 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         test_data_response = self._get("tools/%s/test_data_path?filename=../CONTRIBUTORS.md" % "composite_output")
         assert test_data_response.status_code == 403, test_data_response.text
 
+    @skip_without_tool("dbkey_filter_multi_input")
+    def test_data_table_requirement_annotated(self):
+        test_data_response = self._get("tools/%s/test_data" % "dbkey_filter_multi_input")
+        assert test_data_response.status_code == 200
+        test_case = test_data_response.json()[0]
+        assert test_case['required_data_tables'][0] == 'test_fasta_indexes'
+        assert len(test_case['required_loc_files']) == 0
+
     @skip_without_tool("composite_output")
     def test_test_data_composite_output(self):
         test_data_response = self._get("tools/%s/test_data" % "composite_output")
@@ -313,6 +321,8 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         test_data = test_data_response.json()
         assert len(test_data) == 2
         test_case = test_data[0]
+        assert len(test_case['required_data_tables']) == 0
+        assert len(test_case['required_loc_files']) == 0
         self._assert_has_keys(test_case, "inputs", "outputs", "output_collections", "required_files")
         assert len(test_case["inputs"]) == 3, test_case
 


### PR DESCRIPTION
This does not work if a tool data table entry is selected without
explicitly listing it in the test data setup, but I think that's
a rare case (and that can be fixed now by referencing it explicitly).

xref: https://github.com/galaxyproject/galaxy/issues/7998#issue-445473778