### PR TITLE
[Selenium] fix bibtex  test

### DIFF
--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -134,8 +134,8 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
         references = assert_citations_visible()
 
-        doi_resolved_citation = references[0]
-        assert "Galaxy: A platform for interactive" in doi_resolved_citation.text
+        doi_resolved_citation = references[1]
+        assert "enabling efficient sequence analysis" in doi_resolved_citation.text
         self.screenshot("tool_form_citations_formatted")
 
     def _check_dataset_details_for_inttest_value(self, hid, expected_value="42"):


### PR DESCRIPTION
This test is getting pretty annoying. it keeps failing under each PR of mine
Use 2nd rendered DOI, instead of the 1st, because it returns "-"

example: https://github.com/galaxyproject/galaxy/pull/10807/checks?check_run_id=1459554406

Screenshot from  the test:
![last](https://user-images.githubusercontent.com/15801412/100375887-cf44cc80-300e-11eb-9f0c-763a5c00f491.png)

