### PR TITLE
[WIP] Implement quota tracking options per ObjectStore.

### DIFF
--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.test.js
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.test.js
@@ -10,14 +10,17 @@ const localVue = getLocalVue();
 
 const TEST_STORAGE_API_RESPONSE_WITHOUT_ID = {
     object_store_id: null,
+    private: false,
 };
 const TEST_STORAGE_API_RESPONSE_WITH_ID = {
     object_store_id: "foobar",
+    private: false,
 };
 const TEST_STORAGE_API_RESPONSE_WITH_NAME = {
     object_store_id: "foobar",
     name: "my cool storage",
     description: "My cool **markdown**",
+    private: true,
 };
 const TEST_DATASET_ID = "1";
 const TEST_STORAGE_URL = `/api/datasets/${TEST_DATASET_ID}/storage`;
@@ -46,9 +49,6 @@ describe("Dataset Storage", () => {
         wrapper = shallowMount(DatasetStorage, {
             propsData: { datasetId: TEST_DATASET_ID },
             localVue,
-            stubs: {
-                "loading-span": true,
-            },
         });
     }
 
@@ -102,6 +102,7 @@ describe("Dataset Storage", () => {
         expect(byIdSpan.length).toBe(1);
         const byNameSpan = wrapper.findAll(".display-os-by-name");
         expect(byNameSpan.length).toBe(0);
+        expect(wrapper.find("object-store-restriction-span-stub").props("isPrivate")).toBeFalsy();
     });
 
     it("test dataset storage with object store name", async () => {
@@ -116,6 +117,7 @@ describe("Dataset Storage", () => {
         expect(byIdSpan.length).toBe(0);
         const byNameSpan = wrapper.findAll(".display-os-by-name");
         expect(byNameSpan.length).toBe(1);
+        expect(wrapper.find("object-store-restriction-span-stub").props("isPrivate")).toBeTruthy();
     });
 
     afterEach(() => {

--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -7,12 +7,16 @@
             <p>
                 This dataset is stored in
                 <span class="display-os-by-name" v-if="storageInfo.name">
-                    a Galaxy object store named <b>{{ storageInfo.name }}</b>
+                    a Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store named
+                    <b>{{ storageInfo.name }}</b>
                 </span>
                 <span class="display-os-by-id" v-else-if="storageInfo.object_store_id">
-                    a Galaxy object store with id <b>{{ storageInfo.object_store_id }}</b>
+                    a Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store with id
+                    <b>{{ storageInfo.object_store_id }}</b>
                 </span>
-                <span class="display-os-default" v-else> the default configured Galaxy object store </span>.
+                <span class="display-os-default" v-else>
+                    the default configured Galaxy <object-store-restriction-span :is-private="isPrivate" /> object store </span
+                >.
             </p>
             <div v-html="descriptionRendered"></div>
         </div>
@@ -25,10 +29,12 @@ import { getAppRoot } from "onload/loadConfig";
 import LoadingSpan from "components/LoadingSpan";
 import MarkdownIt from "markdown-it";
 import { errorMessageAsString } from "utils/simple-error";
+import ObjectStoreRestrictionSpan from "./ObjectStoreRestrictionSpan";
 
 export default {
     components: {
         LoadingSpan,
+        ObjectStoreRestrictionSpan,
     },
     props: {
         datasetId: {
@@ -59,6 +65,11 @@ export default {
             .catch((errorMessage) => {
                 this.errorMessage = errorMessageAsString(errorMessage);
             });
+    },
+    computed: {
+        isPrivate() {
+            return this.storageInfo.private;
+        },
     },
     methods: {
         handleResponse(response) {

--- a/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.test.js
+++ b/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.test.js
@@ -1,0 +1,27 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import ObjectStoreRestrictionSpan from "./ObjectStoreRestrictionSpan";
+
+const localVue = getLocalVue();
+
+describe("ObjectStoreRestrictionSpan", () => {
+    let wrapper;
+
+    it("should render info about private storage if isPrivate", () => {
+        wrapper = shallowMount(ObjectStoreRestrictionSpan, {
+            propsData: { isPrivate: true },
+            localVue,
+        });
+        expect(wrapper.find(".stored-how").text()).toBe("private");
+        expect(wrapper.find(".stored-how").attributes("title")).toBeTruthy();
+    });
+
+    it("should render info about unrestricted storage if not isPrivate", () => {
+        wrapper = shallowMount(ObjectStoreRestrictionSpan, {
+            propsData: { isPrivate: false },
+            localVue,
+        });
+        expect(wrapper.find(".stored-how").text()).toBe("unrestricted");
+        expect(wrapper.find(".stored-how").attributes("title")).toBeTruthy();
+    });
+});

--- a/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.vue
+++ b/client/src/components/Dataset/DatasetStorage/ObjectStoreRestrictionSpan.vue
@@ -1,0 +1,38 @@
+<template>
+    <span class="stored-how" v-b-tooltip.hover :title="title">{{ text }}</span>
+</template>
+
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        isPrivate: {
+            // private is reserved word
+            type: Boolean,
+        },
+    },
+    computed: {
+        text() {
+            return this.isPrivate ? "private" : "unrestricted";
+        },
+        title() {
+            if (this.isPrivate) {
+                return "This dataset is stored on storage restricted to a single user. It can not be shared, pubished, or added to Galaxy data libraries.";
+            } else {
+                return "This dataset is stored on unrestricted storage. With sufficient Galaxy permissions, this dataset can be published, shared, or added to Galaxy data libraries.";
+            }
+        },
+    },
+};
+</script>
+
+<style scoped>
+/* Give visual indication of mouseover info */
+.stored-how {
+    text-decoration-line: underline;
+    text-decoration-style: dashed;
+}
+</style>

--- a/client/src/components/Quota/QuotaUsage.vue
+++ b/client/src/components/Quota/QuotaUsage.vue
@@ -1,0 +1,44 @@
+<template>
+    <div>
+        <b>{{ quotaUsage.name }}</b>
+        <progress-bar
+            :note="title"
+            :ok-count="quotaUsage.quota_percent"
+            :total="100"
+            v-if="quotaUsage.quota_percent < 99"
+        />
+        <progress-bar :note="title" :error-count="quotaUsage.quota_percent" :total="100" v-else />
+        <p>
+            <i>Using {{ quotaUsage.nice_total_disk_usage }} out of {{ quotaUsage.quota }}.</i>
+        </p>
+        <hr />
+    </div>
+</template>
+
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import ProgressBar from "components/ProgressBar";
+
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        ProgressBar,
+    },
+    props: {
+        quotaUsage: {
+            type: Object,
+        },
+    },
+    computed: {
+        title() {
+            if (this.quotaUsage.quota_percent == null) {
+                return `Unlimited`;
+            } else {
+                return `Using ${this.quotaUsage.quota_percent}%.`;
+            }
+        },
+    },
+};
+</script>

--- a/client/src/components/Quota/QuotaUsageDialog.vue
+++ b/client/src/components/Quota/QuotaUsageDialog.vue
@@ -1,0 +1,76 @@
+<template>
+    <b-modal visible ok-only ok-title="Close" hide-header>
+        <b-alert v-if="errorMessage" variant="danger" show v-html="errorMessage" />
+        <div v-else-if="usage == null">
+            <span class="fa fa-spinner fa-spin" />
+            <span>Please wait...</span>
+        </div>
+        <div class="d-block" style="overflow: hidden;" v-else>
+            <div v-for="item in effectiveQuotaSourceLabels" :key="item.id">
+                <quota-usage :quotaUsage="item" />
+            </div>
+        </div>
+    </b-modal>
+</template>
+
+<script>
+import axios from "axios";
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+import { getAppRoot } from "onload/loadConfig";
+import { errorMessageAsString } from "utils/simple-error";
+import QuotaUsage from "./QuotaUsage";
+
+Vue.use(BootstrapVue);
+
+export default {
+    components: {
+        QuotaUsage,
+    },
+    props: {
+        quotaSourceLabels: {
+            type: Array,
+        },
+    },
+    data() {
+        return {
+            usage: null,
+            errorMessage: null,
+        };
+    },
+    created() {
+        const url = `${getAppRoot()}api/users/current/usage`;
+        axios
+            .get(url)
+            .then((response) => {
+                this.usage = response.data;
+            })
+            .catch((error) => {
+                this.errorMessage = errorMessageAsString(error);
+            });
+    },
+    computed: {
+        effectiveQuotaSourceLabels() {
+            const labels = [];
+            const usageAsDict = this.usageAsDict;
+            labels.push({ id: "_default_", name: "Default Quota", ...usageAsDict["_default_"] });
+            for (const label of this.quotaSourceLabels) {
+                const usage = usageAsDict[label];
+                labels.push({ id: label, name: `Quota Source: ${label}`, ...usage });
+            }
+            return labels;
+        },
+        usageAsDict() {
+            const asDict = {};
+            for (const usage of this.usage) {
+                if (usage.quota_source_label == null) {
+                    asDict["_default_"] = usage;
+                } else {
+                    asDict[usage.quota_source_label] = usage;
+                }
+            }
+            return asDict;
+        },
+    },
+};
+</script>

--- a/client/src/components/Quota/index.js
+++ b/client/src/components/Quota/index.js
@@ -1,0 +1,1 @@
+export { showQuotaDialog } from "./show";

--- a/client/src/components/Quota/show.js
+++ b/client/src/components/Quota/show.js
@@ -1,0 +1,11 @@
+import Vue from "vue";
+import QuotaUsageDialog from "./QuotaUsageDialog";
+
+export function showQuotaDialog(options = {}) {
+    const instance = Vue.extend(QuotaUsageDialog);
+    const vm = document.createElement("div");
+    document.body.appendChild(vm);
+    new instance({
+        propsData: options,
+    }).$mount(vm);
+}

--- a/client/src/layout/masthead.js
+++ b/client/src/layout/masthead.js
@@ -19,6 +19,7 @@ export class MastheadState {
         Galaxy.quotaMeter = this.quotaMeter = new QuotaMeter.UserQuotaMeter({
             model: Galaxy.user,
             quotaUrl: Galaxy.config.quota_url,
+            quotaSourceLabels: Galaxy.config.quota_source_labels,
         });
 
         // loop through beforeunload functions if the user attempts to unload the page

--- a/client/src/mvc/library/library-model.js
+++ b/client/src/mvc/library/library-model.js
@@ -144,7 +144,7 @@ var HistoryContents = Backbone.Collection.extend({
         this.id = options.id;
     },
     url: function () {
-        return `${this.urlRoot + this.id}/contents`;
+        return `${this.urlRoot + this.id}/contents?sharable=true`;
     },
     model: HistoryItem,
 });

--- a/client/src/mvc/user/user-quotameter.js
+++ b/client/src/mvc/user/user-quotameter.js
@@ -4,6 +4,8 @@ import _ from "underscore";
 import baseMVC from "mvc/base-mvc";
 import _l from "utils/localization";
 
+import { showQuotaDialog } from "components/Quota";
+
 var logNamespace = "user";
 //==============================================================================
 /** @class View to display a user's disk/storage usage
@@ -27,6 +29,7 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
         initialize: function (options) {
             this.log(`${this}.initialize:`, options);
             _.extend(this.options, options);
+            this.useQuotaSourceLabels = options.quotaSourceLabels.length > 0;
 
             //this.bind( 'all', function( event, data ){ this.log( this + ' event:', event, data ); }, this );
             this.listenTo(this.model, "change:quota_percent change:total_disk_usage", this.render);
@@ -126,6 +129,17 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
 
             this.$el.html(meterHtml);
             this.$el.find(".quota-meter-text").tooltip();
+            const $link = this.$el.find(".quota-meter-link");
+            if (this.useQuotaSourceLabels) {
+                $link.attr("href", "").click((e) => {
+                    showQuotaDialog({
+                        quotaSourceLabels: this.options.quotaSourceLabels,
+                    });
+                    e.preventDefault();
+                });
+            } else {
+                $link.attr("href", this.options.quotaUrl);
+            }
             return this;
         },
 
@@ -134,11 +148,10 @@ var UserQuotaMeter = Backbone.View.extend(baseMVC.LoggableMixin).extend(
                 ? `title="Using ${data.nice_total_disk_usage}. Click for details."`
                 : "";
             const using = `${_l("Using")} ${data.quota_percent}%`;
-            const quotaUrl = this.options.quotaUrl;
             return `<div id="quota-meter" class="quota-meter progress">
     <div class="progress-bar" style="width: ${data.quota_percent}%"></div>
     <div class="quota-meter-text" data-placement="left" ${title}>
-        <a href="${quotaUrl}" target="_blank">${using}</a>
+        <a class="quota-meter-link" target="_blank">${using}</a>
     </div>
 </div>`;
         },

--- a/lib/galaxy/actions/admin.py
+++ b/lib/galaxy/actions/admin.py
@@ -40,7 +40,13 @@ class AdminActions:
             raise ActionInputError("Operation for an unlimited quota must be '='.")
         else:
             # Create the quota
-            quota = self.app.model.Quota(name=params.name, description=params.description, amount=create_amount, operation=params.operation)
+            quota = self.app.model.Quota(
+                name=params.name,
+                description=params.description,
+                amount=create_amount,
+                operation=params.operation,
+                quota_source_label=params.quota_source_label,
+            )
             self.sa_session.add(quota)
             # If this is a default quota, create the DefaultQuotaAssociation
             if params.default != 'no':

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -39,6 +39,7 @@ from galaxy.model.base import SharedModelMapping
 from galaxy.model.database_heartbeat import DatabaseHeartbeat
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.tags import GalaxyTagHandler
+from galaxy.objectstore import ObjectStore
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
     send_local_control_task,
@@ -122,6 +123,7 @@ class MinimalGalaxyApplication(BasicApp, config.ConfiguresGalaxyMixin, HaltableC
         if configure_logging:
             config.configure_logging(self.config)
         self._configure_object_store(fsmon=True)
+        self._register_singleton(ObjectStore, self.object_store)
         config_file = kwargs.get('global_conf', {}).get('__file__', None)
         if config_file:
             log.debug('Using "galaxy.ini" config file: %s', config_file)

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -274,7 +274,7 @@ class JobContext(ModelPersistenceContext, BaseJobContext):
         # Permissions must be the same on the LibraryDatasetDatasetAssociation and the associated LibraryDataset
         trans.app.security_agent.copy_library_permissions(trans, ld, ldda)
         # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
-        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user))
+        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user), flush=False, new=True)
         library_folder.add_library_dataset(ld, genome_build=ldda.dbkey)
         trans.sa_session.add(library_folder)
         trans.sa_session.flush()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1513,6 +1513,8 @@ class JobWrapper(HasResourceParameters):
 
         object_store_populator = ObjectStorePopulator(self.app, job.user)
         object_store_id = self.get_destination_configuration("object_store_id", None)
+        require_sharable = job.requires_sharable_storage(self.app.security_agent)
+
         if object_store_id:
             object_store_populator.object_store_id = object_store_id
 
@@ -1524,7 +1526,7 @@ class JobWrapper(HasResourceParameters):
         # afterward. State below needs to happen the same way.
         for dataset_assoc in job.output_datasets + job.output_library_datasets:
             dataset = dataset_assoc.dataset
-            object_store_populator.set_object_store_id(dataset)
+            object_store_populator.set_object_store_id(dataset, require_sharable=require_sharable)
 
         job.object_store_id = object_store_populator.object_store_id
         self._setup_working_directory(job=job)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1781,13 +1781,17 @@ class JobWrapper(HasResourceParameters):
                             tool=self.tool, stdout=job.stdout, stderr=job.stderr)
 
         collected_bytes = 0
+        quota_source_info = None
         # Once datasets are collected, set the total dataset size (includes extra files)
         for dataset_assoc in job.output_datasets:
             if not dataset_assoc.dataset.dataset.purged:
+                # assume all datasets in a job get written to the same objectstore
+                quota_source_info = dataset_assoc.dataset.dataset.quota_source_info
                 collected_bytes += dataset_assoc.dataset.set_total_size()
 
-        if job.user:
-            job.user.adjust_total_disk_usage(collected_bytes)
+        user = job.user
+        if user and collected_bytes > 0 and quota_source_info is not None and quota_source_info.use:
+            user.adjust_total_disk_usage(collected_bytes, quota_source_info.label)
 
         # Empirically, we need to update job.user and
         # job.workflow_invocation_step.workflow_invocation in separate

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -150,7 +150,12 @@ class BaseJobRunner:
         """Add a job to the queue (by job identifier), indicate that the job is ready to run.
         """
         put_timer = ExecutionTimer()
-        job_wrapper.enqueue()
+        try:
+            job_wrapper.enqueue()
+        except Exception as e:
+            job_wrapper.fail(str(e), exception=e)
+            log.debug(f"Job [{job_wrapper.job_id}] failed to queue {put_timer}")
+            return
         self.mark_as_queued(job_wrapper)
         log.debug(f"Job [{job_wrapper.job_id}] queued {put_timer}")
 

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -206,6 +206,7 @@ class ConfigSerializer(base.ModelSerializer):
             'default_panel_view': _use_config,
             'upload_from_form_button': _use_config,
             'release_doc_base_url': _use_config,
+            'quota_source_labels': lambda config, key, **context: list(self.app.object_store.get_quota_source_map().get_quota_source_labels()),
             'user_library_import_dir_available': lambda config, key, **context: bool(config.get('user_library_import_dir')),
         }
 

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -151,8 +151,9 @@ class HDAManager(datasets.DatasetAssociationManager,
             quota_amount_reduction = hda.quota_amount(user)
         super().purge(hda, flush=flush)
         # decrease the user's space used
-        if quota_amount_reduction:
-            user.adjust_total_disk_usage(-quota_amount_reduction)
+        quota_source_info = hda.dataset.quota_source_info
+        if quota_amount_reduction and quota_source_info.use:
+            user.adjust_total_disk_usage(-quota_amount_reduction, quota_source_info.label)
 
     # .... states
     def error_if_uploading(self, hda):

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -384,10 +384,10 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
     def default_permissions(self, user):
         return self.app.security_agent.user_get_default_permissions(user)
 
-    def quota(self, user, total=False):
+    def quota(self, user, total=False, quota_source_label=None):
         if total:
-            return self.app.quota_agent.get_quota_nice_size(user)
-        return self.app.quota_agent.get_percent(user=user)
+            return self.app.quota_agent.get_quota_nice_size(user, quota_source_label=quota_source_label)
+        return self.app.quota_agent.get_percent(user=user, quota_source_label=quota_source_label)
 
     def tags_used(self, user, tag_models=None):
         """
@@ -647,6 +647,15 @@ class UserSerializer(base.ModelSerializer, deletable.PurgableSerializerMixin):
 
             'tags_used': lambda i, k, **c: self.user_manager.tags_used(i),
         })
+
+    def serialize_disk_usage(self, user):
+        rval = user.dictify_usage(self.app.object_store)
+        for usage in rval:
+            quota_source_label = usage["quota_source_label"]
+            usage["quota_percent"] = self.user_manager.quota(user, quota_source_label=quota_source_label)
+            usage["quota"] = self.user_manager.quota(user, total=True, quota_source_label=quota_source_label)
+            usage["nice_total_disk_usage"] = util.nice_size(usage["total_disk_usage"])
+        return rval
 
 
 class UserDeserializer(base.ModelDeserializer):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -110,6 +110,7 @@ JOB_METRIC_PRECISION = 26
 JOB_METRIC_SCALE = 7
 # Tags that get automatically propagated from inputs to outputs when running jobs.
 AUTO_PROPAGATED_TAGS = ["name"]
+CANNOT_SHARE_PRIVATE_DATASET_MESSAGE = "Attempting to share a non-sharable dataset."
 
 
 if TYPE_CHECKING:
@@ -1170,6 +1171,19 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             params_dict[name] = value
         job_attrs['params'] = params_dict
         return job_attrs
+
+    def requires_sharable_storage(self, security_agent):
+        # An easy optimization would be to calculate this in galaxy.tools.actions when the
+        # job is created and all the output permissions are already known. Having to reload
+        # these permissions in the job code shouldn't strictly be needed.
+
+        requires_sharing = False
+        for dataset_assoc in self.output_datasets + self.output_library_datasets:
+            if not security_agent.dataset_is_private_to_a_user(dataset_assoc.dataset.dataset):
+                requires_sharing = True
+                break
+
+        return requires_sharing
 
     def to_dict(self, view='collection', system_details=False):
         if view == 'admin_job_list':
@@ -2299,7 +2313,12 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
         visible = galaxy.util.string_as_bool_or_none(kwds.get('visible', None))
         if visible is not None:
             query = query.filter(content_class.visible == visible)
+        if 'object_store_ids' in kwds:
+            if content_class == HistoryDatasetAssociation:
+                query = query.join(content_class.dataset).filter(Dataset.table.c.object_store_id.in_(kwds.get("object_store_ids")))
+            # else ignoring object_store_ids on HDCAs...
         if 'ids' in kwds:
+            assert 'object_store_ids' not in kwds
             ids = kwds['ids']
             max_in_filter_length = kwds.get('max_in_filter_length', MAX_IN_FILTER_LENGTH)
             if len(ids) < max_in_filter_length:
@@ -2589,11 +2608,24 @@ class Dataset(StorableObject, RepresentById, _HasTable):
     def in_ready_state(self):
         return self.state in self.ready_states
 
+    @property
+    def sharable(self):
+        """Return True if placed into an objectstore not labeled as ``private``."""
+        if self.external_filename:
+            return True
+        else:
+            object_store = self._assert_object_store_set()
+            return not object_store.is_private(self)
+
+    def ensure_sharable(self):
+        if not self.sharable:
+            raise Exception(CANNOT_SHARE_PRIVATE_DATASET_MESSAGE)
+
     def get_file_name(self):
         if not self.external_filename:
-            assert self.object_store is not None, f"Object Store has not been initialized for dataset {self.id}"
-            if self.object_store.exists(self):
-                return self.object_store.get_filename(self)
+            object_store = self._assert_object_store_set()
+            if object_store.exists(self):
+                return object_store.get_filename(self)
             else:
                 return ''
         else:
@@ -2607,6 +2639,10 @@ class Dataset(StorableObject, RepresentById, _HasTable):
         else:
             self.external_filename = filename
     file_name = property(get_file_name, set_file_name)
+
+    def _assert_object_store_set(self):
+        assert self.object_store is not None, f"Object Store has not been initialized for dataset {self.id}"
+        return self.object_store
 
     def get_extra_files_path(self):
         # Unlike get_file_name - external_extra_files_path is not backed by an
@@ -3477,6 +3513,9 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         """
         Copy this HDA to a library optionally replacing an existing LDDA.
         """
+        if not self.dataset.sharable:
+            raise Exception("Attempting to share a non-sharable dataset.")
+
         if replace_dataset:
             # The replace_dataset param ( when not None ) refers to a LibraryDataset that
             #   is being replaced with a new version.

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2827,6 +2827,16 @@ class Dataset(StorableObject, RepresentById, _HasTable):
         quota_source_map = self.object_store.get_quota_source_map()
         return quota_source_map.get_quota_source_info(object_store_id)
 
+    @property
+    def device_source_label(self):
+        return self.device_source_info.label
+
+    @property
+    def device_source_info(self):
+        object_store_id = self.object_store_id
+        device_source_map = self.object_store.get_quota_source_map()
+        return device_source_map.get_device_source_info(object_store_id)
+
     def set_file_name(self, filename):
         if not filename:
             self.external_filename = None

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -33,6 +33,7 @@ from social_core.storage import AssociationMixin, CodeMixin, NonceMixin, Partial
 from sqlalchemy import (
     alias,
     and_,
+    bindparam,
     BigInteger,
     Boolean,
     Column,
@@ -410,6 +411,102 @@ class JobLike:
         raise NotImplementedError("Attempt to set stdout, must set tool_stderr or job_stderr")
 
 
+UNIQUE_DATASET_USER_USAGE = """
+WITH per_user_histories AS
+(
+    SELECT id
+    FROM history
+    WHERE user_id = :id
+        AND NOT purged
+),
+per_hist_hdas AS (
+    SELECT DISTINCT dataset_id
+    FROM history_dataset_association
+    WHERE NOT purged
+        AND history_id IN (SELECT id FROM per_user_histories)
+)
+SELECT COALESCE(SUM(COALESCE(dataset.total_size, dataset.file_size, 0)), 0)
+FROM dataset
+LEFT OUTER JOIN library_dataset_dataset_association ON dataset.id = library_dataset_dataset_association.dataset_id
+WHERE dataset.id IN (SELECT dataset_id FROM per_hist_hdas)
+    AND library_dataset_dataset_association.id IS NULL
+    AND (
+        {dataset_condition}
+    )
+"""
+
+
+def calculate_user_disk_usage_statements(user_id, quota_source_map, for_sqlite=False):
+    """Standalone function so can be reused for postgres directly in pgcleanup.py."""
+    statements = []
+    default_quota_enabled = quota_source_map.default_quota_enabled
+    default_exclude_ids = quota_source_map.default_usage_excluded_ids()
+    default_cond = "dataset.object_store_id IS NULL" if default_quota_enabled else ""
+    exclude_cond = "dataset.object_store_id NOT IN :exclude_object_store_ids" if default_exclude_ids else ""
+    use_or = " OR " if (default_cond != "" and exclude_cond != "") else ""
+    default_usage_dataset_condition = "{default_cond} {use_or} {exclude_cond}".format(
+        default_cond=default_cond,
+        exclude_cond=exclude_cond,
+        use_or=use_or,
+    )
+    default_usage = UNIQUE_DATASET_USER_USAGE.format(
+        dataset_condition=default_usage_dataset_condition
+    )
+    default_usage = """
+UPDATE galaxy_user SET disk_usage = (%s)
+WHERE id = :id
+""" % default_usage
+    params = {"id": user_id}
+    if default_exclude_ids:
+        params["exclude_object_store_ids"] = default_exclude_ids
+    statements.append((default_usage, params))
+    source = quota_source_map.ids_per_quota_source()
+    # TODO: Merge a lot of these settings together by generating a temp table for
+    # the object_store_id to quota_source_label into a temp table of values
+    for (quota_source_label, object_store_ids) in source.items():
+        label_usage = UNIQUE_DATASET_USER_USAGE.format(
+            dataset_condition="dataset.object_store_id IN :include_object_store_ids"
+        )
+        if for_sqlite:
+            # hacky alternative for older sqlite
+            statement = """
+WITH new (user_id, quota_source_label, disk_usage) AS (
+    VALUES(:id, :label, ({label_usage}))
+)
+INSERT OR REPLACE INTO user_quota_source_usage (id, user_id, quota_source_label, disk_usage)
+SELECT old.id, new.user_id, new.quota_source_label, new.disk_usage
+FROM new
+    LEFT JOIN user_quota_source_usage AS old
+        ON new.user_id = old.user_id
+            AND new.quota_source_label = old.quota_source_label
+""".format(label_usage=label_usage)
+        else:
+            statement = """
+INSERT INTO user_quota_source_usage(user_id, quota_source_label, disk_usage)
+VALUES(:user_id, :label, ({label_usage}))
+ON CONFLICT
+ON constraint uqsu_unique_label_per_user
+DO UPDATE SET disk_usage = excluded.disk_usage
+""".format(label_usage=label_usage)
+        statements.append((statement, {"id": user_id, "label": quota_source_label, "include_object_store_ids": object_store_ids}))
+
+    params = {"id": user_id}
+    source_labels = list(source.keys())
+    if len(source_labels) > 0:
+        clean_old_statement = """
+DELETE FROM user_quota_source_usage
+WHERE user_id = :id AND quota_source_label NOT IN :labels
+"""
+        params["labels"] = source_labels
+    else:
+        clean_old_statement = """
+DELETE FROM user_quota_source_usage
+WHERE user_id = :id AND quota_source_label IS NOT NULL
+"""
+    statements.append((clean_old_statement, params))
+    return statements
+
+
 class User(Dictifiable, RepresentById):
     use_pbkdf2 = True
     bootstrap_admin_user = False
@@ -533,14 +630,31 @@ class User(Dictifiable, RepresentById):
                     roles.append(role)
         return roles
 
-    def get_disk_usage(self, nice_size=False):
+    def get_disk_usage(self, nice_size=False, quota_source_label=None):
         """
         Return byte count of disk space used by user or a human-readable
         string if `nice_size` is `True`.
         """
-        rval = 0
-        if self.disk_usage is not None:
-            rval = self.disk_usage
+        if quota_source_label is None:
+            rval = 0
+            if self.disk_usage is not None:
+                rval = self.disk_usage
+        else:
+            statement = """
+SELECT DISK_USAGE
+FROM user_quota_source_usage
+WHERE user_id = :user_id and quota_source_label = :label
+"""
+            sa_session = object_session(self)
+            params = {
+                'user_id': self.id,
+                'label': quota_source_label,
+            }
+            row = sa_session.execute(statement, params).fetchone()
+            if row is not None:
+                rval = row[0]
+            else:
+                rval = 0
         if nice_size:
             rval = galaxy.util.nice_size(rval)
         return rval
@@ -553,9 +667,36 @@ class User(Dictifiable, RepresentById):
 
     total_disk_usage = property(get_disk_usage, set_disk_usage)
 
-    def adjust_total_disk_usage(self, amount):
+    def adjust_total_disk_usage(self, amount, quota_source_label):
+        assert amount is not None
         if amount != 0:
-            self.disk_usage = func.coalesce(self.table.c.disk_usage, 0) + amount
+            if quota_source_label is None:
+                self.disk_usage = func.coalesce(self.table.c.disk_usage, 0) + amount
+            else:
+                # else would work on newer sqlite - 3.24.0
+                sa_session = object_session(self)
+                if "sqlite" in sa_session.bind.dialect.name:
+                    # hacky alternative for older sqlite
+                    statement = """
+WITH new (user_id, quota_source_label) AS ( VALUES(:user_id, :label) )
+INSERT OR REPLACE INTO user_quota_source_usage (id, user_id, quota_source_label, disk_usage)
+SELECT old.id, new.user_id, new.quota_source_label, COALESCE(old.disk_usage + :amount, :amount)
+FROM new LEFT JOIN user_quota_source_usage AS old ON new.user_id = old.user_id AND NEW.quota_source_label = old.quota_source_label;
+"""
+                else:
+                    statement = """
+INSERT INTO user_quota_source_usage(user_id, disk_usage, quota_source_label)
+VALUES(:user_id, :amount, :label)
+ON CONFLICT
+    ON constraint uqsu_unique_label_per_user
+    DO UPDATE SET disk_usage = user_quota_source_usage.disk_usage + :amount
+"""
+                params = {
+                    'user_id': self.id,
+                    'amount': int(amount),
+                    'label': quota_source_label,
+                }
+                sa_session.execute(statement, params)
 
     @property
     def nice_total_disk_usage(self):
@@ -564,51 +705,57 @@ class User(Dictifiable, RepresentById):
         """
         return self.get_disk_usage(nice_size=True)
 
-    def calculate_disk_usage(self):
+    def calculate_disk_usage_default_source(self, object_store):
         """
         Return byte count total of disk space used by all non-purged, non-library
-        HDAs in non-purged histories.
+        HDAs in non-purged histories assigned to default quota source.
         """
-        # maintain a list so that we don't double count
-        return self._calculate_or_set_disk_usage(dryrun=True)
+        # only used in set_user_disk_usage.py
+        assert object_store is not None
+        quota_source_map = object_store.get_quota_source_map()
+        default_quota_enabled = quota_source_map.default_quota_enabled
+        default_cond = "dataset.object_store_id IS NULL OR" if default_quota_enabled else ""
+        default_usage_dataset_condition = "{default_cond} dataset.object_store_id NOT IN :exclude_object_store_ids".format(
+            default_cond=default_cond,
+        )
+        default_usage = UNIQUE_DATASET_USER_USAGE.format(
+            dataset_condition=default_usage_dataset_condition
+        )
+        sql_calc = text(default_usage)
+        sql_calc = sql_calc.bindparams(
+            bindparam("id"),
+            bindparam("exclude_object_store_ids", expanding=True)
+        )
+        params = {'id': self.id, "exclude_object_store_ids": quota_source_map.default_usage_excluded_ids()}
+        sa_session = object_session(self)
+        usage = sa_session.scalar(sql_calc, params)
+        return usage
 
-    def calculate_and_set_disk_usage(self):
+    def calculate_and_set_disk_usage(self, object_store):
         """
         Calculates and sets user disk usage.
         """
-        self._calculate_or_set_disk_usage(dryrun=False)
+        self._calculate_or_set_disk_usage(object_store=object_store)
 
-    def _calculate_or_set_disk_usage(self, dryrun=True):
+    def _calculate_or_set_disk_usage(self, object_store):
         """
         Utility to calculate and return the disk usage.  If dryrun is False,
         the new value is set immediately.
         """
-        sql_calc = """
-            WITH per_user_histories AS
-            (
-                SELECT id
-                FROM history
-                WHERE user_id = :id
-                    AND NOT purged
-            ),
-            per_hist_hdas AS (
-                SELECT DISTINCT dataset_id
-                FROM history_dataset_association
-                WHERE NOT purged
-                    AND history_id IN (SELECT id FROM per_user_histories)
-            )
-            SELECT SUM(COALESCE(dataset.total_size, dataset.file_size, 0))
-            FROM dataset
-            LEFT OUTER JOIN library_dataset_dataset_association ON dataset.id = library_dataset_dataset_association.dataset_id
-            WHERE dataset.id IN (SELECT dataset_id FROM per_hist_hdas)
-                AND library_dataset_dataset_association.id IS NULL
-        """
+        assert object_store is not None
+        quota_source_map = object_store.get_quota_source_map()
         sa_session = object_session(self)
-        usage = sa_session.scalar(sql_calc, {'id': self.id})
-        if not dryrun:
-            self.set_disk_usage(usage)
+        for_sqlite = "sqlite" in sa_session.bind.dialect.name
+        statements = calculate_user_disk_usage_statements(self.id, quota_source_map, for_sqlite)
+        for (sql, args) in statements:
+            statement = text(sql)
+            binds = []
+            for key, val in args.items():
+                expand_binding = key.endswith("s")
+                binds.append(bindparam(key, expanding=expand_binding))
+            statement = statement.bindparams(*binds)
+            sa_session.execute(statement, args)
             sa_session.flush()
-        return usage
 
     @staticmethod
     def user_template_environment(user):
@@ -672,6 +819,32 @@ class User(Dictifiable, RepresentById):
         assoc = UserRoleAssociation(self, role)
         session.add(assoc)
         session.flush()
+
+    def dictify_usage(self, object_store=None):
+        """Include object_store to include empty/unused usage info."""
+        used_labels = set()
+        rval = [{
+            'quota_source_label': None,
+            'total_disk_usage': float(self.disk_usage or 0),
+        }]
+        used_labels.add(None)
+        for quota_source_usage in self.quota_source_usages:
+            label = quota_source_usage.quota_source_label
+            rval.append({
+                'quota_source_label': label,
+                'total_disk_usage': float(quota_source_usage.disk_usage),
+            })
+            used_labels.add(label)
+
+        if object_store is not None:
+            for label in object_store.get_quota_source_map().ids_per_quota_source().keys():
+                if label not in used_labels:
+                    rval.append({
+                        'quota_source_label': label,
+                        'total_disk_usage': 0.0,
+                    })
+
+        return rval
 
 
 class PasswordResetToken(_HasTable):
@@ -2015,7 +2188,9 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
             if set_hid:
                 dataset.hid = self._next_hid()
         if quota and is_dataset and self.user:
-            self.user.adjust_total_disk_usage(dataset.quota_amount(self.user))
+            quota_source_info = dataset.dataset.quota_source_info
+            if quota_source_info.use:
+                self.user.adjust_total_disk_usage(dataset.quota_amount(self.user), quota_source_info.label)
         dataset.history = self
         if is_dataset and genome_build not in [None, '?']:
             self.genome_build = genome_build
@@ -2030,8 +2205,12 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
         if optimize:
             self.__add_datasets_optimized(datasets, genome_build=genome_build)
             if quota and self.user:
-                disk_usage = sum([d.get_total_size() for d in datasets if is_hda(d)])
-                self.user.adjust_total_disk_usage(disk_usage)
+                hdas = [d for d in datasets if is_hda(d)]
+                disk_usage = sum([d.get_total_size() for d in hdas])
+                if disk_usage:
+                    quota_source_info = hdas[0].dataset.quota_source_info
+                    if quota_source_info.use:
+                        self.user.adjust_total_disk_usage(disk_usage, quota_source_info.label)
             sa_session.add_all(datasets)
             if flush:
                 sa_session.flush()
@@ -2381,6 +2560,10 @@ class Role(Base, Dictifiable, RepresentById):
         self.deleted = deleted
 
 
+class UserQuotaSourceUsage(Dictifiable, RepresentById):
+    dict_element_visible_keys = ['disk_usage', 'quota_source_label']
+
+
 class UserQuotaAssociation(Dictifiable, RepresentById):
     dict_element_visible_keys = ['user']
 
@@ -2409,11 +2592,11 @@ class Quota(Base, Dictifiable, RepresentById):
     operation = Column('operation', String(8))
     deleted = Column('deleted', Boolean, index=True, default=False)
 
-    dict_collection_visible_keys = ['id', 'name']
-    dict_element_visible_keys = ['id', 'name', 'description', 'bytes', 'operation', 'display_amount', 'default', 'users', 'groups']
+    dict_collection_visible_keys = ['id', 'name', 'quota_source_label']
+    dict_element_visible_keys = ['id', 'name', 'description', 'bytes', 'operation', 'display_amount', 'default', 'users', 'groups', 'quota_source_label']
     valid_operations = ('+', '-', '=')
 
-    def __init__(self, name=None, description=None, amount=0, operation='='):
+    def __init__(self, name=None, description=None, amount=0, operation='=', quota_source_label=None):
         self.name = name
         self.description = description
         if amount is None:
@@ -2421,6 +2604,7 @@ class Quota(Base, Dictifiable, RepresentById):
         else:
             self.bytes = amount
         self.operation = operation
+        self.quota_source_label = quota_source_label
 
     def get_amount(self):
         if self.bytes == -1:
@@ -2632,6 +2816,16 @@ class Dataset(StorableObject, RepresentById, _HasTable):
             filename = self.external_filename
         # Make filename absolute
         return os.path.abspath(filename)
+
+    @property
+    def quota_source_label(self):
+        return self.quota_source_info.label
+
+    @property
+    def quota_source_info(self):
+        object_store_id = self.object_store_id
+        quota_source_map = self.object_store.get_quota_source_map()
+        return quota_source_map.get_quota_source_info(object_store_id)
 
     def set_file_name(self, filename):
         if not filename:
@@ -3585,11 +3779,11 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         """
         return self.dataset.get_access_roles(security_agent)
 
-    def purge_usage_from_quota(self, user):
+    def purge_usage_from_quota(self, user, quota_source_info):
         """Remove this HDA's quota_amount from user's quota.
         """
-        if user:
-            user.adjust_total_disk_usage(-self.quota_amount(user))
+        if user and quota_source_info.use:
+            user.adjust_total_disk_usage(-self.quota_amount(user), quota_source_info.label)
 
     def quota_amount(self, user):
         """

--- a/lib/galaxy/model/migrate/versions/0172_add_user_quota_source_usage.py
+++ b/lib/galaxy/model/migrate/versions/0172_add_user_quota_source_usage.py
@@ -1,0 +1,64 @@
+"""
+Migration script to add a new user_quota_source_usage table.
+"""
+
+import logging
+
+from migrate.changeset.constraint import UniqueConstraint as MigrateUniqueContraint
+from sqlalchemy import Column, ForeignKey, Integer, MetaData, Numeric, String, Table, UniqueConstraint
+
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    add_index,
+    drop_column,
+    drop_index,
+)
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+user_quota_source_usage_table = Table(
+    "user_quota_source_usage", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
+    Column("quota_source_label", String(32), index=True),
+    # user had an index on disk_usage - does that make any sense? -John
+    Column("disk_usage", Numeric(15, 0)),
+    UniqueConstraint('user_id', 'quota_source_label', name="uqsu_unique_label_per_user"),
+)
+# Column to add.
+quota_source_label_col = Column("quota_source_label", String(32), default=None, nullable=True)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    add_column(quota_source_label_col, 'quota', metadata)
+
+    try:
+        user_quota_source_usage_table.create()
+    except Exception:
+        log.exception("Creating user_quota_source_usage_table table failed")
+
+    try:
+        table = Table("default_quota_association", metadata, autoload=True)
+        MigrateUniqueContraint("type", table=table).drop()
+    except Exception:
+        log.exception("Dropping unique constraint on default_quota_association.type failed")
+
+    add_index("ix_quota_quota_source_label", "quota", "quota_source_label", metadata)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        user_quota_source_usage_table.drop()
+    except Exception:
+        log.exception("Dropping user_quota_source_usage_table table failed")
+
+    drop_index("ix_quota_quota_source_label", "quota", "quota_source_label", metadata)
+    drop_column(quota_source_label_col, 'quota', metadata)

--- a/lib/galaxy/model/security.py
+++ b/lib/galaxy/model/security.py
@@ -814,16 +814,23 @@ class GalaxyRBACAgent(RBACAgent):
         # Make sure that DATASET_MANAGE_PERMISSIONS is associated with at least 1 role
         has_dataset_manage_permissions = False
         permissions = permissions or {}
-        for action, roles in permissions.items():
-            if isinstance(action, Action):
-                if action == self.permitted_actions.DATASET_MANAGE_PERMISSIONS and roles:
-                    has_dataset_manage_permissions = True
-                    break
-            elif action == self.permitted_actions.DATASET_MANAGE_PERMISSIONS.action and roles:
-                has_dataset_manage_permissions = True
-                break
+        for _ in _walk_action_roles(permissions, self.permitted_actions.DATASET_MANAGE_PERMISSIONS):
+            has_dataset_manage_permissions = True
+            break
         if not has_dataset_manage_permissions:
             return "At least 1 role must be associated with manage permissions on this dataset."
+
+        # If this is new, the objectstore likely hasn't been set yet - defer check until
+        # the job handler assigns it.
+        if not new and not dataset.sharable:
+            # ensure dataset not shared.
+            dataset_access_roles = []
+            for _, roles in _walk_action_roles(permissions, self.permitted_actions.DATASET_ACCESS):
+                dataset_access_roles.extend(roles)
+
+            if len(dataset_access_roles) != 1 or dataset_access_roles[0].type != self.model.Role.types.PRIVATE:
+                return galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE
+
         flush_needed = False
         # Delete all of the current permissions on the dataset
         if not new:
@@ -852,6 +859,12 @@ class GalaxyRBACAgent(RBACAgent):
         Permission looks like: { Action.action : [ Role, Role ] }
         """
         permission = permission or {}
+
+        # if modifying access - ensure it is sharable.
+        for _ in _walk_action_roles(permission, self.permitted_actions.DATASET_ACCESS):
+            dataset.ensure_sharable()
+            break
+
         flush_needed = False
         for action, roles in permission.items():
             if isinstance(action, Action):
@@ -891,6 +904,7 @@ class GalaxyRBACAgent(RBACAgent):
         self.set_all_dataset_permissions(dst, self.get_permissions(src))
 
     def privately_share_dataset(self, dataset, users=None):
+        dataset.ensure_sharable()
         intersect = None
         users = users or []
         for user in users:
@@ -1064,6 +1078,19 @@ class GalaxyRBACAgent(RBACAgent):
             else:
                 return False
 
+    def dataset_is_private_to_a_user(self, dataset):
+        """
+        If the Dataset object has exactly one access role and that is
+        the current user's private role then we consider the dataset private.
+        """
+        access_roles = dataset.get_access_roles(self)
+
+        if len(access_roles) != 1:
+            return False
+        else:
+            access_role = access_roles[0]
+            return access_role.type == self.model.Role.types.PRIVATE
+
     def datasets_are_public(self, trans, datasets):
         '''
         Given a transaction object and a list of Datasets, return
@@ -1092,6 +1119,8 @@ class GalaxyRBACAgent(RBACAgent):
     def make_dataset_public(self, dataset):
         # A dataset is considered public if there are no "access" actions associated with it.  Any
         # other actions ( 'manage permissions', 'edit metadata' ) are irrelevant.
+        dataset.ensure_sharable()
+
         flush_needed = False
         for dp in dataset.actions:
             if dp.action == self.permitted_actions.DATASET_ACCESS.action:
@@ -1481,3 +1510,12 @@ class HostAgent(RBACAgent):
             hdadaa = self.model.HistoryDatasetAssociationDisplayAtAuthorization(hda=hda, user=user, site=site)
         self.sa_session.add(hdadaa)
         self.sa_session.flush()
+
+
+def _walk_action_roles(permissions, query_action):
+    for action, roles in permissions.items():
+        if isinstance(action, Action):
+            if action == query_action and roles:
+                yield action, roles
+        elif action == query_action.action and roles:
+            yield action, roles

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -17,6 +17,7 @@ import yaml
 
 from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.util import (
+    asbool,
     directory_hash_id,
     force_symlink,
     parse_xml,
@@ -30,6 +31,7 @@ from galaxy.util.path import (
 from galaxy.util.sleeper import Sleeper
 
 NO_SESSION_ERROR_MESSAGE = "Attempted to 'create' object store entity in configuration with no database session present."
+DEFAULT_PRIVATE = False
 
 log = logging.getLogger(__name__)
 
@@ -90,6 +92,9 @@ class ObjectStore(metaclass=abc.ABCMeta):
 
         This method will create a proper directory structure for
         the file if the directory does not already exist.
+
+        The method returns the concrete objectstore the supplied object is stored
+        in.
         """
         raise NotImplementedError()
 
@@ -199,6 +204,19 @@ class ObjectStore(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
+    def is_private(self, obj):
+        """Return True iff supplied object is stored in private ConcreteObjectStore."""
+
+    def object_store_ids(self, private=None):
+        """Return IDs of all concrete object stores - either private ones or non-private ones.
+
+        This should just return an empty list for non-DistributedObjectStore object stores,
+        i.e. concrete objectstores and the HierarchicalObjectStore since these do not
+        use the object_store_id column for objects (Galaxy Datasets).
+        """
+        return []
+
+    @abc.abstractmethod
     def get_store_usage_percent(self):
         """Return the percentage indicating how full the store is."""
         raise NotImplementedError()
@@ -269,10 +287,11 @@ class BaseObjectStore(ObjectStore):
         extra_dirs = []
         for extra_dir_type, extra_dir_path in self.extra_dirs.items():
             extra_dirs.append({"type": extra_dir_type, "path": extra_dir_path})
+        store_type = self.store_type
         return {
             'config': config_to_dict(self.config),
             'extra_dirs': extra_dirs,
-            'type': self.store_type,
+            'type': store_type,
         }
 
     def _get_object_id(self, obj):
@@ -329,6 +348,16 @@ class BaseObjectStore(ObjectStore):
     def get_store_by(self, obj, **kwargs):
         return self._invoke('get_store_by', obj, **kwargs)
 
+    def is_private(self, obj):
+        return self._invoke('is_private', obj)
+
+    @classmethod
+    def parse_private_from_config_xml(clazz, config_xml):
+        private = DEFAULT_PRIVATE
+        if config_xml is not None:
+            private = asbool(config_xml.attrib.get('private', DEFAULT_PRIVATE))
+        return private
+
 
 class ConcreteObjectStore(BaseObjectStore):
     """Subclass of ObjectStore for stores that don't delegate (non-nested).
@@ -356,9 +385,12 @@ class ConcreteObjectStore(BaseObjectStore):
         self.store_by = config_dict.get("store_by", None) or getattr(config, "object_store_store_by", "id")
         self.name = config_dict.get("name", None)
         self.description = config_dict.get("description", None)
+        # Annotate this as true to prevent sharing of data.
+        self.private = config_dict.get("private", DEFAULT_PRIVATE)
 
     def to_dict(self):
         rval = super().to_dict()
+        rval['private'] = self.private
         rval["store_by"] = self.store_by
         rval["name"] = self.name
         rval["description"] = self.description
@@ -373,6 +405,9 @@ class ConcreteObjectStore(BaseObjectStore):
     def _get_store_by(self, obj):
         return self.store_by
 
+    def _is_private(self, obj):
+        return self.private
+
 
 class DiskObjectStore(ConcreteObjectStore):
     """
@@ -385,7 +420,7 @@ class DiskObjectStore(ConcreteObjectStore):
     >>> file_path=tempfile.mkdtemp()
     >>> obj = Bunch(id=1)
     >>> s = DiskObjectStore(Bunch(umask=0o077, jobs_directory=file_path, new_file_path=file_path, object_store_check_old_style=False), dict(files_dir=file_path))
-    >>> s.create(obj)
+    >>> o = s.create(obj)
     >>> s.exists(obj)
     True
     >>> assert s.get_filename(obj) == file_path + '/000/dataset_1.dat'
@@ -431,6 +466,7 @@ class DiskObjectStore(ConcreteObjectStore):
                     extra_dirs.append({"type": e.get('type'), "path": e.get('path')})
 
         config_dict["extra_dirs"] = extra_dirs
+        config_dict["private"] = BaseObjectStore.parse_private_from_config_xml(config_xml)
         return config_dict
 
     def to_dict(self):
@@ -542,6 +578,7 @@ class DiskObjectStore(ConcreteObjectStore):
             if not dir_only:
                 open(path, 'w').close()  # Should be rb?
                 umask_fix_perms(path, self.config.umask, 0o666)
+        return self
 
     def _empty(self, obj, **kwargs):
         """Override `ObjectStore`'s stub by checking file size on disk."""
@@ -672,7 +709,8 @@ class NestedObjectStore(BaseObjectStore):
 
     def _create(self, obj, **kwargs):
         """Create a backing file in a random backend."""
-        random.choice(list(self.backends.values())).create(obj, **kwargs)
+        objectstore = random.choice(list(self.backends.values()))
+        return objectstore.create(obj, **kwargs)
 
     def _empty(self, obj, **kwargs):
         """For the first backend that has this `obj`, determine if it is empty."""
@@ -710,6 +748,9 @@ class NestedObjectStore(BaseObjectStore):
 
     def _get_concrete_store_description_markdown(self, obj):
         return self._call_method('_get_concrete_store_description_markdown', obj, None, False)
+
+    def _is_private(self, obj):
+        return self._call_method('_is_private', obj, ObjectNotFound, True)
 
     def _get_store_by(self, obj):
         return self._call_method('_get_store_by', obj, None, False)
@@ -879,20 +920,24 @@ class DistributedObjectStore(NestedObjectStore):
 
     def _create(self, obj, **kwargs):
         """The only method in which obj.object_store_id may be None."""
-        if obj.object_store_id is None or not self._exists(obj, **kwargs):
-            if obj.object_store_id is None or obj.object_store_id not in self.backends:
+        object_store_id = obj.object_store_id
+        if object_store_id is None or not self._exists(obj, **kwargs):
+            if object_store_id is None or object_store_id not in self.backends:
                 try:
-                    obj.object_store_id = random.choice(self.weighted_backend_ids)
+                    object_store_id = random.choice(self.weighted_backend_ids)
+                    obj.object_store_id = object_store_id
                 except IndexError:
                     raise ObjectInvalid('objectstore.create, could not generate '
-                                        'obj.object_store_id: %s, kwargs: %s'
+                                        'object_store_id: %s, kwargs: %s'
                                         % (str(obj), str(kwargs)))
                 log.debug("Selected backend '%s' for creation of %s %s"
-                          % (obj.object_store_id, obj.__class__.__name__, obj.id))
+                          % (object_store_id, obj.__class__.__name__, obj.id))
             else:
                 log.debug("Using preferred backend '%s' for creation of %s %s"
-                          % (obj.object_store_id, obj.__class__.__name__, obj.id))
-            self.backends[obj.object_store_id].create(obj, **kwargs)
+                          % (object_store_id, obj.__class__.__name__, obj.id))
+            return self.backends[object_store_id].create(obj, **kwargs)
+        else:
+            return self.backends[object_store_id]
 
     def _call_method(self, method, obj, default, default_is_exception, **kwargs):
         object_store_id = self.__get_store_id_for(obj, **kwargs)
@@ -922,6 +967,14 @@ class DistributedObjectStore(NestedObjectStore):
                 return id
         return None
 
+    def object_store_ids(self, private=None):
+        object_store_ids = []
+        for backend_id, backend in self.backends.items():
+            object_store_ids.extend(backend.object_store_ids(private=private))
+            if backend.private is private or private is None:
+                object_store_ids.append(backend_id)
+        return object_store_ids
+
 
 class HierarchicalObjectStore(NestedObjectStore):
 
@@ -938,22 +991,31 @@ class HierarchicalObjectStore(NestedObjectStore):
         super().__init__(config, config_dict)
 
         backends = {}
+        is_private = config_dict.get("private", DEFAULT_PRIVATE)
         for order, backend_def in enumerate(config_dict["backends"]):
+            backend_is_private = backend_def.get("private")
+            if backend_is_private is not None:
+                assert is_private == backend_is_private, "The private attribute must be defined on the HierarchicalObjectStore and not contained concrete objectstores."
             backends[order] = build_object_store_from_config(config, config_dict=backend_def, fsmon=fsmon)
 
         self.backends = backends
+        self.private = is_private
 
     @classmethod
     def parse_xml(clazz, config_xml):
         backends_list = []
+        is_private = BaseObjectStore.parse_private_from_config_xml(config_xml)
         for b in sorted(config_xml.find('backends'), key=lambda b: int(b.get('order'))):
             store_type = b.get("type")
             objectstore_class, _ = type_to_object_store_class(store_type)
             backend_config_dict = objectstore_class.parse_xml(b)
+            backend_config_dict["private"] = is_private
             backend_config_dict["type"] = store_type
             backends_list.append(backend_config_dict)
 
-        return {"backends": backends_list}
+        config_dict = {"backends": backends_list}
+        config_dict["private"] = is_private
+        return config_dict
 
     def to_dict(self):
         as_dict = super().to_dict()
@@ -962,6 +1024,7 @@ class HierarchicalObjectStore(NestedObjectStore):
             backend_as_dict = backend.to_dict()
             backends.append(backend_as_dict)
         as_dict["backends"] = backends
+        as_dict["private"] = self.private
         return as_dict
 
     def _exists(self, obj, **kwargs):
@@ -973,7 +1036,13 @@ class HierarchicalObjectStore(NestedObjectStore):
 
     def _create(self, obj, **kwargs):
         """Call the primary object store."""
-        self.backends[0].create(obj, **kwargs)
+        return self.backends[0].create(obj, **kwargs)
+
+    def _is_private(self, obj):
+        # Unlink the DistributedObjectStore - the HierarchicalObjectStore does not use
+        # object_store_id - so all the contained object stores need to define is_private
+        # the same way.
+        return self.private
 
 
 def type_to_object_store_class(store, fsmon=False):
@@ -1127,13 +1196,16 @@ class ObjectStorePopulator:
         self.object_store_id = None
         self.user = user
 
-    def set_object_store_id(self, data):
+    def set_object_store_id(self, data, require_sharable=False):
         # Create an empty file immediately.  The first dataset will be
         # created in the "default" store, all others will be created in
         # the same store as the first.
         data.dataset.object_store_id = self.object_store_id
         try:
-            self.object_store.create(data.dataset)
+            ensure_non_private = require_sharable
+            concrete_store = self.object_store.create(data.dataset, ensure_non_private=ensure_non_private)
+            if concrete_store.private and require_sharable:
+                raise Exception("Attempted to create shared output datasets in objectstore with sharing disabled")
         except ObjectInvalid:
             raise Exception('Unable to create output dataset: object store is full')
         self.object_store_id = data.dataset.object_store_id  # these will be the same thing after the first output

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -12,6 +12,7 @@ import random
 import shutil
 import threading
 import time
+from typing import NamedTuple
 
 import yaml
 
@@ -32,6 +33,8 @@ from galaxy.util.sleeper import Sleeper
 
 NO_SESSION_ERROR_MESSAGE = "Attempted to 'create' object store entity in configuration with no database session present."
 DEFAULT_PRIVATE = False
+DEFAULT_QUOTA_SOURCE = None  # Just track quota right on user object in Galaxy.
+DEFAULT_QUOTA_ENABLED = True  # enable quota tracking in object stores by default
 
 log = logging.getLogger(__name__)
 
@@ -229,6 +232,10 @@ class ObjectStore(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def get_quota_source_map(self):
+        """Return QuotaSourceMap describing mapping of object store IDs to quota sources."""
+
 
 class BaseObjectStore(ObjectStore):
 
@@ -362,8 +369,9 @@ class BaseObjectStore(ObjectStore):
 class ConcreteObjectStore(BaseObjectStore):
     """Subclass of ObjectStore for stores that don't delegate (non-nested).
 
-    Currently only adds store_by functionality. Which doesn't make
-    sense for the delegating object stores.
+    Adds store_by and quota_source functionality. These attributes do not make
+    sense for the delegating object stores, they should describe files at actually
+    persisted, not how a file is routed to a persistence source.
     """
 
     def __init__(self, config, config_dict=None, **kwargs):
@@ -387,6 +395,11 @@ class ConcreteObjectStore(BaseObjectStore):
         self.description = config_dict.get("description", None)
         # Annotate this as true to prevent sharing of data.
         self.private = config_dict.get("private", DEFAULT_PRIVATE)
+        # short label describing the quota source or null to use default
+        # quota source right on user object.
+        quota_config = config_dict.get("quota", {})
+        self.quota_source = quota_config.get('source', DEFAULT_QUOTA_SOURCE)
+        self.quota_enabled = quota_config.get('enabled', DEFAULT_QUOTA_ENABLED)
 
     def to_dict(self):
         rval = super().to_dict()
@@ -394,6 +407,10 @@ class ConcreteObjectStore(BaseObjectStore):
         rval["store_by"] = self.store_by
         rval["name"] = self.name
         rval["description"] = self.description
+        rval["quota"] = {
+            "source": self.quota_source,
+            "enabled": self.quota_enabled,
+        }
         return rval
 
     def _get_concrete_store_name(self, obj):
@@ -407,6 +424,13 @@ class ConcreteObjectStore(BaseObjectStore):
 
     def _is_private(self, obj):
         return self.private
+
+    def get_quota_source_map(self):
+        quota_source_map = QuotaSourceMap(
+            self.quota_source,
+            self.quota_enabled,
+        )
+        return quota_source_map
 
 
 class DiskObjectStore(ConcreteObjectStore):
@@ -458,7 +482,12 @@ class DiskObjectStore(ConcreteObjectStore):
             if name is not None:
                 config_dict['name'] = name
             for e in config_xml:
-                if e.tag == 'files_dir':
+                if e.tag == 'quota':
+                    config_dict['quota'] = {
+                        'source': e.get('source', DEFAULT_QUOTA_SOURCE),
+                        'enabled': asbool(e.get('enabled', DEFAULT_QUOTA_ENABLED)),
+                    }
+                elif e.tag == 'files_dir':
                     config_dict["files_dir"] = e.get('path')
                 elif e.tag == 'description':
                     config_dict["description"] = e.text
@@ -803,6 +832,7 @@ class DistributedObjectStore(NestedObjectStore):
             removing backends when they get too full.
         """
         super().__init__(config, config_dict)
+        self._quota_source_map = None
 
         self.backends = {}
         self.weighted_backend_ids = []
@@ -949,6 +979,21 @@ class DistributedObjectStore(NestedObjectStore):
         else:
             return default
 
+    def get_quota_source_map(self):
+        if self._quota_source_map is None:
+            quota_source_map = QuotaSourceMap()
+            self._merge_quota_source_map(quota_source_map, self)
+            self._quota_source_map = quota_source_map
+        return self._quota_source_map
+
+    @classmethod
+    def _merge_quota_source_map(clz, quota_source_map, object_store):
+        for backend_id, backend in object_store.backends.items():
+            if isinstance(backend, DistributedObjectStore):
+                clz._merge_quota_source_map(quota_source_map, backend)
+            else:
+                quota_source_map.backends[backend_id] = backend.get_quota_source_map()
+
     def __get_store_id_for(self, obj, **kwargs):
         if obj.object_store_id is not None:
             if obj.object_store_id in self.backends:
@@ -977,7 +1022,6 @@ class DistributedObjectStore(NestedObjectStore):
 
 
 class HierarchicalObjectStore(NestedObjectStore):
-
     """
     ObjectStore that defers to a list of backends.
 
@@ -996,10 +1040,20 @@ class HierarchicalObjectStore(NestedObjectStore):
             backend_is_private = backend_def.get("private")
             if backend_is_private is not None:
                 assert is_private == backend_is_private, "The private attribute must be defined on the HierarchicalObjectStore and not contained concrete objectstores."
+            backend_quota = backend_def.get("quota")
+            if backend_quota is not None:
+                # Make sure just was using defaults - because cannot override what is
+                # is setup by the HierarchicalObjectStore.
+                assert backend_quota.get("source", DEFAULT_QUOTA_SOURCE) == DEFAULT_QUOTA_SOURCE
+                assert backend_quota.get("enabled", DEFAULT_QUOTA_ENABLED) == DEFAULT_QUOTA_ENABLED
+
             backends[order] = build_object_store_from_config(config, config_dict=backend_def, fsmon=fsmon)
 
         self.backends = backends
         self.private = is_private
+        quota_config = config_dict.get("quota", {})
+        self.quota_source = quota_config.get('source', DEFAULT_QUOTA_SOURCE)
+        self.quota_enabled = quota_config.get('enabled', DEFAULT_QUOTA_ENABLED)
 
     @classmethod
     def parse_xml(clazz, config_xml):
@@ -1043,6 +1097,13 @@ class HierarchicalObjectStore(NestedObjectStore):
         # object_store_id - so all the contained object stores need to define is_private
         # the same way.
         return self.private
+
+    def get_quota_source_map(self):
+        quota_source_map = QuotaSourceMap(
+            self.quota_source,
+            self.quota_enabled,
+        )
+        return quota_source_map
 
 
 def type_to_object_store_class(store, fsmon=False):
@@ -1184,6 +1245,67 @@ def config_to_dict(config):
         'object_store_cache_path': config.object_store_cache_path,
         'gid': config.gid,
     }
+
+
+class QuotaSourceInfo(NamedTuple):
+    label: str
+    use: bool
+
+
+class QuotaSourceMap:
+
+    def __init__(self, source=DEFAULT_QUOTA_SOURCE, enabled=DEFAULT_QUOTA_ENABLED):
+        self.default_quota_source = source
+        self.default_quota_enabled = enabled
+        self.info = QuotaSourceInfo(self.default_quota_source, self.default_quota_enabled)
+        self.backends = {}
+        self._labels = None
+
+    def get_quota_source_info(self, object_store_id):
+        if object_store_id in self.backends:
+            return self.backends[object_store_id].get_quota_source_info(object_store_id)
+        else:
+            return self.info
+
+    def get_quota_source_label(self, object_store_id):
+        if object_store_id in self.backends:
+            return self.backends[object_store_id].get_quota_source_label(object_store_id)
+        else:
+            return self.default_quota_source
+
+    def get_quota_source_labels(self):
+        if self._labels is None:
+            labels = set()
+            if self.default_quota_source:
+                labels.add(self.default_quota_source)
+            for backend in self.backends.values():
+                labels = labels.union(backend.get_quota_source_labels())
+            self._labels = labels
+        return self._labels
+
+    def default_usage_excluded_ids(self):
+        exclude_object_store_ids = []
+        for backend_id, backend_source_map in self.backends.items():
+            if backend_source_map.default_quota_source is not None:
+                exclude_object_store_ids.append(backend_id)
+            elif not backend_source_map.default_quota_enabled:
+                exclude_object_store_ids.append(backend_id)
+        return exclude_object_store_ids
+
+    def get_id_to_source_pairs(self):
+        pairs = []
+        for backend_id, backend_source_map in self.backends.items():
+            if backend_source_map.default_quota_source is not None and backend_source_map.default_quota_enabled:
+                pairs.append((backend_id, backend_source_map.default_quota_source))
+        return pairs
+
+    def ids_per_quota_source(self):
+        quota_sources = {}
+        for (object_id, quota_source_label) in self.get_id_to_source_pairs():
+            if quota_source_label not in quota_sources:
+                quota_sources[quota_source_label] = []
+            quota_sources[quota_source_label].append(object_id)
+        return quota_sources
 
 
 class ObjectStorePopulator:

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -74,6 +74,7 @@ def parse_config_xml(config_xml):
                 'path': staging_path,
             },
             'extra_dirs': extra_dirs,
+            'private': ConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -571,6 +571,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
                 open(os.path.join(self.staging_path, rel_path), 'w').close()
                 self._push_to_os(rel_path, from_string='')
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -98,6 +98,7 @@ def parse_config_xml(config_xml):
                 'path': staging_path,
             },
             'extra_dirs': extra_dirs,
+            'private': DiskObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.
@@ -500,6 +501,7 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
                 open(os.path.join(self.staging_path, rel_path), 'w').close()
                 self._push_to_irods(rel_path, from_string='')
         log.debug("irods_pt _create: %s", ipt_timer)
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/objectstore/pithos.py
+++ b/lib/galaxy/objectstore/pithos.py
@@ -66,6 +66,7 @@ def parse_config_xml(config_xml):
             raise Exception(msg)
         r['extra_dirs'] = [
             {k: e.get(k) for k in attrs} for e in extra_dirs]
+        r['private'] = ConcreteObjectStore.parse_private_from_config_xml(config_xml)
         if 'job_work' not in (d['type'] for d in r['extra_dirs']):
             msg = f'No value for {tag}:type="job_work" in XML tree'
             log.error(msg)
@@ -285,6 +286,7 @@ class PithosObjectStore(ConcreteObjectStore):
                 new_file = os.path.join(self.staging_path, rel_path)
                 open(new_file, 'w').close()
                 self.pithos.upload_from_string(rel_path, '')
+        return self
 
     def _empty(self, obj, **kwargs):
         """

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -96,6 +96,7 @@ def parse_config_xml(config_xml):
                 'path': staging_path,
             },
             'extra_dirs': extra_dirs,
+            'private': ConcreteObjectStore.parse_private_from_config_xml(config_xml),
         }
     except Exception:
         # Toss it back up after logging, we can't continue loading at this point.
@@ -575,6 +576,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
                 rel_path = os.path.join(rel_path, alt_name if alt_name else f"dataset_{self._get_object_id(obj)}.dat")
                 open(os.path.join(self.staging_path, rel_path), 'w').close()
                 self._push_to_os(rel_path, from_string='')
+        return self
 
     def _empty(self, obj, **kwargs):
         if self._exists(obj, **kwargs):

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -23,12 +23,12 @@ class QuotaAgent():  # metaclass=abc.ABCMeta
     """
 
     # TODO: make abstractmethod after they work better with mypy
-    def get_quota(self, user):
+    def get_quota(self, user, quota_source_label=None):
         """Return quota in bytes or None if no quota is set."""
 
-    def get_quota_nice_size(self, user):
+    def get_quota_nice_size(self, user, quota_source_label=None):
         """Return quota as a human-readable string or 'unlimited' if no quota is set."""
-        quota_bytes = self.get_quota(user)
+        quota_bytes = self.get_quota(user, quota_source_label=quota_source_label)
         if quota_bytes is not None:
             quota_str = galaxy.util.nice_size(quota_bytes)
         else:
@@ -36,10 +36,10 @@ class QuotaAgent():  # metaclass=abc.ABCMeta
         return quota_str
 
     # TODO: make abstractmethod after they work better with mypy
-    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
+    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False, quota_source_label=None):
         """Return the percentage of any storage quota applicable to the user/transaction."""
 
-    def get_usage(self, trans=None, user=False, history=False):
+    def get_usage(self, trans=None, user=False, history=False, quota_source_label=None):
         if trans:
             user = trans.user
             history = trans.history
@@ -66,14 +66,14 @@ class NoQuotaAgent(QuotaAgent):
     def __init__(self):
         pass
 
-    def get_quota(self, user):
+    def get_quota(self, user, quota_source_label=None):
         return None
 
     @property
     def default_quota(self):
         return None
 
-    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
+    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False, quota_source_label=None):
         return None
 
     def is_over_quota(self, app, job, job_destination):
@@ -87,7 +87,7 @@ class DatabaseQuotaAgent(QuotaAgent):
         self.model = model
         self.sa_session = model.context
 
-    def get_quota(self, user):
+    def get_quota(self, user, quota_source_label=None):
         """
         Calculated like so:
 
@@ -100,7 +100,7 @@ class DatabaseQuotaAgent(QuotaAgent):
                quotas.
         """
         if not user:
-            return self._default_unregistered_quota
+            return self._default_unregistered_quota(quota_source_label)
         query = text("""
 SELECT (
         COALESCE(MAX(CASE WHEN union_quota.operation = '='
@@ -110,8 +110,9 @@ SELECT (
                  (SELECT default_quota.bytes
                   FROM quota as default_quota
                       LEFT JOIN default_quota_association on default_quota.id = default_quota_association.quota_id
-                      WHERE default_quota_association.type == 'registered'
-                          AND default_quota.deleted != :is_true))
+                      WHERE default_quota_association.type = 'registered'
+                          AND default_quota.deleted != :is_true
+                          AND default_quota.quota_source_label {label_cond}))
         +
         (CASE WHEN SUM(CASE WHEN union_quota.operation = '=' AND union_quota.bytes = -1
                             THEN 1 ELSE 0
@@ -128,41 +129,53 @@ SELECT (
        )
 FROM (
     SELECT user_quota.operation as operation, user_quota.bytes as bytes
-    FROM galaxy_user as user
-        LEFT JOIN user_quota_association as uqa on user.id = uqa.user_id
+    FROM galaxy_user as guser
+        LEFT JOIN user_quota_association as uqa on guser.id = uqa.user_id
         LEFT JOIN quota as user_quota on user_quota.id = uqa.quota_id
     WHERE user_quota.deleted != :is_true
-        AND user.id = :user_id
+        AND user_quota.quota_source_label {label_cond}
+        AND guser.id = :user_id
     UNION ALL
     SELECT group_quota.operation as operation, group_quota.bytes as bytes
-    FROM galaxy_user as user
-        LEFT JOIN user_group_association as uga on user.id = uga.user_id
+    FROM galaxy_user as guser
+        LEFT JOIN user_group_association as uga on guser.id = uga.user_id
         LEFT JOIN galaxy_group on galaxy_group.id = uga.group_id
         LEFT JOIN group_quota_association as gqa on galaxy_group.id = gqa.group_id
         LEFT JOIN quota as group_quota on group_quota.id = gqa.quota_id
     WHERE group_quota.deleted != :is_true
-        AND user.id = :user_id
+        AND group_quota.quota_source_label {label_cond}
+        AND guser.id = :user_id
 ) as union_quota
-""")
+""".format(label_cond="IS NULL" if quota_source_label is None else " = :label"))
         conn = self.sa_session.connection()
         with conn.begin():
-            res = conn.execute(query, is_true=True, user_id=user.id).fetchone()
+            res = conn.execute(query, is_true=True, user_id=user.id, label=quota_source_label).fetchone()
+            if res:
+                return int(res[0]) if res[0] else None
+            else:
+                return None
+
+    def _default_unregistered_quota(self, quota_source_label):
+        return self._default_quota(self.model.DefaultQuotaAssociation.types.UNREGISTERED, quota_source_label)
+
+    def _default_quota(self, default_type, quota_source_label):
+        label_condition = "IS NULL" if quota_source_label is None else "= :label"
+        query = text("""
+SELECT bytes
+FROM quota as default_quota
+LEFT JOIN default_quota_association on default_quota.id = default_quota_association.quota_id
+WHERE default_quota_association.type = :default_type
+    AND default_quota.deleted != :is_true
+    AND default_quota.quota_source_label {label_condition}
+""".format(label_condition=label_condition))
+
+        conn = self.sa_session.connection()
+        with conn.begin():
+            res = conn.execute(query, is_true=True, label=quota_source_label, default_type=default_type).fetchone()
             if res:
                 return res[0]
             else:
                 return None
-
-    @property
-    def _default_unregistered_quota(self):
-        return self._default_quota(self.model.DefaultQuotaAssociation.types.UNREGISTERED)
-
-    def _default_quota(self, default_type):
-        dqa = self.sa_session.query(self.model.DefaultQuotaAssociation).filter(self.model.DefaultQuotaAssociation.table.c.type == default_type).first()
-        if not dqa:
-            return None
-        if dqa.quota.bytes < 0:
-            return None
-        return dqa.quota.bytes
 
     def set_default_quota(self, default_type, quota):
         # Unset the current default(s) associated with this quota, if there are any
@@ -174,16 +187,21 @@ FROM (
         for gqa in quota.groups:
             self.sa_session.delete(gqa)
         # Find the old default, assign the new quota if it exists
-        dqa = self.sa_session.query(self.model.DefaultQuotaAssociation).filter(self.model.DefaultQuotaAssociation.table.c.type == default_type).first()
-        if dqa:
-            dqa.quota = quota
+        label = quota.quota_source_label
+        dqas = self.sa_session.query(self.model.DefaultQuotaAssociation).filter(self.model.DefaultQuotaAssociation.table.c.type == default_type).all()
+        target_default = None
+        for dqa in dqas:
+            if dqa.quota.quota_source_label == label and not dqa.quota.deleted:
+                target_default = dqa
+        if target_default:
+            target_default.quota = quota
         # Or create if necessary
         else:
-            dqa = self.model.DefaultQuotaAssociation(default_type, quota)
-        self.sa_session.add(dqa)
+            target_default = self.model.DefaultQuotaAssociation(default_type, quota)
+        self.sa_session.add(target_default)
         self.sa_session.flush()
 
-    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False):
+    def get_percent(self, trans=None, user=False, history=False, usage=False, quota=False, quota_source_label=None):
         """
         Return the percentage of any storage quota applicable to the user/transaction.
         """
@@ -193,13 +211,13 @@ FROM (
             history = trans.history
         # if quota wasn't passed, attempt to get the quota
         if quota is False:
-            quota = self.get_quota(user)
+            quota = self.get_quota(user, quota_source_label=quota_source_label)
         # return none if no applicable quotas or quotas disabled
         if quota is None:
             return None
         # get the usage, if it wasn't passed
         if usage is False:
-            usage = self.get_usage(trans, user, history)
+            usage = self.get_usage(trans, user, history, quota_source_label=quota_source_label)
         try:
             return min((int(float(usage) / quota * 100), 100))
         except ZeroDivisionError:
@@ -229,10 +247,19 @@ FROM (
             self.sa_session.flush()
 
     def is_over_quota(self, app, job, job_destination):
-        quota = self.get_quota(job.user)
+        # Doesn't work because job.object_store_id until inside handler :_(
+        # quota_source_label = job.quota_source_label
+        if job_destination is not None:
+            object_store_id = job_destination.params.get("object_store_id", None)
+            object_store = app.object_store
+            quota_source_map = object_store.get_quota_source_map()
+            quota_source_label = quota_source_map.get_quota_source_info(object_store_id).label
+        else:
+            quota_source_label = None
+        quota = self.get_quota(job.user, quota_source_label=quota_source_label)
         if quota is not None:
             try:
-                usage = self.get_usage(user=job.user, history=job.history)
+                usage = self.get_usage(user=job.user, history=job.history, quota_source_label=quota_source_label)
                 if usage > quota:
                     return True
             except AssertionError:

--- a/lib/galaxy/quota/__init__.py
+++ b/lib/galaxy/quota/__init__.py
@@ -1,6 +1,8 @@
 """Galaxy Quotas"""
 import logging
 
+from sqlalchemy.sql import text
+
 import galaxy.util
 
 log = logging.getLogger(__name__)
@@ -98,50 +100,61 @@ class DatabaseQuotaAgent(QuotaAgent):
                quotas.
         """
         if not user:
-            return self.default_unregistered_quota
-        quotas = []
-        for group in [uga.group for uga in user.groups]:
-            for quota in [gqa.quota for gqa in group.quotas]:
-                if quota not in quotas:
-                    quotas.append(quota)
-        for quota in [uqa.quota for uqa in user.quotas]:
-            if quota not in quotas:
-                quotas.append(quota)
-        use_default = True
-        max = 0
-        adjustment = 0
-        rval = 0
-        for quota in quotas:
-            if quota.deleted:
-                continue
-            if quota.operation == '=' and quota.bytes == -1:
-                rval = None
-                break
-            elif quota.operation == '=':
-                use_default = False
-                if quota.bytes > max:
-                    max = quota.bytes
-            elif quota.operation == '+':
-                adjustment += quota.bytes
-            elif quota.operation == '-':
-                adjustment -= quota.bytes
-        if use_default:
-            max = self.default_registered_quota
-            if max is None:
-                rval = None
-        if rval is not None:
-            rval = max + adjustment
-            if rval <= 0:
-                rval = 0
-        return rval
+            return self._default_unregistered_quota
+        query = text("""
+SELECT (
+        COALESCE(MAX(CASE WHEN union_quota.operation = '='
+                          THEN union_quota.bytes
+                          ELSE NULL
+                          END),
+                 (SELECT default_quota.bytes
+                  FROM quota as default_quota
+                      LEFT JOIN default_quota_association on default_quota.id = default_quota_association.quota_id
+                      WHERE default_quota_association.type == 'registered'
+                          AND default_quota.deleted != :is_true))
+        +
+        (CASE WHEN SUM(CASE WHEN union_quota.operation = '=' AND union_quota.bytes = -1
+                            THEN 1 ELSE 0
+                            END) > 0
+              THEN NULL
+              ELSE 0 END)
+        +
+        (COALESCE(SUM(
+                CASE WHEN union_quota.operation = '+' THEN union_quota.bytes
+                     WHEN union_quota.operation = '-' THEN -1 * union_quota.bytes
+                     ELSE 0
+                     END
+              ), 0))
+       )
+FROM (
+    SELECT user_quota.operation as operation, user_quota.bytes as bytes
+    FROM galaxy_user as user
+        LEFT JOIN user_quota_association as uqa on user.id = uqa.user_id
+        LEFT JOIN quota as user_quota on user_quota.id = uqa.quota_id
+    WHERE user_quota.deleted != :is_true
+        AND user.id = :user_id
+    UNION ALL
+    SELECT group_quota.operation as operation, group_quota.bytes as bytes
+    FROM galaxy_user as user
+        LEFT JOIN user_group_association as uga on user.id = uga.user_id
+        LEFT JOIN galaxy_group on galaxy_group.id = uga.group_id
+        LEFT JOIN group_quota_association as gqa on galaxy_group.id = gqa.group_id
+        LEFT JOIN quota as group_quota on group_quota.id = gqa.quota_id
+    WHERE group_quota.deleted != :is_true
+        AND user.id = :user_id
+) as union_quota
+""")
+        conn = self.sa_session.connection()
+        with conn.begin():
+            res = conn.execute(query, is_true=True, user_id=user.id).fetchone()
+            if res:
+                return res[0]
+            else:
+                return None
 
     @property
-    def default_unregistered_quota(self):
+    def _default_unregistered_quota(self):
         return self._default_quota(self.model.DefaultQuotaAssociation.types.UNREGISTERED)
-
-    @property
-    def default_registered_quota(self):
-        return self._default_quota(self.model.DefaultQuotaAssociation.types.REGISTERED)
 
     def _default_quota(self, default_type):
         dqa = self.sa_session.query(self.model.DefaultQuotaAssociation).filter(self.model.DefaultQuotaAssociation.table.c.type == default_type).first()

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -190,7 +190,7 @@ def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
     trans.sa_session.flush()
     history.add_dataset(hda, genome_build=uploaded_dataset.dbkey, quota=False)
     permissions = trans.app.security_agent.history_get_default_permissions(history)
-    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+    trans.app.security_agent.set_all_dataset_permissions(hda.dataset, permissions, new=True, flush=False)
     trans.sa_session.flush()
     return hda
 
@@ -253,7 +253,7 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
         trans.app.security_agent.copy_dataset_permissions(library_bunch.replace_dataset.library_dataset_dataset_association.dataset, ldda.dataset)
     else:
         # Copy the current user's DefaultUserPermissions to the new LibraryDatasetDatasetAssociation.dataset
-        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user))
+        trans.app.security_agent.set_all_dataset_permissions(ldda.dataset, trans.app.security_agent.user_get_default_permissions(trans.user), new=True)
         folder.add_library_dataset(ld, genome_build=uploaded_dataset.dbkey)
         trans.sa_session.add(folder)
         trans.sa_session.flush()

--- a/lib/galaxy/web/params.py
+++ b/lib/galaxy/web/params.py
@@ -23,6 +23,7 @@ class QuotaParamParser(BaseParamParser):
                        amount=util.restore_text(params.get('amount', '').strip()),
                        operation=params.get('operation', ''),
                        default=params.get('default', ''),
+                       quota_source_label=params.get('quota_source_label', None),
                        in_users=util.listify(params.get('in_users', [])),
                        out_users=util.listify(params.get('out_users', [])),
                        in_groups=util.listify(params.get('in_groups', [])),

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -688,7 +688,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 # Increase the user's disk usage by the amount of the previous history's datasets if they didn't already
                 # own it.
                 for hda in history.datasets:
-                    user.adjust_total_disk_usage(hda.quota_amount(user))
+                    user.adjust_total_disk_usage(hda.quota_amount(user), hda.dataset.quota_source_info.label)
                 # Only set default history permissions if the history is from the previous session and anonymous
                 set_permissions = True
         elif self.galaxy_session.current_history:

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -183,6 +183,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         return {
             'object_store_id': object_store_id,
+            'sharable': dataset.sharable,
             'name': name,
             'description': description,
             'percent_used': percent_used,

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -181,12 +181,18 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
             # not implemented on nestedobjectstores yet.
             percent_used = None
 
+        quota_source = dataset.quota_source_info
+        quota_source_dict = {
+            'label': quota_source.label,
+            'use': quota_source.use,
+        }
         return {
             'object_store_id': object_store_id,
             'sharable': dataset.sharable,
             'name': name,
             'description': description,
             'percent_used': percent_used,
+            'quota_source': quota_source_dict,
         }
 
     @web.expose_api

--- a/lib/galaxy/webapps/galaxy/api/quotas.py
+++ b/lib/galaxy/webapps/galaxy/api/quotas.py
@@ -63,21 +63,15 @@ class QuotaAPIController(BaseGalaxyAPIController, AdminActions, UsesQuotaMixin, 
         return quota.to_dict(view='element', value_mapper={'id': trans.security.encode_id, 'total_disk_usage': float})
 
     @web.require_admin
-    @web.legacy_expose_api
+    @web.expose_api
     def create(self, trans, payload, **kwd):
         """
         POST /api/quotas
         Creates a new quota.
         """
-        try:
-            self.validate_in_users_and_groups(trans, payload)
-        except Exception as e:
-            raise HTTPBadRequest(detail=util.unicodify(e))
+        self.validate_in_users_and_groups(trans, payload)
         params = self.get_quota_params(payload)
-        try:
-            quota, message = self._create_quota(params)
-        except ActionInputError as e:
-            raise HTTPBadRequest(detail=util.unicodify(e))
+        quota, message = self._create_quota(params)
         item = quota.to_dict(value_mapper={'id': trans.security.encode_id})
         item['url'] = url_for('quota', id=trans.security.encode_id(quota.id))
         item['message'] = message

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -144,36 +144,59 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
         return rval
 
     @expose_api_anonymous
-    def show(self, trans: ProvidesUserContext, id, deleted='False', **kwd):
+    def show(self, trans: ProvidesUserContext, id, **kwd):
         """
         GET /api/users/{encoded_id}
         GET /api/users/deleted/{encoded_id}
         GET /api/users/current
         Displays information about a user.
         """
+        user = self._get_user_full(trans, id, **kwd)
+        if user is not None:
+            return self.user_serializer.serialize_to_view(user, view='detailed')
+        else:
+            item = self.anon_user_api_value(trans)
+            return item
+
+    def _get_user_full(self, trans, user_id, **kwd):
+        """Return referenced user or None if anonymous user is referenced."""
+        deleted = kwd.get("deleted", "False")
         deleted = util.string_as_bool(deleted)
         try:
             # user is requesting data about themselves
-            if id == "current":
+            if user_id == "current":
                 # ...and is anonymous - return usage and quota (if any)
                 if not trans.user:
-                    item = self.anon_user_api_value(trans)
-                    return item
+                    return None
 
                 # ...and is logged in - return full
                 else:
                     user = trans.user
             else:
-                user = self.get_user(trans, id, deleted=deleted)
+                user = self.get_user(trans, user_id, deleted=deleted)
             # check that the user is requesting themselves (and they aren't del'd) unless admin
             if not trans.user_is_admin:
                 assert trans.user == user
                 assert not user.deleted
+            return user
         except exceptions.ItemDeletionException:
             raise
         except Exception:
-            raise exceptions.RequestParameterInvalidException('Invalid user id specified', id=id)
-        return self.user_serializer.serialize_to_view(user, view='detailed')
+            raise exceptions.RequestParameterInvalidException('Invalid user id specified', id=user_id)
+
+    @expose_api
+    def usage(self, trans, user_id, **kwd):
+        """
+        GET /api/users/{user_id}/usage
+
+        Get user's disk usage broken down by quota source.
+        """
+        user = self._get_user_full(trans, user_id, **kwd)
+        if user:
+            rval = self.user_serializer.serialize_disk_usage(user)
+            return rval
+        else:
+            return []
 
     @expose_api
     def create(self, trans: GalaxyWebTransaction, payload: dict, **kwd):
@@ -275,7 +298,7 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
     # TODO: move to more basal, common resource than this
     def anon_user_api_value(self, trans):
         """Return data for an anonymous user, truncated to only usage and quota_percent"""
-        usage = trans.app.quota_agent.get_usage(trans)
+        usage = trans.app.quota_agent.get_usage(trans, history=trans.history)
         percent = trans.app.quota_agent.get_percent(trans=trans, usage=usage)
         return {'total_disk_usage': int(usage),
                 'nice_total_disk_usage': util.nice_size(usage),

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -459,6 +459,7 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('/api/container_resolvers/{index}/toolbox/install', action="resolve_toolbox_with_install", controller="container_resolution", conditions=dict(method=["POST"]))
     webapp.mapper.connect('/api/workflows/get_tool_predictions', action='get_tool_predictions', controller="workflows", conditions=dict(method=["POST"]))
 
+    webapp.mapper.connect('/api/users/{user_id}/usage', action='usage', controller="users", conditions=dict(method=["GET"]))
     webapp.mapper.resource_with_deleted('user', 'users', path_prefix='/api')
     webapp.mapper.resource('genome', 'genomes', path_prefix='/api')
     webapp.mapper.connect('/api/genomes/{id}/indexes', controller='genomes', action='indexes')

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -666,6 +666,9 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         if trans.request.method == 'GET':
             all_users = []
             all_groups = []
+            labels = trans.app.object_store.get_quota_source_map().get_quota_source_labels()
+            label_options = [("Default Quota", None)]
+            label_options.extend([(l, l) for l in labels])
             for user in trans.sa_session.query(trans.app.model.User) \
                                         .filter(trans.app.model.User.table.c.deleted == false()) \
                                         .order_by(trans.app.model.User.table.c.email):
@@ -677,30 +680,42 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
             default_options = [('No', 'no')]
             for type_ in trans.app.model.DefaultQuotaAssociation.types:
                 default_options.append((f"Yes, {type_}", type_))
-            return {'title': 'Create Quota',
-                    'inputs': [
-                        {
-                            'name': 'name',
-                            'label': 'Name'
-                        }, {
-                            'name': 'description',
-                            'label': 'Description'
-                        }, {
-                            'name': 'amount',
-                            'label': 'Amount',
-                            'help': 'Examples: "10000MB", "99 gb", "0.2T", "unlimited"'
-                        }, {
-                            'name': 'operation',
-                            'label': 'Assign, increase by amount, or decrease by amount?',
-                            'options': [('=', '='), ('+', '+'), ('-', '-')]
-                        }, {
-                            'name': 'default',
-                            'label': 'Is this quota a default for a class of users (if yes, what type)?',
-                            'options': default_options,
-                            'help': 'Warning: Any users or groups associated with this quota will be disassociated.'
-                        },
-                        build_select_input('in_groups', 'Groups', all_groups, []),
-                        build_select_input('in_users', 'Users', all_users, [])]}
+            rval = {
+                'title': 'Create Quota',
+                'inputs': [
+                    {
+                        'name': 'name',
+                        'label': 'Name'
+                    }, {
+                        'name': 'description',
+                        'label': 'Description'
+                    }, {
+                        'name': 'amount',
+                        'label': 'Amount',
+                        'help': 'Examples: "10000MB", "99 gb", "0.2T", "unlimited"'
+                    }, {
+                        'name': 'operation',
+                        'label': 'Assign, increase by amount, or decrease by amount?',
+                        'options': [('=', '='), ('+', '+'), ('-', '-')]
+                    }, {
+                        'name': 'default',
+                        'label': 'Is this quota a default for a class of users (if yes, what type)?',
+                        'options': default_options,
+                        'help': 'Warning: Any users or groups associated with this quota will be disassociated.'
+                    },
+                ]
+            }
+            if len(label_options) > 1:
+                rval["inputs"].append({
+                    'name'    : 'quota_source_label',
+                    'label'   : 'Apply quota to labeled object stores.',
+                    'options' : label_options,
+                })
+            rval["inputs"].extend([
+                build_select_input('in_groups', 'Groups', all_groups, []),
+                build_select_input('in_users', 'Users', all_users, []),
+            ])
+            return rval
         else:
             try:
                 quota, message = self._create_quota(util.Params(payload), decode_id=trans.security.decode_id)

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -277,7 +277,15 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             permission_disable = True
             permission_inputs = list()
             if trans.user:
-                if data.dataset.actions:
+                if not data.dataset.sharable:
+                    permission_message = 'The dataset is stored on private storage to you and cannot be shared.'
+                    permission_inputs.append({
+                        'name': 'not_sharable',
+                        'type': 'hidden',
+                        'label': permission_message,
+                        'readonly': True
+                    })
+                elif data.dataset.actions:
                     in_roles = {}
                     for action, roles in trans.app.security_agent.get_permissions(data.dataset).items():
                         in_roles[action.action] = [trans.security.encode_id(role.id) for role in roles]

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -818,7 +818,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
             hda.deleted = True
             # HDA is purgeable
             # Decrease disk usage first
-            hda.purge_usage_from_quota(user)
+            hda.purge_usage_from_quota(user, hda.dataset.quota_source_info)
             # Mark purged
             hda.purged = True
             trans.sa_session.add(hda)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1053,7 +1053,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             for hda in trans.history.datasets:
                 if not hda.deleted or hda.purged:
                     continue
-                hda.purge_usage_from_quota(trans.user)
+                hda.purge_usage_from_quota(trans.user, hda.dataset.quota_source_info)
                 hda.purged = True
                 trans.sa_session.add(hda)
                 trans.log_event(f"HDA id {hda.id} has been purged")

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -160,7 +160,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert len(namelist) == 3, f"Expected 3 elements in [{namelist}]"
 
     def test_hda_security(self):
-        element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id)
+        element_identifiers = self.dataset_collection_populator.pair_identifiers(self.history_id, wait=True)
         self.dataset_populator.make_private(self.history_id, element_identifiers[0]["id"])
         with self._different_user():
             history_id = self.dataset_populator.new_history()

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -138,7 +138,7 @@ class LibrariesApiTestCase(ApiTestCase):
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]['id']
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3")['id']
+        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3", wait=True)['id']
         with self._different_user():
             payload = {'from_hda_id': hda_id}
             create_response = self._post(f"folders/{folder_id}/contents", payload)
@@ -313,7 +313,7 @@ class LibrariesApiTestCase(ApiTestCase):
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]['id']
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3")['id']
+        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3", wait=True)['id']
         payload = {'from_hda_id': hda_id}
         create_response = self._post(f"folders/{folder_id}/contents", payload)
         self._assert_status_code_is(create_response, 200)
@@ -329,7 +329,7 @@ class LibrariesApiTestCase(ApiTestCase):
         print(subfolder_response.json())
         subfolder_id = subfolder_response.json()['id']
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3 sub")['id']
+        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3 sub", wait=True)['id']
         payload = {'from_hda_id': hda_id}
         create_response = self._post(f"folders/{subfolder_id}/contents", payload)
         self._assert_status_code_is(create_response, 200)
@@ -489,4 +489,5 @@ class LibrariesApiTestCase(ApiTestCase):
         hda_id = self.dataset_populator.new_dataset(history_id, content=content, wait=wait)['id']
         payload = {'from_hda_id': hda_id, 'create_type': 'file', 'folder_id': folder_id}
         ld = self._post(f"libraries/{folder_id}/contents", payload)
+        ld.raise_for_status()
         return ld

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -817,7 +817,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
                 else:
                     self._assert_dataset_permission_denied_response(response)
 
-        new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test')
+        new_dataset = self.dataset_populator.new_dataset(history_id, content='Cat1Test', wait=True)
         inputs = dict(
             input1=dataset_to_param(new_dataset),
         )

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -607,6 +607,11 @@ class BaseDatasetPopulator(BasePopulator):
         assert "id" in role, role
         return role["id"]
 
+    def get_usage(self):
+        usage_response = self.galaxy_interactor.get("users/current/usage")
+        usage_response.raise_for_status()
+        return usage_response.json()
+
     def create_role(self, user_ids: list, description: str = None) -> dict:
         payload = {
             "name": self.get_random_name(prefix="testpop"),

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -634,9 +634,23 @@ class BaseDatasetPopulator(BasePopulator):
             "access": [role_id],
             "manage": [role_id],
         }
+        response = self.update_permissions_raw(history_id, dataset_id, payload)
+        response.raise_for_status()
+        return response.json()
+
+    def make_public_raw(self, history_id, dataset_id):
+        role_id = self.user_private_role_id()
+        payload = {
+            "access": json.dumps([]),
+            "manage": json.dumps([role_id]),
+        }
+        response = self.update_permissions_raw(history_id, dataset_id, payload)
+        return response
+
+    def update_permissions_raw(self, history_id, dataset_id, payload):
         url = f"histories/{history_id}/contents/{dataset_id}/permissions"
         update_response = self._put(url, payload, admin=True, json=True)
-        assert update_response.status_code == 200, update_response.content
+        update_response.raise_for_status()
         return update_response.json()
 
     def validate_dataset(self, history_id, dataset_id):
@@ -1562,8 +1576,8 @@ class BaseDatasetCollectionPopulator:
         )
         return payload
 
-    def pair_identifiers(self, history_id, contents=None):
-        hda1, hda2 = self.__datasets(history_id, count=2, contents=contents)
+    def pair_identifiers(self, history_id, contents=None, wait=False):
+        hda1, hda2 = self.__datasets(history_id, count=2, contents=contents, wait=wait)
 
         element_identifiers = [
             dict(name="forward", src="hda", id=hda1["id"]),
@@ -1597,10 +1611,12 @@ class BaseDatasetCollectionPopulator:
         else:
             return self.dataset_populator.fetch(payload)
 
-    def __datasets(self, history_id, count, contents=None):
+    def __datasets(self, history_id, count, contents=None, wait=False):
         datasets = []
         for i in range(count):
-            new_kwds = {}
+            new_kwds = {
+                'wait': wait,
+            }
             if contents:
                 new_kwds["content"] = contents[i]
             datasets.append(self.dataset_populator.new_dataset(history_id, **new_kwds))

--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -10,6 +10,7 @@ import datetime
 import inspect
 import logging
 import os
+import re
 import string
 import sys
 import time
@@ -25,6 +26,7 @@ sys.path.insert(1, os.path.join(galaxy_root, 'lib'))
 
 import galaxy.config
 from galaxy.exceptions import ObjectNotFound
+from galaxy.model import calculate_user_disk_usage_statements
 from galaxy.objectstore import build_object_store_from_config
 from galaxy.util.script import (
     app_properties_from_args,
@@ -74,6 +76,7 @@ class Action:
     Generally you should set at least ``_action_sql`` in subclasses (although it's possible to just override ``sql``
     directly.)
     """
+    requires_objectstore = True
     update_time_sql = ", update_time = NOW() AT TIME ZONE 'utc'"
     force_retry_sql = " AND NOT purged"
     primary_key = None
@@ -114,6 +117,9 @@ class Action:
         self.__row_methods = []
         self.__post_methods = []
         self.__exit_methods = []
+        if self.requires_objectstore:
+            self.object_store = build_object_store_from_config(self._config)
+            self._register_exit_method(self.object_store.shutdown)
         self._init()
 
     def __enter__(self):
@@ -246,13 +252,14 @@ class Action:
 class RemovesObjects:
     """Base class for mixins that remove objects from object stores.
     """
+    requires_objectstore = True
+
     def _init(self):
+        super()._init()
         self.objects_to_remove = set()
         log.info('Initializing object store for action %s', self.name)
-        self.object_store = build_object_store_from_config(self._config)
         self._register_row_method(self.collect_removed_object_info)
         self._register_post_method(self.remove_objects)
-        self._register_exit_method(self.object_store.shutdown)
 
     def collect_removed_object_info(self, row):
         object_id = getattr(row, self.id_column, None)
@@ -353,7 +360,10 @@ class RequiresDiskUsageRecalculation:
 
     To use, ensure your query returns a ``recalculate_disk_usage_user_id`` column.
     """
+    requires_objectstore = True
+
     def _init(self):
+        super()._init()
         self.__recalculate_disk_usage_user_ids = set()
         self._register_row_method(self.collect_recalculate_disk_usage_user_id)
         self._register_post_method(self.recalculate_disk_usage)
@@ -373,30 +383,21 @@ class RequiresDiskUsageRecalculation:
         """
         log.info('Recalculating disk usage for users whose data were purged')
         for user_id in sorted(self.__recalculate_disk_usage_user_ids):
-            # TODO: h.purged = false should be unnecessary once all hdas in purged histories are purged.
-            sql = """
-                   UPDATE galaxy_user
-                      SET disk_usage = (
-                            SELECT COALESCE(SUM(total_size), 0)
-                              FROM (  SELECT d.total_size
-                                        FROM history_dataset_association hda
-                                             JOIN history h ON h.id = hda.history_id
-                                             JOIN dataset d ON hda.dataset_id = d.id
-                                       WHERE h.user_id = %(user_id)s
-                                             AND h.purged = false
-                                             AND hda.purged = false
-                                             AND d.purged = false
-                                             AND d.id NOT IN (SELECT dataset_id
-                                                                FROM library_dataset_dataset_association)
-                                    GROUP BY d.id) AS sizes)
-                    WHERE id = %(user_id)s
-                RETURNING disk_usage;
-            """
-            args = {'user_id': user_id}
-            cur = self._update(sql, args, add_event=False)
-            for row in cur:
-                # disk_usage might be None (e.g. user has purged all data)
-                self.log.info('recalculate_disk_usage user_id %i to %s bytes' % (user_id, row.disk_usage))
+            quota_source_map = self.object_store.get_quota_source_map()
+            statements = calculate_user_disk_usage_statements(
+                user_id, quota_source_map
+            )
+
+            for (sql, args) in statements:
+                sql, _ = re.subn(r"\:([\w]+)", r"%(\1)s", sql)
+                new_args = {}
+                for key, val in args.items():
+                    if isinstance(val, list):
+                        val = tuple(val)
+                    new_args[key] = val
+                self._update(sql, new_args, add_event=False)
+
+            self.log.info('recalculate_disk_usage user_id %i' % user_id)
 
 
 class RemovesMetadataFiles(RemovesObjects):

--- a/scripts/set_user_disk_usage.py
+++ b/scripts/set_user_disk_usage.py
@@ -35,18 +35,18 @@ def init():
     return galaxy.config.init_models_from_config(config, object_store=object_store), object_store, engine
 
 
-def quotacheck(sa_session, users, engine):
+def quotacheck(sa_session, users, engine, object_store):
     sa_session.refresh(user)
     current = user.get_disk_usage()
     print(user.username, '<' + user.email + '>:', end=' ')
 
     if not args.dryrun:
         # Apply new disk usage
-        user.calculate_and_set_disk_usage()
+        user.calculate_and_set_disk_usage(object_store)
         # And fetch
         new = user.get_disk_usage()
     else:
-        new = user.calculate_disk_usage()
+        new = user.calculate_disk_usage_default_source(object_store)
 
     print('old usage:', nice_size(current), 'change:', end=' ')
     if new in (current, None):
@@ -68,7 +68,7 @@ if __name__ == '__main__':
         print('Processing %i users...' % user_count)
         for i, user in enumerate(sa_session.query(model.User).enable_eagerloads(False).yield_per(1000)):
             print('%3i%%' % int(float(i) / user_count * 100), end=' ')
-            quotacheck(sa_session, user, engine)
+            quotacheck(sa_session, user, engine, object_store)
         print('100% complete')
         object_store.shutdown()
         sys.exit(0)
@@ -79,5 +79,5 @@ if __name__ == '__main__':
     if not user:
         print('User not found')
         sys.exit(1)
+    quotacheck(sa_session, user, engine, object_store)
     object_store.shutdown()
-    quotacheck(sa_session, user, engine)

--- a/test/integration/objectstore/test_private_handling.py
+++ b/test/integration/objectstore/test_private_handling.py
@@ -1,0 +1,50 @@
+"""Integration tests for mixing store_by."""
+
+import string
+
+from galaxy_test.base import api_asserts
+from ._base import BaseObjectStoreIntegrationTestCase
+
+PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE = string.Template("""<?xml version="1.0"?>
+<object_store type="disk" id="primary" private="true">
+    <files_dir path="${temp_directory}/files1"/>
+    <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+    <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+</object_store>
+""")
+
+TEST_INPUT_FILES_CONTENT = "1 2 3"
+
+
+class PrivatePreventsSharingObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = True
+        cls._configure_object_store(PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        """Test each object store configures files correctly.
+        """
+        with self.dataset_populator.test_history() as history_id:
+            hda = self.dataset_populator.new_dataset(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True)
+            content = self.dataset_populator.get_history_dataset_content(history_id, hda["id"])
+            assert content.startswith(TEST_INPUT_FILES_CONTENT)
+            response = self.dataset_populator.make_public_raw(history_id, hda["id"])
+            assert response.status_code != 200
+            api_asserts.assert_error_message_contains(response, "Attempting to share a non-sharable dataset.")
+
+
+class PrivateCannotWritePublicDataObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["new_user_dataset_access_role_default_private"] = False
+        cls._configure_object_store(PRIVATE_OBJECT_STORE_CONFIG_TEMPLATE, config)
+
+    def test_both_types(self):
+        with self.dataset_populator.test_history() as history_id:
+            response = self.dataset_populator.new_dataset_request(history_id, content=TEST_INPUT_FILES_CONTENT, wait=True, assert_ok=False)
+            job = response.json()["jobs"][0]
+            final_state = self.dataset_populator.wait_for_job(job["id"])
+            assert final_state == "error"

--- a/test/integration/objectstore/test_quota_limit.py
+++ b/test/integration/objectstore/test_quota_limit.py
@@ -1,0 +1,73 @@
+from ._base import BaseObjectStoreIntegrationTestCase
+from .test_selection import (
+    DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE,
+    JOB_CONFIG_FILE,
+    JOB_RESOURCE_PARAMETERS_CONFIG_FILE,
+)
+
+
+class QuotaIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls._configure_object_store(DISTRIBUTED_OBJECT_STORE_CONFIG_TEMPLATE, config)
+        config["job_config_file"] = JOB_CONFIG_FILE
+        config["job_resource_params_file"] = JOB_RESOURCE_PARAMETERS_CONFIG_FILE
+        config["enable_quotas"] = True
+
+    def test_selection_limit(self):
+        with self.dataset_populator.test_history() as history_id:
+
+            hda1 = self.dataset_populator.new_dataset(history_id, content="1 2 3\n4 5 6\n7 8 9\n")
+            self.dataset_populator.wait_for_history(history_id)
+            hda1_input = {"src": "hda", "id": hda1["id"]}
+
+            quotas = self.dataset_populator.get_quotas()
+            assert len(quotas) == 0
+
+            payload = {
+                'name': 'defaultquota1',
+                'description': 'first default quota',
+                'amount': '1 bytes',
+                'operation': '=',
+                'default': 'registered',
+            }
+            self.dataset_populator.create_quota(payload)
+
+            payload = {
+                'name': 'ebsquota1',
+                'description': 'first ebs quota',
+                'amount': '100 MB',
+                'operation': '=',
+                'default': 'registered',
+                'quota_source_label': 'ebs',
+            }
+            self.dataset_populator.create_quota(payload)
+
+            quotas = self.dataset_populator.get_quotas()
+            assert len(quotas) == 2
+
+            hda2 = self.dataset_populator.new_dataset(history_id, content="1 2 3\n4 5 6\n7 8 9\n")
+            self.dataset_populator.wait_for_history(history_id)
+
+            hda2_now = self.dataset_populator.get_history_dataset_details(history_id, dataset=hda2, wait=False)
+            assert hda2_now["state"] == "paused"
+
+            create_10_inputs = {
+                "input1": hda1_input,
+                "input2": hda1_input,
+                "__job_resource|__job_resource__select": "yes",
+                "__job_resource|how_store": "slow",
+            }
+            create10_response = self.dataset_populator.run_tool(
+                "create_10",
+                create_10_inputs,
+                history_id,
+                assert_ok=False,
+            )
+            job_id = create10_response.json()["jobs"][0]["id"]
+            self.dataset_populator.wait_for_job(job_id)
+            job_details = self.dataset_populator.get_job_details(job_id).json()
+            # This job isn't paused, it goes through because we used a different
+            # objectstore using job parameters.
+            assert job_details["state"] == "ok"

--- a/test/integration/test_quota.py
+++ b/test/integration/test_quota.py
@@ -30,3 +30,20 @@ class QuotaIntegrationTestCase(integration_util.IntegrationTestCase):
 
         quotas = self.dataset_populator.get_quotas()
         assert len(quotas) == 1
+
+        payload = {
+            'name': 'defaultmylabeledquota1',
+            'description': 'first default quota that is labeled',
+            'amount': '120MB',
+            'operation': '=',
+            'default': 'registered',
+            'quota_source_label': 'mylabel',
+        }
+        self.dataset_populator.create_quota(payload)
+
+        quotas = self.dataset_populator.get_quotas()
+        assert len(quotas) == 2
+
+        labels = [q["quota_source_label"] for q in quotas]
+        assert None in labels
+        assert 'mylabel' in labels

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -14,6 +14,7 @@ import galaxy.model.mapping as mapping
 from galaxy.model.database_utils import create_database
 from galaxy.model.metadata import MetadataTempFile
 from galaxy.model.security import GalaxyRBACAgent
+from galaxy.objectstore import QuotaSourceMap
 
 datatypes_registry = galaxy.datatypes.registry.Registry()
 datatypes_registry.load_datatypes()
@@ -442,7 +443,7 @@ class MappingTests(BaseModelTestCase):
 
         u = model.User(email="disk_default@test.com", password="password")
         self.persist(u)
-        u.adjust_total_disk_usage(1)
+        u.adjust_total_disk_usage(1, None)
         u_id = u.id
         self.expunge()
         user_reload = model.session.query(model.User).get(u_id)
@@ -1030,8 +1031,11 @@ class PostgresMappingTests(MappingTests):
 
 class MockObjectStore:
 
-    def __init__(self):
-        pass
+    def __init__(self, quota_source_map=None):
+        self._quota_source_map = quota_source_map or QuotaSourceMap()
+
+    def get_quota_source_map(self):
+        return self._quota_source_map
 
     def size(self, dataset):
         return 42

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -26,6 +26,7 @@ skip_if_not_postgres_base = pytest.mark.skipif(
     not os.environ.get('GALAXY_TEST_UNIT_MAPPING_URI_POSTGRES_BASE'),
     reason="GALAXY_TEST_UNIT_MAPPING_URI_POSTGRES_BASE not set"
 )
+PRIVATE_OBJECT_STORE_ID = "my_private_data"
 
 
 class BaseModelTestCase(unittest.TestCase):
@@ -207,11 +208,13 @@ class MappingTests(BaseModelTestCase):
         assert history.get_display_name() == 'Hello₩◎ґʟⅾ'
 
     def test_hda_to_library_dataset_dataset_association(self):
+        model = self.model
         u = self.model.User(email="mary@example.com", password="password")
-        hda = self.model.HistoryDatasetAssociation(name='hda_name')
+        h1 = model.History(name="History 1", user=u)
+        hda = model.HistoryDatasetAssociation(name='hda_name', create_dataset=True, history=h1, sa_session=model.session)
         self.persist(hda)
         trans = collections.namedtuple('trans', 'user')
-        target_folder = self.model.LibraryFolder(name='library_folder')
+        target_folder = model.LibraryFolder(name='library_folder')
         ldda = hda.to_library_dataset_dataset_association(
             trans=trans(user=u),
             target_folder=target_folder,
@@ -235,6 +238,21 @@ class MappingTests(BaseModelTestCase):
         assert len(new_ldda.library_dataset.expired_datasets) == 1
         assert new_ldda.library_dataset.expired_datasets[0] == ldda
         assert target_folder.item_count == 1
+
+    def test_hda_to_library_dataset_dataset_association_fails_if_private(self):
+        model = self.model
+        u = model.User(email="mary2@example.com", password="password")
+        h1 = model.History(name="History 1", user=u)
+        hda = model.HistoryDatasetAssociation(name='hda_name', create_dataset=True, history=h1, sa_session=model.session)
+        hda.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self.persist(hda)
+        trans = collections.namedtuple('trans', 'user')
+        target_folder = model.LibraryFolder(name='library_folder')
+        with pytest.raises(Exception):
+            hda.to_library_dataset_dataset_association(
+                trans=trans(user=u),
+                target_folder=target_folder,
+            )
 
     def test_tags(self):
         model = self.model
@@ -549,8 +567,8 @@ class MappingTests(BaseModelTestCase):
         self.persist(u, h1, expunge=False)
 
         d1 = self.new_hda(h1, name="1")
-        d2 = self.new_hda(h1, name="2", visible=False)
-        d3 = self.new_hda(h1, name="3", deleted=True)
+        d2 = self.new_hda(h1, name="2", visible=False, object_store_id="foobar")
+        d3 = self.new_hda(h1, name="3", deleted=True, object_store_id="three_store")
         d4 = self.new_hda(h1, name="4", visible=False, deleted=True)
 
         self.session().flush()
@@ -564,8 +582,11 @@ class MappingTests(BaseModelTestCase):
         self.assertEqual(contents_iter_names(), ["1", "2", "3", "4"])
         assert contents_iter_names(deleted=False) == ["1", "2"]
         assert contents_iter_names(visible=True) == ["1", "3"]
+        assert contents_iter_names(visible=True, object_store_ids=["three_store"]) == ["3"]
         assert contents_iter_names(visible=False) == ["2", "4"]
         assert contents_iter_names(deleted=True, visible=False) == ["4"]
+        assert contents_iter_names(deleted=False, object_store_ids=["foobar"]) == ["2"]
+        assert contents_iter_names(deleted=False, object_store_ids=["foobar2"]) == []
 
         assert contents_iter_names(ids=[d1.id, d2.id, d3.id, d4.id]) == ["1", "2", "3", "4"]
         assert contents_iter_names(ids=[d1.id, d2.id, d3.id, d4.id], max_in_filter_length=1) == ["1", "2", "3", "4"]
@@ -894,6 +915,69 @@ class MappingTests(BaseModelTestCase):
         assert security_agent.can_manage_dataset(u_from.all_roles(), d1.dataset)
         assert not security_agent.can_manage_dataset(u_other.all_roles(), d1.dataset)
 
+    def test_cannot_make_private_objectstore_dataset_public(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, _ = self._three_users("cannot_make_private_public")
+
+        h = self.model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        with pytest.raises(Exception) as exec_info:
+            self._make_owned(security_agent, u_from, d1)
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
+    def test_cannot_make_private_objectstore_dataset_shared(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, _ = self._three_users("cannot_make_private_shared")
+
+        h = self.model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        with pytest.raises(Exception) as exec_info:
+            security_agent.privately_share_dataset(d1.dataset, [u_to])
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
+    def test_cannot_set_dataset_permisson_on_private(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, _ = self._three_users("cannot_set_permissions_on_private")
+
+        h = self.model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        role = security_agent.get_private_user_role(u_to, auto_create=True)
+        access_action = security_agent.permitted_actions.DATASET_ACCESS.action
+
+        with pytest.raises(Exception) as exec_info:
+            security_agent.set_dataset_permission(d1.dataset, {access_action: [role]})
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
+    def test_cannot_make_private_dataset_public(self):
+        security_agent = GalaxyRBACAgent(self.model)
+        u_from, u_to, u_other = self._three_users("cannot_make_private_dataset_public")
+
+        h = self.model.History(name="History for Annotation", user=u_from)
+        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        self.persist(h, d1)
+
+        d1.dataset.object_store_id = PRIVATE_OBJECT_STORE_ID
+        self._make_private(security_agent, u_from, d1)
+
+        with pytest.raises(Exception) as exec_info:
+            security_agent.make_dataset_public(d1.dataset)
+        assert galaxy.model.CANNOT_SHARE_PRIVATE_DATASET_MESSAGE in str(exec_info.value)
+
     def _three_users(self, suffix):
         email_from = f"user_{suffix}e1@example.com"
         email_to = f"user_{suffix}e2@example.com"
@@ -910,16 +994,26 @@ class MappingTests(BaseModelTestCase):
         access_action = security_agent.permitted_actions.DATASET_ACCESS.action
         manage_action = security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action
         permissions = {access_action: [role], manage_action: [role]}
-        security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+        self._set_permissions(security_agent, hda.dataset, permissions)
 
     def _make_owned(self, security_agent, user, hda):
         role = security_agent.get_private_user_role(user, auto_create=True)
         manage_action = security_agent.permitted_actions.DATASET_MANAGE_PERMISSIONS.action
         permissions = {manage_action: [role]}
-        security_agent.set_all_dataset_permissions(hda.dataset, permissions)
+        self._set_permissions(security_agent, hda.dataset, permissions)
+
+    def _set_permissions(self, security_agent, dataset, permissions):
+        # TODO: refactor set_all_dataset_permissions to actually throw an exception :|
+        error = security_agent.set_all_dataset_permissions(dataset, permissions)
+        if error:
+            raise Exception(error)
 
     def new_hda(self, history, **kwds):
-        return history.add_dataset(self.model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds))
+        object_store_id = kwds.pop('object_store_id', None)
+        hda = self.model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds)
+        if object_store_id is not None:
+            hda.dataset.object_store_id = object_store_id
+        return history.add_dataset(hda)
 
 
 @skip_if_not_postgres_base
@@ -953,6 +1047,12 @@ class MockObjectStore:
 
     def update_from_file(self, *arg, **kwds):
         pass
+
+    def is_private(self, object):
+        if object.object_store_id == PRIVATE_OBJECT_STORE_ID:
+            return True
+        else:
+            return False
 
 
 def get_suite():

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -99,7 +99,8 @@ class QuotaTestCase(BaseModelTestCase):
         self.persist(quota, uqa, user)
 
     def _assert_user_quota_is(self, user, amount):
-        assert amount == self.quota_agent.get_quota(user)
+        actual_quota = self.quota_agent.get_quota(user)
+        assert amount == actual_quota, "Expected quota [%s], got [%s]" % (amount, actual_quota)
         if amount is None:
             user.total_disk_usage = 1000
             job = self.model.Job()

--- a/test/unit/data/test_quota.py
+++ b/test/unit/data/test_quota.py
@@ -1,25 +1,94 @@
+import uuid
+
+from galaxy.objectstore import QuotaSourceInfo, QuotaSourceMap
 from galaxy.quota import DatabaseQuotaAgent
-from .test_galaxy_mapping import BaseModelTestCase
+from .test_galaxy_mapping import BaseModelTestCase, MockObjectStore
+
+
+class PurgeUsageTestCase(BaseModelTestCase):
+
+    def setUp(self):
+        super().setUp()
+        model = self.model
+        u = model.User(email="purge_usage@example.com", password="password")
+        u.disk_usage = 25
+        self.persist(u)
+
+        h = model.History(name="History for Purging", user=u)
+        self.persist(h)
+        self.u = u
+        self.h = h
+
+    def _setup_dataset(self):
+        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=self.h, create_dataset=True, sa_session=self.model.session)
+        d1.dataset.total_size = 10
+        self.persist(d1)
+        return d1
+
+    def test_calculate_usage(self):
+        d1 = self._setup_dataset()
+        quota_source_info = QuotaSourceInfo(None, True)
+        d1.purge_usage_from_quota(self.u, quota_source_info)
+        self.persist(self.u)
+        assert int(self.u.disk_usage) == 15
+
+    def test_calculate_usage_untracked(self):
+        # test quota tracking off on the objectstore
+        d1 = self._setup_dataset()
+        quota_source_info = QuotaSourceInfo(None, False)
+        d1.purge_usage_from_quota(self.u, quota_source_info)
+        self.persist(self.u)
+        assert int(self.u.disk_usage) == 25
+
+    def test_calculate_usage_per_source(self):
+        self.u.adjust_total_disk_usage(124, "myquotalabel")
+
+        # test quota tracking with a non-default quota label
+        d1 = self._setup_dataset()
+        quota_source_info = QuotaSourceInfo("myquotalabel", True)
+        d1.purge_usage_from_quota(self.u, quota_source_info)
+        self.persist(self.u)
+        assert int(self.u.disk_usage) == 25
+
+        usages = self.u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[1]["quota_source_label"] == "myquotalabel"
+        assert usages[1]["total_disk_usage"] == 114
 
 
 class CalculateUsageTestCase(BaseModelTestCase):
 
+    def setUp(self):
+        model = self.model
+        u = model.User(email="calc_usage%s@example.com" % str(uuid.uuid1()), password="password")
+        self.persist(u)
+        h = model.History(name="History for Calculated Usage", user=u)
+        self.persist(h)
+        self.u = u
+        self.h = h
+
+    def _add_dataset(self, total_size, object_store_id=None):
+        model = self.model
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=self.h, create_dataset=True, sa_session=self.model.session)
+        d1.dataset.total_size = total_size
+        d1.dataset.object_store_id = object_store_id
+        self.persist(d1)
+        return d1
+
     def test_calculate_usage(self):
         model = self.model
-        u = model.User(email="calc_usage@example.com", password="password")
-        self.persist(u)
+        u = self.u
+        h = self.h
 
-        h = model.History(name="History for Usage", user=u)
-        self.persist(h)
+        d1 = self._add_dataset(10)
 
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=model.session)
-        d1.dataset.total_size = 10
-        self.persist(d1)
-
-        assert u.calculate_disk_usage() == 10
+        object_store = MockObjectStore()
+        assert u.calculate_disk_usage_default_source(object_store) == 10
         assert u.disk_usage is None
-        u.calculate_and_set_disk_usage()
-        assert u.disk_usage == 10
+        u.calculate_and_set_disk_usage(object_store)
+        assert u.calculate_disk_usage_default_source(object_store) == 10
+        # method no longer updates user object
+        # assert u.disk_usage == 10
 
         # Test dataset being in another history doesn't duplicate usage cost.
         h2 = model.History(name="Second usage history", user=u)
@@ -31,7 +100,126 @@ class CalculateUsageTestCase(BaseModelTestCase):
         d3 = model.HistoryDatasetAssociation(extension="txt", history=h, dataset=d1.dataset)
         self.persist(d3)
 
-        assert u.calculate_disk_usage() == 10
+        assert u.calculate_disk_usage_default_source(object_store) == 10
+
+    def test_calculate_usage_disabled_quota(self):
+        u = self.u
+
+        self._add_dataset(10, "not_tracked")
+        self._add_dataset(15, "tracked")
+
+        quota_source_map = QuotaSourceMap()
+        not_tracked = QuotaSourceMap()
+        not_tracked.default_quota_enabled = False
+        quota_source_map.backends["not_tracked"] = not_tracked
+
+        object_store = MockObjectStore(quota_source_map)
+
+        assert u.calculate_disk_usage_default_source(object_store) == 15
+
+    def test_calculate_usage_alt_quota(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap()
+        alt_source = QuotaSourceMap()
+        alt_source.default_quota_source = "alt_source"
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        object_store = MockObjectStore(quota_source_map)
+
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage(object_store)
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 10
+
+        assert usages[1]["quota_source_label"] == "alt_source"
+        assert usages[1]["total_disk_usage"] == 15
+
+    def test_calculate_usage_removes_unused_quota_labels(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap()
+        alt_source = QuotaSourceMap()
+        alt_source.default_quota_source = "alt_source"
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        object_store = MockObjectStore(quota_source_map)
+
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 10
+
+        assert usages[1]["quota_source_label"] == "alt_source"
+        assert usages[1]["total_disk_usage"] == 15
+
+        alt_source.default_quota_source = "new_alt_source"
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 10
+
+        assert usages[1]["quota_source_label"] == "new_alt_source"
+        assert usages[1]["total_disk_usage"] == 15
+
+    def test_dictify_usage_unused_quota_labels(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap()
+        alt_source = QuotaSourceMap()
+        alt_source.default_quota_source = "alt_source"
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        unused_source = QuotaSourceMap()
+        unused_source.default_quota_source = "unused_source"
+        quota_source_map.backends["unused_source_store"] = unused_source
+
+        object_store = MockObjectStore(quota_source_map)
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage(object_store)
+        assert len(usages) == 3
+
+    def test_calculate_usage_default_storage_disabled(self):
+        model = self.model
+        u = self.u
+
+        self._add_dataset(10)
+        self._add_dataset(15, "alt_source_store")
+
+        quota_source_map = QuotaSourceMap(None, False)
+        alt_source = QuotaSourceMap("alt_source", True)
+        quota_source_map.backends["alt_source_store"] = alt_source
+
+        object_store = MockObjectStore(quota_source_map)
+
+        u.calculate_and_set_disk_usage(object_store)
+        model.context.refresh(u)
+        usages = u.dictify_usage(object_store)
+        assert len(usages) == 2
+        assert usages[0]["quota_source_label"] is None
+        assert usages[0]["total_disk_usage"] == 0
+
+        assert usages[1]["quota_source_label"] == "alt_source"
+        assert usages[1]["total_disk_usage"] == 15
 
 
 class QuotaTestCase(BaseModelTestCase):
@@ -87,6 +275,27 @@ class QuotaTestCase(BaseModelTestCase):
         self._add_group_quota(u, quota)
         self._assert_user_quota_is(u, None)
 
+    def test_labeled_quota(self):
+        model = self.model
+        u = model.User(email="labeled_quota@example.com", password="password")
+        self.persist(u)
+
+        label1 = "coollabel1"
+        self._assert_user_quota_is(u, None, label1)
+
+        quota = model.Quota(name="default registered labeled", amount=21, quota_source_label=label1)
+        self.quota_agent.set_default_quota(
+            model.DefaultQuotaAssociation.types.REGISTERED,
+            quota,
+        )
+
+        self._assert_user_quota_is(u, 21, label1)
+
+        quota = model.Quota(name="user quota add labeled", amount=31, operation="+", quota_source_label=label1)
+        self._add_user_quota(u, quota)
+
+        self._assert_user_quota_is(u, 52, label1)
+
     def _add_group_quota(self, user, quota):
         group = self.model.Group()
         uga = self.model.UserGroupAssociation(user, group)
@@ -98,18 +307,57 @@ class QuotaTestCase(BaseModelTestCase):
         user.quotas.append(uqa)
         self.persist(quota, uqa, user)
 
-    def _assert_user_quota_is(self, user, amount):
-        actual_quota = self.quota_agent.get_quota(user)
+    def _assert_user_quota_is(self, user, amount, quota_source_label=None):
+        actual_quota = self.quota_agent.get_quota(user, quota_source_label=quota_source_label)
         assert amount == actual_quota, "Expected quota [%s], got [%s]" % (amount, actual_quota)
-        if amount is None:
-            user.total_disk_usage = 1000
-            job = self.model.Job()
-            job.user = user
-            assert not self.quota_agent.is_over_quota(None, job, None)
-        else:
-            job = self.model.Job()
-            job.user = user
-            user.total_disk_usage = amount - 1
-            assert not self.quota_agent.is_over_quota(None, job, None)
-            user.total_disk_usage = amount + 1
-            assert self.quota_agent.is_over_quota(None, job, None)
+        if quota_source_label is None:
+            if amount is None:
+                user.total_disk_usage = 1000
+                job = self.model.Job()
+                job.user = user
+                assert not self.quota_agent.is_over_quota(None, job, None)
+            else:
+                job = self.model.Job()
+                job.user = user
+                user.total_disk_usage = amount - 1
+                assert not self.quota_agent.is_over_quota(None, job, None)
+                user.total_disk_usage = amount + 1
+                assert self.quota_agent.is_over_quota(None, job, None)
+
+
+class UsageTestCase(BaseModelTestCase):
+
+    def test_usage(self):
+        model = self.model
+        u = model.User(email="usage@example.com", password="password")
+        self.persist(u)
+
+        u.adjust_total_disk_usage(123, None)
+        self.persist(u)
+
+        assert u.get_disk_usage() == 123
+
+    def test_labeled_usage(self):
+        model = self.model
+        u = model.User(email="labeled.usage@example.com", password="password")
+        self.persist(u)
+        assert len(u.quota_source_usages) == 0
+
+        u.adjust_total_disk_usage(123, "foobar")
+        usages = u.dictify_usage()
+        assert len(usages) == 1
+
+        assert u.get_disk_usage() == 0
+        assert u.get_disk_usage(quota_source_label="foobar") == 123
+        self.model.context.refresh(u)
+
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+
+        u.adjust_total_disk_usage(124, "foobar")
+        self.model.context.refresh(u)
+
+        usages = u.dictify_usage()
+        assert len(usages) == 2
+        assert usages[1]["quota_source_label"] == "foobar"
+        assert usages[1]["total_disk_usage"] == 247

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -282,8 +282,26 @@ def test_concrete_name_without_objectstore_id():
             assert files1_name is None
 
 
+MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
+<object_store type="distributed">
+    <backends>
+        <backend id="files1" type="disk" weight="1" order="0" store_by="id">
+            <files_dir path="${temp_directory}/files1"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp1"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory1"/>
+        </backend>
+        <backend id="files2" type="disk" weight="1" order="1" store_by="uuid" private="true">
+            <files_dir path="${temp_directory}/files2"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp2"/>
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory2"/>
+        </backend>
+    </backends>
+</object_store>
+"""
+
+
 MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
-<object_store type="hierarchical">
+<object_store type="hierarchical" private="true">
     <backends>
         <backend id="files1" type="disk" weight="1" order="0" store_by="id">
             <files_dir path="${temp_directory}/files1"/>
@@ -301,10 +319,43 @@ MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG = """<?xml version="1.0"?>
 
 
 def test_mixed_store_by():
+    with TestConfig(MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
+        as_dict = object_store.to_dict()
+        assert as_dict["backends"][0]["store_by"] == "id"
+        assert as_dict["backends"][1]["store_by"] == "uuid"
+
     with TestConfig(MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
         as_dict = object_store.to_dict()
         assert as_dict["backends"][0]["store_by"] == "id"
         assert as_dict["backends"][1]["store_by"] == "uuid"
+
+
+def test_mixed_private():
+    # Distributed object store can combine private and non-private concrete objectstores
+    with TestConfig(MIXED_STORE_BY_DISTRIBUTED_TEST_CONFIG) as (directory, object_store):
+        ids = object_store.object_store_ids()
+        print(ids)
+        assert len(ids) == 2
+
+        ids = object_store.object_store_ids(private=True)
+        assert len(ids) == 1
+        assert ids[0] == "files2"
+
+        ids = object_store.object_store_ids(private=False)
+        assert len(ids) == 1
+        assert ids[0] == "files1"
+
+        as_dict = object_store.to_dict()
+        assert not as_dict["backends"][0]["private"]
+        assert as_dict["backends"][1]["private"]
+
+    with TestConfig(MIXED_STORE_BY_HIERARCHICAL_TEST_CONFIG) as (directory, object_store):
+        as_dict = object_store.to_dict()
+        assert as_dict["backends"][0]["private"]
+        assert as_dict["backends"][1]["private"]
+
+        assert object_store.private
+        assert as_dict["private"] is True
 
 
 DISTRIBUTED_TEST_CONFIG = """<?xml version="1.0"?>
@@ -465,7 +516,7 @@ def test_config_parse_pithos():
             assert len(extra_dirs) == 2
 
 
-S3_TEST_CONFIG = """<object_store type="s3">
+S3_TEST_CONFIG = """<object_store type="s3" private="true">
      <auth access_key="access_moo" secret_key="secret_cow" />
      <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
      <cache path="database/object_store_cache" size="1000" />
@@ -477,6 +528,7 @@ S3_TEST_CONFIG = """<object_store type="s3">
 
 S3_TEST_CONFIG_YAML = """
 type: s3
+private: true
 auth:
   access_key: access_moo
   secret_key: secret_cow
@@ -500,6 +552,7 @@ extra_dirs:
 def test_config_parse_s3():
     for config_str in [S3_TEST_CONFIG, S3_TEST_CONFIG_YAML]:
         with TestConfig(config_str, clazz=UnitializeS3ObjectStore) as (directory, object_store):
+            assert object_store.private
             assert object_store.access_key == "access_moo"
             assert object_store.secret_key == "secret_cow"
 

--- a/test/unit/test_routes.py
+++ b/test/unit/test_routes.py
@@ -111,6 +111,12 @@ def test_galaxy_routes():
         action="resolver_dependency"
     )
 
+    test_webapp.assert_maps(
+        "/api/users/current/usage",
+        controller="users",
+        action="usage"
+    )
+
 
 def assert_url_is(actual, expected):
     assert actual == expected, f"Expected URL [{expected}] but obtained [{actual}]"


### PR DESCRIPTION
Redoing #10221 but building on #10840.

## Overview

#6552 implemented the ability for admins to assign job outputs to different object stores at runtime (this could take into account tool/workflow injected parameters or just be based on user, tool, destination, cluster state, etc..). But all the stored data would consume the same quota - regardless of the source selected.

This pull request allows different object stores or different groups of object stores to have different quotas or no quota at all. This enables uses cases such as sending job to cheaper data when a user's quota is getting near full or allowing admin to setup tool and/of workflow parameters to send job outputs higher quality, more redundant storage based on user selected options or user preferences.

This is a substantial step forward toward allowing scratch-space histories, while I suspect we want to implement some higher level convince functions and interface around that (per history preferences, object store preferences types) - I think that would all be based on these abstractions - abstractions that allow even more flexibility for admins who require it.

## Implementation

This adds the quota tag to XML/YAML object store declarations - that allow specifying a "quota source label" for each objectstore in a nested objectstore or disabling quota all together on objectstores.

The following quota block would assign all this storage to a quota source labelled with ``s3``.

```
        <backend id="dynamic_s3" type="disk" weight="0">
            <quota source="s3" />
            <files_dir path="${temp_directory}/files_dynamic_s3"/>
```

Whereas this would disable quota usage for this object store altogether. 

```
        <backend id="temp_disk" type="disk" weight="0">
            <quota enabled="false" />
            <files_dir path="${temp_directory}/files_cloud_scratch"/>
```

In order to implement this a new table/model has been added to track a user's usage per quota source label - namely ``UserQuotaSourceUsage``. Object stores that did not have a source label are still tracked using the User model's ``disk_usage`` attribute. I've updated all the scripts that recalculate user usage.

## UI + API

The quota dialog adds the option to pick a quota source label from those defined on the object stores, though this option only appears if quota source labels are configured.

<img width="1398" alt="Screen Shot 2020-09-28 at 8 45 33 PM" src="https://user-images.githubusercontent.com/216771/94499839-b5803800-01cb-11eb-8bfc-f033cad50917.png">

Likewise, by default the quota meter is unaffected but when multiple quota source labels are configured the meter becomes a link that shows the usage of each quota source.

<img width="776" alt="Screen Shot 2020-09-28 at 8 47 19 PM" src="https://user-images.githubusercontent.com/216771/94499923-e8c2c700-01cb-11eb-8b6d-b4ea44255027.png">

A new API ``/api/users/<user_id|current>/usage`` enables this.

## Abstractions for #4840

While this PR adds significant complexity related to recalculating a User's quota - it does reduce the duplication, adds tests (made more useful by having fewer paths through the quota recalculation code), and bring object store information into the calculation. I think this is all stuff that would be needed for #4840 and currently missing.

Part of this establishes a pattern for how to exclude certain datasets from usage calculation both when it is being added (included in #4840) and when re-calculdated (not included in #4840).

The API endpoints for disk usage across object stores and the UI entry point for displaying that information will hopefully both enable a more robust implementation of #4840.
