### PR TITLE
[20.09] Record invocation_step outputs as appropriate

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -424,6 +424,8 @@ class WorkflowStepExecutionTracker(ExecutionTracker):
     def record_success(self, execution_slice, job, outputs):
         super().record_success(execution_slice, job, outputs)
         if not self.collection_info:
+            for output_name, output in outputs:
+                self.invocation_step.add_output(output_name, output)
             self.invocation_step.job = job
 
     def new_collection_execution_slices(self):
@@ -447,6 +449,8 @@ class WorkflowStepExecutionTracker(ExecutionTracker):
         history = history or self.tool.get_default_history_by_trans(self.trans)
         if self.invocation_step.is_new:
             self.precreate_output_collections(history, params)
+            for output_name, implicit_collection in self.implicit_collections.items():
+                self.invocation_step.add_output(output_name, implicit_collection)
         else:
             collections = {}
             for output_assoc in self.invocation_step.output_dataset_collections:

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -426,6 +426,15 @@ class WorkflowProgress:
             outputs[invocation_step.output_value.workflow_output.output_name] = invocation_step.output_value.value
         self.outputs[step.id] = outputs
         if not already_persisted:
+            for output_name, output_object in outputs.items():
+                if hasattr(output_object, "history_content_type"):
+                    invocation_step.add_output(output_name, output_object)
+                else:
+                    # This is a problem, this non-data, non-collection output
+                    # won't be recovered on a subsequent workflow scheduling
+                    # iteration. This seems to have been a pre-existing problem
+                    # prior to #4584 though.
+                    pass
             for workflow_output in step.workflow_outputs:
                 output_name = workflow_output.output_name
                 if output_name not in outputs:

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -426,15 +426,6 @@ class WorkflowProgress:
             outputs[invocation_step.output_value.workflow_output.output_name] = invocation_step.output_value.value
         self.outputs[step.id] = outputs
         if not already_persisted:
-            for output_name, output_object in outputs.items():
-                if hasattr(output_object, "history_content_type"):
-                    invocation_step.add_output(output_name, output_object)
-                else:
-                    # This is a problem, this non-data, non-collection output
-                    # won't be recovered on a subsequent workflow scheduling
-                    # iteration. This seems to have been a pre-existing problem
-                    # prior to #4584 though.
-                    pass
             for workflow_output in step.workflow_outputs:
                 output_name = workflow_output.output_name
                 if output_name not in outputs:


### PR DESCRIPTION
This fixes https://github.com/galaxyproject/galaxy/issues/10966 and probably fixes https://github.com/galaxyproject/galaxy/issues/10738.

The issue occurs when a collection is being mapped over with more than `maximum_workflow_jobs_per_scheduling_iteration` items, and the `WorkflowProgress` instance tries to recover outputs via `recover_mapping`, which relies on the invocation steps' `output_datasets` and `output_dataset_collections` to be persisted.