### PR TITLE
Fix workflow parameter text value restriction when connected to select and text parameter

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2112,27 +2112,19 @@ class Tool(Dictifiable):
 
         return tool_dict
 
-    def to_json(self, trans, kwd=None, job=None, workflow_building_mode=False):
+    def to_json(self, trans, kwd=None, job=None, workflow_building_mode=False, history=None):
         """
         Recursively creates a tool dictionary containing repeats, dynamic options and updated states.
         """
         if kwd is None:
             kwd = {}
-        history_id = kwd.get('history_id', None)
-        history = None
         if workflow_building_mode is workflow_building_modes.USE_HISTORY or workflow_building_mode is workflow_building_modes.DISABLED:
             # We don't need a history when exporting a workflow for the workflow editor or when downloading a workflow
-            try:
-                if history_id is not None:
-                    history = self.history_manager.get_owned(trans.security.decode_id(history_id), trans.user, current_history=trans.history)
-                else:
-                    history = trans.get_history()
-                if history is None and job is not None:
-                    history = self.history_manager.get_owned(job.history.id, trans.user, current_history=trans.history)
-                if history is None:
-                    raise exceptions.MessageException('History unavailable. Please specify a valid history id')
-            except Exception as e:
-                raise exceptions.MessageException('[history_id={}] Failed to retrieve history. {}.'.format(history_id, unicodify(e)))
+            history = history or trans.get_history()
+            if history is None and job is not None:
+                history = self.history_manager.get_owned(job.history.id, trans.user, current_history=trans.history)
+            if history is None:
+                raise exceptions.MessageException('History unavailable. Please specify a valid history id')
 
         # build request context
         request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode)

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -118,9 +118,13 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
         """
         if 'payload' in kwd:
             kwd = kwd.get('payload')
-        tool_version = kwd.get('tool_version', None)
+        tool_version = kwd.get('tool_version')
+        history_id = kwd.pop('history_id', None)
+        history = None
+        if history_id:
+            history = self.history_manager.get_owned(self.decode_id(history_id), trans.user, current_history=trans.history)
         tool = self._get_tool(id, tool_version=tool_version, user=trans.user)
-        return tool.to_json(trans, kwd.get('inputs', kwd))
+        return tool.to_json(trans, kwd.get('inputs', kwd), history=history)
 
     @web.require_admin
     @expose_api

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -473,7 +473,11 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         style = kwd.get("style", "export")
         download_format = kwd.get('format')
         version = kwd.get('version')
-        ret_dict = self.workflow_contents_manager.workflow_to_dict(trans, stored_workflow, style=style, version=version)
+        history_id = kwd.get('history_id')
+        history = None
+        if history_id:
+            history = self.history_manager.get_accessible(self.decode_id(history_id), trans.user, current_history=trans.history)
+        ret_dict = self.workflow_contents_manager.workflow_to_dict(trans, stored_workflow, style=style, version=version, history=history)
         if download_format == 'json-download':
             sname = stored_workflow.name
             sname = ''.join(c in util.FILENAME_VALID_CHARS and c or '_' for c in sname)[0:150]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -980,7 +980,7 @@ class InputParameterModule(WorkflowModule):
                     tool_inputs = module.tool.inputs  # may not be set, but we're catching the Exception below.
 
                     def callback(input, prefixed_name, context, **kwargs):
-                        if prefixed_name == connection.input_name:
+                        if prefixed_name == connection.input_name and hasattr(input, 'get_options'):
                             static_options.append(input.get_options(self.trans, {}))
                     visit_input_values(tool_inputs, module.state.inputs, callback)
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -882,10 +882,12 @@ class BaseWorkflowPopulator:
         api_asserts.assert_status_code_is(response, 200)
         return response.json()
 
-    def download_workflow(self, workflow_id, style=None):
+    def download_workflow(self, workflow_id, style=None, history_id=None):
         params = {}
         if style is not None:
             params["style"] = style
+        if history_id is not None:
+            params['history_id'] = history_id
         response = self._get("workflows/%s/download" % workflow_id, data=params)
         api_asserts.assert_status_code_is(response, 200)
         if style != "format2":


### PR DESCRIPTION
Text parameters are freestyle parameters, so shouldn't influence the
restricted values, and text parameters also don't have a get_options
attribute. Fixes #10974.

To be able to test this I added an option allow sending history_id to /api/workflows/{encoded_workflow_id}/download
instead of relying on trans.history for the right history.