### PR TITLE
Add `negate` attribute to validators .. and tests for all

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2664,7 +2664,7 @@ class Dataset(StorableObject, RepresentById, _HasTable):
 
     def get_size(self, nice_size=False):
         """Returns the size of the data on disk"""
-        if self.file_size:
+        if self.file_size is not None:
             if nice_size:
                 return galaxy.util.nice_size(self.file_size)
             else:
@@ -2682,7 +2682,7 @@ class Dataset(StorableObject, RepresentById, _HasTable):
         calls to get_total_size or set_total_size - potentially avoiding both a database flush and check against
         the file system.
         """
-        if not self.file_size:
+        if self.file_size is not None:
             self.file_size = self._calculate_size()
             if no_extra_files:
                 self.total_size = self.file_size

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2664,7 +2664,7 @@ class Dataset(StorableObject, RepresentById, _HasTable):
 
     def get_size(self, nice_size=False):
         """Returns the size of the data on disk"""
-        if self.file_size is not None:
+        if self.file_size:
             if nice_size:
                 return galaxy.util.nice_size(self.file_size)
             else:
@@ -2682,7 +2682,7 @@ class Dataset(StorableObject, RepresentById, _HasTable):
         calls to get_total_size or set_total_size - potentially avoiding both a database flush and check against
         the file system.
         """
