### PR TITLE
[20.09] Fix lint error

### DIFF
--- a/test/unit/managers/test_markdown_export.py
+++ b/test/unit/managers/test_markdown_export.py
@@ -56,7 +56,6 @@ class BaseExportTestCase(BaseTestCase):
 
         collection = model.DatasetCollection()
         collection.id = 1
-        elements = []
         element_forward = model.DatasetCollectionElement(
             collection=collection,
             element=hda_forward,


### PR DESCRIPTION
```
py35-lint run-test: commands[0] | bash .ci/flake8_wrapper.sh
./test/unit/managers/test_markdown_export.py:59:9: F841 local variable 'elements' is assigned to but never used
```
Left over after https://github.com/galaxyproject/galaxy/commit/14ced3cbaefddb7e0909797aebf3a675654d3446
(didn't belong there anyway)

Ping @mvdbeek 