### PR TITLE
Revision of sharing component, adds url copy to clipboard feature

### DIFF
--- a/client/src/components/Common/SlugInput.vue
+++ b/client/src/components/Common/SlugInput.vue
@@ -3,6 +3,7 @@
         v-model="slugInput"
         @change="onChange"
         @keydown.esc="onCancel"
+        @keydown.enter="onCancel"
         class="d-inline w-auto h-auto px-1 py-0"
         ref="input"
     />

--- a/client/src/components/Common/SlugInput.vue
+++ b/client/src/components/Common/SlugInput.vue
@@ -2,8 +2,8 @@
     <b-input
         v-model="slugInput"
         @change="onChange"
+        @keydown.enter="onChange"
         @keydown.esc="onCancel"
-        @keydown.enter="onCancel"
         class="d-inline w-auto h-auto px-1 py-0"
         ref="input"
     />

--- a/client/src/components/Common/SlugInput.vue
+++ b/client/src/components/Common/SlugInput.vue
@@ -30,7 +30,11 @@ export default {
     },
     methods: {
         onChange() {
-            this.$emit("onChange", this.slugInput);
+            const slugFormatted = this.slugInput
+                .replace(/\s+/g, "-")
+                .replace(/[^a-zA-Z0-9-]/g, "")
+                .toLowerCase();
+            this.$emit("onChange", slugFormatted);
         },
         onCancel() {
             this.$emit("onChange", this.slug);

--- a/client/src/components/Common/SlugInput.vue
+++ b/client/src/components/Common/SlugInput.vue
@@ -1,0 +1,39 @@
+<template>
+    <b-input
+        v-model="slugInput"
+        @change="onChange"
+        @keydown.esc="onCancel"
+        class="d-inline w-auto h-auto px-1 py-0"
+        ref="input"
+    />
+</template>
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        slug: {
+            type: String,
+        },
+    },
+    data() {
+        return {
+            slugInput: this.slug,
+        };
+    },
+    mounted() {
+        this.$refs.input.select();
+    },
+    methods: {
+        onChange() {
+            this.$emit("onChange", this.slugInput);
+        },
+        onCancel() {
+            this.$emit("onChange", this.slug);
+        },
+    },
+};
+</script>

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -31,7 +31,7 @@
                             <font-awesome-icon icon="edit" />
                         </b-button>
                         <b-button id="tooltip-clipboard" @click="onCopy" @mouseout="onCopyOut" variant="link" size="sm">
-                            <font-awesome-icon :icon="['far', 'clipboard']" />
+                            <font-awesome-icon icon="link" />
                         </b-button>
                         <b-tooltip target="tooltip-clipboard" triggers="hover">
                             {{ tooltipClipboard }}
@@ -46,7 +46,7 @@
                 </div>
                 <div v-else>
                     Access to this {{ model_class }} is currently restricted so that only you and the users listed below
-                    can access it. Note that sharing a History will also allow access to all of its datasets. 
+                    can access it. Note that sharing a History will also allow access to all of its datasets.
                 </div>
             </div>
             <br />
@@ -82,7 +82,7 @@ import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faClipboard, faEdit } from "@fortawesome/free-regular-svg-icons";
+import { faLink, faEdit } from "@fortawesome/free-solid-svg-icons";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import SlugInput from "components/Common/SlugInput";
@@ -90,7 +90,7 @@ import axios from "axios";
 
 Vue.use(BootstrapVue);
 
