### PR TITLE
[20.09] fix  trs_id and trs_server query strings

### DIFF
--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -29,7 +29,7 @@ Vue.use(BootstrapVue);
 
 export default {
     mixins: [TrsMixin],
-    properties: {
+    props: {
         queryTrsServer: {
             type: String,
             default: null,
@@ -49,8 +49,6 @@ export default {
             toolId: null,
             trsTool: null,
             errorMessage: null,
-            queryTrsServer: null,
-            queryTrsId: null,
         };
     },
     computed: {


### PR DESCRIPTION
Fix query string during TRS import
Example link: http://localhost:8080/workflows/trs_import?trs_server=workflowhub.eu&trs_id=2
