### PR TITLE
Speedup xml replacement

### DIFF
--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -24,7 +24,9 @@ def load_with_references(path):
     # Expand xml macros
     macro_dict = _macros_of_type(root, 'xml', lambda el: XmlMacroDef(el))
     _expand_macros([root], macro_dict, tokens)
-
+    for el in root.xpath('//macros'):
+        el.getparent().remove(el)
+    _expand_tokens_for_el(root, tokens)
     return tree, macro_paths
 
 
@@ -131,8 +133,6 @@ def _expand_macros(elements, macros, tokens):
             if expand_el is None:
                 break
             _expand_macro(element, expand_el, macros, tokens)
-
-        _expand_tokens_for_el(element, tokens)
 
 
 def _expand_macro(element, expand_el, macros, tokens):

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -150,23 +150,16 @@ def _expand_macro(element, expand_el, macros, tokens):
     if macro_tokens:
         _expand_tokens(expanded_elements, macro_tokens)
 
-    # HACK for elementtree, newer implementations (etree/lxml) won't
-    # require this parent_map data structure but elementtree does not
-    # track parents or recognize .find('..').
-    # TODO fix this now that we're not using elementtree
-    parent_map = {c: p for p in element.iter() for c in p}
-    _xml_replace(expand_el, expanded_elements, parent_map)
+    _xml_replace(expand_el, expanded_elements)
 
 
 def _expand_yield_statements(macro_def, expand_el):
     yield_els = [yield_el for macro_def_el in macro_def for yield_el in macro_def_el.findall('.//yield')]
 
     expand_el_children = list(expand_el)
-    macro_def_parent_map = \
-        {c: p for macro_def_el in macro_def for p in macro_def_el.iter() for c in p}
 
     for yield_el in yield_els:
-        _xml_replace(yield_el, expand_el_children, macro_def_parent_map)
+        _xml_replace(yield_el, expand_el_children)
 
     # Replace yields at the top level of a macro, seems hacky approach
     replace_yield = True
@@ -258,9 +251,8 @@ def _xml_set_children(element, new_children):
         element.insert(i, new_child)
 
 
-def _xml_replace(query, targets, parent_map):
-    # parent_el = query.find('..') ## Something like this would be better with newer xml library
-    parent_el = parent_map[query]
+def _xml_replace(query, targets):
+    parent_el = query.find('..')
     matching_index = -1
     # for index, el in enumerate(parent_el.iter('.')):  ## Something like this for newer implementation
     for index, el in enumerate(list(parent_el)):

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -24,8 +24,10 @@ def load_with_references(path):
     # Expand xml macros
     macro_dict = _macros_of_type(root, 'xml', lambda el: XmlMacroDef(el))
     _expand_macros([root], macro_dict, tokens)
-    for el in root.xpath('//macros'):
-        el.getparent().remove(el)
+    for el in root.xpath('//macro'):
+        if el.get('type') != 'template':
+            # Only keep template macros
+            el.getparent().remove(el)
     _expand_tokens_for_el(root, tokens)
     return tree, macro_paths
 

--- a/packages/tool_util/requirements.txt
+++ b/packages/tool_util/requirements.txt
@@ -1,2 +1,3 @@
 galaxy-util>=20.1.0.dev0
 galaxy-containers
+lxml


