### PR TITLE
Only enable the workflow save button if it has changes.

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -84,6 +84,7 @@
                         <div class="unified-panel-header" unselectable="on">
                             <div class="unified-panel-header-inner">
                                 <WorkflowOptions
+                                    :hasChanges="hasChanges"
                                     @onSave="onSave"
                                     @onSaveAs="onSaveAs"
                                     @onRun="onRun"

--- a/client/src/components/Workflow/Editor/Options.test.js
+++ b/client/src/components/Workflow/Editor/Options.test.js
@@ -1,0 +1,31 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import Options from "./Options";
+
+const localVue = getLocalVue();
+
+describe("Options", () => {
+    it("render properly", async () => {
+        const wrapper = shallowMount(Options, {
+            propsData: { hasChanges: true },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".editor-button-save").attributes("role")).toBe("button");
+        expect(wrapper.find(".editor-button-save").attributes("disabled")).toBeFalsy();
+        expect(wrapper.find(".editor-button-save").attributes("title")).toBe("Save Workflow");
+
+        // requires a non-shallow mount
+        // wrapper.find('.editor-button-attributes').trigger('click');
+        // expect(wrapper.emitted().onAttributes).toBeTruthy();
+    });
+
+    it("should disable save if no changes", async () => {
+        const wrapper = shallowMount(Options, {
+            propsData: { hasChanges: false },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".editor-button-save").attributes("disabled")).toBe("true");
+    });
+});

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -6,6 +6,7 @@
             title="Edit Attributes"
             variant="link"
             aria-label="Edit Attributes"
+            class="editor-button-attributes"
             v-b-tooltip.hover
             @click="$emit('onAttributes')"
         >
@@ -17,6 +18,8 @@
             title="Save Workflow"
             variant="link"
             aria-label="Save Workflow"
+            class="editor-button-save"
+            :disabled="!hasChanges"
             v-b-tooltip.hover
             @click="$emit('onSave')"
         >
@@ -28,6 +31,7 @@
             title="Edit Report"
             variant="link"
             aria-label="Edit Report"
+            class="editor-button-report"
             v-b-tooltip.hover
             @click="$emit('onReport')"
         >
@@ -41,6 +45,7 @@
             title="Workflow Options"
             variant="link"
             aria-label="Workflow Options"
+            class="editor-button-options"
             v-b-tooltip.hover
         >
             <template v-slot:button-content>
@@ -62,6 +67,7 @@
             title="Run Workflow"
             variant="link"
             aria-label="Run Workflow"
+            class="editor-button-run"
             v-b-tooltip.hover
             @click="$emit('onRun')"
         >
@@ -69,3 +75,13 @@
         </b-button>
     </div>
 </template>
+
+<script>
+export default {
+    props: {
+        hasChanges: {
+            type: Boolean,
+        },
+    },
+};
+</script>

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -343,16 +343,9 @@ steps:
         # Assert workflow not initially bookmarked.
         assert_workflow_bookmarked_status(False)
 
-        save_button = self.components.workflows.save_button
-        save_button.wait_for_clickable()
-
-        # element is clickable, but still might be behind the modal
+        self.components.workflow_editor.canvas_body.wait_for_visible()
         self.wait_for_selector_absent_or_hidden(self.modal_body_selector())
-        save_button.wait_for_and_click()
-
-        # wait for saving
-        self.wait_for_selector_absent_or_hidden(self.modal_body_selector())
-        self.driver.find_element_by_id("workflow").click()
+        self.components.masthead.workflow.wait_for_and_click()
 
         # parse workflow table
         table_elements = self.workflow_index_table_elements()


### PR DESCRIPTION
It makes this check internally anyway (https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/Workflow/Editor/modules/services.js#L38) before firing the server request, so don't allow this click if it isn't going to do anything. I think it is helpful to understand if there are outstanding changes. I want to change the annotation stuff to come through editor Index.vue instead of firing its own ad-hoc request (ala #10987) so this button lighting up will make it super clear that an outstanding change has been made.

Also add a unit test for Workflow/Editor/Options.vue and add selectors to allow writing cleaner integration tests/tours.