### PR TITLE
[WIP] Migrate htcondor runner to use the python htcondor bindings

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/Pipfile
+++ b/lib/galaxy/dependencies/pipfiles/default/Pipfile
@@ -90,6 +90,7 @@ gxformat2 = "*"
 refgenconf = ">=0.7.0"
 future = "*"
 zipstream-new = "*"
+htcondor = "*"
 
 [requires]
 python_version = "3.6"

--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -64,6 +64,7 @@ googleapis-common-protos==1.52.0; python_version >= '2.7' and python_version not
 gxformat2==0.15.0
 h11==0.11.0
 h5py==3.1.0
+htcondor==8.9.10
 httplib2==0.18.1
 humanfriendly==9.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -1,16 +1,6 @@
 """
 Condor helper utilities.
 """
-from subprocess import (
-    CalledProcessError,
-    check_call
-)
-
-from galaxy.util import (
-    commands,
-    unicodify
-)
-from ..external import parse_external_id
 
 DEFAULT_QUERY_CLASSAD = dict(
     universe='vanilla',
@@ -35,87 +25,24 @@ def submission_params(prefix=SUBMIT_PARAM_PREFIX, **kwds):
     return submission_params
 
 
-def build_submit_description(executable, output, error, user_log, query_params):
+def build_submit_description(submit_params, query_params):
     """
     Build up the contents of a condor submit description file.
 
-    >>> submit_args = dict(executable='/path/to/script', output='o', error='e', user_log='ul')
-    >>> submit_args['query_params'] = dict()
-    >>> default_description = build_submit_description(**submit_args)
-    >>> assert 'executable = /path/to/script' in default_description
-    >>> assert 'output = o' in default_description
-    >>> assert 'error = e' in default_description
-    >>> assert 'queue' in default_description
-    >>> assert 'universe = vanilla' in default_description
-    >>> assert 'universe = standard' not in default_description
-    >>> submit_args['query_params'] = dict(universe='standard')
-    >>> std_description = build_submit_description(**submit_args)
-    >>> assert 'universe = vanilla' not in std_description
-    >>> assert 'universe = standard' in std_description
+    >>> submit_args = dict(executable='/path/to/script', output='o', error='e', log='ul')
+    >>> query_args = dict()
+    >>> default_description = build_submit_description(submit_args, query_args)
+    >>> assert ('executable', '/path/to/script') in default_description.items()
+    >>> assert ('output', 'o') in default_description.items()
+    >>> assert ('error', 'e') in default_description.items()
+    >>> assert ('universe', 'vanilla') in default_description.items()
+    >>> assert ('universe', 'standard') not in default_description.items()
+    >>> query_args = dict(universe='standard')
+    >>> std_description = build_submit_description(submit_args, query_args)
+    >>> assert ('universe', 'vanilla') not in std_description.items()
+    >>> assert ('universe', 'standard') in std_description.items()
     """
     all_query_params = DEFAULT_QUERY_CLASSAD.copy()
     all_query_params.update(query_params)
-
-    submit_description = []
-    for key, value in all_query_params.items():
-        submit_description.append(f'{key} = {value}')
-    submit_description.append('executable = ' + executable)
-    submit_description.append('output = ' + output)
-    submit_description.append('error = ' + error)
-    submit_description.append('log = ' + user_log)
-    submit_description.append('queue')
-    return '\n'.join(submit_description)
-
-
-def condor_submit(submit_file):
-    """
-    Submit a condor job described by the given file. Parse an external id for
-    the submission or return None and a reason for the failure.
-    """
-    external_id = None
-    try:
-        message = commands.execute(('condor_submit', submit_file))
-    except commands.CommandLineException as e:
-        message = unicodify(e)
-    else:
-        try:
-            external_id = parse_external_id(message, type='condor')
-        except Exception:
-            message = PROBLEM_PARSING_EXTERNAL_ID
-    return external_id, message
-
-
-def condor_stop(external_id):
-    """
-    Stop running condor job and return a failure_message if this
-    fails.
-    """
-    failure_message = None
-    try:
-        check_call(('condor_rm', external_id))
-    except CalledProcessError:
-        failure_message = "condor_rm failed"
-    except Exception as e:
-        failure_message = "error encountered calling condor_rm: %s" % unicodify(e)
-    return failure_message
-
-
-def summarize_condor_log(log_file, external_id):
-    """
-    """
-    log_job_id = external_id.zfill(3)
-    s1 = s4 = s7 = s5 = s9 = False
-    with open(log_file) as log_handle:
-        for line in log_handle:
-            if '001 (' + log_job_id + '.' in line:
-                s1 = True
-            if '004 (' + log_job_id + '.' in line:
-                s4 = True
-            if '007 (' + log_job_id + '.' in line:
-                s7 = True
-            if '005 (' + log_job_id + '.' in line:
-                s5 = True
-            if '009 (' + log_job_id + '.' in line:
-                s9 = True
-        file_size = log_handle.tell()
-    return s1, s4, s7, s5, s9, file_size
+    all_query_params.update(submit_params)
+    return all_query_params


### PR DESCRIPTION
Advantages:
* using official bindings and an event logging mechanism if needed
* no hand-crafted parsing of condor job logs
* less io (I hope)
* avoid subprocess usage

Disadvantage:
* potentially many (as many jobs as running) open file handles
* the wheel is 30MB

The general question is if event logging or polling or a mixture is the best approach for us. More information can be found here: https://htcondor.readthedocs.io/en/latest/apis/python-bindings/tutorials/Scalable-Job-Tracking.html 

If the job is running longer than a day, we poll ones, to be save.

I appreciate any comments, as I'm not even sure the python bindings are any better than the current state.
