### PR TITLE
More structured workflow create/update parameter handling

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -3,6 +3,7 @@ import logging
 import os
 import uuid
 from collections import namedtuple
+from typing import Dict, Optional
 
 from gxformat2 import (
     from_galaxy_native,
@@ -1447,6 +1448,29 @@ class WorkflowUpdateOptions(WorkflowStateResolutionOptions):
 # workflows with missing tools by default but not updating.
 class WorkflowCreateOptions(WorkflowStateResolutionOptions):
     allow_missing_tools: bool = True
+
+    import_tools: bool = False
+
+    # following are install options, only used if import_tools is true
+    install_repository_dependencies: bool = False
+    install_resolver_dependencies: bool = False
+    install_tool_dependencies: bool = False
+    new_tool_panel_section_label: str = ''
+    tool_panel_section_id: str = ''
+    tool_panel_section_mapping: Dict = {}
+    shed_tool_conf: Optional[str] = None
+
+    @property
+    def install_options(self):
+        return {
+            'install_repository_dependencies': self.install_repository_dependencies,
+            'install_resolver_dependencies': self.install_resolver_dependencies,
+            'install_tool_dependencies': self.install_tool_dependencies,
+            'new_tool_panel_section_label': self.new_tool_panel_section_label,
+            'tool_panel_section_id': self.tool_panel_section_id,
+            'tool_panel_section_mapping': self.tool_panel_section_mapping,
+            'shed_tool_conf': self.shed_tool_conf
+        }
 
 
 class MissingToolsException(exceptions.MessageException):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -10,6 +10,7 @@ from gxformat2 import (
     ImportOptions,
     python_to_workflow,
 )
+from pydantic import BaseModel
 from sqlalchemy import and_
 from sqlalchemy.orm import joinedload, subqueryload
 
@@ -334,13 +335,11 @@ class WorkflowContentsManager(UsesAnnotations):
         self,
         trans,
         raw_workflow_description,
+        workflow_create_options,
         source=None,
         add_to_menu=False,
         publish=False,
         hidden=False,
-        exact_tools=True,
-        fill_defaults=False,
-        from_tool_form=False,
     ):
         data = raw_workflow_description.as_dict
         # Put parameters in workflow mode
@@ -353,10 +352,8 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow, missing_tool_tups = self._workflow_from_raw_description(
             trans,
             raw_workflow_description,
+            workflow_create_options,
             name=name,
-            exact_tools=exact_tools,
-            fill_defaults=fill_defaults,
-            from_tool_form=from_tool_form,
         )
         if 'uuid' in data:
             workflow.uuid = data['uuid']
@@ -394,7 +391,7 @@ class WorkflowContentsManager(UsesAnnotations):
             missing_tools=missing_tool_tups
         )
 
-    def update_workflow_from_raw_description(self, trans, stored_workflow, raw_workflow_description, **kwds):
+    def update_workflow_from_raw_description(self, trans, stored_workflow, raw_workflow_description, workflow_update_options):
         raw_workflow_description = self.ensure_raw_description(raw_workflow_description)
 
         # Put parameters in workflow mode
@@ -403,8 +400,8 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow, missing_tool_tups = self._workflow_from_raw_description(
             trans,
             raw_workflow_description,
+            workflow_update_options,
             name=stored_workflow.name,
-            **kwds
         )
 
         if missing_tool_tups:
@@ -417,7 +414,7 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow.stored_workflow = stored_workflow
         stored_workflow.latest_workflow = workflow
 
-        if kwds.get("update_stored_workflow_attributes", True):
+        if workflow_update_options.update_stored_workflow_attributes:
             update_dict = raw_workflow_description.as_dict
             if 'name' in update_dict:
                 sanitized_name = sanitize_html(update_dict['name'])
@@ -439,7 +436,7 @@ class WorkflowContentsManager(UsesAnnotations):
             errors.append("This workflow contains cycles")
         return workflow, errors
 
-    def _workflow_from_raw_description(self, trans, raw_workflow_description, name, **kwds):
+    def _workflow_from_raw_description(self, trans, raw_workflow_description, workflow_state_resolution_options, name, **kwds):
         data = raw_workflow_description.as_dict
         if isinstance(data, str):
             data = json.loads(data)
