### PR TITLE
[20.09] Fix UTC Date date change

### DIFF
--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -25,8 +25,12 @@ export default {
         },
     },
     created() {
-        if (this.customFormat) this.processedDate = moment(this.date, this.customFormat).format();
-        else this.processedDate = this.date;
+        this.initialize(this.date);
+    },
+    data: function () {
+        return {
+            processedDate: null,
+        };
     },
     computed: {
         elapsedTime: function () {
@@ -34,6 +38,17 @@ export default {
         },
         fullDate: function () {
             return moment.utc(this.processedDate).format();
+        },
+    },
+    watch: {
+        date: function (newDate) {
+            this.initialize(newDate);
+        },
+    },
+    methods: {
+        initialize: function (date) {
+            if (this.customFormat) this.processedDate = moment(date, this.customFormat).format();
+            else this.processedDate = date;
         },
     },
 };

--- a/client/src/components/UtcDate.vue
+++ b/client/src/components/UtcDate.vue
@@ -22,33 +22,22 @@ export default {
         },
         customFormat: {
             type: String,
+            default: null,
         },
-    },
-    created() {
-        this.initialize(this.date);
-    },
-    data: function () {
-        return {
-            processedDate: null,
-        };
     },
     computed: {
         elapsedTime: function () {
-            return moment(moment.utc(this.processedDate)).from(moment().utc());
+            return moment(moment.utc(this.formattedDate)).from(moment().utc());
         },
         fullDate: function () {
-            return moment.utc(this.processedDate).format();
+            return moment.utc(this.formattedDate).format();
         },
-    },
-    watch: {
-        date: function (newDate) {
-            this.initialize(newDate);
-        },
-    },
-    methods: {
-        initialize: function (date) {
-            if (this.customFormat) this.processedDate = moment(date, this.customFormat).format();
-            else this.processedDate = date;
+        formattedDate: function () {
+            if (this.customFormat) {
+                return moment(this.date, this.customFormat).format();
+            } else {
+                return this.date;
+            }
         },
     },
 };


### PR DESCRIPTION
Took me a little while to get what is going on here. The Date stayed the same, even though sorting worked fine.

This PR will update date in `UtcDate.vue`  on props change. It will fix UtcDate sorting in Invocations, Datasetlist, InteractiveTools, LibraryFodler and WorkflowList tables. fixes https://github.com/galaxyproject/galaxy/issues/10600


Before:
![Peek 2020-11-10 18-38](https://user-images.githubusercontent.com/15801412/98710519-0b77fc00-2384-11eb-88c5-bc1d614dd96b.gif)

Now:
![my-f-giff](https://user-images.githubusercontent.com/15801412/98704836-68bc7f00-237d-11eb-9f33-0642eef67db9.gif)

thanks @foellmelanie for reporting