### PR TITLE
Use "email_from" value from schema for tool error report email

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1282,10 +1282,10 @@
 
 :Description:
     Email address to use in the 'From' field when sending emails for
-    account activations, workflow step notifications and password
-    resets. We recommend using string in the following format: Galaxy
-    Project <galaxy-no-reply@example.com> If not configured,
-    '<galaxy-no-reply@HOSTNAME>' will be used.
+    account activations, workflow step notifications, password resets,
+    and tool error reports.  We recommend using a string in the
+    following format: Galaxy Project <galaxy-no-reply@example.com>. If
+    not configured, '<galaxy-no-reply@HOSTNAME>' will be used.
 :Default: ``None``
 :Type: str
 
@@ -1731,6 +1731,16 @@
 :Description:
     The URL linked by the "Wiki" link in the "Help" menu.
 :Default: ``https://galaxyproject.org/``
+:Type: str
+
+
+~~~~~~~~~~~~~
+``quota_url``
+~~~~~~~~~~~~~
+
+:Description:
+    The URL linked for quota information in the UI.
+:Default: ``https://galaxyproject.org/support/account-quotas/``
 :Type: str
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -723,10 +723,10 @@ galaxy:
   #error_email_to: null
 
   # Email address to use in the 'From' field when sending emails for
-  # account activations, workflow step notifications and password
-  # resets. We recommend using string in the following format: Galaxy
-  # Project <galaxy-no-reply@example.com> If not configured,
-  # '<galaxy-no-reply@HOSTNAME>' will be used.
+  # account activations, workflow step notifications, password resets,
+  # and tool error reports.  We recommend using a string in the
+  # following format: Galaxy Project <galaxy-no-reply@example.com>. If
+  # not configured, '<galaxy-no-reply@HOSTNAME>' will be used.
   #email_from: null
 
   # URL of the support resource for the galaxy instance.  Used in
@@ -927,6 +927,9 @@ galaxy:
 
   # The URL linked by the "Wiki" link in the "Help" menu.
   #wiki_url: https://galaxyproject.org/
+
+  # The URL linked for quota information in the UI.
+  #quota_url: https://galaxyproject.org/support/account-quotas/
 
   # The URL linked by the "Support" link in the "Help" menu.
   #support_url: https://galaxyproject.org/support/

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -28,12 +28,13 @@ PASSWORD_MIN_LEN = 6
 
 def validate_email_str(email):
     """Validates a string containing an email address."""
-    message = ''
+    if not email:
+        return "No email address was provided."
     if not(VALID_EMAIL_RE.match(email)):
-        message = "The format of the email address is not correct."
+        return "The format of the email address is not correct."
     elif len(email) > EMAIL_MAX_LEN:
-        message = "Email address cannot be more than %d characters in length." % EMAIL_MAX_LEN
-    return message
+        return "Email address cannot be more than %d characters in length." % EMAIL_MAX_LEN
+    return ""
 
 
 def validate_password_str(password):

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -240,7 +240,7 @@ class EmailErrorReporter(ErrorReporter):
         to_address = self.app.config.error_email_to
         assert to_address, ValueError("Error reporting has been disabled for this Galaxy instance")
 
-        frm = to_address
+        frm = self.app.config.email_from
         # Check email a bit
         email = email or ''
         email = email.strip()

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -922,9 +922,9 @@ mapping:
         required: false
         desc: |
           Email address to use in the 'From' field when sending emails for
-          account activations, workflow step notifications and password resets.
-          We recommend using string in the following format:
-          Galaxy Project <galaxy-no-reply@example.com>
+          account activations, workflow step notifications, password resets, and
+          tool error reports.  We recommend using a string in the following format:
+          Galaxy Project <galaxy-no-reply@example.com>.
           If not configured, '<galaxy-no-reply@HOSTNAME>' will be used.
 
       instance_resource_url:


### PR DESCRIPTION
Fixes #10846.

1. Use `email_from` value from `galaxy.yml` (or schema default if not set) for tool error report email's "from" field.
2. Edit schema to reflect change; run `make config-rebuild` (generated *rst, *sample include `quota_url` update from #10212).
3. Use existing validation function to validate email.
4. Refactor `validate_email_str()` to check for empty `email` argument.