@@ -473,7 +470,7 @@ class WorkflowContentsManager(UsesAnnotations):
         if subworkflows:
             subworkflow_id_map = {}
             for key, subworkflow_dict in subworkflows.items():
-                subworkflow = self.__build_embedded_subworkflow(trans, subworkflow_dict, **kwds)
+                subworkflow = self.__build_embedded_subworkflow(trans, subworkflow_dict, workflow_state_resolution_options)
                 subworkflow_id_map[key] = subworkflow
 
         # Keep track of tools required by the workflow that are not available in
@@ -481,10 +478,12 @@ class WorkflowContentsManager(UsesAnnotations):
         # will be ( tool_id, tool_name, tool_version ).
         missing_tool_tups = []
         for step_dict in self.__walk_step_dicts(data):
-            self.__load_subworkflows(trans, step_dict, subworkflow_id_map, **kwds)
+            self.__load_subworkflows(trans, step_dict, subworkflow_id_map, workflow_state_resolution_options)
 
+        module_kwds = workflow_state_resolution_options.dict()
+        module_kwds.update(kwds)  # TODO: maybe drop this?
         for step_dict in self.__walk_step_dicts(data):
-            module, step = self.__module_from_dict(trans, steps, steps_by_external_id, step_dict, **kwds)
+            module, step = self.__module_from_dict(trans, steps, steps_by_external_id, step_dict, **module_kwds)
             is_tool = is_tool_module_type(module.type)
             if is_tool and module.tool is None:
                 missing_tool_tup = (module.tool_id, module.get_name(), module.tool_version, step_dict['id'])
@@ -1263,11 +1262,11 @@ class WorkflowContentsManager(UsesAnnotations):
 
             yield step_dict
 
-    def __load_subworkflows(self, trans, step_dict, subworkflow_id_map, **kwds):
+    def __load_subworkflows(self, trans, step_dict, subworkflow_id_map, workflow_state_resolution_options):
         step_type = step_dict.get("type", None)
         if step_type == "subworkflow":
             subworkflow = self.__load_subworkflow_from_step_dict(
-                trans, step_dict, subworkflow_id_map, **kwds
+                trans, step_dict, subworkflow_id_map, workflow_state_resolution_options
             )
             step_dict["subworkflow"] = subworkflow
 
@@ -1331,7 +1330,7 @@ class WorkflowContentsManager(UsesAnnotations):
 
         return module, step
 
-    def __load_subworkflow_from_step_dict(self, trans, step_dict, subworkflow_id_map, **kwds):
+    def __load_subworkflow_from_step_dict(self, trans, step_dict, subworkflow_id_map, workflow_state_resolution_options):
         embedded_subworkflow = step_dict.get("subworkflow", None)
         subworkflow_id = step_dict.get("content_id", None)
         if embedded_subworkflow and subworkflow_id:
@@ -1341,7 +1340,7 @@ class WorkflowContentsManager(UsesAnnotations):
             raise Exception("Subworkflow step must define either subworkflow or content_id.")
 
         if embedded_subworkflow:
-            subworkflow = self.__build_embedded_subworkflow(trans, embedded_subworkflow, **kwds)
+            subworkflow = self.__build_embedded_subworkflow(trans, embedded_subworkflow, workflow_state_resolution_options)
         elif subworkflow_id_map is not None:
             # Interpret content_id as a workflow local thing.
             subworkflow = subworkflow_id_map[subworkflow_id[1:]]
@@ -1353,10 +1352,10 @@ class WorkflowContentsManager(UsesAnnotations):
 
         return subworkflow
 
-    def __build_embedded_subworkflow(self, trans, data, **kwds):
+    def __build_embedded_subworkflow(self, trans, data, workflow_state_resolution_options):
         raw_workflow_description = self.ensure_raw_description(data)
         subworkflow = self.build_workflow_from_raw_description(
-            trans, raw_workflow_description, hidden=True, fill_defaults=kwds.get("fill_defaults", False)
+            trans, raw_workflow_description, workflow_state_resolution_options, hidden=True
         ).workflow
         return subworkflow
 
@@ -1407,6 +1406,9 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow = stored_workflow.latest_workflow
         as_dict = self.workflow_to_dict(trans, stored_workflow, style="ga")
         raw_workflow_description = self.normalize_workflow_format(trans, as_dict)
