### PR TITLE
Fix element_is_set for MetadataWrapper

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -214,6 +214,9 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
             self.compute_environment = compute_environment
 
         def __getattr__(self, name):
+            if hasattr(self.metadata, name):
+                return getattr(self.metadata, name)
+
             rval = self.metadata.get(name, None)
             if name in self.metadata.spec:
                 if rval is None:

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -214,9 +214,6 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
             self.compute_environment = compute_environment
 
         def __getattr__(self, name):
-            if hasattr(self.metadata, name):
-                return getattr(self.metadata, name)
-
             rval = self.metadata.get(name, None)
             if name in self.metadata.spec:
                 if rval is None:
@@ -243,6 +240,9 @@ class DatasetFilenameWrapper(ToolParameterValueWrapper):
 
         def __iter__(self):
             return self.metadata.__iter__()
+
+        def element_is_set(self, name):
+            return self.metadata.element_is_set(name)
 
         def get(self, key, default=None):
             try:


### PR DESCRIPTION
follow up to https://github.com/galaxyproject/galaxy/pull/8599

in the planemo tests in the line https://github.com/bernt-matthias/galaxy/blob/1882aa641cdde1c51c077fd983f2241971308377/lib/galaxy/tools/parameters/dynamic_options.py#L205

`r.metadata` is sometimes a `MetadataWrapper` and sometimes a `MetadataCollection`. Wondering why previous tests did not reveal this .. or should we have done a rebase?

In the former case access to the `element_is_set` function defined in `MetadataCollection` is not possible.

Maybe there is a better solution. Also a check that metadata names should not be equal to attributes of `MetadataCollection` could be nice..?