### PR TITLE
Fix Label Verifier in Maintenance Bot 

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,6 +9,8 @@ area/datatypes:
   - lib/galaxy/config/sample/datatypes_conf.xml.sample
 area/documentation:
   - doc/**/*
+area/jobs:
+  - lib/galaxy/jobs/**/*
 area/libraries:
   - client/src/components/LibraryFolder/**/*
   - lib/galaxy/webapps/galaxy/api/libraries.py
@@ -23,7 +25,9 @@ area/testing/selenium:
 area/tools:
   - tools/**/*
   - lib/galaxy/webapps/galaxy/api/tools.py
+  - lib/galaxy/tools/**/*
   - tool-data/**/*
+  - lib/galaxy/tool_util/**/*
 area/toolshed:
   - client/src/toolshed/**/*
   - lib/galaxy/webapps/galaxy/api/toolshed.py

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,16 @@
 ---
 area/admin:
   - client/src/components/admin/**/*
-  - doc/source/admin
+  - doc/source/admin/**/*
+area/API:
+  - lib/galaxy/webapps/galaxy/api/**/*
 area/client:
-  - client/**/*
+  - client/*
 area/datatypes:
   - lib/galaxy/datatypes/**/*
   - lib/galaxy/config/sample/datatypes_conf.xml.sample
+area/dependencies:
+  - lib/galaxy/dependencies/**/*
 area/documentation:
   - doc/**/*
 area/jobs:
@@ -14,22 +18,51 @@ area/jobs:
 area/libraries:
   - client/src/components/LibraryFolder/**/*
   - lib/galaxy/webapps/galaxy/api/libraries.py
+area/objectstore:
+  - lib/galaxy/objectstore/**/*
+area/packaging:
+  - packages/**/*
+area/reports:
+  - client/src/reports/**/*
+  - lib/galaxy/webapps/reports/**/*
+  - templates/webapps/reports/**/*
+area/scripts:
+  - scripts/**/*
+area/security:
+  - lib/galaxy/security/**/*
 area/testing:
+  - lib/galaxy_test/**/*
+  - run_tests.sh
   - test/**/*
   - test-data/**/*
-  - lib/galaxy/tools/test.py
-  - run_tests.sh
+area/testing/api:
+  - lib/galaxy_test/api/**/*
+area/testing/integration:
+  - test/integration/**/*
+  - test/integration_selenium/**/*
 area/testing/selenium:
   - lib/galaxy/selenium/**/*
   - lib/galaxy_test/selenium/**/*
+area/tool-dependencies:
+  - lib/galaxy/tool_util/deps/**/*
+area/tool-framework:
+  - lib/galaxy/tools/**/*
+  - lib/galaxy/tool_util/**/*
+  - lib/galaxy/webapps/galaxy/api/tools.py
 area/tools:
   - tools/**/*
-  - lib/galaxy/webapps/galaxy/api/tools.py
-  - lib/galaxy/tools/**/*
   - tool-data/**/*
-  - lib/galaxy/tool_util/**/*
 area/toolshed:
   - client/src/toolshed/**/*
   - lib/galaxy/webapps/galaxy/api/toolshed.py
+  - lib/toolshed/**/*
+  - templates/webapps/tool_shed/**/*
+area/UI-UX:
+  - client/src/**/*
+  - templates/**/*
+area/util:
+  - lib/galaxy/util/**/*
 area/visualizations:
   - config/plugins/visualizations/**/*
+area/workflows:
+  - lib/galaxy/workflow/**/*

--- a/.github/workflows/labels-verifier.yaml
+++ b/.github/workflows/labels-verifier.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check Labels on merge
         if: |
           github.event.pull_request.merged == true &&
-          contains(join(github.event.pull_request.labels.*.name, ', '), 'kind/') == false
+          ! contains(join(github.event.pull_request.labels.*.name, ', '), 'kind/')
         uses: actions/github-script@0.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels-verifier.yaml