-library.add(faClipboard);
+library.add(faLink);
 library.add(faEdit);
 
 export default {
@@ -201,14 +201,14 @@ export default {
             if (importable) {
                 this.setSharing("make_accessible_via_link");
                 if (this.item.published) {
-                    this.setSharing('publish');
+                    this.setSharing("publish");
                 } else {
-                    this.setSharing('unpublish');
+                    this.setSharing("unpublish");
                 }
             } else {
                 this.item.published = false;
                 this.setSharing("disable_link_access");
-                this.setSharing('unpublish');
+                this.setSharing("unpublish");
             }
         },
         onPublish(published) {
@@ -216,7 +216,7 @@ export default {
                 this.item.importable = true;
                 this.setSharing("make_accessible_and_publish");
             } else {
-                this.setSharing('unpublish');
+                this.setSharing("unpublish");
             }
         },
         getModel() {

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -13,8 +13,6 @@
             <b-button type="submit" variant="primary" @click="setUsername()">Set Username</b-button>
         </div>
         <div v-else>
-            <br />
-            <h3>Make {{ model_class }} Accessible via Link and Publish It</h3>
             <div v-if="item.importable">
                 This {{ modelClassLower }} is currently <strong>{{ itemStatus }}</strong
                 >.

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -12,7 +12,7 @@
         </div>
         <div v-else>
             <b-form-checkbox switch v-model="item.importable" @change="onImportable">
-                Make {{ model_class }} accessible via link.
+                Make {{ model_class }} accessible.
             </b-form-checkbox>
             <b-form-checkbox v-if="item.importable" switch v-model="item.published" @change="onPublish">
                 Make {{ model_class }} publicly available in

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -21,9 +21,18 @@
                 <div>
                     <p>Anyone can view and import this {{ modelClassLower }} by visiting the following URL:</p>
                     <blockquote>
-                        <font-awesome-icon role="button" icon="edit" title="Edit URL" @click="onEdit" />
-                        <font-awesome-icon role="button" :icon="['far', 'clipboard']" class="ml-1" @click="onCopy" />
-                        <a v-if="showUrl" id="item-url" :href="itemUrl" target="_top" class="ml-2">{{ itemUrl }}</a>
+                        <b-button title="Edit URL" @click="onEdit" v-b-tooltip.hover variant="link" size="sm">
+                            <font-awesome-icon icon="edit" />
+                        </b-button>
+                        <b-button id="tooltip-clipboard" @click="onCopy" variant="link" size="sm">
+                            <font-awesome-icon :icon="['far', 'clipboard']" />
+                        </b-button>
+                        <b-tooltip target="tooltip-clipboard" triggers="hover">
+                            {{ tooltipClipboard }}
+                        </b-tooltip>
+                        <a v-if="showUrl" id="item-url" :href="itemUrl" target="_top" class="ml-2">
+                            {{ itemUrl }}
+                        </a>
                         <span v-else id="item-url-text">
                             {{ itemUrlParts[0] }}<SlugInput class="ml-1" :slug="itemUrlParts[1]" @onChange="onChange" />
                         </span>
@@ -186,6 +195,7 @@ export default {
             share_fields: ["email", { key: "id", label: "" }],
             make_members_public: false,
             showUrl: true,
+            tooltipClipboard: "Copy URL",
         };
     },
     computed: {
@@ -236,18 +246,20 @@ export default {
     },
     methods: {
         onCopy() {
-            const clipboard = document.createElement('input');
+            const clipboard = document.createElement("input");
             document.body.appendChild(clipboard);
             clipboard.value = this.itemUrl;
             clipboard.select();
-            document.execCommand('copy');
+            document.execCommand("copy");
             document.body.removeChild(clipboard);
+            this.tooltipClipboard = "Copied!";
         },
         onEdit() {
             this.showUrl = false;
         },
         onChange(newSlug) {
             this.showUrl = true;
+            this.tooltipClipboard = "Copy URL";
             this.item.username_and_slug = `${this.itemSlugParts[0]}${newSlug}`;
             const requestUrl = `${this.slugUrl}&new_slug=${newSlug}`;
             axios.get(requestUrl).catch((error) => (this.err_msg = error.response.data.err_msg));

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -1,23 +1,31 @@
 <template>
     <div v-if="ready">
-        <h2>Share or Publish {{ model_class }} `{{ item.title }}`</h2>
-        <b-alert :show="showDanger" variant="danger" dismissible> {{ err_msg }} </b-alert>
+        <h3>Share or Publish {{ model_class }} `{{ item.title }}`</h3>
+        <b-alert :show="showDanger" variant="danger" dismissible> {{ errMsg }} </b-alert>
         <br />
         <div v-if="!hasUsername">
-            <div>
-                To make a {{ modelClassLower }} accessible via link or publish it, you must create a public username:
-            </div>
+            <div>To make a {{ model_class }} accessible via link or publish it, you must create a public username:</div>
             <form class="form-group" @submit.prevent="setUsername()">
-                <label /> <input class="form-control" type="text" v-model="newUsername" />
+                <input class="form-control" type="text" v-model="newUsername" />
             </form>
             <b-button type="submit" variant="primary" @click="setUsername()">Set Username</b-button>
         </div>
         <div v-else>
-            <div v-if="item.importable">
-                This {{ modelClassLower }} is currently <strong>{{ itemStatus }}</strong
-                >.
-                <div>
-                    <p>Anyone can view and import this {{ modelClassLower }} by visiting the following URL:</p>
+            <b-form-checkbox switch v-model="item.importable" @change="onImportable">
+                Make {{ model_class }} accessible via link.
+            </b-form-checkbox>
+            <b-form-checkbox switch v-model="item.published" @change="onPublish">
+                Make {{ model_class }} publicly available in
+                <a :href="published_url" target="_top">Published {{ plural_name }}</a> section.
+            </b-form-checkbox>
+            <br />
+            <div>
+                <div v-if="item.importable">
+                    <div>
+                        This {{ model_class }} is currently <strong>{{ itemStatus }}</strong
+                        >.
+                    </div>
+                    <p>Anyone can view and import this {{ model_class }} by visiting the following URL:</p>
                     <blockquote>
                         <b-button title="Edit URL" @click="onEdit" v-b-tooltip.hover variant="link" size="sm">
                             <font-awesome-icon icon="edit" />
@@ -35,84 +43,20 @@
                             {{ itemUrlParts[0] }}<SlugInput class="ml-1" :slug="itemUrlParts[1]" @onChange="onChange" />
                         </span>
                     </blockquote>
-                    <div v-if="item.published">
-                        <p>
-                            This {{ modelClassLower }} is publicly listed and searchable in Galaxy's
-                            <a :href="published_url" target="_top">Published {{ plural_name }}</a> section.
-                        </p>
-                        <p>You can:</p>
-                    </div>
-                </div>
-                <div v-if="!item.published">
-                    <!-- Item is importable but not published. User can disable importable or publish. -->
-                    <b-button @click="setSharing('disable_link_access')"
-                        >Disable Access to {{ model_class }} Link</b-button
-                    >
-                    <div class="toolParamHelp">Disables {{ modelClassLower }}'s link so that it is not accessible.</div>
-                    <br />
-                    <b-button id="make_accessible_and_publish" @click="setSharing('publish')"
-                        >Publish {{ model_class }}</b-button
-                    >
-                    <div class="toolParamHelp">
-                        Publishes the {{ modelClassLower }} to Galaxy's
-                        <a :href="published_url" target="_top">Published {{ plural_name }}</a> section, where it is
-                        publicly listed and searchable.
-                    </div>
-                    <br />
                 </div>
                 <div v-else>
-                    <!-- Item is importable and published. User can unpublish or disable import and unpublish. -->
-                    <b-button
-                        id="disable_link_access_and_unpublish"
-                        @click="setSharing('disable_link_access_and_unpublish')"
-                        >Disable Access to {{ model_class }} via Link and Unpublish</b-button
-                    >
-                    <div class="toolParamHelp">
-                        Disables this {{ modelClassLower }}'s link so that it is not accessible and removes
-                        {{ modelClassLower }} from Galaxy's
-                        <a :href="published_url" target="_top">Published {{ plural_name }}</a> section so that it is not
-                        publicly listed or searchable.
-                    </div>
-                    <br />
-                    <b-button @click="setSharing('unpublish')">Unpublish {{ model_class }}</b-button>
-                    <div class="toolParamHelp">
-                        Removes this {{ modelClassLower }} from Galaxy's
-                        <a :href="published_url" target="_top">Published {{ plural_name }}</a> section so that it is not
-                        publicly listed or searchable.
-                    </div>
+                    Access to this {{ model_class }} is currently restricted so that only you and the users listed below
+                    can access it. Note that sharing a History will also allow access to all of its datasets. 
                 </div>
             </div>
-            <div v-else>
-                <p>
-                    This {{ modelClassLower }} is currently restricted so that only you and the users listed below can
-                    access it. You can:
-                </p>
-                <b-button @click="setSharing('make_accessible_via_link')"
-                    >Make {{ model_class }} Accessible via Link</b-button
-                >
-                <div class="toolParamHelp">
-                    Generates a web link that you can share with other people so that they can view and import the
-                    {{ modelClassLower }}.
-                </div>
-                <br />
-                <b-button id="make_accessible_and_publish" @click="setSharing('make_accessible_and_publish')"
-                    >Make {{ model_class }} Accessible and Publish</b-button
-                >
-                <div class="toolParamHelp">
-                    Makes the {{ modelClassLower }} accessible via link (see above) and publishes the
-                    {{ modelClassLower }} to Galaxy's
-                    <a :href="published_url" target="_top">Published {{ plural_name }}</a> section, where it is publicly
-                    listed and searchable.
-                </div>
-            </div>
-            <br /><br />
-            <h3>Share {{ model_class }} with Individual Users</h3>
+            <br />
+            <h4>Share {{ model_class }} with Individual Users</h4>
             <div>
                 <div v-if="item.users_shared_with && item.users_shared_with.length > 0">
                     <b-table small caption-top :fields="shareFields" :items="item.users_shared_with">
                         <template v-slot:table-caption>
-                            The following users will see this {{ modelClassLower }} in their {{ modelClassLower }} list
-                            and will be able to view, import and run it.
+                            The following users will see this {{ model_class }} in their {{ model_class }} list and will
+                            be able to view, import and run it.
                         </template>
                         <template v-slot:cell(id)="cell">
                             <b-button
@@ -125,7 +69,7 @@
                     </b-table>
                 </div>
                 <div v-else>
-                    <p>You have not shared this {{ modelClassLower }} with any users.</p>
+                    <p>You have not shared this {{ model_class }} with any users.</p>
                 </div>
                 <b-button :href="shareUrl" id="share_with_a_user"> <span>Share with a user</span> </b-button>
             </div>
@@ -253,6 +197,28 @@ export default {
             const requestUrl = `${this.slugUrl}&new_slug=${newSlug}`;
             axios.get(requestUrl).catch((error) => (this.errMsg = error.response.data.err_msg));
         },
+        onImportable(importable) {
+            if (importable) {
+                this.setSharing("make_accessible_via_link");
+                if (this.item.published) {
+                    this.setSharing('publish');
+                } else {
+                    this.setSharing('unpublish');
+                }
+            } else {
+                this.item.published = false;
+                this.setSharing("disable_link_access");
+                this.setSharing('unpublish');
+            }
+        },
+        onPublish(published) {
+            if (published) {
+                this.item.importable = true;
+                this.setSharing("make_accessible_and_publish");
+            } else {
+                this.setSharing('unpublish');
+            }
+        },
         getModel() {
             this.ready = false;
             axios
@@ -284,7 +250,6 @@ export default {
             axios
                 .post(`${getAppRoot()}api/${this.pluralNameLower}/${this.id}/sharing`, data)
                 .then((response) => {
-                    Object.assign(this.item, response.data);
                     if (response.data.skipped) {
                         this.errMsg = "Some of the items within this object were not published due to an error.";
                     }

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -5,7 +5,7 @@
         <br />
         <div v-if="!has_username">
             <div>
-                To make a {{ model_class_lc }} accessible via link or publish it, you must create a public username:
+                To make a {{ modelClassLower }} accessible via link or publish it, you must create a public username:
             </div>
             <form class="form-group" @submit.prevent="setUsername()">
                 <label /> <input class="form-control" type="text" v-model="new_username" />
@@ -16,10 +16,10 @@
             <br />
             <h3>Make {{ model_class }} Accessible via Link and Publish It</h3>
             <div v-if="item.importable">
-                This {{ model_class_lc }} is currently <strong>{{ item_status }}</strong
+                This {{ modelClassLower }} is currently <strong>{{ itemStatus }}</strong
                 >.
                 <div>
-                    <p>Anyone can view and import this {{ model_class_lc }} by visiting the following URL:</p>
+                    <p>Anyone can view and import this {{ modelClassLower }} by visiting the following URL:</p>
                     <blockquote>
                         <font-awesome-icon role="button" icon="edit" title="Edit URL" @click="onEdit" />
                         <font-awesome-icon role="button" :icon="['far', 'clipboard']" class="ml-1" @click="onCopy" />
@@ -30,7 +30,7 @@
                     </blockquote>
                     <div v-if="item.published">
                         <p>
-                            This {{ model_class_lc }} is publicly listed and searchable in Galaxy's
+                            This {{ modelClassLower }} is publicly listed and searchable in Galaxy's
                             <a :href="published_url" target="_top">Published {{ plural_name }}</a> section.
                         </p>
                         <p>You can:</p>
@@ -41,13 +41,13 @@
                     <b-button @click="setSharing('disable_link_access')"
                         >Disable Access to {{ model_class }} Link</b-button
                     >
-                    <div class="toolParamHelp">Disables {{ model_class_lc }}'s link so that it is not accessible.</div>
+                    <div class="toolParamHelp">Disables {{ modelClassLower }}'s link so that it is not accessible.</div>
                     <br />
                     <b-button id="make_accessible_and_publish" @click="setSharing('publish')"
                         >Publish {{ model_class }}</b-button
                     >
                     <div class="toolParamHelp">
-                        Publishes the {{ model_class_lc }} to Galaxy's
+                        Publishes the {{ modelClassLower }} to Galaxy's
                         <a :href="published_url" target="_top">Published {{ plural_name }}</a> section, where it is
                         publicly listed and searchable.
                     </div>
@@ -61,15 +61,15 @@
                         >Disable Access to {{ model_class }} via Link and Unpublish</b-button
                     >
                     <div class="toolParamHelp">
-                        Disables this {{ model_class_lc }}'s link so that it is not accessible and removes
-                        {{ model_class_lc }} from Galaxy's
+                        Disables this {{ modelClassLower }}'s link so that it is not accessible and removes
+                        {{ modelClassLower }} from Galaxy's
                         <a :href="published_url" target="_top">Published {{ plural_name }}</a> section so that it is not
                         publicly listed or searchable.
                     </div>
                     <br />
                     <b-button @click="setSharing('unpublish')">Unpublish {{ model_class }}</b-button>
                     <div class="toolParamHelp">
-                        Removes this {{ model_class_lc }} from Galaxy's
+                        Removes this {{ modelClassLower }} from Galaxy's
                         <a :href="published_url" target="_top">Published {{ plural_name }}</a> section so that it is not
                         publicly listed or searchable.
                     </div>
@@ -77,31 +77,31 @@
             </div>
             <div v-else>
                 <p>
-                    This {{ model_class_lc }} is currently restricted so that only you and the users listed below can
+                    This {{ modelClassLower }} is currently restricted so that only you and the users listed below can
                     access it. You can:
                 </p>
                 <b-button @click="setSharing('make_accessible_via_link')"
                     >Make {{ model_class }} Accessible via Link</b-button
                 >
-                <p v-if="has_possible_members" class="mt-2">
+                <p v-if="hasPossibleMembers" class="mt-2">
                     Also make all objects within the {{ model_class }} accessible.
                     <input type="checkbox" v-model="make_members_public" id="chk_make_members_public" />
                 </p>
                 <div class="toolParamHelp">
                     Generates a web link that you can share with other people so that they can view and import the
-                    {{ model_class_lc }}.
+                    {{ modelClassLower }}.
                 </div>
                 <br />
                 <b-button id="make_accessible_and_publish" @click="setSharing('make_accessible_and_publish')"
                     >Make {{ model_class }} Accessible and Publish</b-button
                 >
-                <p v-if="has_possible_members" class="mt-2">
+                <p v-if="hasPossibleMembers" class="mt-2">
                     Also make all objects within the {{ model_class }} accessible.
                     <input type="checkbox" v-model="make_members_public" id="chk_make_members_public" />
                 </p>
                 <div class="toolParamHelp">
-                    Makes the {{ model_class_lc }} accessible via link (see above) and publishes the
-                    {{ model_class_lc }} to Galaxy's
+                    Makes the {{ modelClassLower }} accessible via link (see above) and publishes the
+                    {{ modelClassLower }} to Galaxy's
                     <a :href="published_url" target="_top">Published {{ plural_name }}</a> section, where it is publicly
                     listed and searchable.
                 </div>
@@ -112,7 +112,7 @@
                 <div v-if="item.users_shared_with && item.users_shared_with.length > 0">
                     <b-table small caption-top :fields="share_fields" :items="item.users_shared_with">
                         <template v-slot:table-caption>
-                            The following users will see this {{ model_class_lc }} in their {{ model_class_lc }} list
+                            The following users will see this {{ modelClassLower }} in their {{ modelClassLower }} list
                             and will be able to view, import and run it.
                         </template>
                         <template v-slot:cell(id)="cell">
@@ -126,7 +126,7 @@
                     </b-table>
                 </div>
                 <div v-else>
-                    <p>You have not shared this {{ model_class_lc }} with any users.</p>
+                    <p>You have not shared this {{ modelClassLower }} with any users.</p>
                 </div>
                 <b-button :href="share_url" id="share_with_a_user"> <span>Share with a user</span> </b-button>
             </div>
@@ -191,13 +191,13 @@ export default {
         };
     },
     computed: {
-        model_class_lc() {
+        modelClassLower() {
             return this.model_class.toLowerCase();
         },
-        plural_name_lc() {
+        pluralNameLower() {
             return this.plural_name.toLowerCase();
         },
-        item_status() {
+        itemStatus() {
             return this.item.published ? "accessible via link and published" : "accessible via link";
         },
         itemUrl() {
@@ -217,16 +217,16 @@ export default {
             return [str.substring(0, index + 1), str.substring(index + 1)];
         },
         published_url() {
-            return `${getAppRoot()}${this.plural_name_lc}/list_published`;
+            return `${getAppRoot()}${this.pluralNameLower}/list_published`;
         },
         share_url() {
-            return `${getAppRoot()}${this.model_class_lc}/share/?id=${this.id}`;
+            return `${getAppRoot()}${this.modelClassLower}/share/?id=${this.id}`;
         },
         slugUrl() {
-            return `${getAppRoot()}${this.model_class_lc}/set_slug_async/?id=${this.id}`;
+            return `${getAppRoot()}${this.modelClassLower}/set_slug_async/?id=${this.id}`;
         },
-        has_possible_members() {
-            return ["history"].indexOf(this.model_class_lc) > -1;
+        hasPossibleMembers() {
+            return ["history"].indexOf(this.modelClassLower) > -1;
         },
         showDanger() {
             return this.err_msg !== null;
@@ -249,7 +249,7 @@ export default {
         getModel() {
             this.ready = false;
             axios
-                .get(`${getAppRoot()}api/${this.plural_name_lc}/${this.id}/sharing`)
+                .get(`${getAppRoot()}api/${this.pluralNameLower}/${this.id}/sharing`)
                 .then((response) => {
                     this.item = response.data;
                     this.ready = true;
@@ -274,11 +274,11 @@ export default {
                 action: action,
                 user_id: user_id,
             };
-            if (this.has_possible_members) {
+            if (this.hasPossibleMembers) {
                 data.make_members_public = this.make_members_public;
             }
             axios
-                .post(`${getAppRoot()}api/${this.plural_name_lc}/${this.id}/sharing`, data)
+                .post(`${getAppRoot()}api/${this.pluralNameLower}/${this.id}/sharing`, data)
                 .then((response) => {
                     Object.assign(this.item, response.data);
                     if (response.data.skipped) {

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -21,10 +21,10 @@
                 <div>
                     <p>Anyone can view and import this {{ model_class_lc }} by visiting the following URL:</p>
                     <blockquote>
-                        <font-awesome-icon icon="edit" id="edit-identifier" title="Edit URL" />
-                        <font-awesome-icon :icon="['far', 'clipboard']" class="ml-1" @click="onCopy"/>
-                        <a id="item-url" :href="item_url" target="_top" class="ml-2">{{ item_url }}</a>
-                        <span id="item-url-text" style="display: none;">
+                        <font-awesome-icon icon="edit" id="edit-identifier" role="button" title="Edit URL" />
+                        <font-awesome-icon :icon="['far', 'clipboard']" class="ml-1" role="button" @click="onCopy" />
+                        <a v-if="showUrl" id="item-url" :href="item_url" target="_top" class="ml-2">{{ item_url }}</a>
+                        <span v-else id="item-url-text">
                             {{ item_url_parts[0] }}<span id="item-identifier">{{ item_url_parts[1] }}</span>
                         </span>
                     </blockquote>
@@ -169,6 +169,25 @@ export default {
             required: true,
         },
     },
+    data() {
+        const Galaxy = getGalaxyInstance();
+        return {
+            ready: false,
+            has_username: Galaxy.user.get("username"),
+            new_username: "",
+            err_msg: null,
+            item: {
+                title: "title",
+                username_and_slug: "username_and_slug",
+                importable: false,
+                published: false,
+                users_shared_with: [],
+            },
+            share_fields: ["email", { key: "id", label: "" }],
+            make_members_public: false,
+            showUrl: true,
+        };
+    },
     computed: {
         model_class_lc() {
             return this.model_class.toLowerCase();
@@ -205,25 +224,6 @@ export default {
         show_danger() {
             return this.err_msg !== null;
         },
-    },
-    data() {
-        const Galaxy = getGalaxyInstance();
-        return {
-            ready: false,
-            has_username: Galaxy.user.get("username"),
-            new_username: "",
-            err_msg: null,
-            pencil_url: `${getAppRoot()}static/images/fugue/pencil.png`,
-            item: {
-                title: "title",
-                username_and_slug: "username_and_slug",
-                importable: false,
-                published: false,
-                users_shared_with: [],
-            },
-            share_fields: ["email", { key: "id", label: "" }],
-            make_members_public: false,
-        };
     },
     created: function () {
         this.getModel();

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -140,9 +140,9 @@ import BootstrapVue from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faClipboard, faEdit } from "@fortawesome/free-regular-svg-icons";
-import SlugInput from "components/Common/SlugInput";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
+import SlugInput from "components/Common/SlugInput";
 import axios from "axios";
 
 Vue.use(BootstrapVue);
@@ -198,11 +198,12 @@ export default {
         itemStatus() {
             return this.item.published ? "accessible via link and published" : "accessible via link";
         },
-        itemUrl() {
+        itemRoot() {
             const port = window.location.port ? `:${window.location.port}` : "";
-            return `${window.location.protocol}//${window.location.hostname}${port}${getAppRoot()}${
-                this.item.username_and_slug
-            }`;
+            return `${window.location.protocol}//${window.location.hostname}${port}${getAppRoot()}`;
+        },
+        itemUrl() {
+            return `${this.itemRoot}${this.item.username_and_slug}`;
         },
         itemSlugParts() {
             const str = this.item.username_and_slug;
@@ -235,7 +236,12 @@ export default {
     },
     methods: {
         onCopy() {
-            alert("Copy");
+            const clipboard = document.createElement('input');
+            document.body.appendChild(clipboard);
+            clipboard.value = this.itemUrl;
+            clipboard.select();
+            document.execCommand('copy');
+            document.body.removeChild(clipboard);
         },
         onEdit() {
             this.showUrl = false;

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -90,10 +90,6 @@
                 <b-button @click="setSharing('make_accessible_via_link')"
                     >Make {{ model_class }} Accessible via Link</b-button
                 >
-                <p v-if="hasPossibleMembers" class="mt-2">
-                    Also make all objects within the {{ model_class }} accessible.
-                    <input type="checkbox" v-model="makeMembersPublic" />
-                </p>
                 <div class="toolParamHelp">
                     Generates a web link that you can share with other people so that they can view and import the
                     {{ modelClassLower }}.
@@ -102,10 +98,6 @@
                 <b-button id="make_accessible_and_publish" @click="setSharing('make_accessible_and_publish')"
                     >Make {{ model_class }} Accessible and Publish</b-button
                 >
-                <p v-if="hasPossibleMembers" class="mt-2">
-                    Also make all objects within the {{ model_class }} accessible.
-                    <input type="checkbox" v-model="makeMembersPublic" />
-                </p>
                 <div class="toolParamHelp">
                     Makes the {{ modelClassLower }} accessible via link (see above) and publishes the
                     {{ modelClassLower }} to Galaxy's
@@ -232,9 +224,6 @@ export default {
         slugUrl() {
             return `${getAppRoot()}${this.modelClassLower}/set_slug_async/?id=${this.id}`;
         },
-        hasPossibleMembers() {
-            return ["history"].indexOf(this.modelClassLower) > -1;
-        },
         showDanger() {
             return this.errMsg !== null;
         },
@@ -292,9 +281,6 @@ export default {
                 action: action,
                 user_id: user_id,
             };
-            if (this.hasPossibleMembers) {
-                data.make_members_public = this.makeMembersPublic;
-            }
             axios
                 .post(`${getAppRoot()}api/${this.pluralNameLower}/${this.id}/sharing`, data)
                 .then((response) => {

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -21,13 +21,12 @@
                 <div>
                     <p>Anyone can view and import this {{ model_class_lc }} by visiting the following URL:</p>
                     <blockquote>
-                        <a id="item-url" :href="item_url" target="_top">{{ item_url }}</a>
+                        <font-awesome-icon icon="edit" id="edit-identifier" title="Edit URL" />
+                        <font-awesome-icon :icon="['far', 'clipboard']" class="ml-1" @click="onCopy"/>
+                        <a id="item-url" :href="item_url" target="_top" class="ml-2">{{ item_url }}</a>
                         <span id="item-url-text" style="display: none;">
                             {{ item_url_parts[0] }}<span id="item-identifier">{{ item_url_parts[1] }}</span>
                         </span>
-                        <a href="javascript:void(0)" id="edit-identifier"
-                            ><img :src="pencil_url" alt="Edit Share Url"
-                        /></a>
                     </blockquote>
                     <div v-if="item.published">
                         <p>
@@ -136,17 +135,26 @@
 </template>
 
 <script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faClipboard, faEdit } from "@fortawesome/free-regular-svg-icons";
 import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import axios from "axios";
 import async_save_text from "utils/async-save-text";
-import Vue from "vue";
-import BootstrapVue from "bootstrap-vue";
 
 Vue.use(BootstrapVue);
 
+library.add(faClipboard);
+library.add(faEdit);
+
 export default {
+    components: {
+        FontAwesomeIcon,
+    },
     props: {
         id: {
             type: String,
@@ -224,7 +232,10 @@ export default {
         this.createSlugHandler();
     },
     methods: {
-        getModel: function () {
+        onCopy() {
+            alert("Copy");
+        },
+        getModel() {
             this.ready = false;
             axios
                 .get(`${getAppRoot()}api/${this.plural_name_lc}/${this.id}/sharing`)
@@ -234,7 +245,7 @@ export default {
                 })
                 .catch((error) => (this.err_msg = error.response.data.err_msg));
         },
-        setUsername: function () {
+        setUsername() {
             const Galaxy = getGalaxyInstance();
             axios
                 .put(`${getAppRoot()}api/users/${Galaxy.user.id}/information/inputs`, {
@@ -247,7 +258,7 @@ export default {
                 })
                 .catch((error) => (this.err_msg = error.response.data.err_msg));
         },
-        setSharing: function (action, user_id) {
+        setSharing(action, user_id) {
             const data = {
                 action: action,
                 user_id: user_id,
@@ -265,7 +276,7 @@ export default {
                 })
                 .catch((error) => (this.err_msg = error.response.data.err_msg));
         },
-        createSlugHandler: function () {
+        createSlugHandler() {
             const on_start = function (text_elt) {
                 // Replace URL with URL text.
                 $("#item-url").hide();

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -14,7 +14,7 @@
             <b-form-checkbox switch v-model="item.importable" @change="onImportable">
                 Make {{ model_class }} accessible via link.
             </b-form-checkbox>
-            <b-form-checkbox switch v-model="item.published" @change="onPublish">
+            <b-form-checkbox v-if="item.importable" switch v-model="item.published" @change="onPublish">
                 Make {{ model_class }} publicly available in
                 <a :href="published_url" target="_top">Published {{ plural_name }}</a> section.
             </b-form-checkbox>

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1424,18 +1424,18 @@ class SharableMixin:
             action = payload.get("action")
             if action == "make_accessible_via_link":
                 self._make_item_accessible(trans.sa_session, item)
-                if hasattr(item, "has_possible_members") and item.has_possible_members and payload.get("make_members_public", False):
-                    shared, skipped = self._make_members_public(trans, item)
+                if hasattr(item, "has_possible_members") and item.has_possible_members:
+                    skipped = self._make_members_public(trans, item)
             elif action == "make_accessible_and_publish":
                 self._make_item_accessible(trans.sa_session, item)
-                if hasattr(item, "has_possible_members") and item.has_possible_members and payload.get("make_members_public", False):
-                    shared, skipped = self._make_members_public(trans, item)
+                if hasattr(item, "has_possible_members") and item.has_possible_members:
+                    skipped = self._make_members_public(trans, item)
                 item.published = True
             elif action == "publish":
                 if item.importable:
                     item.published = True
-                    if hasattr(item, "has_possible_members") and item.has_possible_members and payload.get("make_members_public", False):
-                        shared, skipped = self._make_members_public(trans, item)
+                    if hasattr(item, "has_possible_members") and item.has_possible_members:
+                        skipped = self._make_members_public(trans, item)
                 else:
                     raise exceptions.MessageException("%s not importable." % class_name)
             elif action == "disable_link_access":
@@ -1482,7 +1482,7 @@ class SharableMixin:
                 else:
                     log.warning("User without permissions tried to make dataset with id: %s public", dataset.id)
                     skipped = True
-        return item, skipped
+        return skipped
 
     # -- Abstract methods. --
 


### PR DESCRIPTION
This PR revises the sharing component by removing legacy jquery helpers and introducing a slug input component. Additionally it adds a clipboard feature, allowing users to copy the url. It also applies conventional naming and formatting in consensus with newer components and use the font awesome components to render icons. Fixes #10732.

<img width="487" alt="image" src="https://user-images.githubusercontent.com/2105447/99571226-49ec6700-29d3-11eb-9c86-62b6912d798d.png">

