### PR TITLE
Vue-ify warnings about embedded subworkflows.

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -1,6 +1,11 @@
 <template>
     <div id="columns" class="workflow-client">
         <StateUpgradeModal :stateMessages="stateMessages" />
+        <StateUpgradeModal
+            :stateMessages="insertedStateMessages"
+            title="Subworkflow embedded with changes"
+            message="Problems were encountered loading this workflow (possibly a result of tool upgrades). Please review the following parameters and then save."
+        />
         <MarkdownEditor
             v-if="!isCanvas"
             :markdown-text="markdownText"
@@ -232,6 +237,7 @@ export default {
             annotation: null,
             name: null,
             stateMessages: [],
+            insertedStateMessages: [],
         };
     },
     created() {
@@ -503,6 +509,9 @@ export default {
         },
         getCanvasManager() {
             return this.canvasManager;
+        },
+        onInsertedStateMessages(insertedStateMessages) {
+            this.insertedStateMessages = insertedStateMessages;
         },
     },
 };

--- a/client/src/components/Workflow/Editor/StateUpgradeModal.vue
+++ b/client/src/components/Workflow/Editor/StateUpgradeModal.vue
@@ -1,12 +1,12 @@
 <template>
-    <b-modal v-model="show" title="Issues loading this workflow" scrollable ok-only ok-title="Continue">
+    <b-modal v-model="show" :title="title" scrollable ok-only ok-title="Continue">
         <div class="state-upgrade-modal">
-            Please review the following issues, possibly resulting from tool upgrades or changes.
+            {{ message }}
             <ul class="workflow-state-upgrade-step-summaries">
                 <li v-for="(stateMessage, index) in stateMessages" :key="index">
                     <b>
                         <i :class="iconClass(stateMessage)" />
-                        Step {{ humanIndex(stateMessage) }}: {{ title(stateMessage) }}
+                        Step {{ humanIndex(stateMessage) }}: {{ nodeTitle(stateMessage) }}
                     </b>
                     <ul class="workflow-state-upgrade-step-details">
                         <li v-for="(detail, detailIndex) in stateMessage.details" :key="detailIndex">
@@ -29,6 +29,14 @@ export default {
             type: Array,
             requierd: true,
         },
+        title: {
+            type: String,
+            default: "Issues loading this workflow",
+        },
+        message: {
+            type: String,
+            default: "Please review the following issues, possibly resulting from tool upgrades or changes.",
+        },
     },
     data() {
         return {
@@ -39,7 +47,7 @@ export default {
         humanIndex(stateMessage) {
             return `${parseInt(stateMessage.stepIndex, 10) + 1}`;
         },
-        title(stateMessage) {
+        nodeTitle(stateMessage) {
             return stateMessage.label ? stateMessage.label : stateMessage.name;
         },
         iconClass(stateMessage) {

--- a/client/src/components/Workflow/Editor/modules/utilities.js
+++ b/client/src/components/Workflow/Editor/modules/utilities.js
@@ -15,23 +15,9 @@ export function copyIntoWorkflow(workflow, id = null, stepCount = null) {
         show_message("Importing workflow", "progress");
         loadWorkflow(workflow, id, null, true).then((data) => {
             // Determine if any parameters were 'upgraded' and provide message
-            var upgrade_message = "";
-            $.each(data.upgrade_messages, (k, v) => {
-                upgrade_message += `<li>Step ${parseInt(k, 10) + 1}: ${workflow.steps[k].name}<ul>`;
-                $.each(v, (i, vv) => {
-                    upgrade_message += `<li>${vv}</li>`;
-                });
-                upgrade_message += "</ul></li>";
-            });
-            if (upgrade_message) {
-                show_modal(
-                    "Subworkflow embedded with changes",
-                    `Problems were encountered loading this workflow (possibly a result of tool upgrades). Please review the following parameters and then save.<ul>${upgrade_message}</ul>`,
-                    { Continue: hide_modal }
-                );
-            } else {
-                hide_modal();
-            }
+            const insertedStateMessages = getStateUpgradeMessages(data);
+            workflow.onInsertedStateMessages(insertedStateMessages);
+            hide_modal();
         });
     };
     if (stepCount < 2) {


### PR DESCRIPTION
Reusing workflow response parsing and generalizing Vue component from #11036.

Before:

<img width="1024" alt="Screen Shot 2021-01-03 at 11 24 39 AM" src="https://user-images.githubusercontent.com/216771/103483768-8a534900-4db7-11eb-848e-ebea2775480f.png">

After:

<img width="1026" alt="Screen Shot 2021-01-03 at 11 28 55 AM" src="https://user-images.githubusercontent.com/216771/103483771-8f17fd00-4db7-11eb-87dd-e4e56170a38d.png">
