### PR TITLE
Implement expression tool for picking non-null values for CWL-style merging of conditional branches in native Galaxy workflows

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2496,7 +2496,7 @@ class ExpressionTool(Tool):
                 dataset_id = src["id"]
                 copy_object = None
                 for input_dataset in inp_data.values():
-                    if input_dataset.id == dataset_id:
+                    if input_dataset and input_dataset.id == dataset_id:
                         copy_object = input_dataset
                         break
                 if copy_object is None:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2485,10 +2485,14 @@ class ExpressionTool(Tool):
 
     def exec_after_process(self, app, inp_data, out_data, param_dict, job=None, **kwds):
         for key, val in self.outputs.items():
+            if key not in out_data:
+                # Skip filtered outputs
+                continue
             if val.output_type == "data":
+
                 with open(out_data[key].file_name, "r") as f:
                     src = json.load(f)
-                assert isinstance(src, dict)
+                assert isinstance(src, dict), f"Expected dataset 'src' to be a dictionary - actual type is {type(src)}"
                 dataset_id = src["id"]
                 copy_object = None
                 for input_dataset in inp_data.values():

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -137,6 +137,8 @@ def _expand_macros(elements, macros, tokens):
 
 def _expand_macro(element, expand_el, macros, tokens):
     macro_name = expand_el.get('macro')
+    assert macro_name is not None, "Attempted to expand macro with no 'macro' attribute defined."
+    assert macro_name in macros, f"No macro named {macro_name} found, known marcos are {', '.join(macros.keys())}."
     macro_def = macros[macro_name]
     expanded_elements = deepcopy(macro_def.elements)
 

--- a/lib/galaxy_ext/expressions/handle_job.py
+++ b/lib/galaxy_ext/expressions/handle_job.py
@@ -36,8 +36,10 @@ def run(environment_path=None):
     outputs = raw_inputs["outputs"]
     inputs = raw_inputs.copy()
     del inputs["outputs"]
-
     result = evaluate(None, inputs)
+
+    if '__error_message' in result:
+        raise Exception(result['__error_message'])
     for output in outputs:
         path = output["path"]
         from_expression = output["from_expression"]

--- a/test/functional/tools/expression_tools
+++ b/test/functional/tools/expression_tools
@@ -1,0 +1,1 @@
+../../../tools/expression_tools

--- a/test/functional/tools/parse_values_from_file.xml
+++ b/test/functional/tools/parse_values_from_file.xml
@@ -1,1 +1,0 @@
-../../../tools/expression_tools/parse_values_from_file.xml

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -71,7 +71,8 @@
   <tool file="sim_size_delta.xml" />
   <tool file="composite_shapefile.xml" />
   <tool file="is_valid_xml.xml" />
-  <tool file="parse_values_from_file.xml"/>
+  <tool file="expression_tools/parse_values_from_file.xml"/>
+  <tool file="expression_tools/pick_value.xml" />
   <!--
   TODO: Figure out why this transiently fails on Jenkins.
   <tool file="maxseconds.xml" />

--- a/tools/expression_tools/expression_macros.xml
+++ b/tools/expression_tools/expression_macros.xml
@@ -1,0 +1,18 @@
+<macros>
+  <xml name="typed_outputs">
+    <outputs>
+        <output type="text" name="text_param" from="output">
+            <filter>param_type == 'text'</filter>
+        </output>
+        <output type="integer" name="integer_param" from="output">
+            <filter>param_type == 'integer'</filter>
+        </output>
+        <output type="float" name="float_param" from="output">
+            <filter>param_type == 'float'</filter>
+        </output>
+        <output type="boolean" name="boolean_param" from="output">
+            <filter>param_type == 'boolean'</filter>
+        </output>
+    </outputs>
+  </xml>
+</macros>

--- a/tools/expression_tools/parse_values_from_file.xml
+++ b/tools/expression_tools/parse_values_from_file.xml
@@ -1,5 +1,8 @@
 <tool name="Parse parameter value" id="param_value_from_file" version="0.1.0" tool_type="expression">
     <description>from dataset</description>
