### PR TITLE
Allow TRS servers to not be defined 

### DIFF
--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -55,7 +55,7 @@ class TrsProxy:
         else:
             server_list = DEFAULT_TRS_SERVERS
         self._server_list = server_list if server_list else []
-        self._server_dict = {t["id"]: t for t in self._server_list} if self._server_list else {}
+        self._server_dict = {t["id"]: t for t in self._server_list}
 
     def get_servers(self):
         return self._server_list

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -54,9 +54,8 @@ class TrsProxy:
                 server_list = yaml.safe_load(f)
         else:
             server_list = DEFAULT_TRS_SERVERS
-        self._server_list = server_list
-        if self._server_list:
-            self._server_dict = {t["id"]: t for t in self._server_list}
+        self._server_list = server_list if server_list else []
+        self._server_dict = {t["id"]: t for t in self._server_list} if self._server_list else {}
 
     def get_servers(self):
         return self._server_list

--- a/lib/galaxy/workflow/trs_proxy.py
+++ b/lib/galaxy/workflow/trs_proxy.py
@@ -55,7 +55,8 @@ class TrsProxy:
         else:
             server_list = DEFAULT_TRS_SERVERS
         self._server_list = server_list
-        self._server_dict = {t["id"]: t for t in self._server_list}
+        if self._server_list:
+            self._server_dict = {t["id"]: t for t in self._server_list}
 
     def get_servers(self):
         return self._server_list


### PR DESCRIPTION
TRS servers are currently required to be set, but if you configure none to be set, Galaxy will error out because it can't find one (#10815).