### PR TITLE
Move tooltips in rule builder below buttons, and put buttons on the same row

### DIFF
--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -385,8 +385,8 @@
                                     manage column definitions.
                                 </div>
                             </ol>
-                            <div class="rules-buttons">
-                                <div class="btn-group dropup">
+                            <div class="rules-buttons btn-group">
+                                <div class="dropup">
                                     <button
                                         type="button"
                                         v-b-tooltip.hover.bottom
@@ -411,7 +411,7 @@
                                         >
                                     </div>
                                 </div>
-                                <div class="btn-group dropup">
+                                <div class="dropup">
                                     <button
                                         type="button"
                                         v-b-tooltip.hover.bottom
@@ -431,7 +431,7 @@
                                         <rule-target-component :builder="this" rule-type="add_filter_count" />
                                     </div>
                                 </div>
-                                <div class="btn-group dropup">
+                                <div class="dropup">
                                     <button
                                         type="button"
                                         v-b-tooltip.hover.bottom
@@ -1729,7 +1729,7 @@ export default {
     padding: 5px;
 }
 .rules-container-vertical {
-    width: 280px;
+    width: 300px;
     height: 400px;
 }
 .rules-container-horizontal {


### PR DESCRIPTION
Fix for #10765

- Put all buttons in a horizontal button group
- Tool tips drop to the bottom, options drop up 
- Increased the size of the column by 20px to account for all buttons being beside each other.

![Screenshot from 2020-11-18 16-26-31](https://user-images.githubusercontent.com/26912553/99590639-9deb5180-29bb-11eb-8648-a8276982e407.png)