+++ b/.github/workflows/labels-verifier.yaml
@@ -17,4 +17,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: 'This PR was merged without a "kind/" label, please correct.' }) 
+            github.issues.createComment({ issue_number, owner, repo, body: 'This PR was merged without a "kind/" label, please correct.' })

--- a/.github/workflows/labels-verifier.yaml
+++ b/.github/workflows/labels-verifier.yaml
@@ -11,7 +11,8 @@ jobs:
       - name: Check Labels on merge
         if: |
           github.event.pull_request.merged == true &&
-          ! contains(join(github.event.pull_request.labels.*.name, ', '), 'kind/')
+          ! contains(join(github.event.pull_request.labels.*.name, ', '), 'kind/') &&
+          ! contains(github.event.pull_request.labels.*.name, 'merge')
         uses: actions/github-script@0.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels-verifier.yaml
+++ b/.github/workflows/labels-verifier.yaml
@@ -1,6 +1,6 @@
 name: "Labels Verifier"
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:
@@ -11,10 +11,10 @@ jobs:
       - name: Check Labels on merge
         if: |
           github.event.pull_request.merged == true &&
-          contains(github.event.pull_request.labels.*.name, 'kind/') == false
+          contains(join(github.event.pull_request.labels.*.name, ', '), 'kind/') == false
         uses: actions/github-script@0.3.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            github.issues.createComment({ issue_number, owner, repo, body: 'This PR was merged without a "kind/" label, please correct.' })
+            github.issues.createComment({ issue_number, owner, repo, body: 'This PR was merged without a "kind/" label, please correct.' }) 

--- a/.github/workflows/maintainance_bot.yaml
+++ b/.github/workflows/maintainance_bot.yaml
@@ -4,26 +4,23 @@ on:
 
 jobs:
   labeler:
-    name: "Assign Labels"
+    name: Assign labels and milestone
     runs-on: ubuntu-latest
+    env:
+      MILESTONE_NUMBER: 18
     steps:
       - uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  milestone:
-    name: "Assign Milestone"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Assign Milestone
-        if:  |
-          contains(github.event.pull_request.title, 'WIP') == false &&
-          contains(github.event.pull_request.title, 'merge') == false &&
-          github.event.pull_request.draft == false
-        env:
-          MILESTONE_NUMBER: 18
+      - name: Assign milestone
+        if: |
+          ! github.event.pull_request.milestone &&
+          ! contains(github.event.pull_request.labels.*.name, 'merge') &&
+          ! contains(github.event.pull_request.labels.*.name, 'status/WIP') &&
+          ! contains(github.event.pull_request.title, 'WIP') &&
+          ! github.event.pull_request.draft
         run: |
           curl --request PATCH \
           --url ${{ github.event.pull_request.issue_url }} \
           --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
-          --data-raw '{"milestone":  '$MILESTONE_NUMBER'}'
+          --data-raw '{"milestone": '$MILESTONE_NUMBER'}'


### PR DESCRIPTION
Following discussion in https://github.com/galaxyproject/galaxy/pull/10813#issuecomment-736538688
So what was happening is that github doesn't allow using `GITHUB_TOKEN` in gh-actions on PRs from forked branches ([example](https://github.com/galaxyproject/galaxy/actions/runs/393408692), we got 403 even though John has write access). 

However, if you change  `on: pull_request` to `on: pull_request_target` this particular job will run from from the base of the pull request . Since it's considered as "trusted sources" by github, it will allow operations with `GITHUB_TOKEN`, thus allowing us to create a comment. ([if you want to read more](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/))

So this PR does exactly this. It will fix label-verifier and will create a comment if PR wasn't merge with 'kind/'

examples:
merged without kind https://github.com/OlegZharkov/galaxy/pull/79
merged with kind https://github.com/OlegZharkov/galaxy/pull/80

P.S.
Well, since I am here already, I also updated `labeler.yml`