### PR TITLE
[20.09] Drop trigger and update time queries

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1140,34 +1140,17 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
     def set_final_state(self, final_state):
         self.set_state(final_state)
         # TODO: migrate to where-in subqueries?
-        statements = ['''
-            UPDATE history_dataset_collection_association
-            SET update_time = :update_time
-            WHERE id in (
-                SELECT hdca.id
-                FROM history_dataset_collection_association hdca
-                INNER JOIN implicit_collection_jobs icj
-                    on icj.id = hdca.implicit_collection_jobs_id
-                INNER JOIN implicit_collection_jobs_job_association icjja
-                    on icj.id = icjja.implicit_collection_jobs_id
-                WHERE icjja.job_id = :job_id
-                UNION
-                SELECT hdca2.id
-                FROM history_dataset_collection_association hdca2
-                WHERE hdca2.job_id = :job_id
-            );
-        ''', '''
+        statement = '''
             UPDATE workflow_invocation_step
             SET update_time = :update_time
             WHERE job_id = :job_id;
-        ''']
+        '''
         sa_session = object_session(self)
         params = {
             'job_id': self.id,
             'update_time': galaxy.model.orm.now.now()
         }
-        for statement in statements:
-            sa_session.execute(statement, params)
+        sa_session.execute(statement, params)
 
     def get_destination_configuration(self, dest_params, config, key, default=None):
         """ Get a destination parameter that can be defaulted back
@@ -1192,22 +1175,6 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
     def update_output_states(self):
         # TODO: migrate to where-in subqueries?
         statements = ['''
-            UPDATE history_dataset_collection_association
-            SET update_time = :update_time
-            WHERE id in (
-                SELECT hdca.id
-                FROM history_dataset_collection_association hdca
-                INNER JOIN implicit_collection_jobs icj
-                    on icj.id = hdca.implicit_collection_jobs_id
-                INNER JOIN implicit_collection_jobs_job_association icjja
-                    on icj.id = icjja.implicit_collection_jobs_id
-                WHERE icjja.job_id = :job_id
-                UNION
-                SELECT hdca2.id
-                FROM history_dataset_collection_association hdca2
-                WHERE hdca2.job_id = :job_id
-            );
-        ''', '''
             UPDATE dataset
             SET
                 state = :state,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -42,7 +42,7 @@ from galaxy.model.custom_types import JSONType, MetadataType, TrimmedString, UUI
 from galaxy.model.orm.engine_factory import build_engine
 from galaxy.model.orm.now import now
 from galaxy.model.security import GalaxyRBACAgent
-from galaxy.model.triggers import install_timestamp_triggers
+from galaxy.model.triggers import drop_timestamp_triggers
 from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
 from galaxy.model.view.utils import install_views
 
@@ -2888,9 +2888,11 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     # Create tables if needed
     if create_tables:
         metadata.create_all()
-        install_timestamp_triggers(engine)
         install_views(engine)
         # metadata.engine.commit()
+    else:
+        # TODO: replace this in 21.01 with a migration.
+        drop_timestamp_triggers(engine)
 
     result.create_tables = create_tables
     # load local galaxy security policy


### PR DESCRIPTION
I don't think we currently filter on HDA or HDCA update_time in the UI, so this should work around the observed deadlocks, at the cost of having to re-implement a replacement on 21.01 when we'll merge https://github.com/galaxyproject/galaxy/pull/8441.