### PR TITLE
[20.01] Update `sphinx-markdown-tables` to fix conflict

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -52,7 +52,7 @@ scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
 snowballstemmer==2.0.0
-sphinx-markdown-tables==0.0.12
+sphinx-markdown-tables==0.0.13
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2


### PR DESCRIPTION
`sphinx-markdown-tables` 0.0.12 had a strict pin which is causing a conflict error with the new pip 20.3:

```
ERROR: Cannot install -r ./lib/galaxy/dependencies/dev-requirements.txt (line 55) and markdown==3.1.1 because these package versions have conflicting dependencies.

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
The conflict is caused by:
    The user requested markdown==3.1.1
    The user requested markdown==3.1.1
    sphinx-markdown-tables 0.0.12 depends on markdown==3.0.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

See https://github.com/galaxyproject/galaxy/pull/10825/checks?check_run_id=1474883413