### PR TITLE
Overwrite uwsgi default py-call-osafterfork

### DIFF
--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -154,7 +154,7 @@ UWSGI_OPTIONS = OrderedDict([
         'type': 'str',
     }),
     ('py-call-osafterfork', {
-        'desc': """Feature necessary for proper mule signal handling. The default is set to false to prevent a runtime error under Python 3.7+ (see https://github.com/unbit/uwsgi/issues/1978).""",
+        'desc': """Feature necessary for proper mule signal handling on Python versions below 3.7.2. The default is set to false to prevent a runtime error under Python 3.7.2 and newer (see https://github.com/unbit/uwsgi/issues/1978).""",
         'default': False,
         'type': 'bool',
     }),

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -154,8 +154,8 @@ UWSGI_OPTIONS = OrderedDict([
         'type': 'str',
     }),
     ('py-call-osafterfork', {
-        'desc': """Feature necessary for proper mule signal handling""",
-        'default': True,
+        'desc': """Feature necessary for proper mule signal handling. The default is set to false to prevent a runtime error under Python 3.7+ (see https://github.com/unbit/uwsgi/issues/1978).""",
+        'default': False,
         'type': 'bool',
     }),
     ('enable-threads', {
@@ -662,7 +662,6 @@ def _replace_file(args, f, app_desc, from_path, to_path):
 
 
 def _build_sample_yaml(args, app_desc):
-    _overwrite_uwsgi_defaults()
     if app_desc.app_name in ["tool_shed"]:
         UWSGI_OPTIONS.update(SHED_ONLY_UWSGI_OPTIONS)
     schema = app_desc.schema
@@ -690,14 +689,6 @@ def _build_sample_yaml(args, app_desc):
     _write_sample_section(args, f, app_desc.app_name, schema)
     destination = os.path.join(args.galaxy_root, app_desc.sample_destination)
     _write_to_file(args, f, destination)
-
-
-def _overwrite_uwsgi_defaults():
-    # Prevents runtime error in logging module under Python 3.7.1+
-    # (see https://github.com/unbit/uwsgi/issues/1978)
-    key = 'py-call-osafterfork'
-    if key in UWSGI_OPTIONS:
-        UWSGI_OPTIONS[key]['default'] = False
 
 
 def _write_to_file(args, f, path):

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -662,6 +662,7 @@ def _replace_file(args, f, app_desc, from_path, to_path):
 
 
 def _build_sample_yaml(args, app_desc):
+    _overwrite_uwsgi_defaults()
     if app_desc.app_name in ["tool_shed"]:
         UWSGI_OPTIONS.update(SHED_ONLY_UWSGI_OPTIONS)
     schema = app_desc.schema
@@ -689,6 +690,14 @@ def _build_sample_yaml(args, app_desc):
     _write_sample_section(args, f, app_desc.app_name, schema)
     destination = os.path.join(args.galaxy_root, app_desc.sample_destination)
     _write_to_file(args, f, destination)
+
+
+def _overwrite_uwsgi_defaults():
+    # Prevents runtime error in logging module under Python 3.7.1+
+    # (see https://github.com/unbit/uwsgi/issues/1978)
+    key = 'py-call-osafterfork'
+    if key in UWSGI_OPTIONS:
+        UWSGI_OPTIONS[key]['default'] = False
 
 
 def _write_to_file(args, f, path):

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -92,7 +92,9 @@ uwsgi:
   # SIGTERM (its default is to brutally kill workers)
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
-  # Feature necessary for proper mule signal handling
+  # Feature necessary for proper mule signal handling. The default is
+  # set to false to prevent a runtime error under Python 3.7+ (see
+  # https://github.com/unbit/uwsgi/issues/1978).
   py-call-osafterfork: false
 
   # Ensure application threads will run if `threads` is unset.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -92,8 +92,9 @@ uwsgi:
   # SIGTERM (its default is to brutally kill workers)
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
-  # Feature necessary for proper mule signal handling. The default is
-  # set to false to prevent a runtime error under Python 3.7+ (see
+  # Feature necessary for proper mule signal handling on Python versions
+  # below 3.7.2. The default is set to false to prevent a runtime error
+  # under Python 3.7.2 and newer (see
   # https://github.com/unbit/uwsgi/issues/1978).
   py-call-osafterfork: false
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -93,7 +93,7 @@ uwsgi:
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
   # Feature necessary for proper mule signal handling
-  py-call-osafterfork: true
+  py-call-osafterfork: false
 
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -74,7 +74,9 @@ uwsgi:
   # SIGTERM (its default is to brutally kill workers)
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
-  # Feature necessary for proper mule signal handling
+  # Feature necessary for proper mule signal handling. The default is
+  # set to false to prevent a runtime error under Python 3.7+ (see
+  # https://github.com/unbit/uwsgi/issues/1978).
   py-call-osafterfork: false
 
   # Ensure application threads will run if `threads` is unset.

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -74,8 +74,9 @@ uwsgi:
   # SIGTERM (its default is to brutally kill workers)
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
-  # Feature necessary for proper mule signal handling. The default is
-  # set to false to prevent a runtime error under Python 3.7+ (see
+  # Feature necessary for proper mule signal handling on Python versions
+  # below 3.7.2. The default is set to false to prevent a runtime error
+  # under Python 3.7.2 and newer (see
   # https://github.com/unbit/uwsgi/issues/1978).
   py-call-osafterfork: false
 

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -75,7 +75,7 @@ uwsgi:
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
   # Feature necessary for proper mule signal handling
-  py-call-osafterfork: true
+  py-call-osafterfork: false
 
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -74,7 +74,9 @@ uwsgi:
   # SIGTERM (its default is to brutally kill workers)
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
-  # Feature necessary for proper mule signal handling
+  # Feature necessary for proper mule signal handling. The default is
+  # set to false to prevent a runtime error under Python 3.7+ (see
+  # https://github.com/unbit/uwsgi/issues/1978).
   py-call-osafterfork: false
 
   # Ensure application threads will run if `threads` is unset.

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -74,8 +74,9 @@ uwsgi:
   # SIGTERM (its default is to brutally kill workers)
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
-  # Feature necessary for proper mule signal handling. The default is
-  # set to false to prevent a runtime error under Python 3.7+ (see
+  # Feature necessary for proper mule signal handling on Python versions
+  # below 3.7.2. The default is set to false to prevent a runtime error
+  # under Python 3.7.2 and newer (see
   # https://github.com/unbit/uwsgi/issues/1978).
   py-call-osafterfork: false
 

--- a/lib/galaxy/config/sample/tool_shed.yml.sample
+++ b/lib/galaxy/config/sample/tool_shed.yml.sample
@@ -75,7 +75,7 @@ uwsgi:
   hook-master-start: unix_signal:15 gracefully_kill_them_all
 
   # Feature necessary for proper mule signal handling
-  py-call-osafterfork: true
+  py-call-osafterfork: false
 
   # Ensure application threads will run if `threads` is unset.
   enable-threads: true


### PR DESCRIPTION
Prevents runtime error in logging module under Python 3.7.1+

Ref:
https://github.com/galaxyproject/galaxy/issues/9641
https://github.com/unbit/uwsgi/issues/1978
https://gitter.im/galaxyproject/wg-backend?at=5fe0f93daa6bb528c3636941 (most recent discussion)

Run `make config-rebuild`.