### PR TITLE
[20.09] fix history_dataset_as_image in workflow invocations

### DIFF
--- a/client/src/components/Dataset/DatasetAsImage/DatasetAsImage.vue
+++ b/client/src/components/Dataset/DatasetAsImage/DatasetAsImage.vue
@@ -1,6 +1,10 @@
 <template>
     <div>
-        <img v-if="imgUrl" :src="imgUrl" />
+        <div v-if="imageUrl" class="w-50 p-2 float-left">
+            <b-card nobody body-class="p-1">
+                <b-img :src="imageUrl" fluid />
+            </b-card>
+        </div>
         <div v-else>
             <b>Image is not found</b>
         </div>
@@ -26,13 +30,13 @@ export default {
         if (this.path) {
             this.fetchPathDestination({ history_dataset_id: this.history_dataset_id, path: this.path }).then(() => {
                 const pathDestination = this.$store.getters.pathDestination(this.history_dataset_id, this.path);
-                this.imgUrl = pathDestination.fileLink;
+                this.imageUrl = pathDestination.fileLink;
             });
-        } else this.imgUrl = `${getAppRoot()}dataset/display?dataset_id=${this.history_dataset_id}`;
+        } else this.imageUrl = `${getAppRoot()}dataset/display?dataset_id=${this.history_dataset_id}`;
     },
     data() {
         return {
-            imgUrl: undefined,
+            imageUrl: undefined,
         };
     },
     methods: {

--- a/client/src/components/Markdown/Elements/HistoryDatasetAsImage.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetAsImage.vue
@@ -1,8 +1,6 @@
 <template>
-    <div class="w-50 p-2 float-left">
-        <b-card nobody body-class="p-1">
-            <b-img :src="imageUrl" fluid />
-        </b-card>
+    <div>
+        <DatasetAsImage :path="args.path" :history_dataset_id="args.history_dataset_id" />
     </div>
 </template>
 
@@ -10,10 +8,14 @@
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import { getAppRoot } from "onload/loadConfig";
+import DatasetAsImage from "components/Dataset/DatasetAsImage/DatasetAsImage";
 
 Vue.use(BootstrapVue);
 
 export default {
+    components: {
+        DatasetAsImage,
+    },
     props: {
         args: {
             type: Object,


### PR DESCRIPTION
Just little refactoring issue.
Also in general we are not supposed to use async functions in computed, right?

Anyway, it fixes https://github.com/galaxyproject/galaxy/issues/10764