### PR TITLE
[20.09] Fix border between list items

### DIFF
--- a/client/src/style/scss/dataset.scss
+++ b/client/src/style/scss/dataset.scss
@@ -189,7 +189,15 @@
     }
 }
 
-// ---------------------------------------------------------------------------- datasets as list-items
+// ----------------------------------------------------------------------------
+// datasets as list-items
+
+.list-item.dataset,
+.list-item.dataset-collection,
+.list-item.history-content {
+    border-color: rgba(0, 0, 0, 0.15);
+}
+
 .dataset {
     @extend .has-job-state-mixin;
 

--- a/client/src/style/scss/history.scss
+++ b/client/src/style/scss/history.scss
@@ -163,6 +163,9 @@
         &:empty {
             flex-grow: 0 !important;
         }
+        .list-item {
+            border-color: rgba(0,0,0, 0.15);
+        }
         .list-item:first-child {
             border-top-width: 0px;
         }

--- a/client/src/style/scss/history.scss
+++ b/client/src/style/scss/history.scss
@@ -156,18 +156,8 @@
         @extend .flex-column;
         overflow-x: hidden;
         overflow-y: auto;
-
-        &:not(:empty) {
-            border-top: 1px solid $border-color;
-        }
         &:empty {
             flex-grow: 0 !important;
-        }
-        .list-item {
-            border-color: rgba(0,0,0, 0.15);
-        }
-        .list-item:first-child {
-            border-top-width: 0px;
         }
     }
 

--- a/client/src/style/scss/list-item.scss
+++ b/client/src/style/scss/list-item.scss
@@ -17,6 +17,8 @@ $vertical-gap: 8px;
 }
 
 .list-item {
+    border: 1px solid $border-color;
+
     .vertical-spacing {
         @extend %vertical-spacing;
     }


### PR DESCRIPTION
Dropping borders between list items that otherwise have no spacing has been confusing

Fixes https://github.com/galaxyproject/galaxy/issues/10066

This additionally makes the border inherit the color of the relevant list item when it's a dataset.  Looks better than the grey.

![image](https://user-images.githubusercontent.com/155398/98692052-b2d14080-233c-11eb-9119-fe122e6fb2b5.png)