+        workflow_update_options = WorkflowUpdateOptions()
+        workflow_update_options.fill_defaults = False
+
         module_injector = WorkflowModuleInjector(trans)
         WorkflowRefactorExecutor(raw_workflow_description, workflow, module_injector).refactor(refactor_request)
         if refactor_request.dry_run:
@@ -1419,8 +1421,32 @@ class WorkflowContentsManager(UsesAnnotations):
                 trans,
                 stored_workflow,
                 raw_workflow_description,
-                fill_defaults=False,
+                workflow_update_options,
             )
+
+
+class WorkflowStateResolutionOptions(BaseModel):
+    # fill in default tool state when updating, may change tool_state
+    fill_defaults: bool = False
+    # If True, assume all tool state coming from generated form instead of potentially simpler json stored in DB/exported
+    from_tool_form: bool = False
+    # If False, allow running with less exact tool versions
+    exact_tools: bool = True
+    # If True, allow workflow update with missing tools.
+    allow_missing_tools: bool = False
+
+
+class WorkflowUpdateOptions(WorkflowStateResolutionOptions):
+    # Only used internally, don't set. If using the API assume updating the workflows
+    # representation with name or annotation for instance, updates the corresponding
+    # stored workflow
+    update_stored_workflow_attributes: bool = True
+
+
+# Workflow update options but with some different defaults - we allow creating
+# workflows with missing tools by default but not updating.
+class WorkflowCreateOptions(WorkflowStateResolutionOptions):
+    allow_missing_tools: bool = True
 
 
 class MissingToolsException(exceptions.MessageException):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1419,7 +1419,7 @@ class WorkflowContentsManager(UsesAnnotations):
                 trans,
                 stored_workflow,
                 raw_workflow_description,
-                fill_defaults=True,
+                fill_defaults=False,
             )
 
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -339,7 +339,6 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow_create_options,
         source=None,
         add_to_menu=False,
-        publish=False,
         hidden=False,
     ):
         data = raw_workflow_description.as_dict
@@ -366,7 +365,7 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow.stored_workflow = stored
         stored.latest_workflow = workflow
         stored.user = trans.user
-        stored.published = publish
+        stored.published = workflow_create_options.publish
         stored.hidden = hidden
         if data['annotation']:
             annotation = sanitize_html(data['annotation'])
@@ -1451,6 +1450,10 @@ class WorkflowCreateOptions(WorkflowStateResolutionOptions):
 
     import_tools: bool = False
 
+    publish: bool = False
+    # true or false, effectively defaults to ``publish`` if None/unset
+    importable: Optional[bool] = None
+
     # following are install options, only used if import_tools is true
     install_repository_dependencies: bool = False
     install_resolver_dependencies: bool = False
@@ -1459,6 +1462,14 @@ class WorkflowCreateOptions(WorkflowStateResolutionOptions):
     tool_panel_section_id: str = ''
     tool_panel_section_mapping: Dict = {}
     shed_tool_conf: Optional[str] = None
+
+    @property
+    def is_importable(self):
+        # if self.importable is None, use self.publish that has a default.
+        if self.importable is None:
+            return self.publish
+        else:
+            return self.importable
 
     @property
     def install_options(self):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1432,8 +1432,6 @@ class WorkflowStateResolutionOptions(BaseModel):
     from_tool_form: bool = False
     # If False, allow running with less exact tool versions
     exact_tools: bool = True
-    # If True, allow workflow update with missing tools.
-    allow_missing_tools: bool = False
 
 
 class WorkflowUpdateOptions(WorkflowStateResolutionOptions):
@@ -1446,8 +1444,6 @@ class WorkflowUpdateOptions(WorkflowStateResolutionOptions):
 # Workflow update options but with some different defaults - we allow creating
 # workflows with missing tools by default but not updating.
 class WorkflowCreateOptions(WorkflowStateResolutionOptions):
-    allow_missing_tools: bool = True
-
     import_tools: bool = False
 
     publish: bool = False

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -3,7 +3,10 @@ import logging
 import os
 import uuid
 from collections import namedtuple
