### PR TITLE
Vue unit test cleanup, removing jquery, mocking ajax calls

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -2,7 +2,7 @@
     "presets": ["@babel/preset-env"],
     "env": {
         "test": {
-            "plugins": ["@babel/plugin-transform-runtime", "rewire"]
+            "plugins": ["@babel/plugin-transform-runtime"]
         }
     }
 }

--- a/client/README.md
+++ b/client/README.md
@@ -115,8 +115,7 @@ framework.
 For testing Vue components, we use the [Vue testing
 utils](https://vue-test-utils.vuejs.org/) to mount individual components in a
 test bed and check them for rendered features.  Please use jest-based mocking
-for isolating test functionality.  Some tests exist using Rewire, but those
-should be updated over time.
+for isolating test functionality.
 
 A set of older qUnit tests also exist which will be phased-out as the code they
 support is replaced with modern component-based implementations. In the

--- a/client/package.json
+++ b/client/package.json
@@ -120,7 +120,6 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
-    "babel-plugin-rewire": "^1.2.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.3",
     "babel-plugin-transform-vue-template": "^0.4.2",
     "chai": "^4.2.0",

--- a/client/src/components/DataDialog/DataDialog.test.js
+++ b/client/src/components/DataDialog/DataDialog.test.js
@@ -4,7 +4,6 @@ import { Model } from "./model";
 import { UrlTracker } from "./utilities";
 import { Services } from "./services";
 import { shallowMount, createLocalVue } from "@vue/test-utils";
-import { getNewAttachNode } from "jest/helpers";
 
 jest.mock("app");
 
@@ -132,7 +131,6 @@ describe("DataDialog.vue", () => {
         const localVue = createLocalVue();
         wrapper = shallowMount(DataDialog, {
             propsData: mockOptions,
-            attachTo: getNewAttachNode(),
             localVue,
         });
         expect(wrapper.findComponent(SelectionDialog).exists()).toBe(true);
@@ -145,7 +143,7 @@ describe("DataDialog.vue", () => {
 
         // expect(wrapper.find(".fa-spinner").text()).to.equals("");
         // expect(wrapper.contains(".fa-spinner")).to.equals(true);
-        // await Vue.nextTick();
+        // await wrapper.vm.$nextTick();
         // expect(wrapper.findAll(".fa-folder").length).to.equals(2);
         // expect(wrapper.findAll(".fa-file-o").length).to.equals(2);
 

--- a/client/src/components/Dataset/DatasetName.test.js
+++ b/client/src/components/Dataset/DatasetName.test.js
@@ -1,10 +1,14 @@
-import { mount } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import DatasetName from "./DatasetName";
+import { getLocalVue } from "jest/helpers";
+
+const localVue = getLocalVue();
 
 describe("Dataset Name", () => {
     it("test dataset default", async () => {
-        const wrapper = mount(DatasetName, {
+        const wrapper = shallowMount(DatasetName, {
             propsData: { item: { name: "name", state: "success" } },
+            localVue,
         });
         const state = wrapper.findAll(".name");
         expect(state.length).toBe(1);
@@ -17,8 +21,9 @@ describe("Dataset Name", () => {
         expect(Array.isArray(wrapper.emitted().copyDataset)).toBe(true);
     });
     it("test dataset error", async () => {
-        const wrapper = mount(DatasetName, {
+        const wrapper = shallowMount(DatasetName, {
             propsData: { item: { name: "name", state: "error" } },
+            localVue,
         });
         const state = wrapper.findAll(".name");
         expect(state.length).toBe(1);
@@ -28,8 +33,9 @@ describe("Dataset Name", () => {
         expect(errorstate.at(0).classes()).toEqual(expect.arrayContaining(["text-danger"]));
     });
     it("test dataset paused", async () => {
-        const wrapper = mount(DatasetName, {
+        const wrapper = shallowMount(DatasetName, {
             propsData: { item: { name: "name", state: "paused" } },
+            localVue,
         });
         const state = wrapper.findAll(".name");
         expect(state.length).toBe(1);

--- a/client/src/components/Dataset/DatasetName.test.js
+++ b/client/src/components/Dataset/DatasetName.test.js
@@ -1,12 +1,10 @@
 import { mount } from "@vue/test-utils";
 import DatasetName from "./DatasetName";
-import { getNewAttachNode } from "jest/helpers";
 
 describe("Dataset Name", () => {
     it("test dataset default", async () => {
         const wrapper = mount(DatasetName, {
             propsData: { item: { name: "name", state: "success" } },
-            attachTo: getNewAttachNode(),
         });
         const state = wrapper.findAll(".name");
         expect(state.length).toBe(1);
@@ -21,7 +19,6 @@ describe("Dataset Name", () => {
     it("test dataset error", async () => {
         const wrapper = mount(DatasetName, {
             propsData: { item: { name: "name", state: "error" } },
-            attachTo: getNewAttachNode(),
         });
         const state = wrapper.findAll(".name");
         expect(state.length).toBe(1);
@@ -33,7 +30,6 @@ describe("Dataset Name", () => {
     it("test dataset paused", async () => {
         const wrapper = mount(DatasetName, {
             propsData: { item: { name: "name", state: "paused" } },
-            attachTo: getNewAttachNode(),
         });
         const state = wrapper.findAll(".name");
         expect(state.length).toBe(1);

--- a/client/src/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/src/components/InteractiveTools/InteractiveTools.test.js
@@ -1,5 +1,6 @@
 import InteractiveTools from "./InteractiveTools";
-import { mount, createLocalVue } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import flushPromises from "flush-promises";
 import _l from "utils/localization";
 import testInteractiveToolsResponse from "./testData/testInteractiveToolsResponse";
@@ -8,7 +9,7 @@ import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 
 describe("InteractiveTools/InteractiveTools.vue", () => {
-    const localVue = createLocalVue();
+    const localVue = getLocalVue();
     localVue.filter("localize", (value) => _l(value));
     let wrapper;
     let axiosMock;
@@ -23,6 +24,7 @@ describe("InteractiveTools/InteractiveTools.vue", () => {
                     };
                 },
             },
+            localVue,
         });
         axiosMock.onGet("/api/entry_points?running=true").reply(200, testInteractiveToolsResponse);
         axiosMock.onPost("/interactivetool/list").reply(200, { status: "ok", message: "ok" });

--- a/client/src/components/InteractiveTools/InteractiveTools.test.js
+++ b/client/src/components/InteractiveTools/InteractiveTools.test.js
@@ -6,7 +6,6 @@ import testInteractiveToolsResponse from "./testData/testInteractiveToolsRespons
 
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import { getNewAttachNode } from "jest/helpers";
 
 describe("InteractiveTools/InteractiveTools.vue", () => {
     const localVue = createLocalVue();
@@ -24,7 +23,6 @@ describe("InteractiveTools/InteractiveTools.vue", () => {
                     };
                 },
             },
-            attachTo: getNewAttachNode(),
         });
         axiosMock.onGet("/api/entry_points?running=true").reply(200, testInteractiveToolsResponse);
         axiosMock.onPost("/interactivetool/list").reply(200, { status: "ok", message: "ok" });

--- a/client/src/components/JobDestinationParams/JobDestinationParams.test.js
+++ b/client/src/components/JobDestinationParams/JobDestinationParams.test.js
@@ -1,34 +1,43 @@
 import Vuex from "vuex";
-import { mount, createLocalVue } from "@vue/test-utils";
-import { createStore } from "../../store";
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import createCache from "vuex-cache";
 import JobDestinationParams from "./JobDestinationParams";
 import jobDestinationResponse from "./testData/jobDestinationResponse";
 
 const JOB_ID = "foo_job_id";
 
-describe("JobDestinationParams/JobDestinationParams.vue", () => {
-    const localVue = createLocalVue();
-    localVue.use(Vuex);
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
-    const responseKeys = Object.keys(jobDestinationResponse);
-
-    let testStore;
-    let wrapper;
-
-    beforeEach(async () => {
-        testStore = createStore();
-        const propsData = {
-            jobId: JOB_ID,
-        };
-        wrapper = mount(JobDestinationParams, {
-            store: testStore,
-            propsData,
-            localVue,
-            computed: {
-                jobDestinationParams() {
+const testStore = new Vuex.Store({
+    plugins: [createCache()],
+    modules: {
+        jobDestinationParametersStore: {
+            actions: {
+                fetchJobDestinationParams: jest.fn(),
+            },
+            getters: {
+                jobDestinationParams: (state) => (job_id) => {
                     return jobDestinationResponse;
                 },
             },
+        },
+    },
+});
+
+describe("JobDestinationParams/JobDestinationParams.vue", () => {
+    const responseKeys = Object.keys(jobDestinationResponse);
+
+    let wrapper;
+
+    beforeEach(async () => {
+        const propsData = {
+            jobId: JOB_ID,
+        };
+        wrapper = shallowMount(JobDestinationParams, {
+            store: testStore,
+            propsData,
+            localVue,
         });
         expect(responseKeys.length > 0).toBeTruthy();
     });

--- a/client/src/components/Markdown/MarkdownVisualization.test.js
+++ b/client/src/components/Markdown/MarkdownVisualization.test.js
@@ -1,6 +1,5 @@
 import MarkdownVisualization from "./MarkdownVisualization";
 import { shallowMount } from "@vue/test-utils";
-import Vue from "vue";
 
 describe("Markdown/MarkdownVisualization", () => {
     it("test wizard", async () => {
@@ -16,7 +15,7 @@ describe("Markdown/MarkdownVisualization", () => {
                 useLabels: false,
             },
         });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.labelShow).toBe(false);
         expect(Object.keys(wrapper.vm.formInputs).length).toBe(3);
         wrapper.vm.onData("history_dataset_id");
@@ -35,7 +34,7 @@ describe("Markdown/MarkdownVisualization", () => {
                 useLabels: true,
             },
         });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.labelShow).toBe(true);
         expect(wrapper.vm.formInputs).toBe(null);
     });

--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -1,5 +1,6 @@
 import { default as Masthead } from "./Masthead.vue";
-import { mount, createLocalVue } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import Scratchbook from "layout/scratchbook";
 import { fetchMenu } from "layout/menu";
 import { loadWebhookMenuItems } from "./_webhooks";
@@ -33,7 +34,7 @@ describe("Masthead.vue", () => {
     loadWebhookMenuItems.mockImplementation(stubLoadWebhooks);
 
     beforeEach(() => {
-        localVue = createLocalVue();
+        localVue = getLocalVue();
         quotaRendered = false;
         quotaEl = null;
 

--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -1,7 +1,12 @@
-import { default as Masthead, __RewireAPI__ as rewire } from "./Masthead.vue";
+import { default as Masthead } from "./Masthead.vue";
 import { mount, createLocalVue } from "@vue/test-utils";
 import Scratchbook from "layout/scratchbook";
-import { getNewAttachNode } from "jest/helpers";
+import { fetchMenu } from "layout/menu";
+import { loadWebhookMenuItems } from "./_webhooks";
+
+jest.mock("app");
+jest.mock("layout/menu");
+jest.mock("./_webhooks");
 
 describe("Masthead.vue", () => {
     let wrapper;
@@ -24,10 +29,10 @@ describe("Masthead.vue", () => {
         });
     }
 
-    beforeEach(() => {
-        rewire.__Rewire__("fetchMenu", stubFetchMenu);
-        rewire.__Rewire__("loadWebhookMenuItems", stubLoadWebhooks);
+    fetchMenu.mockImplementation(stubFetchMenu);
+    loadWebhookMenuItems.mockImplementation(stubLoadWebhooks);
 
+    beforeEach(() => {
         localVue = createLocalVue();
         quotaRendered = false;
         quotaEl = null;
@@ -83,7 +88,6 @@ describe("Masthead.vue", () => {
                 appRoot: "prefix/",
             },
             localVue,
-            attachTo: getNewAttachNode(),
         });
     });
 

--- a/client/src/components/Masthead/MastheadItem.test.js
+++ b/client/src/components/Masthead/MastheadItem.test.js
@@ -1,8 +1,7 @@
+import { shallowMount, createLocalVue } from "@vue/test-utils";
 import MastheadItem from "./MastheadItem.vue";
-import { mount, createLocalVue } from "@vue/test-utils";
-import { getNewAttachNode } from "jest/helpers";
 
-describe("Masthead.vue", () => {
+describe("MastheadItem.vue", () => {
     let wrapper;
     let localVue;
     let active;
@@ -18,13 +17,12 @@ describe("Masthead.vue", () => {
             menu: menu,
         };
 
-        return mount(MastheadItem, {
+        return shallowMount(MastheadItem, {
             propsData: {
                 tab,
                 activeTab: active,
             },
             localVue,
-            attachTo: getNewAttachNode(),
         });
     }
 

--- a/client/src/components/Masthead/MastheadItem.test.js
+++ b/client/src/components/Masthead/MastheadItem.test.js
@@ -1,4 +1,5 @@
-import { shallowMount, createLocalVue } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import MastheadItem from "./MastheadItem.vue";
 
 describe("MastheadItem.vue", () => {
@@ -8,7 +9,7 @@ describe("MastheadItem.vue", () => {
     let menu;
 
     beforeEach(() => {
-        localVue = createLocalVue();
+        localVue = getLocalVue();
     });
 
     function m() {

--- a/client/src/components/Panels/Common/Tool.test.js
+++ b/client/src/components/Panels/Common/Tool.test.js
@@ -1,6 +1,5 @@
 import { mount } from "@vue/test-utils";
 import Tool from "./Tool";
-import { getNewAttachNode } from "jest/helpers";
 
 describe("Tool", () => {
     test("test tool", () => {
@@ -8,7 +7,6 @@ describe("Tool", () => {
             propsData: {
                 tool: {},
             },
-            attachTo: getNewAttachNode(),
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.at(0).text()).toBe("");
@@ -30,7 +28,6 @@ describe("Tool", () => {
                 operationIcon: "operationIconClass",
                 operationTitle: "operationTitle",
             },
-            attachTo: getNewAttachNode(),
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.at(0).text()).toBe("name");
@@ -48,7 +45,6 @@ describe("Tool", () => {
                 },
                 hideName: true,
             },
-            attachTo: getNewAttachNode(),
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.length).toBe(0);

--- a/client/src/components/Panels/Common/Tool.test.js
+++ b/client/src/components/Panels/Common/Tool.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import Tool from "./Tool";
+
+const localVue = getLocalVue();
 
 describe("Tool", () => {
     test("test tool", () => {
@@ -7,6 +10,7 @@ describe("Tool", () => {
             propsData: {
                 tool: {},
             },
+            localVue,
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.at(0).text()).toBe("");
@@ -28,6 +32,7 @@ describe("Tool", () => {
                 operationIcon: "operationIconClass",
                 operationTitle: "operationTitle",
             },
+            localVue,
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.at(0).text()).toBe("name");
@@ -45,6 +50,7 @@ describe("Tool", () => {
                 },
                 hideName: true,
             },
+            localVue,
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.length).toBe(0);

--- a/client/src/components/Panels/Common/ToolSection.test.js
+++ b/client/src/components/Panels/Common/ToolSection.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import ToolSection from "./ToolSection";
+
+const localVue = getLocalVue();
 
 describe("ToolSection", () => {
     test("test tool section", () => {
@@ -9,6 +12,7 @@ describe("ToolSection", () => {
                     name: "name",
                 },
             },
+            localVue,
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.at(0).text()).toBe("name");
@@ -31,6 +35,7 @@ describe("ToolSection", () => {
                     ],
                 },
             },
+            localVue,
         });
         expect(wrapper.vm.opened).toBe(false);
         const $sectionName = wrapper.find(".name");
@@ -62,6 +67,7 @@ describe("ToolSection", () => {
                 },
                 queryFilter: "test",
             },
+            localVue,
         });
         expect(wrapper.vm.opened).toBe(true);
         const $sectionName = wrapper.find(".name");

--- a/client/src/components/Panels/Common/ToolSection.test.js
+++ b/client/src/components/Panels/Common/ToolSection.test.js
@@ -1,7 +1,5 @@
-import Vue from "vue";
 import { mount } from "@vue/test-utils";
 import ToolSection from "./ToolSection";
-import { getNewAttachNode } from "jest/helpers";
 
 describe("ToolSection", () => {
     test("test tool section", () => {
@@ -11,7 +9,6 @@ describe("ToolSection", () => {
                     name: "name",
                 },
             },
-            attachTo: getNewAttachNode(),
         });
         const nameElement = wrapper.findAll(".name");
         expect(nameElement.at(0).text()).toBe("name");
@@ -34,19 +31,18 @@ describe("ToolSection", () => {
                     ],
                 },
             },
-            attachTo: getNewAttachNode(),
         });
         expect(wrapper.vm.opened).toBe(false);
         const $sectionName = wrapper.find(".name");
         expect($sectionName.text()).toBe("tool_section");
         $sectionName.trigger("click");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         const $names = wrapper.findAll(".name");
         expect($names.at(1).text()).toBe("name");
         const $label = wrapper.find(".tool-panel-label");
         expect($label.text()).toBe("text");
         $sectionName.trigger("click");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.findAll(".name").length).toBe(1);
     });
 
@@ -66,30 +62,29 @@ describe("ToolSection", () => {
                 },
                 queryFilter: "test",
             },
-            attachTo: getNewAttachNode(),
         });
         expect(wrapper.vm.opened).toBe(true);
         const $sectionName = wrapper.find(".name");
         $sectionName.trigger("click");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(false);
         wrapper.setProps({ queryFilter: "" });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(false);
         wrapper.setProps({ queryFilter: "test" });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(true);
         wrapper.setProps({ disableFilter: true });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(true);
         wrapper.setProps({ queryFilter: "" });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(false);
         $sectionName.trigger("click");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(true);
         wrapper.setProps({ queryFilter: "test" });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.vm.opened).toBe(false);
     });
 });

--- a/client/src/components/RuleBuilder/SavedRulesSelector.test.js
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import SavedRulesSelector from "components/RuleBuilder/SavedRulesSelector";
+
+const localVue = getLocalVue();
 
 describe("SavedRulesSelector", () => {
     let wrapper;
@@ -12,6 +15,7 @@ describe("SavedRulesSelector", () => {
                 prefix: "test_prefix_" + new Date().toISOString() + "_",
                 savedRules: [],
             },
+            localVue,
         });
         await wrapper.vm.$nextTick();
     });

--- a/client/src/components/RuleBuilder/SavedRulesSelector.test.js
+++ b/client/src/components/RuleBuilder/SavedRulesSelector.test.js
@@ -1,7 +1,5 @@
-import Vue from "vue";
 import { mount } from "@vue/test-utils";
 import SavedRulesSelector from "components/RuleBuilder/SavedRulesSelector";
-import { getNewAttachNode } from "jest/helpers";
 
 describe("SavedRulesSelector", () => {
     let wrapper;
@@ -14,13 +12,12 @@ describe("SavedRulesSelector", () => {
                 prefix: "test_prefix_" + new Date().toISOString() + "_",
                 savedRules: [],
             },
-            attachTo: getNewAttachNode(),
         });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
     });
 
     afterEach(async () => {
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
     });
 
     it("disables history icon if there is no history", async () => {
@@ -49,7 +46,7 @@ describe("SavedRulesSelector", () => {
             user: "test_user",
             savedRules: [testRules],
         });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         const sessions = wrapper.findAll("div.dropdown-menu > a.saved-rule-item");
         expect(sessions.length > 0).toBeTruthy();
         sessions.wrappers[0].trigger("click");

--- a/client/src/components/Tags/StatelessTags.test.js
+++ b/client/src/components/Tags/StatelessTags.test.js
@@ -1,7 +1,6 @@
 import { mount, createLocalVue } from "@vue/test-utils";
 import StatelessTags from "./StatelessTags";
 import _l from "utils/localization";
-import Vue from "vue";
 
 describe("Tags/StatelessTags.vue", () => {
     const localVue = createLocalVue();
@@ -17,7 +16,7 @@ describe("Tags/StatelessTags.vue", () => {
             value: testTags,
         });
         emitted = wrapper.emitted();
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
     });
 
     it("should render a div for each tag", () => {

--- a/client/src/components/ToolsView/ToolsSchemaJson/ToolsJson.test.js
+++ b/client/src/components/ToolsView/ToolsSchemaJson/ToolsJson.test.js
@@ -3,7 +3,6 @@ import ToolsJson from "./ToolsJson";
 import testToolsListResponse from "../testData/toolsList";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import Vue from "vue";
 import { mount } from "@vue/test-utils";
 
 describe("ToolsView/ToolsView.vue", () => {
@@ -15,11 +14,11 @@ describe("ToolsView/ToolsView.vue", () => {
         axiosMock = new MockAdapter(axios);
         wrapper = mount(ToolsJson);
         axiosMock.onGet("/api/tools?tool_help=True").reply(200, testToolsListResponse);
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
     });
 
     it("schema.org script element is created", async () => {
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         const tools = wrapper.vm.createToolsJson(testToolsListResponse);
         const schemaElement = document.getElementById("schema-json");
         const schemaText = JSON.parse(schemaElement.text);

--- a/client/src/components/ToolsView/ToolsView.test.js
+++ b/client/src/components/ToolsView/ToolsView.test.js
@@ -1,6 +1,6 @@
 import ToolsView from "./ToolsView";
-import { mount, createLocalVue } from "@vue/test-utils";
-import _l from "utils/localization";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import flushPromises from "flush-promises";
 
 // test response
@@ -12,14 +12,14 @@ import axios from "axios";
 jest.mock("app");
 
 describe("ToolsView/ToolsView.vue", () => {
-    const localVue = createLocalVue();
-    localVue.filter("localize", (value) => _l(value));
+    const localVue = getLocalVue();
+
     let wrapper;
     let axiosMock;
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
-        wrapper = mount(ToolsView);
+        wrapper = mount(ToolsView, localVue);
         axiosMock.onGet("/api/tools?tool_help=True").reply(200, testToolsListResponse);
         axiosMock.onGet(new RegExp(`./*/citations`)).reply(200, testCitation);
         await flushPromises();

--- a/client/src/components/ToolsView/ToolsView.test.js
+++ b/client/src/components/ToolsView/ToolsView.test.js
@@ -19,7 +19,7 @@ describe("ToolsView/ToolsView.vue", () => {
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
-        wrapper = mount(ToolsView, localVue);
+        wrapper = mount(ToolsView, { localVue });
         axiosMock.onGet("/api/tools?tool_help=True").reply(200, testToolsListResponse);
         axiosMock.onGet(new RegExp(`./*/citations`)).reply(200, testCitation);
         await flushPromises();

--- a/client/src/components/ToolsView/ToolsView.test.js
+++ b/client/src/components/ToolsView/ToolsView.test.js
@@ -9,6 +9,8 @@ import testCitation from "./testData/citation";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
 
+jest.mock("app");
+
 describe("ToolsView/ToolsView.vue", () => {
     const localVue = createLocalVue();
     localVue.filter("localize", (value) => _l(value));

--- a/client/src/components/Toolshed/InstalledList/Details.test.js
+++ b/client/src/components/Toolshed/InstalledList/Details.test.js
@@ -1,23 +1,28 @@
-import { shallowMount } from "@vue/test-utils";
+import { shallowMount, createLocalVue } from "@vue/test-utils";
 import Details from "./Details";
-import { __RewireAPI__ as rewire } from "./Details";
-import Vue from "vue";
+
+jest.mock("app");
+
+import { getAppRoot } from "onload/loadConfig";
+jest.mock("onload/loadConfig");
+getAppRoot.mockImplementation(() => "/");
+
+import { Services } from "../services";
+jest.mock("../services");
+
+Services.mockImplementation(() => {
+    return {
+        async getRepositoryByName(url, name, owner) {
+            expect(url).toBe("tool_shed_url");
+            expect(name).toBe("name");
+            expect(owner).toBe("owner");
+            return {};
+        },
+    };
+});
 
 describe("Details", () => {
-    beforeEach(() => {
-        rewire.__Rewire__(
-            "Services",
-            class {
-                async getRepositoryByName(url, name, owner) {
-                    expect(url).toBe("tool_shed_url");
-                    expect(name).toBe("name");
-                    expect(owner).toBe("owner");
-                    return {};
-                }
-            }
-        );
-    });
-
+    const localVue = createLocalVue();
     it("test repository details loading", async () => {
         const wrapper = shallowMount(Details, {
             propsData: {
@@ -27,11 +32,12 @@ describe("Details", () => {
                     owner: "owner",
                 },
             },
+            localVue,
         });
         expect(wrapper.findAll("loading-span-stub").length).toBe(1);
         expect(wrapper.find("loading-span-stub").attributes("message")).toBe("Loading installed repository details");
         expect(wrapper.findAll("repositorydetails-stub").length).toBe(0);
-        await Vue.nextTick();
+        await localVue.nextTick();
         expect(wrapper.findAll("loading-span-stub").length).toBe(0);
         expect(wrapper.findAll(".alert").length).toBe(0);
         expect(wrapper.findAll("repositorydetails-stub").length).toBe(1);

--- a/client/src/components/Toolshed/InstalledList/Index.test.js
+++ b/client/src/components/Toolshed/InstalledList/Index.test.js
@@ -1,35 +1,39 @@
 import { mount } from "@vue/test-utils";
 import Index from "./Index";
-import { __RewireAPI__ as rewire } from "./Index";
-import Vue from "vue";
+
+jest.mock("app");
+
+import { getAppRoot } from "onload/loadConfig";
+jest.mock("onload/loadConfig");
+getAppRoot.mockImplementation(() => "/");
+
+import { Services } from "../services";
+jest.mock("../services");
+
+Services.mockImplementation(() => {
+    return {
+        async getInstalledRepositories() {
+            return [
+                {
+                    name: "name_0",
+                    description: "description_0",
+                    tool_shed_status: {
+                        latest_installable_revision: false,
+                    },
+                },
+                {
+                    name: "name_1",
+                    description: "description_1",
+                    tool_shed_status: {
+                        latest_installable_revision: true,
+                    },
+                },
+            ];
+        },
+    };
+});
 
 describe("InstalledList", () => {
-    beforeEach(() => {
-        rewire.__Rewire__(
-            "Services",
-            class {
-                async getInstalledRepositories() {
-                    return [
-                        {
-                            name: "name_0",
-                            description: "description_0",
-                            tool_shed_status: {
-                                latest_installable_revision: false,
-                            },
-                        },
-                        {
-                            name: "name_1",
-                            description: "description_1",
-                            tool_shed_status: {
-                                latest_installable_revision: true,
-                            },
-                        },
-                    ];
-                }
-            }
-        );
-    });
-
     it("test installed list", async () => {
         const wrapper = mount(Index, {
             propsData: {
@@ -40,7 +44,7 @@ describe("InstalledList", () => {
             },
         });
         expect(wrapper.find(".loading-message").text()).toBe("Loading installed repositories...");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.find(".installed-message").text()).toBe("2 repositories installed on this instance.");
         const names = wrapper.findAll(".name");
         expect(names.length).toBe(2);

--- a/client/src/components/Toolshed/InstalledList/Monitor.test.js
+++ b/client/src/components/Toolshed/InstalledList/Monitor.test.js
@@ -1,36 +1,41 @@
-import { mount } from "@vue/test-utils";
+import { createLocalVue, mount } from "@vue/test-utils";
 import Monitor from "./Monitor";
-import { __RewireAPI__ as rewire } from "./Monitor";
-import Vue from "vue";
+
+jest.mock("app");
+
+import { getAppRoot } from "onload/loadConfig";
+jest.mock("onload/loadConfig");
+getAppRoot.mockImplementation(() => "/");
+
+import { Services } from "../services";
+jest.mock("../services");
+
+Services.mockImplementation(() => {
+    return {
+        async getInstalledRepositories() {
+            return [
+                {
+                    name: "name_0",
+                    owner: "owner_0",
+                    status: "status_0_0",
+                    description: "description_0_0",
+                },
+                {
+                    name: "name_1",
+                    owner: "owner_1",
+                    status: "status_1",
+                    description: "description_1",
+                },
+            ];
+        },
+    };
+});
 
 describe("Monitor", () => {
-    beforeEach(() => {
-        rewire.__Rewire__(
-            "Services",
-            class {
-                async getInstalledRepositories() {
-                    return [
-                        {
-                            name: "name_0",
-                            owner: "owner_0",
-                            status: "status_0_0",
-                            description: "description_0_0",
-                        },
-                        {
-                            name: "name_1",
-                            owner: "owner_1",
-                            status: "status_1",
-                            description: "description_1",
-                        },
-                    ];
-                }
-            }
-        );
-    });
-
     it("test monitor", async () => {
-        const wrapper = mount(Monitor, {});
-        await Vue.nextTick();
+        const localVue = createLocalVue();
+        const wrapper = mount(Monitor, localVue);
+        await localVue.nextTick();
         const headers = wrapper.findAll("th");
         expect(headers.length).toBe(2);
         expect(headers.at(0).text()).toBe("Name");

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.test.js
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.test.js
@@ -1,16 +1,9 @@
 import { mount } from "@vue/test-utils";
 import InstallationSettings from "./InstallationSettings";
-import { __RewireAPI__ as rewire } from "./InstallationSettings";
+
+jest.mock("app");
 
 describe("InstallationSettings", () => {
-    beforeEach(() => {
-        rewire.__Rewire__("getGalaxyInstance", () => {
-            return {
-                config: {},
-            };
-        });
-    });
-
     it("test tool repository installer interface", () => {
         const wrapper = mount(InstallationSettings, {
             propsData: {

--- a/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.test.js
+++ b/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.test.js
@@ -1,4 +1,3 @@
-import Vue from "vue";
 import { mount } from "@vue/test-utils";
 import RepositoryTools from "./RepositoryTools";
 
@@ -57,7 +56,7 @@ describe("RepositoryTools", () => {
         expect($third.find("td:last-child").text()).toBe("");
         const $link = wrapper.find("a");
         $link.trigger("click");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
 
         const $elExpanded = wrapper.findAll("tr");
         expect($elExpanded.length).toBe(4);
@@ -69,7 +68,7 @@ describe("RepositoryTools", () => {
         expect($forthExpanded.find("td:last-child").text()).toBe("");
         const $linkExpanded = wrapper.find("a");
         $linkExpanded.trigger("click");
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
 
         const $elCollapsed = wrapper.findAll("tr");
         expect($elCollapsed.length).toBe(3);

--- a/client/src/components/Toolshed/SearchList/Categories.test.js
+++ b/client/src/components/Toolshed/SearchList/Categories.test.js
@@ -1,29 +1,32 @@
-import { mount } from "@vue/test-utils";
+import { mount, createLocalVue } from "@vue/test-utils";
 import Categories from "./Categories";
-import { __RewireAPI__ as rewire } from "./Categories";
-import Vue from "vue";
+
+import { Services } from "../services";
+jest.mock("../services");
+
+Services.mockImplementation(() => {
+    return {
+        async getCategories() {
+            return [
+                {
+                    name: "name_0",
+                    description: "description_0",
+                    repositories: "repositories_0",
+                },
+                {
+                    name: "name_1",
+                    description: "description_1",
+                    repositories: "repositories_1",
+                },
+            ];
+        },
+    };
+});
 
 describe("Categories", () => {
+    let localVue;
     beforeEach(() => {
-        rewire.__Rewire__(
-            "Services",
-            class {
-                async getCategories() {
-                    return [
-                        {
-                            name: "name_0",
-                            description: "description_0",
-                            repositories: "repositories_0",
-                        },
-                        {
-                            name: "name_1",
-                            description: "description_1",
-                            repositories: "repositories_1",
-                        },
-                    ];
-                }
-            }
-        );
+        localVue = createLocalVue();
     });
 
     it("test categories loading", () => {
@@ -32,6 +35,7 @@ describe("Categories", () => {
                 loading: true,
                 toolshedUrl: "toolshedUrl",
             },
+            localVue,
         });
         expect(wrapper.find(".loading-message").text()).toBe("Loading categories...");
     });
@@ -42,8 +46,9 @@ describe("Categories", () => {
                 loading: false,
                 toolshedUrl: "toolshedUrl",
             },
+            localVue,
         });
-        await Vue.nextTick();
+        await localVue.nextTick();
         const links = wrapper.findAll("a");
         expect(links.length).toBe(2);
         expect(links.at(0).text()).toBe("name_0");

--- a/client/src/components/Toolshed/SearchList/Repositories.test.js
+++ b/client/src/components/Toolshed/SearchList/Repositories.test.js
@@ -1,32 +1,34 @@
-import { mount } from "@vue/test-utils";
+import { mount, createLocalVue } from "@vue/test-utils";
 import Repositories from "./Repositories";
-import { __RewireAPI__ as rewire } from "./Repositories";
-import Vue from "vue";
+
+jest.mock("app");
+
+import { Services } from "../services";
+jest.mock("../services");
+
+Services.mockImplementation(() => {
+    return {
+        async getRepositories() {
+            return [
+                {
+                    name: "name_0",
+                    owner: "owner_0",
+                    last_updated: "last_updated_0",
+                    times_downloaded: "times_downloaded_0",
+                },
+                {
+                    name: "name_1",
+                    owner: "owner_1",
+                    last_updated: "last_updated_1",
+                    times_downloaded: "times_downloaded_1",
+                },
+            ];
+        },
+    };
+});
 
 describe("Repositories", () => {
-    beforeEach(() => {
-        rewire.__Rewire__(
-            "Services",
-            class {
-                async getRepositories() {
-                    return [
-                        {
-                            name: "name_0",
-                            owner: "owner_0",
-                            last_updated: "last_updated_0",
-                            times_downloaded: "times_downloaded_0",
-                        },
-                        {
-                            name: "name_1",
-                            owner: "owner_1",
-                            last_updated: "last_updated_1",
-                            times_downloaded: "times_downloaded_1",
-                        },
-                    ];
-                }
-            }
-        );
-    });
+    const localVue = createLocalVue();
 
     it("test repository details loading", async () => {
         const wrapper = mount(Repositories, {
@@ -35,10 +37,11 @@ describe("Repositories", () => {
                 scrolled: false,
                 toolshedUrl: "toolshedUrl",
             },
+            localVue,
         });
         // Test initial state prior to the data fetch tick -- should be loading.
         expect(wrapper.find(".loading-message").text()).toBe("Loading repositories...");
-        await Vue.nextTick();
+        await localVue.nextTick();
         const links = wrapper.findAll("a");
         expect(links.length).toBe(2);
         expect(links.at(0).text()).toBe("name_0");
@@ -46,7 +49,7 @@ describe("Repositories", () => {
         // Reset repositories and state to test empty.
         wrapper.vm.repositories = [];
         wrapper.vm.pageState = 2; // COMPLETE is '2'
-        await Vue.nextTick();
+        await localVue.nextTick();
         expect(wrapper.find(".unavailable-message").text()).toBe("No matching repositories found.");
     });
 });

--- a/client/src/components/User/CloudAuth/CloudAuth.test.js
+++ b/client/src/components/User/CloudAuth/CloudAuth.test.js
@@ -7,8 +7,6 @@ import CloudAuthItem from "./CloudAuthItem";
 import _l from "utils/localization";
 import BootstrapVue from "bootstrap-vue";
 
-import { getNewAttachNode } from "jest/helpers";
-
 jest.mock("./model/service", () => ({
     listCredentials: async () => {
         const listCredentials = require("./testdata/listCredentials.json");
@@ -25,7 +23,7 @@ describe("CloudAuth component", () => {
     let wrapper;
 
     beforeEach(async () => {
-        wrapper = shallowMount(CloudAuth, { localVue, attachTo: getNewAttachNode() });
+        wrapper = shallowMount(CloudAuth, { localVue });
         await flushPromises();
     });
 

--- a/client/src/components/User/CloudAuth/CloudAuth.test.js
+++ b/client/src/components/User/CloudAuth/CloudAuth.test.js
@@ -1,5 +1,6 @@
 import flushPromises from "flush-promises";
-import { shallowMount, createLocalVue } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 
 import { default as CloudAuth } from "./CloudAuth";
 import CloudAuthItem from "./CloudAuthItem";
@@ -15,7 +16,7 @@ jest.mock("./model/service", () => ({
     },
 }));
 
-const localVue = createLocalVue();
+const localVue = getLocalVue();
 localVue.use(BootstrapVue);
 localVue.filter("localize", (value) => _l(value));
 

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -1,20 +1,22 @@
-import Vue from "vue";
-import { mount } from "@vue/test-utils";
+import { mount, createLocalVue } from "@vue/test-utils";
 import Attributes from "./Attributes";
-import { __RewireAPI__ as rewire } from "./Attributes";
+
+jest.mock("app");
+
+import { Services } from "../services";
+jest.mock("../services");
+
+Services.mockImplementation(() => {
+    return {
+        async updateWorkflow() {
+            return {};
+        },
+    };
+});
 
 describe("Attributes", () => {
-    beforeEach(() => {
-        rewire.__Rewire__(
-            "Services",
-            class {
-                async updateWorkflow() {
-                    return {};
-                }
-            }
-        );
-    });
     it("test attributes", async () => {
+        const localVue = createLocalVue();
         const wrapper = mount(Attributes, {
             propsData: {
                 id: "workflow_id",
@@ -26,11 +28,12 @@ describe("Attributes", () => {
             stubs: {
                 LicenseSelector: true,
             },
+            localVue,
         });
         const name = wrapper.find("#workflow-name");
         expect(name.element.value).toBe("workflow_name");
         wrapper.setProps({ name: "new_workflow_name" });
-        await Vue.nextTick();
+        await localVue.nextTick();
         expect(name.element.value).toBe("new_workflow_name");
         const parameters = wrapper.findAll(".list-group-item");
         expect(parameters.length).toBe(2);

--- a/client/src/components/Workflow/Editor/Node.test.js
+++ b/client/src/components/Workflow/Editor/Node.test.js
@@ -1,6 +1,5 @@
 import { mount } from "@vue/test-utils";
 import Node from "./Node";
-import { getNewAttachNode } from "jest/helpers";
 import flushPromises from "flush-promises";
 
 jest.mock("app");
@@ -16,7 +15,6 @@ describe("Node", () => {
                 getManager: () => {},
                 getCanvasManager: () => {},
             },
-            attachTo: getNewAttachNode(),
         });
         await flushPromises();
         const icon = wrapper.findAll("i");

--- a/client/src/components/Workflow/Editor/Node.test.js
+++ b/client/src/components/Workflow/Editor/Node.test.js
@@ -1,8 +1,11 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import Node from "./Node";
 import flushPromises from "flush-promises";
 
 jest.mock("app");
+
+const localVue = getLocalVue();
 
 describe("Node", () => {
     it("test attributes", async () => {
@@ -15,6 +18,7 @@ describe("Node", () => {
                 getManager: () => {},
                 getCanvasManager: () => {},
             },
+            localVue,
         });
         await flushPromises();
         const icon = wrapper.findAll("i");

--- a/client/src/components/Workflow/Editor/Node.test.js
+++ b/client/src/components/Workflow/Editor/Node.test.js
@@ -1,4 +1,4 @@
-import { mount } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import Node from "./Node";
 import flushPromises from "flush-promises";
@@ -9,7 +9,7 @@ const localVue = getLocalVue();
 
 describe("Node", () => {
     it("test attributes", async () => {
-        const wrapper = mount(Node, {
+        const wrapper = shallowMount(Node, {
             propsData: {
                 id: "node-id",
                 name: "node-name",
@@ -17,6 +17,7 @@ describe("Node", () => {
                 step: {},
                 getManager: () => {},
                 getCanvasManager: () => {},
+                datatypesMapper: {},
             },
             localVue,
         });

--- a/client/src/components/Workflow/Editor/ZoomControl.test.js
+++ b/client/src/components/Workflow/Editor/ZoomControl.test.js
@@ -1,15 +1,17 @@
-import { mount, createLocalVue } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import ZoomControl from "./ZoomControl";
 
 jest.mock("app");
 
 describe("ZoomControl", () => {
     it("test zoom control", async () => {
-        const localVue = createLocalVue();
+        const localVue = getLocalVue();
         const wrapper = mount(ZoomControl, {
             propsData: {
                 zoomLevel: 10,
             },
+            localVue,
         });
         const buttons = wrapper.findAll("button");
         expect(buttons.length).toBe(3);

--- a/client/src/components/Workflow/Editor/ZoomControl.test.js
+++ b/client/src/components/Workflow/Editor/ZoomControl.test.js
@@ -1,26 +1,26 @@
-import Vue from "vue";
-import { mount } from "@vue/test-utils";
+import { mount, createLocalVue } from "@vue/test-utils";
 import ZoomControl from "./ZoomControl";
-import { getNewAttachNode } from "jest/helpers";
+
+jest.mock("app");
 
 describe("ZoomControl", () => {
     it("test zoom control", async () => {
+        const localVue = createLocalVue();
         const wrapper = mount(ZoomControl, {
             propsData: {
                 zoomLevel: 10,
             },
-            attachTo: getNewAttachNode(),
         });
         const buttons = wrapper.findAll("button");
         expect(buttons.length).toBe(3);
         buttons.at(0).trigger("click");
-        await Vue.nextTick();
+        await localVue.nextTick();
         expect(wrapper.emitted().onZoom[0][0]).toBe(9);
         buttons.at(1).trigger("click");
-        await Vue.nextTick();
+        await localVue.nextTick();
         expect(wrapper.emitted().onZoom[1][0]).toBe(10);
         buttons.at(2).trigger("click");
-        await Vue.nextTick();
+        await localVue.nextTick();
         expect(wrapper.emitted().onZoom[2][0]).toBe(11);
     });
 });

--- a/client/src/components/admin/BaseList.test.js
+++ b/client/src/components/admin/BaseList.test.js
@@ -1,6 +1,5 @@
 import { mount } from "@vue/test-utils";
 import BaseList from "./BaseList";
-import Vue from "vue";
 
 describe("Categories", () => {
     const getter = async () => {
@@ -32,7 +31,7 @@ describe("Categories", () => {
                 setter: setter,
             },
         });
-        await Vue.nextTick();
+        await wrapper.vm.$nextTick();
         expect(wrapper.find(".card-header").text()).toContain("There are 2");
         const th = wrapper.findAll("th");
         expect(th.length).toBe(3);

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -4,6 +4,7 @@
 import { timer } from "rxjs";
 import { take } from "rxjs/operators";
 import { createLocalVue, shallowMount } from "@vue/test-utils";
+import _l from "utils/localization";
 
 // Creates a watcher on the indicated vm/prop for use in testing
 export function watchForChange({ vm, opts, propName, timeout = 1000, label = "" }) {
@@ -61,6 +62,7 @@ export function getLocalVue() {
     };
     localVue.directive("b-tooltip", mockedDirective);
     localVue.directive("b-popover", mockedDirective);
+    localVue.filter("localize", (value) => _l(value));
     return localVue;
 }
 

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -4,7 +4,8 @@
 import { timer } from "rxjs";
 import { take } from "rxjs/operators";
 import { createLocalVue, shallowMount } from "@vue/test-utils";
-import _l from "utils/localization";
+import { localizationPlugin } from "components/plugins";
+
 
 // Creates a watcher on the indicated vm/prop for use in testing
 export function watchForChange({ vm, opts, propName, timeout = 1000, label = "" }) {
@@ -62,7 +63,7 @@ export function getLocalVue() {
     };
     localVue.directive("b-tooltip", mockedDirective);
     localVue.directive("b-popover", mockedDirective);
-    localVue.filter("localize", (value) => _l(value));
+    localVue.use(localizationPlugin);
     return localVue;
 }
 

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -60,6 +60,7 @@ export function getLocalVue() {
         bind() {},
     };
     localVue.directive("b-tooltip", mockedDirective);
+    localVue.directive("b-popover", mockedDirective);
     return localVue;
 }
 

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -5,14 +5,6 @@ import { timer } from "rxjs";
 import { take } from "rxjs/operators";
 import { shallowMount } from "@vue/test-utils";
 
-export function getNewAttachNode() {
-    const attachElement = document.createElement("div");
-    if (document.body) {
-        document.body.appendChild(attachElement);
-    }
-    return attachElement;
-}
-
 // Creates a watcher on the indicated vm/prop for use in testing
 export function watchForChange({ vm, opts, propName, timeout = 1000, label = '' }) {
     const start = new Date();

--- a/client/tests/jest/helpers.js
+++ b/client/tests/jest/helpers.js
@@ -3,20 +3,24 @@
  */
 import { timer } from "rxjs";
 import { take } from "rxjs/operators";
-import { shallowMount } from "@vue/test-utils";
+import { createLocalVue, shallowMount } from "@vue/test-utils";
 
 // Creates a watcher on the indicated vm/prop for use in testing
-export function watchForChange({ vm, opts, propName, timeout = 1000, label = '' }) {
+export function watchForChange({ vm, opts, propName, timeout = 1000, label = "" }) {
     const start = new Date();
     return new Promise((resolve, reject) => {
         const timeoutID = setTimeout(() => {
             reject(`${propName} never changed ${label}`);
         }, timeout);
-        vm.$watch(propName, function (newVal, oldVal) {
-            clearTimeout(timeoutID);
-            const stop = new Date();
-            resolve({ timeElapsed: stop - start, newVal, oldVal });
-        }, opts);
+        vm.$watch(
+            propName,
+            function (newVal, oldVal) {
+                clearTimeout(timeoutID);
+                const stop = new Date();
+                resolve({ timeElapsed: stop - start, newVal, oldVal });
+            },
+            opts
+        );
     });
 }
 
@@ -48,6 +52,16 @@ export const showAll = (vm) => {
 // waits n milliseconds and then promise resolves
 // usage: await wait(500);
 export const wait = (n) => timer(n).pipe(take(1)).toPromise();
+
+// Gets a localVue with custom directives
+export function getLocalVue() {
+    const localVue = createLocalVue();
+    const mockedDirective = {
+        bind() {},
+    };
+    localVue.directive("b-tooltip", mockedDirective);
+    return localVue;
+}
 
 // Mounts a renderless component with sample content for testing
 export function mountRenderless(component, localVue, propsData) {

--- a/client/tests/jest/jest.config.js
+++ b/client/tests/jest/jest.config.js
@@ -84,7 +84,7 @@ module.exports = {
     },
 
     // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-    // modulePathIgnorePatterns: [],
+    modulePathIgnorePatterns: ["<rootDir>/src/.*/__mocks__"],
 
     // Activates notifications for test results
     // notify: false,

--- a/client/tests/jest/jest.setup.js
+++ b/client/tests/jest/jest.setup.js
@@ -3,3 +3,7 @@ import "@testing-library/jest-dom";
 /* still don't understand what was invoking the following, but nothing should,
 and this makes the tag tests work correctly */
 global.XMLHttpRequest = undefined;
+
+// stops Bootstrap's warnings when components can't find a non-existent doc
+// https://github.com/bootstrap-vue/bootstrap-vue/issues/3303
+process.env.BOOTSTRAP_VUE_NO_WARN = true;

--- a/client/tests/jest/jest.setup.js
+++ b/client/tests/jest/jest.setup.js
@@ -3,7 +3,3 @@ import "@testing-library/jest-dom";
 /* still don't understand what was invoking the following, but nothing should,
 and this makes the tag tests work correctly */
 global.XMLHttpRequest = undefined;
-
-// stops Bootstrap's warnings when components can't find a non-existent doc
-// https://github.com/bootstrap-vue/bootstrap-vue/issues/3303
-process.env.BOOTSTRAP_VUE_NO_WARN = true;

--- a/client/tests/karma/webpack.config.unittest.js
+++ b/client/tests/karma/webpack.config.unittest.js
@@ -31,18 +31,12 @@ module.exports = (env, argv) => {
 
     wpConfig.module = merge.smart(wpConfig.module, ignoreAssetLoaders);
 
-    // Using babel-plugin-rewire to handle dependency mocking since webpack 4
-    // exports immutable bindings for ES modules but we still need a way to
-    // overwrite dependencies during unit-testing.
-    //
-    // Additionally, set exclude for babel-loader to completely ignore *all*
-    // node-modules, without our exceptions to support IE as in parent webpack
-    // config.
+    // Set exclude for babel-loader to completely ignore *all* node-modules,
+    // without our exceptions to support IE as in parent webpack config.
 
     wpConfig.module.rules = wpConfig.module.rules.map((rule) => {
         if (rule.loader == "babel-loader") {
             rule.exclude = [/(node_modules\/)/];
-            rule.options.plugins.push("rewire");
         }
         return rule;
     });

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3743,30 +3743,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000890:
-  version "1.0.30000893"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000893.tgz#284b20932bd41b93e21626975f2050cb01561986"
-  integrity sha512-kOddHcTEef+NgN/fs0zmX2brHTNATVOWMEIhlZHCuwQRtXobjSw9pAECc44Op4bTBcavRjkLaPrGomknH7+Jvg==
-
-caniuse-lite@^1.0.30000929:
-  version "1.0.30000953"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000953.tgz#8054c4e5c4aa69dc3269353a4a5e102909759dbb"
-  integrity sha512-2stdF/q5MZTDhQ6uC65HWbSgI9UMKbc7+HKvlwH5JBIslKoD/J9dvabP4J4Uiifu3NljbHj3iMpfYflLSNt09A==
-
-caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001061:
-  version "1.0.30001062"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001062.tgz#d814b648338504b315222ace6f1a533d9a55e390"
-  integrity sha512-ei9ZqeOnN7edDrb24QfJ0OZicpEbsWxv7WusOiQGz/f2SfvBgHHbOEwBJ8HKGVSyx8Z6ndPjxzR6m0NQq+0bfw==
-
-caniuse-lite@^1.0.30001022:
-  version "1.0.30001022"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz#9eeffe580c3a8f110b7b1742dcf06a395885e4c6"
-  integrity sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==
-
-caniuse-lite@^1.0.30001043:
-  version "1.0.30001053"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001053.tgz#b7ae027567ce2665b965b0437e4512b296ccd20d"
-  integrity sha512-HtV4wwIZl6GA4Oznse8aR274XUOYGZnQLcf/P8vHgmlfqSNelwD+id8CyHOceqLqt9yfKmo7DUZTh1EuS9pukg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000890, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001022, caniuse-lite@^1.0.30001043, caniuse-lite@^1.0.30001061:
+  version "1.0.30001168"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001168.tgz"
+  integrity sha512-P2zmX7swIXKu+GMMR01TWa4csIKELTNnZKc+f1CjebmZJQtTAEXmpQSoKVJVVcvPGAA0TEYTOUp3VehavZSFPQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3041,11 +3041,6 @@ babel-plugin-jest-hoist@^26.2.0:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-rewire@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-rewire/-/babel-plugin-rewire-1.2.0.tgz#822562d72ed2c84e47c0f95ee232c920853e9d89"
-  integrity sha512-JBZxczHw3tScS+djy6JPLMjblchGhLI89ep15H3SyjujIzlxo5nr6Yjo7AXotdeVczeBmWs0tF8PgJWDdgzAkQ==
-
 babel-plugin-transform-es2015-modules-commonjs@^6.26.0:
   version "6.26.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"


### PR DESCRIPTION
There's a lot of client-side unit tests that die or become erratic due to unnecessary 3rd party library usage or unmocked ajax calls. 

Jest doesn't run in a browser, it runs in node, and code that expects to talk to native browser objects (like document or XHR) either dies or runs without response. This is particularly problematic when jQuery is used. I'll be removing that first, then moving on to all the multitudes of unmocked ajax calls.

**Notable changes:**

1. Removed old babel rewire mocking mechanism in favor of jest mocking tools
2. Removed global Vue instances in unit tests. This is normally pretty innocuous, but as more people hang plugins and mixins off of the Vue instance, this can create problems that extend beyond the scope of a single test. Especially problematic are plugins or mixins that reference legacy code that either includes jQuery or fires instant ajax calls upon include, which includes most of the legacy backbone code, and some of the new Vuex initialization use-cases.
3. Removed usage of a jest utility mounter that referenced a non-existent document object.
4. Replaced mounts with shallowMounts in Vue unit tests when possible. In general it's a good idea to try a shallowMount first and then if you REALLY need to, go ahead and do a full mount. Also ask yourself if what you're writing is really a unit test if you require a full tree mount. Perhaps what you are trying to do would be better accomplished with an integration test.

