### PR TITLE
implement a 'duplicate_column_filter'

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5882,6 +5882,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:enumeration value="static_value"/>
       <xs:enumeration value="regexp"/>
       <xs:enumeration value="unique_value"/>
+      <xs:enumeration value="duplicate_column"/>
       <xs:enumeration value="multiple_splitter"/>
       <xs:enumeration value="add_value"/>
       <xs:enumeration value="remove_value"/>

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -339,6 +339,25 @@ class MultipleSplitterFilter(Filter):
         return rval
 
 
+class DuplicateColumnFilter(Filter):
+    """
+    Required Attributes:
+        column: column in options to compare with
+    """
+
+    def __init__(self, d_option, elem):
+        Filter.__init__(self, d_option, elem)
+        column = elem.get("column", None)
+        assert column is not None, "Required 'column' attribute missing from filter"
+        self.column = d_option.column_spec_to_index(column)
+
+    def filter_options(self, options, trans, other_values):
+        rval = []
+        for fields in options:
+            rval.append(fields[0:self.column] + [fields[self.column]] + fields[self.column:])
+        return rval
+
+
 class AttributeValueSplitterFilter(Filter):
     """
     Filters a list of attribute-value pairs to be unique attribute names.
@@ -505,6 +524,7 @@ filter_types = dict(data_meta=DataMetaFilter,
                     unique_value=UniqueValueFilter,
                     multiple_splitter=MultipleSplitterFilter,
                     attribute_value_splitter=AttributeValueSplitterFilter,
+                    duplicate_column=DuplicateColumnFilter,
                     add_value=AdditionalValueFilter,
                     remove_value=RemoveValueFilter,
                     sort_by=SortByColumnFilter)

--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -141,6 +141,9 @@ class SelectToolParameterWrapper(ToolParameterValueWrapper):
             self._compute_environment = compute_environment
 
         def __getattr__(self, name):
+            return self[name]
+
+        def __getitem__(self, name):
             if name not in self._fields:
                 self._fields[name] = self._input.options.get_field_by_name_for_value(name, self._value, None, self._other_values)
             values = map(str, self._fields[name])


### PR DESCRIPTION
assume there is a data table with 2 columns: name and value (e.g. mothur data tables and probably many other old ones).

tools using such data tables can not be tested (to the best of my knowledge) since one needs to specify the value .. which is a path that changes with the test environment.

my first idea was to add a filter that duplicates a column, i.e. (name, value) can be transformed into (name, name, value)

this already works (tested for one mothur tool), but only for accessing the columns by index. accessing the columns by name does not work, since the names still refer to the old columns (which might be confusing for the tool developer .. at least it deserves proper documentation)

Example from mothur `seq.error`: 

```
                <param name="template" type="select" label="reference - Select an alignment database" help="">
                    <options from_data_table="mothur_aligndb">
                        <filter type="static_value" value="@FILTER@" column="2"/>
                    </options>
                </param>
```

In the commands block the access was:  `$template.fields.value`. Now we can add `<filter type="duplicate_column" column="0"/>` and access via `$template.fields[2]`.


alternatively
- one might implement this in `DynamicOptions` by adding a new attribute.
- tweak `tool_data_table.conf` to allow to define duplicate columns (btw. where is the doc for `tool_data_table.conf`)
- ... ?




Also adds the possibility to access `SelectToolParameterFieldWrapper` by index. Which was already documented, but did not work since attributes need to be strings.


