### PR TITLE
[WIP] Implement abstractions to annotate non-sharable datasets & objectstores.

### DIFF
--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.test.js
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.test.js
@@ -10,14 +10,17 @@ const localVue = getLocalVue();
 
 const TEST_STORAGE_API_RESPONSE_WITHOUT_ID = {
     object_store_id: null,
+    private: false,
 };
 const TEST_STORAGE_API_RESPONSE_WITH_ID = {
     object_store_id: "foobar",
+    private: false,
 };
 const TEST_STORAGE_API_RESPONSE_WITH_NAME = {
     object_store_id: "foobar",
     name: "my cool storage",
     description: "My cool **markdown**",
+    private: true,
 };
 const TEST_DATASET_ID = "1";
 const TEST_STORAGE_URL = `/api/datasets/${TEST_DATASET_ID}/storage`;
@@ -46,9 +49,6 @@ describe("Dataset Storage", () => {
         wrapper = shallowMount(DatasetStorage, {
             propsData: { datasetId: TEST_DATASET_ID },
             localVue,
-            stubs: {
-                "loading-span": true,
-            },
         });
     }
 
@@ -102,6 +102,7 @@ describe("Dataset Storage", () => {
         expect(byIdSpan.length).toBe(1);
         const byNameSpan = wrapper.findAll(".display-os-by-name");
         expect(byNameSpan.length).toBe(0);
+        expect(wrapper.find("object-store-restriction-span-stub").props("isPrivate")).toBeFalsy();
     });
 
     it("test dataset storage with object store name", async () => {
@@ -116,6 +117,7 @@ describe("Dataset Storage", () => {
         expect(byIdSpan.length).toBe(0);
         const byNameSpan = wrapper.findAll(".display-os-by-name");
         expect(byNameSpan.length).toBe(1);
+        expect(wrapper.find("object-store-restriction-span-stub").props("isPrivate")).toBeTruthy();
     });
 
     afterEach(() => {

--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -7,12 +7,16 @@
             <p>
                 This dataset is stored in
                 <span class="display-os-by-name" v-if="storageInfo.name">
-                    a Galaxy object store named <b>{{ storageInfo.name }}</b>
+                    a Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store named
+                    <b>{{ storageInfo.name }}</b>
                 </span>
                 <span class="display-os-by-id" v-else-if="storageInfo.object_store_id">
-                    a Galaxy object store with id <b>{{ storageInfo.object_store_id }}</b>
+                    a Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store with id
+                    <b>{{ storageInfo.object_store_id }}</b>
                 </span>
-                <span class="display-os-default" v-else> the default configured Galaxy object store </span>.
+                <span class="display-os-default" v-else>
+                    the default configured Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store </span
+                >.
             </p>
             <div v-html="descriptionRendered"></div>
         </div>
@@ -25,10 +29,12 @@ import { getAppRoot } from "onload/loadConfig";
 import LoadingSpan from "components/LoadingSpan";
 import MarkdownIt from "markdown-it";
 import { errorMessageAsString } from "utils/simple-error";
+import ObjectStoreRestrictionSpan from "./ObjectStoreRestrictionSpan";
 
 export default {
     components: {
         LoadingSpan,
+        ObjectStoreRestrictionSpan,
     },
     props: {
         datasetId: {
@@ -59,6 +65,11 @@ export default {
             .catch((errorMessage) => {
                 this.errorMessage = errorMessageAsString(errorMessage);
             });
+    },
+    computed: {
+        isPrivate() {
+            return this.storageInfo.private;
+        },
     },
     methods: {
         handleResponse(response) {

--- a/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.test.js
+++ b/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.test.js
@@ -1,0 +1,27 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import ObjectStoreRestrictionSpan from "./ObjectStoreRestrictionSpan";
+
+const localVue = getLocalVue();
+
+describe("ObjectStoreRestrictionSpan", () => {
+    let wrapper;
+
+    it("should render info about private storage if isPrivate", () => {
+        wrapper = shallowMount(ObjectStoreRestrictionSpan, {
+            propsData: { isPrivate: true },
+            localVue,
+        });
+        expect(wrapper.find(".stored-how").text()).toBe("private");
+        expect(wrapper.find(".stored-how").attributes("title")).toBeTruthy();
+    });
+
+    it("should render info about unrestricted storage if not isPrivate", () => {
+        wrapper = shallowMount(ObjectStoreRestrictionSpan, {
+            propsData: { isPrivate: false },
+            localVue,
+        });
+        expect(wrapper.find(".stored-how").text()).toBe("unrestricted");
+        expect(wrapper.find(".stored-how").attributes("title")).toBeTruthy();
+    });
+});

--- a/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.vue
+++ b/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.vue
@@ -1,0 +1,38 @@
+<template>
+    <span class="stored-how" v-b-tooltip.hover :title="title">{{ text }}</span>
+</template>
+
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        isPrivate: {
+            // private is reserved word
+            type: Boolean,
+        },
+    },
+    computed: {
+        text() {
+            return this.isPrivate ? "private" : "unrestricted";
+        },
+        title() {
+            if (this.isPrivate) {
+                return "This dataset is stored on storage restricted to a single user. It can not be shared, pubished, or added to Galaxy data libraries.";
+            } else {
+                return "This dataset is stored on unrestricted storage. With sufficient Galaxy permissions, this dataset can be published, shared, or added to Galaxy data libraries.";
+            }
+        },
+    },
+};
+</script>
+
+<style scoped>
+/* Give visual indication of mouseover info */
+.stored-how {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+}
+</style>

--- a/client/src/mvc/library/library-model.js
+++ b/client/src/mvc/library/library-model.js
@@ -144,7 +144,7 @@ var HistoryContents = Backbone.Collection.extend({
         this.id = options.id;
     },
     url: function () {
-        return `${this.urlRoot + this.id}/contents`;
+        return `${this.urlRoot + this.id}/contents?sharable=true`;
     },
     model: HistoryItem,
 });

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -39,6 +39,7 @@ from galaxy.model.base import SharedModelMapping
 from galaxy.model.database_heartbeat import DatabaseHeartbeat
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.tags import GalaxyTagHandler
+from galaxy.objectstore import ObjectStore
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
     send_local_control_task,
@@ -146,6 +147,7 @@ class MinimalGalaxyApplication(BasicApp, config.ConfiguresGalaxyMixin, HaltableC
         if configure_logging:
             config.configure_logging(self.config)
         self._configure_object_store(fsmon=True)
+        self._register_singleton(ObjectStore, self.object_store)
         config_file = kwargs.get('global_conf', {}).get('__file__', None)
         if config_file:
             log.debug('Using "galaxy.ini" config file: %s', config_file)

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -279,7 +279,7 @@ class JobContext(ModelPersistenceContext, BaseJobContext):
         # Permissions must be the same on the LibraryDatasetDatasetAssociation and the associated LibraryDataset
         trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
         # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
-        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user))
+        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user), flush=False, new=True)
         library_folder.add_library_dataset(ld, genome_build=ldda.dbkey)
         trans.sa_session.add(library_folder)
         trans.sa_session.flush()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1514,6 +1514,8 @@ class JobWrapper(HasResourceParameters):
 
         object_store_populator = ObjectStorePopulator(self.app, job.user)
         object_store_id = self.get_destination_configuration("object_store_id", None)
+        require_sharable = job.requires_sharable_storage(self.app.security_agent)
+
         if object_store_id:
             object_store_populator.object_store_id = object_store_id
 
@@ -1525,7 +1527,7 @@ class JobWrapper(HasResourceParameters):
         # afterward. State below needs to happen the same way.
         for dataset_assoc in job.output_datasets + job.output_library_datasets:
             dataset = dataset_assoc.dataset
-            object_store_populator.set_object_store_id(dataset)
+            object_store_populator.set_object_store_id(dataset, require_sharable=require_sharable)
 
         job.object_store_id = object_store_populator.object_store_id
         self._setup_working_directory(job=job)

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -156,7 +156,12 @@ class BaseJobRunner:
         """Add a job to the queue (by job identifier), indicate that the job is ready to run.
         """
         put_timer = ExecutionTimer()
-        job_wrapper.enqueue()
+        try:
+            job_wrapper.enqueue()
+        except Exception as e:
+            job_wrapper.fail(str(e), exception=e)
+            log.debug(f"Job [{job_wrapper.job_id}] failed to queue {put_timer}")
+            return
         self.mark_as_queued(job_wrapper)
         log.debug(f"Job [{job_wrapper.job_id}] queued {put_timer}")
 

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -814,16 +814,23 @@ class GalaxyRBACAgent(RBACAgent):
         # Make sure that DATASET_MANAGE_PERMISSIONS is associated with at least 1 role
         has_dataset_manage_permissions = False
         permissions = permissions or {}
-        for action, roles in permissions.items():
-            if isinstance(action, Action):
-                if action == self.permitted_actions.DATASET_MANAGE_PERMISSIONS and roles:
-                    has_dataset_manage_permissions = True
-                    break
-            elif action == self.permitted_actions.DATASET_MANAGE_PERMISSIONS.action and roles:
-                has_dataset_manage_permissions = True
-                break
+        for _ in _walk_action_roles(permissions, self.permitted_actions.DATASET_MANAGE_PERMISSIONS):
+            has_dataset_manage_permissions = True
+            break
         if not has_dataset_manage_permissions:
             return "At least 1 role must be associated with manage permissions on this dataset."
+
+        # If this is new, the objectstore likely hasn't been set yet - defer check until
+        # the job handler assigns it.
+        if not new and not dataset.sharable:
+            # ensure dataset not shared.
+            dataset_access_roles = []
+            for _, roles in _walk_action_roles(permissions, self.permitted_actions.DATASET_ACCESS):
+                dataset_access_roles.extend(roles)
+
+            if len(dataset_access_roles) != 1 or dataset_access_roles[0].type != self.model.Role.types.PRIVATE:
+                return galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE
+
         flush_needed = False
         # Delete all of the current permissions on the dataset
         if not new:
@@ -852,6 +859,12 @@ class GalaxyRBACAgent(RBACAgent):
         Permission looks like: { Action.action : [ Role, Role ] }
         """
         permission = permission or {}
+
+        # if modifying access - ensure it is sharable.
+        for _ in _walk_action_roles(permission, self.permitted_actions.DATASET_ACCESS):
+            dataset.ensure_sharable()
+            break
+
         flush_needed = False
         for action, roles in permission.items():
             if isinstance(action, Action):
@@ -891,6 +904,7 @@ class GalaxyRBACAgent(RBACAgent):
         self.set_all_dataset_permissions(dst, self.get_permissions(src))
 
     def privately_share_dataset(self, dataset, users=None):
+        dataset.ensure_sharable()
         intersect = None
         users = users or []
         for user in users:
@@ -1064,6 +1078,19 @@ class GalaxyRBACAgent(RBACAgent):
             else:
                 return False
 
+    def dataset_is_private_to_a_user(self, dataset):
+        """
+        If the Dataset object has exactly one access role and that is
+        the current user's private role then we consider the dataset private.
+        """
+        access_roles = dataset.get_access_roles(self)
+
+        if len(access_roles) != 1:
+            return False
+        else:
+            access_role = access_roles[0]
+            return access_role.type == self.model.Role.types.PRIVATE
+
     def datasets_are_public(self, trans, datasets):
         '''
         Given a transaction object and a list of Datasets, return
@@ -1092,6 +1119,8 @@ class GalaxyRBACAgent(RBACAgent):
     def make_dataset_public(self, dataset):
         # A dataset is considered public if there are no "access" actions associated with it.  Any
         # other actions ( 'manage permissions', 'edit metadata' ) are irrelevant.
+        dataset.ensure_sharable()
+
         flush_needed = False
         for dp in dataset.actions:
             if dp.action == self.permitted_actions.DATASET_ACCESS.action:
@@ -1481,3 +1510,12 @@ class HostAgent(RBACAgent):
             hdadaa = self.model.HistoryDatasetAssociationDisplayAtAuthorization(hda=hda, user=user, site=site)
         self.sa_session.add(hdadaa)
         self.sa_session.flush()
+
+
+def _walk_action_roles(permissions, query_action):
+    for action, roles in permissions.items():
+        if isinstance(action, Action):
+            if action == query_action and roles:
+                yield action, roles
+        elif action == query_action.action and roles:
+            yield action, roles

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -75,6 +75,7 @@ def parse_config_xml(config_xml):
                 'path': staging_path,
             },
             'extra_dirs': extra_dirs,
+            'private': ConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -572,6 +572,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
                 open(os.path.join(self.staging_path, rel_path), 'w').close()
                 self._push_to_os(rel_path, from_string='')
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -103,6 +103,7 @@ def parse_config_xml(config_xml):
                 'path': staging_path,
             },
             'extra_dirs': extra_dirs,
+            'private': DiskObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.
@@ -505,6 +506,7 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
                 open(os.path.join(self.staging_path, rel_path), 'w').close()
                 self._push_to_irods(rel_path, from_string='')
         log.debug("irods_pt _create: %s", ipt_timer)
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -66,6 +66,7 @@ def parse_config_xml(config_xml):
             raise Exception(msg)
         r['extra_dirs'] = [
             {k: e.get(k) for k in attrs} for e in extra_dirs]
+        r['private'] = ConcreteObjectStore.parse_private_from_config_xml(config_xml)
         if 'job_work' not in (d['type'] for d in r['extra_dirs']):
             msg = f'No value for {tag}:type="job_work" in XML tree'
             log.error(msg)
@@ -285,6 +286,7 @@ class PithosObjectStore(ConcreteObjectStore):
                 new_file = os.path.join(self.staging_path, rel_path)
                 open(new_file, 'w').close()
                 self.pithos.upload_from_string(rel_path, '')
+        return self
 
     def _empty(self, obj, **kwargs):
         """

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -97,6 +97,7 @@ def parse_config_xml(config_xml):
                 'path': staging_path,
             },
             'extra_dirs': extra_dirs,
+            'private': ConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.
@@ -577,6 +578,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
                 open(os.path.join(self.staging_path, rel_path), 'w').close()
                 self._push_to_os(rel_path, from_string='')
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -190,7 +190,7 @@ def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
     trans.sa_session.flush()
     history.add_dataset(hda, genome_build=uploaded_dataset.dbkey, quota=False)
     permissions = trans.app.security_agent.history_get_default_permissions(history)
-    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
     trans.sa_session.flush()
     return hda
 
@@ -253,7 +253,7 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
         trans.app.security_agent.copy_dataset_permissions(library_bunch.replace_dataset.library_dataset_dataset_association.dataset, ldda.dataset)
     else:
         # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
-        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user))
+        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user), new=True)
         folder.add_library_dataset(ld, genome_build=uploaded_dataset.dbkey)
         trans.sa_session.add(folder)
         trans.sa_session.flush()

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -184,6 +184,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         return {
             'object_store_id': object_store_id,
+            'sharable': dataset.sharable,
             'name': name,
             'description': description,
             'percent_used': percent_used,

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -278,7 +278,15 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             permission_disable = True
             permission_inputs = list()
             if trans.user:
-                if data.dataset.actions:
+                if not data.dataset.sharable:
+                    permission_message = 'The dataset is stored on private storage to you and cannot be shared.'
+                    permission_inputs.append({
+                        'name': 'not_sharable',
+                        'type': 'hidden',
+                        'label': permission_message,
+                        'readonly': True
+                    })
+                elif data.dataset.actions:
                     in_roles = {}
                     for action, roles in trans.app.security_agent.get_permissions(data.dataset).items():
                         in_roles[action.action] = [trans.security.encode_id(role.id) for role in roles]

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -160,7 +160,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
 
     def test_hda_security(self):
-        element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id)
+        element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id, wait=True)
         self.dataset_populator.make_private(self.history_id, element_identifiers[0]["id"])
         with self._different_user():
             history_id = self.dataset_populator.new_history()

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -342,7 +342,7 @@ class LibrariesApiTestCase(ApiTestCase):
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]['id']
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3")['id']
+        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3", wait=True)['id']
         payload = {'from_hda_id': hda_id}
         create_response = self._post(f"folders/{folder_id}/contents", payload)
         self._assert_status_code_is(create_response, 200)
