### PR TITLE
[20.09] Fix Workflow node input terminal not updating

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -332,8 +332,6 @@ export default {
                             x.destroy();
                         }
                     });
-                    // Remove the rendered output terminal
-                    this.outputTerminals[name].$el.remove();
                     // Remove the reference to the output and output terminal
                     delete this.outputTerminals[name];
                     this.outputs.splice(i, 1);


### PR DESCRIPTION
when a new input is selected.
This is easier to describe with a gif:
![switch labels](https://user-images.githubusercontent.com/6804901/98165307-f283cc80-1ee5-11eb-96c7-c6f91985db5b.gif)

Fixes https://github.com/galaxyproject/galaxy/issues/10622