### PR TITLE
Fixes for license and creator saving and updating.

### DIFF
--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -34,11 +34,11 @@
         </div>
         <div id="workflow-license-area" class="mt-2">
             <b>License</b>
-            <LicenseSelector :inputLicense="licenseCurrent" @onLicense="onLicense" />
+            <LicenseSelector :inputLicense="license" @onLicense="onLicense" />
         </div>
         <div id="workflow-creator-area" class="mt-2">
             <b>Creator</b>
-            <CreatorEditor :creators="creatorCurrent" @onCreators="onCreator" />
+            <CreatorEditor :creators="creatorAsList" @onCreators="onCreator" />
         </div>
         <div class="mt-2">
             <b>Tags</b>
@@ -106,25 +106,26 @@ export default {
         },
     },
     data() {
-        let creator = this.creator;
-        if (!creator) {
-            creator = [];
-        } else if (!(creator instanceof Array)) {
-            creator = [creator];
-        }
         return {
             message: null,
             messageVariant: null,
-            licenseCurrent: this.license,
             tagsCurrent: this.tags,
             versionCurrent: this.version,
-            creatorCurrent: creator,
         };
     },
     created() {
         this.services = new Services();
     },
     computed: {
+        creatorAsList() {
+            let creator = this.creator;
+            if (!creator) {
+                creator = [];
+            } else if (!(creator instanceof Array)) {
+                creator = [creator];
+            }
+            return creator;
+        },
         hasParameters() {
             return this.parameters.length > 0;
         },
@@ -180,14 +181,10 @@ export default {
             this.$emit("onVersion", this.versionCurrent);
         },
         onLicense(license) {
-            this.licenseCurrent = license;
-            this.onAttributes({ license });
-            this.$emit("onLicense", this.licenseCurrent);
+            this.$emit("onLicense", license);
         },
         onCreator(creator) {
-            this.creatorCurrent = creator;
-            this.onAttributes({ creator });
-            this.$emit("onCreator", this.creatorCurrent);
+            this.$emit("onCreator", creator);
         },
         onError(error) {
             this.message = error;

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -104,11 +104,13 @@
                                     :parameters="parameters"
                                     :annotation="annotation"
                                     :version="version"
-                                    :license="license"
                                     :versions="versions"
+                                    :license="license"
                                     :creator="creator"
                                     @onVersion="onVersion"
                                     @onRename="onRename"
+                                    @onLicense="onLicense"
+                                    @onCreator="onCreator"
                                 />
                                 <div id="right-content" class="right-content" />
                             </div>
@@ -176,14 +178,6 @@ export default {
             type: String,
             default: "",
         },
-        license: {
-            type: String,
-            default: "",
-        },
-        creator: {
-            type: Object,
-            default: null,
-        },
         moduleSections: {
             type: Array,
             required: true,
@@ -218,6 +212,8 @@ export default {
             report: {},
             activeNode: null,
             labels: {},
+            license: null,
+            creator: null,
         };
     },
     created() {
@@ -405,6 +401,18 @@ export default {
                 .catch((response) => {
                     show_modal("Loading workflow failed...", response, { Ok: hide_modal });
                 });
+        },
+        onLicense(license) {
+            if (this.license != license) {
+                this.hasChanges = true;
+                this.license = license;
+            }
+        },
+        onCreator(creator) {
+            if (this.creator != creator) {
+                this.hasChanges = true;
+                this.creator = creator;
+            }
         },
         getManager() {
             return this;

--- a/client/src/components/Workflow/Editor/modules/model.js
+++ b/client/src/components/Workflow/Editor/modules/model.js
@@ -113,7 +113,9 @@ export function toSimple(workflow) {
         nodes[node.id] = node_data;
     });
     const report = workflow.report;
-    return { steps: nodes, report: report };
+    const license = workflow.license;
+    const creator = workflow.creator;
+    return { steps: nodes, report: report, license: license, creator: creator };
 }
 
 function _scaledBoundingClientRect(element, canvasZoom) {


### PR DESCRIPTION
I was mutating a property, it was possible to save the workflow and lose these, etc.. This new approach is just to delegate to very simple reactive properties in Index.vue and just roll this stuff into the change checking and update framework that it already has. This approach is much cleaner and gives Index.vue the single source of truth (and simply reactive truth) on these properties - which is nice and needed in some downstream work.

I was emulating annotation handling - which is an anti-pattern and should probably be redone to do what I'm doing here. I could have designed a much simpler license selection widget if I would have been just doing this from the get go and not try to emulate annotations.
