### PR TITLE
Drop legacy_eager_objectstore_initialization option.

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -630,27 +630,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``legacy_eager_objectstore_initialization``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    As of 18.09, Galaxy defaults to setting up the object store
-    configuration for output datasets during the job queue step in job
-    handlers. This should generally provide for more robust job
-    submission, more configurability, and a better user experience but
-    may in some cases slightly slow down the job handler job setup
-    process. On the off chance that an admin would like to or need to
-    optimize job handlers at the expense of user experience and web
-    handling this option will remain for some time by setting this
-    option to true. This behavior however should be considered
-    deprecated and this option will likely be removed in future
-    versions of Galaxy. For more information see
-    https://github.com/galaxyproject/galaxy/issues/6513.
-:Default: ``false``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``file_sources_config_file``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -316,6 +316,7 @@ OPTION_ACTIONS = {
     'communication_server_host': _DeprecatedAndDroppedAction(),
     'communication_server_port': _DeprecatedAndDroppedAction(),
     'persistent_communication_rooms': _DeprecatedAndDroppedAction(),
+    'legacy_eager_objectstore_initialization': _DeprecatedAndDroppedAction(),
 }
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -412,20 +412,6 @@ galaxy:
   # option.
   #watch_tours: 'false'
 
-  # As of 18.09, Galaxy defaults to setting up the object store
-  # configuration for output datasets during the job queue step in job
-  # handlers. This should generally provide for more robust job
-  # submission, more configurability, and a better user experience but
-  # may in some cases slightly slow down the job handler job setup
-  # process. On the off chance that an admin would like to or need to
-  # optimize job handlers at the expense of user experience and web
-  # handling this option will remain for some time by setting this
-  # option to true. This behavior however should be considered
-  # deprecated and this option will likely be removed in future versions
-  # of Galaxy. For more information see
-  # https://github.com/galaxyproject/galaxy/issues/6513.
-  #legacy_eager_objectstore_initialization: false
-
   # Configured FileSource plugins.
   # The value of this option will be resolved with respect to
   # <config_dir>.

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -14,7 +14,6 @@ from webob.compat import cgi_FieldStorage
 from galaxy import datatypes, util
 from galaxy.exceptions import (
     ConfigDoesNotAllowException,
-    ObjectInvalid,
     RequestParameterInvalidException,
 )
 from galaxy.model import tags
@@ -430,14 +429,6 @@ def create_job(trans, params, tool, json_file_path, outputs, folder=None, histor
                 job.add_output_library_dataset(output_name, dataset)
             else:
                 job.add_output_dataset(output_name, dataset)
-            # Create an empty file immediately
-            if not dataset.dataset.external_filename and trans.app.config.legacy_eager_objectstore_initialization:
-                dataset.dataset.object_store_id = object_store_id
-                try:
-                    trans.app.object_store.create(dataset.dataset)
-                except ObjectInvalid:
-                    raise Exception('Unable to create output dataset: object store is full')
-                object_store_id = dataset.dataset.object_store_id
 
         trans.sa_session.add(output_object)
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -471,21 +471,6 @@ mapping:
           changes are found, modified tours are automatically reloaded. Takes the same values as the
           'watch_tools' option.
 
-      legacy_eager_objectstore_initialization:
-        type: bool
-        default: false
-        required: false
-        desc: |
-          As of 18.09, Galaxy defaults to setting up the object store configuration
-          for output datasets during the job queue step in job handlers. This should generally
-          provide for more robust job submission, more configurability, and a better
-          user experience but may in some cases slightly slow down the job handler job
-          setup process. On the off chance that an admin would like to or need to optimize job
-          handlers at the expense of user experience and web handling this option will remain
-          for some time by setting this option to true. This behavior however should be
-          considered deprecated and this option will likely be removed in future versions of
-          Galaxy. For more information see https://github.com/galaxyproject/galaxy/issues/6513.
-
       file_sources_config_file:
         type: str
         default: file_sources_conf.yml        

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -164,7 +164,6 @@ class MockAppConfig(Bunch):
         self.shed_tool_config_file_set = False
         self.preserve_python_environment = "always"
         self.enable_beta_gdpr = False
-        self.legacy_eager_objectstore_initialization = True
 
         self.version_major = "19.09"
 


### PR DESCRIPTION
Reduce branching/complexity around when/where objectstore is getting set for downstream work.