### PR TITLE
[20.01] Fix workflow preview for repeats without title

### DIFF
--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -71,12 +71,20 @@ class Repeat(Group):
 
     def __init__(self):
         Group.__init__(self)
-        self.title = None
+        self._title = None
         self.inputs = None
         self.help = None
         self.default = 0
         self.min = None
         self.max = None
+
+    @property
+    def title(self):
+        return self._title or self.name
+
+    @title.setter
+    def title(self, value):
+        self._title = value
 
     @property
     def title_plural(self):


### PR DESCRIPTION
These would fail when visiting the sharing link with
```
URL: http://127.0.0.1:8000/u/mvdbeek/w/covid-19-variation-analysis-reporting-imported-from-uploaded-file
File '/Users/mvandenb/src/galaxy/lib/galaxy/web/framework/middleware/error.py', line 153 in __call__
  app_iter = self.application(environ, sr_checker)
File '/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/paste/recursive.py', line 85 in __call__
  return self.application(environ, start_response)
File '/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/paste/httpexceptions.py', line 640 in __call__
  return self.application(environ, start_response)
File '/Users/mvandenb/src/galaxy/lib/galaxy/web/framework/base.py', line 136 in __call__
  return self.handle_request(environ, start_response)
File '/Users/mvandenb/src/galaxy/lib/galaxy/web/framework/base.py', line 215 in handle_request
  body = method(trans, **kwargs)
File '/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/controllers/workflow.py', line 230 in display_by_username_and_slug
  return self._display(trans, stored_workflow)
File '/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/controllers/workflow.py', line 266 in _display
  return trans.fill_template_mako("workflow/display.mako",
File '/Users/mvandenb/src/galaxy/lib/galaxy/webapps/base/webapp.py', line 971 in fill_template_mako
  return template.render(**data)
File '/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mako/template.py', line 476 in render
  return runtime._render(self, self.callable_, args, data)
File '/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mako/runtime.py', line 878 in _render
  _render_context(
File '/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mako/runtime.py', line 920 in _render_context
  _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
File '/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/mako/runtime.py', line 947 in _exec_template
  callable_(context, *args, **kwargs)
File '/Users/mvandenb/src/galaxy/database/compiled_templates/base/base_panels.mako.py', line 124 in render_body
  __M_writer(str(self.center_panel()))
File '/Users/mvandenb/src/galaxy/database/compiled_templates/display_base.mako.py', line 234 in render_center_panel
  __M_writer(str(self.render_content()))
File '/Users/mvandenb/src/galaxy/database/compiled_templates/display_base.mako.py', line 269 in render_render_content
  __M_writer(str(self.render_item( item, item_data )))
File '/Users/mvandenb/src/galaxy/database/compiled_templates/workflow/display.mako.py', line 256 in render_render_item
  __M_writer(str(do_inputs( tool.inputs, step.state.inputs, "", step )))
File '/Users/mvandenb/src/galaxy/database/compiled_templates/workflow/display.mako.py', line 229 in do_inputs
  return render_do_inputs(context,inputs,values,prefix,step,other_values)
File '/Users/mvandenb/src/galaxy/database/compiled_templates/workflow/display.mako.py', line 88 in render_do_inputs
  __M_writer(str(input.title_plural))
File '/Users/mvandenb/src/galaxy/lib/galaxy/tools/parameters/grouping.py', line 80 in title_plural
  return inflector.pluralize(self.title)
File '/Users/mvandenb/src/galaxy/lib/galaxy/util/inflection.py', line 86 in pluralize
  return self._transform(self.PLURALIZE_RULES, word)
File '/Users/mvandenb/src/galaxy/lib/galaxy/util/inflection.py', line 99 in _transform
  return self._handle_nonchanging(word) or self._handle_irregular(word, pluralize=pluralize) or self._apply_rules(rules, word) or word
File '/Users/mvandenb/src/galaxy/lib/galaxy/util/inflection.py', line 102 in _handle_nonchanging
  lower_cased_word = word.lower()
AttributeError: 'NoneType' object has no attribute 'lower'
```
`title` is a mandatory attribute of repeats, but repeats without title
work fine otherwise. The tool in question is
https://github.com/galaxyproject/tools-iuc/blob/master/tools/compose_text_param/compose_text_param.xml#L13
which has passed planemo linting.