-        if self.file_size is not None:
+        if not self.file_size:
             self.file_size = self._calculate_size()
             if no_extra_files:
                 self.total_size = self.file_size

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -19,12 +19,12 @@ FILTER_TYPES = [
 
 ATTRIB_VALIDATOR_COMPATIBILITY = {
     "check": ["metadata"],
-    "expression": ["regex"],
+    "expression": ["regex", "substitute_value_in_message"],
     "table_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
     "filename": ["dataset_metadata_in_file"],
     "metadata_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "dataset_metadata_in_file"],
     "metadata_column": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_file options"],
-    "line_startswith": ["dataset_metadata_in_file", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
+    "line_startswith": ["dataset_metadata_in_file"],
     "min": ["in_range", "length"],
     "max": ["in_range", "length"],
     "exclude_min": ["in_range"],

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3643,10 +3643,13 @@ parameters a ``metadata`` validator is added automatically.
 - ``dataset_ok_validator``: Check if the data set is in state OK.
 - ``dataset_metadata_in_range``: Check if a numeric metadata value is within
 a given range.
-- ``dataset_metadata_in_file``: Check if a metadata value is contained in a
-specific column of another data set.
-- ``dataset_metadata_in_data_table`` (``dataset_metadata_not_in_data_table``):
-Check if a metadata value is contained in a column of a data table.
+- ``dataset_metadata_in_data_table``: Check if a metadata value is contained in a column of a data table.
+
+Deprecated data validators:
+
+- ``dataset_metadata_in_file``: Use data tables with ``dataset_metadata_in_data_table``.
+Check if a metadata value is contained in a specific column of another data set.
+- ``dataset_metadata_not_in_data_table``: Use ``dataset_metadata_in_data_table`` with ``negate="true"``.
 
 ### Validators for textual inputs (``text``, ``select``, ...)
 
@@ -3666,8 +3669,12 @@ For ``text`` inputs the following validators are useful:
 
 - ``length``: Check if the length of the value is within a range.
 - ``empty_field``: Check if the string is not empty
-- ``value_in_data_table`` (``value_not_in_data_table``): Check if the value is
+- ``value_in_data_table``: Check if the value is
 contained in a column of a given data table.
+
+Deprecated:
+
+- ``value_not_in_data_table``: Use ``value_in_data_table`` with ``negate="true"``.
 
 ### Validators for numeric inputs (``integer``, ``float``)
 
@@ -3725,15 +3732,16 @@ use in filenames may not contain ``..``.
       <xs:extension base="xs:string">
         <xs:attribute name="type" type="ValidatorType" use="required">
           <xs:annotation>
-            <xs:documentation xml:lang="en"><![CDATA[The list of supported
+            <xs:documentation xml:lang="en"><![CDATA[
+Valid values are: ``expression``, ``regex``, ``in_range``, ``length``,
+``metadata``, ``unspecified_build``, ``no_options``, ``empty_field``,
+``dataset_metadata_in_data_table``, ``value_in_data_table``,
+``dataset_ok_validator``, ``dataset_metadata_in_range``.
+Deprecated validators: ``dataset_metadata_in_file``, ``value_not_in_data_table``, ``dataset_metadata_not_in_data_table``.
+The list of supported
 validators is in the ``validator_types`` dictionary in
 [/lib/galaxy/tools/parameters/validation.py](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tools/parameters/validation.py).
-Valid values include: ``expression``, ``regex``, ``in_range``, ``length``,
-``metadata``, ``unspecified_build``, ``no_options``, ``empty_field``,
-``dataset_metadata_in_file``,
-``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``,
-``value_in_data_table``, ``value_not_in_data_table``,
-``dataset_ok_validator``, ``dataset_metadata_in_range``]]></xs:documentation>
+]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="message" type="xs:string">
@@ -3785,13 +3793,6 @@ in ``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, `
 This can be an integer index to the column or a column name.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="line_startswith" type="xs:string">
-          <xs:annotation>
-            <xs:documentation xml:lang="en">Used to indicate lines in the file
-being used for validation start with a this attribute value.
-For use with validators of type ``dataset_metadata_in_file``, ``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, ``value_in_data_table``, ``value_not_in_data_tabl``</xs:documentation>
-          </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="min" type="xs:decimal">
           <xs:annotation>
             <xs:documentation xml:lang="en">When the ``type`` attribute value is
@@ -3829,6 +3830,13 @@ not be modified.</xs:documentation>
             <xs:documentation xml:lang="en">Comma-seperated list of metadata
 fields to skip if type is ``metadata``. If not specified, all non-optional
 metadata fields will be checked unless ``check`` attribute is specified.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="line_startswith" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Deprecated. Used to indicate lines in the file
+being used for validation start with a this attribute value.
+For use with validator ``dataset_metadata_in_file``</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3644,13 +3644,13 @@ parameters a ``metadata`` validator is added automatically.
 - ``dataset_metadata_in_range``: Check if a numeric metadata value is within
 a given range.
 - ``dataset_metadata_in_data_table``: Check if a metadata value is contained in a column of a data table.
+- ``dataset_metadata_not_in_data_table``: Equivalent to ``dataset_metadata_in_data_table`` with ``negate="true"``.
 
 Deprecated data validators:
 
 - ``dataset_metadata_in_file``: Use data tables with ``dataset_metadata_in_data_table``.
 Check if a metadata value is contained in a specific column of a file in the ``tool_data_path``
 (which is set in Galaxy's config).
-- ``dataset_metadata_not_in_data_table``: Use ``dataset_metadata_in_data_table`` with ``negate="true"``.
 
 ### Validators for textual inputs (``text``, ``select``, ...)
 
@@ -3672,10 +3672,7 @@ For ``text`` inputs the following validators are useful:
 - ``empty_field``: Check if the string is not empty
 - ``value_in_data_table``: Check if the value is
 contained in a column of a given data table.
-
-Deprecated:
-
-- ``value_not_in_data_table``: Use ``value_in_data_table`` with ``negate="true"``.
+- ``value_not_in_data_table``: Equivalent to ``value_in_data_table`` with ``negate="true"``.
 
 ### Validators for numeric inputs (``integer``, ``float``)
 
@@ -3736,9 +3733,10 @@ use in filenames may not contain ``..``.
             <xs:documentation xml:lang="en"><![CDATA[
 Valid values are: ``expression``, ``regex``, ``in_range``, ``length``,
 ``metadata``, ``unspecified_build``, ``no_options``, ``empty_field``,
-``dataset_metadata_in_data_table``, ``value_in_data_table``,
+``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``,
+``value_in_data_table``, ``value_not_in_data_table``,
 ``dataset_ok_validator``, ``dataset_metadata_in_range``.
-Deprecated validators: ``dataset_metadata_in_file``, ``value_not_in_data_table``, ``dataset_metadata_not_in_data_table``.
+Deprecated validator: ``dataset_metadata_in_file``.
 The list of supported
 validators is in the ``validator_types`` dictionary in
 [/lib/galaxy/tools/parameters/validation.py](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tools/parameters/validation.py).

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3648,7 +3648,8 @@ a given range.
 Deprecated data validators:
 
 - ``dataset_metadata_in_file``: Use data tables with ``dataset_metadata_in_data_table``.
-Check if a metadata value is contained in a specific column of another data set.
+Check if a metadata value is contained in a specific column of a file in the ``tool_data_path``
+(which is set in Galaxy's config).
 - ``dataset_metadata_not_in_data_table``: Use ``dataset_metadata_in_data_table`` with ``negate="true"``.
 
 ### Validators for textual inputs (``text``, ``select``, ...)
@@ -3775,7 +3776,7 @@ more information.</xs:documentation>
         </xs:attribute>
         <xs:attribute name="filename" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Tool data filename to check against
+            <xs:documentation xml:lang="en">Deprecated: use ``dataset_metadata_in_data_table``. Tool data filename to check against
 if ``type`` is ``dataset_metadata_in_file``. File should be present Galaxy's
 ``tool-data`` directory.</xs:documentation>
           </xs:annotation>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3742,6 +3742,12 @@ Valid values include: ``expression``, ``regex``, ``in_range``, ``length``,
 The error message displayed on the tool form if validation fails.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="negate" type="xs:boolean" default="false">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">
+Negates the result of the validator.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="check" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Comma-seperated list of metadata

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3747,7 +3747,7 @@ validators is in the ``validator_types`` dictionary in
         <xs:attribute name="message" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">
-The error message displayed on the tool form if validation fails.</xs:documentation>
+The error message displayed on the tool form if validation fails. A placeholder string ``%s`` will be repaced by the ``value``</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="negate" type="xs:boolean" default="false">
@@ -3837,6 +3837,11 @@ metadata fields will be checked unless ``check`` attribute is specified.</xs:doc
             <xs:documentation xml:lang="en">Deprecated. Used to indicate lines in the file
 being used for validation start with a this attribute value.
 For use with validator ``dataset_metadata_in_file``</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="substitute_value_in_message" type="xs:string">
+          <xs:annotation>
+            <xs:documentation xml:lang="en">Deprecated. This is now always done.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -586,6 +586,9 @@ class DynamicOptions:
     @property
     def tool_data_table(self):
         if self.tool_data_table_name:
+            # this is needed for the validator unit tests and should not happen in real life
+            if self.tool_param.tool is None:
+                return None
             tool_data_table = self.tool_param.tool.app.tool_data_tables.get(self.tool_data_table_name, None)
             if tool_data_table:
                 # Column definitions are optional, but if provided override those from the table

--- a/lib/galaxy/tools/parameters/test/1.tabular
+++ b/lib/galaxy/tools/parameters/test/1.tabular
@@ -1,0 +1,1 @@
+../../../../../test-data/1.tabular

--- a/lib/galaxy/tools/parameters/test/empty.txt
+++ b/lib/galaxy/tools/parameters/test/empty.txt
@@ -1,0 +1,1 @@
+../../../../../test-data/empty.txt

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -630,7 +630,7 @@ class NoOptionsValidator(Validator):
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="index" type="select" label="Select reference genome">
-    ...     <validator type="no_options" message="No indexes are available for the selected input dataset"/>
+    ...     <validator type="no_options" message="No options available for selection"/>
     ... </param>
     ... '''))
     >>> t = p.validate('foo')
@@ -642,7 +642,7 @@ class NoOptionsValidator(Validator):
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="index" type="select" label="Select reference genome">
     ...     <options from_data_table="bowtie2_indexes"/>
-    ...     <validator type="no_options" message="No indexes are available for the selected input dataset" negate="true"/>
+    ...     <validator type="no_options" negate="true"/>
     ... </param>
     ... '''))
     >>> t = p.validate('foo')

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -234,7 +234,7 @@ class InRangeValidator(Validator):
                    elem.get('exclude_max', 'false'),
                    elem.get('negate', 'false'))
 
-    def __init__(self, message, range_min, range_max, exclude_min, exclude_max, negate):
+    def __init__(self, message, range_min, range_max, exclude_min=False, exclude_max=False, negate=False):
         """
         When the optional exclude_min and exclude_max attributes are set
         to true, the range excludes the end points (i.e., min < value < max),

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -725,8 +725,9 @@ class MetadataInFileColumnValidator(Validator):
     """
     Validator that checks if the value for a dataset's metadata item exists in a file.
 
-    TODO deprecate
-    note: this is covered in a framework test ()
+    Deprecated: DataTables are now the preferred way.
+
+    note: this is covered in a framework test (validation_dataset_metadata_in_file)
     """
     requires_dataset_metadata = True
 
@@ -781,14 +782,10 @@ class ValueInDataTableColumnValidator(Validator):
         except ValueError:
             pass
         message = elem.get("message", f"Value was not found in {table_name}.")
-        # TODO deprecate line_startswith .. not used in all *InDataTableColumnValidator validators
-        line_startswith = elem.get("line_startswith", None)
-        if line_startswith:
-            line_startswith = line_startswith.strip()
         negate = elem.get('negate', 'false')
-        return cls(tool_data_table, column, message, line_startswith, negate)
+        return cls(tool_data_table, column, message, negate)
 
-    def __init__(self, tool_data_table, column, message="Value not found.", line_startswith=None, negate='false'):
+    def __init__(self, tool_data_table, column, message="Value not found.", negate='false'):
         super().__init__(message, negate)
         self.valid_values = []
         self._data_table_content_version = None
@@ -820,11 +817,13 @@ class ValueNotInDataTableColumnValidator(ValueInDataTableColumnValidator):
     """
     Validator that checks if a value is NOT in a tool data table column.
 
+    Deprecated: use now the `negate` attribute
+
     note: this is covered in a framework test (validation_value_in_datatable)
     """
 
-    def __init__(self, tool_data_table, metadata_column, message="Value already present.", line_startswith=None, negate='false'):
-        super().__init__(tool_data_table, metadata_column, message, line_startswith, negate)
+    def __init__(self, tool_data_table, metadata_column, message="Value already present.", negate='false'):
+        super().__init__(tool_data_table, metadata_column, message, negate)
 
     def validate(self, value, trans=None):
         try:
@@ -859,13 +858,10 @@ class MetadataInDataTableColumnValidator(Validator):
         except ValueError:
             pass
         message = elem.get("message", f"Value for metadata {metadata_name} was not found in {table_name}.")
-        line_startswith = elem.get("line_startswith", None)
-        if line_startswith:
-            line_startswith = line_startswith.strip()
         negate = elem.get('negate', 'false')
-        return cls(tool_data_table, metadata_name, metadata_column, message, line_startswith, negate)
+        return cls(tool_data_table, metadata_name, metadata_column, message, negate)
 
-    def __init__(self, tool_data_table, metadata_name, metadata_column, message="Value for metadata not found.", line_startswith=None, negate="false"):
+    def __init__(self, tool_data_table, metadata_name, metadata_column, message="Value for metadata not found.", negate="false"):
         super().__init__(message, negate)
         self.metadata_name = metadata_name
         self.valid_values = []
@@ -898,12 +894,14 @@ class MetadataNotInDataTableColumnValidator(MetadataInDataTableColumnValidator):
     """
     Validator that checks if the value for a dataset's metadata item doesn't exists in a file.
 
+    Deprecated: use now the `negate` attribute
+
     note: this is covered in a framework test (validation_metadata_in_datatable)
     """
     requires_dataset_metadata = True
 
-    def __init__(self, tool_data_table, metadata_name, metadata_column, message="Value for metadata not found.", line_startswith=None, negate="false"):
-        super().__init__(tool_data_table, metadata_name, metadata_column, message, line_startswith, negate)
+    def __init__(self, tool_data_table, metadata_name, metadata_column, message="Value for metadata not found.", negate="false"):
+        super().__init__(tool_data_table, metadata_name, metadata_column, message, negate)
 
     def validate(self, value, trans=None):
         try:
@@ -960,14 +958,17 @@ validator_types = dict(
     empty_field=EmptyTextfieldValidator,
     empty_dataset=DatasetEmptyValidator,
     empty_extra_files_path=DatasetExtraFilesPathEmptyValidator,
-    dataset_metadata_in_file=MetadataInFileColumnValidator,
     dataset_metadata_in_data_table=MetadataInDataTableColumnValidator,
-    dataset_metadata_not_in_data_table=MetadataNotInDataTableColumnValidator,
     dataset_metadata_in_range=MetadataInRangeValidator,
     value_in_data_table=ValueInDataTableColumnValidator,
-    value_not_in_data_table=ValueNotInDataTableColumnValidator,
     dataset_ok_validator=DatasetOkValidator,
 )
+deprecated_validator_types = dict(
+    dataset_metadata_in_file=MetadataInFileColumnValidator,
+    dataset_metadata_not_in_data_table=MetadataNotInDataTableColumnValidator,
+    value_not_in_data_table=ValueNotInDataTableColumnValidator,
+)
+validator_types.update(deprecated_validator_types)
 
 
 def get_suite():

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -816,8 +816,7 @@ class ValueInDataTableColumnValidator(Validator):
 class ValueNotInDataTableColumnValidator(ValueInDataTableColumnValidator):
     """
     Validator that checks if a value is NOT in a tool data table column.
-
-    Deprecated: use now the `negate` attribute
+    Equivalent to ValueInDataTableColumnValidator with `negate="true"`.
 
     note: this is covered in a framework test (validation_value_in_datatable)
     """
@@ -871,8 +870,7 @@ class MetadataInDataTableColumnValidator(ValueInDataTableColumnValidator):
 class MetadataNotInDataTableColumnValidator(MetadataInDataTableColumnValidator):
     """
     Validator that checks if the value for a dataset's metadata item doesn't exists in a file.
-
-    Deprecated: use now the `negate` attribute
+    Equivalent to MetadataInDataTableColumnValidator with `negate="true"`.
 
     note: this is covered in a framework test (validation_metadata_in_datatable)
     """
@@ -940,15 +938,15 @@ validator_types = dict(
     empty_dataset=DatasetEmptyValidator,
     empty_extra_files_path=DatasetExtraFilesPathEmptyValidator,
     dataset_metadata_in_data_table=MetadataInDataTableColumnValidator,
+    dataset_metadata_not_in_data_table=MetadataNotInDataTableColumnValidator,
     dataset_metadata_in_range=MetadataInRangeValidator,
     value_in_data_table=ValueInDataTableColumnValidator,
+    value_not_in_data_table=ValueNotInDataTableColumnValidator,
     dataset_ok_validator=DatasetOkValidator,
 )
 
 deprecated_validator_types = dict(
-    dataset_metadata_in_file=MetadataInFileColumnValidator,
-    dataset_metadata_not_in_data_table=MetadataNotInDataTableColumnValidator,
-    value_not_in_data_table=ValueNotInDataTableColumnValidator,
+    dataset_metadata_in_file=MetadataInFileColumnValidator
 )
 validator_types.update(deprecated_validator_types)
 

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -58,10 +58,16 @@ class Validator(abc.ABC):
         """
         validate a value
 
-        TODO assert bool value and document how to implement in derived classes
+        needs to be implemented in classes derived from validator.
+        the implementation needs to call `super().validate()`
+        giving value as a bool which should be true if the
+        validation is positive and false otherwise.
+        the Validator.validate function will then negate the value
+        depending on `self.negate`
 
         return None if positive validation, otherwise a ValueError is raised
         """
+        assert isinstance(value, bool), 'value must be boolean'
         log.error("VAL value %s" % value)
         if message is None:
             message = self.message

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -345,9 +345,6 @@ class DatasetOkValidator(Validator):
     >>> ok_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', create_dataset=True, sa_session=sa_session))
     >>> ok_hda.set_dataset_state(model.Dataset.states.OK)
     >>> notok_hda = hist.add_dataset(HistoryDatasetAssociation(id=2, extension='interval', create_dataset=True, sa_session=sa_session))
-    >>> # TODO I do not get 100% why for state!=OK the validator is called
-    >>> # TODO because DataToolParameter.validate.do_validate calls the validator only of state=OK
-    >>> # TODO in this light I wonder about the use of this validator at all....
     >>> notok_hda.set_dataset_state(model.Dataset.states.EMPTY)
     >>>
     >>> p = ToolParameter.build(None, XML('''

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -41,7 +41,6 @@ class Validator(abc.ABC):
         return validator_types[_type].from_element(param, elem)
 
     def __init__(self, message, negate=False):
-        log.error("INIT msg %s neg %s" % (message, negate))
         self.message = message
         self.negate = util.asbool(negate)
         super().__init__()
@@ -552,7 +551,6 @@ class MetadataValidator(Validator):
                    negate=elem.get('negate', 'false'))
 
     def __init__(self, message=None, check="", skip="", negate='false'):
-        log.error("MetadataValidator")
         super().__init__(message, negate)
         self.check = check.split(",")
         self.skip = skip.split(",")
@@ -632,7 +630,6 @@ class NoOptionsValidator(Validator):
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="index" type="select" label="Select reference genome">
-    ...     <options from_data_table="bowtie2_indexes"/>
     ...     <validator type="no_options" message="No indexes are available for the selected input dataset"/>
     ... </param>
     ... '''))
@@ -660,7 +657,7 @@ class NoOptionsValidator(Validator):
         return cls(elem.get('message', "No options available for selection"), elem.get('negate', 'false'))
 
     def validate(self, value, trans=None):
-        super().validate(value is None)
+        super().validate(value is not None)
 
 
 class EmptyTextfieldValidator(Validator):

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -266,6 +266,7 @@ class InRangeValidator(Validator):
             maxcmp = self.max.__gt__
         else:
             maxcmp = self.max.__ge__
+        log.error(f"{value} min {mincmp(float(value))} max {maxcmp(float(value))}")
         super().validate(mincmp(float(value)) and maxcmp(float(value)), trans)
 
 
@@ -914,7 +915,6 @@ class MetadataInRangeValidator(InRangeValidator):
             except ValueError:
                 raise ValueError(f'{self.metadata_name} must be a float or an integer')
             super().validate(value_to_check, trans)
-        super().validate(True, trans)
 
 
 validator_types = dict(

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -838,7 +838,6 @@ class MetadataInDataTableColumnValidator(ValueInDataTableColumnValidator):
     """
     Validator that checks if the value for a dataset's metadata item exists in a file.
 
-    TODO Could be derived from ValueInDataTableColumnValidator
     note: this is covered in a framework test (validation_metadata_in_datatable)
     """
     requires_dataset_metadata = True

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -229,8 +229,8 @@ class InRangeValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get('message', None), elem.get('min', '-inf'),
-                   elem.get('max', 'inf'), elem.get('exclude_min', 'false'),
+        return cls(elem.get('message', None), elem.get('min'),
+                   elem.get('max'), elem.get('exclude_min', 'false'),
                    elem.get('exclude_max', 'false'),
                    elem.get('negate', 'false'))
 
@@ -242,9 +242,9 @@ class InRangeValidator(Validator):
         (1.e., min <= value <= max).  Combinations of exclude_min and exclude_max
         values are allowed.
         """
-        self.min = float(range_min)
+        self.min = float(range_min if range_min is not None else '-inf')
         self.exclude_min = util.asbool(exclude_min)
-        self.max = float(range_max)
+        self.max = float(range_max if range_max is not None else 'inf')
         self.exclude_max = util.asbool(exclude_max)
         assert self.min <= self.max, 'min must be less than or equal to max'
         # Remove unneeded 0s and decimal from floats to make message pretty.
@@ -631,7 +631,7 @@ class NoOptionsValidator(Validator):
     >>> from galaxy.util import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
     >>> p = ToolParameter.build(None, XML('''
-    ... <param name="index" type="select" label="Select reference genome" help="If your genome of interest is not listed, contact the Galaxy team">
+    ... <param name="index" type="select" label="Select reference genome">
     ...     <options from_data_table="bowtie2_indexes"/>
     ...     <validator type="no_options" message="No indexes are available for the selected input dataset"/>
     ... </param>
@@ -643,7 +643,7 @@ class NoOptionsValidator(Validator):
     ValueError: No options available for selection
     >>>
     >>> p = ToolParameter.build(None, XML('''
-    ... <param name="index" type="select" label="Select reference genome" help="If your genome of interest is not listed, contact the Galaxy team">
+    ... <param name="index" type="select" label="Select reference genome">
     ...     <options from_data_table="bowtie2_indexes"/>
     ...     <validator type="no_options" message="No indexes are available for the selected input dataset" negate="true"/>
     ... </param>
@@ -660,7 +660,7 @@ class NoOptionsValidator(Validator):
         return cls(elem.get('message', "No options available for selection"), elem.get('negate', 'false'))
 
     def validate(self, value, trans=None):
-        super().validate( value is None )
+        super().validate(value is None)
 
 
 class EmptyTextfieldValidator(Validator):

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -1,6 +1,7 @@
 """
 Classes related to parameter validation.
 """
+import abc
 import logging
 import re
 
@@ -13,7 +14,7 @@ from galaxy import (
 log = logging.getLogger(__name__)
 
 
-class Validator:
+class Validator(abc.ABC):
     """
     A validator checks that a value meets some conditions OR raises ValueError
     """
@@ -39,13 +40,26 @@ class Validator:
         assert _type is not None, "Required 'type' attribute missing from validator"
         return validator_types[_type].from_element(param, elem)
 
-    def validate(self, value, trans=None):
+    def __init__(self, message, negate=False):
+        self.message = message
+        self.negate = util.asbool(negate)
+        super().__init__()
+
+    @abc.abstractmethod
+    def validate(self, value, trans=None, message=None):
         """
         validate a value
 
         return None if positive validation, otherwise a ValueError is raised
         """
-        raise TypeError("Abstract Method")
+        if message is None:
+            message = self.message
+        log.error("validate %s %s" % (value, self.negate))
+        if (not self.negate and value) or (self.negate and not value):
+            return
+        else:
+            raise ValueError(message)
+        pass
 
 
 class RegexValidator(Validator):
@@ -77,7 +91,7 @@ class RegexValidator(Validator):
         return cls(elem.get('message'), elem.text, elem.get('negate', 'false'))
 
     def __init__(self, message, expression, negate):
-        self.message = message
+        super().__init__(message, negate)
         # Compile later. RE objects used to not be thread safe. Not sure about
         # the sre module.
         self.expression = expression
@@ -88,8 +102,7 @@ class RegexValidator(Validator):
             value = [value]
         for val in value:
             match = re.match(self.expression, val or '')
-            if (not self.invert and match is None) or (self.invert and match is not None):
-                raise ValueError(self.message)
+            super().validate(match is not None, trans)
 
 
 class ExpressionValidator(Validator):
@@ -116,7 +129,8 @@ class ExpressionValidator(Validator):
         return cls(elem.get('message'), elem.text, elem.get('substitute_value_in_message'))
 
     def __init__(self, message, expression, substitute_value_in_message):
-        self.message = message
+        super().__init__(message)
+        # TODO 
         self.substitute_value_in_message = substitute_value_in_message
         # Save compiled expression, code objects are thread safe (right?)
         self.expression = compile(expression, '<string>', 'eval')
@@ -129,9 +143,11 @@ class ExpressionValidator(Validator):
             evalresult = eval(self.expression, dict(value=value))
         except Exception:
             log.debug(f"Validator {self.expression} could not be evaluated on {str(value)}", exc_info=True)
-            raise ValueError(message)
+            super().validate(false, trans, message)
         if not(evalresult):
-            raise ValueError(message)
+            super().validate(false, trans, message)
+        else:
+            super().validate(true, trans, message)
 
 
 class InRangeValidator(Validator):
@@ -159,11 +175,12 @@ class InRangeValidator(Validator):
 
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get('message', None), elem.get('min'),
-                   elem.get('max'), elem.get('exclude_min', 'false'),
-                   elem.get('exclude_max', 'false'))
+        return cls(elem.get('message', None), elem.get('min', '-inf'),
+                   elem.get('max', 'inf'), elem.get('exclude_min', 'false'),
+                   elem.get('exclude_max', 'false'),
+                   elem.get('negate', 'false'))
 
-    def __init__(self, message, range_min, range_max, exclude_min=False, exclude_max=False):
+    def __init__(self, message, range_min, range_max, exclude_min, exclude_max, negate):
         """
         When the optional exclude_min and exclude_max attributes are set
         to true, the range excludes the end points (i.e., min < value < max),
@@ -171,9 +188,11 @@ class InRangeValidator(Validator):
         (1.e., min <= value <= max).  Combinations of exclude_min and exclude_max
         values are allowed.
         """
-        self.min = float(range_min if range_min is not None else '-inf')
+        super().__init__(message or f"Value must be {op1} {self_min_str} and {op2} {self_max_str}", negate)
+
+        self.min = float(range_min)
         self.exclude_min = util.asbool(exclude_min)
-        self.max = float(range_max if range_max is not None else 'inf')
+        self.max = float(range_max)
         self.exclude_max = util.asbool(exclude_max)
         assert self.min <= self.max, 'min must be less than or equal to max'
         # Remove unneeded 0s and decimal from floats to make message pretty.
@@ -185,21 +204,16 @@ class InRangeValidator(Validator):
             op1 = '>'
         if self.exclude_max:
             op2 = '<'
-        self.message = message or f"Value must be {op1} {self_min_str} and {op2} {self_max_str}"
 
     def validate(self, value, trans=None):
         if self.exclude_min:
-            if not self.min < float(value):
-                raise ValueError(self.message)
+            super().validate(self.min < float(value), trans)
         else:
-            if not self.min <= float(value):
-                raise ValueError(self.message)
+            super().validate(self.min <= float(value), trans)
         if self.exclude_max:
-            if not float(value) < self.max:
-                raise ValueError(self.message)
+            super().validate(float(value) < self.max, trans)
         else:
-            if not float(value) <= self.max:
-                raise ValueError(self.message)
+            super().validate(float(value) <= self.max, trans)
 
 
 class LengthValidator(Validator):
@@ -230,7 +244,7 @@ class LengthValidator(Validator):
         return cls(elem.get('message', None), elem.get('min', None), elem.get('max', None))
 
     def __init__(self, message, length_min, length_max):
-        self.message = message
+        super().__init__(message)
         if length_min is not None:
             length_min = int(length_min)
         if length_max is not None:
@@ -240,18 +254,17 @@ class LengthValidator(Validator):
 
     def validate(self, value, trans=None):
         if self.min is not None and len(value) < self.min:
-            raise ValueError(self.message or ("Must have length of at least %d" % self.min))
-        if self.max is not None and len(value) > self.max:
-            raise ValueError(self.message or ("Must have length no more than %d" % self.max))
+            super().validate(false, trans, self.message or ("Must have length of at least %d" % self.min))
+        elif self.max is not None and len(value) > self.max:
+            super().validate(false, trans, self.message or ("Must have length no more than %d" % self.max))
+        else:
+            super().validate(true, trans)
 
 
 class DatasetOkValidator(Validator):
     """
     Validator that checks if a dataset is in an 'ok' state
     """
-
-    def __init__(self, message=None):
-        self.message = message
 
     @classmethod
     def from_element(cls, param, elem):
@@ -267,9 +280,6 @@ class DatasetOkValidator(Validator):
 class DatasetEmptyValidator(Validator):
     """Validator that checks if a dataset has a positive file size."""
 
-    def __init__(self, message=None):
-        self.message = message
-
     @classmethod
     def from_element(cls, param, elem):
         return cls(elem.get('message', None))
@@ -284,9 +294,6 @@ class DatasetEmptyValidator(Validator):
 
 class DatasetExtraFilesPathEmptyValidator(Validator):
     """Validator that checks if a dataset's extra_files_path exists and is not empty."""
-
-    def __init__(self, message=None):
-        self.message = message
 
     @classmethod
     def from_element(cls, param, elem):
@@ -306,14 +313,14 @@ class MetadataValidator(Validator):
     """
     requires_dataset_metadata = True
 
-    def __init__(self, message=None, check="", skip=""):
-        self.message = message
-        self.check = check.split(",")
-        self.skip = skip.split(",")
-
     @classmethod
     def from_element(cls, param, elem):
         return cls(message=elem.get('message', None), check=elem.get('check', ""), skip=elem.get('skip', ""))
+
+    def __init__(self, message=None, check="", skip=""):
+        super().__init__(message)
+        self.check = check.split(",")
+        self.skip = skip.split(",")
 
     def validate(self, value, trans=None):
         if value:
@@ -331,15 +338,9 @@ class UnspecifiedBuildValidator(Validator):
     """
     requires_dataset_metadata = True
 
-    def __init__(self, message=None):
-        if message is None:
-            self.message = "Unspecified genome build, click the pencil icon in the history item to set the genome build"
-        else:
-            self.message = message
-
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get('message', None))
+        return cls(elem.get('message', "Unspecified genome build, click the pencil icon in the history item to set the genome build"))
 
     def validate(self, value, trans=None):
         # if value is None, we cannot validate
@@ -354,34 +355,26 @@ class UnspecifiedBuildValidator(Validator):
 class NoOptionsValidator(Validator):
     """Validator that checks for empty select list"""
 
-    def __init__(self, message=None):
-        self.message = message
-
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get('message', None))
+        return cls(elem.get('message', "No options available for selection"))
 
     def validate(self, value, trans=None):
         if value is None:
-            if self.message is None:
-                self.message = "No options available for selection"
             raise ValueError(self.message)
 
 
 class EmptyTextfieldValidator(Validator):
     """Validator that checks for empty text field"""
 
-    def __init__(self, message=None):
-        self.message = message
-
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get('message', None))
+        return cls(elem.get('message', "Field requires a value"))
 
     def validate(self, value, trans=None):
         if value == '':
             if self.message is None:
-                self.message = "Field requires a value"
+                self.message = "
             raise ValueError(self.message)
 
 
@@ -408,8 +401,8 @@ class MetadataInFileColumnValidator(Validator):
         return cls(filename, metadata_name, metadata_column, message, line_startswith, split)
 
     def __init__(self, filename, metadata_name, metadata_column, message="Value for metadata not found.", line_startswith=None, split="\t"):
+        super().__init__(message)
         self.metadata_name = metadata_name
-        self.message = message
         self.valid_values = []
         for line in open(filename):
             if line_startswith is None or line.startswith(line_startswith):
@@ -448,7 +441,7 @@ class ValueInDataTableColumnValidator(Validator):
         return cls(tool_data_table, column, message, line_startswith)
 
     def __init__(self, tool_data_table, column, message="Value not found.", line_startswith=None):
-        self.message = message
+        super().__init__(message)
         self.valid_values = []
         self._data_table_content_version = None
         self._tool_data_table = tool_data_table
@@ -518,8 +511,8 @@ class MetadataInDataTableColumnValidator(Validator):
         return cls(tool_data_table, metadata_name, metadata_column, message, line_startswith)
 
     def __init__(self, tool_data_table, metadata_name, metadata_column, message="Value for metadata not found.", line_startswith=None):
+        super().__init__(message)
         self.metadata_name = metadata_name
-        self.message = message
         self.valid_values = []
         self._data_table_content_version = None
         self._tool_data_table = tool_data_table
@@ -567,23 +560,23 @@ class MetadataNotInDataTableColumnValidator(MetadataInDataTableColumnValidator):
 
 class MetadataInRangeValidator(InRangeValidator):
     """
-    Validator that ensures metadata is in a specified range
+    validator that ensures metadata is in a specified range
     """
-    requires_dataset_metadata = True
+    requires_dataset_metadata = true
 
     @classmethod
     def from_element(cls, param, elem):
-        metadata_name = elem.get('metadata_name', None)
+        metadata_name = elem.get('metadata_name', none)
         assert metadata_name, "dataset_metadata_in_range validator requires metadata_name attribute."
         metadata_name = metadata_name.strip()
-        return cls(metadata_name,
-                   elem.get('message', None), elem.get('min'),
-                   elem.get('max'), elem.get('exclude_min', 'false'),
-                   elem.get('exclude_max', 'false'))
+        return cls(metadata_name, elem.get('message', None),
+                   elem.get('min'), elem.get('max'),
+                   elem.get('exclude_min', 'false'), elem.get('exclude_max', 'false'),
+                   elem.get('negate', 'false'))
 
-    def __init__(self, metadata_name, message, range_min, range_max, exclude_min=False, exclude_max=False):
+    def __init__(self, metadata_name, message, range_min, range_max, exclude_min, exclude_max, negate):
         self.metadata_name = metadata_name
-        super().__init__(message, range_min, range_max, exclude_min, exclude_max)
+        super().__init__(message, range_min, range_max, exclude_min, exclude_max, negate)
 
     def validate(self, value, trans=None):
         if value:
@@ -596,6 +589,7 @@ class MetadataInRangeValidator(InRangeValidator):
             except ValueError:
                 raise ValueError(f'{self.metadata_name} must be a float or an integer')
             super().validate(value_to_check, trans)
+        super().validate(true, trans)
 
 
 validator_types = dict(

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -3,6 +3,7 @@ Classes related to parameter validation.
 """
 import abc
 import logging
+import os.path
 import re
 
 
@@ -12,6 +13,13 @@ from galaxy import (
 )
 
 log = logging.getLogger(__name__)
+
+
+def get_test_fname(fname):
+    """Returns test data filename"""
+    path, name = os.path.split(__file__)
+    full_path = os.path.join(path, 'test', fname)
+    return full_path
 
 
 class Validator(abc.ABC):
@@ -406,9 +414,9 @@ class DatasetEmptyValidator(Validator):
     >>> sa_session.flush()
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
     >>> # TODO is there a better way than hardcoding 'test-data/'
-    >>> empty_dataset = Dataset(external_filename="test-data/empty.txt")
+    >>> empty_dataset = Dataset(external_filename=get_test_fname("empty.txt"))
     >>> empty_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', dataset=empty_dataset, sa_session=sa_session))
-    >>> full_dataset = Dataset(external_filename="test-data/1.tabular")
+    >>> full_dataset = Dataset(external_filename=get_test_fname("1.tabular"))
     >>> full_hda = hist.add_dataset(HistoryDatasetAssociation(id=2, extension='interval', dataset=full_dataset, sa_session=sa_session))
     >>>
     >>> p = ToolParameter.build(None, XML('''

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -391,7 +391,7 @@ class DatasetEmptyValidator(Validator):
     Validator that checks if a dataset has a positive file size.
 
     >>> from galaxy.datatypes.registry import example_datatype_registry_for_sample
-    >>> from galaxy.model import History, HistoryDatasetAssociation, set_datatypes_registry
+    >>> from galaxy.model import Dataset, History, HistoryDatasetAssociation, set_datatypes_registry
     >>> from galaxy.model.mapping import init
     >>> from galaxy.util import XML
     >>> from galaxy.tools.parameters.basic import ToolParameter
@@ -401,10 +401,11 @@ class DatasetEmptyValidator(Validator):
     >>> sa_session.add(hist)
     >>> sa_session.flush()
     >>> set_datatypes_registry(example_datatype_registry_for_sample())
-    >>> empty_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', create_dataset=True, sa_session=sa_session))
-    >>> empty_hda.dataset.file_size = 0
-    >>> full_hda = hist.add_dataset(HistoryDatasetAssociation(id=2, extension='interval', create_dataset=True, sa_session=sa_session))
-    >>> full_hda.dataset.file_size = 1
+    >>> # TODO is there a better way than hardcoding 'test-data/'
+    >>> empty_dataset = Dataset(external_filename="test-data/empty.txt")
+    >>> empty_hda = hist.add_dataset(HistoryDatasetAssociation(id=1, extension='interval', dataset=empty_dataset, sa_session=sa_session))
+    >>> full_dataset = Dataset(external_filename="test-data/1.tabular")
+    >>> full_hda = hist.add_dataset(HistoryDatasetAssociation(id=2, extension='interval', dataset=full_dataset, sa_session=sa_session))
     >>>
     >>> p = ToolParameter.build(None, XML('''
     ... <param name="blah" type="data">

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -390,7 +390,7 @@ class DatasetOkValidator(Validator):
 class DatasetEmptyValidator(Validator):
     """
     Validator that checks if a dataset has a positive file size.
-   
+
     >>> from galaxy.datatypes.registry import example_datatype_registry_for_sample
     >>> from galaxy.model import History, HistoryDatasetAssociation, set_datatypes_registry
     >>> from galaxy.model.mapping import init
@@ -442,7 +442,7 @@ class DatasetEmptyValidator(Validator):
 class DatasetExtraFilesPathEmptyValidator(Validator):
     """
     Validator that checks if a dataset's extra_files_path exists and is not empty.
-   
+
     >>> from galaxy.datatypes.registry import example_datatype_registry_for_sample
     >>> from galaxy.model import History, HistoryDatasetAssociation, set_datatypes_registry
     >>> from galaxy.model.mapping import init
@@ -621,28 +621,51 @@ class UnspecifiedBuildValidator(Validator):
             # TODO can dbkey really be a list?
             if isinstance(dbkey, list):
                 dbkey = dbkey[0]
-            super().validate(dbkey != '?')           
+            super().validate(dbkey != '?')
 
 
 class NoOptionsValidator(Validator):
     """
     Validator that checks for empty select list
 
+    >>> from galaxy.util import XML
+    >>> from galaxy.tools.parameters.basic import ToolParameter
+    >>> p = ToolParameter.build(None, XML('''
+    ... <param name="index" type="select" label="Select reference genome" help="If your genome of interest is not listed, contact the Galaxy team">
+    ...     <options from_data_table="bowtie2_indexes"/>
+    ...     <validator type="no_options" message="No indexes are available for the selected input dataset"/>
+    ... </param>
+    ... '''))
+    >>> t = p.validate('foo')
+    >>> t = p.validate(None)
+    Traceback (most recent call last):
+        ...
+    ValueError: No options available for selection
+    >>>
+    >>> p = ToolParameter.build(None, XML('''
+    ... <param name="index" type="select" label="Select reference genome" help="If your genome of interest is not listed, contact the Galaxy team">
+    ...     <options from_data_table="bowtie2_indexes"/>
+    ...     <validator type="no_options" message="No indexes are available for the selected input dataset" negate="true"/>
+    ... </param>
+    ... '''))
+    >>> t = p.validate('foo')
+    Traceback (most recent call last):
+        ...
+    ValueError: No options available for selection
+    >>> t = p.validate(None)
     """
 
     @classmethod
     def from_element(cls, param, elem):
-        return cls(elem.get('message', "No options available for selection"))
+        return cls(elem.get('message', "No options available for selection"), elem.get('negate', 'false'))
 
     def validate(self, value, trans=None):
-        if value is None:
-            raise ValueError(self.message)
+        super().validate( value is None )
 
 
 class EmptyTextfieldValidator(Validator):
     """
     Validator that checks for empty text field
-   
     """
 
     @classmethod

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # Don't display the pip progress bar when running under CI
 [ "$CI" = 'true' ] && export PIP_PROGRESS_BAR=off

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -135,6 +135,9 @@
   <tool file="validation_sanitizer.xml" />
   <tool file="validation_repeat.xml" />
   <tool file="validation_metadata_in_range.xml"/>
+  <tool file="validation_metadata_in_datatable.xml"/>
+  <tool file="validation_metadata_in_file.xml"/>
+  <tool file="validation_value_in_datatable.xml"/>
   <tool file="empty_output.xml" />
   <tool file="validation_empty_dataset.xml" />
   <tool file="implicit_conversion.xml" />

--- a/test/functional/tools/validation_dataset_metadata_in_file.xml
+++ b/test/functional/tools/validation_dataset_metadata_in_file.xml
@@ -1,0 +1,30 @@
+<tool id="validation_dataset_metadata_in_file" name="validation_dataset_metadata_in_file" profile="19.05" version="0.1">
+    <command><![CDATA[
+echo 'Hello World' > out1
+    ]]></command>
+    <inputs>
+        <!-- test dataset_metadata_in_file validator with and without negation
+             the test also uses the data table fasta_indexes.loc, but it could be any file in the tool data dir -->
+        <param name="value" type="data">
+            <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" metadata_name="dbkey" metadata_column="1"/>
+        </param>
+        <param name="value_neg" type="data">
+            <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" metadata_name="dbkey" metadata_column="1" negate="true"/>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" from_work_dir="out1"/>
+    </outputs>
+    <tests>
+        <test expect_failure="false">
+            <param name="value" value="1.fasta" dbkey="hg19"/> <!-- hg19 is in the test data table-->
+            <param name="value_neg" value="1.fasta" dbkey="hg38"/>
+        </test>
+        <test expect_failure="true">
+            <param name="value" value="1.fasta" dbkey="hg38"/> <!-- hg19 is in the test data table-->
+            <param name="value_neg" value="1.fasta" dbkey="hg19"/>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/validation_dataset_metadata_in_file.xml
+++ b/test/functional/tools/validation_dataset_metadata_in_file.xml
@@ -1,28 +1,30 @@
-<tool id="validation_dataset_metadata_in_file" name="validation_dataset_metadata_in_file" profile="19.05" version="0.1">
+<tool id="validation_dataset_metadata_in_file" name="validation_dataset_metadata_in_file" profile="21.09" version="0.1">
     <command><![CDATA[
 echo 'Hello World' > out1
     ]]></command>
     <inputs>
         <!-- test dataset_metadata_in_file validator with and without negation
              the test also uses the data table fasta_indexes.loc, but it could be any file in the tool data dir -->
-        <param name="value" type="data">
+        <param name="value" type="data" format="data">
             <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" metadata_name="dbkey" metadata_column="1"/>
         </param>
-        <param name="value_neg" type="data">
-            <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" metadata_name="dbkey" metadata_column="1" negate="true"/>
+        <param name="value_neg" type="data" format="data">
+            <validator type="dataset_metadata_in_file" filename="fasta_indexes.loc" line_startswith="h" metadata_name="dbkey" metadata_column="1" negate="true"/>
         </param>
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" from_work_dir="out1"/>
     </outputs>
     <tests>
+        <!-- hg19 is in the file and hg38 isn't -->
+        <!-- TODO These tests fail if the same test data is used .. no idea why -->
         <test expect_failure="false">
-            <param name="value" value="1.fasta" dbkey="hg19"/> <!-- hg19 is in the test data table-->
-            <param name="value_neg" value="1.fasta" dbkey="hg38"/>
-        </test>
+            <param name="value" value="1.fasta" dbkey="hg19"/> 
+            <param name="value_neg" value="2.fasta" dbkey="hg38"/>
+           </test>
         <test expect_failure="true">
-            <param name="value" value="1.fasta" dbkey="hg38"/> <!-- hg19 is in the test data table-->
-            <param name="value_neg" value="1.fasta" dbkey="hg19"/>
+            <param name="value" value="1.fasta" dbkey="hg38"/>
+            <param name="value_neg" value="2.fasta" dbkey="hg19"/>
         </test>
     </tests>
     <help>

--- a/test/functional/tools/validation_dataset_metadata_in_file.xml
+++ b/test/functional/tools/validation_dataset_metadata_in_file.xml
@@ -17,7 +17,6 @@ echo 'Hello World' > out1
     </outputs>
     <tests>
         <!-- hg19 is in the file and hg38 isn't -->
-        <!-- TODO These tests fail if the same test data is used .. no idea why -->
         <test expect_failure="false">
             <param name="value" value="1.fasta" dbkey="hg19"/> 
             <param name="value_neg" value="2.fasta" dbkey="hg38"/>

--- a/test/functional/tools/validation_metadata_in_datatable.xml
+++ b/test/functional/tools/validation_metadata_in_datatable.xml
@@ -5,14 +5,14 @@ echo 'Hello World' > out1
     <inputs>
         <!-- test dataset_metadata_in_data_table validator with and without negation
              we simply use dbkey as metadata field here -->
-        <param name="value" type="data">
+        <param name="value" type="data" format="data">
             <validator type="dataset_metadata_in_data_table" table_name="test_fasta_indexes" metadata_column="1" metadata_name="dbkey"/>
         </param>
-        <param name="value_neg" type="text">
-            <validator type="value_in_data_table" table_name="test_fasta_indexes" metadata_column="1" negate="true"/>
+        <param name="value_neg" type="data" format="data">
+            <validator type="dataset_metadata_in_data_table" table_name="test_fasta_indexes" metadata_column="1" metadata_name="dbkey" negate="true"/>
         </param>
         <!-- also test deprecated dataset_metadata_not_in_data_table validator-->
-        <param name="value_neg_deprecated" type="text">
+        <param name="value_neg_deprecated" type="data" format="data">
             <validator type="dataset_metadata_not_in_data_table" table_name="test_fasta_indexes" metadata_column="1" metadata_name="dbkey"/>
         </param>
     </inputs>
@@ -20,15 +20,17 @@ echo 'Hello World' > out1
         <data name="out_file1" format="txt" from_work_dir="out1"/>
     </outputs>
     <tests>
+        <!-- hg19 is in the test data table and hg38 not-->
+        <!-- TODO These tests fail if the same test data is used .. no idea why -->
         <test expect_failure="false">
-            <param name="value" value="1.fasta" dbkey="hg19"/> <!-- hg19 is in the test data table-->
-            <param name="value_neg" value="1.fasta" dbkey="hg38"/>
-            <param name="value_neg_deprecated" value="1.fasta" dbkey="hg38"/>
+            <param name="value" value="1.fasta" dbkey="hg19"/> 
+            <param name="value_neg" value="2.fasta" dbkey="hg38"/>
+            <param name="value_neg_deprecated" value="3.bed" dbkey="hg38"/>
         </test>
         <test expect_failure="true">
             <param name="value" value="1.fasta" dbkey="hg38"/> <!-- hg38 is not in the test data table-->
-            <param name="value_neg" value="1.fasta" dbkey="hg19"/>
-            <param name="value_neg_deprecated" value="1.fasta" dbkey="hg19"/>
+            <param name="value_neg" value="2.fasta" dbkey="hg19"/>
+            <param name="value_neg_deprecated" value="3.bed" dbkey="hg19"/>
         </test>
     </tests>
     <help>

--- a/test/functional/tools/validation_metadata_in_datatable.xml
+++ b/test/functional/tools/validation_metadata_in_datatable.xml
@@ -21,7 +21,6 @@ echo 'Hello World' > out1
     </outputs>
     <tests>
         <!-- hg19 is in the test data table and hg38 not-->
-        <!-- TODO These tests fail if the same test data is used .. no idea why -->
         <test expect_failure="false">
             <param name="value" value="1.fasta" dbkey="hg19"/> 
             <param name="value_neg" value="2.fasta" dbkey="hg38"/>

--- a/test/functional/tools/validation_metadata_in_datatable.xml
+++ b/test/functional/tools/validation_metadata_in_datatable.xml
@@ -1,0 +1,36 @@
+<tool id="validation_metadata_in_datatable" name="validation_metadata_in_datatable" profile="21.09" version="0.1">
+    <command><![CDATA[
+echo 'Hello World' > out1
+    ]]></command>
+    <inputs>
+        <!-- test dataset_metadata_in_data_table validator with and without negation
+             we simply use dbkey as metadata field here -->
+        <param name="value" type="data">
+            <validator type="dataset_metadata_in_data_table" table_name="test_fasta_indexes" metadata_column="1" metadata_name="dbkey"/>
+        </param>
+        <param name="value_neg" type="text">
+            <validator type="value_in_data_table" table_name="test_fasta_indexes" metadata_column="1" negate="true"/>
+        </param>
+        <!-- also test deprecated dataset_metadata_not_in_data_table validator-->
+        <param name="value_neg_deprecated" type="text">
+            <validator type="dataset_metadata_not_in_data_table" table_name="test_fasta_indexes" metadata_column="1" metadata_name="dbkey"/>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" from_work_dir="out1"/>
+    </outputs>
+    <tests>
+        <test expect_failure="false">
+            <param name="value" value="1.fasta" dbkey="hg19"/> <!-- hg19 is in the test data table-->
+            <param name="value_neg" value="1.fasta" dbkey="hg38"/>
+            <param name="value_neg_deprecated" value="1.fasta" dbkey="hg38"/>
+        </test>
+        <test expect_failure="true">
+            <param name="value" value="1.fasta" dbkey="hg38"/> <!-- hg38 is not in the test data table-->
+            <param name="value_neg" value="1.fasta" dbkey="hg19"/>
+            <param name="value_neg_deprecated" value="1.fasta" dbkey="hg19"/>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/validation_value_in_datatable.xml
+++ b/test/functional/tools/validation_value_in_datatable.xml
@@ -1,4 +1,4 @@
-<tool id="validation_value_in_datatable" name="validation_value_in_datatable" profile="19.05" version="0.1">
+<tool id="validation_value_in_datatable" name="validation_value_in_datatable" profile="21.09" version="0.1">
     <command><![CDATA[
 echo 'Hello World' > out1
     ]]></command>

--- a/test/functional/tools/validation_value_in_datatable.xml
+++ b/test/functional/tools/validation_value_in_datatable.xml
@@ -1,0 +1,35 @@
+<tool id="validation_value_in_datatable" name="validation_value_in_datatable" profile="19.05" version="0.1">
+    <command><![CDATA[
+echo 'Hello World' > out1
+    ]]></command>
+    <inputs>
+        <!-- test value_in_data_table validator with and without negation-->
+        <param name="value" type="text">
+            <validator type="value_in_data_table" table_name="test_fasta_indexes" metadata_column="1"/>
+        </param>
+        <param name="value_neg" type="text">
+            <validator type="value_in_data_table" table_name="test_fasta_indexes" metadata_column="1" negate="true"/>
+        </param>
+        <!-- also test deprecated value_not_in_data_table validator-->
+         <param name="value_neg_deprecated" type="text">
+            <validator type="value_not_in_data_table" table_name="test_fasta_indexes" metadata_column="1"/>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" from_work_dir="out1"/>
+    </outputs>
+    <tests>
+        <test expect_failure="false">
+            <param name="value" value="hg19"/>
+            <param name="value_neg" value="wrongvalue"/>
+            <param name="value_neg_deprecated" value="wrongvalue"/>
+        </test>
+        <test expect_failure="true">
+            <param name="value" value="wrongvalue"/>
+            <param name="value_neg" value="hg19"/>
+            <param name="value_deprecated" value="hg19"/>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
- Adds a `negate` attribute to all validators. Can be helpful for example
  - for the regexp validator because it is sometimes difficult to implement a regexp, but easy to implement the inverse
  - for the inrange validators to express that a value needs to be outside of a range
- Adds tests to all validators (either unit/doc tests of functional tests -- the later for tools requiring data tables which seemed to be hard to implement as doc test)
- deprecate `MetadataInFileColumnValidator` (data tables should be used nowadays) and the attribute `line_startswith` that was only (properly) implemented in this validator
- deprecate the `*notin*` validators: the `negate` attribute should be used instead
- deprecate `substitute_value_in_message` which was only implemented for `ExpressionValidator`: `%s` in the message is now replaced by all validators.
- more useful default messages
- Remove some code duplication by subclassing
  - `InRangeValidator` as subclass of `ExpressionValidator`
  - `LengthValidator` as subclass of `InRangeValidator`
  - `MetadataInDataTableColumnValidator` as subclass of `ValueInDataTableColumnValidator`

TODOs:

- [x] document how to implement new validators
- [x] `Validator.validate` assert `bool` for `value`
- [x] more useful messages for `negate=True`
- [x] doc `substitute_value_in_message` and implement for all
- [x] `InRangeValidator` as subclass of `ExpressionValidator`
- [x] `LengthValidator` as subclass of `InRangeValidator`
- [x] `MetadataInDataTableColumnValidator` as subclass of `ValueInDataTableColumnValidator`
- [x] test validators for `multiple="true"` data parameters
  - already covered in https://github.com/galaxyproject/galaxy/blob/dev/test/functional/tools/validation_empty_dataset.xml
- [x] deprecate `MetadataInFileColumnValidator`
- [x] deprecate `line_startswith`
- [x] deprecate ``*NotIn*Validators``
- [x] `*InRange*` validators also for strings?
  - maybe later
- [ ] Validators that evaluate a dataset value often include  `hasattr(value, "metadata")` in the validation expression. This is odd/wrong in the negation and may be better here https://github.com/galaxyproject/galaxy/blob/2b95bfceed1177a48ada1423833b91cc601fdeb7/lib/galaxy/tools/parameters/basic.py#L1807 or we require tool developers to add a `MetadataValidator`
- [x] remove debug output
- [ ] adapt linting (deprectaed validators)?
- [x] Bug in functional tests see TODO in `validation_dataset_metadata_in_file`
  - I think this is a feature not a bug. Test files are probably referenced by their name in tests. If the same file is used 2x in the same test this leads to conflicts.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

Sometimes its difficult to implement a regexp, but easy to implement the inverse. 

I guess this might also be of interest for other validators (e.g. InRangeValidator, LengthValidator) and avoid the definition of things like ValueNotInDataTableColumnValidator and ValueInDataTableColumnValidator as I did in https://github.com/galaxyproject/galaxy/pull/7500

Ideas, suggestions?

TODO 

- [x] doc in xsd
- [x] test