### PR TITLE
API workflow test showing structure of default/optionals parameters.

### DIFF
--- a/lib/galaxy_test/api/test_workflows_from_yaml.py
+++ b/lib/galaxy_test/api/test_workflows_from_yaml.py
@@ -3,11 +3,12 @@ import os
 
 from galaxy_test.base.populators import uses_test_history
 from galaxy_test.base.workflow_fixtures import (
+    WORKFLOW_PARAMETER_INPUT_INTEGER_DEFAULT,
     WORKFLOW_RUNTIME_PARAMETER_SIMPLE,
     WORKFLOW_SIMPLE_CAT_AND_RANDOM_LINES,
     WORKFLOW_SIMPLE_CAT_TWICE,
     WORKFLOW_WITH_OUTPUT_ACTIONS,
-    WORKFLOW_WITH_OUTPUTS
+    WORKFLOW_WITH_OUTPUTS,
 )
 from .test_workflows import BaseWorkflowsApiTestCase
 
@@ -319,6 +320,14 @@ test_data:
         )
         content = self.dataset_populator.get_history_dataset_content(history_id)
         self.assertEqual(content, "hello world\nhello world 2\n")
+
+    def test_parameter_default_rep(self):
+        workflow = self._upload_and_download(WORKFLOW_PARAMETER_INPUT_INTEGER_DEFAULT)
+        int_input = self._steps_by_label(workflow)["int_input"]
+        int_input_state = json.loads(int_input["tool_state"])
+        assert int_input_state["default"] == 3
+        assert int_input_state["optional"] is True
+        assert int_input_state["parameter_type"] == "integer"
 
     def _steps_by_label(self, workflow_as_dict):
         by_label = {}


### PR DESCRIPTION
- Shows how to find them, name of parameters, odd double encoding of tool_state, and shows parameters with default values are implicitly optional = True.

We already had a test or two about running them and them functioning, but it is good to have some assertions to make structure clear. 