### PR TITLE
[20.09] Restore the ability to pull containers from admin menu

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -414,13 +414,13 @@ class MulledDockerContainerResolver(ContainerResolver):
                     hash_func=self.hash_func,
                     resolution_cache=resolution_cache,
             ):
-                destination = {}
+                destination_info = {}
                 if destination_for_container_type:
-                    destination = destination_for_container_type(self.container_type)
+                    destination_info = destination_for_container_type(self.container_type)
                 container = CONTAINER_CLASSES[self.container_type](container_description.identifier,
                                                                    self.app_info,
                                                                    tool_info,
-                                                                   destination,
+                                                                   destination_info,
                                                                    {},
                                                                    container_description)
                 self.pull(container)

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -407,7 +407,6 @@ class MulledDockerContainerResolver(ContainerResolver):
                 type=self.container_type,
                 shell=self.shell,
             )
-            destination_for_container_type = kwds.get('destination_for_container_type')
             if install and not self.cached_container_description(
                     targets,
                     namespace=self.namespace,
@@ -415,6 +414,7 @@ class MulledDockerContainerResolver(ContainerResolver):
                     resolution_cache=resolution_cache,
             ):
                 destination_info = {}
+                destination_for_container_type = kwds.get('destination_for_container_type')
                 if destination_for_container_type:
                     destination_info = destination_for_container_type(self.container_type)
                 container = CONTAINER_CLASSES[self.container_type](container_description.identifier,

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -408,16 +408,19 @@ class MulledDockerContainerResolver(ContainerResolver):
                 shell=self.shell,
             )
             destination_for_container_type = kwds.get('destination_for_container_type')
-            if install and destination_for_container_type and not self.cached_container_description(
+            if install and not self.cached_container_description(
                     targets,
                     namespace=self.namespace,
                     hash_func=self.hash_func,
                     resolution_cache=resolution_cache,
             ):
+                destination = {}
+                if destination_for_container_type:
+                    destination = destination_for_container_type(self.container_type)
                 container = CONTAINER_CLASSES[self.container_type](container_description.identifier,
                                                                    self.app_info,
                                                                    tool_info,
-                                                                   destination_for_container_type(self.container_type),
+                                                                   destination,
                                                                    {},
                                                                    container_description)
                 self.pull(container)

--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -259,7 +259,7 @@ class ContainerRegistry:
             if not install and container_resolver.builds_on_resolution:
                 continue
 
-            container_description = container_resolver.resolve(enabled_container_types, tool_info, resolution_cache=resolution_cache, session=session)
+            container_description = container_resolver.resolve(enabled_container_types, tool_info, install=install, resolution_cache=resolution_cache, session=session)
             log.info("Checking with container resolver [{}] found description [{}]".format(container_resolver, container_description))
             if container_description:
                 assert container_description.type in enabled_container_types


### PR DESCRIPTION
This used to work in the old dependency menu because it went through
https://github.com/mvdbeek/galaxy/blob/dev/lib/galaxy/tool_util/deps/__init__.py#L263