### PR TITLE
Drop 'unreachable'-ish showWarnings method in workflow editor.

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -144,7 +144,6 @@
 import { getDatatypesMapper } from "components/Datatypes";
 import { getModule, getVersions, saveWorkflow, loadWorkflow, refactor } from "./modules/services";
 import {
-    showWarnings,
     getStateUpgradeMessages,
     copyIntoWorkflow,
     getLegacyWorkflowParameters,
@@ -419,7 +418,6 @@ export default {
             !hideProgress && show_message("Saving workflow...", "progress");
             return saveWorkflow(this)
                 .then((data) => {
-                    showWarnings(data);
                     getVersions(this.id).then((versions) => {
                         this.versions = versions;
                         hide_modal();

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -45,27 +45,6 @@ export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
     }
 }
 
-export function showWarnings(data) {
-    const body = $("<div/>").text(data.message);
-    if (data.errors) {
-        body.addClass("warningmark");
-        var errlist = $("<ul/>");
-        $.each(data.errors, (i, v) => {
-            $("<li/>").text(v).appendTo(errlist);
-        });
-        body.append(errlist);
-    } else {
-        body.addClass("donemark");
-    }
-    if (data.errors) {
-        show_modal("Saving workflow", body, {
-            Ok: hide_modal,
-        });
-    } else {
-        hide_modal();
-    }
-}
-
 export function showAttributes() {
     $(".right-content").hide();
     $("#edit-attributes").show();


### PR DESCRIPTION
It was added in https://github.com/galaxyproject/galaxy/commit/c922711612f217d0d780581b3ecaf5cfa3397f77 which didn't have the exception handler for this request that is now there - so I think it must have been responding to different API requests.

Regardless of history, ``showWarnings`` only shows a modal if the response is a JSON object with the key ``errors`` in its root. I've searched the model/__init__.py, managers/workflows.py, api/workflows.py, and controller/workflow.py and the only response that would include that is in the ``save_workflow_as``, but the ``saveAs`` function in the client does not use this ``showWarnings``.

Update: You can sort of see why I was cleaning up modal related functions - to try to get it all centralized into Vue with (https://github.com/galaxyproject/galaxy/pull/11046). The save as and copy_into modals should probably still be rewritten into Vue but this was a start.
