### PR TITLE
auto-import workflow with trs

### DIFF
--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -90,7 +90,7 @@ export default {
                     this.errorMessage = null;
                     const version = this.trsTool.versions.find((version) => version.id === this.queryTrsVersionId);
                     if (version) {
-                        this.importVersion(this.trsTool.id, version);
+                        this.importVersion(this.trsTool.id, version, true);
                     }
                 })
                 .catch((errorMessage) => {

--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -90,7 +90,7 @@ export default {
                     this.errorMessage = null;
                     const version = this.trsTool.versions.find((version) => version.id === this.queryTrsVersionId);
                     if (version) {
-                        this.importVersion(this.trsTool.id, version, true);
+                        this.importVersion(this.trsTool.id, version, this.isRun);
                     }
                 })
                 .catch((errorMessage) => {

--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -15,7 +15,7 @@
             <b-form-input v-model="toolId" />
         </div>
 
-        <trs-tool :trs-tool="trsTool" v-if="trsTool != null" @onImport="importVersion(trsTool.id, $event)" />
+        <trs-tool :trs-tool="trsTool" v-if="trsTool" @onImport="importVersion(trsTool.id, $event)" />
     </b-card>
 </template>
 
@@ -37,6 +37,14 @@ export default {
         queryTrsId: {
             type: String,
             default: null,
+        },
+        queryTrsVersionId: {
+            type: String,
+            default: null,
+        },
+        isRun: {
+            type: Boolean,
+            default: false,
         },
     },
     created() {
@@ -80,6 +88,10 @@ export default {
                 .then((tool) => {
                     this.trsTool = tool;
                     this.errorMessage = null;
+                    const version = this.trsTool.versions.find((version) => version.id === this.queryTrsVersionId);
+                    if (version) {
+                        this.importVersion(this.trsTool.id, version);
+                    }
                 })
                 .catch((errorMessage) => {
                     this.trsTool = null;

--- a/client/src/components/Workflow/WorkflowImport.vue
+++ b/client/src/components/Workflow/WorkflowImport.vue
@@ -31,6 +31,7 @@ import { getGalaxyInstance } from "app";
 import axios from "axios";
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
+import {redirectOnImport} from "./utils"
 
 Vue.use(BootstrapVue);
 
@@ -67,9 +68,7 @@ export default {
                 axios
                     .post(`${getAppRoot()}api/workflows`, formData)
                     .then((response) => {
-                        window.location = `${getAppRoot()}workflows/list?message=${
-                            response.data.message
-                        }&status=success`;
+                        redirectOnImport(getAppRoot(), response.data)
                     })
                     .catch((error) => {
                         const message = error.response.data && error.response.data.err_msg;

--- a/client/src/components/Workflow/WorkflowImport.vue
+++ b/client/src/components/Workflow/WorkflowImport.vue
@@ -31,7 +31,7 @@ import { getGalaxyInstance } from "app";
 import axios from "axios";
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
-import {redirectOnImport} from "./utils"
+import { redirectOnImport } from "./utils";
 
 Vue.use(BootstrapVue);
 
@@ -68,7 +68,7 @@ export default {
                 axios
                     .post(`${getAppRoot()}api/workflows`, formData)
                     .then((response) => {
-                        redirectOnImport(getAppRoot(), response.data)
+                        redirectOnImport(getAppRoot(), response.data);
                     })
                     .catch((error) => {
                         const message = error.response.data && error.response.data.err_msg;

--- a/client/src/components/Workflow/trsMixin.js
+++ b/client/src/components/Workflow/trsMixin.js
@@ -13,14 +13,6 @@ export default {
             this.services
                 .importTrsTool(this.trsSelection.id, toolId, version.name)
                 .then((response_data) => {
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
-                    console.log("isRunFormRedirect", isRunFormRedirect);
                     redirectOnImport(getAppRoot(), response_data, isRunFormRedirect);
                 })
                 .catch((errorMessage) => {

--- a/client/src/components/Workflow/trsMixin.js
+++ b/client/src/components/Workflow/trsMixin.js
@@ -1,6 +1,7 @@
 import { getAppRoot } from "onload/loadConfig";
 import TrsServerSelection from "./TrsServerSelection";
 import TrsTool from "./TrsTool";
+import { redirectOnImport } from "./utils";
 
 export default {
     components: {
@@ -8,12 +9,19 @@ export default {
         TrsTool,
     },
     methods: {
-        importVersion(toolId, version) {
+        importVersion(toolId, version, isRunFormRedirect = false) {
             this.services
                 .importTrsTool(this.trsSelection.id, toolId, version.name)
                 .then((response_data) => {
-                    // copied from the WorkflowImport, de-duplicate somehow
-                    window.location = `${getAppRoot()}workflows/list?message=${response_data.message}&status=success`;
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    console.log("isRunFormRedirect", isRunFormRedirect);
+                    redirectOnImport(getAppRoot(), response_data, isRunFormRedirect);
                 })
                 .catch((errorMessage) => {
                     this.errorMessage = errorMessage || "Import failed for an unknown reason.";

--- a/client/src/components/Workflow/utils.js
+++ b/client/src/components/Workflow/utils.js
@@ -1,0 +1,5 @@
+export function redirectOnImport(appRoot, response, isRunFormRedirect = false) {
+    isRunFormRedirect
+        ? (window.location = `${appRoot}workflows/run?id=${response.id}`)
+        : (window.location = `${appRoot}workflows/list?message=${response.message}&status=success`);
+}

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -342,9 +342,13 @@ export const getAnalysisRouter = (Galaxy) =>
         show_workflows_trs_import: function () {
             const queryTrsServer = QueryStringParsing.get("trs_server");
             const queryTrsId = QueryStringParsing.get("trs_id");
+            const queryTrsVersionId = QueryStringParsing.get("trs_version");
+            const isRun = QueryStringParsing.get("run_form") === "true";
             const propsData = {
                 queryTrsServer,
                 queryTrsId,
+                queryTrsVersionId,
+                isRun,
             };
             this._display_vue_helper(TrsImport, propsData);
         },


### PR DESCRIPTION
Import workflow automatically if server, id and version are specified. 
This is done for automatic import directly from Workflowhub/Dockstore

url example:

This request will automatically import specified workflow version 
```
/workflows/trs_import?trs_server={server}&trs_id={id}&trs_version={id}
```

this will import the workflow and redirect to the run form
```
/workflows/trs_import?trs_server={server}&trs_id={id}&trs_version={id}&run_form=true
```

If the version is missing, but run_form is true, it will redirect to run_form after user chooses the version  
```
/workflows/trs_import?trs_server={server}&trs_id={id}&run_form=true
```

Why do we need this? We want to create a few buttons on Dockstore/Workflowhub like: "Run this workflow on Galaxy" and "Import this workflow on Galaxy"
