### PR TITLE
[20.01] Update lxml for CVE-2020-27783

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -52,7 +52,7 @@ scandir==1.10.0 ; python_version < '3.5'
 selenium==3.141.0
 six==1.11.0
 snowballstemmer==2.0.0
-sphinx-markdown-tables==0.0.13
+sphinx-markdown-tables==0.0.14
 sphinx-rtd-theme==0.4.3
 sphinx==1.8.5
 sphinxcontrib-websupport==1.1.2

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-dev-requirements.txt
@@ -20,7 +20,7 @@ idna==2.8
 imagesize==1.1.0
 importlib-metadata==1.2.0 ; python_version < '3.8'
 jinja2==2.10.3
-lxml==4.4.2
+lxml==4.6.2
 markdown==3.1.1
 markupsafe==1.1.1
 mirakuru==1.1.0

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -81,7 +81,7 @@ jsonschema==3.2.0
 keystoneauth1==3.18.0
 kombu==4.6.6
 lockfile==0.12.2
-lxml==4.4.2
+lxml==4.6.2
 mako==1.1.0
 markdown==3.1.1
 markupsafe==1.1.1


### PR DESCRIPTION
Also update sphinx-markdown-tables to a non-buggy version.