### PR TITLE
Fix collection elements losing tags when copied across histories

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3223,6 +3223,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
                                         flush=False)
         # update init non-keywords as well
         hda.purged = self.purged
+
         hda.copy_tags_to(copy_tags)
         object_session(self).add(hda)
         hda.metadata = self.metadata
@@ -3236,7 +3237,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
 
     def copy_tags_to(self, copy_tags=None):
         if copy_tags is not None:
-            for tag in copy_tags.values():
+            for tag in copy_tags:
                 copied_tag = tag.copy(cls=HistoryDatasetAssociationTagAssociation)
                 self.tags.append(copied_tag)
 
@@ -4655,7 +4656,7 @@ class DatasetCollectionElement(Dictifiable, RepresentById):
                     flush=flush
                 )
             else:
-                new_element_object = element_object.copy(flush=flush)
+                new_element_object = element_object.copy(flush=flush, copy_tags=element_object.tags)
                 new_element_object.visible = False
                 if destination is not None and element_object.hidden_beneath_collection_instance:
                     new_element_object.hidden_beneath_collection_instance = destination

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -413,7 +413,7 @@ class DefaultToolAction:
                 trans.sa_session.add(data)
                 if not completed_job:
                     trans.app.security_agent.set_all_dataset_permissions(data.dataset, output_permissions, new=True, flush=False)
-            data.copy_tags_to(preserved_tags)
+            data.copy_tags_to(preserved_tags.values())
 
             if not completed_job and trans.app.config.legacy_eager_objectstore_initialization:
                 # Must flush before setting object store id currently.


### PR DESCRIPTION
…ameter in copy call


Fix for Issue #10230

Changed copy_tags to an array in copy_tags_to method
Added a copy_tags parameter (element_object.tags) to copy call in copy_to_collection

Many thanks to @mvdbeek for his help!
