### PR TITLE
Allow relative paths when staging jobs (e.g. with planemo run)

### DIFF
--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -213,7 +213,7 @@ class StagingInterace(metaclass=abc.ABCMeta):
             assert job is None
             with open(job_path) as f:
                 job = yaml.safe_load(f)
-            job_dir = os.path.dirname(job_path)
+            job_dir = os.path.dirname(os.path.abspath(job_path))
         else:
             assert job is not None
             # Figure out what "." should be here instead.


### PR DESCRIPTION
So that a command like `planemo run wf.ga wf-job.yml` with:

```
Dataset 1:
  class: File
  path: "data/dataset1.txt"

```

will work correctly.

Currently, either the job file or the dataset paths need to be specified with an absolute path, otherwise `stage` isn't able to find `job_dir`.