### PR TITLE
Add a script to start Galaxy under aiohttp

### DIFF
--- a/client/src/mvc/tool/tool-form.js
+++ b/client/src/mvc/tool/tool-form.js
@@ -262,79 +262,84 @@ const View = Backbone.View.extend({
             return;
         }
         Galaxy.emit.debug("tool-form::submit()", "Validation complete.", job_def);
-        Utils.request({
-            type: "POST",
-            url: `${getAppRoot()}api/tools`,
-            data: job_def,
-            success: (response) => {
-                callback && callback();
-                this.$el.children().hide();
-                if (response.produces_entry_points) {
-                    for (const job of response.jobs) {
-                        const toolEntryPointsInstance = Vue.extend(ToolEntryPoints);
-                        const vm = document.createElement("div");
-                        this.$el.append(vm);
-                        const instance = new toolEntryPointsInstance({
-                            propsData: {
-                                jobId: job.id,
-                            },
-                        });
-                        instance.$mount(vm);
-                    }
-                }
-                this.$el.append(this._templateSuccess(response, job_def));
-                const enable_tool_recommendations = Galaxy.config.enable_tool_recommendations;
-                if (enable_tool_recommendations === true || enable_tool_recommendations === "true") {
-                    // show tool recommendations
-                    const ToolRecommendationInstance = Vue.extend(ToolRecommendation);
-                    const vm = document.createElement("div");
-                    this.$el.append(vm);
-                    const instance = new ToolRecommendationInstance({
-                        propsData: {
-                            toolId: job_def.tool_id,
-                        },
-                    });
-                    instance.$mount(vm);
-                }
-                this.$el.parent().scrollTop(0);
-                // Show Webhook if job is running
-                if (response.jobs && response.jobs.length > 0) {
-                    this.$el.append($("<div/>", { id: "webhook-view" }));
-                    new Webhooks.WebhookView({
-                        type: "tool",
-                        toolId: job_def.tool_id,
-                    });
-                }
-                if (Galaxy.currHistoryPanel) {
-                    this.form.stopListening(Galaxy.currHistoryPanel.collection);
-                    Galaxy.currHistoryPanel.refreshContents();
-                }
-            },
-            error: (response) => {
-                callback && callback();
-                Galaxy.emit.debug("tool-form::submit", "Submission failed.", response);
-                let input_found = false;
-                if (response && response.err_data) {
-                    const error_messages = this.form.data.matchResponse(response.err_data);
-                    for (const input_id in error_messages) {
-                        this.form.highlight(input_id, error_messages[input_id]);
-                        input_found = true;
-                        break;
-                    }
-                }
-                if (!input_found) {
-                    this.modal.show({
-                        title: _l("Job submission failed"),
-                        body: this._templateError(job_def, response && response.err_msg),
-                        buttons: {
-                            Close: () => {
-                                this.modal.hide();
-                            },
-                        },
-                    });
-                }
-            },
-        });
+        const target = window.location.host + '/ws';
+        console.log(target);
+        let ws;
+        ws = new WebSocket(`ws://${target}`);
+        ws.onopen = () => ws.send(JSON.stringify(job_def))
+        // Utils.request({
+        //     type: "POST",
+        //     url: `${getAppRoot()}api/tools`,
+        //     data: job_def,
+        //     success: (response) => {
+        //         callback && callback();
+        //         this.$el.children().hide();
+        //         if (response.produces_entry_points) {
+        //             for (const job of response.jobs) {
+        //                 const toolEntryPointsInstance = Vue.extend(ToolEntryPoints);
+        //                 const vm = document.createElement("div");
+        //                 this.$el.append(vm);
+        //                 const instance = new toolEntryPointsInstance({
+        //                     propsData: {
+        //                         jobId: job.id,
+        //                     },
+        //                 });
+        //                 instance.$mount(vm);
+        //             }
+        //         }
+        //         this.$el.append(this._templateSuccess(response, job_def));
+        //         const enable_tool_recommendations = Galaxy.config.enable_tool_recommendations;
+        //         if (enable_tool_recommendations === true || enable_tool_recommendations === "true") {
+        //             // show tool recommendations
+        //             const ToolRecommendationInstance = Vue.extend(ToolRecommendation);
+        //             const vm = document.createElement("div");
+        //             this.$el.append(vm);
+        //             const instance = new ToolRecommendationInstance({
+        //                 propsData: {
+        //                     toolId: job_def.tool_id,
+        //                 },
+        //             });
+        //             instance.$mount(vm);
+        //         }
+        //         this.$el.parent().scrollTop(0);
+        //         // Show Webhook if job is running
+        //         if (response.jobs && response.jobs.length > 0) {
+        //             this.$el.append($("<div/>", { id: "webhook-view" }));
+        //             new Webhooks.WebhookView({
+        //                 type: "tool",
+        //                 toolId: job_def.tool_id,
+        //             });
+        //         }
+        //         if (Galaxy.currHistoryPanel) {
+        //             this.form.stopListening(Galaxy.currHistoryPanel.collection);
+        //             Galaxy.currHistoryPanel.refreshContents();
+        //         }
+        //     },
+        //     error: (response) => {
+        //         callback && callback();
+        //         Galaxy.emit.debug("tool-form::submit", "Submission failed.", response);
+        //         let input_found = false;
+        //         if (response && response.err_data) {
+        //             const error_messages = this.form.data.matchResponse(response.err_data);
+        //             for (const input_id in error_messages) {
+        //                 this.form.highlight(input_id, error_messages[input_id]);
+        //                 input_found = true;
+        //                 break;
+        //             }
+        //         }
+        //         if (!input_found) {
+        //             this.modal.show({
+        //                 title: _l("Job submission failed"),
+        //                 body: this._templateError(job_def, response && response.err_msg),
+        //                 buttons: {
+        //                     Close: () => {
+        //                         this.modal.hide();
+        //                     },
+        //                 },
+        //             });
+        //         }
+        //     },
+        // });
     },
 
     /** Validate job dictionary.

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -92,6 +92,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
     has_remaining_jobs = False
     execution_slice = None
 
+    trans.send(f"Creating {job_count} jobs")
     for i, execution_slice in enumerate(execution_tracker.new_execution_slices()):
         if max_num_jobs and jobs_executed >= max_num_jobs:
             has_remaining_jobs = True
@@ -100,6 +101,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
             execute_single_job(execution_slice, completed_jobs[i])
             history = execution_slice.history or history
             jobs_executed += 1
+            trans.send(jobs_executed)
 
     if execution_slice:
         # a side effect of adding datasets to a history is a commit within db_next_hid (even with flush=False).

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -1,3 +1,6 @@
+import asyncio
+import json
+
 from galaxy.managers.context import (
     ProvidesAppContext,
     ProvidesHistoryContext,
@@ -18,14 +21,19 @@ class WorkRequestContext(ProvidesAppContext, ProvidesUserContext, ProvidesHistor
     objects.
     """
 
-    def __init__(self, app, user=None, history=None, workflow_building_mode=False):
+    def __init__(self, app, user=None, history=None, workflow_building_mode=False, ws=None):
         self.app = app
         self.security = app.security
         self.__user = user
         self.__user_current_roles = None
         self.__history = history
+        self.__ws = ws
         self.api_inherit_admin = False
         self.workflow_building_mode = workflow_building_mode
+    
+    def send(self, msg):
+        if self.__ws:
+            asyncio.get_event_loop().run_until_complete(self.__ws.send_str(json.dumps(msg)))
 
     def get_history(self, create=False):
         return self.__history

--- a/scripts/galaxy-aiohttp.py
+++ b/scripts/galaxy-aiohttp.py
@@ -1,0 +1,31 @@
+from galaxy_main import (
+    GalaxyConfigBuilder,
+    main,
+)
+from aiohttp import web  # noqa: I100
+from aiohttp_wsgi import WSGIHandler
+
+from galaxy.util.properties import load_app_properties
+from galaxy.webapps.galaxy.buildapp import app_factory
+
+
+def aiohttp_loop(args, log):
+    config_builder = GalaxyConfigBuilder(args)
+    kwds = config_builder.app_kwds()
+    kwds = load_app_properties(**kwds)
+    gx = app_factory(global_conf=config_builder.global_conf(), **kwds)
+    wsgi_handler = WSGIHandler(gx)
+    app = web.Application()
+    routes = web.RouteTableDef()
+
+    @routes.get('/hello')
+    async def hello(request):
+        return web.Response(text="Hello, world")
+
+    app.add_routes(routes)
+    app.router.add_route("*", "/{path_info:.*}", wsgi_handler)
+    web.run_app(app)
+
+
+if __name__ == "__main__":
+    main(aiohttp_loop)

--- a/scripts/galaxy-aiohttp.py
+++ b/scripts/galaxy-aiohttp.py
@@ -1,16 +1,12 @@
-import json
-
 from galaxy_main import (
     GalaxyConfigBuilder,
     main,
 )
-from aiohttp import web, WSMsgType  # noqa: I100
-from aiohttp_wsgi import WSGIHandler
+from aiohttp import web  # noqa: I100
+from aiohttp_wsgi import WSGIHandler  # noqa: I100
 
 from galaxy.util.properties import load_app_properties
-from galaxy.webapps.galaxy.api import tools
 from galaxy.webapps.galaxy.buildapp import app_factory
-from galaxy.work.context import WorkRequestContext
 
 
 def aiohttp_loop(args, log):
@@ -20,41 +16,6 @@ def aiohttp_loop(args, log):
     gx = app_factory(global_conf=config_builder.global_conf(), **kwds)
     wsgi_handler = WSGIHandler(gx)
     app = web.Application()
-    app['websockets'] = []
-    routes = web.RouteTableDef()
-
-    @routes.get('/hello')
-    async def hello(request):
-        return web.Response(text="Hello, world")
-    
-    @routes.get('/ws')
-    async def ws(request):
-        ws = web.WebSocketResponse()
-
-        # track websockets for the fun of it
-        request.app['websockets'].append(ws)
-        await ws.prepare(request)
-        async for msg in ws:
-            if msg.type == WSMsgType.TEXT:
-                if msg.data == 'close':
-                    await ws.close()
-                else:
-                    from galaxy.app import app as galaxy_app
-                    tc = tools.ToolsController(galaxy_app)
-                    user = galaxy_app.model.session.query(galaxy_app.model.User).get(1)
-                    trans = WorkRequestContext(galaxy_app, user=user, ws=ws)
-                    payload = json.loads(msg.data)
-                    tc._create(trans=trans, payload=payload)
-                    # Respond to all sockets, otherwise just respond to ws
-                    await ws.send_str(msg.data + '/answer')
-            elif msg.type == WSMsgType.ERROR:
-                print('ws connection closed with exception %s' %
-                      ws.exception())
-
-        print('websocket connection closed')
-        return ws
-
-    app.add_routes(routes)
     app.router.add_route("*", "/{path_info:.*}", wsgi_handler)
     web.run_app(app)
 

--- a/scripts/galaxy-aiohttp.py
+++ b/scripts/galaxy-aiohttp.py
@@ -1,12 +1,16 @@
+import json
+
 from galaxy_main import (
     GalaxyConfigBuilder,
     main,
 )
-from aiohttp import web  # noqa: I100
+from aiohttp import web, WSMsgType  # noqa: I100
 from aiohttp_wsgi import WSGIHandler
 
 from galaxy.util.properties import load_app_properties
+from galaxy.webapps.galaxy.api import tools
 from galaxy.webapps.galaxy.buildapp import app_factory
+from galaxy.work.context import WorkRequestContext
 
 
 def aiohttp_loop(args, log):
@@ -16,11 +20,39 @@ def aiohttp_loop(args, log):
     gx = app_factory(global_conf=config_builder.global_conf(), **kwds)
     wsgi_handler = WSGIHandler(gx)
     app = web.Application()
+    app['websockets'] = []
     routes = web.RouteTableDef()
 
     @routes.get('/hello')
     async def hello(request):
         return web.Response(text="Hello, world")
+    
+    @routes.get('/ws')
+    async def ws(request):
+        ws = web.WebSocketResponse()
+
+        # track websockets for the fun of it
+        request.app['websockets'].append(ws)
+        await ws.prepare(request)
+        async for msg in ws:
+            if msg.type == WSMsgType.TEXT:
+                if msg.data == 'close':
+                    await ws.close()
+                else:
+                    from galaxy.app import app as galaxy_app
+                    tc = tools.ToolsController(galaxy_app)
+                    user = galaxy_app.model.session.query(galaxy_app.model.User).get(1)
+                    trans = WorkRequestContext(galaxy_app, user=user, ws=ws)
+                    payload = json.loads(msg.data)
+                    tc._create(trans=trans, payload=payload)
+                    # Respond to all sockets, otherwise just respond to ws
+                    await ws.send_str(msg.data + '/answer')
+            elif msg.type == WSMsgType.ERROR:
+                print('ws connection closed with exception %s' %
+                      ws.exception())
+
+        print('websocket connection closed')
+        return ws
 
     app.add_routes(routes)
     app.router.add_route("*", "/{path_info:.*}", wsgi_handler)

--- a/scripts/galaxy-main
+++ b/scripts/galaxy-main
@@ -250,7 +250,7 @@ class GalaxyConfigBuilder:
                 )
 
 
-def main():
+def main(func=app_loop):
     arg_parser = ArgumentParser(description=DESCRIPTION)
     GalaxyConfigBuilder.populate_options(arg_parser)
     args = arg_parser.parse_args()
@@ -283,14 +283,14 @@ def main():
         daemon = Daemonize(
             app="galaxy",
             pid=pid_file,
-            action=functools.partial(app_loop, args, log),
+            action=functools.partial(func, args, log),
             verbose=DEFAULT_VERBOSE,
             logger=log,
             keep_fds=keep_fds,
         )
         daemon.start()
     else:
-        app_loop(args, log)
+        func(args, log)
 
 
 if __name__ == "__main__":

--- a/scripts/galaxy_main.py
+++ b/scripts/galaxy_main.py
@@ -1,0 +1,1 @@
+galaxy-main


### PR DESCRIPTION
This is nice because we can run Galaxy under a pure-python, non-blocking
server, and we properly parse galaxy.yml. That means we can debug in
vscode without needing the old galaxy.ini.

Obviously we'd want to integrate this a bit better so we can decorate our to-be-created async / websocket routes.