### PR TITLE
Run maintenance bot only once

### DIFF
--- a/.github/workflows/maintenance_bot.yaml
+++ b/.github/workflows/maintenance_bot.yaml
@@ -1,6 +1,7 @@
 name: "Maintenance Bot"
 on:
-  - pull_request_target
+  pull_request_target:
+    types: [opened]
 
 jobs:
   labeler:


### PR DESCRIPTION
Run maintenance bot only on once when PR is opened.
bad behavior (bot adds removed label):
https://github.com/galaxyproject/galaxy/pull/10856
https://github.com/OlegZharkov/galaxy/pull/92
new behavior:
https://github.com/OlegZharkov/galaxy/pull/93