### PR TITLE
[20.09] Fix list of cached Docker images not getting updated

### DIFF
--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -124,10 +124,7 @@ class ContainerFinder:
         return NULL_CONTAINER
 
     def resolution_cache(self):
-        cache = ResolutionCache()
-        if self.container_registry.mulled_resolution_cache is not None:
-            cache.mulled_resolution_cache = self.container_registry.mulled_resolution_cache
-        return cache
+        return self.container_registry.get_resolution_cache()
 
     def __overridden_container_id(self, container_type, destination_info):
         if not self.__container_type_enabled(container_type, destination_info):
@@ -234,6 +231,12 @@ class ContainerRegistry:
         import galaxy.tool_util.deps.container_resolvers
         return plugin_config.plugins_dict(galaxy.tool_util.deps.container_resolvers, 'resolver_type')
 
+    def get_resolution_cache(self):
+        cache = ResolutionCache()
+        if self.mulled_resolution_cache is not None:
+            cache.mulled_resolution_cache = self.mulled_resolution_cache
+        return cache
+
     def find_best_container_description(self, enabled_container_types, tool_info, **kwds):
         """Yield best container description of supplied types matching tool info."""
         try:
@@ -244,7 +247,7 @@ class ContainerRegistry:
         return None if resolved_container_description is None else resolved_container_description.container_description
 
     def resolve(self, enabled_container_types, tool_info, index=None, resolver_type=None, install=True, resolution_cache=None, session=None):
-        resolution_cache = resolution_cache or self.mulled_resolution_cache
+        resolution_cache = resolution_cache or self.get_resolution_cache()
         for i, container_resolver in enumerate(self.container_resolvers):
             if index is not None and i != index:
                 continue


### PR DESCRIPTION
by using the ephemeral cache as it was intended.

In #10451 we started passing in the beaker-backed persistent cache, when the code was expecting to be able to set per-request ephemeral values in the `ResolutionCache` object. This fixes new docker images not being returned in the `CachedDocker` resolver.

That is the simplest fix, but we should probably refactor this in `dev` so that even successful resolution has an expiry date, in case there is an updated image on quay that should be used.