### PR TITLE
Run CI labeler on reopened PRs, but skip if area labels are present

### DIFF
--- a/.github/workflows/maintenance_bot.yaml
+++ b/.github/workflows/maintenance_bot.yaml
@@ -1,7 +1,7 @@
 name: "Maintenance Bot"
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   labeler:
@@ -10,7 +10,9 @@ jobs:
     env:
       MILESTONE_NUMBER: 18
     steps:
-      - uses: actions/labeler@main
+      - name: Add area labels
+        if: ! contains(join(github.event.pull_request.labels.*.name, ', '), 'area/')
+        uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Assign milestone


### PR DESCRIPTION
So if a PR is already labelled when created, no spurious labels are added.