@@ -358,7 +358,7 @@ class LibrariesApiTestCase(ApiTestCase):
         print(subfolder_response.json())
         subfolder_id = subfolder_response.json()['id']
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3 sub")['id']
+        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3 sub", wait=True)['id']
         payload = {'from_hda_id': hda_id}
         create_response = self._post(f"folders/{subfolder_id}/contents", payload)
         self._assert_status_code_is(create_response, 200)
@@ -518,4 +518,5 @@ class LibrariesApiTestCase(ApiTestCase):
         hda_id = self.dataset_populator.new_dataset(history_id, content=content, wait=wait)['id']
         payload = {'from_hda_id': hda_id, 'create_type': 'file', 'folder_id': folder_id}
         ld = self._post(f"libraries/{folder_id}/contents", payload)
+        ld.raise_for_status()
         return ld

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -893,7 +893,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
                 else:
                     self._assert_dataset_permission_denied_response(response)
 
-        new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
+        new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test', wait=True)
         inputs = dict(
             input1=dataset_to_param(new_dataset),
         )

--- a/test/integration/objectstore/test_private_handling.py
+++ b/test/integration/objectstore/test_private_handling.py
@@ -1,0 +1,50 @@
+"""Integration tests for mixing store_by."""
+
+import string
+
+from galaxy_test.base import api_asserts
+from ._base import BaseObjectStoreIntegrationTestCase
+
+PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0"?>
+<object_store type="disk" id="primary" private="true">
+    <files_dir path="${temp_directory}/files1"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+</object_store>
+""")
+
+TEST_INPUT_FILES_CONTENT = "1 2 3"
+
+
+class PrivatePreventsSharingObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = True
+        cls._configure_object_store(PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        """Test each object store configures files correctly.
+        """
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True)
+            content = self.dataset_populator.get_history_dataset_content(history_id, hda["id"])
+            assert content.startswith(TEST_INPUT_FILES_CONTENT)
+            response = self.dataset_populator.make_public_raw(history_id, hda["id"])
+            assert response.status_code != 200
+            api_asserts.assert_error_message_contains(response, "Attempting to share a non-sharable dataset.")
+
+
+class PrivateCannotWritePublicDataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = False
+        cls._configure_object_store(PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator.new_dataset_request(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True, assert_ok=False)
+            job = response.json()["jobs"][0]
+            final_state = self.dataset_populator.wait_for_job(job["id"])
+            assert final_state == "error"

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -301,8 +301,26 @@ def test_concrete_name_without_objectstore_id():
             assert files1_name is None
 
 
+MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
+<object_store type="distributed">
+    <backends>
+        <backend id="files1" type="disk" weight="1" order="0" store_by="id">
+            <files_dir path="${temp_directory}/files1"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+        </backend>
+        <backend id="files2" type="disk" weight="1" order="1" store_by="uuid" private="true">
+            <files_dir path="${temp_directory}/files2"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp2"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory2"/>
+        </backend>
+    </backends>
+</object_store>
+"""
+
+
 MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
