### PR TITLE
Allow YAML list format for config options

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -275,10 +275,11 @@ class BaseAppConfiguration:
             # check for `not None` explicitly (value can be falsy)
             if value is not None and datatype in type_converters:
                 # convert value or each item in value to type `datatype`
+                f = type_converters[datatype]
                 if isinstance(value, list):
-                    return [type_converters[datatype](item) for item in value]
+                    return [f(item) for item in value]
                 else:
-                    return type_converters[datatype](value)
+                    return f(value)
             return value
 
         def strip_deprecated_dir(key, value):

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -274,13 +274,17 @@ class BaseAppConfiguration:
             datatype = self.schema.app_schema[key].get('type')
             # check for `not None` explicitly (value can be falsy)
             if value is not None and datatype in type_converters:
-                return type_converters[datatype](value)
+                # convert value or each item in value to type `datatype`
+                if type(value) is list:
+                    return [type_converters[datatype](item) for item in value]
+                else:
+                    return type_converters[datatype](value)
             return value
 
         def strip_deprecated_dir(key, value):
             resolves_to = self.schema.paths_to_resolve.get(key)
             if resolves_to:  # value contains paths that will be resolved
-                paths = [path.strip() for path in value.split(',')]
+                paths = listify(value, do_strip=True)
                 for i, path in enumerate(paths):
                     first_dir = path.split(os.sep)[0]  # get first directory component
                     if first_dir == self.deprecated_dirs.get(resolves_to):  # first_dir is deprecated for this option

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -295,6 +295,10 @@ class BaseAppConfiguration:
                             "to suppress this warning: %s", key, resolves_to, ignore, path
                         )
                         paths[i] = path[len(ignore):]
+
+                # return list or string, depending on type of `value`
+                if isinstance(value, list):
+                    return paths
                 return ','.join(paths)
             return value
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -275,7 +275,7 @@ class BaseAppConfiguration:
             # check for `not None` explicitly (value can be falsy)
             if value is not None and datatype in type_converters:
                 # convert value or each item in value to type `datatype`
-                if type(value) is list:
+                if isinstance(value, list):
                     return [type_converters[datatype](item) for item in value]
                 else:
                     return type_converters[datatype](value)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -413,10 +413,7 @@ class CommonConfigurationMixin:
     @admin_users.setter
     def admin_users(self, value):
         self._admin_users = value
-        if value:
-            self.admin_users_list = [u.strip() for u in value.split(',') if u]
-        else:  # provide empty list for convenience (check membership, etc.)
-            self.admin_users_list = []
+        self.admin_users_list = listify(value)
 
     def is_admin_user(self, user):
         """Determine if the provided user is listed in `admin_users`."""

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -209,6 +209,15 @@ def test_kwargs_listify(mock_init, monkeypatch):
     assert config.path4 == ['my-config/new1', 'my-config/new2']
 
 
+def test_kwargs_as_list_listify(mock_init, monkeypatch):
+    # Expected: use values from kwargs; each value resolved and listified
+    new_path4 = ['new1', 'new2']
+    config = BaseAppConfiguration(path4=new_path4)
+
+    assert config._raw_config['path4'] == 'new1,new2'
+    assert config.path4 == ['my-config/new1', 'my-config/new2']
+
+
 @pytest.fixture
 def mock_check_against_root(mock_init, monkeypatch):
 

--- a/test/unit/config/test_path_resolves_to.py
+++ b/test/unit/config/test_path_resolves_to.py
@@ -214,7 +214,7 @@ def test_kwargs_as_list_listify(mock_init, monkeypatch):
     new_path4 = ['new1', 'new2']
     config = BaseAppConfiguration(path4=new_path4)
 
-    assert config._raw_config['path4'] == 'new1,new2'
+    assert config._raw_config['path4'] == ['new1', 'new2']
     assert config.path4 == ['my-config/new1', 'my-config/new2']
 
 


### PR DESCRIPTION
Fixes #10942

This allows specifying multiple values in galaxy.yml as a YAML list in addition to comma-separated string:

```yaml
tool_data_table_config_path:
- path1
- path2

some_other_config: 'path1, path2'
```
EDIT: This is applicable to any options that allow multiple values (not just paths). This includes `admin_users`.