### PR TITLE
extension lookup with lower case extension

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2599,6 +2599,8 @@ class DatasetHash(RepresentById):
 
 
 def datatype_for_extension(extension, datatypes_registry=None):
+    if extension is not None:
+        extension = extension.lower()
     if datatypes_registry is None:
         datatypes_registry = _get_datatypes_registry()
     if not extension or extension == 'auto' or extension == '_sniff_':


### PR DESCRIPTION
Galaxy uses lower case extensions. Realworld often does not.
For instance mzML, XML, ...

When using `<discover_datasets pattern="__name_and_ext__" ... />`
this requires to rename all output files to have lower case
extensions. Otherwise one sees:

```
Datatype class not found for extension: XYZ
```

(Actually I'm not sure what the name and ext will be in such a case)

So instead I thought that we can simply test against a lower
case extension.

Alternatively we could do this in `get_datatype_by_extension` in
datatypes/registry.py but I was afaid of side effects.