### PR TITLE
Allow build_list inputs to be optional

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2864,8 +2864,8 @@ class BuildListCollectionTool(DatabaseOperationTool):
         new_elements = OrderedDict()
 
         for i, incoming_repeat in enumerate(incoming["datasets"]):
-            new_dataset = incoming_repeat["input"].copy(copy_tags=tags)
-            new_elements["%d" % i] = new_dataset
+            if incoming_repeat["input"]:
+                new_elements["%d" % i] = incoming_repeat["input"].copy(copy_tags=tags)
 
         self._add_datasets_to_history(history, new_elements.values())
         output_collections.create_collection(

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -192,7 +192,9 @@ GALAXY_LIB_TOOLS_VERSIONED = {
 safe_update = collections.namedtuple("SafeUpdate", "min_version current_version")
 # Tool updates that did not change parameters in a way that requires rebuilding workflows
 WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
-    'Filter1': safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.1.1"))
+    'Filter1': safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.1.1")),
+    '__BUILD_LIST__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
+    '__APPLY_RULES__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.1.0")),
 }
 
 

--- a/lib/galaxy/tools/build_list.xml
+++ b/lib/galaxy/tools/build_list.xml
@@ -1,6 +1,6 @@
 <tool id="__BUILD_LIST__"
       name="Build List"
-      version="1.0.0"
+      version="1.1.0"
       tool_type="build_list">
   <description>from one or more datasets</description>
   <type class="BuildListCollectionTool" module="galaxy.tools" />
@@ -8,7 +8,7 @@
           class="ModelOperationToolAction"/>
   <inputs>
     <repeat name="datasets" title="Dataset">
-      <param type="data" name="input" label="Input Dataset" />
+      <param type="data" name="input" optional="true" label="Input Dataset" />
     </repeat>
   </inputs>
   <outputs>
@@ -33,6 +33,12 @@ This tool will create a new collection from your history datasets but your quota
               <has_text_matching expression="^This is a line of text.\n$"/>
           </assert_contents>
         </element>
+      </output_collection>
+    </test>
+    <test>
+      <repeat name="datasets">
+      </repeat>
+      <output_collection name="output" type="list" count="0">
       </output_collection>
     </test>
   </tests>


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/10863 + fix tests by adding `__BUILD_LIST__ ` to `WORKFLOW_SAFE_TOOL_VERSION_UPDATES `