-<object_store type="hierarchical">
+<object_store type="hierarchical" private="true">
     <backends>
         <backend id="files1" type="disk" weight="1" order="0" store_by="id">
             <files_dir path="${temp_directory}/files1"/>
@@ -320,10 +338,43 @@ MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
 
 
 def test_mixed_store_by():
+    with TestConfig(MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
+        as_dict = object_store.to_dict()
+        assert as_dict["backends"][0]["store_by"] == "id"
+        assert as_dict["backends"][1]["store_by"] == "uuid"
+
     with TestConfig(MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
         as_dict = object_store.to_dict()
         assert as_dict["backends"][0]["store_by"] == "id"
         assert as_dict["backends"][1]["store_by"] == "uuid"
+
+
+def test_mixed_private():
+    # Distributed object store can combine private and non-private concrete objectstores
+    with TestConfig(MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
+        ids = object_store.object_store_ids()
+        print(ids)
+        assert len(ids) == 2
+
+        ids = object_store.object_store_ids(private=True)
+        assert len(ids) == 1
+        assert ids[0] == "files2"
+
+        ids = object_store.object_store_ids(private=False)
+        assert len(ids) == 1
+        assert ids[0] == "files1"
+
+        as_dict = object_store.to_dict()
+        assert not as_dict["backends"][0]["private"]
+        assert as_dict["backends"][1]["private"]
+
+    with TestConfig(MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
+        as_dict = object_store.to_dict()
+        assert as_dict["backends"][0]["private"]
+        assert as_dict["backends"][1]["private"]
+
+        assert object_store.private
+        assert as_dict["private"] is True
 
 
 DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
@@ -484,7 +535,7 @@ def test_config_parse_pithos():
             assert len(extra_dirs) == 2
 
 
-S3_TEST_CONFIG = """<object_store type="s3">
+S3_TEST_CONFIG = """<object_store type="s3" private="true">
      <auth access_key="access_moo" secret_key="secret_cow" />
      <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
      <cache path="database/object_store_cache" size="1000" />
@@ -496,6 +547,7 @@ S3_TEST_CONFIG = """<object_store type="s3">
 
 S3_TEST_CONFIG_YAML = """
 type: s3
+private: true
 auth:
   access_key: access_moo
   secret_key: secret_cow
@@ -519,6 +571,7 @@ extra_dirs:
 def test_config_parse_s3():
     for config_str in [S3_TEST_CONFIG, S3_TEST_CONFIG_YAML]:
         with TestConfig(config_str, clazz=UnitializeS3ObjectStore) as (directory, object_store):
+            assert object_store.private
             assert object_store.access_key == "access_moo"
             assert object_store.secret_key == "secret_cow"
 


### PR DESCRIPTION
Sketched out so far:
- Allow marking objectstores (in either XML or YAML) as ``private`` - indicating datasets stored in them should not be shared.
- Add ``sharable`` property to ``model.Dataset`` that checks its ``object_store_id`` against the configured object store to determine if it is not stored in a ``private`` objectstore.
- Add abstraction to ``security_agent`` to check if a dataset is restricted to a single user and augment ``galaxy.jobs.JobWrapper._set_object_store_ids`` and ``ObjectStorePopulator`` to prevent jobs that might create non-private datasets in private objectstores.
- Model/security layer prevents copying non-sharable dataset into libraries or attaching private sharing roles to them.
- The edit metadata form will display a message that the dataset is unsharable on the permissions page.
- Integration test case to ensure cannot upload public datasets to a private objectstore.
- Integration test case to ensure cannot modify access permissions of datasets stored in private objectstores.
- Expose information about whether objectstores are private in newly merged ObjectStore metadata display (#10233). 

Left to do:
- Test case to verify library sets can't be uploaded to private objectstores.
- Test case to verify private object stores operate appropriately with dynamically discovered collection datasets. (past @jmchilton had this in his notes - not sure exactly what his concern was).

xrefs:
- The Nate white paper on related things (https://docs.google.com/document/d/1TQCbQxwLLijKHl_sZgTDQCpNXX2jejJQBljVrNslOvA/edit)
- Implementing quotas per objectstore #10221 
- Per-user objectstore configurations #4840 
