### PR TITLE
Fix change feed

### DIFF
--- a/client/src/components/History/caching/CacheApi.js
+++ b/client/src/components/History/caching/CacheApi.js
@@ -17,7 +17,7 @@ export * from "./db/promises";
 export { loadDscContent } from "./loadDscContent";
 export { loadHistoryContents, clearHistoryDateStore } from "./loadHistoryContents";
 export { monitorHistoryContent } from "./monitorHistoryContent";
-export { wipeDatabase } from "./db/pouch";
+export { wipeDatabase } from "./db/wipeDatabase";
 
 // generic content query monitor
 export const monitorContentQuery = (cfg = {}) => {

--- a/client/src/components/History/caching/db/changes.js
+++ b/client/src/components/History/caching/db/changes.js
@@ -40,6 +40,7 @@ const buildFeed = (db, cfg = {}) => {
         return () => {
             // console.log("CANCELLING FEED", db.name);
             feed.cancel();
+            feeds.delete(db);
         };
     });
 

--- a/client/src/components/History/caching/db/changes.js
+++ b/client/src/components/History/caching/db/changes.js
@@ -12,7 +12,6 @@ export const feeds = new Map();
 export const changes = (cfg = {}) => {
     return pipe(
         switchMap((db) => {
-            // console.log("SUBSCRIBING TO FEED", db.name);
             if (!feeds.has(db)) {
                 feeds.set(db, buildFeed(db, cfg));
             }

--- a/client/src/components/History/caching/db/changes.js
+++ b/client/src/components/History/caching/db/changes.js
@@ -1,5 +1,5 @@
 import { pipe, Observable } from "rxjs";
-import { switchMap, filter, share, shareReplay } from "rxjs/operators";
+import { switchMap, filter, share } from "rxjs/operators";
 
 // feed observables, keyed by underlying database instance
 export const feeds = new Map();
@@ -12,7 +12,7 @@ export const feeds = new Map();
 export const changes = (cfg = {}) => {
     return pipe(
         switchMap((db) => {
-            // console.log("subscribing to changes", db.name);
+            // console.log("SUBSCRIBING TO FEED", db.name);
             if (!feeds.has(db)) {
                 feeds.set(db, buildFeed(db, cfg));
             }
@@ -32,15 +32,15 @@ const buildFeed = (db, cfg = {}) => {
     const { live = true, returnDocs = true, include_docs = true, since = "now", timeout = false } = cfg;
 
     const feed$ = new Observable((obs) => {
-        // console.log("creating feed", db.name);
+        // console.log("CREATING FEED", db.name);
         const changeOpts = { live, include_docs, returnDocs, since, timeout };
         const feed = db.changes(changeOpts);
         feed.on("change", (update) => obs.next(update));
         feed.on("error", (err) => obs.error(err));
         return () => {
-            // console.log("cancelling feed", db.name);
+            // console.log("CANCELLING FEED", db.name);
             feed.cancel();
-        }
+        };
     });
 
     return feed$.pipe(share());

--- a/client/src/components/History/caching/db/changes.js
+++ b/client/src/components/History/caching/db/changes.js
@@ -37,7 +37,6 @@ const buildFeed = (db, cfg = {}) => {
         feed.on("change", (update) => obs.next(update));
         feed.on("error", (err) => obs.error(err));
         return () => {
-            // console.log("CANCELLING FEED", db.name);
             feed.cancel();
             feeds.delete(db);
         };

--- a/client/src/components/History/caching/db/changes.js
+++ b/client/src/components/History/caching/db/changes.js
@@ -31,7 +31,6 @@ const buildFeed = (db, cfg = {}) => {
     const { live = true, returnDocs = true, include_docs = true, since = "now", timeout = false } = cfg;
 
     const feed$ = new Observable((obs) => {
-        // console.log("CREATING FEED", db.name);
         const changeOpts = { live, include_docs, returnDocs, since, timeout };
         const feed = db.changes(changeOpts);
         feed.on("change", (update) => obs.next(update));

--- a/client/src/components/History/caching/db/changes.test.js
+++ b/client/src/components/History/caching/db/changes.test.js
@@ -1,4 +1,5 @@
-import { takeWhile, share } from "rxjs/operators";
+import { timer } from "rxjs";
+import { takeWhile, share, takeUntil } from "rxjs/operators";
 import { content$, dscContent$ } from "./observables";
 import { wipeDatabase } from "./wipeDatabase";
 import {
@@ -9,7 +10,8 @@ import {
     getCachedCollectionContent,
     cacheCollectionContent,
 } from "./promises";
-import { changes } from "./changes";
+import { changes, feeds } from "./changes";
+import { wait } from "jest/helpers";
 
 // test data
 import historyContent from "../../test/json/historyContent.json";
@@ -120,4 +122,55 @@ describe("changes operator", () => {
             expect(floobars.length).toEqual(1);
         });
     });
+
+    describe("change feed should be shared", () => {
+
+        const lifeTime = 300;
+        const spinUpTime = 100;
+
+        test("subscriging should show 1 feed, unsubscribing should show 0", async () => {
+
+            // subscribe to changes onece
+            const feed$ = content$.pipe(changes(), takeUntil(timer(lifeTime)));
+            const spy = new ObserverSpy();
+            feed$.subscribe(spy);
+
+            // give it a little time to put itself together
+            await wait(spinUpTime);
+            expect(feeds.size).toEqual(1);
+
+            // complete, share() should now remove instance
+            await spy.onComplete();
+            expect(feeds.size).toEqual(0);
+        })
+
+        test("subscribing 2 times should result in one feed if it's the same DB", async () => {
+
+            // subscribe to changes onece
+            const feed$ = content$.pipe(changes(), takeUntil(timer(2 * lifeTime)));
+            const spy = new ObserverSpy();
+            feed$.subscribe(spy);
+
+            // give it a little time to put itself together
+            await wait(spinUpTime);
+            expect(feeds.size).toEqual(1);
+
+            // subscribe again
+            const feed2$ = content$.pipe(changes(), takeUntil(timer(lifeTime)));
+            const spy2 = new ObserverSpy();
+            feed2$.subscribe(spy2);
+
+            await wait(spinUpTime);
+            expect(feeds.size).toEqual(1);
+            
+            // unsub from 2nd feed
+            await spy2.onComplete();
+            expect(feeds.size).toEqual(1);
+
+            // unsub from 1st feed
+            await spy.onComplete();
+            expect(feeds.size).toEqual(0);
+
+        });
+    })
 });

--- a/client/src/components/History/caching/db/changes.test.js
+++ b/client/src/components/History/caching/db/changes.test.js
@@ -1,6 +1,6 @@
 import { takeWhile, share } from "rxjs/operators";
 import { content$, dscContent$ } from "./observables";
-import { wipeDatabase } from "./pouch";
+import { wipeDatabase } from "./wipeDatabase";
 import {
     bulkCacheContent,
     cacheContent,

--- a/client/src/components/History/caching/db/changes.test.js
+++ b/client/src/components/History/caching/db/changes.test.js
@@ -128,7 +128,7 @@ describe("changes operator", () => {
         const spinUpTime = 100;
 
         test("subscriging should show 1 feed, unsubscribing should show 0", async () => {
-            // subscribe to changes onece
+            // subscribe to changes once
             const feed$ = content$.pipe(changes(), takeUntil(timer(lifeTime)));
             const spy = new ObserverSpy();
             feed$.subscribe(spy);

--- a/client/src/components/History/caching/db/changes.test.js
+++ b/client/src/components/History/caching/db/changes.test.js
@@ -124,12 +124,10 @@ describe("changes operator", () => {
     });
 
     describe("change feed should be shared", () => {
-
         const lifeTime = 300;
         const spinUpTime = 100;
 
         test("subscriging should show 1 feed, unsubscribing should show 0", async () => {
-
             // subscribe to changes onece
             const feed$ = content$.pipe(changes(), takeUntil(timer(lifeTime)));
             const spy = new ObserverSpy();
@@ -142,10 +140,9 @@ describe("changes operator", () => {
             // complete, share() should now remove instance
             await spy.onComplete();
             expect(feeds.size).toEqual(0);
-        })
+        });
 
         test("subscribing 2 times should result in one feed if it's the same DB", async () => {
-
             // subscribe to changes onece
             const feed$ = content$.pipe(changes(), takeUntil(timer(2 * lifeTime)));
             const spy = new ObserverSpy();
@@ -162,7 +159,7 @@ describe("changes operator", () => {
 
             await wait(spinUpTime);
             expect(feeds.size).toEqual(1);
-            
+
             // unsub from 2nd feed
             await spy2.onComplete();
             expect(feeds.size).toEqual(1);
@@ -170,7 +167,6 @@ describe("changes operator", () => {
             // unsub from 1st feed
             await spy.onComplete();
             expect(feeds.size).toEqual(0);
-
         });
-    })
+    });
 });

--- a/client/src/components/History/caching/db/db.test.js
+++ b/client/src/components/History/caching/db/db.test.js
@@ -1,6 +1,6 @@
 import isPromise from "is-promise";
 import { isObservable } from "rxjs";
-import { wipeDatabase } from "./pouch";
+import { wipeDatabase } from "./wipeDatabase";
 import { content$, dscContent$, buildContentId, buildCollectionId, prepContent, prepDscContent } from "./observables";
 import { firstValueFrom } from "utils/observable/firstValueFrom";
 

--- a/client/src/components/History/caching/db/find.test.js
+++ b/client/src/components/History/caching/db/find.test.js
@@ -2,7 +2,7 @@ import { Subject } from "rxjs";
 import { take } from "rxjs/operators";
 import { ObserverSpy } from "@hirez_io/observer-spy";
 
-import { wipeDatabase } from "./pouch";
+import { wipeDatabase } from "./wipeDatabase";
 import { bulkCacheContent, bulkCacheDscContent } from "./promises";
 import { content$, dscContent$, buildContentId } from "./observables";
 import { find } from "./find";

--- a/client/src/components/History/caching/db/index.js
+++ b/client/src/components/History/caching/db/index.js
@@ -13,4 +13,4 @@ export { changes } from "./changes";
 export { monitorQuery } from "./monitorQuery";
 
 // utility function
-export { wipeDatabase } from "./pouch";
+export { wipeDatabase } from "./wipeDatabase";

--- a/client/src/components/History/caching/db/monitorQuery.test.js
+++ b/client/src/components/History/caching/db/monitorQuery.test.js
@@ -2,7 +2,7 @@ import { of, timer } from "rxjs";
 import { take, takeUntil } from "rxjs/operators";
 import { ObserverSpy } from "@hirez_io/observer-spy";
 import { wait } from "jest/helpers";
-import { wipeDatabase } from "./pouch";
+import { wipeDatabase } from "./wipeDatabase";
 
 import { monitorQuery, ACTIONS } from "./monitorQuery";
 import { content$, dscContent$ } from "./observables";

--- a/client/src/components/History/caching/db/pouch.js
+++ b/client/src/components/History/caching/db/pouch.js
@@ -8,6 +8,7 @@ import deepEqual from "deep-equal";
 import { defer, pipe, from } from "rxjs";
 import { tap, filter, mergeMap, reduce, shareReplay } from "rxjs/operators";
 import { needs } from "../operators/needs";
+import { dasherize } from "underscore.string";
 
 import PouchDB from "pouchdb";
 import PouchAdapterMemory from "pouchdb-adapter-memory";
@@ -27,7 +28,7 @@ PouchDB.plugin(PouchErase);
 // const show = (obj) => console.log(JSON.stringify(obj, null, 4));
 
 // Instance storage map, keyed by database name
-const dbs = new Map();
+export const dbs = new Map();
 
 /**
  * Generate an observable that initializes and shares a pouchdb instance.
@@ -71,7 +72,7 @@ async function buildCollection(opts, appConfig) {
 function collectionName(opts, appConfig) {
     const { name: dbName } = opts;
     const { name: envName } = appConfig;
-    return `${dbName}-${envName}`;
+    return dasherize(`${dbName} ${envName}`);
 }
 
 async function installCollectionIndexes(db, indexes = []) {
@@ -231,11 +232,3 @@ export async function deleteIndexes(db) {
     return await Promise.all(promises);
 }
 
-/**
- * Erases all stored database instances
- */
-export async function wipeDatabase() {
-    for (const db of dbs.values()) {
-        await db.erase();
-    }
-}

--- a/client/src/components/History/caching/db/pouch.js
+++ b/client/src/components/History/caching/db/pouch.js
@@ -231,4 +231,3 @@ export async function deleteIndexes(db) {
     const promises = doomedIndexes.map((idx) => db.deleteIndex(idx));
     return await Promise.all(promises);
 }
-

--- a/client/src/components/History/caching/db/wipeDatabase.js
+++ b/client/src/components/History/caching/db/wipeDatabase.js
@@ -1,0 +1,10 @@
+import { dbs } from "./pouch";
+
+/**
+ * Erases all stored database instances
+ */
+export async function wipeDatabase() {
+    for (const db of dbs.values()) {
+        await db.erase();
+    }
+}

--- a/client/src/components/History/caching/loadHistoryContents.js
+++ b/client/src/components/History/caching/loadHistoryContents.js
@@ -93,7 +93,6 @@ export const loadHistoryContents = (cfg = {}) => (rawInputs$) => {
 // TODO: method in history model maybe? Or maybe Searchparams?
 export const buildHistoryContentsUrl = (windowSize) => (inputs) => {
     const [historyId, filters, hid] = inputs;
-    // console.log("buildHistoryContentsUrl", windowSize, hid);
 
     // Filtering
     const { showDeleted, showHidden } = filters;

--- a/client/src/components/History/caching/loadHistoryContents.js
+++ b/client/src/components/History/caching/loadHistoryContents.js
@@ -93,7 +93,7 @@ export const loadHistoryContents = (cfg = {}) => (rawInputs$) => {
 // TODO: method in history model maybe? Or maybe Searchparams?
 export const buildHistoryContentsUrl = (windowSize) => (inputs) => {
     const [historyId, filters, hid] = inputs;
-    console.log("buildHistoryContentsUrl", windowSize, hid);
+    // console.log("buildHistoryContentsUrl", windowSize, hid);
 
     // Filtering
     const { showDeleted, showHidden } = filters;

--- a/client/src/components/History/caching/monitorHistoryContent.test.js
+++ b/client/src/components/History/caching/monitorHistoryContent.test.js
@@ -1,7 +1,7 @@
 import { timer, of } from "rxjs";
 import { take, pluck, takeUntil } from "rxjs/operators";
 import { firstValueFrom } from "utils/observable/firstValueFrom";
-import { wipeDatabase } from "../caching/db/pouch";
+import { wipeDatabase } from "./db/wipeDatabase";
 import { wait } from "jest/helpers";
 import { ObserverSpy } from "@hirez_io/observer-spy";
 

--- a/client/src/components/History/providers/DscProvider/DscProvider.test.js
+++ b/client/src/components/History/providers/DscProvider/DscProvider.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 import { createLocalVue } from "@vue/test-utils";
 import { wait, mountRenderless } from "jest/helpers";
-import { wipeDatabase } from "../../caching/db/pouch";
+import { wipeDatabase } from "../../caching";
 import { cacheContent, getCachedContent, cacheCollectionContent, getCachedCollectionContent } from "../../caching";
 import { DatasetCollection } from "../../model/DatasetCollection";
 import DscProvider from "./DscProvider";

--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -8,6 +8,7 @@ import { loadWebhookMenuItems } from "./_webhooks";
 jest.mock("app");
 jest.mock("layout/menu");
 jest.mock("./_webhooks");
+jest.mock("../History/caching");
 
 describe("Masthead.vue", () => {
     let wrapper;

--- a/client/src/components/Upload/UploadModal.test.js
+++ b/client/src/components/Upload/UploadModal.test.js
@@ -6,6 +6,7 @@ import { shallowMount, createLocalVue } from "@vue/test-utils";
 import BootstrapVue from "bootstrap-vue";
 
 jest.mock("app");
+jest.mock("../History/caching");
 
 const propsData = {
     chunkUploadSize: 1024,

--- a/client/src/config/development.js
+++ b/client/src/config/development.js
@@ -1,5 +1,5 @@
 export default {
-    name: "development configs",
+    name: "development",
     debug: true,
     rxjsDebug: true,
     caching: {

--- a/client/src/config/production.js
+++ b/client/src/config/production.js
@@ -1,5 +1,5 @@
 export default {
-    name: "production configs",
+    name: "production",
     debug: false,
     rxjsDebug: false,
     caching: {

--- a/client/src/config/testing.js
+++ b/client/src/config/testing.js
@@ -1,5 +1,5 @@
 export default {
-    name: "unit testing configs",
+    name: "testing",
     testBuild: true,
     debug: false,
     rxjsDebug: false,

--- a/client/tests/jest/__mocks__/config.js
+++ b/client/tests/jest/__mocks__/config.js
@@ -1,5 +1,5 @@
 export default {
-    name: "unit testing configs",
+    name: "testing",
     testBuild: true,
     debug: false,
     caching: {


### PR DESCRIPTION
A flaw in the pouchDB object that monitors changes (db/changes.js) was causing too many event emitters to be created. I've beefed up the management of those objects and added some unit tests to test the situation.