### PR TITLE
Resolve uncaught exception in admin/tool_box_dependencies for containers

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -447,7 +447,7 @@ class MulledSingularityContainerResolver(MulledDockerContainerResolver):
         self.hash_func = hash_func
         self.auto_install = string_as_bool(auto_install)
 
-    def cached_container_description(self, targets, namespace, hash_func):
+    def cached_container_description(self, targets, namespace, hash_func, resolution_cache=None):
         return singularity_cached_container_description(targets,
                                                         cache_directory=self.cache_directory,
                                                         hash_func=hash_func)


### PR DESCRIPTION
This PR deals with #10790, seen originally in 20.01, but judging by the current dev code, this fix is still applicable. This enables the UI to present the admin/tool_box_dependencies for containers.