### PR TITLE
Pass `job` to `setup_external_metadata()` in `SetMetadataToolAction.execute_via_app()`

### DIFF
--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -115,6 +115,8 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
                                 kwds=None):
         assert job_metadata, "setup_external_metadata must be supplied with job_metadata path"
         kwds = kwds or {}
+        if not job:
+            job = sa_session.query(galaxy.model.Job).get(self.job_id)
         tmp_dir = _init_tmp_dir(tmp_dir)
 
         metadata_dir = os.path.join(tmp_dir, "metadata")
@@ -294,6 +296,8 @@ class JobExternalOutputMetadataWrapper(MetadataCollectionStrategy):
                                 object_store_conf=None, tool=None, job=None,
                                 kwds=None):
         kwds = kwds or {}
+        if not job:
+            job = sa_session.query(galaxy.model.Job).get(self.job_id)
         tmp_dir = _init_tmp_dir(tmp_dir)
         _assert_datatypes_config(datatypes_config)
 
@@ -335,7 +339,6 @@ class JobExternalOutputMetadataWrapper(MetadataCollectionStrategy):
             # so we will only populate the dictionary once
             metadata_files = self._get_output_filenames_by_dataset(dataset, sa_session)
             if not metadata_files:
-                job = sa_session.query(galaxy.model.Job).get(self.job_id)
                 metadata_files = galaxy.model.JobExternalOutputMetadata(job=job, dataset=dataset)
                 # we are using tempfile to create unique filenames, tempfile always returns an absolute path
                 # we will use pathnames relative to the galaxy root, to accommodate instances where the galaxy root

--- a/lib/galaxy/tools/actions/metadata.py
+++ b/lib/galaxy/tools/actions/metadata.py
@@ -103,8 +103,9 @@ class SetMetadataToolAction(ToolAction):
                                                                      datatypes_config=datatypes_config,
                                                                      job_metadata=os.path.join(job_working_dir, 'working', tool.provided_metadata_file),
                                                                      include_command=False,
-                                                                     validate_outputs=validate_outputs,
                                                                      max_metadata_value_size=app.config.max_metadata_value_size,
+                                                                     validate_outputs=validate_outputs,
+                                                                     job=job,
                                                                      kwds={'overwrite': overwrite})
         incoming['__SET_EXTERNAL_METADATA_COMMAND_LINE__'] = cmd_line
         for name, value in tool.params_to_strings(incoming, app).items():


### PR DESCRIPTION
- Make `PortableDirectoryMetadataGenerator.setup_external_metadata()` resistant to missing `job`
- Get `job` only once in `JobExternalOutputMetadataWrapper.setup_external_metadata()`

Fix the following traceback:
```
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/web/framework/decorators.py", line 305, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/history_contents.py", line 654, in update
    return self.__update_dataset(trans, history_id, id, payload, **kwd)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/history_contents.py", line 691, in __update_dataset
    self.__deserialize_dataset(hda, payload, trans)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/history_contents.py", line 718, in __deserialize_dataset
    self.hda_deserializer.deserialize(hda, payload, user=trans.user, trans=trans)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/managers/base.py", line 740, in deserialize
    new_dict[key] = self.deserializers[key](item, key, val, **context)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/managers/datasets.py", line 690, in deserialize_datatype
    self.app.datatypes_registry.set_external_metadata_tool.tool_action.execute(self.app.datatypes_registry.set_external_metadata_tool, trans, incoming={'input1': item}, overwrite=False)  # overwrite is False as per existing behavior
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/tools/actions/metadata.py", line 29, in execute
    overwrite, history, job_params)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/tools/actions/metadata.py", line 108, in execute_via_app
    kwds={'overwrite': overwrite})
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/metadata/__init__.py", line 158, in setup_external_metadata
    "job_id_tag": job.get_id_tag(),
AttributeError: 'NoneType' object has no attribute 'get_id_tag'
```