### PR TITLE
Remove IUC conda channel from default configuration

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -433,7 +433,7 @@
 :Description:
     conda channels to enable by default
     (https://conda.io/docs/user-guide/tasks/manage-channels.html)
-:Default: ``iuc,conda-forge,bioconda,defaults``
+:Default: ``conda-forge,bioconda,defaults``
 :Type: str
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -316,7 +316,7 @@ galaxy:
 
   # conda channels to enable by default
   # (https://conda.io/docs/user-guide/tasks/manage-channels.html)
-  #conda_ensure_channels: iuc,conda-forge,bioconda,defaults
+  #conda_ensure_channels: conda-forge,bioconda,defaults
 
   # Use locally-built conda packages.
   #conda_use_local: false

--- a/lib/galaxy/tool_util/deps/resolvers/conda.py
+++ b/lib/galaxy/tool_util/deps/resolvers/conda.py
@@ -39,9 +39,8 @@ from ..conda_util import (
 DEFAULT_BASE_PATH_DIRECTORY = "_conda"
 DEFAULT_CONDARC_OVERRIDE = "_condarc"
 # Conda channel order from highest to lowest, following the one used in
-# https://github.com/bioconda/bioconda-recipes/blob/master/config.yml , but
-# adding `iuc` as first channel (for Galaxy-specific packages)
-DEFAULT_ENSURE_CHANNELS = "iuc,conda-forge,bioconda,defaults"
+# https://github.com/bioconda/bioconda-recipes/blob/master/config.yml
+DEFAULT_ENSURE_CHANNELS = "conda-forge,bioconda,defaults"
 CONDA_SOURCE_CMD = """[ "$(basename "$CONDA_DEFAULT_ENV")" = "$(basename '{environment_path}')" ] || {{
 MAX_TRIES=3
 COUNT=0

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -329,7 +329,7 @@ mapping:
 
       conda_ensure_channels:
         type: str
-        default: iuc,conda-forge,bioconda,defaults
+        default: conda-forge,bioconda,defaults
         required: false
         desc: |
           conda channels to enable by default


### PR DESCRIPTION
I suggest to drop the IUC conda channel. My initial motivation an error caused by the emboss package in this channel:

```
ClobberError: This transaction has incompatible packages due to a shared path.
  packages: iuc::emboss-5.0.0-0, conda-forge::libpng-1.6.37-h21135ba_2
  path: 'share/man/man5/png.5'
```

But I guess its not needed anymore.