### PR TITLE
Expand image formats for viewing in OpenSeadragon

### DIFF
--- a/config/plugins/visualizations/openseadragon/config/openseadragon.xml
+++ b/config/plugins/visualizations/openseadragon/config/openseadragon.xml
@@ -5,8 +5,10 @@
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
+            <test type="isinstance" test_attr="datatype" result_type="datatype">images.Gif</test>
             <test type="isinstance" test_attr="datatype" result_type="datatype">images.Jpg</test>
             <test type="isinstance" test_attr="datatype" result_type="datatype">images.Png</test>
+            <test type="isinstance" test_attr="datatype" result_type="datatype">images.Tiff</test>
             <test type="isinstance" test_attr="datatype" result_type="datatype">xml.Dzi</test>
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>

--- a/config/plugins/visualizations/openseadragon/templates/openseadragon.mako
+++ b/config/plugins/visualizations/openseadragon/templates/openseadragon.mako
@@ -31,7 +31,7 @@
             const xmlns = "http://schemas.microsoft.com/deepzoom/2008";
             const image_types = ["gif", "jpg", "png", "tiff"];
 
-            if (image_types.indexOf(hda_ext) >= 0) {
+            if (image_types.includes(hda_ext)) {
                 var viewer = OpenSeadragon({
                     id: viewer_id,
                     prefixUrl: prefixUrl,

--- a/config/plugins/visualizations/openseadragon/templates/openseadragon.mako
+++ b/config/plugins/visualizations/openseadragon/templates/openseadragon.mako
@@ -29,8 +29,9 @@
             const prefixUrl = "//openseadragon.github.io/openseadragon/images/";
             const simple_image_url = "${h.url_for(controller='/datasets', action='index')}/" + hda_id + "/display";
             const xmlns = "http://schemas.microsoft.com/deepzoom/2008";
+            const image_types = ["gif", "jpg", "png", "tiff"];
 
-            if (hda_ext == 'jpg' || hda_ext == 'png') {
+            if (image_types.indexOf(hda_ext) >= 0) {
                 var viewer = OpenSeadragon({
                     id: viewer_id,
                     prefixUrl: prefixUrl,


### PR DESCRIPTION
@bgruening The OpenSeadragon viewer works with each of these formats, which seem to be the most likely to be used within Galaxy.  We'll eventually need a tool to convert these formats into the dzi (deep zoom image) format to get the real benefits of this viewer.  There are several tool candidates that can be wrapped for Galaxy, so eventually one will be added to the tools-iuc repo.