### PR TITLE
Start mypy type checking during CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,3 +21,5 @@ jobs:
       run: pip install tox
     - name: run tests
       run: tox -e lint
+    - name: run mypy checks
+      run: tox -e mypy

--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -16,7 +16,7 @@ have nothing to do with the web - keep this in mind when defining exception name
 and messages.
 """
 
-from ..exceptions import error_codes
+from ..exceptions.error_codes import error_codes_by_name
 
 
 class MessageException(Exception):
@@ -24,7 +24,7 @@ class MessageException(Exception):
     # status code to be set when used with API.
     status_code = 400
     # Error code information embedded into API json responses.
-    err_code = error_codes.UNKNOWN
+    err_code = error_codes_by_name['UNKNOWN']
 
     def __init__(self, err_msg=None, type="info", **extra_error_info):
         self.err_msg = err_msg or self.err_code.default_error_message
@@ -56,7 +56,7 @@ class ObjectInvalid(Exception):
 
 class ActionInputError(MessageException):
     status_code = 400
-    err_code = error_codes.USER_REQUEST_INVALID_PARAMETER
+    err_code = error_codes_by_name['USER_REQUEST_INVALID_PARAMETER']
 
     def __init__(self, err_msg, type="error"):
         super().__init__(err_msg, type)
@@ -64,52 +64,52 @@ class ActionInputError(MessageException):
 
 class DuplicatedSlugException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_SLUG_DUPLICATE
+    err_code = error_codes_by_name['USER_SLUG_DUPLICATE']
 
 
 class DuplicatedIdentifierException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_IDENTIFIER_DUPLICATE
+    err_code = error_codes_by_name['USER_IDENTIFIER_DUPLICATE']
 
 
 class ObjectAttributeInvalidException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_OBJECT_ATTRIBUTE_INVALID
+    err_code = error_codes_by_name['USER_OBJECT_ATTRIBUTE_INVALID']
 
 
 class ObjectAttributeMissingException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_OBJECT_ATTRIBUTE_MISSING
+    err_code = error_codes_by_name['USER_OBJECT_ATTRIBUTE_MISSING']
 
 
 class MalformedId(MessageException):
     status_code = 400
-    err_code = error_codes.MALFORMED_ID
+    err_code = error_codes_by_name['MALFORMED_ID']
 
 
 class MalformedContents(MessageException):
     status_code = 400
-    err_code = error_codes.MALFORMED_CONTENTS
+    err_code = error_codes_by_name['MALFORMED_CONTENTS']
 
 
 class UnknownContentsType(MessageException):
     status_code = 400
-    err_code = error_codes.UNKNOWN_CONTENTS_TYPE
+    err_code = error_codes_by_name['UNKNOWN_CONTENTS_TYPE']
 
 
 class RequestParameterMissingException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_REQUEST_MISSING_PARAMETER
+    err_code = error_codes_by_name['USER_REQUEST_MISSING_PARAMETER']
 
 
 class ToolMetaParameterException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_TOOL_META_PARAMETER_PROBLEM
+    err_code = error_codes_by_name['USER_TOOL_META_PARAMETER_PROBLEM']
 
 
 class ToolMissingException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_TOOL_MISSING_PROBLEM
+    err_code = error_codes_by_name['USER_TOOL_MISSING_PROBLEM']
 
     def __init__(self, err_msg=None, type="info", tool_id=None, **extra_error_info):
         super().__init__(err_msg, type, **extra_error_info)
@@ -118,59 +118,59 @@ class ToolMissingException(MessageException):
 
 class RequestParameterInvalidException(MessageException):
     status_code = 400
-    err_code = error_codes.USER_REQUEST_INVALID_PARAMETER
+    err_code = error_codes_by_name['USER_REQUEST_INVALID_PARAMETER']
 
 
 class ToolInputsNotReadyException(MessageException):
     status_code = 400
-    error_code = error_codes.TOOL_INPUTS_NOT_READY
+    error_code = error_codes_by_name['TOOL_INPUTS_NOT_READY']
 
 
 class AuthenticationFailed(MessageException):
     status_code = 401
-    err_code = error_codes.USER_AUTHENTICATION_FAILED
+    err_code = error_codes_by_name['USER_AUTHENTICATION_FAILED']
 
 
 class AuthenticationRequired(MessageException):
     status_code = 403
     # TODO: as 401 and send WWW-Authenticate: ???
-    err_code = error_codes.USER_NO_API_KEY
+    err_code = error_codes_by_name['USER_NO_API_KEY']
 
 
 class ItemAccessibilityException(MessageException):
     status_code = 403
-    err_code = error_codes.USER_CANNOT_ACCESS_ITEM
+    err_code = error_codes_by_name['USER_CANNOT_ACCESS_ITEM']
 
 
 class ItemOwnershipException(MessageException):
     status_code = 403
-    err_code = error_codes.USER_DOES_NOT_OWN_ITEM
+    err_code = error_codes_by_name['USER_DOES_NOT_OWN_ITEM']
 
 
 class ConfigDoesNotAllowException(MessageException):
     status_code = 403
-    err_code = error_codes.CONFIG_DOES_NOT_ALLOW
+    err_code = error_codes_by_name['CONFIG_DOES_NOT_ALLOW']
 
 
 class InsufficientPermissionsException(MessageException):
     status_code = 403
-    err_code = error_codes.INSUFFICIENT_PERMISSIONS
+    err_code = error_codes_by_name['INSUFFICIENT_PERMISSIONS']
 
 
 class AdminRequiredException(MessageException):
     status_code = 403
-    err_code = error_codes.ADMIN_REQUIRED
+    err_code = error_codes_by_name['ADMIN_REQUIRED']
 
 
 class UserActivationRequiredException(MessageException):
     status_code = 403
-    err_code = error_codes.USER_ACTIVATION_REQUIRED
+    err_code = error_codes_by_name['USER_ACTIVATION_REQUIRED']
 
 
 class ObjectNotFound(MessageException):
     """ Accessed object was not found """
     status_code = 404
-    err_code = error_codes.USER_OBJECT_NOT_FOUND
+    err_code = error_codes_by_name['USER_OBJECT_NOT_FOUND']
 
 
 class DeprecatedMethod(MessageException):
@@ -179,32 +179,32 @@ class DeprecatedMethod(MessageException):
     """
     status_code = 404
     # TODO:?? 410 Gone?
