### PR TITLE
Simplify JobInformation and DatasetInformation components

### DIFF
--- a/client/src/components/DatasetInformation/DatasetInformation.test.js
+++ b/client/src/components/DatasetInformation/DatasetInformation.test.js
@@ -1,4 +1,6 @@
 import Vuex from "vuex";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import { mount, createLocalVue } from "@vue/test-utils";
 import DatasetInformation from "./DatasetInformation";
 import datasetResponse from "./testData/datasetResponse";
@@ -30,6 +32,16 @@ const testStore = new Vuex.Store({
 describe("DatasetInformation/DatasetInformation.vue", () => {
     let wrapper;
     let datasetInfoTable;
+    let axiosMock;
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet(new RegExp(`api/configuration/decode/*`)).reply(200, { decoded_id: 123 });
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
 
     beforeEach(async () => {
         const propsData = {
@@ -49,8 +61,8 @@ describe("DatasetInformation/DatasetInformation.vue", () => {
         // table should exist
         expect(datasetInfoTable).toBeTruthy();
         const rows = datasetInfoTable.findAll("tbody > tr");
-        // should contain 7 rows
-        expect(rows.length).toBe(7);
+        // should contain 11 rows
+        expect(rows.length).toBe(11);
     });
 
     it("filesize should be formatted", async () => {

--- a/client/src/components/DatasetInformation/DatasetInformation.vue
+++ b/client/src/components/DatasetInformation/DatasetInformation.vue
@@ -33,6 +33,26 @@
                     <td>File contents</td>
                     <td id="file-contents"><a :href="dataset.download_url">contents</a></td>
                 </tr>
+                <tr v-if="dataset.id">
+                    <td>History Content API ID</td>
+                    <td>
+                        <div id="dataset-id">{{ dataset.id }} <decoded-id :id="dataset.id" /></div>
+                    </td>
+                </tr>
+                <tr v-if="dataset.history_id">
+                    <td>History API ID</td>
+                    <td>
+                        <div id="history_id">{{ dataset.history_id }} <decoded-id :id="dataset.history_id" /></div>
+                    </td>
+                </tr>
+                <tr v-if="dataset.uuid">
+                    <td>UUID</td>
+                    <td id="dataset-uuid">{{ dataset.uuid }}</td>
+                </tr>
+                <tr v-if="dataset.file_name">
+                    <td>Full Path</td>
+                    <td id="file_name">{{ dataset.file_name }}</td>
+                </tr>
             </tbody>
         </table>
     </div>
@@ -42,6 +62,7 @@
 import { mapCacheActions } from "vuex-cache";
 import Utils from "utils/utils";
 import UtcDate from "components/UtcDate";
+import DecodedId from "../DecodedId";
 
 export default {
     props: {
@@ -51,6 +72,7 @@ export default {
         },
     },
     components: {
+        DecodedId,
         UtcDate,
     },
     created: function () {

--- a/client/src/components/DecodedId.vue
+++ b/client/src/components/DecodedId.vue
@@ -1,0 +1,42 @@
+<template>
+    <span v-if="this.decoded_id">({{ decoded_id }})</span>
+</template>
+<script>
+import axios from "axios";
+import { rethrowSimple } from "utils/simple-error";
+import { getAppRoot } from "onload/loadConfig";
+import { getGalaxyInstance } from "app";
+
+export default {
+    props: {
+        id: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return { decoded_id: null };
+    },
+    created: function () {
+        this.decodeId(this.id);
+    },
+    computed: {
+        isAdmin() {
+            // window.parent.Galaxy is needed when instance is mounted in mako
+            const Galaxy = getGalaxyInstance() || window.parent.Galaxy;
+            return Galaxy?.user?.isAdmin() || false;
+        },
+    },
+    methods: {
+        decodeId: async function (id) {
+            const url = `${getAppRoot()}api/configuration/decode/${id}`;
+            try {
+                const response = await axios.get(url);
+                this.decoded_id = response.data.decoded_id;
+            } catch (e) {
+                rethrowSimple(e);
+            }
+        },
+    },
+};
+</script>

--- a/client/src/components/JobInformation/CodeRow.vue
+++ b/client/src/components/JobInformation/CodeRow.vue
@@ -2,13 +2,13 @@
     <tr @click="toggleExpanded">
         <td>
             {{ codeLabel }}
-            <span v-if="codeItem && !expanded"><i>(Click to expand)</i></span>
         </td>
         <td v-if="expanded">
             <pre class="code">{{ codeItem }}</pre>
         </td>
         <td v-else-if="codeItem">
             <pre class="code preview">{{ codeItem }}</pre>
+            <b>(Click to expand)</b>
         </td>
         <td v-else><i>empty</i></td>
     </tr>

--- a/client/src/components/JobInformation/CodeRow.vue
+++ b/client/src/components/JobInformation/CodeRow.vue
@@ -1,0 +1,38 @@
+<template>
+    <tr @click="toggleExpanded">
+        <td>
+            {{ codeLabel }}
+            <span v-if="codeItem && !expanded"><i>(Click to expand)</i></span>
+        </td>
+        <td v-if="expanded">
+            <pre class="code">{{ codeItem }}</pre>
+        </td>
+        <td v-else-if="codeItem">
+            <pre class="code preview">{{ codeItem }}</pre>
+        </td>
+        <td v-else><i>empty</i></td>
+    </tr>
+</template>
+<script>
+import Vue from "vue";
+import BootstrapVue from "bootstrap-vue";
+
+Vue.use(BootstrapVue);
+
+export default {
+    props: {
+        codeLabel: String,
+        codeItem: String,
+    },
+    data() {
+        return { expanded: false };
+    },
+    methods: {
+        toggleExpanded() {
+            if (this.codeItem) {
+                this.expanded = !this.expanded;
+            }
+        },
+    },
+};
+</script>

--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -1,4 +1,6 @@
 import Vuex from "vuex";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
 import { mount, createLocalVue } from "@vue/test-utils";
 import JobInformation from "./JobInformation";
 import datasetResponse from "components/DatasetInformation/testData/datasetResponse";
@@ -9,7 +11,6 @@ import createCache from "vuex-cache";
 
 jest.mock("app");
 
-const HDA_ID = "FOO_HDA_ID";
 const JOB_ID = "test_id";
 
 const localVue = createLocalVue();
@@ -38,6 +39,16 @@ const jobStore = new Vuex.Store({
 describe("JobInformation/JobInformation.vue", () => {
     let wrapper;
     let jobInfoTable;
+    let axiosMock;
+
+    beforeEach(() => {
+        axiosMock = new MockAdapter(axios);
+        axiosMock.onGet(new RegExp(`api/configuration/decode/*`)).reply(200, { decoded_id: 123 });
+    });
+
+    afterEach(() => {
+        axiosMock.restore();
+    });
 
     const verifyValues = (rendered_entries, infoTable, backendResponse) => {
         rendered_entries.forEach((entry) => {
@@ -45,13 +56,13 @@ describe("JobInformation/JobInformation.vue", () => {
             const backendText = entry.wrapped_in_brackets
                 ? `(${backendResponse[entry.backend_key]})`
                 : backendResponse[entry.backend_key];
-            expect(renderedText).toBe(backendText.toString());
+            // use includes because we append the decoded id
+            expect(renderedText.includes(backendText.toString())).toBeTruthy();
         });
     };
 
     beforeEach(async () => {
         const propsData = {
-            hda_id: HDA_ID,
             job_id: JOB_ID,
         };
 
@@ -69,14 +80,13 @@ describe("JobInformation/JobInformation.vue", () => {
         expect(jobInfoTable).toBeTruthy();
         const rows = jobInfoTable.findAll("tr");
         // should contain 9 rows
-        expect(rows.length).toBe(12);
+        expect(rows.length).toBe(9);
     });
 
-    it("stdout, stderr links", async () => {
-        ["stderr", "stdout"].forEach((std) => {
-            const rendered_link = jobInfoTable.find(`#${std} > a`);
-            expect(rendered_link.text()).toBe(std);
-            expect(rendered_link.attributes("href")).toBe(`/datasets/${HDA_ID}/${std}`);
+    it("stdout and stderr should be rendered", async () => {
+        ["stdout", "stderr"].forEach((std) => {
+            const label = jobInfoTable.find("#" + std);
+            expect(label.text().endsWith(std)).toBeTruthy();
         });
     });
 
@@ -97,16 +107,5 @@ describe("JobInformation/JobInformation.vue", () => {
             { id: "encoded-copied-from-job-id", backend_key: "copied_from_job_id" },
         ];
         verifyValues(rendered_entries, jobInfoTable, jobResponse);
-    });
-
-    it("dataset API content", async () => {
-        const rendered_entries = [
-            { id: "file_name", backend_key: "file_name" },
-            { id: "dataset-uuid", backend_key: "uuid" },
-            { id: "history_id", backend_key: "history_id" },
-            { id: "history-dataset-id", backend_key: "dataset_id", wrapped_in_brackets: true },
-            { id: "dataset-id", backend_key: "id" },
-        ];
-        verifyValues(rendered_entries, jobInfoTable, datasetResponse);
     });
 });

--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -86,7 +86,8 @@ describe("JobInformation/JobInformation.vue", () => {
     it("stdout and stderr should be rendered", async () => {
         ["stdout", "stderr"].forEach((std) => {
             const label = jobInfoTable.find("#" + std);
-            expect(label.text().endsWith(std)).toBeTruthy();
+            const value = label.find(".code");
+            expect(value.text()).toBe(std);
         });
     });
 

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <h3>Job Information</h3>
-        <table id="job-information" class="tabletip">
+        <table id="job-information" class="tabletip info_data_table">
             <tbody>
                 <tr v-if="job && job.tool_id">
                     <td>Galaxy Tool ID:</td>
@@ -11,24 +11,13 @@
                     <td>Galaxy Tool Version:</td>
                     <td id="galaxy-tool-version">{{ job.tool_version }}</td>
                 </tr>
-                <tr v-if="dataset.tool_version">
-                    <td>Tool Version:</td>
-                    <td id="tool-version">{{ dataset.tool_version }}</td>
-                </tr>
-                <tr>
-                    <td>Tool Standard Output:</td>
-                    <td id="stdout"><a :href="`${getAppRoot()}datasets/${this.dataset.id}/stdout`">stdout</a></td>
-                </tr>
-                <tr>
-                    <td>Tool Standard Error:</td>
-                    <td id="stderr"><a :href="`${getAppRoot()}datasets/${this.dataset.id}/stderr`">stderr</a></td>
-                </tr>
-
+                <code-row id="command-line" v-if="job" :codeLabel="'Command Line'" :codeItem="job.command_line" />
+                <code-row id="stdout" v-if="job" :codeLabel="'Tool Standard Output'" :codeItem="job.tool_stdout" />
+                <code-row id="stderr" v-if="job" :codeLabel="'Tool Standard Error'" :codeItem="job.tool_stderr" />
                 <tr v-if="job">
                     <td>Tool Exit Code:</td>
                     <td id="exist-code">{{ job.exit_code }}</td>
                 </tr>
-
                 <tr id="job-messages" v-if="job && job.job_messages && job.job_messages.length > 0">
                     <td>Job Messages</td>
                     <td>
@@ -37,48 +26,15 @@
                         </ul>
                     </td>
                 </tr>
-
-                <tr>
-                    <td>History Content API ID:</td>
-                    <td>
-                        <div id="dataset-id">{{ dataset.id }}</div>
-                        <div id="history-dataset-id" v-if="dataset.dataset_id">({{ dataset.dataset_id }})</div>
-                    </td>
-                </tr>
-
-                <tr v-if="job">
+                <tr v-if="job && job.id">
                     <td>Job API ID:</td>
-                    <td>
-                        <div id="encoded-job-id">{{ job.id }}</div>
-                        <div id="job-id" v-if="isEligibleForDecode && decoded_job_id">({{ decoded_job_id }})</div>
-                    </td>
+                    <td id="encoded-job-id">{{ job.id }} <decoded-id :id="job.id" /></td>
                 </tr>
-                <tr v-if="isCopiedFromJobId">
+                <tr v-if="job && job.copied_from_job_id">
                     <td>Copied from Job API ID:</td>
-                    <td>
-                        <div id="encoded-copied-from-job-id">{{ job.copied_from_job_id }}</div>
-                        <div id="copied-from-job-id" v-if="decoded_copied_from_job_id">
-                            ({{ decoded_copied_from_job_id }})
-                        </div>
+                    <td id="encoded-copied-from-job-id">
+                        {{ job.copied_from_job_id }} <decoded-id :id="job.copied_from_job_id" />
                     </td>
-                </tr>
-
-                <tr v-if="dataset.history_id">
-                    <td>History API ID:</td>
-                    <td>
-                        <div id="history_id">{{ dataset.history_id }}</div>
-                        <div v-if="isEligibleForDecode && decoded_history_id">({{ decoded_history_id }})</div>
-                    </td>
-                </tr>
-
-                <tr v-if="dataset.uuid">
-                    <td>UUID:</td>
-                    <td id="dataset-uuid">{{ dataset.uuid }}</td>
-                </tr>
-
-                <tr v-if="dataset.file_name">
-                    <td>Full Path:</td>
-                    <td id="file_name">{{ dataset.file_name }}</td>
                 </tr>
             </tbody>
         </table>
@@ -88,79 +44,34 @@
 <script>
 import { mapCacheActions } from "vuex-cache";
 import { getAppRoot } from "onload/loadConfig";
-import { getGalaxyInstance } from "app";
-import { Services } from "./services";
+import DecodedId from "../DecodedId.vue";
+import CodeRow from "./CodeRow.vue";
 
 export default {
-    data() {
-        return {
-            decoded_history_id: undefined,
-            decoded_job_id: undefined,
-            decoded_copied_from_job_id: undefined,
-        };
+    components: {
+        CodeRow,
+        DecodedId,
     },
     props: {
-        hda_id: {
-            type: String,
-            required: true,
-        },
         job_id: {
             type: String,
             required: true,
         },
     },
     created: function () {
-        this.fetchDataset(this.hda_id);
         this.fetchJob(this.job_id);
-        this.services = new Services({ root: this.root });
     },
     computed: {
-        isAdmin: function () {
-            const Galaxy = getGalaxyInstance();
-            return Galaxy?.user?.isAdmin() || false;
-        },
-        dataset: function () {
-            return this.$store.getters.dataset(this.hda_id);
-        },
         job: function () {
             const job = this.$store.getters.job(this.job_id);
             return job;
         },
-        isEligibleForDecode: function () {
-            if (this.job.id && this.dataset.history_id && this.isAdmin) {
-                this.decode_ids();
-                return true;
-            } else {
-                return false;
-            }
-        },
-        isCopiedFromJobId() {
-            let value = false;
-            if (this.job.copied_from_job_id) {
-                value = true;
-                if (this.isAdmin) {
-                    this.decode_copied_from_job_id();
-                }
-            }
-            return value;
-        },
     },
     methods: {
-        decode_ids: async function () {
-            this.decoded_history_id = await this.decode(this.dataset.history_id);
-            this.decoded_job_id = await this.decode(this.job.id);
-        },
-        decode_copied_from_job_id: async function () {
-            this.decoded_copied_from_job_id = await this.decode(this.job.copied_from_job_id);
-        },
+        ...mapCacheActions(["fetchJob"]),
         getAppRoot() {
             return getAppRoot();
         },
-        decode: async function (id) {
-            const response = await this.services.decode(id);
-            return response.data.decoded_id;
-        },
-        ...mapCacheActions(["fetchJob", "fetchDataset"]),
     },
 };
 </script>

--- a/client/src/components/JobInformation/mount.js
+++ b/client/src/components/JobInformation/mount.js
@@ -6,7 +6,6 @@ import { mountVueComponent } from "utils/mountVueComponent";
 
 export const mountJobInformation = (propsData = {}) => {
     document.querySelectorAll(".job-information").forEach((element) => {
-        propsData.hda_id = element.getAttribute("hda_id");
         propsData.job_id = element.getAttribute("job_id");
         mountVueComponent(JobInformation)(propsData, element);
     });

--- a/client/src/components/JobInformation/testData/jobInformationResponse.json
+++ b/client/src/components/JobInformation/testData/jobInformationResponse.json
@@ -2,6 +2,9 @@
     "tool_id": "upload1",
     "tool_version": "1.1.7",
     "exit_code": 0,
+    "tool_stdout": "stdout",
+    "tool_stderr": "stderr",
+    "command_line": "commandline",
     "job_messages": ["test-msg1", "test-msg2", "test-msg3", "test-msg4"],
     "id": "test_id",
     "copied_from_job_id": "test_copied_from_job_id"

--- a/client/src/components/JobParameters/JobParameters.vue
+++ b/client/src/components/JobParameters/JobParameters.vue
@@ -2,7 +2,7 @@
     <div>
         <div v-if="!isSingleParam" class="tool-parameters">
             <h3 v-if="includeTitle">Tool Parameters</h3>
-            <table class="tabletip" id="tool-parameters">
+            <table class="tabletip info_data_table" id="tool-parameters">
                 <thead>
                     <tr>
                         <th>Input Parameter</th>
@@ -130,12 +130,3 @@ export default {
     },
 };
 </script>
-<style scoped>
-table.info_data_table {
-    table-layout: fixed;
-    word-break: break-word;
-}
-table.info_data_table td:nth-child(1) {
-    width: 25%;
-}
-</style>

--- a/client/src/components/admin/JobDetails.vue
+++ b/client/src/components/admin/JobDetails.vue
@@ -1,7 +1,5 @@
 <template>
     <b-card>
-        <h5>Command Line</h5>
-        <pre class="text-white bg-dark"><code class="break-word">{{ commandLine }}</code></pre>
         <h5>Job Parameters</h5>
         <job-parameters :job-id="jobId" :include-title="false" />
         <h5>Job Metrics</h5>

--- a/client/src/style/scss/overrides.scss
+++ b/client/src/style/scss/overrides.scss
@@ -126,7 +126,25 @@ pre.code {
     white-space: pre-wrap;
     background: #1d1f21;
     color: white;
-    padding: 1em;
+    margin-top: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+pre.code.preview {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+table.info_data_table {
+    table-layout: fixed;
+    word-break: break-word;
+}
+table.info_data_table td:nth-child(1) {
+    width: 25%;
+}
+table.info_data_table th:nth-child(1) {
+    width: 25%;
 }
 
 // increase visibility of links within alert boxes

--- a/templates/show_params.mako
+++ b/templates/show_params.mako
@@ -25,17 +25,16 @@ encoded_history_id = trans.security.encode_id( hda.history_id )
 %>
 
 <div class="dataset-information" hda_id="${encoded_hda_id}"></div>
-<div class="job-information" hda_id="${encoded_hda_id}" job_id="${trans.security.encode_id( job.id )}"></div>
-
-<div class="dataset-storage" dataset_id="${encoded_hda_id}" dataset_type="hda">
-</div>
-
+<p>
 %if job:
 <div class="job-parameters" dataset_id="${encoded_hda_id}" dataset_type="hda">
 </div>
+<p>
 %endif
-
-
+<div class="job-information" hda_id="${encoded_hda_id}" job_id="${trans.security.encode_id( job.id )}"></div>
+<p>
+<div class="dataset-storage" dataset_id="${encoded_hda_id}" dataset_type="hda"></div>
+<p>
 
 <h3>Inheritance Chain</h3>
 <div class="inherit" style="background-color: #fff; font-weight:bold;">${hda.name | h}</div>
@@ -46,24 +45,19 @@ encoded_history_id = trans.security.encode_id( hda.history_id )
         '${dep[0].name | h}' in ${dep[1]}<br/>
     </div>
 % endfor
-
-
-
-%if job and job.command_line and (trans.user_is_admin or trans.app.config.expose_dataset_path):
-<h3>Command Line</h3>
-<pre class="code">
-${ job.command_line | h }</pre>
-%endif
+<p>
 
 %if job and (trans.user_is_admin or trans.app.config.expose_potentially_sensitive_job_metrics):
 <div class="job-metrics" dataset_id="${encoded_hda_id}" aws_estimate="${trans.app.config.aws_estimate}" dataset_type="hda">
 </div>
+<p>
 %endif
 
 %if trans.user_is_admin:
 <h3>Destination Parameters</h3>
 <div class="job-destination-parameters" job_id="${trans.security.encode_id(job.id)}">
 </div>
+<p>
 %endif
 
 %if job and job.dependencies:
@@ -99,6 +93,7 @@ ${ job.command_line | h }</pre>
 
         </tbody>
     </table>
+    <p>
 %endif
 
 %if hda.peek:


### PR DESCRIPTION
JobInformation contained a lot of dataset related infos.
This reworks the JobInformation component to
- only deal with job-related fields
- pushes the off-topic fields into DatasetInformation

This also adds a component that can nicely display rows with
code (stdout/stderr/command line) and that can expand these.
I also refactored out the id decoding logic into a standalone component
for re-use.
Finally I fixed the varying table widths across the different tables by making `table.info_data_table` a global style.

This will be very useful for the invocation PR.
This is how it looks like now:
<img width="1298" alt="Screenshot 2020-12-21 at 19 46 04" src="https://user-images.githubusercontent.com/6804901/102811137-3747c200-43c5-11eb-9aee-a2e7b4ece740.png">
