### PR TITLE
[20.05] Use newer setup-miniconda action

### DIFF
--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Install tox
       run: pip install tox
     - name: Install and activate miniconda  # use this job to test using Python from a conda environment
-      uses: goanpeca/setup-miniconda@v1
+      uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: ''
     - name: run tests


### PR DESCRIPTION
Fix the failing OSX startup tests