### PR TITLE
Test configuration for running Selenium tests against beta history panel.

### DIFF
--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -2,7 +2,7 @@ name: Selenium tests (beta history panel)
 on: [push, pull_request]
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
-  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 'true'
+  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   GALAXY_TEST_SELENIUM_RETRIES: 1
   GALAXY_TEST_SELENIUM_BETA_HISTORY: 1
 jobs:

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -38,10 +38,9 @@ jobs:
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
       - uses: nanasess/setup-chromedriver@master
       - name: Run tests
-        run: ./run_tests.sh -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
+        run: ./run_tests.sh -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }} || true
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
-        if: failure()
         with:
           name: Selenium test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
           path: 'galaxy root/database/test_errors'

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -42,5 +42,10 @@ jobs:
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
         with:
-          name: Selenium test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
+          name: Selenium beta history panel test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
           path: 'galaxy root/database/test_errors'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Selenium beta history panel test results (${{ matrix.python-version }})
+          path: 'galaxy root/run_selenium_tests.html'
+ 

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -1,0 +1,47 @@
+name: Selenium tests (beta history panel)
+on: [push, pull_request]
+env:
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 'true'
+  GALAXY_TEST_SELENIUM_RETRIES: 1
+  GALAXY_TEST_SELENIUM_BETA_HISTORY: 1
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7']
+        chunk: [0, 1, 2]
+    continue-on-error: true
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: 'galaxy root'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dir
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - uses: nanasess/setup-chromedriver@master
+      - name: Run tests
+        run: ./run_tests.sh -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
+        working-directory: 'galaxy root'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Selenium test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
+          path: 'galaxy root/database/test_errors'

--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -8,6 +8,7 @@ either through the props, and make updates through the events -->
 <template>
     <div
         class="dataset"
+        :id="typedId"
         :class="{ expanded, collapsed, selected }"
         :data-state="dataset.state"
         @keydown.arrow-left.self.stop="$emit('update:expanded', false)"