-    err_code = error_codes.DEPRECATED_API_CALL
+    err_code = error_codes_by_name['DEPRECATED_API_CALL']
 
 
 class Conflict(MessageException):
     status_code = 409
-    err_code = error_codes.CONFLICT
+    err_code = error_codes_by_name['CONFLICT']
 
 
 class ConfigurationError(Exception):
     status_code = 500
-    err_code = error_codes.CONFIG_ERROR
+    err_code = error_codes_by_name['CONFIG_ERROR']
 
 
 class InconsistentDatabase(MessageException):
     status_code = 500
-    err_code = error_codes.INCONSISTENT_DATABASE
+    err_code = error_codes_by_name['INCONSISTENT_DATABASE']
 
 
 class InternalServerError(MessageException):
     status_code = 500
-    err_code = error_codes.INTERNAL_SERVER_ERROR
+    err_code = error_codes_by_name['INTERNAL_SERVER_ERROR']
 
 
 class ToolExecutionError(MessageException):
     status_code = 500
-    err_code = error_codes.TOOL_EXECUTION_ERROR
+    err_code = error_codes_by_name['TOOL_EXECUTION_ERROR']
 
     def __init__(self, err_msg, type="error", job=None):
         super().__init__(err_msg, type)
@@ -213,12 +213,12 @@ class ToolExecutionError(MessageException):
 
 class NotImplemented(MessageException):
     status_code = 501
-    err_code = error_codes.NOT_IMPLEMENTED
+    err_code = error_codes_by_name['NOT_IMPLEMENTED']
 
 
 class InvalidFileFormatError(MessageException):
     status_code = 500
-    err_code = error_codes.INVALID_FILE_FORMAT
+    err_code = error_codes_by_name['INVALID_FILE_FORMAT']
 
 
 # non-web exceptions