-from typing import Dict, Optional
+from typing import (
+    Dict,
+    Optional,
+)
 
 from gxformat2 import (
     from_galaxy_native,

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1261,25 +1261,6 @@ class UsesStoredWorkflowMixin(SharableItemSecurityMixin, UsesAnnotations):
         session.flush()
         return imported_stored
 
-    def _workflow_from_dict(self, trans, data, source=None, add_to_menu=False, publish=False, exact_tools=True, fill_defaults=False, from_tool_form=False):
-        """
-        Creates a workflow from a dict. Created workflow is stored in the database and returned.
-        """
-        # TODO: replace this method with direct access to manager.
-        workflow_contents_manager = workflows.WorkflowContentsManager(self.app)
-        raw_workflow_description = workflow_contents_manager.ensure_raw_description(data)
-        created_workflow = workflow_contents_manager.build_workflow_from_raw_description(
-            trans,
-            raw_workflow_description,
-            source=source,
-            add_to_menu=add_to_menu,
-            publish=publish,
-            exact_tools=exact_tools,
-            fill_defaults=fill_defaults,
-            from_tool_form=from_tool_form,
-        )
-        return created_workflow.stored_workflow, created_workflow.missing_tools
-
     def _workflow_to_dict(self, trans, stored):
         """
         Converts a workflow to a dict of attributes suitable for exporting.

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -1389,6 +1389,25 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         )
         return self.__encode_invocation_step(trans, invocation_step)
 
+    def _workflow_from_dict(self, trans, data, source=None, add_to_menu=False, publish=False, exact_tools=True, fill_defaults=False, from_tool_form=False):
+        """Creates a workflow from a dict.
+
+        Created workflow is stored in the database and returned.
+        """
+        workflow_contents_manager = self.app.workflow_contents_manager
+        raw_workflow_description = workflow_contents_manager.ensure_raw_description(data)
+        created_workflow = workflow_contents_manager.build_workflow_from_raw_description(
+            trans,
+            raw_workflow_description,
+            source=source,
+            add_to_menu=add_to_menu,
+            publish=publish,
+            exact_tools=exact_tools,
+            fill_defaults=fill_defaults,
+            from_tool_form=from_tool_form,
+        )
+        return created_workflow.stored_workflow, created_workflow.missing_tools
+
     def __encode_invocation_step(self, trans, invocation_step):
         return self.encode_all_ids(
             trans,

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -723,9 +723,6 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         if not data:
             raise exceptions.MessageException("The data content is missing.")
         raw_workflow_description = self.__normalize_workflow(trans, data)
-        # TODO: pass more options into here for consistency
-        # TODO: for consistency, find a way to prevent this operation on missing_tool_tups
-        #       if options.allow_missing_tools is false
         workflow_create_options = WorkflowCreateOptions(**payload)
         workflow, missing_tool_tups = self._workflow_from_dict(trans, raw_workflow_description, workflow_create_options, source=source)
         workflow_id = workflow.id
@@ -747,9 +744,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
     def __api_import_new_workflow(self, trans, payload, **kwd):
         data = payload['workflow']
         raw_workflow_description = self.__normalize_workflow(trans, data)
-        data = raw_workflow_description.as_dict
         workflow_create_options = WorkflowCreateOptions(**payload)
-
         workflow, missing_tool_tups = self._workflow_from_dict(
             trans,
             raw_workflow_description,
@@ -1346,7 +1341,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         )
         return self.__encode_invocation_step(trans, invocation_step)
 
-    def _workflow_from_dict(self, trans, data, workflow_create_options, source=None, add_to_menu=False):
+    def _workflow_from_dict(self, trans, data, workflow_create_options, source=None):
         """Creates a workflow from a dict.
 
         Created workflow is stored in the database and returned.
@@ -1363,7 +1358,6 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
             raw_workflow_description,
             workflow_create_options,
             source=source,
-            add_to_menu=add_to_menu,
         )
         if importable:
             self._make_item_accessible(trans.sa_session, created_workflow.stored_workflow)

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -20,9 +20,9 @@ from galaxy import (
 )
 from galaxy.managers import (
     histories,
-    workflows
 )
 from galaxy.managers.jobs import fetch_job_states, invocation_job_source_iter, summarize_job_metrics
+from galaxy.managers.workflows import MissingToolsException
 from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.tool_shed.galaxy_install.install_manager import InstallRepositoryManager
 from galaxy.tools import recommendations
@@ -57,8 +57,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
     def __init__(self, app):
         super().__init__(app)
         self.history_manager = histories.HistoryManager(app)
