### PR TITLE
Implement edit & upgrade subworkflow buttons in workflow editor.

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -12,6 +12,7 @@
             @onWorkflowError="onWorkflowError"
             @onWorkflowMessage="onWorkflowMessage"
             @onRefactor="onRefactor"
+            @onShow="hideModal()"
         />
         <MarkdownEditor
             v-if="!isCanvas"
@@ -319,6 +320,9 @@ export default {
         },
         onWorkflowMessage(title, body) {
             show_message(title, body);
+        },
+        hideModal() {
+            hide_modal();
         },
         async onRefactor(response) {
             await fromSimple(this, response.workflow);

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -149,7 +149,6 @@
 import { getDatatypesMapper } from "components/Datatypes";
 import { getModule, getVersions, saveWorkflow, loadWorkflow, refactor } from "./modules/services";
 import {
-    showWarnings,
     getStateUpgradeMessages,
     copyIntoWorkflow,
     getLegacyWorkflowParameters,
@@ -432,7 +431,6 @@ export default {
             !hideProgress && show_message("Saving workflow...", "progress");
             return saveWorkflow(this)
                 .then((data) => {
-                    showWarnings(data);
                     getVersions(this.id).then((versions) => {
                         this.versions = versions;
                         hide_modal();

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -132,7 +132,7 @@
                                     :license="license"
                                     :nodes="nodes"
                                     @onAttributes="onAttributes"
-                                    @refactor="_prepareForRefactor"
+                                    @refactor="attemptRefactor"
                                     @scrollTo="scrollTo"
                                 />
                                 <div id="right-content" class="right-content" />
@@ -282,7 +282,7 @@ export default {
             showForm(this, node, this.datatypes);
             this.canvasManager.drawOverview();
         },
-        _prepareForRefactor(actions) {
+        attemptRefactor(actions) {
             if (this.hasChanges) {
                 const r = window.confirm(
                     "You've made changes to your workflow that need to be saved before attempting the requested action. Save those changes and continue?"
@@ -344,6 +344,10 @@ export default {
             this.activeNode = null;
             this.hasChanges = true;
             showAttributes();
+        },
+        onEditSubworkflow(contentId) {
+            const editUrl = `${getAppRoot()}workflow/editor?workflow_id=${contentId}`;
+            this.onNavigate(editUrl);
         },
         onClone(node) {
             Vue.set(this.steps, this.nodeIndex++, {
@@ -410,12 +414,15 @@ export default {
         },
         onRun() {
             const runUrl = `${getAppRoot()}workflows/run?id=${this.id}`;
+            this.onNavigate(runUrl);
+        },
+        onNavigate(url) {
             if (this.hasChanges) {
                 this.onSave(true).then(() => {
-                    window.location = runUrl;
+                    window.location = url;
                 });
             } else {
-                window.location = runUrl;
+                window.location = url;
             }
         },
         onZoom(zoomLevel) {

--- a/client/src/components/Workflow/Editor/RefactorConfirmationModal.test.js
+++ b/client/src/components/Workflow/Editor/RefactorConfirmationModal.test.js
@@ -1,0 +1,71 @@
+jest.mock("./modules/services");
+
+import { shallowMount, createLocalVue } from "@vue/test-utils";
+import RefactorConfirmationModal from "./RefactorConfirmationModal";
+import { refactor } from "./modules/services";
+import flushPromises from "flush-promises";
+
+const localVue = createLocalVue();
+const TEST_WORKFLOW_ID = "test123";
+
+describe("RefactorConfirmationModal.vue", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = shallowMount(RefactorConfirmationModal, {
+            propsData: {
+                refactorActions: [],
+                workflowId: TEST_WORKFLOW_ID,
+            },
+            localVue,
+        });
+    });
+
+    it("should not attempt a dry run refactor is there are no actions", async () => {
+        wrapper.setProps({
+            refactorActions: [],
+        });
+        await flushPromises();
+        expect(refactor.mock.calls.length).toBe(0);
+    });
+
+    it("should call refactor on dryRun on update and pass along errors", async () => {
+        refactor.mockReturnValue(
+            new Promise((then, error) => {
+                error("foo");
+            })
+        );
+        wrapper.setProps({
+            refactorActions: [{ action_type: "type1" }],
+        });
+        await flushPromises();
+        expect(wrapper.emitted().onWorkflowError.length).toBe(1);
+        expect(refactor.mock.calls[0][0]).toEqual(TEST_WORKFLOW_ID);
+        expect(refactor.mock.calls[0][2]).toBeTruthy(); // dry run argument
+
+        // onRefactor never emitted because there was a failure
+        expect(wrapper.emitted().onRefactor).toBeFalsy();
+    });
+
+    it("should call refactor on dryRun and run without dryRun if all fine", async () => {
+        refactor.mockReturnValue(
+            new Promise((then, error) => {
+                then({});
+            })
+        );
+        wrapper.setProps({
+            refactorActions: [{ action_type: "type1" }],
+        });
+        await flushPromises();
+        expect(wrapper.emitted().onWorkflowError).toBeFalsy();
+        // called with dry run as true...
+        expect(refactor.mock.calls[0][0]).toEqual(TEST_WORKFLOW_ID);
+        expect(refactor.mock.calls[0][2]).toBeTruthy();
+        // ... and then as false
+        expect(refactor.mock.calls[1][0]).toEqual(TEST_WORKFLOW_ID);
+        expect(refactor.mock.calls[1][2]).toBeFalsy();
+
+        // second time onRefactor emitted with the final response
+        expect(wrapper.emitted().onRefactor.length).toBe(1);
+    });
+});

--- a/client/src/components/Workflow/Editor/RefactorConfirmationModal.vue
+++ b/client/src/components/Workflow/Editor/RefactorConfirmationModal.vue
@@ -1,6 +1,17 @@
 <template>
-    <b-modal v-model="show" :title="title" scrollable ok-only ok-title="Save">
-        <div class="workflow-refactor-modal"></div>
+    <b-modal v-model="show" :title="title" scrollable ok-title="Save" @ok="executeRefactoring">
+        <div class="workflow-refactor-modal">
+            {{ message }}
+            <ul>
+                <li v-for="(actionExecution, executionIndex) in confirmActionExecutions" :key="executionIndex">
+                    <ul>
+                        <li v-for="(message, messageIndex) in actionExecution.messages" :key="messageIndex">
+                            - {{ message.message }}
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
     </b-modal>
 </template>
 
@@ -19,10 +30,19 @@ export default {
             type: String,
             required: true,
         },
+        title: {
+            type: String,
+            default: "Issues reworking this workflow",
+        },
+        message: {
+            type: String,
+            default: "Please review the following potential issues...",
+        },
     },
     data() {
         return {
             show: this.refactorActions.length > 0,
+            confirmActionExecutions: [],
         };
     },
     watch: {
@@ -31,25 +51,46 @@ export default {
                 this.dryRun();
             }
         },
+        show() {
+            if (this.show) {
+                // emit that this is showing, so the workflow editor
+                // can hide modal.
+                this.$emit("onShow");
+            }
+        },
     },
     methods: {
         dryRun() {
             this.$emit("onWorkflowMessage", "Pre-checking requested workflow changes (dry run)...", "progress");
             refactor(this.workflowId, this.refactorActions, true) // dry run
-                .then((data) => {
-                    // TODO: render in the confirmation dialog above if there are
-                    // any messages.
-                    this.$emit("onWorkflowMessage", "Applying requested workflow changes...", "progress");
-                    refactor(this.workflowId, this.refactorActions)
-                        .then((data) => {
-                            this.$emit("onRefactor", data);
-                        })
-                        .catch(this.onError);
-                })
+                .then(this.onDryRunResponse)
                 .catch(this.onError);
         },
         onError(response) {
             this.$emit("onWorkflowError", "Reworking workflow failed...", response);
+        },
+        onDryRunResponse(data) {
+            let anyRequireConfirmation = false;
+            for (const actionExecution of data.action_executions) {
+                if (actionExecution.messages.length > 0) {
+                    anyRequireConfirmation = true;
+                }
+            }
+            if (anyRequireConfirmation) {
+                this.show = true;
+                this.confirmActionExecutions = data.action_executions;
+            } else {
+                this.executeRefactoring();
+            }
+        },
+        executeRefactoring() {
+            this.show = false;
+            this.$emit("onWorkflowMessage", "Applying requested workflow changes...", "progress");
+            refactor(this.workflowId, this.refactorActions)
+                .then((data) => {
+                    this.$emit("onRefactor", data);
+                })
+                .catch(this.onError);
         },
     },
 };

--- a/client/src/components/Workflow/Editor/RefactorConfirmationModal.vue
+++ b/client/src/components/Workflow/Editor/RefactorConfirmationModal.vue
@@ -1,0 +1,56 @@
+<template>
+    <b-modal v-model="show" :title="title" scrollable ok-only ok-title="Save">
+        <div class="workflow-refactor-modal"></div>
+    </b-modal>
+</template>
+
+<script>
+import { refactor } from "./modules/services";
+import { BModal } from "bootstrap-vue";
+
+export default {
+    components: { BModal },
+    props: {
+        refactorActions: {
+            type: Array,
+            required: true,
+        },
+        workflowId: {
+            type: String,
+            required: true,
+        },
+    },
+    data() {
+        return {
+            show: this.refactorActions.length > 0,
+        };
+    },
+    watch: {
+        refactorActions() {
+            if (this.refactorActions.length > 0) {
+                this.dryRun();
+            }
+        },
+    },
+    methods: {
+        dryRun() {
+            this.$emit("onWorkflowMessage", "Pre-checking requested workflow changes (dry run)...", "progress");
+            refactor(this.workflowId, this.refactorActions, true) // dry run
+                .then((data) => {
+                    // TODO: render in the confirmation dialog above if there are
+                    // any messages.
+                    this.$emit("onWorkflowMessage", "Applying requested workflow changes...", "progress");
+                    refactor(this.workflowId, this.refactorActions)
+                        .then((data) => {
+                            this.$emit("onRefactor", data);
+                        })
+                        .catch(this.onError);
+                })
+                .catch(this.onError);
+        },
+        onError(response) {
+            this.$emit("onWorkflowError", "Reworking workflow failed...", response);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -6,17 +6,41 @@ import Utils from "utils/utils";
 import Form from "mvc/form/form-view";
 import ToolFormBase from "mvc/tool/tool-form-base";
 import WorkflowIcons from "components/Workflow/icons";
+import Ui from "mvc/ui/ui-misc";
 
 /** Default form wrapper for non-tool modules in the workflow editor. */
 export class DefaultForm {
     constructor(options) {
         const self = this;
         const node = options.node;
-        this.workflow = options.workflow;
+        const workflow = options.workflow;
+        this.workflow = workflow;
         _addLabelAnnotation(this, node);
+        const operations = {};
+        if (node.type == "subworkflow") {
+            operations.edit_subworkflow = new Ui.Button({
+                tooltip: _l(
+                    "Edit targeted subworkflow at its newest version. You'll need to return here and upgrade this workflow step after."
+                ),
+                icon: "fa-pencil-alt",
+                onclick: function () {
+                    workflow.onEditSubworkflow(node.content_id);
+                },
+            });
+            operations.upgrade_subworkflow = new Ui.Button({
+                tooltip: _l("Attempted automated upgrade of subworkflow."),
+                icon: "fa-cubes",
+                onclick: function () {
+                    workflow.attemptRefactor([
+                        { action_type: "upgrade_subworkflow", step: { order_index: parseInt(node.id) } },
+                    ]);
+                },
+            });
+        }
         this.form = new Form({
             ...node.config_form,
             icon: WorkflowIcons[node.type],
+            operations: operations,
             cls: "ui-portlet-section",
             onchange() {
                 axios

--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -28,7 +28,7 @@ export class DefaultForm {
                 },
             });
             operations.upgrade_subworkflow = new Ui.Button({
-                tooltip: _l("Attempted automated upgrade of subworkflow."),
+                tooltip: _l("Attempt to upgrade this step to latest version of this subworkflow."),
                 icon: "fa-cubes",
                 onclick: function () {
                     workflow.attemptRefactor([

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -22,7 +22,7 @@ export async function getModule(request_data) {
     }
 }
 
-export async function refactor(workflow, id, actions, dryRun = false) {
+export async function refactor(id, actions, dryRun = false) {
     try {
         const requestData = {
             actions: actions,
@@ -30,10 +30,6 @@ export async function refactor(workflow, id, actions, dryRun = false) {
             dry_run: dryRun,
         };
         const { data } = await axios.put(`${getAppRoot()}api/workflows/${id}/refactor`, requestData);
-        if (!dryRun) {
-            // TODO: display messages (if any...)
-            fromSimple(workflow, data.workflow);
-        }
         return data;
     } catch (e) {
         rethrowSimple(e);

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -31,7 +31,8 @@ export async function refactor(workflow, id, actions, dryRun = false) {
         };
         const { data } = await axios.put(`${getAppRoot()}api/workflows/${id}/refactor`, requestData);
         if (!dryRun) {
-            fromSimple(workflow, data);
+            // TODO: display messages (if any...)
+            fromSimple(workflow, data.workflow);
         }
         return data;
     } catch (e) {

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -31,27 +31,6 @@ export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
     }
 }
 
-export function showWarnings(data) {
-    const body = $("<div/>").text(data.message);
-    if (data.errors) {
-        body.addClass("warningmark");
-        var errlist = $("<ul/>");
-        $.each(data.errors, (i, v) => {
-            $("<li/>").text(v).appendTo(errlist);
-        });
-        body.append(errlist);
-    } else {
-        body.addClass("donemark");
-    }
-    if (data.errors) {
-        show_modal("Saving workflow", body, {
-            Ok: hide_modal,
-        });
-    } else {
-        hide_modal();
-    }
-}
-
 export function showAttributes() {
     $(".right-content").hide();
     $("#edit-attributes").show();

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -970,8 +970,10 @@ class WorkflowContentsManager(UsesAnnotations):
                         step_data_output['collection_type'] = collection_type
         return steps
 
-    def _workflow_to_dict_export(self, trans, stored=None, workflow=None):
+    def _workflow_to_dict_export(self, trans, stored=None, workflow=None, internal=False):
         """ Export the workflow contents to a dictionary ready for JSON-ification and export.
+
+        If internal, use content_ids instead subworkflow definitions.
         """
         annotation_str = ""
         tag_str = ""
@@ -1047,7 +1049,7 @@ class WorkflowContentsManager(UsesAnnotations):
                         action_arguments=pja.action_arguments)
                 step_dict['post_job_actions'] = pja_dict
 
-            if module.type == 'subworkflow':
+            if module.type == 'subworkflow' and not internal:
                 del step_dict['content_id']
                 del step_dict['errors']
                 del step_dict['tool_version']
@@ -1417,7 +1419,7 @@ class WorkflowContentsManager(UsesAnnotations):
         """Apply supplied actions to stored_workflow.latest_workflow to build a new version.
         """
         workflow = stored_workflow.latest_workflow
-        as_dict = self.workflow_to_dict(trans, stored_workflow, style="ga")
+        as_dict = self._workflow_to_dict_export(trans, stored_workflow, workflow=workflow, internal=True)
         raw_workflow_description = self.normalize_workflow_format(trans, as_dict)
         workflow_update_options = WorkflowUpdateOptions(
             fill_defaults=False,

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -45,6 +45,7 @@ from galaxy.workflow.modules import (
     WorkflowModuleInjector
 )
 from galaxy.workflow.refactor.execute import WorkflowRefactorExecutor
+from galaxy.workflow.refactor.schema import RefactorActions
 from galaxy.workflow.reports import generate_report
 from galaxy.workflow.resources import get_resource_mapper_function
 from galaxy.workflow.steps import attach_ordered_steps
@@ -1408,7 +1409,7 @@ class WorkflowContentsManager(UsesAnnotations):
             if default_label and util.unicodify(default_label).lower() not in ['input dataset', 'input dataset collection']:
                 step.label = module.label = default_label
 
-    def refactor(self, trans, stored_workflow, refactor_request):
+    def do_refactor(self, trans, stored_workflow, refactor_request):
         """Apply supplied actions to stored_workflow.latest_workflow to build a new version.
         """
         workflow = stored_workflow.latest_workflow
@@ -1433,6 +1434,15 @@ class WorkflowContentsManager(UsesAnnotations):
                 raw_workflow_description,
                 workflow_update_options,
             )
+
+    def refactor(self, trans, stored_workflow, refactor_request):
+        stored_workflow, errors = self.do_refactor(trans, stored_workflow, refactor_request)
+        # TODO: handle errors...
+        return self.workflow_to_dict(trans, stored_workflow, style=refactor_request.style)
+
+
+class RefactorRequest(RefactorActions):
+    style: str = "export"
 
 
 class WorkflowStateResolutionOptions(BaseModel):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -411,7 +411,7 @@ class WorkflowContentsManager(UsesAnnotations):
             name=stored_workflow.name,
         )
 
-        if missing_tool_tups:
+        if missing_tool_tups and not workflow_update_options.allow_missing_tools:
             errors = []
             for missing_tool_tup in missing_tool_tups:
                 errors.append("Step %i: Requires tool '%s'." % (int(missing_tool_tup[3]) + 1, missing_tool_tup[0]))
@@ -1414,8 +1414,10 @@ class WorkflowContentsManager(UsesAnnotations):
         workflow = stored_workflow.latest_workflow
         as_dict = self.workflow_to_dict(trans, stored_workflow, style="ga")
         raw_workflow_description = self.normalize_workflow_format(trans, as_dict)
-        workflow_update_options = WorkflowUpdateOptions()
-        workflow_update_options.fill_defaults = False
+        workflow_update_options = WorkflowUpdateOptions(
+            fill_defaults=False,
+            allow_missing_tools=True,
+        )
 
         module_injector = WorkflowModuleInjector(trans)
         WorkflowRefactorExecutor(raw_workflow_description, workflow, module_injector).refactor(refactor_request)
@@ -1447,6 +1449,7 @@ class WorkflowUpdateOptions(WorkflowStateResolutionOptions):
     # representation with name or annotation for instance, updates the corresponding
     # stored workflow
     update_stored_workflow_attributes: bool = True
+    allow_missing_tools: bool = False
 
 
 # Workflow update options but with some different defaults - we allow creating

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1458,7 +1458,7 @@ class WorkflowContentsManager(UsesAnnotations):
 
         module_injector = WorkflowModuleInjector(trans)
         refactor_executor = WorkflowRefactorExecutor(raw_workflow_description, workflow, module_injector)
-        actions_executed = refactor_executor.refactor(refactor_request)
+        action_executions = refactor_executor.refactor(refactor_request)
         refactored_workflow, errors = self.update_workflow_from_raw_description(
             trans,
             stored_workflow,
@@ -1471,12 +1471,12 @@ class WorkflowContentsManager(UsesAnnotations):
         #   so this is really more of a warning - we disregard it the other two places
         #   it is used also. These same messages will appear in the dictified version we
         #   we send back anyway
-        return refactored_workflow, actions_executed
+        return refactored_workflow, action_executions
 
     def refactor(self, trans, stored_workflow, refactor_request):
-        refactored_workflow, actions_executed = self.do_refactor(trans, stored_workflow, refactor_request)
+        refactored_workflow, action_executions = self.do_refactor(trans, stored_workflow, refactor_request)
         return RefactorResponse(
-            actions_executed=actions_executed,
+            action_executions=action_executions,
             workflow=self.workflow_to_dict(trans, refactored_workflow.stored_workflow, style=refactor_request.style),
             dry_run=refactor_request.dry_run,
         )
@@ -1487,7 +1487,7 @@ class RefactorRequest(RefactorActions):
 
 
 class RefactorResponse(BaseModel):
-    actions_executed: List[RefactorActionExecution]
+    action_executions: List[RefactorActionExecution]
     workflow: dict
     dry_run: bool
 

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -987,6 +987,8 @@ class WorkflowContentsManager(UsesAnnotations):
             data['report'] = workflow.reports_config
         if workflow.creator_metadata:
             data['creator'] = workflow.creator_metadata
+        if workflow.license:
+            data['license'] = workflow.license
         # For each step, rebuild the form and encode the state
         for step in workflow.steps:
             # Load from database representation

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -36,7 +36,10 @@ from galaxy.tools.parameters.basic import (
     RuntimeValue,
     workflow_building_modes
 )
-from galaxy.util.json import safe_loads
+from galaxy.util.json import (
+    safe_dumps,
+    safe_loads,
+)
 from galaxy.util.sanitize_html import sanitize_html
 from galaxy.web import url_for
 from galaxy.workflow.modules import (
@@ -1490,6 +1493,11 @@ class RefactorResponse(BaseModel):
     action_executions: List[RefactorActionExecution]
     workflow: dict
     dry_run: bool
+
+    class Config:
+        # Workflows have dictionaries with integer keys, which pydantic doesn't coerce to strings.
+        # Integer object keys aren't valid JSON, so the client fails.
+        json_dumps = safe_dumps
 
 
 class WorkflowStateResolutionOptions(BaseModel):

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1354,8 +1354,7 @@ class WorkflowContentsManager(UsesAnnotations):
             # Interpret content_id as a workflow local thing.
             subworkflow = subworkflow_id_map[subworkflow_id[1:]]
         else:
-            workflow_manager = WorkflowsManager(self.app)
-            subworkflow = workflow_manager.get_owned_workflow(
+            subworkflow = self.app.workflow_manager.get_owned_workflow(
                 trans, subworkflow_id
             )
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5192,6 +5192,15 @@ class WorkflowStep(RepresentById):
     def log_str(self):
         return "WorkflowStep[index=%d,type=%s]" % (self.order_index, self.type)
 
+    def clear_module_extras(self):
+        # the module code adds random dynamic state to the step, this
+        # attempts to clear that.
+        for module_attribute in ["module"]:
+            try:
+                delattr(self, module_attribute)
+            except AttributeError:
+                pass
+
 
 class WorkflowStepInput(RepresentById):
     default_merge_type = None

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -24,6 +24,7 @@ from galaxy.managers import (
 from galaxy.managers.jobs import fetch_job_states, invocation_job_source_iter, summarize_job_metrics
 from galaxy.managers.workflows import (
     MissingToolsException,
+    RefactorRequest,
     WorkflowCreateOptions,
     WorkflowUpdateOptions,
 )
@@ -49,7 +50,6 @@ from galaxy.webapps.base.controller import (
 )
 from galaxy.workflow.extract import extract_workflow
 from galaxy.workflow.modules import module_factory
-from galaxy.workflow.refactor.schema import RefactorRequest
 from galaxy.workflow.run import invoke, queue_invoke
 from galaxy.workflow.run_request import build_workflow_run_configs
 
@@ -656,12 +656,9 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
         """
         stored_workflow = self.__get_stored_workflow(trans, id, **kwds)
         refactor_request = RefactorRequest(**payload)
-        style = payload.get("style", "export")
-        result, errors = self.workflow_contents_manager.refactor(
+        return self.workflow_contents_manager.refactor(
             trans, stored_workflow, refactor_request
         )
-        # TODO: handle errors...
-        return self.workflow_contents_manager.workflow_to_dict(trans, stored_workflow, style=style)
 
     @expose_api
     def build_module(self, trans, payload=None):

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -646,13 +646,20 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
 
     @web.expose
     @web.require_login("edit workflows")
-    def editor(self, trans, id=None, version=None):
+    def editor(self, trans, id=None, workflow_id=None, version=None):
         """
         Render the main workflow editor interface. The canvas is embedded as
         an iframe (necessary for scrolling to work properly), which is
         rendered by `editor_canvas`.
         """
         if not id:
+            if workflow_id:
+                workflow = trans.sa_session.query(model.Workflow).get(trans.security.decode_id(workflow_id))
+                stored_workflow = workflow.stored_workflow
+                self.security_check(trans, stored_workflow, True, False)
+                stored_workflow_id = trans.security.encode_id(stored_workflow.id)
+                return trans.response.send_redirect(f'{url_for("/")}workflow/editor?id={stored_workflow_id}')
+
             error("Invalid workflow id")
         stored = self.get_stored_workflow(trans, id)
         # The following query loads all user-owned workflows,

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -106,7 +106,7 @@ class WorkflowModule:
 
     # ---- Saving in various forms ------------------------------------------
 
-    def save_to_step(self, step):
+    def save_to_step(self, step, detached=False):
         step.type = self.type
         step.tool_inputs = self.get_state()
 
@@ -403,6 +403,8 @@ class SubWorkflowModule(WorkflowModule):
     def from_dict(Class, trans, d, **kwds):
         module = super().from_dict(trans, d, **kwds)
         if "subworkflow" in d:
+            detached = kwds.get("detached", False)
+            assert not detached  # dry run requires content_id
             module.subworkflow = d["subworkflow"]
         elif "content_id" in d:
             module.subworkflow = trans.app.workflow_manager.get_owned_workflow(trans, d["content_id"])
@@ -416,7 +418,7 @@ class SubWorkflowModule(WorkflowModule):
         module.subworkflow = step.subworkflow
         return module
 
-    def save_to_step(self, step):
+    def save_to_step(self, step, **kwd):
         step.type = self.type
         step.subworkflow = self.subworkflow
 
@@ -660,7 +662,7 @@ class InputModule(WorkflowModule):
         state = json.dumps(state)
         return state
 
-    def save_to_step(self, step):
+    def save_to_step(self, step, **kwd):
         step.type = self.type
         step.tool_inputs = self._parse_state_into_dict()
 
@@ -1176,7 +1178,7 @@ class InputParameterModule(WorkflowModule):
             rval.update({"parameter_type": self.default_parameter_type, "optional": self.default_optional})
         return rval
 
-    def save_to_step(self, step):
+    def save_to_step(self, step, **kwd):
         step.type = self.type
         step.tool_inputs = self._parse_state_into_dict()
 
@@ -1332,8 +1334,8 @@ class ToolModule(WorkflowModule):
 
     # ---- Saving in various forms ------------------------------------------
 
-    def save_to_step(self, step):
-        super().save_to_step(step)
+    def save_to_step(self, step, detached=False):
+        super().save_to_step(step, detached=detached)
         step.tool_id = self.tool_id
         if self.tool:
             step.tool_version = self.get_version()
@@ -1342,9 +1344,10 @@ class ToolModule(WorkflowModule):
         tool_uuid = getattr(self, "tool_uuid", None)
         if tool_uuid:
             step.dynamic_tool = self.trans.app.dynamic_tool_manager.get_tool_by_uuid(tool_uuid)
-        for k, v in self.post_job_actions.items():
-            pja = self.__to_pja(k, v, step)
-            self.trans.sa_session.add(pja)
+        if not detached:
+            for k, v in self.post_job_actions.items():
+                pja = self.__to_pja(k, v, step)
+                self.trans.sa_session.add(pja)
 
     # ---- General attributes ------------------------------------------------
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -405,8 +405,7 @@ class SubWorkflowModule(WorkflowModule):
         if "subworkflow" in d:
             module.subworkflow = d["subworkflow"]
         elif "content_id" in d:
-            from galaxy.managers.workflows import WorkflowsManager
-            module.subworkflow = WorkflowsManager(trans.app).get_owned_workflow(trans, d["content_id"])
+            module.subworkflow = trans.app.workflow_manager.get_owned_workflow(trans, d["content_id"])
         else:
             raise Exception("Step associated subworkflow could not be found.")
         return module

--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -22,7 +22,7 @@ from .schema import (
     FillStepDefaultsAction,
     InputReferenceByOrderIndex,
     OutputReferenceByOrderIndex,
-    RefactorRequest,
+    RefactorActions,
     RemoveUnlabeledWorkflowOutputs,
     step_reference_union,
     StepReferenceByLabel,
@@ -51,7 +51,7 @@ class WorkflowRefactorExecutor:
         self.workflow = workflow
         self.module_injector = module_injector
 
-    def refactor(self, refactor_request: RefactorRequest):
+    def refactor(self, refactor_request: RefactorActions):
         for action in refactor_request.actions:
             action_type = action.action_type
             refactor_method_name = "_apply_%s" % action_type

--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -61,6 +61,10 @@ class WorkflowRefactorExecutor:
     def refactor(self, refactor_request: RefactorActions):
         action_executions = []
         for action in refactor_request.actions:
+            # TODO: we need to regenerate a detached workflow from as_dict after
+            # after each iteration here. Otherwise one set of changes might render
+            # the workflow state out of sync. It is fine if you're just executing one
+            # action at a time or just performing actions that use raw_workflow_description.
             action_type = action.action_type
             refactor_method_name = "_apply_%s" % action_type
             refactor_method = getattr(self, refactor_method_name, None)

--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Any, Dict
 
-from galaxy import model
 from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
@@ -35,6 +34,7 @@ from .schema import (
     UpdateCreatorAction,
     UpdateLicenseAction,
     UpdateNameAction,
+    UpdateOutputLabelAction,
     UpdateReportAction,
     UpdateStepLabelAction,
     UpdateStepPositionAction,
@@ -87,6 +87,14 @@ class WorkflowRefactorExecutor:
     def _apply_update_step_position(self, action: UpdateStepPositionAction, execution: RefactorActionExecution):
         step = self._find_step_for_action(action)
         step["position"] = action.position.to_dict()
+
+    def _apply_update_output_label(self, action: UpdateOutputLabelAction, execution: RefactorActionExecution):
+        output_reference = action.output
+        output_step_dict = self._find_step(output_reference)
+        output_name = output_reference.output_name
+        for workflow_output_def in output_step_dict.get("workflow_outputs", []):
+            if workflow_output_def["output_name"] == output_name:
+                workflow_output_def["label"] = action.output_label
 
     def _apply_update_name(self, action: UpdateNameAction, execution: RefactorActionExecution):
         self._as_dict["name"] = action.name

--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -19,6 +19,7 @@ from .schema import (
     DisconnectAction,
     ExtractInputAction,
     ExtractLegacyParameter,
+    FileDefaultsAction,
     FillStepDefaultsAction,
     InputReferenceByOrderIndex,
     OutputReferenceByOrderIndex,
@@ -179,6 +180,13 @@ class WorkflowRefactorExecutor:
             'id': output_order_index,
             'output_name': output_name,
         })
+
+    def _apply_fill_defaults(self, action: FileDefaultsAction, execution: RefactorActionExecution):
+        for _, step in self._iterate_over_step_pairs(execution):
+            module = step.module
+            if module.type != "tool":
+                continue
+            self._as_dict["steps"][step.order_index]["tool_state"] = step.module.get_tool_state()
 
     def _apply_fill_step_defaults(self, action: FillStepDefaultsAction, execution: RefactorActionExecution):
         step = self._find_step_with_module_for_action(action, execution)

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -166,6 +166,11 @@ class UpdateReportAction(BaseAction):
     report: Report
 
 
+class FillStepDefaultsAction(BaseAction):
+    action_type: Literal['fill_step_defaults']
+    step: step_reference_union
+
+
 union_action_classes = Union[
     AddInputAction,
     AddStepAction,
@@ -173,6 +178,7 @@ union_action_classes = Union[
     DisconnectAction,
     ExtractInputAction,
     ExtractLegacyParameter,
+    FillStepDefaultsAction,
     UpdateAnnotationAction,
     UpdateCreatorAction,
     UpdateNameAction,

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -172,6 +172,10 @@ class FillStepDefaultsAction(BaseAction):
     step: step_reference_union
 
 
+class FileDefaultsAction(BaseAction):
+    action_type: Literal['fill_defaults']
+
+
 union_action_classes = Union[
     AddInputAction,
     AddStepAction,
@@ -179,6 +183,7 @@ union_action_classes = Union[
     DisconnectAction,
     ExtractInputAction,
     ExtractLegacyParameter,
+    FileDefaultsAction,
     FillStepDefaultsAction,
     UpdateAnnotationAction,
     UpdateCreatorAction,

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -176,11 +176,17 @@ class FileDefaultsAction(BaseAction):
     action_type: Literal['fill_defaults']
 
 
-class UpgradeSubworkflow(BaseAction):
+class UpgradeSubworkflowAction(BaseAction):
     action_type: Literal['upgrade_subworkflow']
     step: step_reference_union
     # should be decoded before stuffing it into the database...
     content_id: Optional[str]
+
+
+class UpgradeToolAction(BaseAction):
+    action_type: Literal['upgrade_tool']
+    step: step_reference_union
+    tool_version: Optional[str]
 
 
 union_action_classes = Union[
@@ -199,7 +205,8 @@ union_action_classes = Union[
     UpdateReportAction,
     UpdateStepLabelAction,
     UpdateStepPositionAction,
-    UpgradeSubworkflow,
+    UpgradeSubworkflowAction,
+    UpgradeToolAction,
     RemoveUnlabeledWorkflowOutputs,
 ]
 

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -232,7 +232,7 @@ class RefactorActions(BaseModel):
 class RefactorActionExecutionMessageTypeEnum(str, Enum):
     tool_version_change = 'tool_version_change'
     tool_state_adjustment = 'tool_state_adjustment'
-    connection_dropped_forced = 'connection_dropped_forced'
+    connection_drop_forced = 'connection_drop_forced'
 
 
 class RefactorActionExecutionMessage(BaseModel):
@@ -240,7 +240,9 @@ class RefactorActionExecutionMessage(BaseModel):
     message_type: RefactorActionExecutionMessageTypeEnum
     # messages don't have to be bound to a step, but if they are should
     # specify step_label and order_index below - these are the label and
-    # order_index before applying the refactoring.
+    # order_index before applying the refactoring. If connections are
+    # dropped this step reference should refer to the step with the
+    # previously connected input.
     step_label: Optional[str]
     order_index: Optional[int]
 
@@ -248,6 +250,15 @@ class RefactorActionExecutionMessage(BaseModel):
     # the input name should be specified here. Should be a prefixed name
     # in the case of tool inputs (e.g. 'cond|repeat_0|input')
     input_name: Optional[str]
+
+    # messages don't have to be bound to a step with inputs, but if they are
+    # the output name should be specified here.
+    output_name: Optional[str]
+
+    # For dropped connections these optional attributes refer to the output
+    # side of the connection that was dropped.
+    from_step_label: Optional[str]
+    from_order_index: Optional[int]
 
 
 class RefactorActionExecution(BaseModel):

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
@@ -53,7 +54,7 @@ class BaseAction(BaseModel):
     """Refactoring actions."""
 
 
-class Action:
+class Action(BaseAction):
     action_type: str
 
     @classmethod
@@ -199,3 +200,28 @@ for action_class in union_action_classes.__args__:  # type: ignore
 class RefactorActions(BaseModel):
     actions: List[Action]
     dry_run: bool = False
+
+
+class RefactorActionExecutionMessageTypeEnum(str, Enum):
+    tool_version_change = 'tool_version_change'
+    tool_state_adjustment = 'tool_state_adjustment'
+
+
+class RefactorActionExecutionMessage(BaseModel):
+    message: str
+    message_type: RefactorActionExecutionMessageTypeEnum
+    # messages don't have to be bound to a step, but if they are should
+    # specify step_label and order_index below - these are the label and
+    # order_index before applying the refactoring.
+    step_label: Optional[str]
+    order_index: Optional[int]
+
+    # messages don't have to be bound to a step with inputs, but if they are
+    # the input name should be specified here. Should be a prefixed name
+    # in the case of tool inputs (e.g. 'cond|repeat_0|input')
+    input_name: Optional[str]
+
+
+class RefactorActionExecution(BaseModel):
+    action: Action
+    messages: List[RefactorActionExecutionMessage]

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -196,6 +196,6 @@ for action_class in union_action_classes.__args__:  # type: ignore
     ACTION_CLASSES_BY_TYPE[action_type] = action_class
 
 
-class RefactorRequest(BaseModel):
+class RefactorActions(BaseModel):
     actions: List[Action]
     dry_run: bool = False

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -225,6 +225,7 @@ class RefactorActions(BaseModel):
 class RefactorActionExecutionMessageTypeEnum(str, Enum):
     tool_version_change = 'tool_version_change'
     tool_state_adjustment = 'tool_state_adjustment'
+    connection_dropped_forced = 'connection_dropped_forced'
 
 
 class RefactorActionExecutionMessage(BaseModel):

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -233,6 +233,7 @@ class RefactorActionExecutionMessageTypeEnum(str, Enum):
     tool_version_change = 'tool_version_change'
     tool_state_adjustment = 'tool_state_adjustment'
     connection_drop_forced = 'connection_drop_forced'
+    workflow_output_drop_forced = 'workflow_output_drop_forced'
 
 
 class RefactorActionExecutionMessage(BaseModel):
@@ -259,6 +260,9 @@ class RefactorActionExecutionMessage(BaseModel):
     # side of the connection that was dropped.
     from_step_label: Optional[str]
     from_order_index: Optional[int]
+
+    # For workflow_output_drop_forced, this is the output label dropped.
+    output_label: Optional[str]
 
 
 class RefactorActionExecution(BaseModel):

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -176,6 +176,13 @@ class FileDefaultsAction(BaseAction):
     action_type: Literal['fill_defaults']
 
 
+class UpgradeSubworkflow(BaseAction):
+    action_type: Literal['upgrade_subworkflow']
+    step: step_reference_union
+    # should be decoded before stuffing it into the database...
+    content_id: Optional[str]
+
+
 union_action_classes = Union[
     AddInputAction,
     AddStepAction,
@@ -192,6 +199,7 @@ union_action_classes = Union[
     UpdateReportAction,
     UpdateStepLabelAction,
     UpdateStepPositionAction,
+    UpgradeSubworkflow,
     RemoveUnlabeledWorkflowOutputs,
 ]
 

--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -167,6 +167,12 @@ class UpdateReportAction(BaseAction):
     report: Report
 
 
+class UpdateOutputLabelAction(BaseAction):
+    action_type: Literal['update_output_label']
+    output: output_reference_union  # TODO: allow reference by output_label
+    output_label: str
+
+
 class FillStepDefaultsAction(BaseAction):
     action_type: Literal['fill_step_defaults']
     step: step_reference_union
@@ -202,6 +208,7 @@ union_action_classes = Union[
     UpdateCreatorAction,
     UpdateNameAction,
     UpdateLicenseAction,
+    UpdateOutputLabelAction,
     UpdateReportAction,
     UpdateStepLabelAction,
     UpdateStepPositionAction,

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -486,20 +486,27 @@ steps:
         actions = [
             {"action_type": "update_step_label", "step": {"order_index": 0}, "label": "new_label"},
         ]
+        # perform refactoring as dry run
         refactor_response = self.workflow_populator.refactor_workflow(workflow_id, actions, dry_run=True)
         refactor_response.raise_for_status()
-        # it was with dry_run=True - so the result is unchanged...
-        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "test_input"
+        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "new_label"
 
+        # perform refactoring as dry run but specify editor style response
         refactor_response = self.workflow_populator.refactor_workflow(workflow_id, actions, dry_run=True, style="editor")
         refactor_response.raise_for_status()
-        # it was with dry_run=True - so the result is unchanged...
-        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "test_input"
+        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "new_label"
+
+        # download the original workflow and make sure the dry run didn't modify that label
+        workflow_dict = self.workflow_populator.download_workflow(workflow_id)
+        assert workflow_dict["steps"]["0"]["label"] == "test_input"
 
         refactor_response = self.workflow_populator.refactor_workflow(workflow_id, actions)
         refactor_response.raise_for_status()
-        # this time dry_run was default of False, so the label is indeed changed
         assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "new_label"
+
+        # this time dry_run was default of False, so the label is indeed changed
+        workflow_dict = self.workflow_populator.download_workflow(workflow_id)
+        assert workflow_dict["steps"]["0"]["label"] == "new_label"
 
     def test_update_no_tool_id(self):
         workflow_object = self.workflow_populator.load_workflow(name="test_import")

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -489,17 +489,17 @@ steps:
         refactor_response = self.workflow_populator.refactor_workflow(workflow_id, actions, dry_run=True)
         refactor_response.raise_for_status()
         # it was with dry_run=True - so the result is unchanged...
-        assert refactor_response.json()["steps"]["0"]["label"] == "test_input"
+        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "test_input"
 
         refactor_response = self.workflow_populator.refactor_workflow(workflow_id, actions, dry_run=True, style="editor")
         refactor_response.raise_for_status()
         # it was with dry_run=True - so the result is unchanged...
-        assert refactor_response.json()["steps"]["0"]["label"] == "test_input"
+        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "test_input"
 
         refactor_response = self.workflow_populator.refactor_workflow(workflow_id, actions)
         refactor_response.raise_for_status()
         # this time dry_run was default of False, so the label is indeed changed
-        assert refactor_response.json()["steps"]["0"]["label"] == "new_label"
+        assert refactor_response.json()["workflow"]["steps"]["0"]["label"] == "new_label"
 
     def test_update_no_tool_id(self):
         workflow_object = self.workflow_populator.load_workflow(name="test_import")

--- a/lib/galaxy_test/base/data/test_workflow_two_random_lines.ga
+++ b/lib/galaxy_test/base/data/test_workflow_two_random_lines.ga
@@ -1,0 +1,99 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "two_lines",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": "random_lines1",
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select random lines",
+                    "name": "input"
+                }
+            ],
+            "label": "random1",
+            "name": "Select random lines",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 401.5,
+                "height": 92,
+                "left": 727,
+                "right": 927,
+                "top": 309.5,
+                "width": 200,
+                "x": 727,
+                "y": 309.5
+            },
+            "post_job_actions": {},
+            "tool_id": "random_lines1",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": \"1\", \"seed_source\": {\"seed_source_selector\": \"no_seed\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.2",
+            "type": "tool",
+            "uuid": "9c6b3bb2-6513-4f4b-ace9-984a5aadf4e1",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "c7af6d97-dfba-44ad-8a1d-47749f95311e"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": "random_lines1",
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Select random lines",
+                    "name": "input"
+                }
+            ],
+            "label": "random2",
+            "name": "Select random lines",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 553.5,
+                "height": 92,
+                "left": 735,
+                "right": 935,
+                "top": 461.5,
+                "width": 200,
+                "x": 735,
+                "y": 461.5
+            },
+            "post_job_actions": {},
+            "tool_id": "random_lines1",
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"num_lines\": \"1\", \"seed_source\": {\"seed_source_selector\": \"no_seed\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "2.0.2",
+            "type": "tool",
+            "uuid": "d7281924-1423-482c-98e4-bc37c08b3dc1",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "1d4ff58b-6127-45fd-917e-6c8739a32478"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "878dd32d-d7f3-46d4-bc2b-7f10e69a9498",
+    "version": 1
+}

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -943,7 +943,8 @@ class BaseWorkflowPopulator:
     def export_for_update(self, workflow_id):
         workflow_object = self.download_workflow(workflow_id)
         yield workflow_object
-        self.update_workflow(workflow_id, workflow_object)
+        put_respose = self.update_workflow(workflow_id, workflow_object)
+        put_respose.raise_for_status()
 
     def run_workflow(self, has_workflow, test_data=None, history_id=None, wait=True, source_type=None, jobs_descriptions=None, expected_response=200, assert_ok=True, client_convert=None, round_trip_format_conversion=False, raw_yaml=False):
         """High-level wrapper around workflow API, etc. to invoke format 2 workflows."""

--- a/test/functional/tools/multiple_versions_changes_v01.xml
+++ b/test/functional/tools/multiple_versions_changes_v01.xml
@@ -1,0 +1,21 @@
+<tool id="multiple_versions_changes" name="multiple_versions_changes" version="0.1">
+    <command>
+        echo "Version 0.1" > $out_file1
+    </command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="intest" value="1" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Version 0.1" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/multiple_versions_changes_v02.xml
+++ b/test/functional/tools/multiple_versions_changes_v02.xml
@@ -1,0 +1,22 @@
+<tool id="multiple_versions_changes" name="multiple_versions_changes" version="0.2">
+    <command>
+        echo "Version 0.2" > $out_file1
+    </command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+        <param name="floattest" value="1.0" type="float" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="intest" value="1" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Version 0.2" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -188,6 +188,8 @@
 
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v02.xml" />
+  <tool file="multiple_versions_changes_v01.xml" />
+  <tool file="multiple_versions_changes_v02.xml" />
 
   <tool file="interactivetool_simple.xml" />
   <tool file="interactivetool_two_entry_points.xml" />

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -31,45 +31,45 @@ steps:
         actions = [
             {"action_type": "update_name", "name": "my cool new name"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.stored_workflow.name == "my cool new name"
 
         actions = [
             {"action_type": "update_annotation", "annotation": "my cool new annotation"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         # TODO: test annotation change...
 
         actions = [
             {"action_type": "update_license", "license": "AFL-3.0"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.license == "AFL-3.0"
 
         actions = [
             {"action_type": "update_creator", "creator": [{"class": "Person", "name": "Mary"}]},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.creator_metadata[0]["class"] == "Person"
         assert self._latest_workflow.creator_metadata[0]["name"] == "Mary"
 
         actions = [
             {"action_type": "update_report", "report": {"markdown": "my report..."}}
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.reports_config["markdown"] == "my report..."
 
         assert self._latest_workflow.step_by_index(0).label == "test_input"
         actions = [
             {"action_type": "update_step_label", "step": {"order_index": 0}, "label": "new_label"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_index(0).label == "new_label"
 
         actions = [
             {"action_type": "update_step_position", "step": {"order_index": 0}, "position": {"left": 3, "top": 5}},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_index(0).label == "new_label"
         assert self._latest_workflow.step_by_index(0).position["left"] == 3
         assert self._latest_workflow.step_by_index(0).position["top"] == 5
@@ -78,7 +78,7 @@ steps:
         actions = [
             {"action_type": "add_step", "type": "parameter_input", "label": "new_param", "tool_state": {"parameter_type": "text"}, "position": {"left": 10, "top": 50}},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_label("new_param").label == "new_param"
         assert self._latest_workflow.step_by_label("new_param").tool_inputs.get("optional", False) is False
         assert self._latest_workflow.step_by_label("new_param").position["left"] == 10
@@ -88,7 +88,7 @@ steps:
         actions = [
             {"action_type": "add_input", "type": "text", "label": "new_param2", "optional": True, "position": {"top": 1, "left": 2}},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_label("new_param2").label == "new_param2"
         assert self._latest_workflow.step_by_label("new_param2").tool_inputs.get("optional", False) is True
         assert self._latest_workflow.step_by_label("new_param2").position["top"] == 1
@@ -102,7 +102,7 @@ steps:
                 "output": {"label": "new_label"},
             }
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert len(self._latest_workflow.step_by_label("first_cat").inputs) == 0
 
         actions = [
@@ -112,7 +112,7 @@ steps:
                 "output": {"label": "new_label"},
             }
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert len(self._latest_workflow.step_by_label("first_cat").inputs) == 1
 
         # Re-disconnect so we can test extract_input
@@ -123,7 +123,7 @@ steps:
                 "output": {"label": "new_label"},
             }
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
 
         # try to create an input for first_cat/input1 automatically
         actions = [
@@ -133,7 +133,7 @@ steps:
                 "label": "extracted_input",
             }
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_label("extracted_input")
         assert len(self._latest_workflow.step_by_label("first_cat").inputs) == 1
 
@@ -144,7 +144,7 @@ steps:
             {"action_type": "extract_legacy_parameter", "name": "seed"},
             {"action_type": "extract_legacy_parameter", "name": "num", "label": "renamed_num"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_label("seed").tool_inputs["parameter_type"] == "text"
         assert self._latest_workflow.step_by_label("renamed_num").tool_inputs["parameter_type"] == "integer"
         random_lines_state = self._latest_workflow.step_by_index(2).tool_inputs
@@ -196,7 +196,7 @@ steps:
         actions = [
             {"action_type": "extract_legacy_parameter", "name": "pja_only_param"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_label("pja_only_param").tool_inputs["parameter_type"] == "text"
 
     def test_refactoring_legacy_parameters_without_tool_state_relabel(self):
@@ -217,7 +217,7 @@ steps:
         actions = [
             {"action_type": "extract_legacy_parameter", "name": "pja_only_param", "label": "new_label"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         assert self._latest_workflow.step_by_label("new_label").tool_inputs["parameter_type"] == "text"
         pjas = self._latest_workflow.step_by_label("first_cat").post_job_actions
         assert len(pjas) == 1
@@ -233,7 +233,7 @@ steps:
         actions = [
             {"action_type": "remove_unlabeled_workflow_outputs"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         only_step = self._latest_workflow.step_by_index(0)
         assert len(only_step.workflow_outputs) == 0
 
@@ -269,7 +269,7 @@ steps:
         actions = [
             {"action_type": "update_step_label", "step": {"order_index": 0}, "label": "random1_new"},
         ]
-        self._refactor_without_errors(actions)
+        self._refactor(actions)
         first_step = self._latest_workflow.step_by_label("random1_new")
         assert "num_lines" not in first_step.tool_inputs
 
@@ -287,9 +287,7 @@ steps:
         actions = [
             {"action_type": "update_step_label", "step": {"order_index": 1}, "label": "random2_new"},
         ]
-        updated, errors = self._refactor(actions)
-        assert updated
-        assert errors  # we have a "message" about the un-validated state, but I is fine as long as it was preserved
+        self._refactor(actions)
         assert self._latest_workflow.step_by_index(1).label == "random2_new"
         assert "num_lines" in self._latest_workflow.step_by_index(1).tool_inputs
 
@@ -307,15 +305,16 @@ steps:
         actions = [
             {"action_type": "fill_step_defaults", "step": {"order_index": 0}},
         ]
-        self._refactor_without_errors(actions)
+        action_executions = self._refactor(actions)
         first_step = self._latest_workflow.step_by_label("random1")
         assert "num_lines" in first_step.tool_inputs
-
-    def _refactor_without_errors(self, actions):
-        updated, errors = self._refactor(actions)
-        assert updated
-        assert not errors
-        return updated
+        assert len(action_executions) == 1
+        action_execution = action_executions[0]
+        assert len(action_execution.messages) == 1
+        message = action_execution.messages[0]
+        assert message.order_index == 0
+        assert message.step_label == "random1"
+        assert message.input_name == "num_lines"
 
     def _refactor(self, actions):
         user = self._app.model.session.query(self._app.model.User).order_by(self._app.model.User.id.desc()).limit(1).one()

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -1,7 +1,7 @@
 import json
 
 from galaxy.managers.context import ProvidesAppContext
-from galaxy.workflow.refactor.schema import RefactorRequest
+from galaxy.workflow.refactor.schema import RefactorActions
 from galaxy_test.base.populators import (
     WorkflowPopulator,
 )
@@ -320,10 +320,10 @@ steps:
     def _refactor(self, actions):
         user = self._app.model.session.query(self._app.model.User).order_by(self._app.model.User.id.desc()).limit(1).one()
         mock_trans = MockTrans(self._app, user)
-        return self._manager.refactor(
+        return self._manager.do_refactor(
             mock_trans,
             self._most_recent_stored_workflow,
-            RefactorRequest(**{"actions": actions})
+            RefactorActions(**{"actions": actions})
         )
 
     @property

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -418,7 +418,7 @@ steps:
         actions = [
             {"action_type": "fill_step_defaults", "step": {"order_index": 0}},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
         first_step = self._latest_workflow.step_by_label("random1")
         assert "num_lines" in first_step.tool_inputs
         assert len(action_executions) == 1
@@ -439,9 +439,9 @@ steps:
             {"action_type": "fill_step_defaults", "step": {"order_index": 0}},
         ]
         response = self._dry_run(actions)
-        actions_executed = response.actions_executed
-        assert len(actions_executed) == 1
-        action_execution = actions_executed[0]
+        action_executions = response.action_executions
+        assert len(action_executions) == 1
+        action_execution = action_executions[0]
         assert len(action_execution.messages) == 1
         message = action_execution.messages[0]
         assert message.order_index == 0
@@ -461,7 +461,7 @@ steps:
         actions = [
             {"action_type": "fill_defaults"},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
 
         first_step = self._latest_workflow.step_by_label("random1")
         assert "num_lines" in first_step.tool_inputs
@@ -497,7 +497,7 @@ steps:
         # t = self._app.toolbox.get_tool("multiple_versions", tool_version="0.1")
         # assert t is not None
         # assert t.version == "0.1"
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
         assert len(action_executions) == 1
         assert len(action_executions[0].messages) == 0
         assert self._latest_workflow.step_by_label("the_step").tool_version == "0.2"
@@ -516,7 +516,7 @@ steps:
         actions = [
             {"action_type": "upgrade_tool", "step": {"label": "the_step"}, "tool_version": "0.2"},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
 
         assert self._latest_workflow.step_by_label("the_step").tool_version == "0.2"
 
@@ -556,13 +556,13 @@ steps:
             {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}},
         ]
         response = self._dry_run(actions)
-        actions_executed = response.actions_executed
-        assert len(actions_executed) == 1
-        assert len(actions_executed[0].messages) == 0
+        action_executions = response.action_executions
+        assert len(action_executions) == 1
+        assert len(action_executions[0].messages) == 0
 
-        actions_executed = self._refactor(actions).actions_executed
-        assert len(actions_executed) == 1
-        assert len(actions_executed[0].messages) == 0
+        action_executions = self._refactor(actions).action_executions
+        assert len(action_executions) == 1
+        assert len(action_executions[0].messages) == 0
 
         post_upgrade_native = self._download_native(self._most_recent_stored_workflow)
         self._assert_nested_workflow_num_lines_is(post_upgrade_native, "2")
@@ -591,7 +591,11 @@ steps:
         actions = [
             {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}, "content_id": middle_workflow_id},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._dry_run(actions).action_executions
+        assert len(action_executions) == 1
+        assert len(action_executions[0].messages) == 0
+
+        action_executions = self._refactor(actions).action_executions
         assert len(action_executions) == 1
         assert len(action_executions[0].messages) == 0
         post_upgrade_native = self._download_native(self._most_recent_stored_workflow)
@@ -609,7 +613,7 @@ steps:
         actions = [
             {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
         native_dict = self._download_native()
         nested_step = _step_with_label(native_dict, "nested_workflow")
         # order_index of subworkflow shifts down from "2" because it has no
@@ -644,7 +648,7 @@ steps:
         actions = [
             {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
         assert len(action_executions) == 1
         messages = action_executions[0].messages
 
@@ -675,7 +679,7 @@ steps:
         actions = [
             {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}},
         ]
-        action_executions = self._refactor(actions).actions_executed
+        action_executions = self._refactor(actions).action_executions
         assert len(action_executions) == 1
         messages = action_executions[0].messages
         assert len(messages) == 1

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -612,10 +612,44 @@ steps:
         assert len(messages) == 1
 
         message = messages[0]
-        assert message.message_type == RefactorActionExecutionMessageTypeEnum.connection_dropped_forced
+        assert message.message_type == RefactorActionExecutionMessageTypeEnum.connection_drop_forced
         assert message.order_index == 2
         assert message.step_label == "nested_workflow"
         assert message.input_name == "inner_input"
+        assert message.from_step_label == "first_cat"
+        assert message.from_order_index == 1
+        assert message.output_name == "out_file1"
+
+    def test_subworkflow_upgrade_connection_output_dropped(self):
+        self.workflow_populator.upload_yaml_workflow(WORKFLOW_NESTED_SIMPLE)
+
+        nested_stored_workflow = self._recent_stored_workflow(2)
+        actions = [
+            {
+                "action_type": "update_output_label",
+                "output": {"label": "random_lines", "output_name": "out_file1"},
+                "output_label": "renamed_output",
+            }
+        ]
+        self._refactor(actions, stored_workflow=nested_stored_workflow)
+
+        actions = [
+            {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}},
+        ]
+        action_executions = self._refactor(actions).actions_executed
+        assert len(action_executions) == 1
+        messages = action_executions[0].messages
+
+        # it was connected to two inputs on second_cat step
+        assert len(messages) == 2
+        for message in messages:
+            assert message.message_type == RefactorActionExecutionMessageTypeEnum.connection_drop_forced
+            assert message.order_index == 3
+            assert message.step_label == "second_cat"
+            assert message.input_name in ["input1", "queries_0|input2"]
+            assert message.from_step_label == "nested_workflow"
+            assert message.from_order_index == 2
+            assert message.output_name == "workflow_output"
 
     def _download_native(self, workflow=None):
         workflow = workflow or self._most_recent_stored_workflow
@@ -631,13 +665,24 @@ steps:
     def _refactor(self, actions, stored_workflow=None, dry_run=False, style="ga"):
         user = self._app.model.session.query(User).order_by(User.id.desc()).limit(1).one()
         mock_trans = MockTrans(self._app, user)
-        return self._manager.refactor(
-            mock_trans,
-            stored_workflow or self._most_recent_stored_workflow,
-            RefactorRequest(
-                actions=actions, dry_run=dry_run, style=style
+
+        app = self._app
+        original_url_for = app.url_for
+
+        def url_for(*args, **kwd):
+            return ''
+
+        app.url_for = url_for
+        try:
+            return self._manager.refactor(
+                mock_trans,
+                stored_workflow or self._most_recent_stored_workflow,
+                RefactorRequest(
+                    actions=actions, dry_run=dry_run, style=style
+                )
             )
-        )
+        finally:
+            app = url_for = original_url_for
 
     def _dry_run(self, actions, stored_workflow=None):
         # Do a bunch of checks to ensure nothing workflow related was written to the database

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -555,9 +555,14 @@ steps:
         actions = [
             {"action_type": "upgrade_subworkflow", "step": {"label": "nested_workflow"}},
         ]
-        action_executions = self._refactor(actions).actions_executed
-        assert len(action_executions) == 1
-        assert len(action_executions[0].messages) == 0
+        response = self._dry_run(actions)
+        actions_executed = response.actions_executed
+        assert len(actions_executed) == 1
+        assert len(actions_executed[0].messages) == 0
+
+        actions_executed = self._refactor(actions).actions_executed
+        assert len(actions_executed) == 1
+        assert len(actions_executed[0].messages) == 0
 
         post_upgrade_native = self._download_native(self._most_recent_stored_workflow)
         self._assert_nested_workflow_num_lines_is(post_upgrade_native, "2")

--- a/test/integration/test_workflow_refactoring.py
+++ b/test/integration/test_workflow_refactoring.py
@@ -293,6 +293,24 @@ steps:
         assert self._latest_workflow.step_by_index(1).label == "random2_new"
         assert "num_lines" in self._latest_workflow.step_by_index(1).tool_inputs
 
+    def test_refactor_fill_step_defaults(self):
+        # populating a workflow with incomplete state...
+        wf = self.workflow_populator.load_workflow_from_resource("test_workflow_two_random_lines")
+        ts = json.loads(wf["steps"]["0"]["tool_state"])
+        del ts["num_lines"]
+        wf["steps"]["0"]["tool_state"] = json.dumps(ts)
+        self.workflow_populator.create_workflow(wf, fill_defaults=False)
+
+        first_step = self._latest_workflow.step_by_label("random1")
+        assert "num_lines" not in first_step.tool_inputs
+
+        actions = [
+            {"action_type": "fill_step_defaults", "step": {"order_index": 0}},
+        ]
+        self._refactor_without_errors(actions)
+        first_step = self._latest_workflow.step_by_label("random1")
+        assert "num_lines" in first_step.tool_inputs
+
     def _refactor_without_errors(self, actions):
         updated, errors = self._refactor(actions)
         assert updated

--- a/test/unit/workflows/test_refactor_models.py
+++ b/test/unit/workflows/test_refactor_models.py
@@ -1,4 +1,7 @@
-from galaxy.workflow.refactor.schema import RefactorActions
+from galaxy.workflow.refactor.schema import (
+    RefactorActionExecution,
+    RefactorActions,
+)
 
 
 def test_root_list():
@@ -57,3 +60,13 @@ def test_root_list():
     a9 = actions[9]
     assert a9.name == "foo"
     assert a9.label == "new_foo"
+
+
+def test_executions():
+    ar = RefactorActions(actions=[
+        {"action_type": "extract_legacy_parameter", "name": "foo"}
+    ])
+    execution = RefactorActionExecution(action={"action_type": "extract_legacy_parameter", "name": "foo"}, messages=[])
+    assert isinstance(execution.messages, (list,))
+    execution = RefactorActionExecution(action=ar.actions[0].dict(), messages=[])
+    assert isinstance(execution.messages, (list,))

--- a/test/unit/workflows/test_refactor_models.py
+++ b/test/unit/workflows/test_refactor_models.py
@@ -1,4 +1,4 @@
-from galaxy.workflow.refactor.schema import RefactorRequest
+from galaxy.workflow.refactor.schema import RefactorActions
 
 
 def test_root_list():
@@ -16,7 +16,7 @@ def test_root_list():
             {"action_type": "extract_legacy_parameter", "name": "foo", "label": "new_foo"},
         ],
     }
-    ar = RefactorRequest(**request)
+    ar = RefactorActions(**request)
     actions = ar.actions
 
     a0 = actions[0]

--- a/test/unit/workflows/workflow_support.py
+++ b/test/unit/workflows/workflow_support.py
@@ -3,6 +3,7 @@ from functools import partial
 import yaml
 
 from galaxy import model
+from galaxy.managers.workflows import WorkflowsManager
 from galaxy.model import mapping
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import bunch
@@ -49,6 +50,7 @@ class TestApp:
         self.toolbox = TestToolbox()
         self.datatypes_registry = TestDatatypesRegistry()
         self.security = IdEncodingHelper(id_secret="testing")
+        self.workflow_manager = WorkflowsManager(self)
 
 
 class TestDatatypesRegistry:


### PR DESCRIPTION
... building on the enhancements to new workflow refactoring API. This PR is really about the refactoring API and improving its structure but those two buttons are big usability wins for people using subworkflows so I changed the title of this PR. 

<img width="306" alt="Screen Shot 2021-01-04 at 12 35 13 AM" src="https://user-images.githubusercontent.com/216771/103504282-f8822500-4e24-11eb-96dc-4f80923906a9.png">

<img width="329" alt="Screen Shot 2021-01-04 at 12 35 19 AM" src="https://user-images.githubusercontent.com/216771/103504292-fc15ac00-4e24-11eb-9053-4aeba6712c50.png">

<img width="823" alt="Screen Shot 2021-01-04 at 12 36 41 AM" src="https://user-images.githubusercontent.com/216771/103504294-fddf6f80-4e24-11eb-846d-3c00a136fd60.png">


Workflow Refactoring API improvements:
- ~Builds on  #11016~ (merged)
- Includes https://github.com/galaxyproject/galaxy/pull/11041
- Fixes bug where the refactor API would create a new subworkflow for each update to an existing workflow.
- Fixes older bug from start of this release cycle where license wouldn't appear in export workflows.
- Implement five new refactoring actions ``fill_defaults``, ``fill_step_defaults``, ``upgrade_subworkflow``, ``upgrade_tool`` (this one is a bit beta but it isn't used in the GUI), ``update_output_label``. 
- All sorts of new tests to clarify test new actions and clarify how the API deals with missing steps, incomplete step state, etc...
- All sorts of new tests to clarify catching and reporting potential issues during subworkflow upgrades.
- Rework the workflow API response to include typed, structured messages in addition to a workflow. This structure is all important to record and store in the database with each version I think (this is outlined in #11005 and important for #9166. Four potential error types are captured:
   - ``tool_version_change``
   - ``tool_state_adjustment``
   - ``connection_drop_forced``
   - ``workflow_output_drop_forced``
- Comprehensive reworking of the ``dry_run`` option to the API. It now works and returns the workflow as it would be if it were modified according to the request. This includes a bunch of new tests that ensure the database isn't changing in response to ``dry_run`` requests.
- Use the new and improved ``dry_run`` option and the typed messages to report potential problems with refactorings in the UI and have the user confirm before up upgrading workflows.
