### PR TITLE
Import `Mapping` from `collection.abc`

### DIFF
--- a/.github/workflows/maintenance_bot.yaml
+++ b/.github/workflows/maintenance_bot.yaml
@@ -11,7 +11,7 @@ jobs:
       MILESTONE_NUMBER: 18
     steps:
       - name: Add area labels
-        if: ! contains(join(github.event.pull_request.labels.*.name, ', '), 'area/')
+        if: ${{ ! contains(join(github.event.pull_request.labels.*.name, ', '), 'area/') }}
         uses: actions/labeler@main
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -10,10 +10,8 @@ import shutil
 import sys
 import tempfile
 import weakref
-from collections import (
-    Mapping,
-    OrderedDict,
-)
+from collections import OrderedDict
+from collections.abc import Mapping
 from os.path import abspath
 
 from sqlalchemy.orm import object_session


### PR DESCRIPTION
Fix the following warning:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```

Also fix initial exclamation mark breaking the maintenance GH workflow.