### PR TITLE
show warning on trs-workflow import for anonymous users

### DIFF
--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -24,7 +24,7 @@
             </div>
         </b-card>
         <b-alert v-else show variant="danger" class="text-center my-2"
-            >Only registered users can import workflows!</b-alert
+            >Anonymous user cannot import workflows, please register or log in</b-alert
         >
     </div>
 </template>

--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -77,7 +77,7 @@ export default {
             return this.errorMessage != null;
         },
         isAnonymous() {
-            return !getGalaxyInstance().user.isAnonymous();
+            return getGalaxyInstance().user.isAnonymous();
         },
     },
     watch: {

--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-card title="GA4GH Tool Registry Server (TRS) Workflow Import">
+        <b-card v-if="isRegistered" title="GA4GH Tool Registry Server (TRS) Workflow Import">
             <b-alert :show="hasErrorMessage" variant="danger">{{ errorMessage }}</b-alert>
             <div>
                 <b>TRS Server:</b>
@@ -23,6 +23,9 @@
                 <trs-tool :trs-tool="trsTool" v-if="trsTool" @onImport="importVersion(trsTool.id, $event)" />
             </div>
         </b-card>
+        <b-alert v-else show variant="danger" class="text-center my-2"
+            >Only registered users can import workflows!</b-alert
+        >
     </div>
 </template>
 
@@ -32,6 +35,7 @@ import BootstrapVue from "bootstrap-vue";
 import { Services } from "./services";
 import TrsMixin from "./trsMixin";
 import { Toast } from "ui/toast";
+import { getGalaxyInstance } from "app";
 
 Vue.use(BootstrapVue);
 
@@ -71,6 +75,9 @@ export default {
     computed: {
         hasErrorMessage() {
             return this.errorMessage != null;
+        },
+        isRegistered() {
+            return !getGalaxyInstance().user.isAnonymous();
         },
     },
     watch: {

--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-card v-if="isRegistered" title="GA4GH Tool Registry Server (TRS) Workflow Import">
+        <b-card v-if="isAnonymous" title="GA4GH Tool Registry Server (TRS) Workflow Import">
             <b-alert :show="hasErrorMessage" variant="danger">{{ errorMessage }}</b-alert>
             <div>
                 <b>TRS Server:</b>
@@ -11,7 +11,7 @@
                     @onError="onTrsSelectionError"
                 />
             </div>
-            <div v-if="isAutoImport" class="text-center my-2">
+            <div v-if="isAutoImport && !hasErrorMessage" class="text-center my-2">
                 <b-spinner class="align-middle"></b-spinner>
                 <strong>Loading your Workflow...</strong>
             </div>
@@ -76,7 +76,7 @@ export default {
         hasErrorMessage() {
             return this.errorMessage != null;
         },
-        isRegistered() {
+        isAnonymous() {
             return !getGalaxyInstance().user.isAnonymous();
         },
     },

--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <b-card v-if="isAnonymous" title="GA4GH Tool Registry Server (TRS) Workflow Import">
+        <b-card v-if="!isAnonymous" title="GA4GH Tool Registry Server (TRS) Workflow Import">
             <b-alert :show="hasErrorMessage" variant="danger">{{ errorMessage }}</b-alert>
             <div>
                 <b>TRS Server:</b>


### PR DESCRIPTION
Since we want to deploy auto-import [buttons](https://gist.github.com/bgruening/a891880ba98534f11ceb42be73d90646). We need some sort of warning for unregistered users