### PR TITLE
[20.09] Fix workflow crashing on change_datatype step

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -580,12 +580,12 @@ class Registry:
         """Returns a datatype object based on an extension"""
         return self.datatypes_by_extension.get(ext, None)
 
-    def change_datatype(self, data, ext):
+    def change_datatype(self, data, ext, dataset_is_new=False):
         data.extension = ext
         # call init_meta and copy metadata from itself.  The datatype
         # being converted *to* will handle any metadata copying and
         # initialization.
-        if data.has_data():
+        if not dataset_is_new and data.has_data():
             data.set_size()
             data.init_meta(copy_from=data)
         return data

--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -95,12 +95,12 @@ class ChangeDatatypeAction(DefaultJobAction):
     def execute(cls, app, sa_session, action, job, replacement_dict):
         for dataset_assoc in job.output_datasets:
             if action.output_name == '' or dataset_assoc.name == action.output_name:
-                app.datatypes_registry.change_datatype(dataset_assoc.dataset, action.action_arguments['newtype'])
+                app.datatypes_registry.change_datatype(dataset_assoc.dataset, action.action_arguments['newtype'], dataset_is_new=True)
         for dataset_collection_assoc in job.output_dataset_collection_instances:
             if action.output_name == '' or dataset_collection_assoc.name == action.output_name:
                 for dataset_instance in dataset_collection_assoc.dataset_collection_instance.dataset_instances:
                     if dataset_instance:
-                        app.datatypes_registry.change_datatype(dataset_instance, action.action_arguments['newtype'])
+                        app.datatypes_registry.change_datatype(dataset_instance, action.action_arguments['newtype'], dataset_is_new=True)
 
     @classmethod
     def get_short_str(cls, pja):


### PR DESCRIPTION
Should also be a minor speedup.
The traceback that this fixes is:
```
alaxy.workflow.run ERROR 2020-12-15 07:12:54,544 Failed to schedule Workflow[id=345991,name=COVID-19: variation analysis reporting v2], problem occurred on WorkflowStep[index=10,type=tool].
Traceback (most recent call last):
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/workflow/run.py", line 190, in invoke
    incomplete_or_none = self._invoke_step(workflow_invocation_step)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/workflow/run.py", line 266, in _invoke_step
    use_cached_job=self.workflow_invocation.use_cached_job)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/workflow/modules.py", line 1761, in execute
    workflow_resource_parameters=resource_parameters
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/tools/execute.py", line 103, in execute
    execute_single_job(execution_slice, completed_jobs[i])
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/tools/execute.py", line 74, in execute_single_job
    execution_tracker.record_success(execution_slice, job, result)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/tools/execute.py", line 432, in record_success
    self.job_callback(job)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/workflow/modules.py", line 1759, in <lambda>
    job_callback=lambda job: self._handle_post_job_actions(step, job, invocation.replacement_dict),
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/workflow/modules.py", line 1812, in _handle_post_job_actions
    ActionBox.execute(self.trans.app, self.trans.sa_session, pja, job, replacement_dict)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/actions/post.py", line 517, in execute
    ActionBox.actions[pja.action_type].execute(app, sa_session, pja, job, replacement_dict)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/jobs/actions/post.py", line 103, in execute
    app.datatypes_registry.change_datatype(dataset_instance, action.action_arguments['newtype'])
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/datatypes/registry.py", line 590, in change_datatype
    data.init_meta(copy_from=data)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/model/__init__.py", line 2783, in init_meta
    return self.datatype.init_meta(self, copy_from=copy_from)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/datatypes/data.py", line 171, in init_meta
    dataset.metadata = copy_from.metadata
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/model/__init__.py", line 2705, in set_metadata
    self._metadata = self.metadata.make_dict_copy(bunch)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/model/metadata.py", line 161, in make_dict_copy
    rval[key] = self.spec[key].param.make_copy(value, target_context=self, source_context=to_copy)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/model/metadata.py", line 281, in make_copy
    return copy.deepcopy(value)
  File "/cvmfs/main.galaxyproject.org/deps/_conda/envs/_galaxy_/lib/python3.6/copy.py", line 161, in deepcopy
    y = copier(memo)
  File "/cvmfs/main.galaxyproject.org/galaxy/lib/galaxy/model/custom_types.py", line 232, in __deepcopy__
    return MutationList(MutationObj.coerce(self._key, copy.deepcopy(self[:])))
AttributeError: 'MutationList' object has no attribute '_key'
```
which occurs if metadata hasn't been persisted yet (which passes through `coerce`, which sets `_key`).