### PR TITLE
[20.09] Fix reference error

### DIFF
--- a/config/plugins/visualizations/mvpapp/src/index.js
+++ b/config/plugins/visualizations/mvpapp/src/index.js
@@ -1971,7 +1971,7 @@ var PeptideView = (function (pv) {
 
         option.scoreSummary = true;
 
-        psmDetailDP = new AjaxDataProvider(option);
+        let psmDetailDP = new AjaxDataProvider(option);
         psmDetailDP.generateTable();
         //Move to table
         $("html, body").animate(


### PR DESCRIPTION
From console.log:

"Uncaught ReferenceError: psmDetailDP is not defined " is preventing a table from getting populated.

Fixed with proper declaration.