@@ -142,6 +143,9 @@ export default {
         },
         ok() {
             return this.dataset.state == "ok";
+        },
+        typedId() {
+            return `dataset-${this.dataset.id}`;
         },
     },
     methods: {

--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -63,7 +63,7 @@ either through the props, and make updates through the events -->
         </div>
 
         <!-- expanded view with editors -->
-        <header v-if="expanded" class="p-2">
+        <header v-if="expanded" class="p-2 details">
             <ClickToEdit
                 v-if="dataset.canEditName"
                 tag-name="h4"

--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -18,7 +18,12 @@ either through the props, and make updates through the events -->
         <!-- name, state buttons, menus -->
         <nav class="content-top-menu" @click.stop="$emit('update:expanded', !expanded)">
             <div class="content-status-indicators" @click.stop>
-                <b-check v-if="showSelection" :checked="selected" @change="$emit('update:selected', $event)" />
+                <b-check
+                    class="selector"
+                    v-if="showSelection"
+                    :checked="selected"
+                    @change="$emit('update:selected', $event)"
+                />
                 <StatusIcon v-if="!ok" class="status-icon px-1" :state="dataset.state" @click.stop="onStatusClick" />
                 <StateBtn
                     v-if="!dataset.visible"

--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -7,7 +7,7 @@ either through the props, and make updates through the events -->
 
 <template>
     <div
-        class="dataset"
+        class="dataset history-content"
         :id="typedId"
         :class="{ expanded, collapsed, selected }"
         :data-state="dataset.state"

--- a/client/src/components/History/ContentItem/DatasetCollection/DatasetCollection.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DatasetCollection.vue
@@ -3,7 +3,7 @@
         v-if="dsc"
         v-bind="$attrs"
         v-on="$listeners"
-        class="dataset-collection"
+        class="dataset-collection history-content"
         :dsc="dsc"
         @update:dsc="onUpdate"
         @delete="onDelete"

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -5,6 +5,7 @@
     <div
         class="dataset dataset-collection collapsed"
         :class="{ selected }"
+        :id="typedId"
         :data-state="dsc.state"
         @keydown.arrow-right.self.stop="$emit('viewCollection')"
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
@@ -97,6 +98,11 @@ export default {
     methods: {
         onStatusClick() {
             console.log("onStatusClick", ...arguments);
+        },
+    },
+    computed: {
+        typedId() {
+            return this.dsc.type_id;
         },
     },
 };

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -13,7 +13,12 @@
     >
         <nav class="content-top-menu">
             <div class="content-status-indicators mr-1" @click.stop>
-                <b-check v-if="showSelection" :checked="selected" @change="$emit('update:selected', $event)" />
+                <b-check
+                    class="selector"
+                    v-if="showSelection"
+                    :checked="selected"
+                    @change="$emit('update:selected', $event)"
+                />
 
                 <StatusIcon
                     v-if="dsc.state != 'ok'"

--- a/client/src/components/History/ContentOperations.vue
+++ b/client/src/components/History/ContentOperations.vue
@@ -20,6 +20,7 @@
                 <PriorityMenuItem
                     key="selection"
                     title="Operations on multiple datasets"
+                    class="show-history-content-selectors-btn"
                     icon="fas fa-check-square"
                     @click="$emit('update:show-selection', !showSelection)"
                     :pressed="showSelection"
@@ -68,7 +69,10 @@
         </transition>
 
         <transition name="shutterfade">
-            <b-button-toolbar v-if="showSelection" class="content-selection justify-content-between mt-1">
+            <b-button-toolbar
+                v-if="showSelection"
+                class="content-selection justify-content-between mt-1 list-action-menu"
+            >
                 <b-button-group>
                     <b-button size="sm" @click="$emit('selectAllContent')">
                         {{ "Select All" | localize }}
@@ -78,7 +82,12 @@
                     </b-button>
                 </b-button-group>
 
-                <b-dropdown class="ml-auto" size="sm" text="With Selected" :disabled="!hasSelection">
+                <b-dropdown
+                    class="ml-auto history-contents-list-action-menu-btn"
+                    size="sm"
+                    text="With Selected"
+                    :disabled="!hasSelection"
+                >
                     <b-dropdown-item @click="hideSelected">
                         {{ "Hide Datasets" | localize }}
                     </b-dropdown-item>

--- a/client/src/components/History/ContentOperations.vue
+++ b/client/src/components/History/ContentOperations.vue
@@ -27,6 +27,7 @@
 
                 <PriorityMenuItem
                     key="copy-datasets"
+                    class="copy-datasets-menu-item"
                     title="Copy Datasets"
                     icon="fas fa-copy"
                     @click="iframeRedirect('/dataset/copy_datasets')"

--- a/client/src/components/History/CurrentCollection/Details.vue
+++ b/client/src/components/History/CurrentCollection/Details.vue
@@ -1,5 +1,5 @@
 <template>
-    <section class="history-details">
+    <section class="history-details controls">
         <ClickToEdit
             :value="dsc.name"
             v-if="writable"

--- a/client/src/components/History/CurrentCollection/Panel.vue
+++ b/client/src/components/History/CurrentCollection/Panel.vue
@@ -8,7 +8,7 @@
                 :get-item-key="(item) => item.type_id"
                 v-slot="{ isExpanded, setExpanded }"
             >
-                <Layout>
+                <Layout class="dataset-collection-panel">
                     <template v-slot:nav>
                         <TopNav :history="history" :selected-collections="selectedCollections" v-on="$listeners" />
                     </template>

--- a/client/src/components/History/CurrentCollection/TopNav.vue
+++ b/client/src/components/History/CurrentCollection/TopNav.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="navigation">
         <b-dropdown v-if="breadCrumbOptions.length" class="mr-auto" size="sm" text="Go to..." boundary="viewport">
             <b-dropdown-item @click="close"> History: {{ history.name }} </b-dropdown-item>
             <b-dropdown-item v-for="option in breadCrumbOptions" :key="option.key" @click="reselect(option.value)">
@@ -7,7 +7,7 @@
             </b-dropdown-item>
         </b-dropdown>
 
-        <b-button v-else size="sm" class="mr-auto" @click="close"> Back to: {{ history.name }} </b-button>
+        <b-button v-else size="sm" class="mr-auto back" @click="close"> Back to: {{ history.name }} </b-button>
 
         <PriorityMenu :starting-height="27">
             <PriorityMenuItem

--- a/client/src/components/History/CurrentHistoryPanel.vue
+++ b/client/src/components/History/CurrentHistoryPanel.vue
@@ -3,7 +3,7 @@
         <UserHistories v-if="user" :user="user" v-slot="{ currentHistory, histories, handlers }">
             <HistoryPanel v-if="currentHistory" :history="currentHistory" v-on="handlers">
                 <template v-slot:nav>
-                    <div>
+                    <div id="current-history-panel">
                         <HistorySelector
                             :histories="histories"
                             :current-history="currentHistory"

--- a/client/src/components/History/CurrentHistoryPanel.vue
+++ b/client/src/components/History/CurrentHistoryPanel.vue
@@ -1,9 +1,9 @@
 <template>
     <CurrentUser class="d-flex flex-column" v-slot="{ user }">
         <UserHistories v-if="user" :user="user" v-slot="{ currentHistory, histories, handlers }">
-            <HistoryPanel v-if="currentHistory" :history="currentHistory" v-on="handlers">
+            <HistoryPanel v-if="currentHistory" :history="currentHistory" v-on="handlers" id="current-history-panel">
                 <template v-slot:nav>
-                    <div id="current-history-panel">
+                    <div>
                         <HistorySelector
                             :histories="histories"
                             :current-history="currentHistory"

--- a/client/src/components/History/HistoriesMenu.vue
+++ b/client/src/components/History/HistoriesMenu.vue
@@ -17,6 +17,7 @@
             key="view-all-histories"
             title="View All Histories"
             icon="fa fa-columns"
+            class="history-view-multi-button"
             @click="redirect('/history/view_multiple')"
         />
         <PriorityMenuItem
@@ -28,7 +29,8 @@
         <PriorityMenuItem
             key="clear-history-cache"
             title="Refresh History"
-            icon="fa fa-sync"
+            icon="fa fa-refresh"
+            class="history-refresh-button"
             @click.stop="clearCache"
         />
         <PriorityMenuItem

--- a/client/src/components/History/HistoriesMenu.vue
+++ b/client/src/components/History/HistoriesMenu.vue
@@ -9,6 +9,7 @@
         <PriorityMenuItem
             key="create-new-history"
             title="Create New History"
+            class="history-new-button"
             icon="fa fa-plus"
             @click="$emit('createNewHistory')"
         />

--- a/client/src/components/History/HistoryDetails.vue
+++ b/client/src/components/History/HistoryDetails.vue
@@ -1,14 +1,15 @@
 <template>
     <header>
-        <div class="d-flex justify-content-between align-items-center">
+        <div class="d-flex justify-content-between align-items-center actions">
             <h6 class="text-nowrap text-truncate mr-auto">
-                <span class="size">{{ history.niceSize | localize }}</span>
+                <span class="size history-size">{{ history.niceSize | localize }}</span>
             </h6>
 
             <PriorityMenu style="max-width: 50%" :starting-height="28">
                 <PriorityMenuItem
                     key="edit-history-tags"
                     title="Edit History Tags"
+                    class="history-tag-btn"
                     icon="fas fa-tags"
                     :pressed="showTags"
                     @click="showTags = !showTags"
@@ -16,6 +17,7 @@
                 <PriorityMenuItem
                     key="edit-history-annotation"
                     title="Edit Annotation"
+                    class="history-annotate-btn"
                     icon="fas fa-comment"
                     :pressed="showAnnotation"
                     @click="showAnnotation = !showAnnotation"
@@ -94,8 +96,8 @@
             class="history-title mt-2"
             tag-name="h3"
             v-model="historyName"
-            :tooltip-title="'Rename history...' | localize"
-            tooltip-placement="top"
+            :title="'Rename history...' | localize"
+            v-b-tooltip.hover="{ boundary: 'viewport', placement: 'left' }"
         />
 
         <transition name="shutterfade">

--- a/client/src/components/History/HistoryEmpty.vue
+++ b/client/src/components/History/HistoryEmpty.vue
@@ -1,7 +1,7 @@
 <template>
     <b-alert show>
         <h4 class="mb-1">
-            <i class="fa fa-info-circle"></i>
+            <i class="fa fa-info-circle empty-message"></i>
             <span>{{ message | l }}</span>
         </h4>
         <p>

--- a/client/src/components/PriorityMenu/Menu.vue
+++ b/client/src/components/PriorityMenu/Menu.vue
@@ -14,7 +14,7 @@
             <div class="overflow" v-if="overflow.length">
                 <b-dropdown no-caret right variant="link" size="sm" boundary="window" toggle-class="p-1">
                     <template v-slot:button-content>
-                        <i class="fas fa-ellipsis-v priority-menu-expand" />
+                        <i class="fas fa-ellipsis-v priority-menu-expand menu-expand-button" />
                         <span class="sr-only">...</span>
                     </template>
                     <b-dropdown-item v-for="item in overflow" :key="item.key" v-bind="item.attrs" v-on="item.on">

--- a/client/src/components/PriorityMenu/Menu.vue
+++ b/client/src/components/PriorityMenu/Menu.vue
@@ -14,7 +14,7 @@
             <div class="overflow" v-if="overflow.length">
                 <b-dropdown no-caret right variant="link" size="sm" boundary="window" toggle-class="p-1">
                     <template v-slot:button-content>
-                        <i class="fas fa-ellipsis-v" />
+                        <i class="fas fa-ellipsis-v priority-menu-expand" />
                         <span class="sr-only">...</span>
                     </template>
                     <b-dropdown-item v-for="item in overflow" :key="item.key" v-bind="item.attrs" v-on="item.on">

--- a/client/src/entry/panels/history-panel.js
+++ b/client/src/entry/panels/history-panel.js
@@ -30,7 +30,7 @@ const HistoryPanel = Backbone.View.extend({
         this.buttonRefresh = new Ui.ButtonLink({
             id: "history-refresh-button",
             title: _l("Refresh history"),
-            cls: "panel-header-button",
+            cls: "panel-header-button history-refresh-button",
             icon: "fa fa-sync",
             onclick: () => {
                 this.historyView.loadCurrentHistory();
@@ -54,7 +54,7 @@ const HistoryPanel = Backbone.View.extend({
         this.buttonViewMulti = new Ui.ButtonLink({
             id: "history-view-multi-button",
             title: _l("View all histories"),
-            cls: "panel-header-button",
+            cls: "panel-header-button history-view-multi-button",
             icon: "fa fa-columns",
             href: `${this.root}history/view_multiple`,
         });

--- a/client/src/entry/panels/history-panel.js
+++ b/client/src/entry/panels/history-panel.js
@@ -42,7 +42,7 @@ const HistoryPanel = Backbone.View.extend({
             this.buttonNew = new Ui.ButtonLink({
                 id: "history-new-button",
                 title: _l("Create new history"),
-                cls: "panel-header-button",
+                cls: "panel-header-button history-new-button",
                 icon: "fa fa-plus",
                 onclick: function () {
                     Galaxy.currHistoryPanel.createNewHistory();

--- a/client/src/entry/panels/history-panel.js
+++ b/client/src/entry/panels/history-panel.js
@@ -63,7 +63,7 @@ const HistoryPanel = Backbone.View.extend({
         this.buttonOptions = new Ui.ButtonLink({
             id: "history-options-button",
             title: _l("History options"),
-            cls: "panel-header-button",
+            cls: "panel-header-button menu-expand-button",
             target: "galaxy_main",
             icon: "fa fa-cog",
             href: `${this.root}root/history_options`,
@@ -72,7 +72,7 @@ const HistoryPanel = Backbone.View.extend({
 
         this.model = new Backbone.Model({
             // define components
-            cls: "history-right-panel",
+            cls: "history-right-panel history-details",
             title: _l("History"),
             buttons: panelHeaderButtons,
         });

--- a/client/src/mvc/collection/collection-li.js
+++ b/client/src/mvc/collection/collection-li.js
@@ -255,6 +255,7 @@ var NestedDCDCEListItemView = DCListItemView.extend(
             DCListItemView.prototype._swapNewRender.call(this, $newRender);
             var state = this.model.get("state") || "ok";
             this.$el.addClass(`state-${state}`);
+            this.$el.attr("data-state", state);
             return this.$el;
         },
 

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -135,6 +135,7 @@ export var DatasetListItemView = _super.extend(
             _super.prototype._swapNewRender.call(this, $newRender);
             if (this.model.has("state")) {
                 this.$el.addClass(`state-${this.model.get("state")}`);
+                this.$el.attr("data-state", this.model.get("state"));
             }
             return this.$el;
         },

--- a/client/src/mvc/history/hda-li.js
+++ b/client/src/mvc/history/hda-li.js
@@ -33,7 +33,7 @@ HDAListItemView.prototype.templates = (() => {
     var titleBarTemplate = (dataset) => `
         <div class="title-bar clear" tabindex="0">
             <span class="state-icon"></span>
-            <div class="title">
+            <div class="title content-title">
                 <span class="hid">${dataset.hid}</span>
                 <span class="name">${_.escape(dataset.name)}</span>
             </div>

--- a/client/src/mvc/history/hdca-li.js
+++ b/client/src/mvc/history/hdca-li.js
@@ -75,6 +75,7 @@ var HDCAListItemView = _super.extend(
                 state = this.model.get("populated_state") ? STATES.OK : STATES.RUNNING;
             }
             this.$el.addClass(`state-${state}`);
+            this.$el.attr("data-state", state);
             const collection = this.model;
             const stateContainer = this.$el.find(".state-description")[0];
             mountCollectionJobStates({ jobStatesSummary, collection }, stateContainer);

--- a/client/src/mvc/history/hdca-li.js
+++ b/client/src/mvc/history/hdca-li.js
@@ -104,7 +104,7 @@ HDCAListItemView.prototype.templates = (() => {
     var titleBarTemplate = (collection) => `
         <div class="title-bar clear" tabindex="0">
             <span class="state-icon"></span>
-            <div class="title">
+            <div class="title content-title">
                 <span class="hid">${collection.hid}</span>
                 <span class="name">${_.escape(collection.name)}</span>
             </div>

--- a/client/src/mvc/history/history-view-edit.js
+++ b/client/src/mvc/history/history-view-edit.js
@@ -227,7 +227,7 @@ var HistoryViewEdit = _super.extend(
             var nameSelector = "> .controls .name";
             $where
                 .find(nameSelector)
-                .attr("title", _l("Click to rename history"))
+                .attr("title", _l("Rename history..."))
                 .tooltip({ placement: "bottom" })
                 .make_text_editable({
                     on_finish: function (newName) {

--- a/client/src/mvc/history/history-view-edit.js
+++ b/client/src/mvc/history/history-view-edit.js
@@ -485,7 +485,7 @@ var HistoryViewEdit = _super.extend(
         // ------------------------------------------------------------------------ panel events
         /** event map */
         events: _.extend(_.clone(_super.prototype.events), {
-            "click .show-selectors-btn": "toggleSelectors",
+            "click .show-history-content-selectors-btn": "toggleSelectors",
             "click .toggle-deleted-link": function (ev) {
                 this.toggleShowDeleted();
             },

--- a/client/src/mvc/history/history-view.js
+++ b/client/src/mvc/history/history-view.js
@@ -520,14 +520,14 @@ var HistoryView = _super.extend(
 HistoryView.prototype.templates = (() => {
     var mainTemplate = () =>
         `<div>
-            <div class="controls"></div>
+            <div class="controls history-details"></div>
             <ul class="list-items"></ul>
             <div class="empty-message infomessagesmall"></div>',
         </div>`;
 
     var controlsTemplate = BASE_MVC.wrapTemplate(
         [
-            '<div class="controls">',
+            '<div class="controls history-details">',
             '<div class="title">',
             '<div class="name"><%- history.name %></div>',
             "</div>",
@@ -561,7 +561,7 @@ HistoryView.prototype.templates = (() => {
 
             // add tags and annotations
             '<div class="tags-display"></div>',
-            '<div class="annotation-display"></div>',
+            '<div class="annotation-display history-annotation"></div>',
 
             '<div class="search">',
             '<div class="search-input"></div>',

--- a/client/src/mvc/history/history-view.js
+++ b/client/src/mvc/history/history-view.js
@@ -32,6 +32,7 @@ var _super = LIST_VIEW.ModelListPanel;
 var HistoryView = _super.extend(
     /** @lends HistoryView.prototype */ {
         _logNamespace: "history",
+        actionButtonClass: "history-contents-list-action-menu-btn",
 
         /** class to use for constructing the HDA views */
         HDAViewClass: HDA_LI.HDAListItemView,
@@ -172,18 +173,18 @@ var HistoryView = _super.extend(
             // do not render (and remove even) if nothing to select
             if (!this.views.length) {
                 this.hideSelectors();
-                $where.find(".controls .actions .show-selectors-btn").remove();
+                $where.find(".controls .actions .show-history-content-selectors-btn").remove();
                 return null;
             }
             // don't bother rendering if there's one already
-            var $existing = $where.find(".controls .actions .show-selectors-btn");
+            var $existing = $where.find(".controls .actions .show-history-content-selectors-btn");
             if ($existing.length) {
                 return $existing;
             }
 
             return faIconButton({
                 title: _l("Operations on multiple datasets"),
-                classes: "show-selectors-btn",
+                classes: "show-history-content-selectors-btn",
                 faIcon: "fa-check-square-o",
                 tooltipConfig: { placement: "top" },
             }).prependTo($where.find(".controls .actions"));
@@ -347,7 +348,7 @@ var HistoryView = _super.extend(
         // ------------------------------------------------------------------------ panel events
         /** event map */
         events: _.extend(_.clone(_super.prototype.events), {
-            "click .show-selectors-btn": "toggleSelectors",
+            "click .show-history-content-selectors-btn": "toggleSelectors",
             "click > .controls .prev": "_clickPrevPage",
             "click > .controls .next": "_clickNextPage",
             "change > .controls .pages": "_changePageSelect",

--- a/client/src/mvc/history/options-menu.js
+++ b/client/src/mvc/history/options-menu.js
@@ -219,6 +219,7 @@ function buildMenu(isAnon, purgeAllowed, urlRoot) {
             menuOption.href = urlRoot + menuOption.href;
             menuOption.target = menuOption.target || "galaxy_main";
         }
+        menuOption.title = menuOption.html;
 
         if (menuOption.confirm) {
             menuOption.func = () => {

--- a/client/src/mvc/list/list-view.js
+++ b/client/src/mvc/list/list-view.js
@@ -36,6 +36,7 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
 
         tagName: "div",
         className: "list-panel",
+        actionButtonClass: "list-action-menu-btn",
 
         /** (in ms) that jquery effects will use */
         fxSpeed: "fast",
@@ -297,7 +298,7 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
             }
             var $newMenu = $(
                 `<div class="list-action-menu btn-group">
-                    <button class="list-action-menu-btn btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                    <button class="${this.actionButtonClass} btn btn-secondary dropdown-toggle" data-toggle="dropdown">
                         ${_l("For all selected")}...
                     </button>
                     <div class="dropdown-menu float-right" role="menu"/>

--- a/client/src/mvc/ui/popup-menu.js
+++ b/client/src/mvc/ui/popup-menu.js
@@ -84,7 +84,8 @@ const PopupMenu = Backbone.View.extend({
             const href = option.href || "javascript:void(0);";
             const target = option.target ? `target="${option.target}"` : "";
             const check = option.checked ? '<span class="fa fa-check mr-1"/>' : "";
-            return `<a class="popupmenu-option dropdown-item" href="${href}" ${target}>${check}${option.html}</a>`;
+            const title = option.title ? `title="${option.title}"` : "";
+            return `<a class="popupmenu-option dropdown-item" href="${href}" ${title} ${target}>${check}${option.html}</a>`;
         }).join("");
     },
 

--- a/lib/galaxy/selenium/components.py
+++ b/lib/galaxy/selenium/components.py
@@ -23,12 +23,13 @@ class Target(metaclass=ABCMeta):
 
 class SelectorTemplate(Target):
 
-    def __init__(self, selector, selector_type, children=None, kwds=None, with_classes=None):
+    def __init__(self, selector, selector_type, children=None, kwds=None, with_classes=None, with_data=None):
         self._selector = selector
         self.selector_type = selector_type
         self._children = children or {}
         self.__kwds = kwds or {}
         self.with_classes = with_classes or []
+        self._with_data = with_data or {}
 
     @staticmethod
     def from_dict(raw_value, children=None):
@@ -40,7 +41,13 @@ class SelectorTemplate(Target):
 
     def with_class(self, class_):
         assert self.selector_type == "css"
-        return SelectorTemplate(self._selector, self.selector_type, kwds=self.__kwds, with_classes=self.with_classes + [class_], children=self._children)
+        return SelectorTemplate(self._selector, self.selector_type, kwds=self.__kwds, with_classes=self.with_classes + [class_], with_data=self._with_data.copy(), children=self._children)
+
+    def with_data(self, key, value):
+        assert self.selector_type == "css"
+        with_data = self._with_data.copy()
+        with_data[key] = value
+        return SelectorTemplate(self._selector, self.selector_type, kwds=self.__kwds, with_classes=self.with_classes, with_data=with_data, children=self._children)
 
     def descendant(self, has_selector):
         assert self.selector_type == "css"
@@ -72,6 +79,9 @@ class SelectorTemplate(Target):
         if self.__kwds is not None:
             selector = string.Template(selector).substitute(self.__kwds)
         selector = selector + "".join(f".{c}" for c in self.with_classes)
+        if self._with_data:
+            for key, value in self._with_data.items():
+                selector = selector + f'[data-{key}="{value}"]'
         return selector
 
     @property

--- a/lib/galaxy/selenium/driver_factory.py
+++ b/lib/galaxy/selenium/driver_factory.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 try:
@@ -10,6 +11,8 @@ from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.remote.webdriver import WebDriver
 
+logger = logging.getLogger('selenium.webdriver.remote.remote_connection')
+logger.setLevel(logging.WARNING)
 
 DEFAULT_BROWSER = "auto"
 DEFAULT_DOWNLOAD_PATH = '/tmp/'

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -208,8 +208,12 @@ class HasDriver:
         submit_button.click()
 
     def prepend_timeout_message(self, timeout_exception, message):
+        msg = message
+        timeout_msg = timeout_exception.msg
+        if timeout_msg:
+            msg += f" {timeout_msg}"
         return TimeoutException(
-            msg=message + (timeout_exception.msg or ''),
+            msg=msg,
             screen=timeout_exception.screen,
             stacktrace=timeout_exception.stacktrace,
         )

--- a/lib/galaxy/selenium/has_driver.py
+++ b/lib/galaxy/selenium/has_driver.py
@@ -50,6 +50,9 @@ class HasDriver:
     def assert_absent(self, selector_template):
         assert len(self.find_elements(selector_template)) == 0
 
+    def element_absent(self, selector_template):
+        return len(self.find_elements(selector_template)) == 0
+
     def wait_for_xpath(self, xpath, **kwds):
         element = self._wait_on(
             ec.presence_of_element_located((By.XPATH, xpath)),

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1400,10 +1400,10 @@ class NavigatesGalaxy(HasDriver):
     def history_panel_click_item_title(self, hid, **kwds):
         item_component = self.history_panel_item_component(hid=hid)
         details_component = item_component.details
-        details_displayed = details_component.is_displayed
         item_component.title.wait_for_and_click()
 
         if kwds.get("wait", False):
+            details_displayed = details_component.is_displayed
             if details_displayed:
                 details_component.wait_for_absent_or_hidden()
             else:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1218,10 +1218,7 @@ class NavigatesGalaxy(HasDriver):
 
     @retry_during_transitions
     def click_history_options(self):
-        if self.is_beta_history():
-            component = self.components.history_panel.options_button_icon_beta
-        else:
-            component = self.components.history_panel.options_button_icon
+        component = self.components.history_panel.options_button_icon
         component.wait_for_and_click()
 
     def click_history_option(self, option_label_or_component):
@@ -1232,7 +1229,7 @@ class NavigatesGalaxy(HasDriver):
             option_label = option_label_or_component
             # Click labelled option
             self.wait_for_visible(self.navigation.history_panel.options_menu)
-            menu_item_sizzle_selector = f"#history-options-button-menu > a:contains('{option_label}')"
+            menu_item_sizzle_selector = self.navigation.history_panel.options_menu_item(option_label=option_label).selector
             menu_selection_element = self.wait_for_sizzle_selector_clickable(menu_item_sizzle_selector)
             menu_selection_element.click()
         else:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1199,15 +1199,20 @@ class NavigatesGalaxy(HasDriver):
     def click_history_options(self):
         self.components.history_panel.options_button_icon.wait_for_and_click()
 
-    def click_history_option(self, option_label):
+    def click_history_option(self, option_label_or_component):
         # Open menu
         self.click_history_options()
 
-        # Click labelled option
-        self.wait_for_visible(self.navigation.history_panel.options_menu)
-        menu_item_sizzle_selector = f"#history-options-button-menu > a:contains('{option_label}')"
-        menu_selection_element = self.wait_for_sizzle_selector_clickable(menu_item_sizzle_selector)
-        menu_selection_element.click()
+        if isinstance(option_label_or_component, str):
+            option_label = option_label_or_component
+            # Click labelled option
+            self.wait_for_visible(self.navigation.history_panel.options_menu)
+            menu_item_sizzle_selector = f"#history-options-button-menu > a:contains('{option_label}')"
+            menu_selection_element = self.wait_for_sizzle_selector_clickable(menu_item_sizzle_selector)
+            menu_selection_element.click()
+        else:
+            option_component = option_label_or_component
+            option_component.wait_for_and_click()
 
     def history_click_create_new(self):
         self.components.history_panel.new_history_button.wait_for_and_click()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -357,7 +357,8 @@ class NavigatesGalaxy(HasDriver):
 
     def history_panel_wait_for_hid_state(self, hid, state, allowed_force_refreshes=0):
         history_item_selector = self.history_panel_wait_for_hid_visible(hid, allowed_force_refreshes=allowed_force_refreshes)
-        history_item_selector_state = history_item_selector.with_class(f"state-{state}")
+        # history_item_selector_state = history_item_selector.with_class(f"state-{state}")
+        history_item_selector_state = history_item_selector.with_data("state", state)
         try:
             self.history_item_wait_for(history_item_selector_state, allowed_force_refreshes)
         except self.TimeoutException as e:

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -299,6 +299,8 @@ class NavigatesGalaxy(HasDriver):
         item = self.components.history_panel.item.selector
         if multi_history_panel:
             item = self.components.multi_history_view.item
+        elif self.is_beta_history():
+            item = self.components.history_panel.beta_item.selector
         return item(
             history_content_type=history_item["history_content_type"],
             id=history_item["id"]
@@ -1248,7 +1250,10 @@ class NavigatesGalaxy(HasDriver):
         self.components.history_panel.new_history_button.wait_for_and_click()
 
     def history_panel_click_copy_elements(self):
-        self.click_history_option("Copy Datasets")
+        if self.is_beta_history():
+            self.components.history_panel.options_button_copy_datasets_beta.wait_for_and_click()
+        else:
+            self.click_history_option("Copy Datasets")
 
     @retry_during_transitions
     def histories_click_advanced_search(self):

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -12,6 +12,7 @@ from functools import partial, wraps
 
 import requests
 import yaml
+from selenium.webdriver.common.keys import Keys
 
 from galaxy.util import DEFAULT_SOCKET_TIMEOUT
 from . import sizzle
@@ -299,8 +300,6 @@ class NavigatesGalaxy(HasDriver):
         item = self.components.history_panel.item.selector
         if multi_history_panel:
             item = self.components.multi_history_view.item
-        elif self.is_beta_history():
-            item = self.components.history_panel.beta_item.selector
         return item(
             history_content_type=history_item["history_content_type"],
             id=history_item["id"]
@@ -1618,7 +1617,12 @@ class NavigatesGalaxy(HasDriver):
         editable.wait_for_and_click()
         edit_el = edit.wait_for_and_click()
         if clear_text:
-            edit_el.clear()
+            # previously this was just edit_el.clear() but
+            # .clear() doesn't work with beta history panel
+            action_chains = self.action_chains()
+            for _ in range(40):
+                action_chains.send_keys(Keys.BACKSPACE)
+            action_chains.perform()
         edit_el.send_keys(annotation)
 
         if self.is_beta_history():

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -296,10 +296,10 @@ class NavigatesGalaxy(HasDriver):
         if history_item is None:
             assert hid
             history_item = self.hid_to_history_item(hid)
-        item = self.components.history_panel.item
+        item = self.components.history_panel.item.selector
         if multi_history_panel:
             item = self.components.multi_history_view.item
-        return item.selector(
+        return item(
             history_content_type=history_item["history_content_type"],
             id=history_item["id"]
         )

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -254,6 +254,8 @@ multi_history_view:
 
   selectors:
     _: '.multi-panel-history'
+    item: '.multi-panel-history #${history_content_type}-${id}'
+
     histories: '.middle .history-column'
     current_label: '.current-label'
     create_new_button: '.create-new'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -200,6 +200,9 @@ history_panel:
     options_show_export_history_to_file:
       type: xpath
       selector: '//a[text()="Export History to File"]'
+    options_use_beta_history:
+      type: xpath
+      selector: '//a[text()="Use Beta History Panel"]'
     new_history_button: '.history-new-button'
     multi_view_button: '#history-view-multi-button'
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -113,7 +113,9 @@ history_panel:
 
   item:
     selectors:
-      _: '#${history_content_type}-${id}'
+      # These now appear other places :_( - e.g. in the invocation view so we'll try
+      # prefixing ids with #current-history-panel but obviously we need to switch to classes or data
+      _: '#current-history-panel #${history_content_type}-${id}'
 
       title: '${_} .title'
       hid: '${_} .hid'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -111,6 +111,10 @@ history_panel:
     labels:
       new: 'Create New'
 
+  beta_item:
+    selectors:
+      _: ' #${history_content_type}-${id}' 
+
   item:
     selectors:
       # These now appear other places :_( - e.g. in the invocation view so we'll try
@@ -175,7 +179,7 @@ history_panel:
     name_beta: '.history-title span:last-child'
     name_edit_input: '.name input'
     name_edit_input_beta: '.history-title input'
-    contents: '#current-history-panel .list-items div.history-content'
+    contents: '#current-history-panel .history-content'
 
     empty_message: '.empty-message'
     size: '.history-size'
@@ -195,6 +199,7 @@ history_panel:
     options_button: '#history-options-button'
     options_button_icon: '.history-details .menu-expand-button'
     options_button_icon_beta: '.history-details .menu-expand-button'
+    options_button_copy_datasets_beta: '.copy-datasets-menu-item'
     options_menu: '#history-options-button-menu'
     options_menu_item:
       type: sizzle

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -193,9 +193,13 @@ history_panel:
     annotation_done: '.history-details .history-annotation .annotation button'
 
     options_button: '#history-options-button'
-    options_button_icon: '#history-options-button span.fa-cog'
-    options_button_icon_beta: 'section.history-details .priority-menu-expand'
+    options_button_icon: '.history-details .menu-expand-button'
+    options_button_icon_beta: '.history-details .menu-expand-button'
     options_menu: '#history-options-button-menu'
+    options_menu_item:
+      type: sizzle
+      selector: '#history-options-button-menu > a:contains("${option_label}")'
+
     options_show_history_structure:
       type: xpath
       selector: '//a[contains(text(), "Show Structure")]'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -208,9 +208,7 @@ history_panel:
     options_show_history_structure:
       type: xpath
       selector: '//a[contains(text(), "Show Structure")]'
-    options_show_export_history_to_file:
-      type: xpath
-      selector: '//a[text()="Export History to File"]'
+    options_show_export_history_to_file: 'a[title="Export History to File"]'
     options_use_beta_history:
       type: xpath
       selector: '//a[text()="Use Beta History Panel"]'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -157,7 +157,7 @@ history_panel:
 
   collection_view:
     selectors:
-      _: '.list-panel.dataset-collection-panel'
+      _: '.dataset-collection-panel'
       back: '.navigation .back'
       title: '.dataset-collection-panel .controls .title .editable-text'
       title_input: '.dataset-collection-panel .controls .title input'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -111,17 +111,13 @@ history_panel:
     labels:
       new: 'Create New'
 
-  beta_item:
-    selectors:
-      _: ' #${history_content_type}-${id}' 
-
   item:
     selectors:
       # These now appear other places :_( - e.g. in the invocation view so we'll try
       # prefixing ids with #current-history-panel but obviously we need to switch to classes or data
       _: '#current-history-panel #${history_content_type}-${id}'
 
-      title: '${_} .title'
+      title: '${_} .content-title'
       hid: '${_} .hid'
       name: '${_} .name'
       details: '${_} .details'

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -149,9 +149,9 @@ history_panel:
 
   multi_operations:
     selectors:
-      show_button: '#current-history-panel .actions .show-selectors-btn'
-      action_button: '#current-history-panel .list-action-menu .list-action-menu-btn'
-      action_menu: '.list-action-menu div.dropdown-menu'
+      show_button: '.show-history-content-selectors-btn'
+      action_button: '.history-contents-list-action-menu-btn'
+      action_menu: '.list-action-menu .dropdown-menu'
 
     labels:
       build_pair: "Build Dataset Pair"

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -165,36 +165,42 @@ history_panel:
       list_items: '.dataset-collection-panel .list-items .list-item'
 
   selectors:
+    beta: 'section.history'
     _: '#current-history-panel'
     search: '#current-history-panel input.search-query'
     refresh_button: '#history-refresh-button'
     name: '.title .name'
+    name_beta: '.history-title span:last-child'
     name_edit_input: '.name input'
+    name_edit_input_beta: '.history-title input'
     contents: '#current-history-panel .list-items div.history-content'
 
     empty_message: '.empty-message'
     size: '.history-size'
     tag_icon: '.actions .history-tag-btn'
-    tag_area: '.controls .tags-display'
-    tag_area_input: '.controls .tags-display .tags-input input'
+    tag_area: '.history-details .tags-display'
+    tag_area_input: '.history-details .tags-display .tags-input input'
     tag_close_btn: '.tags-display .ti-icon-close'
     tags: 'li.ti-tag.ti-valid .tag-name'
     annotation_icon: '.actions .history-annotate-btn'
-    annotation_area: '.controls .annotation-display'
-    annotation_editable_text: '.controls .annotation-display .annotation.editable-text'
-    annotation_edit: '.controls .annotation-display .annotation textarea'
-    annotation_done: '.controls .annotation-display .annotation button'
+    annotation_area: '.history-details .history-annotation'
+    annotation_editable_text: '.history-details .history-annotation .annotation.editable-text'
+    annotation_editable_text_beta: '.history-details .history-annotation.clickToEdit'
+    annotation_edit: '.history-details .history-annotation .annotation textarea'
+    annotation_edit_beta: '.history-details .history-annotation textarea'
+    annotation_done: '.history-details .history-annotation .annotation button'
 
     options_button: '#history-options-button'
     options_button_icon: '#history-options-button span.fa-cog'
+    options_button_icon_beta: 'section.history-details .priority-menu-expand'
     options_menu: '#history-options-button-menu'
     options_show_history_structure:
       type: xpath
-      selector: '//a[text()="Show Structure"]'
+      selector: '//a[contains(text(), "Show Structure")]'
     options_show_export_history_to_file:
       type: xpath
       selector: '//a[text()="Export History to File"]'
-    new_history_button: '#history-new-button'
+    new_history_button: '.history-new-button'
     multi_view_button: '#history-view-multi-button'
 
     pagination_pages: '.list-pagination .pages'
@@ -205,7 +211,7 @@ history_panel:
 
 
   text:
-    tooltip_name: 'Click to rename history'
+    tooltip_name: 'Rename history...'
     new_name: 'Unnamed history'
     new_size: '(empty)'
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -168,7 +168,7 @@ history_panel:
     beta: 'section.history'
     _: '#current-history-panel'
     search: '#current-history-panel input.search-query'
-    refresh_button: '#history-refresh-button'
+    refresh_button: '.history-refresh-button'
     name: '.title .name'
     name_beta: '.history-title span:last-child'
     name_edit_input: '.name input'
@@ -204,7 +204,7 @@ history_panel:
       type: xpath
       selector: '//a[text()="Use Beta History Panel"]'
     new_history_button: '.history-new-button'
-    multi_view_button: '#history-view-multi-button'
+    multi_view_button: '.history-view-multi-button'
 
     pagination_pages: '.list-pagination .pages'
     pagination_pages_options: '.list-pagination .pages option'

--- a/lib/galaxy/selenium/smart_components.py
+++ b/lib/galaxy/selenium/smart_components.py
@@ -75,6 +75,10 @@ class SmartTarget:
     def is_displayed(self):
         return self._has_driver.is_displayed(self._target)
 
+    @property
+    def is_absent(self):
+        return self._has_driver.element_absent(self._target)
+
     def wait_for_absent_or_hidden(self, **kwds):
         self._has_driver.wait_for_absent_or_hidden(self._target, **kwds)
 

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -217,6 +217,8 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
     # will be used to login.
     ensure_registered = False
 
+    ensure_beta_history = False
+
     # Override this in subclasses to annotate that an admin user
     # is required for the test to run properly. Override admin user
     # login info with GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL /
@@ -256,6 +258,8 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
         """
         if self.ensure_registered:
             self.login()
+            if self.ensure_beta_history:
+                self.use_beta_history()
 
     def tear_down_selenium(self):
         self.tear_down_driver()
@@ -363,6 +367,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
         initial_size_str = self.components.history_panel.new_size.text
         size_selector = self.components.history_panel.size
         size_text = size_selector.wait_for_text()
+
         assert initial_size_str in size_text, f"{initial_size_str} not in {size_text}"
 
         self.components.history_panel.empty_message.wait_for_visible()

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -63,6 +63,7 @@ GALAXY_TEST_SELENIUM_USER_EMAIL = os.environ.get("GALAXY_TEST_SELENIUM_USER_EMAI
 GALAXY_TEST_SELENIUM_USER_PASSWORD = os.environ.get("GALAXY_TEST_SELENIUM_USER_PASSWORD", None)
 GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL = os.environ.get("GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL", DEFAULT_ADMIN_USER)
 GALAXY_TEST_SELENIUM_ADMIN_USER_PASSWORD = os.environ.get("GALAXY_TEST_SELENIUM_ADMIN_USER_PASSWORD", DEFAULT_ADMIN_PASSWORD)
+GALAXY_TEST_SELENIUM_BETA_HISTORY = os.environ.get("GALAXY_TEST_SELENIUM_BETA_HISTORY", "0") == "1"
 
 # JS code to execute in Galaxy JS console to setup localStorage of session for logging and
 # logging "flatten" messages because it seems Selenium (with Chrome at least) only grabs
@@ -217,7 +218,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
     # will be used to login.
     ensure_registered = False
 
-    ensure_beta_history = False
+    ensure_beta_history = GALAXY_TEST_SELENIUM_BETA_HISTORY
 
     # Override this in subclasses to annotate that an admin user
     # is required for the test to run properly. Override admin user

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -19,7 +19,7 @@ class CollectionBuildersTestCase(SeleniumTestCase):
         self.collection_builder_set_name("my cool list")
         self.screenshot("collection_builder_list")
         self.collection_builder_create()
-        self.history_panel_wait_for_hid_ok(2)
+        self._collection_builder_wait_for_hid_ok(2)
 
     @selenium_test
     def test_build_list_and_show_items(self):
@@ -34,7 +34,7 @@ class CollectionBuildersTestCase(SeleniumTestCase):
         self.collection_builder_set_name("my cool list")
 
         self.collection_builder_create()
-        self.history_panel_wait_for_hid_ok(3)
+        self._collection_builder_wait_for_hid_ok(3)
 
     @selenium_test
     def test_build_pair_simple_hidden(self):
@@ -49,7 +49,17 @@ class CollectionBuildersTestCase(SeleniumTestCase):
         self.collection_builder_set_name("my awesome pair")
         self.screenshot("collection_builder_pair")
         self.collection_builder_create()
-        self.history_panel_wait_for_hid_ok(3)
+        self._collection_builder_wait_for_hid_ok(3)
+
+    def _collection_builder_wait_for_hid_ok(self, hid):
+        # a hacked up version of super().history_panel_wait_for_hid_ok for beta history panel not refreshing correctly.
+        allowed_force_refreshes = 0
+        if self.use_beta_history:
+            # so collection builder no longer forces refreshes of history panel.
+            # Why doesn't the panel pick it up automatically - an sqlite limitation?
+            # Or maybe refresh doesn't work if things are selected in the panel?
+            allowed_force_refreshes = 2
+        self.history_panel_wait_for_hid_ok(hid, allowed_force_refreshes=allowed_force_refreshes)
 
     @selenium_test
     def test_build_paired_list_simple(self):
@@ -68,7 +78,7 @@ class CollectionBuildersTestCase(SeleniumTestCase):
         self.collection_builder_set_name("my awesome paired list")
         self.screenshot("collection_builder_paired_list")
         self.collection_builder_create()
-        self.history_panel_wait_for_hid_ok(3)
+        self._collection_builder_wait_for_hid_ok(3)
         self.history_panel_wait_for_hid_hidden(1)
         self.history_panel_wait_for_hid_hidden(2)
 
@@ -98,7 +108,7 @@ class CollectionBuildersTestCase(SeleniumTestCase):
         self.collection_builder_set_name("my awesome paired list")
 
         self.collection_builder_create()
-        self.history_panel_wait_for_hid_ok(5)
+        self._collection_builder_wait_for_hid_ok(5)
         self.history_panel_refresh_click()
         self.history_panel_wait_for_hid_ok(1)
         self.history_panel_wait_for_hid_ok(2)

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -16,11 +16,10 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
 
         self.home()
 
-        hdca_selector = self.history_panel_wait_for_hid_state(input_hid, "ok")
-
         self.components.history_panel.multi_view_button.wait_for_and_click()
         self.components.multi_history_view.create_new_button.wait_for_and_click()
         self.components.multi_history_view.drag_drop_help.wait_for_visible()
+        hdca_selector = self.history_panel_wait_for_hid_state(input_hid, "ok", multi_history_panel=True)
         self.wait_for_visible(hdca_selector)
         self.screenshot("multi_history_collection")
 
@@ -144,6 +143,6 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
         self.home()
         self.components.history_panel.multi_view_button.wait_for_and_click()
 
-        selector = self.history_panel_wait_for_hid_state(collection_hid, "ok")
+        selector = self.history_panel_wait_for_hid_state(collection_hid, "ok", multi_history_panel=True)
         self.click(selector)
         return selector

--- a/lib/galaxy_test/selenium/test_history_multi_view.py
+++ b/lib/galaxy_test/selenium/test_history_multi_view.py
@@ -17,10 +17,10 @@ class HistoryMultiViewTestCase(SeleniumTestCase):
         self.home()
 
         self.components.history_panel.multi_view_button.wait_for_and_click()
-        self.components.multi_history_view.create_new_button.wait_for_and_click()
-        self.components.multi_history_view.drag_drop_help.wait_for_visible()
         hdca_selector = self.history_panel_wait_for_hid_state(input_hid, "ok", multi_history_panel=True)
         self.wait_for_visible(hdca_selector)
+        self.components.multi_history_view.create_new_button.wait_for_and_click()
+        self.components.multi_history_view.drag_drop_help.wait_for_visible()
         self.screenshot("multi_history_collection")
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -179,7 +179,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
     @selenium_test
     def test_refresh_preserves_state(self):
         if self.is_beta_history():
-            raise pytest.skip("Beta History Panel does not preserve state")
+            raise pytest.skip("Beta History Panel does not preserve state xref https://github.com/galaxyproject/galaxy/issues/12119")
         self.perform_upload(self.get_filename("1.txt"))
         self.wait_for_history()
 

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -205,7 +205,3 @@ class HistoryPanelTestCase(SeleniumTestCase):
     def assert_name_changed(self):
         name = self.history_panel_name()
         self.assertEqual(name, NEW_HISTORY_NAME)
-
-
-class BetaHistoryPanelTestCase(HistoryPanelTestCase):
-    ensure_beta_history = True

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -1,7 +1,12 @@
+import pytest
+
 from .framework import (
+    retry_assertion_during_transitions,
     selenium_test,
-    SeleniumTestCase
+    SeleniumTestCase,
 )
+
+NEW_HISTORY_NAME = "New History Name"
 
 
 class HistoryPanelTestCase(SeleniumTestCase):
@@ -24,26 +29,32 @@ class HistoryPanelTestCase(SeleniumTestCase):
     @selenium_test
     def test_history_panel_rename(self):
         editable_text_input_element = self.history_panel_click_to_rename()
-        editable_text_input_element.send_keys("New History Name")
+        if self.is_beta_history():
+            editable_text_input_element.clear()
+        editable_text_input_element.send_keys(NEW_HISTORY_NAME)
         self.send_enter(editable_text_input_element)
 
-        assert "New History Name" in self.history_panel_name()
+        self.assert_name_changed()
 
     @selenium_test
     def test_history_rename_confirm_with_click(self):
         editable_text_input_element = self.history_panel_click_to_rename()
-        editable_text_input_element.send_keys("New History Name")
+        if self.is_beta_history():
+            editable_text_input_element.clear()
+        editable_text_input_element.send_keys(NEW_HISTORY_NAME)
         self.click_center()
         self.assert_absent(self.navigation.history_panel.selectors.name_edit_input)
-        assert "New History Name" in self.history_panel_name()
+        self.assert_name_changed()
 
     @selenium_test
     def test_history_rename_cancel_with_escape(self):
         editable_text_input_element = self.history_panel_click_to_rename()
-        editable_text_input_element.send_keys("New History Name")
+        if self.is_beta_history():
+            editable_text_input_element.clear()
+        editable_text_input_element.send_keys(NEW_HISTORY_NAME)
         self.send_escape(editable_text_input_element)
         self.assert_absent(self.navigation.history_panel.selectors.name_edit_input)
-        assert "New History Name" not in self.history_panel_name()
+        assert NEW_HISTORY_NAME not in self.history_panel_name()
 
     @selenium_test
     def test_history_tags_and_annotations_buttons(self):
@@ -79,10 +90,17 @@ class HistoryPanelTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_history_panel_annotations_change(self):
+        history_panel = self.components.history_panel
 
+        @retry_assertion_during_transitions
         def assert_current_annotation(expected, error_message="History annotation",
                                       is_equal=True):
-            current_annotation = self.components.history_panel.annotation_editable_text.wait_for_visible()
+
+            if self.is_beta_history():
+                text_component = history_panel.annotation_editable_text_beta
+            else:
+                text_component = history_panel.annotation_editable_text
+            current_annotation = text_component.wait_for_visible()
             error_message += " given: [%s] expected [%s] "
             if is_equal:
                 assert current_annotation.text == expected, error_message % (
@@ -97,7 +115,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
             return random_annotation
 
         # assert that annotation wasn't set before
-        self.components.history_panel.annotation_area.assert_absent_or_hidden()
+        history_panel.annotation_area.assert_absent_or_hidden()
 
         # assign annotation random text
         initial_annotation = set_random_annotation()
@@ -160,6 +178,8 @@ class HistoryPanelTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_refresh_preserves_state(self):
+        if self.is_beta_history():
+            raise pytest.skip("Beta History Panel does not preserve state")
         self.perform_upload(self.get_filename("1.txt"))
         self.wait_for_history()
 
@@ -180,3 +200,12 @@ class HistoryPanelTestCase(SeleniumTestCase):
         self.sleep_for(self.wait_types.UX_TRANSITION)
         self.wait_for_selector_clickable(self.history_panel_item_selector(hid=1))
         assert not self.history_panel_item_showing_details(hid=1)
+
+    @retry_assertion_during_transitions
+    def assert_name_changed(self):
+        name = self.history_panel_name()
+        self.assertEqual(name, NEW_HISTORY_NAME)
+
+
+class BetaHistoryPanelTestCase(HistoryPanelTestCase):
+    ensure_beta_history = True

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -158,7 +158,7 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
         collection_view = self._click_and_wait_for_collection_view(collection_hid)
 
         # the space on the end of the parent_selector is important
-        self.tagging_add(["#moo"], parent_selector="#current-history-panel .dataset-collection-panel .controls ")
+        self.tagging_add(["#moo"], parent_selector=".dataset-collection-panel .controls ")
 
         self.screenshot("history_panel_collection_view_add_nametag")
         collection_view.back.wait_for_and_click()

--- a/lib/galaxy_test/selenium/test_history_structure.py
+++ b/lib/galaxy_test/selenium/test_history_structure.py
@@ -24,9 +24,8 @@ class HistoryStructureTestCase(SeleniumTestCase):
         self.wait_for_history()
         self.components.history_structure.header.assert_absent_or_hidden()
         self.components.history_structure.dataset.assert_absent_or_hidden()
-        self.click_history_options()
 
-        self.components.history_panel.options_show_history_structure.wait_for_and_click()
+        self.click_history_option(self.components.history_panel.options_show_history_structure)
 
         # assert details are not visible before expand
         self.components.history_structure.details.assert_absent_or_hidden()

--- a/lib/galaxy_test/selenium/test_navigates_galaxy.py
+++ b/lib/galaxy_test/selenium/test_navigates_galaxy.py
@@ -22,7 +22,7 @@ class NavigatesGalaxySeleniumTestCase(SeleniumTestCase):
         # Open the details, verify they are open and do a refresh.
         exception = None
         try:
-            refresh_button = self.wait_for_selector("#history-refresh-button")
+            refresh_button = self.wait_for_selector(".history-refresh-button")
             refresh_button.click()
         except Exception as e:
             exception = e


### PR DESCRIPTION
Duplicate Selenium test configuration and run a separate set of tests against the beta history panel that won't fail the build. Various changes to both the old and new history panels to synchronize classes, how state is encoded in the DOM, etc..