### PR TITLE
Always expand tool about section if metadata is available

### DIFF
--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -1,90 +1,71 @@
 <template>
-    <div class="tool-footer">
-        <b-link
-            v-if="hasContent"
-            :aria-expanded="expanded"
-            aria-controls="collapse-about"
-            class="collapse-about"
-            @click="expanded = !expanded"
-        >
-            About this tool
-            <font-awesome-icon v-if="expanded" icon="angle-double-up" />
-            <font-awesome-icon v-else icon="angle-double-down" />
-        </b-link>
-        <b-collapse id="collapse-about" class="mt-2" v-model="expanded">
-            <b-card>
-                <div v-if="hasCitations" class="mb-1">
-                    <span class="font-weight-bold">Citations:</span>
-                    <font-awesome-icon
-                        v-b-tooltip.hover
-                        title="Copy all citations as BibTeX"
-                        icon="copy"
-                        style="cursor: pointer;"
-                        @click="copyBibtex"
-                    />
-                    <Citation
-                        class="formatted-reference"
-                        v-for="(citation, index) in citations"
-                        :key="index"
-                        :citation="citation"
-                        output-format="bibliography"
-                        prefix="-"
-                    />
-                </div>
-                <div v-if="hasRequirements" class="mb-1">
-                    <span class="font-weight-bold"
-                        >Requirements:
-                        <a href="https://galaxyproject.org/tools/requirements/" target="_blank">
-                            <font-awesome-icon
-                                v-b-tooltip.hover
-                                title="Learn more about Galaxy Requirements"
-                                icon="question"
-                            />
-                        </a>
-                    </span>
-                    <div v-for="(requirement, index) in requirements" :key="index">
-                        - {{ requirement.name }}
-                        <span v-if="requirement.version"> (Version {{ requirement.version }}) </span>
-                    </div>
-                </div>
-                <div class="mb-1" v-if="hasLicense">
-                    <span class="font-weight-bold">License:</span>
-                    <License :licenseId="license" />
-                </div>
-                <div v-if="hasReferences" class="mb-1">
-                    <span class="font-weight-bold">References:</span>
-                    <div v-for="(xref, index) in xrefs" :key="index">
-                        - {{ xref.reftype }}:
-                        <template v-if="xref.reftype == 'bio.tools'">
-                            {{ xref.value }}
-                            (<a :href="`https://bio.tools/${xref.value}`" target="_blank">
-                                bio.tools
-                                <font-awesome-icon
-                                    v-b-tooltip.hover
-                                    title="Visit bio.tools reference"
-                                    icon="external-link-alt"
-                                /> </a
-                            >) (<a :href="`https://openebench.bsc.es/tool/${xref.value}`" target="_blank"
-                                >OpenEBench
-                                <font-awesome-icon
-                                    v-b-tooltip.hover
-                                    title="Visit OpenEBench reference"
-                                    icon="external-link-alt"
-                                /> </a
-                            >)
-                        </template>
-                        <template v-else>
-                            {{ xref.value }}
-                        </template>
-                    </div>
-                </div>
-                <div v-if="hasCreators" class="mb-1">
-                    <span class="font-weight-bold">Creators:</span>
-                    <Creators :creators="creators" />
-                </div>
-            </b-card>
-        </b-collapse>
-    </div>
+    <b-card class="tool-footer" v-if="hasContent">
+        <div v-if="hasCitations" class="mb-1">
+            <span class="font-weight-bold">Citations:</span>
+            <font-awesome-icon
+                v-b-tooltip.hover
+                title="Copy all citations as BibTeX"
+                icon="copy"
+                style="cursor: pointer;"
+                @click="copyBibtex"
+            />
+            <Citation
+                class="formatted-reference"
+                v-for="(citation, index) in citations"
+                :key="index"
+                :citation="citation"
+                output-format="bibliography"
+                prefix="-"
+            />
+        </div>
+        <div v-if="hasRequirements" class="mb-1">
+            <span class="font-weight-bold"
+                >Requirements:
+                <a href="https://galaxyproject.org/tools/requirements/" target="_blank">
+                    <font-awesome-icon v-b-tooltip.hover title="Learn more about Galaxy Requirements" icon="question" />
+                </a>
+            </span>
+            <div v-for="(requirement, index) in requirements" :key="index">
+                - {{ requirement.name }}
+                <span v-if="requirement.version"> (Version {{ requirement.version }}) </span>
+            </div>
+        </div>
+        <div class="mb-1" v-if="hasLicense">
+            <span class="font-weight-bold">License:</span>
+            <License :licenseId="license" />
+        </div>
+        <div v-if="hasReferences" class="mb-1">
+            <span class="font-weight-bold">References:</span>
+            <div v-for="(xref, index) in xrefs" :key="index">
+                - {{ xref.reftype }}:
+                <template v-if="xref.reftype == 'bio.tools'">
+                    {{ xref.value }}
+                    (<a :href="`https://bio.tools/${xref.value}`" target="_blank">
+                        bio.tools
+                        <font-awesome-icon
+                            v-b-tooltip.hover
+                            title="Visit bio.tools reference"
+                            icon="external-link-alt"
+                        /> </a
+                    >) (<a :href="`https://openebench.bsc.es/tool/${xref.value}`" target="_blank"
+                        >OpenEBench
+                        <font-awesome-icon
+                            v-b-tooltip.hover
+                            title="Visit OpenEBench reference"
+                            icon="external-link-alt"
+                        /> </a
+                    >)
+                </template>
+                <template v-else>
+                    {{ xref.value }}
+                </template>
+            </div>
+        </div>
+        <div v-if="hasCreators" class="mb-1">
+            <span class="font-weight-bold">Creators:</span>
+            <Creators :creators="creators" />
+        </div>
+    </b-card>
 </template>
 
 <script>
