### PR TITLE
[20.09] Fix cache key for lint CI workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,24 +1,22 @@
 name: Python linting
 on: [push, pull_request]
 jobs:
-
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.8]
+        python-version: [3.5, 3.9]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip dir
-      uses: actions/cache@v1
-      id: pip-cache
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
     - name: Install tox
       run: pip install tox
     - name: run tests


### PR DESCRIPTION
Also:
- test on Python 3.9 instead of 3.8
- update some action versions

xref. https://github.com/galaxyproject/galaxy/pull/10615#pullrequestreview-521926167