### PR TITLE
Implement read-only conda resolver (alternative)

### DIFF
--- a/doc/source/admin/dependency_resolvers.rst
+++ b/doc/source/admin/dependency_resolvers.rst
@@ -236,3 +236,7 @@ copy_dependencies
     linking them when creating per job environments. This should be considered somewhat
     deprecated because Conda will do this as needed for newer versions of Conda - such
     as the version targeted with Galaxy 17.01+.
+
+read_only
+    If ``True``, Galaxy will not attempt to install or uninstall requirement sets into
+    this environment.

--- a/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/__init__.py
@@ -25,6 +25,7 @@ class ContainerResolver(Dictifiable, metaclass=ABCMeta):
     dict_collection_visible_keys = ['resolver_type', 'can_uninstall_dependencies', 'builds_on_resolution']
     can_uninstall_dependencies = False
     builds_on_resolution = False
+    read_only = True  # not used for containers, but set for when they are used like dependency resolvers
 
     def __init__(self, app_info=None, **kwds):
         """Default initializer for ``ContainerResolver`` subclasses."""

--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -19,7 +19,7 @@ class DependencyResolver(Dictifiable, metaclass=ABCMeta):
     """Abstract description of a technique for resolving container images for tool execution."""
 
     # Keys for dictification.
-    dict_collection_visible_keys = ['resolver_type', 'resolves_simple_dependencies', 'can_uninstall_dependencies']
+    dict_collection_visible_keys = ['resolver_type', 'resolves_simple_dependencies', 'can_uninstall_dependencies', 'read_only']
     # A "simple" dependency is one that does not depend on the the tool
     # resolving the dependency. Classic tool shed dependencies are non-simple
     # because the repository install context is used in dependency resolution
@@ -29,6 +29,7 @@ class DependencyResolver(Dictifiable, metaclass=ABCMeta):
     resolves_simple_dependencies = True
     can_uninstall_dependencies = False
     config_options: Dict[str, Any] = {}
+    read_only = True
 
     @abstractmethod
     def resolve(self, requirement, **kwds):
@@ -241,9 +242,16 @@ class InstallableDependencyResolver(metaclass=ABCMeta):
     """ Mix this into a ``DependencyResolver`` and implement to indicate
     the dependency resolver can attempt to install new dependencies.
     """
+    read_only = False
+
+    def install_dependency(self, name, version, type, **kwds):
+        if self.read_only:
+            return False
+        else:
+            return self._install_dependency(name, version, type, **kwds)
 
     @abstractmethod
-    def install_dependency(self, name, version, type, **kwds):
+    def _install_dependency(self, name, version, type, **kwds):
         """ Attempt to install this dependency if a recipe to do so
         has been registered in some way.
         """

--- a/lib/galaxy/tool_util/deps/resolvers/__init__.py
+++ b/lib/galaxy/tool_util/deps/resolvers/__init__.py
@@ -27,7 +27,6 @@ class DependencyResolver(Dictifiable, metaclass=ABCMeta):
     # resolution.
     disabled = False
     resolves_simple_dependencies = True
-    can_uninstall_dependencies = False
     config_options: Dict[str, Any] = {}
     read_only = True
 
