### PR TITLE
[20.09] Speed up invocation serialization

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -931,7 +931,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         :raises: exceptions.MessageException, exceptions.ObjectNotFound
         """
         decoded_workflow_invocation_id = self.decode_id(invocation_id)
-        workflow_invocation = self.workflow_manager.get_invocation(trans, decoded_workflow_invocation_id)
+        workflow_invocation = self.workflow_manager.get_invocation(trans, decoded_workflow_invocation_id, eager=True)
         if workflow_invocation:
             step_details = util.string_as_bool(kwd.get('step_details', 'False'))
             legacy_job_state = util.string_as_bool(kwd.get('legacy_job_state', 'False'))


### PR DESCRIPTION
Serializing a 2 step invocation with 2000 output datasets:
```
*** PROFILER RESULTS ***
show_invocation (/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/workflows.py:905)
function called 1 times

         684631 function calls (643973 primitive calls) in 0.827 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 942 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    0.812    0.812 workflows.py:905(show_invocation)
        1    0.000    0.000    0.752    0.752 workflows.py:161(get_invocation)
        1    0.000    0.000    0.746    0.746 query.py:935(get)
        1    0.000    0.000    0.746    0.746 query.py:1077(_get_impl)
        1    0.000    0.000    0.745    0.745 loading.py:211(load_on_pk_identity)
        1    0.000    0.000    0.745    0.745 query.py:3417(one)
        1    0.000    0.000    0.745    0.745 query.py:3381(one_or_none)
    24/21    0.000    0.000    0.745    0.035 loading.py:35(instances)
       11    0.000    0.000    0.742    0.067 loading.py:81(<listcomp>)
 16012/10    0.058    0.000    0.742    0.074 loading.py:509(_instance)
 14011/10    0.049    0.000    0.741    0.074 loading.py:710(_populate_full)
        1    0.000    0.000    0.741    0.741 strategies.py:1393(load_collection_from_subq)
        1    0.000    0.000    0.741    0.741 strategies.py:1332(get)
        1    0.000    0.000    0.741    0.741 strategies.py:1337(_load)
        1    0.003    0.003    0.614    0.614 loading.py:83(<listcomp>)
     2001    0.002    0.000    0.609    0.000 loading.py:84(<listcomp>)
     1999    0.002    0.000    0.596    0.000 strategies.py:2059(load_scalar_from_joined_existing_row)
     1999    0.003    0.000    0.586    0.000 strategies.py:2020(load_collection_from_joined_existing_row)
6002/2001    0.008    0.000    0.554    0.000 strategies.py:2054(load_scalar_from_joined_new_row)
     4036    0.006    0.000    0.290    0.000 attr.py:316(__call__)
     8012    0.023    0.000    0.284    0.000 custom_types.py:143(load)
7667/7291    0.005    0.000    0.187    0.000 langhelpers.py:880(__get__)
4001/3999    0.010    0.000    0.183    0.000 strategies.py:2010(load_collection_from_joined_new_row)
     6004    0.004    0.000    0.173    0.000 mutable.py:375(_parents)
     6004    0.169    0.000    0.169    0.000 weakref.py:343(__init__)
        2    0.000    0.000    0.097    0.048 query.py:3476(__iter__)
       12    0.000    0.000    0.095    0.008 query.py:3501(_execute_and_instances)
       12    0.000    0.000    0.094    0.008 base.py:952(execute)
       12    0.000    0.000    0.094    0.008 elements.py:296(_execute_on_connection)
       12    0.000    0.000    0.094    0.008 base.py:1088(_execute_clauseelement)
       12    0.000    0.000    0.078    0.007 base.py:1195(_execute_context)
       12    0.000    0.000    0.077    0.006 default.py:589(do_execute)
       12    0.076    0.006    0.077    0.006 {method 'execute' of 'psycopg2.extensions.cursor' objects}
     6012    0.004    0.000    0.062    0.000 type_api.py:1280(process)
        1    0.000    0.000    0.060    0.060 workflows.py:1355(__encode_invocation)
        1    0.000    0.000    0.060    0.060 workflows.py:275(serialize_workflow_invocation)
        1    0.009    0.009    0.060    0.060 __init__.py:5303(to_dict)
     6012    0.006    0.000    0.052    0.000 custom_types.py:98(process_result_value)
40190/40090    0.017    0.000    0.050    0.000 attributes.py:279(__get__)
     8012    0.025    0.000    0.047    0.000 state.py:677(unloaded)

```
without commit:
```
*** PROFILER RESULTS ***
show_invocation (/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/api/workflows.py:905)
function called 1 times

         4006285 function calls (3865075 primitive calls) in 6.737 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 730 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    6.723    6.723 workflows.py:905(show_invocation)
        1    0.000    0.000    6.720    6.720 workflows.py:1355(__encode_invocation)
        1    0.000    0.000    6.720    6.720 workflows.py:267(serialize_workflow_invocation)
        1    0.018    0.018    6.719    6.719 __init__.py:5303(to_dict)
40054/40052    0.024    0.000    6.688    0.000 attributes.py:279(__get__)
8034/4017    0.016    0.000    6.664    0.002 attributes.py:699(get)
     4017    0.022    0.000    6.600    0.002 strategies.py:665(_load_for_state)
     4013    0.007    0.000    6.494    0.002 <string>:1(<lambda>)
     4013    0.035    0.000    6.487    0.002 strategies.py:774(_emit_lazyload)
     4013    0.032    0.000    3.612    0.001 baked.py:421(__iter__)
        1    0.000    0.000    3.585    3.585 __init__.py:5476(jobs)
        1    0.000    0.000    3.584    3.584 __init__.py:1503(job_list)
        1    0.002    0.002    3.560    3.560 __init__.py:1505(<listcomp>)
     4014    0.014    0.000    3.411    0.001 query.py:3501(_execute_and_instances)
     2006    0.050    0.000    3.378    0.002 baked.py:557(_load_on_pk_identity)
     4014    0.006    0.000    3.167    0.001 base.py:952(execute)
     4014    0.005    0.000    3.159    0.001 elements.py:296(_execute_on_connection)
     4014    0.023    0.000    3.155    0.001 base.py:1088(_execute_clauseelement)
     4014    0.033    0.000    3.105    0.001 base.py:1195(_execute_context)
     4014    0.003    0.000    2.924    0.001 default.py:589(do_execute)
     4014    2.839    0.001    2.921    0.001 {method 'execute' of 'psycopg2.extensions.cursor' objects}
     2007    0.029    0.000    2.912    0.001 baked.py:539(all)
    10027    0.039    0.000    2.579    0.000 loading.py:35(instances)
     4014    0.005    0.000    1.283    0.000 loading.py:59(<listcomp>)
     4014    0.015    0.000    1.278    0.000 query.py:4345(row_processor)
10014/4014    0.304    0.000    1.261    0.000 loading.py:354(_instance_processor)
110078/56078    0.112    0.000    1.042    0.000 interfaces.py:559(create_row_processor)
6000/4000    0.030    0.000    0.871    0.000 strategies.py:1970(create_row_processor)
     4014    0.207    0.000    0.726    0.000 result.py:1268(fetchall)
     4014    0.005    0.000    0.501    0.000 loading.py:81(<listcomp>)
12013/6013    0.064    0.000    0.496    0.000 loading.py:509(_instance)
     4014    0.009    0.000    0.468    0.000 result.py:926(_soft_close)
     4014    0.010    0.000    0.451    0.000 base.py:899(close)
     4014    0.006    0.000    0.442    0.000 base.py:1031(close)
     4014    0.006    0.000    0.436    0.000 base.py:858(_checkin)
     4014    0.014    0.000    0.430    0.000 base.py:671(_finalize_fairy)
   110343    0.100    0.000    0.409    0.000 interfaces.py:518(_get_context_loader)
     4014    0.010    0.000    0.355    0.000 base.py:872(_reset)
     4014    0.012    0.000    0.343    0.000 default.py:539(do_rollback)
     4014    0.328    0.000    0.328    0.000 {method 'rollback' of 'psycopg2.extensions.connection' objects}
```
Of course we shouldn't serialize all of this if we don't need it,
but that's a quick and easy optimization.