### PR TITLE
[20.09] Cleanup announce samples

### DIFF
--- a/doc/source/releases/20.09_announce.rst
+++ b/doc/source/releases/20.09_announce.rst
@@ -54,11 +54,9 @@ The following configuration options have been changed
 New Configuration Files
 -----------------------
 
-The following files are new, or recently converted to yaml
+The following configuration file is new:
 
 -  ``config/trs_servers_conf.yml.sample``
--  ``config/build_mulled_singularity_mapping_file.yml.sample``
--  ``config/singularity_mapping.yml.sample``
 
 
 Get Galaxy


### PR DESCRIPTION
I'm not sure where these came from but I am not grepping any mention/use of them in the codebase.  My guess is doc gen gone awry.

Fixes #10749