### PR TITLE
Added handler for history options menu webhook

### DIFF
--- a/client/src/mvc/history/options-menu.js
+++ b/client/src/mvc/history/options-menu.js
@@ -178,7 +178,7 @@ Webhooks.load({
             if (webhook.activate) {
                 webhooks_menu.push({
                     html: _l(webhook.config.title),
-                    // func: function() {},
+                    func: webhook.config.function && new Function(webhook.config.function),
                     anon: true,
                 });
             }


### PR DESCRIPTION
I have tried to add a custom menu entry to the "history options" menu with a webhook. But although my webhook appears in the menu, nothing happens when I select the menu item.

I notice that in the code for the history options menu, there is a line which seems to be the handler (line 181), but this line is commented out. I believe it has been like this from the very beginning, and I don't know if this is intentional or just an oversight, or if I have completely misunderstood how this webhook is supposed to work.

**client/src/mvc/history/options-menu.js**
```javascript
webhooks.each(model => {
    var webhook = model.toJSON();
    if (webhook.activate) {
        webhooks_menu.push({
            html: _l(webhook.config.title),
            // func: function() {},
            anon: true
        });
    }
});
```
Inspired by the similar "masthead" webhook, I propose to change this line to allow the definition of a function in the webhook config file, which will be run when the user selects the menu item.

**client/src/mvc/history/options-menu.js**  (Alternative 1)
```javascript
webhooks.each(model => {
    var webhook = model.toJSON();
    if (webhook.activate) {
        webhooks_menu.push({
            html: _l(webhook.config.title),
            func: webhook.config.function && new Function(webhook.config.function)
            anon: true
        });
    }
});
```
The code above will only try to call the handler function if it is defined in the webhook config file, but the webhook will still be added to the history options menu. The second alternative below will not add the webhook to the menu unless the handler function is defined.

**client/src/mvc/history/options-menu.js**  (Alternative 2)
```javascript
webhooks.each(model => {
    var webhook = model.toJSON();
    if (webhook.activate && webhook.config.function) {
        webhooks_menu.push({
            html: _l(webhook.config.title),
            func: new Function(webhook.config.function)
            anon: true
        });
    }
});
```

Here is an example webhook configuration file that just redirects to the Galaxy Community Hub web page.

**config/plugins/webhooks/demo/community_hub/config.yml**
```yaml
id: community_hub
type:
  - history-menu
activate: true
title: Galaxy Community Hub

function: >
  window.location.href = "https://galaxyproject.org/"
```