### PR TITLE
Drop API Key listings from user list 

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -88,13 +88,6 @@ class UserListGrid(grids.Grid):
             else:
                 return 'N'
 
-    class APIKeyColumn(grids.GridColumn):
-        def get_value(self, trans, grid, user):
-            if user.api_keys:
-                return user.api_keys[0].key
-            else:
-                return ""
-
     # Grid definition
     title = "Users"
     title_id = "users-grid"
@@ -120,7 +113,6 @@ class UserListGrid(grids.Grid):
         StatusColumn("Status", attach_popup=False),
         TimeCreatedColumn("Created", attach_popup=False),
         ActivatedColumn("Activated", attach_popup=False),
-        APIKeyColumn("API Key", attach_popup=False),
         # Columns that are valid for filtering but are not visible.
         grids.DeletedColumn("Deleted", key="deleted", visible=False, filterable="advanced"),
         grids.PurgedColumn("Purged", key="purged", visible=False, filterable="advanced")


### PR DESCRIPTION
Admins can get this via impersonate or other means if they really need it, but it's kinda like showing all the passwords and we should not do it by default.

Fixes #10734 