@@ -150,7 +131,6 @@ export default {
     data() {
         return {
             citations: [],
-            expanded: false,
         };
     },
     created() {

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -49,7 +49,7 @@
                     <span class="metadata-key">License:</span>
                     <License :licenseId="license" />
                 </div>
-                <div v-if="xrefs && xrefs.length > 0" class="metadata-section">
+                <div v-if="hasReferences" class="metadata-section">
                     <span class="metadata-key">References:</span>
                     <div v-for="(xref, index) in xrefs" :key="index">
                         - {{ xref.reftype }}:
@@ -128,7 +128,10 @@ export default {
     },
     computed: {
         hasRequirements() {
-            return requirements && requirements.length > 0;
+            return this.requirements && this.requirements.length > 0;
+        },
+        hasRequirements() {
+            return this.xrefs && this.xrefs.length > 0
         },
     }
     data() {

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -76,7 +76,7 @@
                         </template>
                     </div>
                 </div>
-                <div v-if="creators && creators.length > 0" class="metadata-section">
+                <div v-if="hasCreators" class="metadata-section">
                     <span class="metadata-key">Creators:</span>
                     <Creators :creators="creators" />
                 </div>
@@ -131,7 +131,10 @@ export default {
             return this.requirements && this.requirements.length > 0;
         },
         hasRequirements() {
-            return this.xrefs && this.xrefs.length > 0
+            return this.xrefs && this.xrefs.length > 0;
+        },
+        hasCreators() {
+            return this.creators && this.creators.length > 0;
         },
     }
     data() {

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -1,18 +1,20 @@
 <template>
     <div class="tool-footer">
-        <!-- <b-button v-b-toggle.collapse-about>About this tool</b-button> -->
         <b-link
+            v-if="hasContent"
             :aria-expanded="expanded"
             aria-controls="collapse-about"
             class="collapse-about"
             @click="expanded = !expanded"
-            >About this tool
-            <font-awesome-icon :icon="expanded ? 'angle-double-up' : 'angle-double-down'" />
+        >
+            About this tool
+            <font-awesome-icon v-if="expanded" icon="angle-double-up" />
+            <font-awesome-icon v-else icon="angle-double-down" />
         </b-link>
         <b-collapse id="collapse-about" class="mt-2" v-model="expanded">
             <b-card>
-                <div v-if="hasCitations" class="metadata-section">
-                    <span class="metadata-key">Citations:</span>
+                <div v-if="hasCitations" class="mb-1">
+                    <span class="font-weight-bold">Citations:</span>
                     <font-awesome-icon
                         v-b-tooltip.hover
                         title="Copy all citations as BibTeX"
@@ -29,8 +31,8 @@
                         prefix="-"
                     />
                 </div>
-                <div v-if="hasRequirements" class="metadata-section">
-                    <span class="metadata-key"
+                <div v-if="hasRequirements" class="mb-1">
+                    <span class="font-weight-bold"
                         >Requirements:
                         <a href="https://galaxyproject.org/tools/requirements/" target="_blank">
                             <font-awesome-icon
@@ -45,18 +47,18 @@
                         <span v-if="requirement.version"> (Version {{ requirement.version }}) </span>
                     </div>
                 </div>
-                <div class="metadata-section" v-if="license">
-                    <span class="metadata-key">License:</span>
+                <div class="mb-1" v-if="hasLicense">
+                    <span class="font-weight-bold">License:</span>
                     <License :licenseId="license" />
                 </div>
-                <div v-if="hasReferences" class="metadata-section">
-                    <span class="metadata-key">References:</span>
+                <div v-if="hasReferences" class="mb-1">
+                    <span class="font-weight-bold">References:</span>
                     <div v-for="(xref, index) in xrefs" :key="index">
                         - {{ xref.reftype }}:
                         <template v-if="xref.reftype == 'bio.tools'">
                             {{ xref.value }}
-                            (<a :href="`https://bio.tools/${xref.value}`" target="_blank"
-                                >bio.tools
+                            (<a :href="`https://bio.tools/${xref.value}`" target="_blank">
+                                bio.tools
                                 <font-awesome-icon
                                     v-b-tooltip.hover
                                     title="Visit bio.tools reference"
@@ -76,8 +78,8 @@
                         </template>
                     </div>
                 </div>
-                <div v-if="hasCreators" class="metadata-section">
-                    <span class="metadata-key">Creators:</span>
+                <div v-if="hasCreators" class="mb-1">
+                    <span class="font-weight-bold">Creators:</span>
                     <Creators :creators="creators" />
                 </div>
             </b-card>
@@ -130,13 +132,21 @@ export default {
         hasRequirements() {
             return this.requirements && this.requirements.length > 0;
         },
-        hasRequirements() {
+        hasReferences() {
             return this.xrefs && this.xrefs.length > 0;
         },
         hasCreators() {
             return this.creators && this.creators.length > 0;
         },
-    }
+        hasLicense() {
+            return !!this.license;
+        },
+        hasContent() {
+            return (
+                this.hasRequirements || this.hasReferences || this.hasCreators || this.hasCitations || this.hasLicense
+            );
+        },
+    },
     data() {
         return {
             citations: [],
@@ -167,12 +177,3 @@ export default {
     },
 };
 </script>
-
-<style scoped>
-.metadata-key {
-    font-weight: bold;
-}
-.metadata-section {
-    margin-bottom: 5px;
-}
-</style>

--- a/client/src/components/Tool/ToolFooter.vue
+++ b/client/src/components/Tool/ToolFooter.vue
@@ -29,7 +29,7 @@
                         prefix="-"
                     />
                 </div>
-                <div v-if="requirements && requirements.length > 0" class="metadata-section">
+                <div v-if="hasRequirements" class="metadata-section">
                     <span class="metadata-key"
                         >Requirements:
                         <a href="https://galaxyproject.org/tools/requirements/" target="_blank">
@@ -126,6 +126,11 @@ export default {
             type: Array,
         },
     },
+    computed: {
+        hasRequirements() {
+            return requirements && requirements.length > 0;
+        },
+    }
     data() {
         return {
             citations: [],

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -328,7 +328,7 @@ tool_form:
     execute: 'button#execute'
     parameter_div: 'div.ui-form-element[tour_id="${parameter}"]'
     reference: '.formatted-reference'
-    about: '.collapse-about'
+    about: '.tool-footer'
 
   labels:
     generate_tour: 'Generate Tour'


### PR DESCRIPTION
Now that the tool about section has been integrated, it seems to be better to always show the `About this tool` content without requiring the user to manually expand the area. Also fixes #10839.