### PR TITLE
Simplify workflow editor metadata handling.

### DIFF
--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -14,24 +14,31 @@ Services.mockImplementation(() => {
     };
 });
 
+const TEST_ANNOTATION = "my cool annotation";
+const TEST_NAME = "workflow_name";
+
 describe("Attributes", () => {
     it("test attributes", async () => {
         const localVue = createLocalVue();
         const wrapper = mount(Attributes, {
             propsData: {
                 id: "workflow_id",
-                name: "workflow_name",
+                name: TEST_NAME,
                 tags: ["workflow_tag_0", "workflow_tag_1"],
                 parameters: ["workflow_parameter_0", "workflow_parameter_1"],
                 versions: ["workflow_version_0"],
+                annotation: TEST_ANNOTATION,
             },
             stubs: {
                 LicenseSelector: true,
             },
             localVue,
         });
+        expect(wrapper.find(`[itemprop='description']`).attributes("content")).toBe(TEST_ANNOTATION);
+        expect(wrapper.find(`[itemprop='name']`).attributes("content")).toBe(TEST_NAME);
+
         const name = wrapper.find("#workflow-name");
-        expect(name.element.value).toBe("workflow_name");
+        expect(name.element.value).toBe(TEST_NAME);
         wrapper.setProps({ name: "new_workflow_name" });
         await localVue.nextTick();
         expect(name.element.value).toBe("new_workflow_name");
@@ -39,5 +46,6 @@ describe("Attributes", () => {
         expect(parameters.length).toBe(2);
         expect(parameters.at(0).text()).toBe("1: workflow_parameter_0");
         expect(parameters.at(1).text()).toBe("2: workflow_parameter_1");
+        expect(wrapper.find("#workflow-annotation").element.value).toBe(TEST_ANNOTATION);
     });
 });

--- a/client/src/components/Workflow/Editor/Attributes.test.js
+++ b/client/src/components/Workflow/Editor/Attributes.test.js
@@ -3,17 +3,6 @@ import Attributes from "./Attributes";
 
 jest.mock("app");
 
-import { Services } from "../services";
-jest.mock("../services");
-
-Services.mockImplementation(() => {
-    return {
-        async updateWorkflow() {
-            return {};
-        },
-    };
-});
-
 const TEST_ANNOTATION = "my cool annotation";
 const TEST_NAME = "workflow_name";
 

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -6,7 +6,7 @@
         <div id="workflow-name-area">
             <b>Name</b>
             <meta itemprop="name" :content="name" />
-            <b-input id="workflow-name" :value="name" @change="onRename" />
+            <b-input id="workflow-name" v-model="nameCurrent" @keyup="$emit('update:nameCurrent', nameCurrent)" />
         </div>
         <div id="workflow-version-area" class="mt-2">
             <b>Version</b>
@@ -115,6 +115,7 @@ export default {
             tagsCurrent: this.tags,
             versionCurrent: this.version,
             annotationCurrent: this.annotation,
+            nameCurrent: this.name,
         };
     },
     created() {
@@ -163,18 +164,17 @@ export default {
             }
             this.creatorCurrent = creator;
         },
-        annotation(newAnnotation) {
-            this.annotationCurrent = newAnnotation;
+        annotation() {
+            this.annotationCurrent = this.annotation;
+        },
+        name() {
+            this.nameCurrent = this.name;
         },
     },
     methods: {
         onTags(tags) {
             this.tagsCurrent = tags;
             this.onAttributes({ tags });
-        },
-        onRename(name) {
-            this.onAttributes({ name });
-            this.$emit("onRename", name);
         },
         onVersion() {
             this.$emit("onVersion", this.versionCurrent);

--- a/client/src/components/Workflow/Editor/Attributes.vue
+++ b/client/src/components/Workflow/Editor/Attributes.vue
@@ -26,8 +26,12 @@
         </div>
         <div id="workflow-annotation-area" class="mt-2">
             <b>Annotation</b>
-            <meta itemprop="description" :content="annotation" />
-            <b-textarea id="workflow-annotation" :value="annotation" @input="onAnnotation" />
+            <meta itemprop="description" :content="annotationCurrent" />
+            <b-textarea
+                id="workflow-annotation"
+                v-model="annotationCurrent"
+                @keyup="$emit('update:annotationCurrent', annotationCurrent)"
+            />
             <div class="form-text text-muted">
                 These notes will be visible when this workflow is viewed.
             </div>
@@ -83,7 +87,6 @@ export default {
         },
         annotation: {
             type: String,
-            default: "",
         },
         license: {
             type: String,
@@ -111,6 +114,7 @@ export default {
             messageVariant: null,
             tagsCurrent: this.tags,
             versionCurrent: this.version,
+            annotationCurrent: this.annotation,
         };
     },
     created() {
@@ -159,19 +163,14 @@ export default {
             }
             this.creatorCurrent = creator;
         },
+        annotation(newAnnotation) {
+            this.annotationCurrent = newAnnotation;
+        },
     },
     methods: {
         onTags(tags) {
             this.tagsCurrent = tags;
             this.onAttributes({ tags });
-        },
-        onAnnotation(annotation) {
-            if (this.annotationTimeout) {
-                clearTimeout(this.annotationTimeout);
-            }
-            this.annotationTimeout = setTimeout(() => {
-                this.onAttributes({ annotation });
-            }, 300);
         },
         onRename(name) {
             this.onAttributes({ name });
@@ -194,9 +193,6 @@ export default {
             this.services.updateWorkflow(this.id, data).catch((error) => {
                 this.onError(error);
             });
-        },
-        beforeDestroy: function () {
-            clearTimeout(this.annotationTimeout);
         },
     },
 };

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -84,6 +84,7 @@
                         <div class="unified-panel-header" unselectable="on">
                             <div class="unified-panel-header-inner">
                                 <WorkflowOptions
+                                    :hasChanges="hasChanges"
                                     @onSave="onSave"
                                     @onSaveAs="onSaveAs"
                                     @onRun="onRun"

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -103,6 +103,7 @@
                                     :name="name"
                                     :tags="tags"
                                     :parameters="parameters"
+                                    :annotationCurrent.sync="annotation"
                                     :annotation="annotation"
                                     :version="version"
                                     :versions="versions"
@@ -175,10 +176,6 @@ export default {
             type: Array,
             required: true,
         },
-        annotation: {
-            type: String,
-            default: "",
-        },
         moduleSections: {
             type: Array,
             required: true,
@@ -215,6 +212,7 @@ export default {
             labels: {},
             license: null,
             creator: null,
+            annotation: null,
         };
     },
     created() {
@@ -233,6 +231,13 @@ export default {
                 return "There are unsaved changes to your workflow which will be lost.";
             }
         };
+    },
+    watch: {
+        annotation: function (newAnnotation, oldAnnotation) {
+            if (newAnnotation != oldAnnotation) {
+                this.hasChanges = true;
+            }
+        },
     },
     methods: {
         onActivate(node) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -100,11 +100,12 @@
                             <div class="m-1">
                                 <WorkflowAttributes
                                     :id="id"
-                                    :name="name"
                                     :tags="tags"
                                     :parameters="parameters"
                                     :annotationCurrent.sync="annotation"
                                     :annotation="annotation"
+                                    :nameCurrent.sync="name"
+                                    :name="name"
                                     :version="version"
                                     :versions="versions"
                                     :license="license"
@@ -168,10 +169,6 @@ export default {
             type: Number,
             required: true,
         },
-        name: {
-            type: String,
-            required: true,
-        },
         tags: {
             type: Array,
             required: true,
@@ -213,6 +210,7 @@ export default {
             license: null,
             creator: null,
             annotation: null,
+            name: null,
         };
     },
     created() {
@@ -235,6 +233,11 @@ export default {
     watch: {
         annotation: function (newAnnotation, oldAnnotation) {
             if (newAnnotation != oldAnnotation) {
+                this.hasChanges = true;
+            }
+        },
+        name: function (newName, oldName) {
+            if (newName != oldName) {
                 this.hasChanges = true;
             }
         },

--- a/client/src/components/Workflow/Editor/Options.test.js
+++ b/client/src/components/Workflow/Editor/Options.test.js
@@ -1,0 +1,31 @@
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import Options from "./Options";
+
+const localVue = getLocalVue();
+
+describe("Options", () => {
+    it("render properly", async () => {
+        const wrapper = shallowMount(Options, {
+            propsData: { hasChanges: true },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".editor-button-save").attributes("role")).toBe("button");
+        expect(wrapper.find(".editor-button-save").attributes("disabled")).toBeFalsy();
+        expect(wrapper.find(".editor-button-save").attributes("title")).toBe("Save Workflow");
+
+        // requires a non-shallow mount
+        // wrapper.find('.editor-button-attributes').trigger('click');
+        // expect(wrapper.emitted().onAttributes).toBeTruthy();
+    });
+
+    it("should disable save if no changes", async () => {
+        const wrapper = shallowMount(Options, {
+            propsData: { hasChanges: false },
+            localVue,
+        });
+        await wrapper.vm.$nextTick();
+        expect(wrapper.find(".editor-button-save").attributes("disabled")).toBe("true");
+    });
+});

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -6,6 +6,7 @@
             title="Edit Attributes"
             variant="link"
             aria-label="Edit Attributes"
+            class="editor-button-attributes"
             v-b-tooltip.hover
             @click="$emit('onAttributes')"
         >
@@ -17,6 +18,8 @@
             title="Save Workflow"
             variant="link"
             aria-label="Save Workflow"
+            class="editor-button-save"
+            :disabled="!hasChanges"
             v-b-tooltip.hover
             @click="$emit('onSave')"
         >
@@ -28,6 +31,7 @@
             title="Edit Report"
             variant="link"
             aria-label="Edit Report"
+            class="editor-button-report"
             v-b-tooltip.hover
             @click="$emit('onReport')"
         >
@@ -41,6 +45,7 @@
             title="Workflow Options"
             variant="link"
             aria-label="Workflow Options"
+            class="editor-button-options"
             v-b-tooltip.hover
         >
             <template v-slot:button-content>
@@ -62,6 +67,7 @@
             title="Run Workflow"
             variant="link"
             aria-label="Run Workflow"
+            class="editor-button-run"
             v-b-tooltip.hover
             @click="$emit('onRun')"
         >
@@ -69,3 +75,13 @@
         </b-button>
     </div>
 </template>
+
+<script>
+export default {
+    props: {
+        hasChanges: {
+            type: Boolean,
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/Editor/modules/model.js
+++ b/client/src/components/Workflow/Editor/modules/model.js
@@ -117,7 +117,8 @@ export function toSimple(workflow) {
     const license = workflow.license;
     const creator = workflow.creator;
     const annotation = workflow.annotation;
-    return { steps: nodes, report, license, creator, annotation };
+    const name = workflow.name;
+    return { steps: nodes, report, license, creator, annotation, name };
 }
 
 function _scaledBoundingClientRect(element, canvasZoom) {

--- a/client/src/components/Workflow/Editor/modules/model.js
+++ b/client/src/components/Workflow/Editor/modules/model.js
@@ -8,6 +8,7 @@ export function fromSimple(workflow, data, appendData = false) {
     } else {
         workflow.nodeIndex = 0;
         workflow.name = data.name;
+        workflow.annotation = data.annotation;
         Object.values(workflow.nodes).forEach((node) => {
             node.onRemove();
         });
@@ -115,7 +116,8 @@ export function toSimple(workflow) {
     const report = workflow.report;
     const license = workflow.license;
     const creator = workflow.creator;
-    return { steps: nodes, report: report, license: license, creator: creator };
+    const annotation = workflow.annotation;
+    return { steps: nodes, report, license, creator, annotation };
 }
 
 function _scaledBoundingClientRect(element, canvasZoom) {

--- a/client/src/components/Workflow/Editor/modules/model.js
+++ b/client/src/components/Workflow/Editor/modules/model.js
@@ -9,6 +9,8 @@ export function fromSimple(workflow, data, appendData = false) {
         workflow.nodeIndex = 0;
         workflow.name = data.name;
         workflow.annotation = data.annotation;
+        workflow.license = data.license;
+        workflow.creator = data.creator;
         Object.values(workflow.nodes).forEach((node) => {
             node.onRemove();
         });

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -43,6 +43,7 @@ export async function saveWorkflow(workflow) {
             workflow.hasChanges = false;
             workflow.stored = true;
             workflow.version = data.version;
+            workflow.annotation = data.annotation;
             return data;
         } catch (e) {
             rethrowSimple(e);

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -735,8 +735,8 @@ class WorkflowContentsManager(UsesAnnotations):
         data['upgrade_messages'] = {}
         data['report'] = workflow.reports_config or {}
         data['license'] = workflow.license
-        log.info("creator_metadata is %s" % workflow.creator_metadata)
         data['creator'] = workflow.creator_metadata
+        data['annotation'] = self.get_item_annotation_str(trans.sa_session, trans.user, stored) or ''
 
         output_label_index = set()
         input_step_types = set(workflow.input_step_types)

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -412,6 +412,12 @@ class WorkflowContentsManager(UsesAnnotations):
                 errors.append("Step %i: Requires tool '%s'." % (int(missing_tool_tup[3]) + 1, missing_tool_tup[0]))
             raise MissingToolsException(workflow, errors)
 
+        as_dict = raw_workflow_description.as_dict
+        if 'name' in as_dict:
+            sanitized_name = sanitize_html(as_dict['name'])
+            workflow.name = sanitized_name
+            stored_workflow.name = sanitized_name
+
         # Connect up
         workflow.stored_workflow = stored_workflow
         stored_workflow.latest_workflow = workflow

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -438,6 +438,8 @@ class WorkflowContentsManager(UsesAnnotations):
 
         if 'report' in data:
             workflow.reports_config = data['report']
+        workflow.license = data.get('license')
+        workflow.creator_metadata = data.get('creator')
 
         # Assume no errors until we find a step that has some
         workflow.has_errors = False
@@ -1153,6 +1155,8 @@ class WorkflowContentsManager(UsesAnnotations):
             inputs[index] = {'label': label, 'value': '', 'uuid': step_uuid}
         item['inputs'] = inputs
         item['annotation'] = self.get_item_annotation_str(sa_session, stored.user, stored)
+        item['license'] = workflow.license
+        item['creator'] = workflow.creator_metadata
         steps = {}
         steps_to_order_index = {}
         for step in workflow.steps:

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -383,6 +383,7 @@ workflow_editor:
     connector_for: "div[output-handle-id='${source_id}'][input-handle-id='${sink_id}']"
 
     connector_destroy_callout: '.delete-terminal'
+    save_button: '.editor-button-save'
 
 tour:
   popover:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -576,27 +576,13 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             raw_workflow_description = self.__normalize_workflow(trans, workflow_dict)
             workflow_dict = raw_workflow_description.as_dict
             new_workflow_name = workflow_dict.get('name')
-            license_set = 'license' in workflow_dict
-            creator_set = 'creator' in workflow_dict
             old_workflow = stored_workflow.latest_workflow
             name_updated = (new_workflow_name and new_workflow_name != stored_workflow.name)
-            license_updated = license_set and workflow_dict['license'] != old_workflow.license
-            update_attributes = name_updated or license_updated or creator_set
-            if update_attributes:
+            if name_updated:
                 sanitized_name = sanitize_html(new_workflow_name or old_workflow.name)
                 workflow = old_workflow.copy(user=trans.user)
                 workflow.stored_workflow = stored_workflow
                 workflow.name = sanitized_name
-                if license_set:
-                    new_workflow_license = workflow_dict.get('license')
-                else:
-                    new_workflow_license = old_workflow.license
-                if creator_set:
-                    new_workflow_creator = workflow_dict.get('creator')
-                else:
-                    new_workflow_creator = old_workflow.creator_metadata
-                workflow.license = new_workflow_license
-                workflow.creator_metadata = new_workflow_creator
                 stored_workflow.name = sanitized_name
                 stored_workflow.latest_workflow = workflow
                 trans.sa_session.add(workflow, stored_workflow)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -578,7 +578,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             new_workflow_name = workflow_dict.get('name')
             old_workflow = stored_workflow.latest_workflow
             name_updated = (new_workflow_name and new_workflow_name != stored_workflow.name)
-            if name_updated:
+            steps_updated = 'steps' in workflow_dict
+            if name_updated and not steps_updated:
                 sanitized_name = sanitize_html(new_workflow_name or old_workflow.name)
                 workflow = old_workflow.copy(user=trans.user)
                 workflow.stored_workflow = stored_workflow

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -27,13 +27,16 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         editor = self.components.workflow_editor
         annotation = "basic_test"
         name = self.workflow_create_new(annotation=annotation)
-        edit_name_element = self.components.workflow_editor.edit_name.wait_for_visible()
-        actual_name = edit_name_element.get_attribute("value")
-        assert name in actual_name, f"'{name}' unequal name '{actual_name}'"
+        self.assert_wf_name_is(name)
         self.assert_wf_annotation_is(annotation)
 
         editor.canvas_body.wait_for_visible()
         editor.tool_menu.wait_for_visible()
+
+        # shouldn't have changes on fresh load
+        save_button = self.components.workflow_editor.save_button
+        save_button.wait_for_visible()
+        assert save_button.has_class("disabled")
 
         self.screenshot("workflow_editor_blank")
 
@@ -61,16 +64,26 @@ class WorkflowEditorTestCase(SeleniumTestCase):
 
         editor.canvas_body.wait_for_visible()
 
-        save_button = self.components.workflow_editor.save_button
-        save_button.wait_for_visible()
-        assert save_button.has_class("disabled")
         new_annotation = 'look new annotation'
         edit_annotation.wait_for_and_send_keys(new_annotation)
-
-        save_button.wait_for_and_click()
+        self.assert_has_changes_and_save()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.workflow_index_open_with_name(name)
         self.assert_wf_annotation_is(new_annotation)
+
+    @selenium_test
+    def test_edit_name(self):
+        editor = self.components.workflow_editor
+        name = self.workflow_create_new()
+        editor.canvas_body.wait_for_visible()
+        new_name = self._get_random_name()
+        edit_name = self.components.workflow_editor.edit_name
+        edit_name.wait_for_and_send_keys(new_name)
+
+        self.assert_has_changes_and_save()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_index_open_with_name(new_name)
+        self.assert_wf_name_is(name)
 
     @selenium_test
     def test_data_input(self):
@@ -499,6 +512,19 @@ steps:
         inputs[1].send_keys(annotation)
         form_element.click()
         return name
+
+    @retry_assertion_during_transitions
+    def assert_has_changes_and_save(self):
+        save_button = self.components.workflow_editor.save_button
+        save_button.wait_for_visible()
+        assert not save_button.has_class("disabled")
+        save_button.wait_for_and_click()
+
+    @retry_assertion_during_transitions
+    def assert_wf_name_is(self, expected_name):
+        edit_name_element = self.components.workflow_editor.edit_name.wait_for_visible()
+        actual_name = edit_name_element.get_attribute("value")
+        assert expected_name in actual_name, f"'{expected_name}' unequal name '{actual_name}'"
 
     @retry_assertion_during_transitions
     def assert_wf_annotation_is(self, expected_annotation):

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -343,16 +343,9 @@ steps:
         # Assert workflow not initially bookmarked.
         assert_workflow_bookmarked_status(False)
 
-        save_button = self.components.workflows.save_button
-        save_button.wait_for_clickable()
-
-        # element is clickable, but still might be behind the modal
+        self.components.workflow_editor.canvas_body.wait_for_visible()
         self.wait_for_selector_absent_or_hidden(self.modal_body_selector())
-        save_button.wait_for_and_click()
-
-        # wait for saving
-        self.wait_for_selector_absent_or_hidden(self.modal_body_selector())
-        self.driver.find_element_by_id("workflow").click()
+        self.components.masthead.workflow.wait_for_and_click()
 
         # parse workflow table
         table_elements = self.workflow_index_table_elements()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -30,9 +30,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         edit_name_element = self.components.workflow_editor.edit_name.wait_for_visible()
         actual_name = edit_name_element.get_attribute("value")
         assert name in actual_name, f"'{name}' unequal name '{actual_name}'"
-        edit_annotation_element = self.components.workflow_editor.edit_annotation.wait_for_visible()
-        actual_annotation = edit_annotation_element.get_attribute("value")
-        assert annotation in actual_annotation, f"'{annotation}' unequal annotation '{actual_annotation}'"
+        self.assert_wf_annotation_is(annotation)
 
         editor.canvas_body.wait_for_visible()
         editor.tool_menu.wait_for_visible()
@@ -52,6 +50,27 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         self.sleep_for(self.wait_types.UX_RENDER)
 
         self.screenshot("workflow_editor_left_and_right_collapsed")
+
+    @selenium_test
+    def test_edit_annotation(self):
+        editor = self.components.workflow_editor
+        annotation = "new_annotation_test"
+        name = self.workflow_create_new(annotation=annotation)
+        edit_annotation = self.components.workflow_editor.edit_annotation
+        self.assert_wf_annotation_is(annotation)
+
+        editor.canvas_body.wait_for_visible()
+
+        save_button = self.components.workflow_editor.save_button
+        save_button.wait_for_visible()
+        assert save_button.has_class("disabled")
+        new_annotation = 'look new annotation'
+        edit_annotation.wait_for_and_send_keys(new_annotation)
+
+        save_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_index_open_with_name(name)
+        self.assert_wf_annotation_is(new_annotation)
 
     @selenium_test
     def test_data_input(self):
@@ -480,6 +499,13 @@ steps:
         inputs[1].send_keys(annotation)
         form_element.click()
         return name
+
+    @retry_assertion_during_transitions
+    def assert_wf_annotation_is(self, expected_annotation):
+        edit_annotation = self.components.workflow_editor.edit_annotation
+        edit_annotation_element = edit_annotation.wait_for_visible()
+        actual_annotation = edit_annotation_element.get_attribute("value")
+        assert expected_annotation in actual_annotation, f"'{expected_annotation}' unequal annotation '{actual_annotation}'"
 
     @retry_assertion_during_transitions
     def assert_modal_has_text(self, expected_text):


### PR DESCRIPTION
A few different related changes here.
- Move responsibility for hitting the server to update annotation & name from Attributes.vue to Index.vue. This unifies & simplifies both the server interaction, user experience, and sets up addressing both #9166 & #10989
- Simplify backend related to license and creator in response to simpler frontend in #10987 (easy to simplify the API here since we haven't done a release with this yet).
- Do not create two workflow versions for each new name. We're exposing workflow versions so we should try to constrain the number of new versions we create - without these changes it is easy to create several versions by just renaming the workflow a couple times.
- Add selenium tests for rename workflows and updating annotations.