### PR DESCRIPTION
This speeds up tool parsing significantly (if the tool isn't already in the tool cache).
I would like to thank John from February 2013 for the hint :).
Before:
```
*** PROFILER RESULTS ***
load_with_references (/Users/mvandenb/src/galaxy/lib/galaxy/util/xml_macros.py:10)
function called 2057 times

         37174705 function calls (26399913 primitive calls) in 159.561 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 63 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2057    0.019    0.000  159.561    0.078 xml_macros.py:10(load_with_references)
36510/2049   10.706    0.000  151.955    0.074 xml_macros.py:126(_expand_macros)
34461/23486    0.246    0.000  123.611    0.005 xml_macros.py:140(_expand_macro)
    34461  115.626    0.003  115.626    0.003 xml_macros.py:159(<dictcomp>)
5403373/79830   13.579    0.000   21.819    0.000 xml_macros.py:106(_expand_tokens_for_el)
5415134/73970    1.894    0.000   21.360    0.000 xml_macros.py:98(_expand_tokens)
     2049    0.007    0.000    6.373    0.003 xml_macros.py:63(_import_macros)
 11965416    5.378    0.000    6.353    0.000 xml_macros.py:119(_expand_tokens_str)
     3880    6.227    0.002    6.227    0.002 __init__.py:227(parse_xml)
3323/1500    0.011    0.000    5.820    0.004 xml_macros.py:187(_load_macros)
3323/1500    0.009    0.000    5.801    0.004 xml_macros.py:224(_load_imported_macros)
1823/1817    0.004    0.000    5.771    0.003 xml_macros.py:250(_load_macro_file)
159530/98533    2.130    0.000    2.492    0.000 copy.py:128(deepcopy)
    37859    0.292    0.000    1.612    0.000 xml_macros.py:263(_xml_replace)
    34461    0.060    0.000    1.058    0.000 copy.py:200(_deepcopy_list)
 12008626    0.957    0.000    0.957    0.000 {method 'items' of 'dict' objects}
    34461    0.124    0.000    0.737    0.000 xml_macros.py:163(_expand_yield_statements)
     2057    0.003    0.000    0.696    0.000 xml_macros.py:50(raw_xml_tree)
     1500    0.500    0.000    0.500    0.000 xml_macros.py:256(_xml_set_children)
     4098    0.052    0.000    0.495    0.000 xml_macros.py:76(_macros_of_type)
     3000    0.132    0.000    0.443    0.000 xml_macros.py:81(<listcomp>)
    34461    0.347    0.000    0.347    0.000 xml_macros.py:168(<dictcomp>)
    79164    0.034    0.000    0.308    0.000 xml_macros.py:27(<lambda>)
    79164    0.245    0.000    0.274    0.000 xml_macros.py:282(__init__)
    34461    0.226    0.000    0.226    0.000 xml_macros.py:164(<listcomp>)
     3323    0.208    0.000    0.216    0.000 xml_macros.py:197(_load_embedded_macros)
   159530    0.146    0.000    0.183    0.000 copy.py:242(_keep_alive)
    34461    0.062    0.000    0.070    0.000 xml_macros.py:300(macro_tokens)
   452054    0.058    0.000    0.058    0.000 {built-in method builtins.id}
   319060    0.042    0.000    0.042    0.000 {method 'get' of 'dict' objects}
     3323    0.035    0.000    0.036    0.000 xml_macros.py:239(_imported_macro_paths_from_el)
   168105    0.029    0.000    0.029    0.000 {method 'startswith' of 'str' objects}
     2049    0.018    0.000    0.025    0.000 posixpath.py:150(dirname)
   221720    0.025    0.000    0.025    0.000 {method 'append' of 'list' objects}
     2049    0.021    0.000    0.022    0.000 xml_macros.py:88(expand_nested_tokens)
    51119    0.022    0.000    0.022    0.000 {method 'replace' of 'str' objects}
   125069    0.022    0.000    0.022    0.000 {built-in method builtins.getattr}
   125069    0.020    0.000    0.020    0.000 {built-in method builtins.issubclass}
     2049    0.020    0.000    0.020    0.000 xml_macros.py:72(_macros_el)
     1823    0.007    0.000    0.010    0.000 posixpath.py:71(join)
```
After:
```
*** PROFILER RESULTS ***
load_with_references (/Users/mvandenb/src/galaxy/lib/galaxy/util/xml_macros.py:14)
function called 2057 times

         4643955 function calls (3915049 primitive calls) in 16.777 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 56 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2057    0.600    0.000   16.776    0.008 xml_macros.py:14(load_with_references)
36510/2049    3.571    0.000    6.934    0.003 xml_macros.py:133(_expand_macros)
     2049    0.008    0.000    6.161    0.003 xml_macros.py:70(_import_macros)
     3880    6.039    0.002    6.039    0.002 __init__.py:227(parse_xml)
3323/1500    0.011    0.000    5.630    0.004 xml_macros.py:185(_load_macros)
3323/1500    0.009    0.000    5.609    0.004 xml_macros.py:222(_load_imported_macros)
1823/1817    0.004    0.000    5.578    0.003 xml_macros.py:248(_load_macro_file)
34461/23486    0.143    0.000    3.746    0.000 xml_macros.py:145(_expand_macro)
159530/98533    1.836    0.000    2.147    0.000 copy.py:128(deepcopy)
320270/19670    1.372    0.000    2.015    0.000 xml_macros.py:113(_expand_tokens_for_el)
332031/13810    0.139    0.000    1.985    0.000 xml_macros.py:105(_expand_tokens)
    37859    0.309    0.000    1.413    0.000 xml_macros.py:261(_xml_replace)
    34461    0.051    0.000    0.943    0.000 copy.py:200(_deepcopy_list)
     4098    0.055    0.000    0.761    0.000 xml_macros.py:83(_macros_of_type)
     3000    0.153    0.000    0.706    0.000 xml_macros.py:88(<listcomp>)
     2057    0.002    0.000    0.687    0.000 xml_macros.py:57(raw_xml_tree)
    79164    0.037    0.000    0.549    0.000 xml_macros.py:31(<lambda>)
    79164    0.482    0.000    0.512    0.000 xml_macros.py:279(__init__)
   822694    0.424    0.000    0.511    0.000 xml_macros.py:126(_expand_tokens_str)
     1500    0.479    0.000    0.479    0.000 xml_macros.py:254(_xml_set_children)
    34461    0.090    0.000    0.328    0.000 xml_macros.py:163(_expand_yield_statements)
     3323    0.194    0.000    0.202    0.000 xml_macros.py:195(_load_embedded_macros)
    34461    0.194    0.000    0.194    0.000 xml_macros.py:164(<listcomp>)
   159530    0.119    0.000    0.153    0.000 copy.py:242(_keep_alive)
   865904    0.078    0.000    0.078    0.000 {method 'items' of 'dict' objects}
    34461    0.059    0.000    0.068    0.000 xml_macros.py:297(macro_tokens)
   452054    0.053    0.000    0.053    0.000 {built-in method builtins.id}
   319060    0.037    0.000    0.037    0.000 {method 'get' of 'dict' objects}
     3323    0.036    0.000    0.037    0.000 xml_macros.py:237(_imported_macro_paths_from_el)
   168105    0.030    0.000    0.030    0.000 {method 'startswith' of 'str' objects}
     2049    0.017    0.000    0.025    0.000 posixpath.py:150(dirname)
   221720    0.024    0.000    0.024    0.000 {method 'append' of 'list' objects}
     2049    0.022    0.000    0.023    0.000 xml_macros.py:95(expand_nested_tokens)
     2049    0.020    0.000    0.020    0.000 xml_macros.py:79(_macros_el)
   125069    0.019    0.000    0.019    0.000 {built-in method builtins.getattr}
   125069    0.017    0.000    0.017    0.000 {built-in method builtins.issubclass}
    40948    0.016    0.000    0.016    0.000 {method 'replace' of 'str' objects}
     1823    0.007    0.000    0.011    0.000 posixpath.py:71(join)
     3872    0.003    0.000    0.005    0.000 posixpath.py:41(_get_sep)
     8767    0.004    0.000    0.004    0.000 xml_macros.py:27(<lambda>)
```

Looks like it was really as simple as this. If we could now make `_expand_tokens_for_el` a bit faster maybe we wouldn't need to worry about all the limitations of the tool cache.