### PR TITLE
Rework a few model security operations to not require trans.

### DIFF
--- a/lib/galaxy/managers/datasets.py
+++ b/lib/galaxy/managers/datasets.py
@@ -328,14 +328,15 @@ class DatasetAssociationManager(base.ModelManager,
             dataset = dataset_assoc.dataset
 
         # Omit duplicated roles by converting to set
-        access_roles = set(dataset.get_access_roles(trans))
-        manage_roles = set(dataset.get_manage_permissions_roles(trans))
+        security_agent = trans.app.security_agent
+        access_roles = set(dataset.get_access_roles(security_agent))
+        manage_roles = set(dataset.get_manage_permissions_roles(security_agent))
 
         access_dataset_role_list = [(access_role.name, trans.security.encode_id(access_role.id)) for access_role in access_roles]
         manage_dataset_role_list = [(manage_role.name, trans.security.encode_id(manage_role.id)) for manage_role in manage_roles]
         rval = dict(access_dataset_roles=access_dataset_role_list, manage_dataset_roles=manage_dataset_role_list)
         if library_dataset is not None:
-            modify_roles = set(trans.app.security_agent.get_roles_for_action(library_dataset, trans.app.security_agent.permitted_actions.LIBRARY_MODIFY))
+            modify_roles = set(security_agent.get_roles_for_action(library_dataset, trans.app.security_agent.permitted_actions.LIBRARY_MODIFY))
             modify_item_role_list = [(modify_role.name, trans.security.encode_id(modify_role.id)) for modify_role in modify_roles]
             rval["modify_item_roles"] = modify_item_role_list
         return rval

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -225,16 +225,17 @@ class HDAManager(datasets.DatasetAssociationManager,
     def _set_permissions(self, trans, hda, role_ids_dict):
         # The user associated the DATASET_ACCESS permission on the dataset with 1 or more roles.  We
         # need to ensure that they did not associate roles that would cause accessibility problems.
+        security_agent = trans.app.security_agent
         permissions, in_roles, error, message = \
-            trans.app.security_agent.derive_roles_from_access(trans, hda.dataset.id, 'root', **role_ids_dict)
+            security_agent.derive_roles_from_access(trans, hda.dataset.id, 'root', **role_ids_dict)
         if error:
             # Keep the original role associations for the DATASET_ACCESS permission on the dataset.
-            access_action = trans.app.security_agent.get_action(trans.app.security_agent.permitted_actions.DATASET_ACCESS.action)
-            permissions[access_action] = hda.dataset.get_access_roles(trans)
+            access_action = security_agent.get_action(security_agent.permitted_actions.DATASET_ACCESS.action)
+            permissions[access_action] = hda.dataset.get_access_roles(security_agent)
             trans.sa_session.refresh(hda.dataset)
             raise exceptions.RequestParameterInvalidException(message)
         else:
-            error = trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+            error = security_agent.set_all_dataset_permissions(hda.dataset, permissions)
             trans.sa_session.refresh(hda.dataset)
             if error:
                 raise exceptions.RequestParameterInvalidException(error)

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -255,7 +255,7 @@ class LibraryManager:
         """
         Load access roles for all library permissions
         """
-        return set(library.get_access_roles(trans))
+        return set(library.get_access_roles(trans.app.security_agent))
 
     def get_modify_roles(self, trans, library):
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2532,23 +2532,23 @@ class Dataset(StorableObject, RepresentById):
         self.deleted = True
         self.purged = True
 
-    def get_access_roles(self, trans):
+    def get_access_roles(self, security_agent):
         roles = []
         for dp in self.actions:
-            if dp.action == trans.app.security_agent.permitted_actions.DATASET_ACCESS.action:
+            if dp.action == security_agent.permitted_actions.DATASET_ACCESS.action:
                 roles.append(dp.role)
         return roles
 
-    def get_manage_permissions_roles(self, trans):
+    def get_manage_permissions_roles(self, security_agent):
         roles = []
         for dp in self.actions:
-            if dp.action == trans.app.security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action:
+            if dp.action == security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action:
                 roles.append(dp.role)
         return roles
 
-    def has_manage_permissions_roles(self, trans):
+    def has_manage_permissions_roles(self, security_agent):
         for dp in self.actions:
-            if dp.action == trans.app.security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action:
+            if dp.action == security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action:
                 return True
         return False
 
@@ -3315,11 +3315,11 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         for assoc in self.implicitly_converted_parent_datasets:
             assoc.clear(purge=purge, delete_dataset=False)
 
-    def get_access_roles(self, trans):
+    def get_access_roles(self, security_agent):
         """
         Return The access roles associated with this HDA's dataset.
         """
-        return self.dataset.get_access_roles(trans)
+        return self.dataset.get_access_roles(security_agent)
 
     def purge_usage_from_quota(self, user):
         """Remove this HDA's quota_amount from user's quota.
@@ -3554,10 +3554,10 @@ class Library(Dictifiable, HasName, RepresentById):
             active_folders.extend(self.get_active_folders(active_folder, folders))
         return sort_by_attr(active_folders, 'id')
 
-    def get_access_roles(self, trans):
+    def get_access_roles(self, security_agent):
         roles = []
         for lp in self.actions:
-            if lp.action == trans.app.security_agent.permitted_actions.LIBRARY_ACCESS.action:
+            if lp.action == security_agent.permitted_actions.LIBRARY_ACCESS.action:
                 roles.append(lp.role)
         return roles
 
@@ -3808,14 +3808,14 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, RepresentById):
     def clear_associated_files(self, metadata_safe=False, purge=False):
         return
 
-    def get_access_roles(self, trans):
-        return self.dataset.get_access_roles(trans)
+    def get_access_roles(self, security_agent):
+        return self.dataset.get_access_roles(security_agent)
 
-    def get_manage_permissions_roles(self, trans):
-        return self.dataset.get_manage_permissions_roles(trans)
+    def get_manage_permissions_roles(self, security_agent):
+        return self.dataset.get_manage_permissions_roles(security_agent)
 
-    def has_manage_permissions_roles(self, trans):
-        return self.dataset.has_manage_permissions_roles(trans)
+    def has_manage_permissions_roles(self, security_agent):
+        return self.dataset.has_manage_permissions_roles(security_agent)
 
     def serialize(self, id_encoder, serialization_options, for_link=False):
         if for_link:

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -158,7 +158,7 @@ class GalaxyRBACAgent(RBACAgent):
         # User will see all the roles derived from the access roles on the item
         else:
             # If item has roles associated with the access permission, we need to start with them.
-            access_roles = item.get_access_roles(trans)
+            access_roles = item.get_access_roles(self)
             for role in access_roles:
                 if self.ok_to_display(trans.user, role):
                     roles.append(role)
@@ -213,7 +213,7 @@ class GalaxyRBACAgent(RBACAgent):
                 (isinstance(item, self.model.Dataset) and self.dataset_is_public(item)):
             return self.get_all_roles(trans, cntrller)
         # If item has roles associated with the access permission, we need to start with them.
-        access_roles = item.get_access_roles(trans)
+        access_roles = item.get_access_roles(self)
         for role in access_roles:
             if admin_controller or self.ok_to_display(trans.user, role):
                 roles.add(role)
@@ -936,7 +936,7 @@ class GalaxyRBACAgent(RBACAgent):
                         # Permission setting related to DATASET_MANAGE_PERMISSIONS was broken for a period of time,
                         # so it is possible that some Datasets have no roles associated with the DATASET_MANAGE_PERMISSIONS
                         # permission.  In this case, we'll reset this permission to the library_item user's private role.
-                        if not library_item.dataset.has_manage_permissions_roles(trans):
+                        if not library_item.dataset.has_manage_permissions_roles(self):
                             # Well this looks like a bug, this should be looked at.
                             # Default permissions above is single hash that keeps getting reeditted here
                             # because permission is being defined instead of permissions. -John
@@ -1042,7 +1042,7 @@ class GalaxyRBACAgent(RBACAgent):
         Different implementation of the method above with signature:
         def dataset_is_public( self, dataset )
         """
-        return len(dataset.library_dataset_dataset_association.get_access_roles(trans)) == 0
+        return len(dataset.library_dataset_dataset_association.get_access_roles(self)) == 0
 
     def dataset_is_private_to_user(self, trans, dataset):
         """
@@ -1050,7 +1050,7 @@ class GalaxyRBACAgent(RBACAgent):
         the current user's private role then we consider the dataset private.
         """
         private_role = self.get_private_user_role(trans.user)
-        access_roles = dataset.get_access_roles(trans)
+        access_roles = dataset.get_access_roles(self)
 
         if len(access_roles) != 1:
             return False


### PR DESCRIPTION
It didn't and shouldn't use it, it only needs the security agent so only send it. I want to do some pretty reasonable things without trans and this should help enable that.