### PR TITLE
[20.09] Disable tool cache if there is a problem

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -276,10 +276,11 @@ class ToolBox(BaseGalaxyToolBox):
         that re-opens the database after forking.
         """
         for region in self.cache_regions.values():
-            region.persist()
-            if register_postfork:
-                region.close()
-                self.app.application_stack.register_postfork_function(region.reopen_ro)
+            if not region.disabled:
+                region.persist()
+                if register_postfork:
+                    region.close()
+                    self.app.application_stack.register_postfork_function(region.reopen_ro)
 
     def can_load_config_file(self, config_filename):
         if config_filename == self.app.config.shed_tool_config_file and not self.app.config.is_set('shed_tool_config_file'):
@@ -313,8 +314,8 @@ class ToolBox(BaseGalaxyToolBox):
         return self.cache_regions[tool_cache_data_dir]
 
     def create_tool(self, config_file, tool_cache_data_dir=None, **kwds):
-        if config_file.endswith('.xml'):
-            cache = self.get_cache_region(tool_cache_data_dir or self.app.config.tool_cache_data_dir)
+        cache = self.get_cache_region(tool_cache_data_dir or self.app.config.tool_cache_data_dir)
+        if config_file.endswith('.xml') and not cache.disabled:
             tool_document = cache.get(config_file)
             if tool_document:
                 tool_source = self.get_expanded_tool_source(

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -38,20 +38,33 @@ class ToolDocumentCache:
             os.makedirs(self.cache_dir)
         self.cache_file = os.path.join(self.cache_dir, 'cache.sqlite')
         self.writeable_cache_file = None
-        # Create database if necessary using 'c' flag
-        self._cache = SqliteDict(self.cache_file, flag='c', encode=encoder, decode=decoder, autocommit=False)
-        # Switch SqliteDict back to readonly
-        self._cache.flag = 'r'
+        self._cache = None
+        self.disabled = False
+        self._get_cache(create_if_necessary=True)
 
     def close(self):
-        self._cache.close()
+        self._cache and self._cache.close()
+
+    def _get_cache(self, flag='r', create_if_necessary=False):
+        try:
+            if create_if_necessary and not os.path.exists(self.cache_file):
+                # Create database if necessary using 'c' flag
+                self._cache = SqliteDict(self.cache_file, flag='c', encode=encoder, decode=decoder, autocommit=False)
+                if flag == 'r':
+                    self._cache.flag = flag
+            else:
+                self._cache = SqliteDict(self.cache_file, flag=flag, encode=encoder, decode=decoder, autocommit=False)
+        except sqlite3.OperationalError:
+            log.warning('Tool document cache unavailable')
+            self._cache = None
+            self.disabled = True
 
     @property
     def cache_file_is_writeable(self):
         return os.access(self.cache_file, os.W_OK)
 
     def reopen_ro(self):
-        self._cache = SqliteDict(self.cache_file, flag='r', encode=encoder, decode=decoder, autocommit=False)
+        self._get_cache(flag='r')
         self.writeable_cache_file = None
 
     def get(self, config_file):
@@ -75,7 +88,7 @@ class ToolDocumentCache:
             self.writeable_cache_file = tempfile.NamedTemporaryFile(dir=self.cache_dir, suffix='cache.sqlite.tmp', delete=False)
             if os.path.exists(self.cache_file):
                 shutil.copy(self.cache_file, self.writeable_cache_file.name)
-            self._cache = SqliteDict(self.writeable_cache_file.name, flag='c', encode=encoder, decode=decoder, autocommit=False)
+            self._get_cache(flag='c')
 
     def persist(self):
         if self.writeable_cache_file:
@@ -169,7 +182,7 @@ class ToolCache:
                     if tool_id in self._new_tool_ids:
                         self._new_tool_ids.remove(tool_id)
                 if persist_tool_document_cache:
-                    tool.toolbox.persist_tool_document_cache()
+                    tool.toolbox.persist_cache()
         except Exception as e:
             log.debug("Exception while checking tools to remove from cache: %s", unicodify(e))
             # If by chance the file is being removed while calculating the hash or modtime


### PR DESCRIPTION
There are a couple of circumstances where the tool document cache is not working correctly, such as if the cache is on NFS or CIFS.

This will disable the cache in case there are any sqlite3.OperationalErrors.
I've verified this works correctly by putting the tool cache on NFS and installing a couple of tools, making sure the tools are loaded both in the installing processes and the various workers.