### PR TITLE
[20.09] Fix masthead items disappearing on small screens

### DIFF
--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -116,7 +116,7 @@ export default {
         },
         tabs() {
             const scratchbookTabs = [this.mastheadState.frame.buttonActive, this.mastheadState.frame.buttonLoad];
-            const tabs = [].concat(this.baseTabs, scratchbookTabs, this.extensionTabs);
+            const tabs = [].concat(this.baseTabs, this.extensionTabs, scratchbookTabs);
             return tabs.map(this._tabToJson);
         },
     },

--- a/client/src/components/Masthead/Masthead.vue
+++ b/client/src/components/Masthead/Masthead.vue
@@ -1,12 +1,5 @@
 <template>
-    <b-navbar
-        id="masthead"
-        toggleable="lg"
-        type="dark"
-        role="navigation"
-        aria-label="Main"
-        class="justify-content-center"
-    >
+    <b-navbar id="masthead" type="dark" role="navigation" aria-label="Main" class="justify-content-center">
         <b-navbar-brand :href="brandLink" aria-label="homepage">
             <img alt="logo" class="navbar-brand-image" :src="brandImage" />
             <span class="navbar-brand-title">{{ brandTitle }}</span>

--- a/client/src/layout/page.js
+++ b/client/src/layout/page.js
@@ -200,15 +200,18 @@ const View = Backbone.View.extend({
                     if (Galaxy.user.id !== null) {
                         if ($chat_icon_element.css("visibility") === "hidden") {
                             $chat_icon_element.css("visibility", "visible");
+                            $chat_icon_element.css("display", "initial");
                         }
                     }
                 })
                 .error((data) => {
                     // hide the communication icon if the communication server is not available
                     $chat_icon_element.css("visibility", "hidden");
+                    $chat_icon_element.css("display", "none");
                 });
         } else {
             $chat_icon_element.css("visibility", "hidden");
+            $chat_icon_element.css("display", "none");
         }
     },
 });


### PR DESCRIPTION
The fix is to not set toggleable on `<b-navbar>`. I also played with with adding a `<b-navbar-toggle/>` to display a button on the right for small screens, but I didn't manage to get something that looks nice, though it's probably not hard for someone that knows css.

To get a little bit more space in the navbar I'm setting the (non-functional) chat server item to `display: none` and I'm moving the scratchbook to the rightmost position (since it reserves some space just on the right to display active scratchbooks).

With this in place I see the full navbar on my phone.

Fixes https://github.com/galaxyproject/galaxy/issues/9844.