### PR TITLE
[20.09] Fix generation of BCO `object_id` and `etag`

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -2,6 +2,7 @@
 API operations for Workflows
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -1188,9 +1189,6 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         }
 
         bco_dict = {
-            'object_id': url_for(controller="api/invocations/%s" % invocation_id, action='invocation_export_bco', qualified=True),
-            'spec_version': spec_version,
-            'etag': str(model.uuid4().hex),
             'provenance_domain': provenance_domain,
             'usability_domain': usability_domain,
             'extension_domain': extension,
@@ -1208,6 +1206,14 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             },
             'error_domain': error_domain,
         }
+        # Generate etag from the BCO excluding object_id and spec_version, as
+        # specified in https://github.com/biocompute-objects/BCO_Specification/blob/main/docs/top-level.md#203-etag-etag
+        etag = hashlib.sha256(json.dumps(bco_dict, sort_keys=True).encode()).hexdigest()
+        bco_dict.update({
+            'object_id': url_for(controller="api/invocations/%s" % invocation_id, action='biocompute', qualified=True),
+            'spec_version': spec_version,
+            'etag': etag,
+        })
         return bco_dict
 
     @expose_api


### PR DESCRIPTION
1. The API endpoint to generate the the BCO was changed in commit 79552d6 , update the `object_id`    accordingly
2. The `etag` should be the sha256 of the BCO excluding `object_id` and `spec_version`

Ping @HadleyKing and @mr-c : it looks like I was wrong today about how we generate the `object_id`, it was "https://usegalaxy.eu/api/invocations/9430402b04f2c6ad/invocation_export_bco" , with this PR it will be ""https://usegalaxy.eu/api/invocations/9430402b04f2c6ad/biocompute" , which is the correct endpoint to regenerate the BCO. The `9430402b04f2c6ad` part is the encoded database id of the invocation, not an UUID.