### PR TITLE
[20.09] Don't use tool cache during repository installation

### DIFF
--- a/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
+++ b/lib/galaxy/tool_shed/galaxy_install/metadata/installed_repository_metadata_manager.py
@@ -74,7 +74,7 @@ class InstalledRepositoryMetadataManager(MetadataGenerator):
                 guid = tool_dict.get('guid', None)
                 if relative_path and guid:
                     try:
-                        tool = self.app.toolbox.load_tool(os.path.abspath(load_relative_path), guid=guid, use_cached=False)
+                        tool = self.app.toolbox.load_tool(os.path.abspath(load_relative_path), guid=guid, use_cached=False, from_cache=False)
                     except Exception:
                         log.exception("Error while loading tool at path '%s'", load_relative_path)
                         tool = None

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -312,8 +312,8 @@ class ToolBox(BaseGalaxyToolBox):
             self.cache_regions[tool_cache_data_dir] = ToolDocumentCache(cache_dir=tool_cache_data_dir)
         return self.cache_regions[tool_cache_data_dir]
 
-    def create_tool(self, config_file, tool_cache_data_dir=None, **kwds):
-        if config_file.endswith('.xml'):
+    def create_tool(self, config_file, tool_cache_data_dir=None, from_cache=True, **kwds):
+        if config_file.endswith('.xml') and from_cache:
             cache = self.get_cache_region(tool_cache_data_dir or self.app.config.tool_cache_data_dir)
             tool_document = cache.get(config_file)
             if tool_document:


### PR DESCRIPTION
Might work around https://gist.github.com/jmchilton/bf9b1ca0b5cc4e0281f737da677fdc6f, which I think happens during parallel repository installations. This doesn't seem to be an issue during toolbox reloads, so I'm hoping that's all that is needed.