+    <macros>
+        <import>expression_macros.xml</import>
+    </macros>
     <expression type="ecma5.1">{
 var output;
 if ($job.remove_newlines || $job.param_type != 'text') {
@@ -36,20 +39,7 @@ return {'output': output};
         </param>
         <param name="remove_newlines" checked="true" type="boolean" label="Remove newlines ?" help="Uncheck this only if newlines should be preserved in parameter"/>
     </inputs>
-    <outputs>
-        <output type="text" name="text_param" from="output">
-            <filter>param_type == 'text'</filter>
-        </output>
-        <output type="integer" name="integer_param" from="output">
-            <filter>param_type == 'integer'</filter>
-        </output>
-        <output type="float" name="float_param" from="output">
-            <filter>param_type == 'float'</filter>
-        </output>
-        <output type="boolean" name="boolean_param" from="output">
-            <filter>param_type == 'boolean'</filter>
-        </output>
-     </outputs>
+    <expand macro="typed_outputs" />
     <tests>
         <test expect_num_outputs="1">
             <param name="input1" value="simple_line.txt"/>

--- a/tools/expression_tools/pick_value.xml
+++ b/tools/expression_tools/pick_value.xml
@@ -1,0 +1,372 @@
+<tool name="Pick parameter value" id="pick_value" version="0.1.0" tool_type="expression">
+    <macros>
+        <xml name="booleans">
+            <repeat name="pick_from" title="Pick from">
+                <param name="value" type="boolean" optional="true" label="Value" />
+            </repeat>
+        </xml>
+        <xml name="integers">
+            <repeat name="pick_from" title="Pick from">
+                <param name="value" type="integer" label="Value" optional="true" />
+            </repeat>
+        </xml>
+        <xml name="floats">
+            <repeat name="pick_from" title="Pick from">
+                <param name="value" type="float" label="Value" optional="true" />
+            </repeat>
+        </xml>
+        <xml name="texts">
+            <repeat name="pick_from" title="Pick from">
+                <param name="value" type="text" optional="true" label="Value" />
+            </repeat>
+        </xml>
+        <xml name="datas">
+            <repeat name="pick_from" title="Pick from">
+                <param name="value" type="data" format="data" optional="true" label="Value" />
+            </repeat>
+        </xml>
+        <xml name="param_type">
+            <param name="param_type" type="select" label="Select type of parameter to select from">
+                <option value="data">Dataset</option>
+                <option value="text">Text</option>
+                <option value="integer">Integer</option>
+                <option value="float">Float</option>
+                <option value="boolean">Boolean</option>
+            </param>
+        </xml>
+        <xml name="param_pick_style">
+            <param name="pick_style" type="select" label="Picking behavior" help="How should the case when not exactly one value is non-null be handled?">
+                <option value="first">Pick first value</option>
+                <option value="first_or_default">Pick first value (or provide default)</option>
+                <option value="first_or_error">Pick first value (or fail)</option>
+                <option value="only">Pick only value</option>
+            </param>
+        </xml>
+        <xml name="type_conditional">
+            <conditional name="type_cond">
+                <expand macro="param_type" />
+                <when value="text">
+                    <expand macro="texts" />
+                </when>
+                <when value="integer">
+                    <expand macro="integers" />
+                </when>
+                <when value="float">
+                    <expand macro="floats" />
+                </when>
+                <when value="boolean">
+                    <expand macro="booleans" />
+                </when>
+                <when value="data">
+                    <expand macro="datas" />
+                </when>
+            </conditional>
+        </xml>
+        <xml name="type_conditional_with_default">
+            <conditional name="type_cond">
+                <expand macro="param_type" />
+                <when value="text">
+                    <expand macro="texts" />
+                    <param name="default_value" type="text" label="Default Value" />
+                </when>
+                <when value="integer">
+                    <expand macro="integers" />
+                    <param name="default_value" type="integer" optional="true" label="Default Value" />
+                </when>
+                <when value="float">
+                    <expand macro="floats" />
+                    <param name="default_value" type="float" optional="true" label="Default Value" />
+                </when>
+                <when value="boolean">
+                    <expand macro="booleans" />
+                    <param name="default_value" type="boolean" label="Default Value" />
+                </when>
+                <when value="data">
+                    <expand macro="datas" />
+                    <param name="default_value" type="data" format="data" label="Default Value" />
+                </when>
+            </conditional>
+        </xml>
+        <xml name="style_conditional">
+            <conditional name="style_cond">
+                <expand macro="param_pick_style" />
+                <when value="first">
+                    <expand macro="type_conditional" />
+                </when>
+                <when value="first_or_default">
+                    <expand macro="type_conditional_with_default" />
+                </when>
+                <when value="first_or_error">
+                    <expand macro="type_conditional" />
+                </when>
+                <when value="only">
+                    <expand macro="type_conditional" />
+                </when>
+            </conditional>
+        </xml>
+    </macros>
+    <expression type="ecma5.1"><![CDATA[{
+var out = null;
+var pickStyle = $job.style_cond.pick_style;
+var paramType = $job.style_cond.type_cond.param_type;
+var pickFrom = $job.style_cond.type_cond.pick_from;
+for ( var i = 0; i < pickFrom.length; i++ ) {
+    if ( pickFrom[i].value !== null ) {
+        if ( pickStyle == 'only' && out !== null ) {
+            return { '__error_message': 'Multiple null values found, only one allowed.' };
+        } else if ( out == null ) {
+            out = pickFrom[i].value;
+        }
+    }
+}
+if ( out == null && pickStyle == 'first_or_default' ) {
+    out = $job.style_cond.type_cond.default_value;
+}
+if ( paramType == "data" && out ) {
+    out = out.src;
+}
+if ( out == null && ( pickStyle == "first_or_error" || pickStyle == "only" ) ) {
+    return { '__error_message': 'No non-null values found among tool inputs.' };
+}
+return { 'output': out };
+}]]></expression>
+    <inputs>
+        <expand macro="style_conditional" />
+    </inputs>
+    <outputs>
+        <output type="text" name="text_param" from="output">
+            <filter>style_cond['type_cond']['param_type'] == 'text'</filter>
+        </output>
+        <output type="integer" name="integer_param" from="output">
+            <filter>style_cond['type_cond']['param_type'] == 'integer'</filter>
+        </output>
+        <output type="float" name="float_param" from="output">
+            <filter>style_cond['type_cond']['param_type'] == 'float'</filter>
+        </output>
+        <output type="boolean" name="boolean_param" from="output">
+            <filter>style_cond['type_cond']['param_type'] == 'boolean'</filter>
+        </output>
+        <output type="data" name="data_param" from="output">
+            <filter>style_cond['type_cond']['param_type'] == 'data'</filter>
+        </output>
+    </outputs>
+    <help>
+A "null" value is an empty value, it means some input wasn't specified or some tool produced
+an empty value or was skipped entirely. This can be thought of as an NA in Excel or a None value
+in Python. This expression tool can be fed multiple values - from parameter inputs or the
+outputs or other tools or workflows - and pick one. This allows building workflows which can
+skip steps and branch in complex ways.
+
+There are subtle but important distinctions between the selection style - though they all
+essentially pick the first value that is non-null (i.e. the first input with a real value).
+
+- "Pick first value" is the default and will just return its own null value if none of the inputs
+are non-null.
+- "Pick first value (or provide default)" allows picking a default value that will be used if none of the
+inputs are non-null.
+- "Pick first value (or fail)" will cause the tool execution to fail if none of the selections are
+non-null. This can be important because it provides a clearer indication that something went
+wrong and can prevent the further evaluation of a worklfow.
+- "Pick only value" is like "First value (or fail)" in that it will cause an error if none of the
+inputs are non-null but it will go further to ensure that exactly one value is non-null. When
+building conditonal paths through a workflow this can ensure that at most one path is
+taken.
+    </help>
+    <tests>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="data" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value="simple_line.txt" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value="simple_line_alternative.txt" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="data_param" value="simple_line.txt" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="true" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="true" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="true" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="true" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="false" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="false" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="false" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="true" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="false" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="true" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="false" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="true" />
+        </test>
+        <test expect_failure="true">
+            <conditional name="style_cond">
+                <param name="pick_style" value="only" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="true" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="false" />
+                    </repeat>
+                </conditional>
+            </conditional>
+        </test>
+        <test expect_failure="true">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first_or_error" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                </conditional>
+            </conditional>
+        </test>
+        <test expect_failure="true">
+            <conditional name="style_cond">
+                <param name="pick_style" value="only" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                </conditional>
+            </conditional>
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="null" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first_or_default" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <param name="default_value" value_json="true" />
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="true" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first_or_default" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="boolean" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <param name="default_value" value_json="false" />
+                </conditional>
+            </conditional>
+            <output name="boolean_param" value_json="false" />
+        </test>
+        <test expect_num_outputs="1">
+            <conditional name="style_cond">
+                <param name="pick_style" value="first_or_default" />
+                <conditional name="type_cond">
+                    <param name="param_type" value="data" />
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <repeat name="pick_from">
+                        <param name="value" value_json="null" />
+                    </repeat>
+                    <param name="default_value" value="simple_line.txt" />
+                </conditional>
+            </conditional>
+            <output name="data_param" value="simple_line.txt" />
+        </test>
+    </tests>
+</tool>


### PR DESCRIPTION
I have CWL conditional branching working down stream (https://github.com/common-workflow-language/galaxy/pull/123/commits/074175b04b45cb70e556ceb3ff0bd29f5c9131bb) - CWL describes branching by simply attaching an expression to steps of the workflow and replace all the outputs with null values if the expression does not evaluate to ``true``. This will work very naturally in Galaxy workflows and the Galaxy workflow editor.

The matching CWL syntax for merging branches is simply to pick non-null values from various branches to continue the workflow with. The tool contained in this PR is a very natural, native Galaxy way of doing that.

This tool could be used to build some cool conditional logic with collections without even needing the forthcoming 'when' expressions on workflow steps. Imagine for instance, we added a "Replace Failed" (or "Replace Empty") collection operation to match "Filter Failed" (or "Filter Empty") that could replace collection elements with 'null' values or a supplied default. We could then run two different algorithms across a list (e.g. one that works well for small datasets but fails out for large ones and one that works well with large datasets) and then run "Replace Failed" with null values and then map both results over this tool. Using purely data flow constructs you've picked the right tool for each element of a list.

I haven't added this to the default tool panel yet though, might be worth waiting for either those when branching expressions or more collection operation tool support.