@@ -43,6 +42,22 @@ class DependencyResolver(Dictifiable, metaclass=ABCMeta):
         version (which may differ from requested version for instance if the
         request version is 'default'.)
         """
+
+    def install_dependency(self, name, version, type, **kwds):
+        if self.read_only:
+            return False
+        else:
+            return self._install_dependency(name, version, type, **kwds)
+
+    def _install_dependency(self, name, version, type, **kwds):
+        """ Attempt to install this dependency if a recipe to do so
+        has been registered in some way.
+        """
+        return False
+
+    @property
+    def can_uninstall_dependencies(self):
+        return not self.read_only
 
 
 class MultipleDependencyResolver:
@@ -236,25 +251,6 @@ class SpecificationPatternDependencyResolver(SpecificationAwareDependencyResolve
             requirement.version = version
 
         return requirement
-
-
-class InstallableDependencyResolver(metaclass=ABCMeta):
-    """ Mix this into a ``DependencyResolver`` and implement to indicate
-    the dependency resolver can attempt to install new dependencies.
-    """
-    read_only = False
-
-    def install_dependency(self, name, version, type, **kwds):
-        if self.read_only:
-            return False
-        else:
-            return self._install_dependency(name, version, type, **kwds)
-
-    @abstractmethod
-    def _install_dependency(self, name, version, type, **kwds):
-        """ Attempt to install this dependency if a recipe to do so
-        has been registered in some way.
-        """
 
 
 class Dependency(Dictifiable, metaclass=ABCMeta):

--- a/lib/galaxy/tool_util/deps/resolvers/conda.py
+++ b/lib/galaxy/tool_util/deps/resolvers/conda.py
@@ -13,7 +13,6 @@ from . import (
     Dependency,
     DependencyException,
     DependencyResolver,
-    InstallableDependencyResolver,
     ListableDependencyResolver,
     MappableDependencyResolver,
     MultipleDependencyResolver,
@@ -64,7 +63,7 @@ done
 log = logging.getLogger(__name__)
 
 
-class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, ListableDependencyResolver, InstallableDependencyResolver, SpecificationPatternDependencyResolver, MappableDependencyResolver):
+class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, ListableDependencyResolver, SpecificationPatternDependencyResolver, MappableDependencyResolver):
     dict_collection_visible_keys = DependencyResolver.dict_collection_visible_keys + ['prefix', 'versionless', 'ensure_channels', 'auto_install', 'auto_init', 'use_local']
     resolver_type = "conda"
     config_options = {
@@ -82,7 +81,6 @@ class CondaDependencyResolver(DependencyResolver, MultipleDependencyResolver, Li
     def __init__(self, dependency_manager, **kwds):
         read_only = _string_as_bool(kwds.get('read_only', 'false'))
         self.read_only = read_only
-        self.can_uninstall_dependencies = not read_only
         self._setup_mapping(dependency_manager, **kwds)
         self.versionless = _string_as_bool(kwds.get('versionless', 'false'))
         self.dependency_manager = dependency_manager

--- a/lib/galaxy/tool_util/deps/views.py
+++ b/lib/galaxy/tool_util/deps/views.py
@@ -144,8 +144,8 @@ class DependencyResolversView:
         False if not successful
         """
         resolver = self._dependency_resolver(index)
-        if not hasattr(resolver, "install_dependency"):
-            raise exceptions.NotImplemented()
+        if resolver.read_only:
+            raise exceptions.RequestParameterInvalidException("Attempted to install on a read_only dependency resolver.")
 
         name, version, type, extra_kwds = self._parse_dependency_info(payload)
         return resolver.install_dependency(
@@ -198,7 +198,7 @@ class DependencyResolversView:
         """
         List index for all active resolvers that have the 'install_dependency' attribute.
         """
-        return [index for index, resolver in enumerate(self._dependency_resolvers) if hasattr(resolver, "install_dependency") and not resolver.disabled]
+        return [index for index, resolver in enumerate(self._dependency_resolvers) if not resolver.read_only and not resolver.disabled]
 
     @property
     def uninstallable_resolvers(self):

--- a/lib/galaxy/tool_util/deps/views.py
+++ b/lib/galaxy/tool_util/deps/views.py
@@ -146,6 +146,8 @@ class DependencyResolversView:
         resolver = self._dependency_resolver(index)
         if resolver.read_only:
             raise exceptions.RequestParameterInvalidException("Attempted to install on a read_only dependency resolver.")
+        if resolver.disabled:
+            raise exceptions.RequestParameterInvalidException("Attempted to install on a disabled dependency resolver.")
 
         name, version, type, extra_kwds = self._parse_dependency_info(payload)
         return resolver.install_dependency(

--- a/test/unit/tool_util/test_conda_resolution.py
+++ b/test/unit/tool_util/test_conda_resolution.py
@@ -23,6 +23,12 @@ def test_conda_resolution():
             auto_install=True,
             use_path_exec=False,  # For the test ensure this is always a clean install
         )
+        resolver.read_only = True
+        req = ToolRequirement(name="samtools", version=None, type="package")
+        dependency = resolver.resolve(req, job_directory=job_dir)
+        assert dependency.shell_commands() is None
+
+        resolver.read_only = False
         req = ToolRequirement(name="samtools", version=None, type="package")
         dependency = resolver.resolve(req, job_directory=job_dir)
         assert dependency.shell_commands() is not None


### PR DESCRIPTION
Move install stuff into base resolver as recommended by @nsoranzo.

I do not prefer this design but I get it. Replacing a hasattr is cleaner to use but I don't think the dependency resolvers that don't have the option to install should have install junk in their class definition. I'll put both of these out there though and let y'all decide.