--- a/lib/galaxy/exceptions/error_codes.py
+++ b/lib/galaxy/exceptions/error_codes.py
@@ -3,6 +3,7 @@
 See the file error_codes.json for actual error code descriptions.
 """
 from json import loads
+from typing import Dict
 
 from pkg_resources import resource_string
 
@@ -45,6 +46,9 @@ def _from_dict(entry):
 
 
 error_codes_json = unicodify(resource_string(__name__, 'error_codes.json'))
+error_codes_by_name: Dict[str, ErrorCode] = {}
+
 for entry in loads(error_codes_json):
     name, error_code_obj = _from_dict(entry)
     globals()[name] = error_code_obj
+    error_codes_by_name[name] = error_code_obj

--- a/lib/galaxy/job_metrics/collectl/subsystems.py
+++ b/lib/galaxy/job_metrics/collectl/subsystems.py
@@ -20,7 +20,7 @@ class CollectlSubsystem(metaclass=ABCMeta):
 
     @property
     @abstractmethod
-    def name(self, job_directory):
+    def name(self):
         """ High-level name for subsystem as consumed by this module.
         """
 

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -6,11 +6,7 @@ import os
 import shutil
 from datetime import datetime
 from functools import partial
-try:
-    from pathlib import Path
-except ImportError:
-    # Use backport on python 2
-    from pathlib2 import Path
+from pathlib import Path
 
 try:
     import irods

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -17,7 +17,7 @@ try:
     from boto.s3.connection import S3Connection
     from boto.s3.key import Key
 except ImportError:
-    boto = None
+    boto = None  # type: ignore
 
 from galaxy.exceptions import ObjectInvalid, ObjectNotFound
 from galaxy.util import (

--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -14,7 +14,7 @@ try:
     import boto
     from boto.s3.connection import S3Connection
 except ImportError:
-    boto = None
+    boto = None  # type: ignore
 
 
 def mp_from_ids(s3server, mp_id, mp_keyname, mp_bucketname):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -40,7 +40,7 @@ try:
     import grp
 except ImportError:
     # For Pulsar on Windows (which does not use the function that uses grp)
-    grp = None
+    grp = None  # type: ignore
 from boltons.iterutils import (
     default_enter,
     remap,
@@ -50,7 +50,7 @@ try:
     from lxml import etree
 except ImportError:
     LXML_AVAILABLE = False
-    import xml.etree.ElementTree as etree
+    import xml.etree.ElementTree as etree  # type: ignore
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -1551,8 +1551,8 @@ def safe_str_cmp(a, b):
     return rv == 0
 
 
-galaxy_root_path = os.path.join(__path__[0], os.pardir, os.pardir, os.pardir)
-galaxy_samples_path = os.path.join(__path__[0], os.pardir, 'config', 'sample')
+galaxy_root_path = os.path.join(__path__[0], os.pardir, os.pardir, os.pardir)  # type: ignore
+galaxy_samples_path = os.path.join(__path__[0], os.pardir, 'config', 'sample')  # type: ignore
 
 
 def galaxy_directory():

--- a/lib/galaxy/util/object_wrapper.py
+++ b/lib/galaxy/util/object_wrapper.py
@@ -23,40 +23,18 @@ from types import (
     TracebackType,
 )
 
-try:
-    from types import NoneType
-except ImportError:
-    NoneType = type(None)
-try:
-    from types import NotImplementedType
-except ImportError:
-    NotImplementedType = type(NotImplemented)
+NoneType = type(None)
+NotImplementedType = type(NotImplemented)
+EllipsisType = type(Ellipsis)
+XRangeType = range
+SliceType = slice
 
-try:
-    from types import EllipsisType
-except ImportError:
-    EllipsisType = type(Ellipsis)
-
-try:
-    from types import XRangeType
-except ImportError:
-    XRangeType = range
-
-try:
-    from types import SliceType
-except ImportError:
-    SliceType = slice
-
-try:
-    from types import (
-        BufferType,
-        DictProxyType
-    )
-except ImportError:
-    # Py3 doesn't have these concepts, just treat them like SliceType that
-    # so they are __WRAP_NO_SUBCLASS__.
-    BufferType = SliceType
-    DictProxyType = SliceType
+# Python 2 version was:
+# from types import BufferType, DictProxyType
+# Py3 doesn't have these concepts, just treat them like SliceType that
+# so they are __WRAP_NO_SUBCLASS__.
+BufferType = SliceType
+DictProxyType = SliceType
 
 from galaxy.util import sanitize_lists_to_string as _sanitize_lists_to_string
 
@@ -73,9 +51,6 @@ __WRAP_NO_SUBCLASS__ = (ModuleType, XRangeType, SliceType, BufferType, Traceback
 
 # Don't wrap or sanitize.
 __DONT_SANITIZE_TYPES__ = (Number, bool, NoneType, NotImplementedType, EllipsisType, bytearray, )
-
-# Don't wrap, but do sanitize.
-__DONT_WRAP_TYPES__ = tuple()  # ( basestring, ) so that we can get the unsanitized string, we will now wrap basestring instances
 
 # Wrap contents, but not the container
 __WRAP_SEQUENCES__ = (tuple, list, )
@@ -133,8 +108,6 @@ def wrap_with_safe_string(value, no_wrap_classes=None):
             safe_class = SafeStringWrapper
         if isinstance(value, no_wrap_classes):
             return value
-        if isinstance(value, __DONT_WRAP_TYPES__):
-            return sanitize_lists_to_string(value, valid_characters=VALID_CHARACTERS, character_map=CHARACTER_MAP)
         if isinstance(value, __WRAP_NO_SUBCLASS__):
             return safe_class(value, safe_string_wrapper_function=__do_wrap)
         for this_type in __WRAP_SEQUENCES__ + __WRAP_SETS__:

--- a/lib/galaxy/util/pastescript/loadwsgi.py
+++ b/lib/galaxy/util/pastescript/loadwsgi.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import re
 import sys
+from typing import Callable, Dict, List, Optional, Union
 from urllib.parse import unquote
 
 import pkg_resources
@@ -146,9 +147,9 @@ def _flatten(lst):
 
 class _ObjectType:
 
-    name = None
-    egg_protocols = None
-    config_prefixes = None
+    name: Optional[str] = None
+    egg_protocols: Optional[List[Union[str, List[str]]]] = None
+    config_prefixes: Optional[List[Union[List[str], str]]] = None
 
     def __init__(self):
         # Normalize these variables:
@@ -304,7 +305,7 @@ def appconfig(uri, name=None, relative_to=None, global_conf=None):
     return context.config()
 
 
-_loaders = {}
+_loaders: Dict[str, Callable] = {}
 
 
 def loadobj(object_type, uri, name=None, relative_to=None,

--- a/lib/galaxy/util/pastescript/serve.py
+++ b/lib/galaxy/util/pastescript/serve.py
@@ -34,7 +34,9 @@ import sys
 import textwrap
 import threading
 import time
+from gettext import gettext as _
 from logging.config import fileConfig
+from typing import Optional
 
 from .loadwsgi import loadapp, loadserver
 
@@ -48,11 +50,6 @@ A subclass of ``optparse.OptionParser`` that allows boolean long
 options (like ``--verbose``) to also take arguments (like
 ``--verbose=true``).  Arguments *must* use ``=``.
 """
