### PR TITLE
[20.09] Fix creating hdas without history when creating collection from library

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -219,7 +219,7 @@ class DatasetCollectionManager:
                                          history=None):
         if collection_type_description.has_subcollections():
             # Nested collection - recursively create collections and update identifiers.
-            self.__recursively_create_collections_for_identifiers(trans, element_identifiers, hide_source_items, copy_elements)
+            self.__recursively_create_collections_for_identifiers(trans, element_identifiers, hide_source_items, copy_elements, history=history)
         new_collection = False
         for element_identifier in element_identifiers:
             if element_identifier.get("src") == "new_collection" and element_identifier.get('collection_type') == '':
@@ -351,7 +351,7 @@ class DatasetCollectionManager:
             context.flush()
         return dataset_collection_instance
 
-    def __recursively_create_collections_for_identifiers(self, trans, element_identifiers, hide_source_items, copy_elements):
+    def __recursively_create_collections_for_identifiers(self, trans, element_identifiers, hide_source_items, copy_elements, history=None):
         for index, element_identifier in enumerate(element_identifiers):
             try:
                 if element_identifier.get("src", None) != "new_collection":
@@ -369,6 +369,7 @@ class DatasetCollectionManager:
                 element_identifiers=element_identifier["element_identifiers"],
                 hide_source_items=hide_source_items,
                 copy_elements=copy_elements,
+                history=history,
             )
             element_identifier["__object__"] = collection
 

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -329,6 +329,31 @@ class LibrariesApiTestCase(ApiTestCase, TestsDatasets):
     def test_ldda_collection_import_to_history_hide_source(self):
         self._import_to_history(visible=False)
 
+    def test_import_paired_collection(self):
+        ld = self._create_dataset_in_folder_in_library("ForHistoryImport").json()
+        history_id = self.dataset_populator.new_history()
+        url = "histories/%s/contents" % history_id
+        collection_name = 'Paired-end data (from library)'
+        payload = {
+            'name': collection_name,
+            'collection_type': 'list:paired',
+            "type": "dataset_collection",
+            'element_identifiers': json.dumps([
+                {
+                    'src': 'new_collection',
+                    'name': 'pair1',
+                    'collection_type': 'paired',
+                    'element_identifiers': [{'name': 'forward', 'src': 'ldda', 'id': ld['id']},
+                                            {'name': 'reverse', 'src': 'ldda', 'id': ld['id']}]
+                }
+            ])
+        }
+        new_collection = self._post(url, payload).json()
+        assert new_collection['name'] == collection_name
+        pair = new_collection['elements'][0]
+        assert pair['element_identifier'] == 'pair1'
+        assert pair['object']['elements'][0]['object']['history_id'] == history_id
+
     def _import_to_history(self, visible=True):
         ld = self._create_dataset_in_folder_in_library("ForHistoryImport").json()
         history_id = self.dataset_populator.new_history()


### PR DESCRIPTION
Fixes
```
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: galaxy.web.framework.decorators ERROR 2020-11-07 20:11:46,559 [p:3365515,w:2,m:0] [uWSGIWorker2Core0] Uncaught exception in exposed API method:
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: Traceback (most recent call last):
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/web/framework/decorators.py", line 169, in decorator
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: rval = func(self, trans, *args, **kwargs)
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/webapps/galaxy/api/datasets.py", line 153, in show
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: view=kwd.get('view', 'detailed'), user=trans.user, trans=trans)
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/managers/base.py", line 688, in serialize_to_view
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: return self.serialize(item, all_keys, **context)
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/managers/hdas.py", line 372, in serialize
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: return super().serialize(hda, keys, user=user, **context)
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/managers/datasets.py", line 612, in serialize
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: serialized = super().serialize(dataset_assoc, keys, **context)
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/managers/base.py", line 601, in serialize
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: returned[key] = self.serializers[key](item, key, **context)
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: File "lib/galaxy/managers/hdas.py", line 355, in <lambda>
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: history_id=self.app.security.encode_id(i.history.id),
Nov 07 20:11:46 sn04.bi.uni-freiburg.de uwsgi[3357126]: AttributeError: 'NoneType' object has no attribute 'id'
```
when attempting to view these in a history, and fixes
```
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: galaxy.tools ERROR 2020-11-06 23:07:51,127 [p:619665,w:4,m:0] [uWSGIWorker4Core0] Exception caught while attempting to execute tool with id '__FILTER_EMPTY_DATASETS__':
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: Traceback (most recent call last):
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/__init__.py", line 1656, in handle_single_execution
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: flush_job=flush_job,
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/__init__.py", line 1745, in execute
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs)
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/actions/model_operations.py", line 60, in execute
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/actions/model_operations.py", line 74, in _produce_outputs
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags)
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/__init__.py", line 3019, in produce_outputs
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: elements=new_elements
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/actions/__init__.py", line 872, in create_collection
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: check_elements(elements)
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: File "lib/galaxy/tools/actions/__init__.py", line 866, in check_elements
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: assert dataset.history is not None or dataset.history_id is not None
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: AssertionError
Nov 06 23:07:51 sn04.bi.uni-freiburg.de uwsgi[3212738]: galaxy.tools.execute WARNING 2020-11-06 23:07:51,139 [p:619665,w:4,m:0] [uWSGIWorker4Core0] There was a failure executing a job for tool [__FILTER_EMPTY_DATASETS__] - Error executing tool with id '__FILTER_EMPTY_DATASETS__':
```
when running database operation tools on these collections.