-        self.workflow_manager = workflows.WorkflowsManager(app)
-        self.workflow_contents_manager = workflows.WorkflowContentsManager(app)
+        self.workflow_manager = app.workflow_manager
+        self.workflow_contents_manager = app.workflow_contents_manager
         self.tool_recommendations = recommendations.ToolRecommendations()
 
     def __get_full_shed_url(self, url):
@@ -626,7 +626,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
                         raw_workflow_description,
                         **from_dict_kwds
                     )
-                except workflows.MissingToolsException:
+                except MissingToolsException:
                     raise exceptions.MessageException("This workflow contains missing tools. It cannot be saved until they have been removed from the workflow or installed.")
 
         else:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -712,7 +712,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
     #
     # -- Helper methods --
     #
-    def __api_import_from_archive(self, trans, archive_data, source=None, payload={}):
+    def __api_import_from_archive(self, trans, archive_data, source=None, payload=None):
+        payload = payload or {}
         try:
             data = json.loads(archive_data)
         except Exception:

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -14,7 +14,7 @@ from galaxy import (
     util,
     web
 )
-from galaxy.managers.workflows import MissingToolsException
+from galaxy.managers.workflows import MissingToolsException, WorkflowUpdateOptions
 from galaxy.model.item_attrs import UsesItemRatings
 from galaxy.model.mapping import desc
 from galaxy.security.validate_user_input import validate_publicname
@@ -602,14 +602,16 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             session = trans.sa_session
             session.add(stored_workflow)
             session.flush()
-
+            workflow_update_options = WorkflowUpdateOptions(
+                update_stored_workflow_attributes=False,  # taken care of above
+                from_tool_form=from_tool_form,
+            )
             try:
                 workflow, errors = workflow_contents_manager.update_workflow_from_raw_description(
                     trans,
                     stored_workflow,
                     workflow_data,
-                    from_tool_form=from_tool_form,
-                    update_stored_workflow_attributes=False,  # taken care of above
+                    workflow_update_options,
                 )
             except MissingToolsException as e:
                 return dict(

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -14,7 +14,10 @@ from galaxy import (
     util,
     web
 )
-from galaxy.managers.workflows import MissingToolsException, WorkflowUpdateOptions
+from galaxy.managers.workflows import (
+    MissingToolsException,
+    WorkflowUpdateOptions,
+)
 from galaxy.model.item_attrs import UsesItemRatings
 from galaxy.model.mapping import desc
 from galaxy.security.validate_user_input import validate_publicname

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -14,7 +14,7 @@ from galaxy import (
     util,
     web
 )
-from galaxy.managers import workflows
+from galaxy.managers.workflows import MissingToolsException
 from galaxy.model.item_attrs import UsesItemRatings
 from galaxy.model.mapping import desc
 from galaxy.security.validate_user_input import validate_publicname
@@ -585,7 +585,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         """
         user = trans.get_user()
         if workflow_name is not None:
-            workflow_contents_manager = workflows.WorkflowContentsManager(trans.app)
+            workflow_contents_manager = self.app.workflow_contents_manager
             stored_workflow = model.StoredWorkflow()
             stored_workflow.name = workflow_name
             stored_workflow.user = user
@@ -611,7 +611,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
                     from_tool_form=from_tool_form,
                     update_stored_workflow_attributes=False,  # taken care of above
                 )
-            except workflows.MissingToolsException as e:
+            except MissingToolsException as e:
                 return dict(
                     name=e.workflow.name,
                     message=("This workflow includes missing or invalid tools. "
@@ -729,7 +729,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         """
         trans.workflow_building_mode = workflow_building_modes.ENABLED
         stored = self.get_stored_workflow(trans, id, check_ownership=True, check_accessible=False)
-        workflow_contents_manager = workflows.WorkflowContentsManager(trans.app)
+        workflow_contents_manager = self.app.workflow_contents_manager
         return workflow_contents_manager.workflow_to_dict(trans, stored, style="editor", version=version)
 
     @web.expose


### PR DESCRIPTION
Builds on #11015. 

See individual commits for details - but the big idea is to reduce duplication between different ways to create workflows and the one way to update one while also using structured, validated options instead of just passing ``**kwds`` around a bunch of different layers.