-
-try:
-    _ = optparse._
-except AttributeError:
-    from gettext import gettext as _
 
 
 class BoolOptionParser(optparse.OptionParser):
@@ -144,19 +141,19 @@ class Command:
 
     max_args = None
     max_args_error = 'You must provide no more than %(max_args)s arguments'
-    min_args = None
+    min_args: Optional[int] = None
     min_args_error = 'You must provide at least %(min_args)s arguments'
     required_args = None
     # If this command takes a configuration file, set this to 1 or -1
     # Then if invoked through #! the config file will be put into the positional
     # arguments -- at the beginning with 1, at the end with -1
-    takes_config_file = None
+    takes_config_file: Optional[int] = None
 
     # Grouped in help messages by this:
     group_name = ''
 
     required_args = ()
-    description = None
+    description: Optional[str] = None
     usage = ''
     hidden = False
     # This is the default verbosity level; --quiet subtracts,
@@ -259,7 +256,7 @@ class Command:
         else:
             return ' ' * (length - len(s)) + s
 
-    def standard_parser(cls, verbose=True,
+    def _standard_parser(cls, verbose=True,
                         interactive=False,
                         no_interactive=False,
                         simulate=False,
@@ -309,7 +306,7 @@ class Command:
                               help="Overwrite files (warnings will be emitted for non-matching files otherwise)")
         return parser
 
-    standard_parser = classmethod(standard_parser)
+    standard_parser = classmethod(_standard_parser)
 
     def quote_first_command_arg(self, arg):
         """
@@ -399,7 +396,7 @@ class ServeCommand(Command):
     usage = 'CONFIG_FILE [start|stop|restart|status] [var=value]'
     takes_config_file = 1
     summary = "Serve the described application"
-    description = """\
+    description: Optional[str] = """\
     This command serves a web application that uses a paste.deploy
     configuration file for the server and application.
 

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -9,7 +9,7 @@ from functools import partial
 try:
     from grp import getgrgid
 except ImportError:
-    getgrgid = None
+    getgrgid = None  # type: ignore
 from itertools import starmap
 from operator import getitem
 from os import (
@@ -35,7 +35,7 @@ from os.path import (
 try:
     from pwd import getpwuid
 except ImportError:
-    getpwuid = None
+    getpwuid = None  # type: ignore
 
 
 import galaxy.util
@@ -204,7 +204,7 @@ def __path_permission_for_user(path, username):
     :type username:     string
     :param username:    a username matching the systems username
     """
-    if getpwuid is None:
+    if getpwuid is None or getgrgid is None:
         raise NotImplementedError("This functionality is not implemented for Windows.")
 
     group_id_of_file = stat(path).st_gid

--- a/lib/galaxy/util/plugin_config.py
+++ b/lib/galaxy/util/plugin_config.py
@@ -1,9 +1,6 @@
 import collections
 
-try:
-    import yaml
-except ImportError:
-    yaml = None
+import yaml
 
 from galaxy.util import parse_xml
 from galaxy.util.submodules import import_submodules

--- a/lib/galaxy/util/rules_dsl.py
+++ b/lib/galaxy/util/rules_dsl.py
@@ -1,6 +1,7 @@
 import abc
 import itertools
 import re
+from typing import List, Type
 
 import yaml
 from pkg_resources import resource_stream
@@ -567,7 +568,7 @@ class RuleSet:
         return message
 
 
-RULES_DEFINITION_CLASSES = [
+RULES_DEFINITION_CLASSES: List[Type[BaseRuleDefinition]] = [
     AddColumnMetadataRuleDefinition,
     AddColumnGroupTagValueRuleDefinition,
     AddColumnConcatenateRuleDefinition,

--- a/lib/galaxy/util/yaml_util.py
+++ b/lib/galaxy/util/yaml_util.py
@@ -6,7 +6,7 @@ import yaml
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
-    from yaml import SafeLoader
+    from yaml import SafeLoader  # type: ignore
 from yaml.constructor import ConstructorError
 
 

--- a/lib/galaxy_test/api/_framework.py
+++ b/lib/galaxy_test/api/_framework.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     # Galaxy libraries and galaxy test driver not available, just assume we're
     # targetting a remote Galaxy.
-    GalaxyTestDriver = None
+    GalaxyTestDriver = None  # type: ignore
 
 
 class ApiTestCase(FunctionalTestCase, UsesApiTestCaseMixin, TestCase):

--- a/packages/job_metrics/galaxy/__init__.py
+++ b/packages/job_metrics/galaxy/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/packages/objectstore/galaxy/__init__.py
+++ b/packages/objectstore/galaxy/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/packages/package-dev-requirements.txt
+++ b/packages/package-dev-requirements.txt
@@ -3,6 +3,7 @@
 
 # For dev
 sphinx
+mypy
 
 # For release
 wheel

--- a/packages/package.Makefile
+++ b/packages/package.Makefile
@@ -91,3 +91,6 @@ push-release:
 	echo "Makefile doesn't manually push release."
 
 release: release-local push-release
+
+mypy:
+	mypy $(SOURCE_DIR) $(TEST_DIR)

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -14,6 +14,7 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 
 virtualenv -p "$TEST_PYTHON" "$TEST_ENV_DIR"
 . "${TEST_ENV_DIR}/bin/activate"
+pip install mypy
 
 # ensure ordered by dependency dag
 PACKAGE_DIRS=(
@@ -33,9 +34,11 @@ PACKAGE_DIRS=(
 # tool_util not yet working 100%,
 # data has many problems quota, tool shed install database, etc..
 RUN_TESTS=(1 1 1 1 1 1 1 1 1 1 0 0)
+RUN_MYPY=(1 1 0 0 0 0 0 0 0 0 0 0)
 for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
     package_dir=${PACKAGE_DIRS[$i]}
     run_tests=${RUN_TESTS[$i]}
+    run_mypy=${RUN_MYPY[$i]}
 
     cd "$package_dir"
     pip install -e '.'
@@ -51,6 +54,9 @@ for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
 
     if [[ "$run_tests" == "1" ]]; then
         pytest --doctest-modules galaxy tests
+    fi
+    if [[ "$run_mypy" == "1" ]]; then
+        make mypy
     fi
     cd ..
 done

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -34,7 +34,7 @@ PACKAGE_DIRS=(
 # tool_util not yet working 100%,
 # data has many problems quota, tool shed install database, etc..
 RUN_TESTS=(1 1 1 1 1 1 1 1 1 1 0 0)
-RUN_MYPY=(1 1 0 0 0 0 0 0 0 0 0 0)
+RUN_MYPY=(1 1 1 0 0 0 0 0 0 0 0 0)
 for ((i=0; i<${#PACKAGE_DIRS[@]}; i++)); do
     package_dir=${PACKAGE_DIRS[$i]}
     run_tests=${RUN_TESTS[$i]}

--- a/packages/util/galaxy/__init__.py
+++ b/packages/util/galaxy/__init__.py
@@ -1,1 +1,1 @@
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ exclude = lib/galaxy/util/jstree.py
 # https://github.com/PyCQA/flake8-import-order/blob/master/tests/test_cases/complete_smarkets.py
 import-order-style = smarkets
 application-import-names = galaxy,galaxy_test,tool_shed
+
+[mypy]
+ignore_missing_imports = True

--- a/test/integration/objectstore/test_objectstore_datatype_upload.py
+++ b/test/integration/objectstore/test_objectstore_datatype_upload.py
@@ -3,6 +3,7 @@ import os
 import string
 import subprocess
 import time
+from typing import Optional
 
 import pytest
 
@@ -106,7 +107,7 @@ def stop_irods(container_name):
 
 class BaseObjectstoreUploadTest(UploadTestDatatypeDataTestCase):
 
-    object_store_template = None
+    object_store_template: Optional[string.Template] = None
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):

--- a/test/integration/resubmission_runners.py
+++ b/test/integration/resubmission_runners.py
@@ -1,4 +1,5 @@
 import time
+from typing import List
 
 from galaxy import model
 from galaxy.jobs.runners import (
@@ -66,7 +67,7 @@ class AssertionJobRunner(LocalJobRunner):
 class FailOnlyFirstJobRunner(LocalJobRunner):
     """Job runner that knows about test cases and checks final state assumptions."""
 
-    tests_seen = []
+    tests_seen: List[str] = []
 
     def queue_job(self, job_wrapper):
         resource_parameters = job_wrapper.get_resource_parameters()

--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -6,7 +6,8 @@ from galaxy_test.driver import integration_util
 from tool_shed.util import hg_util
 from .uses_shed import UsesShed
 
-REPO = namedtuple('Repository', 'name owner changeset')(
+REPO_TYPE = namedtuple('Repository', 'name owner changeset')
+REPO = REPO_TYPE(
     'collection_column_join',
     'iuc',
     'dfde09461b1e',  # revision 2, a known installable revision

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -35,10 +35,11 @@ CONFIG_TEST_TOOL_VERSION_TEMPLATE = string.Template(
 CONFIG_TEST_TOOL_VERSION_1 = CONFIG_TEST_TOOL_VERSION_TEMPLATE.safe_substitute(dict(version="1"))
 CONFIG_TEST_TOOL_VERSION_2 = CONFIG_TEST_TOOL_VERSION_TEMPLATE.safe_substitute(dict(version="2"))
 
-DEFAULT_TEST_REPO = collections.namedtuple(
+REPO_TYPE = collections.namedtuple(
     'DEFAULT_TEST_REPO',
     'tool_shed owner name changeset_revision installed_changeset_revision description status',
-)('github.com', 'galaxyproject', 'example', '1', '1', 'description', 'OK')
+)
+DEFAULT_TEST_REPO = REPO_TYPE('github.com', 'galaxyproject', 'example', '1', '1', 'description', 'OK')
 
 
 class BaseToolBoxTestCase(unittest.TestCase, UsesApp, UsesTools):

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ commands =
     lint_docstring_include_list: bash .ci/flake8_wrapper_docstrings.sh --include
 
     unit: bash run_tests.sh -u
+    # start with test here but obviously someday all of it...
+    mypy: mypy test
 whitelist_externals = bash
 passenv = 
     CI CONDA_EXE
@@ -28,6 +30,7 @@ setenv =
 deps =
     lint,lint_docstring,lint_docstring_include_list: -rlib/galaxy/dependencies/pipfiles/flake8/pinned-requirements.txt
     unit: mock-ssh-server
+    mypy: mypy
 
 [testenv:mulled]
 commands =  bash run_tests.sh --skip-venv -u test/unit/tool_util/mulled


### PR DESCRIPTION
Starts with mypy checking all of ``test/`` with the linting job and testing individual sub-projects as part of package CI testing for Galaxy. So far galaxy-util, galaxy-job-metrics, and galaxy-objectstore are covered.

Also adds a bunch of type annotations, reworks a bunch of hacks, and drops some Python 2 stuff in order to get this all green locally.