### PR TITLE
[20.01] Cast `ncores` to str for `subprocess.call()`

### DIFF
--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -437,7 +437,7 @@ class S3ObjectStore(ObjectStore, CloudConfigMixin):
                 log.debug("Parallel pulled key '%s' into cache to %s", rel_path, self._get_cache_path(rel_path))
                 ncores = multiprocessing.cpu_count()
                 url = key.generate_url(7200)
-                ret_code = subprocess.call(['axel', '-a', '-n', ncores, url])
+                ret_code = subprocess.call(['axel', '-a', '-n', str(ncores), url])
                 if ret_code == 0:
                     return True
             else:


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/10824 .