### PR TITLE
[20.09] Execute immediate post job actions just after creating jobs and outputs

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1638,7 +1638,7 @@ class Tool(Dictifiable):
                         output_collections=execution_tracker.output_collections,
                         implicit_collections=execution_tracker.implicit_collections)
 
-    def handle_single_execution(self, trans, rerun_remap_job_id, execution_slice, history, execution_cache=None, completed_job=None, collection_info=None, flush_job=True):
+    def handle_single_execution(self, trans, rerun_remap_job_id, execution_slice, history, execution_cache=None, completed_job=None, collection_info=None, job_callback=None, flush_job=True):
         """
         Return a pair with whether execution is successful as well as either
         resulting output data or an error message indicating the problem.
@@ -1653,6 +1653,7 @@ class Tool(Dictifiable):
                 dataset_collection_elements=execution_slice.dataset_collection_elements,
                 completed_job=completed_job,
                 collection_info=collection_info,
+                job_callback=job_callback,
                 flush_job=flush_job,
             )
             job = rval[0]

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -280,7 +280,22 @@ class DefaultToolAction:
                         preserved_tags[tag.value] = tag
         return history, inp_data, inp_dataset_collections, preserved_tags, all_permissions
 
-    def execute(self, tool, trans, incoming=None, return_job=False, set_output_hid=True, history=None, job_params=None, rerun_remap_job_id=None, execution_cache=None, dataset_collection_elements=None, completed_job=None, collection_info=None, flush_job=True):
+    def execute(self,
+                tool,
+                trans,
+                incoming=None,
+                return_job=False,
+                set_output_hid=True,
+                history=None,
+                job_params=None,
+                rerun_remap_job_id=None,
+                execution_cache=None,
+                dataset_collection_elements=None,
+                completed_job=None,
+                collection_info=None,
+                job_callback=None,
+                flush_job=True
+                ):
         """
         Executes a tool, creating job and tool outputs, associating them, and
         submitting the job to the job queue. If history is not specified, use
@@ -543,6 +558,9 @@ class DefaultToolAction:
         job, galaxy_session = self._new_job_for_session(trans, tool, history)
         self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)
+        # execute immediate post job actions and associate post job actions that are to be executed after the job is complete
+        if job_callback:
+            job_callback(job)
         job.object_store_id = object_store_populator.object_store_id
         if job_params:
             job.params = dumps(job_params)

--- a/lib/galaxy/tools/actions/model_operations.py
+++ b/lib/galaxy/tools/actions/model_operations.py
@@ -22,7 +22,7 @@ class ModelOperationToolAction(DefaultToolAction):
 
         tool.check_inputs_ready(inp_data, inp_dataset_collections)
 
-    def execute(self, tool, trans, incoming={}, set_output_hid=False, overwrite=True, history=None, job_params=None, execution_cache=None, collection_info=None, **kwargs):
+    def execute(self, tool, trans, incoming={}, set_output_hid=False, overwrite=True, history=None, job_params=None, execution_cache=None, collection_info=None, job_callback=None, **kwargs):
         trans.check_user_activation()
 
         if execution_cache is None:
@@ -60,6 +60,8 @@ class ModelOperationToolAction(DefaultToolAction):
         self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
         self._record_inputs(trans, tool, job, incoming, inp_data, inp_dataset_collections)
         self._record_outputs(job, out_data, output_collections)
+        if job_callback:
+            job_callback(job)
         job.state = job.states.OK
         trans.sa_session.add(job)
 


### PR DESCRIPTION
On large mapped-over submissions it is possible that the job callback
will be called when the job and its outputs have already progressed
beyond the new state, thereby entering
https://github.com/mvdbeek/galaxy/blob/release_20.09/lib/galaxy/datatypes/registry.py#L588.
(Note that doesn't seem to happen on instances that store objects by
uuid, where the job won't be flushed until the end of the map over).
That is currently failing with:
```
AttributeError: 'MutationList' object has no attribute '_key'
  File "galaxy/workflow/run.py", line 83, in __invoke
    outputs = invoker.invoke()
  File "galaxy/workflow/run.py", line 190, in invoke
    incomplete_or_none = self._invoke_step(workflow_invocation_step)
  File "galaxy/workflow/run.py", line 266, in _invoke_step
    use_cached_job=self.workflow_invocation.use_cached_job)
  File "galaxy/workflow/modules.py", line 1761, in execute
    workflow_resource_parameters=resource_parameters
  File "galaxy/tools/execute.py", line 103, in execute
    execute_single_job(execution_slice, completed_jobs[i])
  File "galaxy/tools/execute.py", line 74, in execute_single_job
    execution_tracker.record_success(execution_slice, job, result)
  File "galaxy/tools/execute.py", line 432, in record_success
    self.job_callback(job)
  File "galaxy/workflow/modules.py", line 1759, in <lambda>
    job_callback=lambda job: self._handle_post_job_actions(step, job, invocation.replacement_dict),
  File "galaxy/workflow/modules.py", line 1812, in _handle_post_job_actions
    ActionBox.execute(self.trans.app, self.trans.sa_session, pja, job, replacement_dict)
  File "galaxy/jobs/actions/post.py", line 517, in execute
    ActionBox.actions[pja.action_type].execute(app, sa_session, pja, job, replacement_dict)
  File "galaxy/jobs/actions/post.py", line 103, in execute
    app.datatypes_registry.change_datatype(dataset_instance, action.action_arguments['newtype'])
  File "galaxy/datatypes/registry.py", line 590, in change_datatype
    data.init_meta(copy_from=data)
  File "galaxy/model/__init__.py", line 2783, in init_meta
    return self.datatype.init_meta(self, copy_from=copy_from)
  File "galaxy/datatypes/data.py", line 171, in init_meta
    dataset.metadata = copy_from.metadata
  File "galaxy/model/__init__.py", line 2705, in set_metadata
    self._metadata = self.metadata.make_dict_copy(bunch)
  File "galaxy/model/metadata.py", line 161, in make_dict_copy
    rval[key] = self.spec[key].param.make_copy(value, target_context=self, source_context=to_copy)
  File "galaxy/model/metadata.py", line 281, in make_copy
    return copy.deepcopy(value)
  File "python3.6/copy.py", line 161, in deepcopy
    y = copier(memo)
  File "galaxy/model/custom_types.py", line 232, in __deepcopy__
    return MutationList(MutationObj.coerce(self._key, copy.deepcopy(self[:])))
```
and will be fixed on dev. This fix here however is stil good, because
it will preserve any metadata passed through from an input, regardless
of the job state.