### PR TITLE
Upgrade h5py to 3.1.0 and numpy to 1.19.0

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -62,7 +62,7 @@ google-api-python-client==1.7.8
 google-auth-httplib2==0.0.3
 google-auth==1.18.0
 gxformat2==0.11.3
-h5py==2.10.0
+h5py==3.1.0
 httplib2==0.18.1
 humanfriendly==8.2
 idna==2.9
@@ -94,7 +94,7 @@ netifaces==0.10.9
 networkx==1.11
 nodeenv==1.4.0
 nose==1.3.7
-numpy==1.18.5
+numpy==1.19.0
 oauth2client==4.1.3
 oauthlib==3.1.0
 openstacksdk==0.17.0


### PR DESCRIPTION
Upgrading h5py and numpy is required in order to startup Galaxy on Catalina 10.15.7