### PR TITLE
Redirection after remote user logout

### DIFF
--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -28,6 +28,8 @@ export function userLogout(logoutAll = false) {
         .then((response) => {
             if (response.data?.redirect_uri) {
                 window.top.location.href = response.data.redirect_uri;
+            } else if (galaxy.config.use_remote_user && galaxy.config.remote_user_logout_href) {
+                window.top.location.href = galaxy.config.remote_user_logout_href;
             } else {
                 window.top.location.href = `${galaxy.root}${POST_LOGOUT_URL}`;
             }


### PR DESCRIPTION
We use an external identity provider to authenticate "remote_users" in our Galaxy.  When a user selects "Logout" from the "User" menu, they are supposed to be redirected to the IdP's logout page to invalidate the session. This page was configured with the setting `remote_user_logout_href` in "galaxy.yml". 

It worked fine for many years, but after a recent Galaxy upgrade (don't remember exactly which version), the users were suddenly redirected to Galaxy's own login page instead (which is potentially very confusing).

The submitted hack fixed the problem for us, but I'm not sure if there is supposed to be a better solution.