### PR TITLE
[20.09] Fix hide history panel glitch

### DIFF
--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -159,7 +159,7 @@ body {
     @extend .unified-panel;
     right: 0px;
     width: $panel-width;
-    overflow: unset !important;
+    overflow: unset;
 }
 #right > .unified-panel-footer {
     .drag {


### PR DESCRIPTION
That fixes https://github.com/galaxyproject/galaxy/issues/10638, but it may break other stuff ?
https://github.com/galaxyproject/galaxy/commit/9eb70d87297778c127d1da3a6acf0363ccb79bff
suggests this was in place to prevent a double scroller bug. I haven't noticed those.