### PR TITLE
[20.09] Fix anonymous user uploads if file sources configured

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -1,6 +1,9 @@
 import logging
 import os
-from collections import namedtuple
+from collections import (
+    defaultdict,
+    namedtuple,
+)
 
 from galaxy import exceptions
 from galaxy.util import (
@@ -229,7 +232,7 @@ class ProvidesUserFileSourcesUserContext(object):
     @property
     def preferences(self):
         user = self.trans.user
-        return user and user.extra_preferences
+        return user and user.extra_preferences or defaultdict(lambda: None)
 
 
 class DictFileSourcesUserContext(object):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -15,6 +15,7 @@ import pwd
 import random
 import string
 import time
+from collections import defaultdict
 from datetime import datetime, timedelta
 from string import Template
 from uuid import UUID, uuid4
@@ -380,7 +381,7 @@ class User(Dictifiable, RepresentById):
 
     @property
     def extra_preferences(self):
-        data = {}
+        data = defaultdict(lambda: None)
         extra_user_preferences = self.preferences.get('extra_user_preferences')
         if extra_user_preferences:
             try:


### PR DESCRIPTION
To get both file source uploads to work and anonymous uploads
you would need to use something like
```
${user.preferences.get('dropbox|access_token') if $user.preferences else ''}
```
This simplifies that back to the documented
```
${user.preferences['dropbox|access_token']
```

Overall I don't think we benefit from KeyErrors in the extra file
preferences, so I've made this `defaultdict(lambda: None)`, but we could
limit that to just the ProvidesUserFileSourcesUserContext.

Fixes https://github.com/galaxyproject/galaxy/issues/10595.