### PR TITLE
Move framework tests to GitHub workflows + lint test tools

### DIFF
--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -1,0 +1,40 @@
+name: Framework tests
+on: [push, pull_request]
+env:
+  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: 'galaxy root'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dir
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Run tests
+        run: ./run_tests.sh --framework
+        working-directory: 'galaxy root'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Framework test results (${{ matrix.python-version }})
+          path: 'galaxy root/run_framework_tests.html'

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.constants import (
     ONE_TO_SIX_ON_WINDOWS,
@@ -754,8 +756,12 @@ class ToolsUploadTestCase(ApiTestCase):
             assert extra_file["path"] == "composite"
             assert extra_file["class"] == "File"
 
-    @skip_if_site_down("https://usegalaxy.org")
     def test_upload_from_invalid_url(self):
+        with pytest.raises(AssertionError):
+            self._upload('https://foo.invalid', assert_ok=False)
+
+    @skip_if_site_down("https://usegalaxy.org")
+    def test_upload_from_404_url(self):
         history_id, new_dataset = self._upload('https://usegalaxy.org/bla123', assert_ok=False)
         dataset_details = self.dataset_populator.get_history_dataset_details(history_id, dataset_id=new_dataset["id"], assert_ok=False)
         assert dataset_details['state'] == 'error', "expected dataset state to be 'error', but got '%s'" % dataset_details['state']

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -111,19 +111,20 @@ def skip_without_datatype(extension):
     return method_wrapper
 
 
-def skip_if_site_down(url):
+def is_site_up(url):
+    try:
+        response = requests.get(url, timeout=10)
+        return response.status_code == 200
+    except Exception:
+        return False
 
-    def site_down():
-        try:
-            response = requests.get(url, timeout=10)
-            return response.status_code != 200
-        except Exception:
-            return False
+
+def skip_if_site_down(url):
 
     def method_wrapper(method):
         @wraps(method)
         def wrapped_method(api_test_case, *args, **kwargs):
-            _raise_skip_if(site_down(), "Test depends on [%s] being up and it appears to be down." % url)
+            _raise_skip_if(not is_site_up(url), f"Test depends on [{url}] being up and it appears to be down.")
             method(api_test_case, *args, **kwargs)
 
         return wrapped_method

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -198,7 +198,7 @@ steps:
         # Also the connector should disappear
         tool_input.wait_for_absent_or_hidden()
 
-        # Now make it connected again and watch the requestss
+        # Now make it connected again and watch the requests
         connect_icon.wait_for_and_click()
 
         tool_input.wait_for_visible()

--- a/test/functional/tools/bibtex.xml
+++ b/test/functional/tools/bibtex.xml
@@ -10,10 +10,10 @@
             name="Galaxy IUC" />
     </creator>
     <xrefs>
-      <xref type="bio.tools">Citation.js</xref>
+        <xref type="bio.tools">Citation.js</xref>
     </xrefs>
     <command><![CDATA[
-      echo "$input1" > "$out_file1"
+echo '$input1' > '$out_file1'
    ]]></command>
     <inputs>
         <param name="input1" type="integer" help="integer" value="8" />
@@ -21,17 +21,18 @@
     <outputs>
         <data name="out_file1" format="txt" />
     </outputs>
-    <help>
-
+    <tests>
+    </tests>
+    <help><![CDATA[
 .. class:: warningmark
 
 **WARNING:** Be careful not to concatenate datasets of different kinds (e.g., sequences with intervals). This tool does not check if the datasets being concatenated are in the same format. 
 
-    </help>
+    ]]></help>
     <citations>
-      <citation type="doi">10.1101/gr.4086505</citation>
-      <citation type="doi">10.6084/m9.figshare.979190</citation>
-      <citation type="bibtex">
+        <citation type="doi">10.1101/gr.4086505</citation>
+        <citation type="doi">10.6084/m9.figshare.979190</citation>
+        <citation type="bibtex">
 @misc{Garrison2015,
   author = {Garrison, Erik},
   year = {2015},
@@ -40,8 +41,8 @@
   journal = {GitHub repository},
   url = {https://github.com/ekg/vcflib},
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @online{lh32017,
   author = {Heng Li},
   year = {2017},
@@ -50,19 +51,19 @@
   journal = {GitHub repository},
   url = {https://github.com/lh3/bwa},
 }
-      </citation>
-      <!-- BibTeX examples taken from:
-      http://www2.galcit.caltech.edu/~jeshep/GraphicsBib/NatBib/node3.html
-      -->
-      <citation type="bibtex">
+        </citation>
+        <!-- BibTeX examples taken from:
+        http://www2.galcit.caltech.edu/~jeshep/GraphicsBib/NatBib/node3.html
+        -->
+        <citation type="bibtex">
 @ARTICLE{article-minimal,
    author = {L[eslie] A. Aamport},
    title = {The Gnats and Gnus Document Preparation System},
    journal = {\mbox{G-Animal's} Journal},
    year = 1986,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @ARTICLE{article-full,
    author = {L[eslie] A. Aamport},
    title = {The Gnats and Gnus Document Preparation System},
@@ -74,8 +75,8 @@
    month = jul,
    note = "This is a full ARTICLE entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @INBOOK{inbook-minimal,
    author = "Donald E. Knuth",
    title = "Fundamental Algorithms",
@@ -83,8 +84,9 @@
    year = "{\noopsort{1973b}}1973",
    chapter = "1.2",
 
-}      </citation>
-      <citation type="bibtex">
+}
+        </citation>
+        <citation type="bibtex">
 @INBOOK{inbook-full,
    author = "Donald E. Knuth",
    title = "Fundamental Algorithms",
@@ -100,16 +102,16 @@
    pages = "10--119",
    note = "This is a full INBOOK entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @BOOK{book-minimal,
    author = "Donald E. Knuth",
    title = "Seminumerical Algorithms",
    publisher = "Addison-Wesley",
    year = "{\noopsort{1973c}}1981",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @BOOK{book-full,
    author = "Donald E. Knuth",
    title = "Seminumerical Algorithms",
@@ -122,8 +124,8 @@
    year = "{\noopsort{1973c}}1981",
    note = "This is a full BOOK entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @BOOK{whole-set,
    author = "Donald E. Knuth",
    publisher = "Addison-Wesley",
@@ -132,8 +134,8 @@
    year = "{\noopsort{1973a}}{\switchargs{--90}{1968}}",
    note = "Seven volumes planned (this is a cross-referenced set of BOOKs)",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @BOOKLET{booklet-full,
    author = "Jill C. Knvth",
    title = "The Programming of Computer Art",
@@ -143,8 +145,8 @@
    year = 1988,
    note = "This is a full BOOKLET entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @INCOLLECTION{incollection-minimal,
    author = "Daniel D. Lincoll",
    title = "Semigroups of Recurrences",
@@ -152,8 +154,8 @@
    publisher = "Academic Press",
    year = 1977,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @INCOLLECTION{incollection-full,
    author = "Daniel D. Lincoll",
    title = "Semigroups of Recurrences",
@@ -171,8 +173,8 @@
    year = 1977,
    note = "This is a full INCOLLECTION entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @BOOK{whole-collection,
    editor = "David J. Lipcoll and D. H. Lawrie and A. H. Sameh",
    title = "High Speed Computer and Algorithm Organization",
@@ -185,8 +187,8 @@
    month = sep,
    year = 1977,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @MANUAL{manual-full,
    author = "Larry Manmaker",
    title = "The Definitive Computer Manual",
@@ -197,16 +199,16 @@
    year = 1986,
    note = "This is a full MANUAL entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @MASTERSTHESIS{mastersthesis-minimal,
    author = "{\'{E}}douard Masterly",
    title = "Mastering Thesis Writing",
    school = "Stanford University",
    year = 1988,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @MASTERSTHESIS{mastersthesis-full,
    author = "{\'{E}}douard Masterly",
    title = "Mastering Thesis Writing",
@@ -217,8 +219,8 @@
    year = 1988,
    note = "This is a full MASTERSTHESIS entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @MISC{misc-full,
    author = "Joe-Bob Missilany",
    title = "Handing out random pamphlets in airports",
@@ -227,16 +229,16 @@
    year = 1984,
    note = "This is a full MISC entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @INPROCEEDINGS{inproceedings-minimal,
    author = "Alfred V. Oaho and Jeffrey D. Ullman and Mihalis Yannakakis",
    title = "On Notions of Information Transfer in {VLSI} Circuits",
    booktitle = "Proc. Fifteenth Annual ACM" # STOC,
    year = 1983,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @INPROCEEDINGS{inproceedings-full,
    author = "Alfred V. Oaho and Jeffrey D. Ullman and Mihalis Yannakakis",
    title = "On Notions of Information Transfer in {VLSI} Circuits",
@@ -252,8 +254,8 @@
    publisher = "Academic Press",
    note = "This is a full INPROCEDINGS entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @INPROCEEDINGS{inproceedings-crossref,
    crossref = "whole-proceedings",
    author = "Alfred V. Oaho and Jeffrey D. Ullman and Mihalis Yannakakis",
@@ -262,8 +264,8 @@
    pages = "133--139",
    note = "This is a cross-referencing INPROCEEDINGS entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @PROCEEDINGS{proceedings-full,
    editor = "Wizard V. Oz and Mihalis Yannakakis",
    title = "Proc. Fifteenth Annual" # STOC,
@@ -276,16 +278,16 @@
    publisher = "Academic Press",
    note = "This is a full PROCEEDINGS entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @PHDTHESIS{phdthesis-minimal,
    author = "F. Phidias Phony-Baloney",
    title = "Fighting Fire with Fire: Festooning {F}rench Phrases",
    school = "Fanstord University",
    year = 1988,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @PHDTHESIS{phdthesis-full,
    author = "F. Phidias Phony-Baloney",
    title = "Fighting Fire with Fire: Festooning {F}rench Phrases",
@@ -296,16 +298,16 @@
    year = 1988,
    note = "This is a full PHDTHESIS entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @TECHREPORT{techreport-minimal,
    author = "Tom Terrific",
    title = "An {$O(n \log n / \! \log\log n)$} Sorting Algorithm",
    institution = "Fanstord University",
    year = 1988,
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @TECHREPORT{techreport-full,
    author = "Tom T{\'{e}}rrific",
    title = "An {$O(n \log n / \! \log\log n)$} Sorting Algorithm",
@@ -317,15 +319,15 @@
    year = 1988,
    note = "This is a full TECHREPORT entry",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @UNPUBLISHED{unpublished-minimal,
    author = "Ulrich {\"{U}}nderwood and Ned {\~N}et and Paul {\={P}}ot",
    title = "Lower Bounds for Wishful Research Results",
    note = "Talk at Fanstord University (this is a minimal UNPUBLISHED entry)",
 }
-      </citation>
-      <citation type="bibtex">
+        </citation>
+        <citation type="bibtex">
 @UNPUBLISHED{unpublished-full,
    author = "Ulrich {\"{U}}nderwood and Ned {\~N}et and Paul {\={P}}ot",
    title = "Lower Bounds for Wishful Research Results",
@@ -333,6 +335,6 @@
    year = 1988,
    note = "Talk at Fanstord University (this is a full UNPUBLISHED entry)",
 }
-      </citation>
+        </citation>
     </citations>
 </tool>

--- a/test/functional/tools/catDocker.xml
+++ b/test/functional/tools/catDocker.xml
@@ -1,18 +1,17 @@
-<tool id="catdc" name="Concatenate datasets (in docker)">
+<tool id="catdc" name="Concatenate datasets (in docker)" version="1.0.0">
     <description>tail-to-head</description>
     <requirements>
-      <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
-    <command>
-      echo "Galaxy slots passed through contain as \$GALAXY_SLOTS";
-      cat $input1
-      #for $q in $queries
-            ${q.input2}
-      #end for
-      &gt; $out_file1;
-      echo "Work dir output" &gt; working_file
-
-    </command>
+    <command><![CDATA[
+echo "Galaxy slots passed through contain as \$GALAXY_SLOTS" &&
+cat '$input1'
+#for $q in $queries
+    '${q.input2}'
+#end for
+> '$out_file1' &&
+echo 'Work dir output' > working_file
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Concatenate Dataset"/>
         <repeat name="queries" title="Dataset">
@@ -23,6 +22,8 @@
         <data name="out_file1" format="input" metadata_source="input1"/>
         <data name="out_file2" format="txt" from_work_dir="working_file" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/collection_cat_group_tag.xml
+++ b/test/functional/tools/collection_cat_group_tag.xml
@@ -1,12 +1,12 @@
-<tool id="collection_cat_group_tag" name="Concatenate multiple datasets (based on group tag)">
+<tool id="collection_cat_group_tag" name="Concatenate multiple datasets (based on group tag)" version="1.0.0">
     <description>tail-to-head</description>
-    <command>
-        cat
-        #for $file in $input1.get_datasets_for_group($group):
-            '$file'
-        #end for
-        > '$out_file1'
-    </command>
+    <command><![CDATA[
+cat
+#for $file in $input1.get_datasets_for_group($group):
+    '$file'
+#end for
+> '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data_collection" collection_type="list" label="Concatenate Dataset" multiple="true" />
         <param name="group" type="group_tag" data_ref="input1" />

--- a/test/functional/tools/collection_cat_group_tag_multiple.xml
+++ b/test/functional/tools/collection_cat_group_tag_multiple.xml
@@ -1,13 +1,13 @@
-<tool id="collection_cat_group_tag_multiple" name="Concatenate multiple datasets (based on group tags)">
+<tool id="collection_cat_group_tag_multiple" name="Concatenate multiple datasets (based on group tags)" version="1.0.0">
     <description>tail-to-head</description>
     <command>
-        cat
-        #for $group in $groups:
-        #for $file in $input1.get_datasets_for_group($group):
-            '$file'
-        #end for
-        #end for
-        > '$out_file1'
+cat
+#for $group in $groups:
+    #for $file in $input1.get_datasets_for_group($group):
+        '$file'
+    #end for
+#end for
+> '$out_file1'
     </command>
     <inputs>
         <param name="input1" type="data_collection" collection_type="list" label="Concatenate Dataset" multiple="true" />

--- a/test/functional/tools/column_multi_param.xml
+++ b/test/functional/tools/column_multi_param.xml
@@ -1,25 +1,25 @@
-<tool id="column_multi_param" name="Column Param Multi">
-  <command>
-    #for $input in $input1#
-      cut -f '$col' '$input' >> 'col_output';
-    #end for#
-  </command>
-  <inputs>
-    <param name="input1" type="data" format="tabular" label="Input 1" multiple="true" />
-    <param name="col" type="data_column" data_ref="input1" label="Column to Use" />
-  </inputs>
-  <outputs>
-    <data name="output1" format="tabular" from_work_dir="col_output" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="input1" value="2.tabular,2.tabular" />
-      <param name="col" value="2" />
-      <output name="outpu1">
-        <assert_contents>
-          <has_line line="68" />
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
+<tool id="column_multi_param" name="Column Param Multi" version="1.0.0">
+    <command><![CDATA[
+#for $input in $input1#
+    cut -f '$col' '$input' >> 'col_output';
+#end for#
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" format="tabular" multiple="true" label="Input 1" />
+        <param name="col" type="data_column" data_ref="input1" label="Column to Use" />
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" from_work_dir="col_output" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="2.tabular,2.tabular" />
+            <param name="col" value="2" />
+            <output name="outpu1">
+                <assert_contents>
+                    <has_line line="68" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/column_param.xml
+++ b/test/functional/tools/column_param.xml
@@ -1,50 +1,50 @@
-<tool id="column_param" name="Column Param">
-  <command><![CDATA[
+<tool id="column_param" name="Column Param" version="1.0.0">
+    <command><![CDATA[
 cut -f '$col' '$input1' > '$output1' &&
 echo "col $col" > '$output2' &&
 echo "col_names $col_names" >> '$output2'
-  ]]></command>
-  <inputs>
-    <param type="data" format="tabular" name="input1" label="Input 1" />
-    <param name="col" type="data_column" data_ref="input1" label="Column to Use" />
-    <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
-  </inputs>
-  <outputs>
-    <data name="output1" format="tabular" />
-    <data name="output2" format="txt" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="input1" value="2.tabular" />
-      <param name="col" value="2" />
-      <param name="col_names" value="2" />
-      <output name="output1">
-        <assert_contents>
-          <has_line line="68" />
-        </assert_contents>
-      </output>
-      <output name="output2">
-        <assert_contents>
-          <has_line line="col 2" />
-          <has_line line="col_names 2" />
-        </assert_contents>
-      </output>
-    </test>
-    <!-- test if non tabular data also creates entries by using the default
-         value (which is the 1st column, but empty if filling the options fails) -->
-    <test>
-      <param name="input1" value="1.bed" />
-      <output name="output1">
-        <assert_contents>
-          <has_line line="chr1" />
-        </assert_contents>
-      </output>
-      <output name="output2">
-        <assert_contents>
-          <has_line line="col 1" />
-          <has_line line="col_names 1" />
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" format="tabular" label="Input 1" />
+        <param name="col" type="data_column" data_ref="input1" label="Column to Use" />
+        <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" />
+        <data name="output2" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="2.tabular" />
+            <param name="col" value="2" />
+            <param name="col_names" value="2" />
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="68" />
+                </assert_contents>
+            </output>
+            <output name="output2">
+                <assert_contents>
+                    <has_line line="col 2" />
+                    <has_line line="col_names 2" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- test if non tabular data also creates entries by using the default
+            value (which is the 1st column, but empty if filling the options fails) -->
+        <test>
+            <param name="input1" value="1.bed" />
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="chr1" />
+                </assert_contents>
+            </output>
+            <output name="output2">
+                <assert_contents>
+                    <has_line line="col 1" />
+                    <has_line line="col_names 1" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/column_param_configfile.xml
+++ b/test/functional/tools/column_param_configfile.xml
@@ -1,10 +1,10 @@
-<tool id="column_param_configfile" name="Column Param into configfile" >
-  <command detect_errors="exit_code"><![CDATA[
-    python $check_inputs inputs.json
-  ]]></command>
-  <configfiles>
-    <inputs name="inputs" filename="inputs.json" />
-      <configfile name="check_inputs"><![CDATA[
+<tool id="column_param_configfile" name="Column Param into configfile" version="1.0.0">
+    <command detect_errors="exit_code"><![CDATA[
+python '$check_inputs' inputs.json
+    ]]></command>
+    <configfiles>
+        <inputs name="inputs" filename="inputs.json" />
+        <configfile name="check_inputs"><![CDATA[
 import json
 import sys
 
@@ -19,25 +19,25 @@ assert_equals(as_dict["col_mult"], [1,2,3])
 with open("$output1", "w") as f:
     f.write("okay\n")
 ]]></configfile>
-  </configfiles>
-  <inputs>
-    <param type="data" format="tabular" name="input1" label="Input 1" />
-    <param name="col" type="data_column" data_ref="input1" label="Column to Use"/>
-    <param name="col_mult" type="data_column" data_ref="input1" label="Columns to Use" multiple="true"/>
-  </inputs>
-  <outputs>
-    <data name="output1" format="data" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="input1" value="11.tabular" />
-      <param name="col" value="11" />
-      <param name="col_mult" value="1,2,3" />
-      <output name="output1">
-        <assert_contents>
-          <has_line line="okay" />
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+        <param name="input1" type="data" format="tabular" label="Input 1" />
+        <param name="col" type="data_column" data_ref="input1" label="Column to Use"/>
+        <param name="col_mult" type="data_column" data_ref="input1" label="Columns to Use" multiple="true"/>
+    </inputs>
+    <outputs>
+        <data name="output1" format="data" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="11.tabular" />
+            <param name="col" value="11" />
+            <param name="col_mult" value="1,2,3" />
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="okay" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/composite.xml
+++ b/test/functional/tools/composite.xml
@@ -1,20 +1,21 @@
 <tool id="composite" name="composite" version="1.0.0">
-  <command>cat '$input.extra_files_path/Sequences' > $output</command>
-  <inputs>
-    <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
-  </inputs>
-  <outputs>
-    <data format="txt" name="output" label="${tool.name} on ${on_string}: LastGraph">
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" value="velveth_test1/output.html" ftype="velvet" >
-        <composite_data value="velveth_test1/Sequences"/>
-        <composite_data value="velveth_test1/Roadmaps"/>
-        <composite_data value="velveth_test1/Log"/>
-      </param>
-      <output name="unused_reads_fasta" file="velveth_test1/Sequences" compare="diff"/>
-    </test>
-  </tests>
+    <command><![CDATA[
+cat '$input.extra_files_path/Sequences' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" label="${tool.name} on ${on_string}: LastGraph" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="velveth_test1/output.html" ftype="velvet" >
+                <composite_data value="velveth_test1/Sequences"/>
+                <composite_data value="velveth_test1/Roadmaps"/>
+                <composite_data value="velveth_test1/Log"/>
+            </param>
+            <output name="unused_reads_fasta" file="velveth_test1/Sequences" compare="diff"/>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/composite_output.xml
+++ b/test/functional/tools/composite_output.xml
@@ -1,26 +1,31 @@
 <tool id="composite_output" name="composite_output" version="1.0.0">
-  <command>mkdir $output.extra_files_path; cp $input.extra_files_path/* $output.extra_files_path; cp $input.extra_files_path/Log $output.extra_files_path/second_log; mkdir $output.extra_files_path/nested; cp $input.extra_files_path/Log $output.extra_files_path/nested/nested_log</command>
-  <inputs>
-    <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
-  </inputs>
-  <outputs>
-    <data format="velvet" name="output" label="">
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" value="velveth_test1/output.html" ftype="velvet" >
-        <composite_data value="velveth_test1/Sequences" />
-        <composite_data value="velveth_test1/Roadmaps" />
-        <composite_data value="velveth_test1/Log" />
-      </param>
-      <output name="output" file="velveth_test1/output.html">
-        <extra_files type="file" name="Sequences" value="velveth_test1/Sequences" />
-        <extra_files type="file" name="Roadmaps" value="velveth_test1/Roadmaps" />
-        <extra_files type="file" name="Log" value="composite_output_expected_log" />
-        <extra_files type="file" name="second_log" value="composite_output_expected_log" />
-        <extra_files type="file" name="nested/nested_log" value="composite_output_expected_log" />
-      </output>
-    </test>
-  </tests>
+    <command><![CDATA[
+mkdir '$output.extra_files_path' &&
+cp '$input.extra_files_path'/* '$output.extra_files_path' &&
+cp '$input.extra_files_path'/Log '$output.extra_files_path'/second_log &&
+mkdir '$output.extra_files_path'/nested &&
+cp '$input.extra_files_path'/Log '$output.extra_files_path'/nested/nested_log
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
+    </inputs>
+    <outputs>
+        <data name="output" format="velvet" label="" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="velveth_test1/output.html" ftype="velvet" >
+                <composite_data value="velveth_test1/Sequences" />
+                <composite_data value="velveth_test1/Roadmaps" />
+                <composite_data value="velveth_test1/Log" />
+            </param>
+            <output name="output" file="velveth_test1/output.html">
+                <extra_files type="file" name="Sequences" value="velveth_test1/Sequences" />
+                <extra_files type="file" name="Roadmaps" value="velveth_test1/Roadmaps" />
+                <extra_files type="file" name="Log" value="composite_output_expected_log" />
+                <extra_files type="file" name="second_log" value="composite_output_expected_log" />
+                <extra_files type="file" name="nested/nested_log" value="composite_output_expected_log" />
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/create_10.xml
+++ b/test/functional/tools/create_10.xml
@@ -1,16 +1,16 @@
-<tool id="create_10" name="create_10">
+<tool id="create_10" name="create_10" version="1.0.0">
     <description>create 10 datasets for testing tools with many outputs</description>
     <command><![CDATA[
-        echo "1" > 1;
-        echo "2" > 2;
-        echo "3" > 3;
-        echo "4" > 4;
-        echo "5" > 5;
-        echo "6" > 6;
-        echo "7" > 7;
-        echo "8" > 8;
-        echo "9" > 9;
-        echo "10" > 10;
+echo '1' > 1 &&
+echo '2' > 2 &&
+echo '3' > 3 &&
+echo '4' > 4 &&
+echo '5' > 5 &&
+echo '6' > 6 &&
+echo '7' > 7 &&
+echo '8' > 8 &&
+echo '9' > 9 &&
+echo '10' > 10
     ]]></command>
     <inputs>
         <param name="input1" type="data" label="Concatenate Dataset"/>

--- a/test/functional/tools/create_2.xml
+++ b/test/functional/tools/create_2.xml
@@ -1,11 +1,11 @@
-<tool id="create_2" name="create_2">
+<tool id="create_2" name="create_2" version="1.0.0">
     <command detect_errors="exit_code"><![CDATA[
-        echo "1" > '$out_file1';
-        echo "2" > '$out_file2';
-        sleep '$sleep_time';
+echo '1' > '$out_file1' &&
+echo '2' > '$out_file2' &&
+sleep $sleep_time
     ]]></command>
     <inputs>
-        <param name="sleep_time" type="integer" label="Sleep" help="Optionally simulates computation before creating collection" value="0" />
+        <param name="sleep_time" type="integer" value="0" label="Sleep" help="Optionally simulates computation before creating collection" />
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" />

--- a/test/functional/tools/dbkey_filter_input.xml
+++ b/test/functional/tools/dbkey_filter_input.xml
@@ -1,20 +1,20 @@
 <tool id="dbkey_filter_input" name="dbkey_filter_input" version="0.1.0">
     <description>Filter (single) input on a dbkey</description>
-    <command>
-        cat $inputs > $output
-    </command>
+    <command><![CDATA[
+cat '$inputs' > '$output'
+    ]]></command>
     <inputs>
-        <param format="txt" name="inputs" type="data" label="Inputs" help="" />
+        <param name="inputs" type="data" format="txt" label="Inputs" help="" />
         <param name="index" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="data_meta" ref="inputs" key="dbkey" column="1" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
     </inputs>
 
     <outputs>
-        <data format="txt" name="output" />
+        <data name="output" format="txt" />
     </outputs>
 
     <tests>
@@ -37,7 +37,6 @@
             <output name="output" file="simple_line.txt" />
         </test>
     </tests>
-
     <help>
     </help>
 </tool>

--- a/test/functional/tools/dbkey_filter_multi_input.xml
+++ b/test/functional/tools/dbkey_filter_multi_input.xml
@@ -1,23 +1,22 @@
 <tool id="dbkey_filter_multi_input" name="dbkey_filter_multi_input" version="0.1.0">
     <description>Filter select on dbkey of multiple inputs and use of named column</description>
     <command><![CDATA[
-        #for $input in $inputs#
-        cat $input >> $output;
-        #end for#
-    ]]>
-    </command>
+#for $input in $inputs#
+    cat '$input' >> '$output';
+#end for#
+    ]]></command>
     <inputs>
-        <param format="txt" name="inputs" type="data" label="Inputs" multiple="true" help="" />
+        <param name="inputs" type="data" format="txt" multiple="true" label="Inputs" help="" />
         <param name="index" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="data_meta" ref="inputs" key="dbkey" column="dbkey" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="data_meta" ref="inputs" key="dbkey" column="dbkey" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
     </inputs>
 
     <outputs>
-        <data format="txt" name="output" />
+        <data name="output" format="txt" />
     </outputs>
 
     <tests>
@@ -40,7 +39,6 @@
             <output name="output" file="simple_line_x2.txt"/>
         </test>
     </tests>
-
     <help>
     </help>
 </tool>

--- a/test/functional/tools/dbkey_output_action.xml
+++ b/test/functional/tools/dbkey_output_action.xml
@@ -1,16 +1,18 @@
 <tool id="dbkey_output_action" name="dbkey_output_action" version="0.1.0">
-    <command>echo foo > $mapped_reads</command>
+    <command><![CDATA[
+echo foo > '$mapped_reads'
+    ]]></command>
     <inputs>
         <param name="input" type="data" />
         <param name="index" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="data_meta" ref="input" key="dbkey" column="1" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="data_meta" ref="input" key="dbkey" column="1" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
     </inputs>
     <outputs>
-        <data format="txt" name="mapped_reads">
+        <data name="mapped_reads" format="txt">
             <actions>
                 <action type="metadata" name="dbkey">
                     <option type="from_data_table" name="test_fasta_indexes" column="1" offset="0">

--- a/test/functional/tools/detect_errors.xml
+++ b/test/functional/tools/detect_errors.xml
@@ -11,13 +11,13 @@
        <regex match="^Branch A" level="warning" description="Branch A was taken in execution" />
     </stdio>
     <command><![CDATA[
-        #if str($stdoutmsg)!=""
-            echo "$stdoutmsg"; 
-        #end if
-        #if str($stderrmsg)!=""
-            >2& echo "$stderrmsg"; 
-        #end if
-        sh -c "exit $exit_code"
+#if str($stdoutmsg) != ""
+    echo '$stdoutmsg' &&
+#end if
+#if str($stderrmsg) != ""
+    >2& echo '$stderrmsg' && 
+#end if
+sh -c 'exit $exit_code'
     ]]>
     </command>
     <inputs>

--- a/test/functional/tools/disambiguate_cond.xml
+++ b/test/functional/tools/disambiguate_cond.xml
@@ -1,47 +1,47 @@
-<tool id="disambiguate_cond" name="disambiguate_cond">
-    <command>
-        echo "$p1.p1v $p2.p2v $p3.p3v" > $out_file1;
-        #if $files.attach_files
-        cat "$files.p4.file" >> $out_file1;
-        #else
-        echo "no file specified" >> $out_file1;
-        #end if
-    </command>
+<tool id="disambiguate_cond" name="disambiguate_cond" version="1.0.0">
+    <command><![CDATA[
+echo "$p1.p1v $p2.p2v $p3.p3v" > '$out_file1' &&
+#if $files.attach_files
+    cat '$files.p4.file' >> '$out_file1'
+#else
+    echo 'no file specified' >> '$out_file1'
+#end if
+    ]]></command>
     <inputs>
         <conditional name="p1">
-            <param type="boolean" name="use" />
+            <param name="use" type="boolean" />
             <when value="true">
-                <param name="p1v" value="4" type="integer" />
+                <param name="p1v" type="integer" value="4" />
             </when>
             <when value="false">
-                <param name="p1v" value="7" type="integer" />
+                <param name="p1v" type="integer" value="7" />
             </when>
         </conditional>
         <conditional name="p2">
-            <param type="boolean" name="use" />
+            <param name="use" type="boolean" />
             <when value="true">
-                <param name="p2v" value="4" type="integer" />
+                <param name="p2v" type="integer" value="4" />
             </when>
             <when value="false">
-                <param name="p2v" value="7" type="integer" />
+                <param name="p2v" type="integer" value="7" />
             </when>            
         </conditional>
         <conditional name="p3">
-            <param type="boolean" name="use" />
+            <param name="use" type="boolean" />
             <when value="true">
-                <param name="p3v" value="4" type="integer" />
+                <param name="p3v" type="integer" value="4" />
             </when>
             <when value="false">
-                <param name="p3v" value="7" type="integer" />
+                <param name="p3v" type="integer" value="7" />
             </when>            
         </conditional>
         <conditional name="files">
             <param name="attach_files" type="boolean" checked="true" />
             <when value="true">
                 <conditional name="p4">
-                    <param type="boolean" name="use" />
+                    <param name="use" type="boolean" />
                     <when value="true">
-                        <param type="data" name="file" />
+                        <param name="file" type="data" />
                     </when>
                     <when value="false" />
                 </conditional>

--- a/test/functional/tools/disambiguate_repeats.xml
+++ b/test/functional/tools/disambiguate_repeats.xml
@@ -1,6 +1,6 @@
-<tool id="disambiguate_repeats" name="disambiguate_repeats">
+<tool id="disambiguate_repeats" name="disambiguate_repeats" version="1.0.0">
     <command>
-        cat #for $q in $queries# ${q.input} #end for# #for $q in $more_queries# ${q.input} #end for# > $out_file1
+cat #for $q in $queries# '${q.input}' #end for# #for $q in $more_queries# '${q.input}' #end for# > '$out_file1'
     </command>
     <inputs>
         <repeat name="queries" title="Dataset">
@@ -58,6 +58,5 @@
 
             <output name="out_file1" file="simple_lines_interleaved.txt"/>
         </test>
-
     </tests>
 </tool>

--- a/test/functional/tools/exit_code_from_env.xml
+++ b/test/functional/tools/exit_code_from_env.xml
@@ -1,9 +1,9 @@
-<tool id="exit_code_from_env" name="exit_code_from_env">
+<tool id="exit_code_from_env" name="exit_code_from_env" version="1.0.0">
     <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
-        echo 'Hello' > '$out_file1';
-        : \${GX_TARGET_EXIT_CODE:-0};
-        exit \${GX_TARGET_EXIT_CODE};
+echo 'Hello' > '$out_file1' &&
+: \${GX_TARGET_EXIT_CODE:-0} &&
+exit \${GX_TARGET_EXIT_CODE}
     ]]></command>
     <inputs>
         <param name="input" type="integer" label="Dummy" value="6" />
@@ -11,8 +11,6 @@
     <outputs>
         <data name="out_file1" />
     </outputs>
-    <help>
-    </help>
     <tests>
         <test>
             <param name="input" value="5" />
@@ -23,4 +21,6 @@
             </output>
         </test>
     </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/exit_code_from_file.xml
+++ b/test/functional/tools/exit_code_from_file.xml
@@ -1,6 +1,6 @@
-<tool id="exit_code_from_file" name="exit_code_from_file">
+<tool id="exit_code_from_file" name="exit_code_from_file" version="1.0.0">
     <command detect_errors="exit_code">
-        sh -c "exit `cat $input`"
+sh -c "exit \$(cat '$input')"
     </command>
     <inputs>
         <param name="input" type="data" label="Exit code file" />
@@ -8,6 +8,8 @@
     <outputs>
         <data name="out_file1" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/exit_code_oom.xml
+++ b/test/functional/tools/exit_code_oom.xml
@@ -1,16 +1,15 @@
 <tool id="exit_code_oom" name="exit_code_oom" version="0.1.1" profile="16.04">
     <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
-        mv hi.txt '$out_file1';
-        echo "\$GALAXY_MEMORY_MB";
-        : \${GALAXY_MEMORY_MB:=20};
-        echo "\$GALAXY_MEMORY_MB";
-        if [ "\$GALAXY_MEMORY_MB" -lt 10 ];
-        then
-            exit 42;
-        else
-            exit 0;
-        fi
+mv hi.txt '$out_file1' &&
+echo "\$GALAXY_MEMORY_MB" &&
+: \${GALAXY_MEMORY_MB:=20} &&
+echo "\$GALAXY_MEMORY_MB" &&
+if [ "\$GALAXY_MEMORY_MB" -lt 10 ]; then
+    exit 42;
+else
+    exit 0;
+fi
     ]]></command>
     <configfiles>
         <!-- also tests that configfiles are placed in working dir and that this works on resubmission as well -->
@@ -22,8 +21,6 @@
     <outputs>
         <data name="out_file1" />
     </outputs>
-    <help>
-    </help>
     <tests>
         <test>
             <param name="input" value="5" />
@@ -34,4 +31,6 @@
             </output>
         </test>
     </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/expression_forty_two.xml
+++ b/test/functional/tools/expression_forty_two.xml
@@ -11,5 +11,9 @@
     <outputs>
         <output type="integer" name="out1" from="output" />
     </outputs>
-    <help>Produces the integer 42.</help>
+    <tests>
+    </tests>
+    <help><![CDATA[
+Produces the integer 42.
+    ]]></help>
 </tool>

--- a/test/functional/tools/expression_log_line_count.xml
+++ b/test/functional/tools/expression_log_line_count.xml
@@ -10,5 +10,8 @@
     <outputs>
         <output type="integer" name="out1" from="output" />
     </outputs>
-    <help></help>
+    <tests>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/expression_parse_int.xml
+++ b/test/functional/tools/expression_parse_int.xml
@@ -10,5 +10,9 @@
     <outputs>
         <output type="integer" name="out1" from="output" />
     </outputs>
-    <help>Parse an integer from text.</help>
+    <tests>
+    </tests>
+    <help><![CDATA[
+Parse an integer from text.
+    ]]></help>
 </tool>

--- a/test/functional/tools/expression_pick_larger_file.xml
+++ b/test/functional/tools/expression_pick_larger_file.xml
@@ -16,14 +16,12 @@
         }
     ]]></expression>
     <inputs>
-        <param type="data" label="First file." optional="true" name="input1" />
-        <param type="data" label="Second file." optional="true" name="input2" />
+        <param name="input1" type="data" optional="true" label="First file" />
+        <param name="input2" type="data" optional="true" label="Second file" />
     </inputs>
     <outputs>
-        <output type="data" name="larger_file" from="output" />
+        <output name="larger_file" type="data" from="output" />
     </outputs>
-    <help>
-    </help>
     <tests>
         <test>
             <param name="input1" value="simple_line.txt" />
@@ -41,4 +39,6 @@
             <output name="larger_file" file="simple_line.txt"/>
         </test>
     </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/fail_identifier.xml
+++ b/test/functional/tools/fail_identifier.xml
@@ -1,10 +1,13 @@
-<tool id="fail_identifier" name="Fail input with identifier that contains fail">
+<tool id="fail_identifier" name="Fail input with identifier that contains fail" version="1.0.0">
+    <stdio>
+        <exit_code range="127" level="fatal" description="Failing exit code." />
+    </stdio>
     <command><![CDATA[
-        #if $failbool and 'fail' in $input1.element_identifier
-            sh -c "exit 127"
-        #else
-            cp '$input1' '$out_file1'
-        #end if
+#if $failbool and 'fail' in $input1.element_identifier
+    sh -c 'exit 127'
+#else
+    cp '$input1' '$out_file1'
+#end if
     ]]></command>
     <inputs>
         <param name="input1" type="data" label="An input file" />
@@ -13,9 +16,8 @@
     <outputs>
         <data name="out_file1" format="data"/>
     </outputs>
-    <stdio>
-        <exit_code range="127"   level="fatal"   description="Failing exit code." />
-    </stdio>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/fail_writing_work_dir_file.xml
+++ b/test/functional/tools/fail_writing_work_dir_file.xml
@@ -1,9 +1,9 @@
 <tool id="fail_writing_work_dir_file" name="fail_writing_work_dir_file" version="0.1.0">
     <command><![CDATA[
-        echo 'Some output' ;
-        #if not $failbool
-            echo 'Hello World' > 'foo.txt'
-        #end if
+echo 'Some output' &&
+#if not $failbool
+    echo 'Hello World' > 'foo.txt'
+#end if
     ]]></command>
     <inputs>
         <param name="failbool" type="boolean" label="The failure property" checked="false" />
@@ -11,6 +11,8 @@
     <outputs>
         <data name="out_file1" format="txt" from_work_dir="foo.txt" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/filter_static_regexp.xml
+++ b/test/functional/tools/filter_static_regexp.xml
@@ -1,45 +1,45 @@
 <tool id="filter_static_regexp" name="filter_static_regexp" version="0.1.0">
     <description>Filter by static value and regexp</description>
-    <command>
-        echo $index_static > '$output'
-        echo $index_static_keep >> '$output'
-        echo $index_regexp >> '$output'
-        echo $index_regexp_keep >> '$output'
-    </command>
+    <command><![CDATA[
+echo $index_static > '$output' &&
+echo $index_static_keep >> '$output' &&
+echo $index_regexp >> '$output' &&
+echo $index_regexp_keep >> '$output' &&
+    ]]></command>
     <inputs>
         <!-- tests for static_value filter: remove hp18 from the options by 
              a) removing it explicitly (due to keep="false") 
              b) keeping only the other option, i.e. hg19 -->
         <param name="index" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="static_value" column="dbkey" value="hg18" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="static_value" column="dbkey" value="hg18" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
         <param name="index2" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="static_value" column="dbkey" value="hg19" keep="true" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="static_value" column="dbkey" value="hg19" keep="true" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
         <!-- tests for regexp filter: remove hp18 from the options 
              essentially the same as for the static value filter, just using a simple regexp -->
         <param name="index_regexp" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="regexp" column="dbkey" value="hg.8" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="regexp" column="dbkey" value="hg.8" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
         <param name="index_regexp_keep" type="select" label="Using reference genome">
-          <options from_data_table="test_fasta_indexes">
-            <filter type="regexp" column="dbkey" value="hg.9" keep="true" />
-            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
-          </options>
+            <options from_data_table="test_fasta_indexes">
+                <filter type="regexp" column="dbkey" value="hg.9" keep="true" />
+                <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+            </options>
         </param>
     </inputs>
 
     <outputs>
-        <data format="txt" name="output" />
+        <data name="output" format="txt" />
     </outputs>
 
     <tests>
@@ -88,7 +88,6 @@
             <output name="output"/>
         </test>
     </tests>
-
     <help>
     </help>
 </tool>

--- a/test/functional/tools/for_workflows/cat.xml
+++ b/test/functional/tools/for_workflows/cat.xml
@@ -1,8 +1,8 @@
-<tool id="cat" name="Concatenate datasets (for test workflows)">
+<tool id="cat" name="Concatenate datasets (for test workflows)" version="1.0.0">
     <description>tail-to-head</description>
-    <command>
-        cat $input1 #for $q in $queries# ${q.input2} #end for# > $out_file1
-    </command>
+    <command><![CDATA[
+cat '$input1' #for $q in $queries# '${q.input2}' #end for# > '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Concatenate Dataset"/>
         <repeat name="queries" title="Dataset">

--- a/test/functional/tools/for_workflows/cat_collection.xml
+++ b/test/functional/tools/for_workflows/cat_collection.xml
@@ -1,10 +1,10 @@
-<tool id="cat_collection" name="Concatenate dataset collection (for test workflows)">
+<tool id="cat_collection" name="Concatenate dataset collection (for test workflows)" version="1.0.0">
     <description>tail-to-head</description>
     <command>
 cat #for $q in $input1# '$q' #end for# >'$out_file1'
     </command>
     <inputs>
-        <param name="input1" type="data_collection" label="Concatenate Dataset" collection_type="list,paired" />
+        <param name="input1" type="data_collection" collection_type="list,paired" label="Concatenate Dataset" />
     </inputs>
     <outputs>
         <data name="out_file1" format="input" />

--- a/test/functional/tools/for_workflows/cat_interleave.xml
+++ b/test/functional/tools/for_workflows/cat_interleave.xml
@@ -1,8 +1,8 @@
-<tool id="cat_interleave" name="Interleave two inputs (for test workflows)">
-    <command>
-        cat $input1 $input2 > $out_file1;
-        cat $input2 $input1 > $out_file2;
-    </command>
+<tool id="cat_interleave" name="Interleave two inputs (for test workflows)" version="1.0.0">
+    <command><![CDATA[
+cat '$input1' '$input2' > '$out_file1' &&
+cat '$input2' '$input1' > '$out_file2'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Input 1"/>
         <param name="input2" type="data" label="Input 2"/>

--- a/test/functional/tools/for_workflows/cat_list.xml
+++ b/test/functional/tools/for_workflows/cat_list.xml
@@ -1,10 +1,10 @@
-<tool id="cat_list" name="Concatenate multiple datasets (for test workflows)">
-    <description>tail-to-head</description>
-    <command>
-        cat #for $q in $input1# $q #end for# > $out_file1
-    </command>
+<tool id="cat_list" name="Concatenate multiple datasets (for test workflows)" version="1.0.0">
+    <description></description>
+    <command><![CDATA[
+cat #for $q in $input1# '$q' #end for# > '$out_file1'
+    ]]></command>
     <inputs>
-        <param name="input1" type="data" label="Concatenate Dataset" multiple="true" />
+        <param name="input1" type="data" multiple="true" label="Concatenate Dataset" />
     </inputs>
     <outputs>
         <data name="out_file1" format="input" metadata_source="input1"/>

--- a/test/functional/tools/for_workflows/count_list.xml
+++ b/test/functional/tools/for_workflows/count_list.xml
@@ -1,10 +1,10 @@
-<tool id="count_list" name="count_list">
+<tool id="count_list" name="count_list" version="1.0.0">
     <description>count the number of items in a list</description>
     <command><![CDATA[
-        echo '${len($input1.keys())}' > '$out_file1'
+echo '${len($input1.keys())}' > '$out_file1'
     ]]></command>
     <inputs>
-        <param name="input1" type="data_collection" label="Concatenate Dataset" collection_type="list" />
+        <param name="input1" type="data_collection" collection_type="list" label="Concatenate Dataset" />
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" />

--- a/test/functional/tools/for_workflows/count_multi_file.xml
+++ b/test/functional/tools/for_workflows/count_multi_file.xml
@@ -1,10 +1,10 @@
-<tool id="count_multi_file" name="count_multi_file">
+<tool id="count_multi_file" name="count_multi_file" version="1.0.0">
     <description>count the number of datasets in a multiple file input</description>
     <command><![CDATA[
-        echo '${len($input1)}' > '$out_file1'
+echo '${len($input1)}' > '$out_file1'
     ]]></command>
     <inputs>
-        <param name="input1" type="data" label="Concatenate Dataset" multiple="true" />
+        <param name="input1" type="data" multiple="true" label="Concatenate Dataset" />
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" />

--- a/test/functional/tools/for_workflows/head.xml
+++ b/test/functional/tools/for_workflows/head.xml
@@ -1,13 +1,17 @@
-<tool id="head" name="Select first">
-  <description>lines from a dataset</description>
-  <command>head -n $lineNum '$input' > '$out_file1'</command>
-  <inputs>
-    <param name="lineNum" type="integer" value="10" label="Select first" help="lines"/>
-    <param name="input" type="data" format="txt" label="from"/>
-  </inputs>
-  <outputs>
-    <data name="out_file1" format="input" metadata_source="input"/>
-  </outputs>
-  <help>
-  </help>
+<tool id="head" name="Select first" version="1.0.0">
+    <description>lines from a dataset</description>
+    <command><![CDATA[
+head -n $lineNum '$input' > '$out_file1'
+    ]]></command>
+    <inputs>
+        <param name="lineNum" type="integer" value="10" label="Select first" help="lines"/>
+        <param name="input" type="data" format="txt" label="from"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="input" metadata_source="input"/>
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/for_workflows/split.xml
+++ b/test/functional/tools/for_workflows/split.xml
@@ -1,33 +1,33 @@
 <tool id="split" name="split" version="0.1.0">
-  <command detect_errors="exit_code">
-    bash $script
-  </command>
-  <configfiles>
-    <configfile name="script">
-      mkdir outputs;
-      cd outputs;
-      i=1;
-      while read -r line || [[ -n "\$line" ]]; do
-        printf "\$line\n" &gt; \$i ;
-        i=\$[\$i +1];
-      done &lt; "$input1";
-    </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input1" type="data" format="txt" label="Input Text" />
-  </inputs>
-  <outputs>
-    <collection name="output" type="list" label="lines">
-      <discover_datasets pattern="__name__" directory="outputs" />
-    </collection>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input1" value="simple_lines_both.txt" />
-      <output_collection name="output" type="list">
-        <element name="1" file="simple_line.txt" />
-        <element name="2" file="simple_line_alternative.txt" />
-      </output_collection>
-    </test>
-  </tests>
+    <command detect_errors="exit_code"><![CDATA[
+bash '$script'
+    ]]></command>
+    <configfiles>
+        <configfile name="script"><![CDATA[
+mkdir outputs &&
+cd outputs/ &&
+i=1 &&
+while read -r line || [[ -n "\$line" ]]; do
+    printf "\$line\n" > \$i ;
+    i=\$[\$i +1];
+done < '$input1'
+        ]]></configfile>
+    </configfiles>
+    <inputs>
+        <param name="input1" type="data" format="txt" label="Input Text" />
+    </inputs>
+    <outputs>
+        <collection name="output" type="list" label="lines">
+            <discover_datasets pattern="__name__" directory="outputs" />
+        </collection>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="simple_lines_both.txt" />
+            <output_collection name="output" type="list">
+                <element name="1" file="simple_line.txt" />
+                <element name="2" file="simple_line_alternative.txt" />
+            </output_collection>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/gzipped_inputs.xml
+++ b/test/functional/tools/gzipped_inputs.xml
@@ -1,7 +1,7 @@
-<tool id="gzipped_inputs" name="Echo Dataset">
-    <command>
-        cat $input1 > $out_file1
-    </command>
+<tool id="gzipped_inputs" name="Echo Dataset" version="1.0.0">
+    <command><![CDATA[
+cat '$input1' > '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Concatenate Dataset"/>
     </inputs>

--- a/test/functional/tools/identifier_in_conditional.xml
+++ b/test/functional/tools/identifier_in_conditional.xml
@@ -1,4 +1,4 @@
-<tool id="identifier_in_conditional" name="identifier_in_conditional">
+<tool id="identifier_in_conditional" name="identifier_in_conditional" version="1.0.0">
     <command><![CDATA[
 #if str($outer_cond.multi_input) == 'true':
     #for $input in $input1#
@@ -12,10 +12,10 @@
         <conditional name="outer_cond">
             <param name="multi_input" type="boolean" checked="true" />
             <when value="true">
-                <param type="data" name="input1" label="multi input" multiple="true" />
+                <param name="input1" type="data" multiple="true" label="multi input" />
             </when>
             <when value="false">
-                <param type="data" name="input1" label="single input" multiple="false" />
+                <param name="input1" type="data" multiple="false" label="single input" />
             </when>
         </conditional>
     </inputs>

--- a/test/functional/tools/identifier_multiple.xml
+++ b/test/functional/tools/identifier_multiple.xml
@@ -1,15 +1,15 @@
-<tool id="identifier_multiple" name="identifier_multiple">
-  <command>
-    #for $input in $input1#
+<tool id="identifier_multiple" name="identifier_multiple" version="1.0.0">
+    <command><![CDATA[
+#for $input in $input1#
     echo '$input.element_identifier' >> 'output1';
-    #end for#
-  </command>
-  <inputs>
-    <param type="data" name="input1" label="Input 1" multiple="true" />
-  </inputs>
-  <outputs>
-    <data name="output1" format="tabular" from_work_dir="output1" />
-  </outputs>
-  <tests>
-  </tests>
+#end for#
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" multiple="true" label="Input 1" />
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" from_work_dir="output1" />
+    </outputs>
+    <tests>
+    </tests>
 </tool>

--- a/test/functional/tools/identifier_multiple_in_conditional.xml
+++ b/test/functional/tools/identifier_multiple_in_conditional.xml
@@ -1,25 +1,25 @@
-<tool id="identifier_multiple_in_conditional" name="identifier_multiple_in_conditional">
-  <command><![CDATA[
-    #for $input in $outer_cond.inner_cond.input1#
+<tool id="identifier_multiple_in_conditional" name="identifier_multiple_in_conditional" version="1.0.0">
+    <command><![CDATA[
+#for $input in $outer_cond.inner_cond.input1#
     echo '$input.element_identifier' >> 'output1';
-    #end for#
-  ]]></command>
-  <inputs>
-    <conditional name="outer_cond">
-      <param name="cond_param_outer" type="boolean" checked="true" />
-      <when value="true">
-        <conditional name="inner_cond">
-          <param name="cond_param_inner" type="boolean" checked="true" />
-          <when value="true">
-            <param type="data" name="input1" label="True Input" multiple="true" />
-          </when>
+#end for#
+    ]]></command>
+    <inputs>
+        <conditional name="outer_cond">
+            <param name="cond_param_outer" type="boolean" checked="true" />
+            <when value="true">
+                <conditional name="inner_cond">
+                    <param name="cond_param_inner" type="boolean" checked="true" />
+                    <when value="true">
+                        <param type="data" name="input1" label="True Input" multiple="true" />
+                    </when>
+                </conditional>
+            </when>
         </conditional>
-      </when>
-    </conditional>
-  </inputs>
-  <outputs>
-    <data name="output1" format="tabular" from_work_dir="output1" />
-  </outputs>
-  <tests>
-  </tests>
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" from_work_dir="output1" />
+    </outputs>
+    <tests>
+    </tests>
 </tool>

--- a/test/functional/tools/identifier_multiple_in_repeat.xml
+++ b/test/functional/tools/identifier_multiple_in_repeat.xml
@@ -1,27 +1,27 @@
-<tool id="identifier_multiple_in_repeat" name="identifier_multiple_in_repeat">
-  <command><![CDATA[
-    #for $repeat_instance in $the_repeat#
-      #for $input in $repeat_instance.the_data.input1#
+<tool id="identifier_multiple_in_repeat" name="identifier_multiple_in_repeat" version="1.0.0">
+    <command><![CDATA[
+#for $repeat_instance in $the_repeat#
+    #for $input in $repeat_instance.the_data.input1#
         echo '$input.element_identifier' >> 'output1';
-      #end for#
     #end for#
-  ]]></command>
-  <inputs>
-    <repeat name="the_repeat" title="Repeat Inputs">
-      <conditional name="the_data">
-        <param name="cond_param" type="boolean" />
-        <when value="true">
-          <param type="data" name="input1" label="True Input" multiple="true" />
-        </when>
-        <when value="false">
-          <param type="data" name="input1" label="False Input" multiple="true" />
-        </when>
-      </conditional>
-    </repeat>
-  </inputs>
-  <outputs>
-    <data name="output1" format="tabular" from_work_dir="output1" />
-  </outputs>
-  <tests>
-  </tests>
+#end for#
+    ]]></command>
+    <inputs>
+        <repeat name="the_repeat" title="Repeat Inputs">
+            <conditional name="the_data">
+                <param name="cond_param" type="boolean" />
+                <when value="true">
+                    <param name="input1" type="data" multiple="true" label="True Input" />
+                </when>
+                <when value="false">
+                    <param name="input1" type="data" multiple="true" label="False Input" />
+                </when>
+            </conditional>
+        </repeat>
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" from_work_dir="output1" />
+    </outputs>
+    <tests>
+    </tests>
 </tool>

--- a/test/functional/tools/identifier_single.xml
+++ b/test/functional/tools/identifier_single.xml
@@ -1,13 +1,13 @@
-<tool id="identifier_single" name="identifier_single">
-  <command>
-    echo '$input1.element_identifier' > 'output1'
-  </command>
-  <inputs>
-    <param type="data" name="input1" label="Input 1" />
-  </inputs>
-  <outputs>
-    <data name="output1" format="tabular" from_work_dir="output1" />
-  </outputs>
-  <tests>
-  </tests>
+<tool id="identifier_single" name="identifier_single" version="1.0.0">
+    <command><![CDATA[
+echo '$input1.element_identifier' > 'output1'
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" label="Input 1" />
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" from_work_dir="output1" />
+    </outputs>
+    <tests>
+    </tests>
 </tool>

--- a/test/functional/tools/identifier_single_in_repeat.xml
+++ b/test/functional/tools/identifier_single_in_repeat.xml
@@ -1,4 +1,4 @@
-<tool id="identifier_single_in_repeat" name="identifier_single_in_repeat">
+<tool id="identifier_single_in_repeat" name="identifier_single_in_repeat" version="1.0.0">
     <command><![CDATA[
 #for $repeat_instance in $the_repeat#
     echo '$repeat_instance.the_data.input1.element_identifier' >> 'output1';
@@ -9,10 +9,10 @@
             <conditional name="the_data">
                 <param name="cond_param" type="boolean" />
                 <when value="true">
-                    <param type="data" name="input1" label="The Input" />
+                    <param name="input1" type="data" label="The Input" />
                 </when>
                 <when value="false">
-                    <param type="data" name="input1" label="The Input" />
+                    <param name="input1" type="data" label="The Input" />
                 </when>
             </conditional>
         </repeat>

--- a/test/functional/tools/identifier_source.xml
+++ b/test/functional/tools/identifier_source.xml
@@ -1,11 +1,9 @@
 <tool id="identifier_source" name="identifier_source" version="0.1.0">
     <description>verifies identifier source can be specified from input</description>
-    <command>
-<![CDATA[
-    cat '$inputA' '$inputB' >'$outputA' &&
-    cat '$inputA' '$inputB' > '$outputB'
-]]>
-    </command>
+    <command><![CDATA[
+cat '$inputA' '$inputB' >'$outputA' &&
+cat '$inputA' '$inputB' > '$outputB'
+    ]]></command>
     <inputs>
         <param name="inputA" type="data"/>
         <param name="inputB" type="data"/>
@@ -14,6 +12,8 @@
         <data name="outputA" default_identifier_source="inputA"/>
         <data name="outputB" default_identifier_source="inputB"/>
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/implicit_default_conds.xml
+++ b/test/functional/tools/implicit_default_conds.xml
@@ -1,8 +1,8 @@
-<tool id="implicit_default_conds" name="implicit_default_conds">
-    <command>
-        echo "$param_group[0].p1.val"  >> $out_file1;
-        echo "$param_group[0].p2.val"  >> $out_file1;
-    </command>
+<tool id="implicit_default_conds" name="implicit_default_conds" version="1.0.0">
+    <command><![CDATA[
+echo '$param_group[0].p1.val' > '$out_file1' &&
+echo '$param_group[0].p2.val' >> '$out_file1'
+    ]]></command>
     <inputs>
         <repeat name="param_group" title="Param Group" min="1">
             <conditional name="p1">
@@ -11,10 +11,10 @@
                     <option value="different">A different value</option>
                 </param>
                 <when value="default">
-                    <param name="val" value="p1default" type="text" />
+                    <param name="val" type="text" value="p1default" />
                 </when>
                 <when value="different">
-                    <param name="val" value="p1different" type="text" />
+                    <param name="val" type="text" value="p1different" />
                 </when>
             </conditional>
             <conditional name="p2">
@@ -23,10 +23,10 @@
                     <option value="different" selected="true">A different value</option>
                 </param>
                 <when value="default">
-                    <param name="val" value="p2default" type="text" />
+                    <param name="val" type="text" value="p2default" />
                 </when>
                 <when value="different">
-                    <param name="val" value="p2different" type="text" />
+                    <param name="val" type="text" value="p2different" />
                 </when>
             </conditional>
             <param name="int_param" type="integer" value="8" />

--- a/test/functional/tools/job_environment_default.xml
+++ b/test/functional/tools/job_environment_default.xml
@@ -1,16 +1,16 @@
 <tool id="job_environment_default" name="job_environment_default" version="0.1.0" profile="18.01">
     <requirements>
-      <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-      echo 'Writing environment properties to output files.';
-      (>&2 echo 'Example tool stderr output.');
-      echo `id -u` > '$user_id';
-      echo `id -g` > '$group_id';
-      echo `pwd` > '$pwd';
-      echo "\$HOME" > '$home';
-      echo "\$TMP"  > '$tmp';
-      echo "\$SOME_ENV_VAR" > '$some_env_var';
+echo 'Writing environment properties to output files.' &&
+(>&2 echo 'Example tool stderr output.') &&
+echo \$(id -u) > '$user_id' &&
+echo \$(id -g) > '$group_id' &&
+echo \$(pwd) > '$pwd' &&
+echo "\$HOME" > '$home' &&
+echo "\$TMP"  > '$tmp' &&
+echo "\$SOME_ENV_VAR" > '$some_env_var'
     ]]></command>
     <inputs>
     </inputs>
@@ -22,6 +22,8 @@
         <data name="tmp" format="txt" label="tmp" />
         <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/job_environment_default_legacy.xml
+++ b/test/functional/tools/job_environment_default_legacy.xml
@@ -1,14 +1,14 @@
 <tool id="job_environment_default_legacy" name="job_environment_default_legacy" version="0.1.0">
     <requirements>
-      <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-      echo `id -u` > '$user_id';
-      echo `id -g` > '$group_id';
-      echo `pwd` > '$pwd';
-      echo "\$HOME" > '$home';
-      echo "\$TMP"  > '$tmp';
-      echo "\$SOME_ENV_VAR" > '$some_env_var';
+echo \$(id -u) > '$user_id' &&
+echo \$(id -g) > '$group_id' &&
+echo \$(pwd) > '$pwd' &&
+echo "\$HOME" > '$home' &&
+echo "\$TMP"  > '$tmp' &&
+echo "\$SOME_ENV_VAR" > '$some_env_var'
     ]]></command>
     <inputs>
     </inputs>
@@ -20,6 +20,8 @@
         <data name="tmp" format="txt" label="tmp" />
         <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/job_environment_explicit_isolated_home.xml
+++ b/test/functional/tools/job_environment_explicit_isolated_home.xml
@@ -3,12 +3,12 @@
         <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
     <command use_shared_home="false"><![CDATA[
-echo `id -u` > '$user_id';
-echo `id -g` > '$group_id';
-echo `pwd` > '$pwd';
-echo "\$HOME" > '$home';
-echo "\$TMP"  > '$tmp';
-echo "\$SOME_ENV_VAR" > '$some_env_var';
+echo \$(id -u) > '$user_id' &&
+echo \$(id -g) > '$group_id' &&
+echo \$(pwd) > '$pwd' &&
+echo "\$HOME" > '$home' &&
+echo "\$TMP"  > '$tmp' &&
+echo "\$SOME_ENV_VAR" > '$some_env_var'
     ]]></command>
     <inputs>
     </inputs>
@@ -20,6 +20,8 @@ echo "\$SOME_ENV_VAR" > '$some_env_var';
         <data name="tmp" format="txt" label="tmp" />
         <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/job_environment_explicit_shared_home.xml
+++ b/test/functional/tools/job_environment_explicit_shared_home.xml
@@ -1,14 +1,14 @@
 <tool id="job_environment_explicit_shared_home" name="job_environment_explicit_shared_home" version="0.1.0" profile="18.01">
     <requirements>
-      <container type="docker">busybox:ubuntu-14.04</container>
+        <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
     <command use_shared_home="true"><![CDATA[
-      echo `id -u` > '$user_id';
-      echo `id -g` > '$group_id';
-      echo `pwd` > '$pwd';
-      echo "\$HOME" > '$home';
-      echo "\$TMP"  > '$tmp';
-      echo "\$SOME_ENV_VAR" > '$some_env_var';
+echo \$(id -u) > '$user_id' &&
+echo \$(id -g) > '$group_id' &&
+echo \$(pwd) > '$pwd' &&
+echo "\$HOME" > '$home' &&
+echo "\$TMP"  > '$tmp' &&
+echo "\$SOME_ENV_VAR" > '$some_env_var'
     ]]></command>
     <inputs>
     </inputs>
@@ -20,6 +20,8 @@
         <data name="tmp" format="txt" label="tmp" />
         <data name="some_env_var" format="txt" label="env_var" />
     </outputs>
+    <tests>
+    </tests>
     <help>
     </help>
 </tool>

--- a/test/functional/tools/job_properties.xml
+++ b/test/functional/tools/job_properties.xml
@@ -1,25 +1,26 @@
-<tool id="job_properties" name="Test Job Properties">
+<tool id="job_properties" name="Test Job Properties" version="1.0.0">
     <stdio>
         <exit_code range="127" level="fatal" description="Failing exit code." />
     </stdio>
     <version_command>echo 'v1.1'</version_command>
     <command><![CDATA[
-        #if $thebool
-            echo "The bool is true" &&
-            echo "The bool is really true" 1>&2 &&
-            echo "This is a line of text." > '$out_file1' &&
-            cp '$out_file1' '$one' &&
-            cp '$out_file1' '$two'
-        #else
-            echo "The bool is not true" &&
-            echo "The bool is very not true" 1>&2 &&
-            echo "This is a different line of text." > '$out_file1' &&
-            sh -c "exit 2"
-        #end if
-        #if $failbool
-            ; sh -c "exit 127"
-        #end if
-
+#if $thebool
+    echo 'The bool is true' &&
+    echo 'The bool is really true' 1>&2 &&
+    echo 'This is a line of text.' > '$out_file1' &&
+    cp '$out_file1' '$one' &&
+    cp '$out_file1' '$two'
+#else
+    echo 'The bool is not true' &&
+    echo 'The bool is very not true' 1>&2 &&
+    echo 'This is a different line of text.' > '$out_file1' &&
+    sh -c 'exit 2'
+#end if
+#if $failbool
+    ## use ';' to concatenate commands so that the next one is run independently
+    ## of the exit code of the previous one
+    ; exit 127
+#end if
     ]]></command>
     <inputs>
         <param name="thebool" type="boolean" label="The boolean property" />

--- a/test/functional/tools/metadata.xml
+++ b/test/functional/tools/metadata.xml
@@ -1,29 +1,34 @@
 <tool id="metadata" name="metadata" version="1.0.0">
-  <command>mkdir $output_copy_of_input.extra_files_path; cp $input.extra_files_path/* $output_copy_of_input.extra_files_path; echo "$input.metadata.base_name" > $output_of_input_metadata</command>
-  <inputs>
-    <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
-  </inputs>
-  <outputs>
-    <data format="txt" name="output_of_input_metadata" />
-    <data format="velvet" name="output_copy_of_input" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" value="velveth_test1/output.html" ftype="velvet" >
-        <composite_data value="velveth_test1/Sequences" />
-        <composite_data value="velveth_test1/Roadmaps" />
-        <composite_data value="velveth_test1/Log"/>
-        <metadata name="base_name" value="Example Metadata" />
-      </param>
-      <!-- This ouptut tests setting input metadata above -->
-      <output name="output_of_input_metadata" ftype="txt">
-        <assert_contents>
-          <has_line line="Example Metadata" />
-        </assert_contents>
-      </output>
-      <!-- This output tests an assertion about output metadata -->
-      <output name="output_copy_of_input" file="velveth_test1/output.html">
-        <metadata name="base_name" value="velvet" />
-      </output>
-    </test>
-  </tests></tool>
+    <command><![CDATA[
+mkdir '$output_copy_of_input.extra_files_path' &&
+cp '$input.extra_files_path'/* '$output_copy_of_input.extra_files_path' &&
+echo '$input.metadata.base_name' > '$output_of_input_metadata'
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
+    </inputs>
+    <outputs>
+        <data name="output_of_input_metadata" format="txt" />
+        <data name="output_copy_of_input" format="velvet" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="velveth_test1/output.html" ftype="velvet" >
+                <composite_data value="velveth_test1/Sequences" />
+                <composite_data value="velveth_test1/Roadmaps" />
+                <composite_data value="velveth_test1/Log"/>
+                <metadata name="base_name" value="Example Metadata" />
+            </param>
+            <!-- This ouptut tests setting input metadata above -->
+            <output name="output_of_input_metadata" ftype="txt">
+                <assert_contents>
+                    <has_line line="Example Metadata" />
+                </assert_contents>
+            </output>
+            <!-- This output tests an assertion about output metadata -->
+            <output name="output_copy_of_input" file="velveth_test1/output.html">
+                <metadata name="base_name" value="velvet" />
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/metadata_bcf.xml
+++ b/test/functional/tools/metadata_bcf.xml
@@ -1,16 +1,18 @@
 <tool id="metadata_bcf" name="metadata_BCF" version="1.0.0">
-    <command>file "${input_bcf.metadata.bcf_index}" &gt; "${output_of_input_metadata}"</command>
+    <command><![CDATA[
+file '${input_bcf.metadata.bcf_index}' > '${output_of_input_metadata}'
+    ]]></command>
     <inputs>
-      <param name="input_bcf" type="data" format="bcf" label="BCF File"/>
+        <param name="input_bcf" type="data" format="bcf" label="BCF File"/>
     </inputs>
     <outputs>
-      <data format="txt" name="output_of_input_metadata" />
+        <data name="output_of_input_metadata" format="txt" />
     </outputs>
     <tests>
-      <test>
-        <param name="input_bcf" value="bcf_index_metadata_test.bcf" ftype="bcf" />
-        <!-- Tests whether the .bcf.csi file is of "gzip compressed data, extra field" type -->
-        <output name="output_of_input_metadata" ftype="txt" file="bcf_index_metadata_test.txt" compare="contains"/>
-      </test>
+        <test>
+            <param name="input_bcf" value="bcf_index_metadata_test.bcf" ftype="bcf" />
+            <!-- Tests whether the .bcf.csi file is of "gzip compressed data, extra field" type -->
+            <output name="output_of_input_metadata" ftype="txt" file="bcf_index_metadata_test.txt" compare="contains"/>
+        </test>
     </tests>
 </tool>

--- a/test/functional/tools/metadata_biom1.xml
+++ b/test/functional/tools/metadata_biom1.xml
@@ -1,5 +1,7 @@
 <tool id="metadata_biom1" name="metadata_BIOM1" version="1.0.0">
-    <command>cp "${input_metadata_values}" "${output_of_input_metadata}"</command>
+    <command><![CDATA[
+cp '${input_metadata_values}' '${output_of_input_metadata}'
+    ]]></command>
     <configfiles>
         <configfile name="input_metadata_values">table_rows: ${input_biom1.metadata.table_rows}
 table_matrix_element_type: ${input_biom1.metadata.table_matrix_element_type}
@@ -14,15 +16,15 @@ table_id: ${input_biom1.metadata.table_id}
 table_columns: ${input_biom1.metadata.table_columns}</configfile>
     </configfiles>
     <inputs>
-      <param name="input_biom1" type="data" format="biom1" label="BIOM1 File"/>
+        <param name="input_biom1" type="data" format="biom1" label="BIOM1 File"/>
     </inputs>
     <outputs>
-      <data format="txt" name="output_of_input_metadata" />
+        <data name="output_of_input_metadata" format="txt" />
     </outputs>
     <tests>
-      <test>
-        <param name="input_biom1" value="input_taxonomy.biom1" ftype="biom1" />
-        <output name="output_of_input_metadata" ftype="txt" file="biom1_metadata_test.txt" lines_diff="4"/>
-      </test>
+        <test>
+            <param name="input_biom1" value="input_taxonomy.biom1" ftype="biom1" />
+            <output name="output_of_input_metadata" ftype="txt" file="biom1_metadata_test.txt" lines_diff="4"/>
+        </test>
     </tests>
 </tool>

--- a/test/functional/tools/mulled_example_broken_no_requirements.xml
+++ b/test/functional/tools/mulled_example_broken_no_requirements.xml
@@ -10,16 +10,16 @@
         <exit_code range="2:" />
     </stdio>
     <command><![CDATA[
-        bwa > $output_1 2>&1
+bwa > $output_1 2>&1
     ]]></command>
     <inputs>
     </inputs>
     <outputs>
-      <data name="output_1" />
+        <data name="output_1" />
     </outputs>
-    <help><![CDATA[
-        TODO: Fill in help.
-    ]]></help>
     <tests>
     </tests>
+    <help><![CDATA[
+TODO: Fill in help.
+    ]]></help>
 </tool>

--- a/test/functional/tools/mulled_example_explicit.xml
+++ b/test/functional/tools/mulled_example_explicit.xml
@@ -7,16 +7,16 @@
         <exit_code range="2:" />
     </stdio>
     <command><![CDATA[
-        bwa > $output_1 2>&1
+bwa > $output_1 2>&1
     ]]></command>
     <inputs>
     </inputs>
     <outputs>
-      <data name="output_1" />
+        <data name="output_1" />
     </outputs>
-    <help><![CDATA[
-        TODO: Fill in help.
-    ]]></help>
     <tests>
     </tests>
+    <help><![CDATA[
+TODO: Fill in help.
+    ]]></help>
 </tool>

--- a/test/functional/tools/mulled_example_invalid_case.xml
+++ b/test/functional/tools/mulled_example_invalid_case.xml
@@ -9,16 +9,16 @@
         <exit_code range="2:" />
     </stdio>
     <command><![CDATA[
-        bwa > $output_1 2>&1
+bwa > '$output_1' 2>&1
     ]]></command>
     <inputs>
     </inputs>
     <outputs>
-      <data name="output_1" />
+        <data name="output_1" />
     </outputs>
-    <help><![CDATA[
-        TODO: Fill in help.
-    ]]></help>
     <tests>
     </tests>
+    <help><![CDATA[
+TODO: Fill in help.
+    ]]></help>
 </tool>

--- a/test/functional/tools/mulled_example_multi_1.xml
+++ b/test/functional/tools/mulled_example_multi_1.xml
@@ -18,10 +18,10 @@
         <requirement type="package" version="2.26.0">bedtools</requirement>
     </requirements>
     <command><![CDATA[
-        bedtools --version > '$out_file1' &&
-        echo "Moo" >> '$out_file1' &&
-        samtools >> '$out_file1' 2>&1 &&
-        echo "Cow" >> '$out_file1'
+bedtools --version > '$out_file1' &&
+echo "Moo" >> '$out_file1' &&
+samtools >> '$out_file1' 2>&1 &&
+echo "Cow" >> '$out_file1'
     ]]></command>
     <inputs>
         <param name="input1" type="data" optional="true" />
@@ -29,10 +29,12 @@
     <outputs>
         <data name="out_file1" format="txt" />
     </outputs>
-    <help>
-        This is an example mulled tool that combines bedtools and samtools in one
-        command-line invocation.
-    </help>
+    <tests>
+    </tests>
+    <help><![CDATA[
+This is an example mulled tool that combines bedtools and samtools in one
+command-line invocation.
+    ]]></help>
     <citations>
         <citation type="doi">10.1093/bioinformatics/btq033</citation>
         <citation type="bibtex">

--- a/test/functional/tools/mulled_example_multi_incomplete.xml
+++ b/test/functional/tools/mulled_example_multi_incomplete.xml
@@ -1,9 +1,9 @@
 <tool id="mulled_example_multi_incomplete" name="mulled_example_multi_incomplete" version="0.1.0">
     <command><![CDATA[
-        bedtools --version > $out_file1 ;
-        echo "Moo" >> $out_file1 ;
-        samtools >> $out_file1 2>&1 ;
-        echo "Cow" >> $out_file1 ;
+bedtools --version > '$out_file1' &&
+echo 'Moo' >> '$out_file1' &&
+samtools >> '$out_file1' 2>&1 &&
+echo 'Cow' >> '$out_file1'
     ]]></command>
     <requirements>
         <requirement type="package" version="1.3.1">samtools</requirement>

--- a/test/functional/tools/mulled_example_multi_versionless.xml
+++ b/test/functional/tools/mulled_example_multi_versionless.xml
@@ -1,9 +1,9 @@
 <tool id="mulled_example_multi_versionless" name="mulled_example_multi_versionless" version="0.1.0">
     <command><![CDATA[
-        bedtools --version > $out_file1 ;
-        echo "Moo" >> $out_file1 ;
-        samtools >> $out_file1 2>&1 ;
-        echo "Cow" >> $out_file1 ;
+bedtools --version > '$out_file1' &&
+echo 'Moo' >> '$out_file1' &&
+samtools >> '$out_file1' 2>&1 &&
+echo 'Cow' >> '$out_file1'
     ]]></command>
     <requirements>
         <requirement type="package">samtools</requirement>

--- a/test/functional/tools/mulled_example_simple.xml
+++ b/test/functional/tools/mulled_example_simple.xml
@@ -6,16 +6,16 @@
         <exit_code range="2:" />
     </stdio>
     <command><![CDATA[
-        bwa > $output_1 2>&1
+bwa > '$output_1' 2>&1
     ]]></command>
     <inputs>
     </inputs>
     <outputs>
-      <data name="output_1" />
+        <data name="output_1" />
     </outputs>
+    <tests>
+    </tests>
     <help><![CDATA[
         TODO: Fill in help.
     ]]></help>
-    <tests>
-    </tests>
 </tool>

--- a/test/functional/tools/multi_repeats.xml
+++ b/test/functional/tools/multi_repeats.xml
@@ -1,7 +1,7 @@
-<tool id="multi_repeats" name="multi_repeats">
-    <command>
-        cat $input1 #for $q in $queries# ${q.input2} #end for# #for $q in $more_queries# ${q.more_queries_input} #end for# > $out_file1
-    </command>
+<tool id="multi_repeats" name="multi_repeats" version="1.0.0">
+    <command><![CDATA[
+cat '$input1' #for $q in $queries# '${q.input2}' #end for# #for $q in $more_queries# '${q.more_queries_input}' #end for# > '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Concatenate Dataset"/>
         <repeat name="queries" title="Dataset">

--- a/test/functional/tools/multi_select.xml
+++ b/test/functional/tools/multi_select.xml
@@ -1,45 +1,50 @@
 <tool id="multi_select" name="multi_select" version="1.0.0">
-  <description>multi_select</description>
-  <configfiles>
-    <configfile name="config">${select_ex}</configfile>
-  </configfiles>
-  <command>cat $config > $output; echo '$select_optional' > $output2</command>
-  <inputs>
-    <param name="select_ex" type="select" display="checkboxes" multiple="true">
-      <option value="--ex1">Ex1</option>
-      <option value="ex2">Ex2</option>
-      <option value="--ex3">Ex3</option>
-      <option value="--ex4">Ex4</option>
-      <option value="ex5">Ex5</option>
-    </param>
-    <param name="select_optional" type="select" optional="true">
-      <option value="--ex1">Ex1</option>
-      <option value="ex2">Ex2</option>
-      <option value="--ex3">Ex3</option>
-      <option value="--ex4">Ex4</option>
-      <option value="ex5">Ex5</option>
-    </param>
-  </inputs>
-  <outputs>
-    <data format="txt" name="output" />
-    <data format="txt" name="output2" />    
-  </outputs>
-  <tests>
-    <test>
-      <param name="select_ex" value="--ex1,ex2,--ex3" />
-      <output name="output">
-        <assert_contents>
-          <has_line line="--ex1,ex2,--ex3" />
-        </assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="select_ex" value="Ex1" />
-      <output name="output">
-        <assert_contents>
-          <has_line line="--ex1" />
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
+    <description>multi_select</description>
+    <command><![CDATA[
+cat '$config' > '$output' &&
+echo '$select_optional' > '$output2'
+    ]]></command>
+    <configfiles>
+        <configfile name="config">${select_ex}</configfile>
+    </configfiles>
+    <inputs>
+        <param name="select_ex" type="select" display="checkboxes" multiple="true">
+            <option value="--ex1">Ex1</option>
+            <option value="ex2">Ex2</option>
+            <option value="--ex3">Ex3</option>
+            <option value="--ex4">Ex4</option>
+            <option value="ex5">Ex5</option>
+        </param>
+        <param name="select_optional" type="select" optional="true">
+            <option value="--ex1">Ex1</option>
+            <option value="ex2">Ex2</option>
+            <option value="--ex3">Ex3</option>
+            <option value="--ex4">Ex4</option>
+            <option value="ex5">Ex5</option>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+        <data name="output2" format="txt" />    
+    </outputs>
+    <tests>
+        <test>
+            <param name="select_ex" value="--ex1,ex2,--ex3" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="--ex1,ex2,--ex3" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="select_ex" value="Ex1" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="--ex1" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/output_auto_format.xml
+++ b/test/functional/tools/output_auto_format.xml
@@ -1,16 +1,17 @@
 <tool id="output_auto_format" name="output_auto_format" version="1.0.0">
-  <command>cp $input 'out'</command>
-  <inputs>
-    <param name="input" type="data" format="data" label="An input dataset" help=""/>
-  </inputs>
-  <outputs>
-    <data auto_format="true" name="output" label="Auto Output" from_work_dir="out">
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" value="simple_line.txt" ftype="txt" />
-      <output name="output" file="simple_line.txt" ftype="txt" />
-    </test>
-  </tests>
+    <command><![CDATA[
+cp '$input' out
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="data" label="An input dataset" help=""/>
+    </inputs>
+    <outputs>
+        <data name="output" auto_format="true" label="Auto Output" from_work_dir="out" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" ftype="txt" />
+            <output name="output" file="simple_line.txt" ftype="txt" />
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/output_filter.xml
+++ b/test/functional/tools/output_filter.xml
@@ -1,95 +1,174 @@
 <tool id="output_filter" name="output_filter" version="1.0.0">
-  <description>test for output filtering and expect_num_outputs</description>
-  <command>
-    echo "test" > 1;
-    echo "test" > 2;
-    echo "test" > 3;
-    echo "test" > 4;
-    echo "test" > 5;
-    echo "test" > p1.forward;
-    echo "test" > p1.reverse;
-    echo "test" > p2.forward;
-    echo "test" > p2.reverse;
-  </command>
-  <inputs>
-    <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
-    <param name="filter_text_1" type="text" value="1" />
-    <param name="produce_collection" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Collection Filter" />
-    <param name="produce_paired_collection" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Paired Collection Filter" />
-  </inputs>
-  <outputs>
-    <data format="txt" from_work_dir="1" name="out_1">
-      <filter>produce_out_1 is True</filter>
-    </data>
-    <data format="txt" from_work_dir="2" name="out_2">
-      <filter>filter_text_1 in ["foo", "bar"]</filter>
-      <!-- Must pass all filters... -->
-      <filter>filter_text_1 == "foo"</filter>
-    </data>
-    <data format="txt" from_work_dir="3" name="out_3"/>
-    <collection name="list_output" type="list" label="List">
-      <discover_datasets pattern="(?P&lt;identifier_0&gt;[45])" ext="txt" visible="true" />
-      <filter>produce_collection is True</filter>
-    </collection>
-    <collection name="paired_list_output" type="list:paired" label="paired list">
-      <discover_datasets pattern="(?P&lt;identifier_0&gt;p[12])\.(?P&lt;identifier_1&gt;.*)" ext="txt" visible="true" />
-      <filter>produce_paired_collection is True</filter>
-    </collection>
-  </outputs>
-  <tests>
-    <test expect_num_outputs="3">
-      <param name="produce_out_1" value="true" />
-      <param name="filter_text_1" value="foo" />
-      <output name="out_1"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_2"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
-    </test>
-    <test expect_num_outputs="2">
-      <param name="produce_out_1" value="true" />
-      <param name="filter_text_1" value="bar" /> <!-- fails second filter in out2 -->
-      <output name="out_1"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
-    </test>
-    <test expect_num_outputs="1">
-      <param name="produce_out_1" value="false" />
-      <param name="filter_text_1" value="not_foo_or_bar" />
-      <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
-    </test>
-    <test expect_num_outputs="4">
-      <param name="produce_out_1" value="true" />
-      <param name="filter_text_1" value="foo" />
-      <param name="produce_collection" value="true" />
-      <output name="out_1"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_2"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output_collection name="list_output" type="list" count="2">
-        <element name="4"><assert_contents><has_line line="test" /></assert_contents></element>
-        <element name="5"><assert_contents><has_line line="test" /></assert_contents></element>
-      </output_collection>
-    </test>
-    <test expect_num_outputs="5">
-      <param name="produce_out_1" value="true" />
-      <param name="filter_text_1" value="foo" />
-      <param name="produce_collection" value="true" />
-      <param name="produce_paired_collection" value="true" />
-      <output name="out_1"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_2"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_3"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output_collection name="list_output" type="list" count="2">
-        <element name="4"><assert_contents><has_line line="test" /></assert_contents></element>
-        <element name="5"><assert_contents><has_line line="test" /></assert_contents></element>
-      </output_collection>
-      <output_collection name="paired_list_output" type="list:paired" count="2">
-        <element name="p1">
-          <element name="forward"><assert_contents><has_line line="test" /></assert_contents></element>
-          <element name="reverse"><assert_contents><has_line line="test" /></assert_contents></element>
-        </element>
-        <element name="p2">
-          <element name="forward"><assert_contents><has_line line="test" /></assert_contents></element>
-          <element name="reverse"><assert_contents><has_line line="test" /></assert_contents></element>
-        </element>
-      </output_collection>
-    </test>
-  </tests>
+    <description>test for output filtering and expect_num_outputs</description>
+    <command><![CDATA[
+echo 'test' > 1 &&
+echo 'test' > 2 &&
+echo 'test' > 3 &&
+echo 'test' > 4 &&
+echo 'test' > 5 &&
+echo 'test' > p1.forward &&
+echo 'test' > p1.reverse &&
+echo 'test' > p2.forward &&
+echo 'test' > p2.reverse 
+    ]]></command>
+    <inputs>
+        <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
+        <param name="filter_text_1" type="text" value="1" />
+        <param name="produce_collection" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Collection Filter" />
+        <param name="produce_paired_collection" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Paired Collection Filter" />
+    </inputs>
+    <outputs>
+        <data name="out_1" format="txt" from_work_dir="1">
+            <filter>produce_out_1 is True</filter>
+        </data>
+        <data name="out_2" format="txt" from_work_dir="2">
+            <filter>filter_text_1 in ["foo", "bar"]</filter>
+            <!-- Must pass all filters... -->
+            <filter>filter_text_1 == "foo"</filter>
+        </data>
+        <data name="out_3" format="txt" from_work_dir="3"/>
+        <collection name="list_output" type="list" label="List">
+            <discover_datasets pattern="(?P&lt;identifier_0&gt;[45])" ext="txt" visible="true" />
+            <filter>produce_collection is True</filter>
+        </collection>
+        <collection name="paired_list_output" type="list:paired" label="paired list">
+            <discover_datasets pattern="(?P&lt;identifier_0&gt;p[12])\.(?P&lt;identifier_1&gt;.*)" ext="txt" visible="true" />
+            <filter>produce_paired_collection is True</filter>
+        </collection>
+    </outputs>
+    <tests>
+        <test expect_num_outputs="3">
+            <param name="produce_out_1" value="true" />
+            <param name="filter_text_1" value="foo" />
+            <output name="out_1">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_2">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_3">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="2">
+            <param name="produce_out_1" value="true" />
+            <param name="filter_text_1" value="bar" /> <!-- fails second filter in out2 -->
+            <output name="out_1">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_3">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="1">
+            <param name="produce_out_1" value="false" />
+            <param name="filter_text_1" value="not_foo_or_bar" />
+            <output name="out_3">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_num_outputs="4">
+            <param name="produce_out_1" value="true" />
+            <param name="filter_text_1" value="foo" />
+            <param name="produce_collection" value="true" />
+            <output name="out_1">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_2">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_3">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output_collection name="list_output" type="list" count="2">
+                <element name="4">
+                    <assert_contents>
+                        <has_line line="test" />
+                    </assert_contents>
+                </element>
+                <element name="5">
+                    <assert_contents>
+                        <has_line line="test" />
+                    </assert_contents>
+                </element>
+            </output_collection>
+        </test>
+        <test expect_num_outputs="5">
+            <param name="produce_out_1" value="true" />
+            <param name="filter_text_1" value="foo" />
+            <param name="produce_collection" value="true" />
+            <param name="produce_paired_collection" value="true" />
+            <output name="out_1">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_2">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_3">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output_collection name="list_output" type="list" count="2">
+                <element name="4">
+                    <assert_contents>
+                        <has_line line="test" />
+                    </assert_contents>
+                </element>
+                <element name="5">
+                    <assert_contents>
+                        <has_line line="test" />
+                    </assert_contents>
+                </element>
+            </output_collection>
+            <output_collection name="paired_list_output" type="list:paired" count="2">
+                <element name="p1">
+                    <element name="forward">
+                        <assert_contents>
+                            <has_line line="test" />
+                        </assert_contents>
+                    </element>
+                    <element name="reverse">
+                        <assert_contents>
+                            <has_line line="test" />
+                        </assert_contents>
+                    </element>
+                </element>
+                <element name="p2">
+                    <element name="forward">
+                        <assert_contents>
+                            <has_line line="test" />
+                        </assert_contents>
+                    </element>
+                    <element name="reverse">
+                        <assert_contents>
+                            <has_line line="test" />
+                        </assert_contents>
+                    </element>
+                </element>
+            </output_collection>
+        </test>
+    </tests>
 </tool>
-

--- a/test/functional/tools/output_filter_exception_1.xml
+++ b/test/functional/tools/output_filter_exception_1.xml
@@ -1,35 +1,39 @@
 <tool id="output_filter_exception_1" name="output_filter_exception_1" version="1.0.0">
-  <command>
-    echo "test" > 1;
-    echo "test" > 2;
-    echo "test" > 3;
-    echo "test" > 4;
-    echo "test" > 5;
-  </command>
-  <inputs>
-    <conditional name="options">
-      <param help="" label="Options" name="options" type="select">
-        <option selected="True" value="default">Use defaults</option>
-        <option value="advanced">Specify advanced options</option>
-      </param>
-      <when value="default" />
-      <when value="advanced">
-        <param falsevalue="" truevalue="--adv_opt1" help="" name="adv_opt1" type="boolean" />
-      </when>
-    </conditional>
-  </inputs>
-  <outputs>
-    <data format="txt" from_work_dir="1" name="out_1">
-    </data>
-    <data format="txt" from_work_dir="2" name="out_2">
-      <filter>options['adv_opt1'] is True</filter>
-    </data>
-  </outputs>
-  <tests>
-    <!-- Filter condition throws exception, filter "fails" and so output is produced. -->
-    <test expect_num_outputs="2">
-      <output name="out_1"><assert_contents><has_line line="test" /></assert_contents></output>
-      <output name="out_2"><assert_contents><has_line line="test" /></assert_contents></output>
-    </test>
-  </tests>
+    <command><![CDATA[
+echo 'test' > 1 &&
+echo 'test' > 2
+    ]]></command>
+    <inputs>
+        <conditional name="options">
+            <param help="" label="Options" name="options" type="select">
+                <option selected="True" value="default">Use defaults</option>
+                <option value="advanced">Specify advanced options</option>
+            </param>
+            <when value="default" />
+            <when value="advanced">
+                <param falsevalue="" truevalue="--adv_opt1" help="" name="adv_opt1" type="boolean" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out_1" format="txt" from_work_dir="1" />
+        <data name="out_2" format="txt" from_work_dir="2">
+            <filter>options['adv_opt1'] is True</filter>
+        </data>
+    </outputs>
+    <tests>
+        <!-- Filter condition throws exception, filter "fails" and so output is produced. -->
+        <test expect_num_outputs="2">
+            <output name="out_1">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="out_2">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/output_filter_with_input.xml
+++ b/test/functional/tools/output_filter_with_input.xml
@@ -1,31 +1,29 @@
 <tool id="output_filter_with_input" name="output_filter_with_input" version="1.0.0">
-  <!-- output_filter.xml but with an input -->
-  <command>
-    echo "test" > 1;
-    echo "test" > 2;
-    echo "test" > 3;
-    echo "test" > 4;
-    echo "test" > 5;
-  </command>
-  <inputs>
-    <param name="input_1" type="data" />
-    <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
-    <param name="filter_text_1" type="text" value="1" />
-  </inputs>
-  <outputs>
-    <data format="txt" from_work_dir="1" name="out_1">
-      <filter>produce_out_1 is True</filter>
-    </data>
-    <data format="txt" from_work_dir="2" name="out_2">
-      <filter>filter_text_1 in ["foo", "bar"]</filter>
-      <!-- Must pass all filters... -->
-      <filter>filter_text_1 == "foo"</filter>
-    </data>
-    <data format="txt" from_work_dir="3" name="out_3">
-      <!-- always produce out_3 -->
-      <filter>input_1.ext != 'xyz'</filter>
-    </data>
-  </outputs>
-  <tests>
-  </tests>
+    <!-- output_filter.xml but with an input -->
+    <command><![CDATA[
+echo 'test' > 1 &&
+echo 'test' > 2 &&
+echo 'test' > 3
+    ]]></command>
+    <inputs>
+        <param name="input_1" type="data" />
+        <param name="produce_out_1" type="boolean" truevalue="true" falsevalue="false" checked="False" label="Do Filter 1" />
+        <param name="filter_text_1" type="text" value="1" />
+    </inputs>
+    <outputs>
+        <data name="out_1" format="txt" from_work_dir="1">
+            <filter>produce_out_1 is True</filter>
+        </data>
+        <data name="out_2" format="txt" from_work_dir="2">
+            <filter>filter_text_1 in ["foo", "bar"]</filter>
+            <!-- Must pass all filters... -->
+            <filter>filter_text_1 == "foo"</filter>
+        </data>
+        <data name="out_3" format="txt" from_work_dir="3">
+            <!-- always produce out_3 -->
+            <filter>input_1.ext != 'xyz'</filter>
+        </data>
+    </outputs>
+    <tests>
+    </tests>
 </tool>

--- a/test/functional/tools/output_format.xml
+++ b/test/functional/tools/output_format.xml
@@ -1,74 +1,88 @@
 <tool id="output_format" name="output_format" version="1.0.0">
-  <command>
-    echo "test" > 1;
-    echo "test" > 2;
-    echo "test" > 3;
-    echo "test" > 4;
-    echo "test" > 5;
-  </command>
-  <inputs>
-    <param name="input_data_1" type="data" format="data" label="input_data_1" />
-    <param name="input_data_2" type="data" format="data" label="input_data_2" />
-    <param name="input_text" type="text" value="1"  label="input_text" />
-  </inputs>
-  <outputs>
-    <data format="txt" from_work_dir="1" name="direct_output" />
-    <!-- TODO: fixme, following input gets random type fastqsanger or
-    fastqsolexa. -->
-    <data format="input" from_work_dir="2" name="input_based_output" />
-    <data format="txt" from_work_dir="3" name="format_source_1_output" format_source="input_data_1" />
-    <data format="txt" from_work_dir="4" name="format_source_2_output" format_source="input_data_2" />
-    <data format="txt" from_work_dir="5" name="change_format_output">
-      <change_format>
-        <when input="input_text" value="foo" format="fastqsolexa" />
-        <when input="input_text" value="bar" format="fastqillumina" />
-      </change_format>
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
-      <param name="input_data_2" value="1.fastqsolexa" ftype="fastqsolexa" />
-      <param name="input_text" value="foo" />
-      <output name="direct_output" ftype="txt">
-        <assert_contents><has_line line="test" /></assert_contents>
-        <metadata name="created_from_basename" value="1" />
-      </output>
-      <!-- In this case input_based_output ftype is "randomly" either
-           fastqsanger or fastqsolexa -->
-      <output name="format_source_1_output" ftype="fastqsanger">
-        <assert_contents><has_line line="test" /></assert_contents>
-        <metadata name="created_from_basename" value="3" />
-      </output>
-      <output name="format_source_2_output" ftype="fastqsolexa">
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-      <!-- input_text == foo => format set to fastsolexa -->
-      <output name="change_format_output" ftype="fastqsolexa">
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
-      <param name="input_data_2" value="1.fastqsanger" ftype="fastqsanger" />
-      <param name="input_text" value="bar" />
-      <output name="input_based_output" ftype="fastqsanger">
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-      <!-- input_text == bar => format set to fastqillumina -->
-      <output name="change_format_output" ftype="fastqillumina">
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
-      <param name="input_data_2" value="1.fastqsanger" ftype="fastqsanger" />
-      <param name="input_text" value="not_foo_or_bar" />
-      <!-- input_text doesn't match any when, default to explicitly declared
-      type. -->
-      <output name="change_format_output" ftype="txt">
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-    </test>
-  </tests>
+    <command><![CDATA[
+echo 'test' > 1 &&
+echo 'test' > 2 &&
+echo 'test' > 3 &&
+echo 'test' > 4 &&
+echo 'test' > 5
+    ]]></command>
+    <inputs>
+        <param name="input_data_1" type="data" format="data" label="input_data_1" />
+        <param name="input_data_2" type="data" format="data" label="input_data_2" />
+        <param name="input_text" type="text" value="1"  label="input_text" />
+    </inputs>
+    <outputs>
+        <data name="direct_output" format="txt" from_work_dir="1" />
+        <!-- TODO: fixme, following input gets random type fastqsanger or
+        fastqsolexa. -->
+        <data name="input_based_output" format="input" from_work_dir="2" />
+        <data name="format_source_1_output" format_source="input_data_1" from_work_dir="3" />
+        <data name="format_source_2_output" format_source="input_data_2" from_work_dir="4" />
+        <data name="change_format_output" format="txt" from_work_dir="5">
+            <change_format>
+                <when input="input_text" value="foo" format="fastqsolexa" />
+                <when input="input_text" value="bar" format="fastqillumina" />
+            </change_format>
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
+            <param name="input_data_2" value="1.fastqsolexa" ftype="fastqsolexa" />
+            <param name="input_text" value="foo" />
+            <output name="direct_output" ftype="txt">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+                <metadata name="created_from_basename" value="1" />
+            </output>
+            <!-- In this case input_based_output ftype is "randomly" either
+                fastqsanger or fastqsolexa -->
+            <output name="format_source_1_output" ftype="fastqsanger">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+                <metadata name="created_from_basename" value="3" />
+            </output>
+            <output name="format_source_2_output" ftype="fastqsolexa">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <!-- input_text == foo => format set to fastsolexa -->
+            <output name="change_format_output" ftype="fastqsolexa">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
+            <param name="input_data_2" value="1.fastqsanger" ftype="fastqsanger" />
+            <param name="input_text" value="bar" />
+            <output name="input_based_output" ftype="fastqsanger">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <!-- input_text == bar => format set to fastqillumina -->
+            <output name="change_format_output" ftype="fastqillumina">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
+            <param name="input_data_2" value="1.fastqsanger" ftype="fastqsanger" />
+            <param name="input_text" value="not_foo_or_bar" />
+            <!-- input_text doesn't match any when, default to explicitly declared
+            type. -->
+            <output name="change_format_output" ftype="txt">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/output_format_collection.xml
+++ b/test/functional/tools/output_format_collection.xml
@@ -1,35 +1,35 @@
 <tool id="output_format_collection" name="output_format_collection" version="1.0.0">
-  <command>
-    echo "test" > 1;
-    echo "test" > 2;
-  </command>
-  <inputs>
-    <param name="input_collection" type="data_collection" format="data" />
-  </inputs>
-  <outputs>
-    <!-- Access by element name (for paired data) -->
-    <data from_work_dir="1" name="format_source_1_output" format_source="input_collection['forward']" />
-    <!-- Access by element index (for any collection) -->
-    <data from_work_dir="2" name="format_source_2_output" format_source="input_collection[0]" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="input_collection">
-        <collection type="paired">
-          <element name="forward" value="simple_line.txt" />
-          <element name="reverse" value="simple_line_alternative.txt" />
-        </collection>
-      </param>
-      <output name="format_source_1_output" ftype="txt">
-          <assert_contents>
-            <has_line line="test" />
-          </assert_contents>
-      </output>
-      <output name="format_source_2_output" ftype="txt">
-          <assert_contents>
-            <has_line line="test" />
-          </assert_contents>
-      </output>
-    </test>
-  </tests>
+    <command><![CDATA[
+echo "test" > 1 &&
+echo "test" > 2
+    ]]></command>
+    <inputs>
+        <param name="input_collection" type="data_collection" format="data" />
+    </inputs>
+    <outputs>
+        <!-- Access by element name (for paired data) -->
+        <data name="format_source_1_output" format_source="input_collection['forward']" from_work_dir="1" />
+        <!-- Access by element index (for any collection) -->
+        <data name="format_source_2_output" format_source="input_collection[0]" from_work_dir="2" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input_collection">
+                <collection type="paired">
+                    <element name="forward" value="simple_line.txt" />
+                    <element name="reverse" value="simple_line_alternative.txt" />
+                </collection>
+            </param>
+            <output name="format_source_1_output" ftype="txt">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+            <output name="format_source_2_output" ftype="txt">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/output_format_deprecated_when.xml
+++ b/test/functional/tools/output_format_deprecated_when.xml
@@ -1,30 +1,34 @@
 <tool id="output_format_deprecated_when" name="output_format_deprecated_when" version="1.0.0">
-  <command>
-    echo "test" > 5;
-  </command>
-  <inputs>
-    <param name="input_data_1" type="data" format="data" label="input_data_1" />
-  </inputs>
-  <outputs>
-    <data format="txt" from_work_dir="5" name="change_format_deprecated">
-      <change_format>
-        <when input_dataset="input_data_1" attribute="extension" value="fastq" format="fastq" />
-      </change_format>
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input_data_1" value="1.fastqsanger" ftype="fastq" />
-      <output name="change_format_deprecated" ftype="fastq">
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-    </test>
-    <test>
-      <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
-      <output name="change_format_deprecated" ftype="txt">
-        <!-- Fails to check subclasses, use format_soure if possible -->
-        <assert_contents><has_line line="test" /></assert_contents>
-      </output>
-    </test>
-  </tests>
+    <command><![CDATA[
+echo "test" > 5
+    ]]></command>
+    <inputs>
+        <param name="input_data_1" type="data" format="data" label="input_data_1" />
+    </inputs>
+    <outputs>
+        <data name="change_format_deprecated" format="txt" from_work_dir="5">
+            <change_format>
+                <when input_dataset="input_data_1" attribute="extension" value="fastq" format="fastq" />
+            </change_format>
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input_data_1" value="1.fastqsanger" ftype="fastq" />
+            <output name="change_format_deprecated" ftype="fastq">
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+        <test>
+            <param name="input_data_1" value="1.fastqsanger" ftype="fastqsanger" />
+            <output name="change_format_deprecated" ftype="txt">
+                <!-- Fails to check subclasses, use format_soure if possible -->
+                <assert_contents>
+                    <has_line line="test" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/output_order.xml
+++ b/test/functional/tools/output_order.xml
@@ -1,25 +1,28 @@
 <tool id="output_order" name="output_order" version="0.1.0">
-  <command>echo $pa > $output_a; echo $pb > $output_b</command>
-  <inputs>
-    <param name="pa" type="integer" value="1" />
-    <param name="pb" type="integer" value="2" />
-  </inputs>
-  <outputs>
-    <data format="txt" name="output_a" />
-    <data format="txt" name="output_b" />
-  </outputs>
-  <tests>
-    <test>
-      <output name="output_b">
-        <assert_contents>
-          <has_line line="2" />
-        </assert_contents>
-      </output>
-      <output name="output_a">
-        <assert_contents>
-          <has_line line="1" />
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
+    <command><![CDATA[
+echo $pa > '$output_a' &&
+echo $pb > '$output_b'
+    ]]></command>
+    <inputs>
+        <param name="pa" type="integer" value="1" />
+        <param name="pb" type="integer" value="2" />
+    </inputs>
+    <outputs>
+        <data name="output_a" format="txt" />
+        <data name="output_b" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output_b">
+                <assert_contents>
+                    <has_line line="2" />
+                </assert_contents>
+            </output>
+            <output name="output_a">
+                <assert_contents>
+                    <has_line line="1" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/parallelism.xml
+++ b/test/functional/tools/parallelism.xml
@@ -1,8 +1,8 @@
-<tool id="parallelism" name="Split file line-by-line and rebuild dataset">
+<tool id="parallelism" name="Split file line-by-line and rebuild dataset" version="1.0.0">
     <parallelism method="multi" split_inputs="input1" split_mode="to_size" split_size="1" merge_outputs="out_file1" />
-    <command detect_errors="exit_code">
-        cat '$input1' > '$out_file1'
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+cat '$input1' > '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Dataset"/>
     </inputs>

--- a/test/functional/tools/parallelism_optional.xml
+++ b/test/functional/tools/parallelism_optional.xml
@@ -1,11 +1,11 @@
-<tool id="parallelism_optional" name="Split file line-by-line and rebuild dataset (with optional dataset)">
+<tool id="parallelism_optional" name="Split file line-by-line and rebuild dataset (with optional dataset)" version="1.0.0">
     <parallelism method="multi" split_inputs="input1" split_mode="to_size" split_size="1" merge_outputs="out_file1" />
-    <command detect_errors="exit_code">
-        cat '$input1' > '$out_file1'
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+cat '$input1' > '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" label="Dataset"/>
-        <param name="input2" type="data" label="Optional Dataset" optional="true" />
+        <param name="input2" type="data" optional="true" label="Optional Dataset" />
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" />

--- a/test/functional/tools/param_text_option.xml
+++ b/test/functional/tools/param_text_option.xml
@@ -1,7 +1,7 @@
 <tool id="param_text_option" name="param_text_option" version="1.0.0">
-    <command>
-        echo "$text_param"  > $out_file1;
-    </command>
+    <command><![CDATA[
+echo "$text_param"  > $out_file1;
+    ]]></command>
     <inputs>
         <param name="text_param" type="text" value="foo 1">
             <option value="foo 1">Foo 1</option>

--- a/test/functional/tools/python_environment_problem.xml
+++ b/test/functional/tools/python_environment_problem.xml
@@ -3,9 +3,9 @@
         This script imports galaxy.eggs which is no longer available to tools
         by default. Only declared legacy tools have this available.
     -->
-    <command>
-        python $__tool_directory__/python_environment_problem.py '$out_file1'
-    </command>
+    <command><![CDATA[
+python '$__tool_directory__/python_environment_problem.py' '$out_file1'
+    ]]></command>
     <inputs>
     </inputs>
     <outputs>

--- a/test/functional/tools/qc_stdout.xml
+++ b/test/functional/tools/qc_stdout.xml
@@ -3,11 +3,11 @@
        <regex match="Quality of sample is .*%\." source="stdout" level="qc" />
     </stdio>
     <command detect_errors="exit_code"><![CDATA[
-        cp $input $output;
-        echo "Some example stdout........";
-        echo "Quality of sample is ${int($quality) * 10}%.";
-        echo "Some more example stdout........";
-        >&2 echo "my standard error"
+cp '$input' '$output' &&
+echo "Some example stdout........" &&
+echo "Quality of sample is ${int($quality) * 10}%." &&
+echo "Some more example stdout........" &&
+>&2 echo "my standard error"
     ]]></command>
     <inputs>
         <param name="input" type="data" format="txt" label="Input data" />

--- a/test/functional/tools/sam_to_bam.xml
+++ b/test/functional/tools/sam_to_bam.xml
@@ -1,7 +1,7 @@
 <tool id="sam_to_conversion" name="Test sam to bam conversion">
-    <command>
-        cat '$input1' > '$out_file1'
-    </command>
+    <command><![CDATA[
+cat '$input1' > '$out_file1'
+    ]]></command>
     <inputs>
         <param name="input1" type="data" format="bam" label="Concatenate Dataset"/>
     </inputs>

--- a/test/functional/tools/section.xml
+++ b/test/functional/tools/section.xml
@@ -1,8 +1,8 @@
-<tool id="section" name="section">
-    <command>
-        echo "$int.inttest"   >> $out_file1; 
-        echo "$float.floattest" >> $out_file1; 
-    </command>
+<tool id="section" name="section" version="1.0.0">
+    <command><![CDATA[
+echo $int.inttest > '$out_file1' &&
+echo $float.floattest >> '$out_file1'
+    ]]></command>
     <inputs>
         <section name="int" title="Integer Section" expanded="true">
             <param name="inttest" value="1" type="integer" />

--- a/test/functional/tools/select_from_dataset.xml
+++ b/test/functional/tools/select_from_dataset.xml
@@ -1,39 +1,39 @@
 <tool id="select_from_dataset" name="select_from_dataset" version="0.1.0">
     <description>Create dynamic options from data sets</description>
     <command><![CDATA[
-        echo select_single $select_single > '$output' && 
-        echo select_multiple $select_multiple >> '$output' &&
-        echo select_collection $select_collection >> '$output'
+echo select_single '$select_single' > '$output' && 
+echo select_multiple '$select_multiple' >> '$output' &&
+echo select_collection '$select_collection' >> '$output'
     ]]></command>
 	<inputs>
         <param name="single" type="data" format="tabular" label="single"/>
         <param name="select_single" type="select" label="select_single">
-          <options from_dataset="single">
-              <column name="name" index="0"/>
-              <column name="value" index="0"/>
-              <validator type="no_options" message="No data is available in single" />
-          </options>
+            <options from_dataset="single">
+                <column name="name" index="0"/>
+                <column name="value" index="0"/>
+                <validator type="no_options" message="No data is available in single" />
+            </options>
         </param>
         <param name="multiple" type="data" format="tabular" multiple="true" label="multiple"/>
         <param name="select_multiple" type="select" multiple="true" label="select_multiple">
-          <options from_dataset="multiple">
-              <column name="name" index="0"/>
-              <column name="value" index="0"/>
-            <validator type="no_options" message="No data is available in single" />
-          </options>
+            <options from_dataset="multiple">
+                <column name="name" index="0"/>
+                <column name="value" index="0"/>
+                <validator type="no_options" message="No data is available in single" />
+            </options>
         </param>
 		<param name="collection" type="data_collection" format="tabular" collection_type="list" label="collection"/>
         <param name="select_collection" type="select" multiple="true" label="select_collection">
-          <options from_dataset="collection">
-              <column name="name" index="0"/>
-              <column name="value" index="0"/>
-            <validator type="no_options" message="No data is available in single" />
-          </options>
+            <options from_dataset="collection">
+                <column name="name" index="0"/>
+                <column name="value" index="0"/>
+                <validator type="no_options" message="No data is available in single" />
+            </options>
 		</param>
     </inputs>
 
     <outputs>
-        <data format="txt" name="output" />
+        <data name="output" format="txt" />
     </outputs>
 
     <tests>
@@ -58,7 +58,6 @@
             </output>
         </test>
     </tests>
-
     <help>
     </help>
 </tool>

--- a/test/functional/tools/simple_constructs.xml
+++ b/test/functional/tools/simple_constructs.xml
@@ -1,16 +1,16 @@
 <tool id="simple_constructs" name="simple_constructs" version="1.0.0">
-    <command>
-        echo "$p1.p1val"  >> $out_file1;
-        echo "$booltest"  >> $out_file1;
-        echo "$inttest"   >> $out_file1; 
-        echo "$floattest" >> $out_file1;
-        echo "$radio_select" >> $out_file1;
-        echo "$check_select" >> $out_file1;
-        echo "$drop_select"  >> $out_file1;
-        #if len($files) > 0
-        cat "$files[0].file" >> $out_file1;
-        #end if
-    </command>
+    <command><![CDATA[
+echo '$p1.p1val'  > '$out_file1' &&
+echo $booltest  >> '$out_file1' &&
+echo $inttest   >> '$out_file1' &&
+echo $floattest >> '$out_file1' &&
+echo $radio_select >> '$out_file1' &&
+echo $check_select >> '$out_file1' &&
+echo $drop_select  >> '$out_file1' &&
+#if len($files) > 0
+    cat '$files[0].file' >> '$out_file1'
+#end if
+    ]]></command>
     <inputs>
         <conditional name="p1">
             <param type="boolean" name="p1use" />

--- a/test/functional/tools/special_params.xml
+++ b/test/functional/tools/special_params.xml
@@ -1,36 +1,44 @@
 <tool id="special_params" name="special_params" version="1.0.0">
-  <command>echo $__root_dir__ > out_root_dir;
-    echo $__datatypes_config__ > out_datatypes_config;
-    echo $__admin_users__ > out_admin_users;
-    echo $__user_email__ > out_user_email
-  </command>
-  <inputs>
-    <param name="ignored" type="integer" value="0" />
-  </inputs>
-  <outputs>
-    <data format="txt" name="out_root_dir" from_work_dir="out_root_dir" />
-    <data format="txt" name="out_datatypes_config" from_work_dir="out_datatypes_config" />
-    <data format="txt" name="out_admin_users" from_work_dir="out_admin_users" />
-    <data format="txt" name="out_user_email" from_work_dir="out_user_email" />
-  </outputs>
-  <tests>
-    <test>
-      <output name="out_root_dir">
-        <!-- Is an absolute path. -->
-        <assert_contents><has_line_matching expression="^\/.*$" /></assert_contents>
-      </output>
-      <output name="out_datatypes_config">
-        <!-- Is an absolute path. -->
-        <assert_contents><has_line_matching expression="^\/.*$" /></assert_contents>
-      </output>
-      <output name="out_admin_users">
-        <!-- Has at least on e-mail address. -->
-        <assert_contents><has_text text="@" /></assert_contents>
-      </output>
-      <output name="out_user_email">
-        <!-- Looks like an e-mail address. -->
-        <assert_contents><has_line_matching expression="[^@]+@[^@]+\.[^@]+" /></assert_contents>
-      </output>
-    </test>
-  </tests>
+    <command><![CDATA[
+echo '$__root_dir__' > out_root_dir &&
+echo '$__datatypes_config__' > out_datatypes_config &&
+echo '$__admin_users__' > out_admin_users &&
+echo '$__user_email__' > out_user_email
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="out_root_dir" format="txt" from_work_dir="out_root_dir" />
+        <data name="out_datatypes_config" format="txt" from_work_dir="out_datatypes_config" />
+        <data name="out_admin_users" format="txt" from_work_dir="out_admin_users" />
+        <data name="out_user_email" format="txt" from_work_dir="out_user_email" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="out_root_dir">
+                <!-- Is an absolute path. -->
+                <assert_contents>
+                    <has_line_matching expression="^\/.*$" />
+                </assert_contents>
+            </output>
+            <output name="out_datatypes_config">
+                <!-- Is an absolute path. -->
+                <assert_contents>
+                    <has_line_matching expression="^\/.*$" />
+                </assert_contents>
+            </output>
+            <output name="out_admin_users">
+                <!-- Has at least on e-mail address. -->
+                <assert_contents>
+                    <has_text text="@" />
+                </assert_contents>
+            </output>
+            <output name="out_user_email">
+                <!-- Looks like an e-mail address. -->
+                <assert_contents>
+                    <has_line_matching expression="[^@]+@[^@]+\.[^@]+" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/strict_shell.xml
+++ b/test/functional/tools/strict_shell.xml
@@ -1,9 +1,9 @@
 <tool id="strict_shell" name="strict_shell" version="1.0.0">
-    <command strict="true" detect_errors="exit_code">
-        echo "Hello" > $out_file1
-        ; sh -c "exit $exit_code"
-        ; sh -c "exit 0"
-    </command>
+    <command strict="true" detect_errors="exit_code"><![CDATA[
+echo "Hello" > '$out_file1';
+sh -c 'exit $exit_code';
+sh -c 'exit 0'
+    ]]></command>
     <inputs>
         <param name="exit_code" type="integer" value="0" label="exit code"/>
     </inputs>

--- a/test/functional/tools/strict_shell_default_off.xml
+++ b/test/functional/tools/strict_shell_default_off.xml
@@ -1,9 +1,9 @@
 <tool id="strict_shell_default_off" name="strict_shell_default_off" version="1.0.0">
-    <command detect_errors="exit_code">
-        echo "Hello" > $out_file1
-        ; sh -c "exit $exit_code"
-        ; sh -c "exit 0"
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+echo 'Hello' > '$out_file1'
+; sh -c 'exit $exit_code'
+; sh -c 'exit 0'
+    ]]></command>
     <inputs>
         <param name="exit_code" type="integer" value="0" label="exit code"/>
     </inputs>

--- a/test/functional/tools/strict_shell_profile.xml
+++ b/test/functional/tools/strict_shell_profile.xml
@@ -1,9 +1,9 @@
 <tool id="strict_shell_profile" name="strict_shell_profile" version="1.0.0" profile="20.09">
-    <command detect_errors="exit_code">
-        echo "Hello" > $out_file1
-        ; sh -c "exit $exit_code"
-        ; sh -c "exit 0"
-    </command>
+    <command detect_errors="exit_code"><![CDATA[
+echo 'Hello' > '$out_file1'
+; sh -c 'exit $exit_code'
+; sh -c 'exit 0'
+    ]]></command>
     <inputs>
         <param name="exit_code" type="integer" value="0" label="exit code"/>
     </inputs>

--- a/test/functional/tools/tool_directory.xml
+++ b/test/functional/tools/tool_directory.xml
@@ -1,20 +1,19 @@
-<tool id="tool_directory" name="tool_directory">
-  <command>
-    cp $__tool_directory__/tool_directory.xml output1
-  </command>
-  <inputs>
-    <param type="integer" name="ignored" label="Ignored" value="0" />
-  </inputs>
-  <outputs>
-    <data name="output1" format="xml" from_work_dir="output1" />
-  </outputs>
-  <tests>
-    <test>
-      <output name="output1">
-        <assert_contents>
-          <has_text text="QUINE" />
-        </assert_contents>
-      </output>
-    </test>
-  </tests>
+<tool id="tool_directory" name="tool_directory" version="1.0.0">
+    <command><![CDATA[
+cp '$__tool_directory__/tool_directory.xml' output1
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="output1" format="xml" from_work_dir="output1" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output1">
+                <assert_contents>
+                    <has_text text="QUINE" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_1.xml
+++ b/test/functional/tools/tool_provided_metadata_1.xml
@@ -1,30 +1,28 @@
-<tool id="tool_provided_metadata_1" name="tool_provided_metadata_1">
+<tool id="tool_provided_metadata_1" name="tool_provided_metadata_1" version="1.0.0">
     <!-- Demonstrate setting simple dataset metadata for output datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
-    <command>
-      echo "This is a line of text." > $out1;
-      cp $c1 galaxy.json;
-    </command>
+    <command><![CDATA[
+echo 'This is a line of text.' > '$out1' &&
+cp '$c1' galaxy.json
+    ]]></command>
     <configfiles>
-      <configfile name="c1">{"type": "dataset", "dataset_id": $out1.dataset.dataset.id, "name": "my dynamic name", "ext": "txt", "info": "my dynamic info", "dbkey": "cust1"}</configfile>
+        <configfile name="c1">{"type": "dataset", "dataset_id": $out1.dataset.dataset.id, "name": "my dynamic name", "ext": "txt", "info": "my dynamic info", "dbkey": "cust1"}</configfile>
     </configfiles>
     <inputs>
-        <param name="input1" type="data" label="Input Dataset"/>
     </inputs>
     <outputs>
         <!-- Set format="auto" to read from galaxy.json, use auto_format="true"
              to sniff. -->
         <data name="out1" format="auto" />
     </outputs>
+    <tests>
+        <test>
+            <output name="out1" file="simple_line.txt" ftype="txt">
+                <metadata name="name" value="my dynamic name" />
+                <metadata name="info" value="my dynamic info" />
+                <metadata name="dbkey" value="cust1" />
+            </output>
+        </test>
+    </tests>
     <help>
     </help>
-    <tests>
-      <test>
-        <param name="input1" value="simple_line.txt" />
-        <output name="out1" file="simple_line.txt" ftype="txt">
-          <metadata name="name" value="my dynamic name" />
-          <metadata name="info" value="my dynamic info" />
-          <metadata name="dbkey" value="cust1" />
-        </output>
-      </test>
-    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_10.xml
+++ b/test/functional/tools/tool_provided_metadata_10.xml
@@ -1,38 +1,38 @@
 <tool id="tool_provided_metadata_10" name="tool_provided_metadata_10" profile="17.09" version="1.0.0">
-  <!-- Demonstrate setting datatype defined metadata for discovered datasets via galaxy.json for
-  profile >= 17.09 tools (see tool_provided_metadata_3 for legacy version of this test). -->
-  <command>
-    echo "1" > sample1.report.tsv;
-    cp $c1 galaxy.json;
-  </command>
-  <configfiles>
-      <configfile name="c1">{"sample": {
+    <!-- Demonstrate setting datatype defined metadata for discovered datasets via galaxy.json for
+    profile >= 17.09 tools (see tool_provided_metadata_3 for legacy version of this test). -->
+    <command><![CDATA[
+echo '1' > sample1.report.tsv &&
+cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"sample": {
 "datasets": [
 {"filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19", "metadata": {"data_lines": 10}}
 ]
 }}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <metadata name="name" value="cool name 1" />
-          <metadata name="dbkey" value="hg19" />
-          <metadata name="info" value="cool 1 info" />
-          <metadata name="data_lines" value="10" />
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 1" />
+                    <metadata name="dbkey" value="hg19" />
+                    <metadata name="info" value="cool 1 info" />
+                    <metadata name="data_lines" value="10" />
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_11.xml
+++ b/test/functional/tools/tool_provided_metadata_11.xml
@@ -1,41 +1,45 @@
-<tool id="tool_provided_metadata_11" name="tool_provided_metadata_11">
-  <!-- Demonstrate setting simple dataset metadata for discovered datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
-  <command>
-    mkdir sample1data;
-    echo "1" > sample1.report.tsv;
-    echo "foo line" > sample1data/foo;
-    echo "moo cow bar" > sample1data/bar;
-    cp $c1 galaxy.json;
-  </command>
-  <configfiles>
-      <configfile name="c1">{"type": "new_primary_dataset", "filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19", "extra_files": "sample1data"}
+<tool id="tool_provided_metadata_11" name="tool_provided_metadata_11" version="1.0.0">
+    <!-- Demonstrate setting simple dataset metadata for discovered datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
+    <command><![CDATA[
+mkdir sample1data &&
+echo '1' > sample1.report.tsv &&
+echo 'foo line' > sample1data/foo &&
+echo 'moo cow bar' > sample1data/bar &&
+cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"type": "new_primary_dataset", "filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19", "extra_files": "sample1data"}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <metadata name="name" value="cool name 1" />
-          <metadata name="dbkey" value="hg19" />
-          <metadata name="info" value="cool 1 info" />
-          <extra_files type="file" name="foo">
-            <assert_contents><has_line line="foo line" /></assert_contents>
-          </extra_files>
-          <extra_files type="file" name="bar">
-            <assert_contents><has_line line="moo cow bar" /></assert_contents>
-          </extra_files>
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 1" />
+                    <metadata name="dbkey" value="hg19" />
+                    <metadata name="info" value="cool 1 info" />
+                    <extra_files type="file" name="foo">
+                        <assert_contents>
+                            <has_line line="foo line" />
+                        </assert_contents>
+                    </extra_files>
+                    <extra_files type="file" name="bar">
+                        <assert_contents>
+                            <has_line line="moo cow bar" />
+                        </assert_contents>
+                    </extra_files>
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_12.xml
+++ b/test/functional/tools/tool_provided_metadata_12.xml
@@ -1,45 +1,51 @@
 <tool id="tool_provided_metadata_12" name="tool_provided_metadata_12" profile="17.09" version="1.0.0">
-  <!-- Demonstrate setting extra_files for discovered primary datasets in profile >= 17.09 tools. -->
-  <command>
-    mkdir sample1data;
-    echo "1" > sample1.report.tsv;
-    echo "foo line" > sample1data/foo;
-    echo "moo cow bar" > sample1data/bar;
-    cp $c1 galaxy.json;
-  </command>
-  <configfiles>
-      <configfile name="c1">{"sample": {
+    <!-- Demonstrate setting extra_files for discovered primary datasets in profile >= 17.09 tools. -->
+    <command><![CDATA[
+mkdir sample1data &&
+echo '1' > sample1.report.tsv &&
+echo 'foo line' > sample1data/foo &&
+echo 'moo cow bar' > sample1data/bar &&
+cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"sample": {
 "datasets": [
 {"filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19", "extra_files": "sample1data"}
 ]
 }}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <metadata name="name" value="cool name 1" />
-          <metadata name="dbkey" value="hg19" />
-          <metadata name="info" value="cool 1 info" />
-          <extra_files type="file" name="foo">
-            <assert_contents><has_line line="foo line" /></assert_contents>
-          </extra_files>
-          <extra_files type="file" name="bar">
-            <assert_contents><has_line line="moo cow bar" /></assert_contents>
-          </extra_files>
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+        <param name="input" type="data" />
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" ftype="txt" value="simple_line.txt"/>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 1" />
+                    <metadata name="dbkey" value="hg19" />
+                    <metadata name="info" value="cool 1 info" />
+                    <extra_files type="file" name="foo">
+                        <assert_contents>
+                            <has_line line="foo line" />
+                        </assert_contents>
+                    </extra_files>
+                    <extra_files type="file" name="bar">
+                        <assert_contents>
+                            <has_line line="moo cow bar" />
+                        </assert_contents>
+                    </extra_files>
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_2.xml
+++ b/test/functional/tools/tool_provided_metadata_2.xml
@@ -1,39 +1,41 @@
-<tool id="tool_provided_metadata_2" name="tool_provided_metadata_2">
-  <!-- Demonstrate setting simple dataset metadata for discovered datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
-  <command>
-    echo "1" > sample1.report.tsv;
-    echo "2" > sample2.report.tsv;
-    cp $c1 galaxy.json;
-  </command>
-  <configfiles>
-      <configfile name="c1">{"type": "new_primary_dataset", "filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19"}
+<tool id="tool_provided_metadata_2" name="tool_provided_metadata_2" version="1.0.0">
+    <!-- Demonstrate setting simple dataset metadata for discovered datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
+    <command><![CDATA[
+echo '1' > sample1.report.tsv &&
+echo '2' > sample2.report.tsv &&
+cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"type": "new_primary_dataset", "filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19"}
 {"type": "new_primary_dataset", "filename": "sample2.report.tsv", "name": "cool name 2", "ext": "txt", "info": "cool 2 info", "dbkey": "hg19"}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <metadata name="name" value="cool name 1" />
-          <metadata name="dbkey" value="hg19" />
-          <metadata name="info" value="cool 1 info" />
-        </discovered_dataset>
-        <discovered_dataset designation="sample2" ftype="txt">
-          <assert_contents><has_line line="2" /></assert_contents>
-          <metadata name="name" value="cool name 2" />
-          <metadata name="info" value="cool 2 info" />
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 1" />
+                    <metadata name="dbkey" value="hg19" />
+                    <metadata name="info" value="cool 1 info" />
+                </discovered_dataset>
+                <discovered_dataset designation="sample2" ftype="txt">
+                    <assert_contents>
+                        <has_line line="2" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 2" />
+                    <metadata name="info" value="cool 2 info" />
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_3.xml
+++ b/test/functional/tools/tool_provided_metadata_3.xml
@@ -1,44 +1,46 @@
-<tool id="tool_provided_metadata_3" name="tool_provided_metadata_3">
-  <!-- Demonstrate setting datatype defined metadata for discovered datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
-  <command>
-    echo "1" > sample1.report.tsv;
-    echo "2" > sample2.report.tsv;
-    cp $c1 galaxy.json;
-  </command>
-  <configfiles>
-      <configfile name="c1">{"type": "new_primary_dataset", "filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19", "metadata": {"data_lines": 10, "foo": "bar"}}
+<tool id="tool_provided_metadata_3" name="tool_provided_metadata_3" version="1.0.0">
+    <!-- Demonstrate setting datatype defined metadata for discovered datasets via galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
+    <command><![CDATA[
+echo '1' > sample1.report.tsv &&
+echo '2' > sample2.report.tsv &&
+cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"type": "new_primary_dataset", "filename": "sample1.report.tsv", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19", "metadata": {"data_lines": 10, "foo": "bar"}}
 {"type": "new_primary_dataset", "filename": "sample2.report.tsv", "name": "cool name 2", "ext": "txt", "info": "cool 2 info", "dbkey": "hg19", "metadata": {"data_lines": 20, "foo": "bar"}}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <!-- Datatype defined metadata can be overridden/specified directly.
-          -->
-          <metadata name="data_lines" value="10" />
-          <!-- Non-datatype defined metadata values are ignored by the framework.
-               Uncommenting the following test will break this test.
-          -->
-          <!--
-          <metadata name="foo" value="bar" />
-          -->
-        </discovered_dataset>
-        <discovered_dataset designation="sample2" ftype="txt">
-          <assert_contents><has_line line="2" /></assert_contents>
-          <metadata name="data_lines" value="20" />
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <!-- Datatype defined metadata can be overridden/specified directly.
+                    -->
+                    <metadata name="data_lines" value="10" />
+                    <!-- Non-datatype defined metadata values are ignored by the framework.
+                        Uncommenting the following test will break this test.
+                    -->
+                    <!--
+                    <metadata name="foo" value="bar" />
+                    -->
+                </discovered_dataset>
+                <discovered_dataset designation="sample2" ftype="txt">
+                    <assert_contents>
+                        <has_line line="2" />
+                    </assert_contents>
+                    <metadata name="data_lines" value="20" />
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_4.xml
+++ b/test/functional/tools/tool_provided_metadata_4.xml
@@ -1,31 +1,29 @@
 <tool id="tool_provided_metadata_4" name="tool_provided_metadata_4" version="1.0.0">
     <!-- Demonstrate indexing dataset metadata by dataset basename instead of dataset id in galaxy.json for legacy tools (galaxy.json structure changes for profile >= 17.09 tools). -->
-    <command>
-      echo "This is a line of text." > '$out1';
-      cp $c1 galaxy.json;
-    </command>
+    <command><![CDATA[
+echo 'This is a line of text.' > '$out1' &&
+cp '$c1' galaxy.json
+    ]]></command>
     <configfiles>
-      <configfile name="c1">#import os
+        <configfile name="c1">#import os
 {"type": "dataset", "dataset": "${os.path.basename(str($out1))}", "name": "my dynamic name", "ext": "txt", "info": "my dynamic info", "dbkey": "cust1"}</configfile>
     </configfiles>
     <inputs>
-        <param name="input1" type="data" label="Input Dataset"/>
     </inputs>
     <outputs>
         <!-- Set format="auto" to read from galaxy.json, use auto_format="true"
              to sniff. -->
         <data name="out1" format="auto" />
     </outputs>
+    <tests>
+        <test>
+            <output name="out1" file="simple_line.txt" ftype="txt">
+                <metadata name="name" value="my dynamic name" />
+                <metadata name="info" value="my dynamic info" />
+                <metadata name="dbkey" value="cust1" />
+            </output>
+        </test>
+    </tests>
     <help>
     </help>
-    <tests>
-      <test>
-        <param name="input1" value="simple_line.txt" />
-        <output name="out1" file="simple_line.txt" ftype="txt">
-          <metadata name="name" value="my dynamic name" />
-          <metadata name="info" value="my dynamic info" />
-          <metadata name="dbkey" value="cust1" />
-        </output>
-      </test>
-    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_5.xml
+++ b/test/functional/tools/tool_provided_metadata_5.xml
@@ -1,9 +1,9 @@
 <tool id="tool_provided_metadata_5" name="tool_provided_metadata_5" profile="17.09" version="1.0.0">
     <!-- Demonstrate setting simple output dataset metadata via galaxy.json for profile >= 17.09 tools. -->
-    <command>
-      echo "This is a line of text." > $out1;
-      cp $c1 galaxy.json;
-    </command>
+    <command><![CDATA[
+echo 'This is a line of text.' > '$out1' &&
+cp '$c1' galaxy.json
+    ]]></command>
     <configfiles>
       <configfile name="c1">{"out1": {
   "name": "my dynamic name",
@@ -14,23 +14,21 @@
 </configfile>
     </configfiles>
     <inputs>
-        <param name="input1" type="data" label="Input Dataset"/>
     </inputs>
     <outputs>
         <!-- Set format="auto" to read from galaxy.json, use auto_format="true"
             j to sniff. -->
         <data name="out1" format="auto" />
     </outputs>
+    <tests>
+        <test>
+            <output name="out1" file="simple_line.txt" ftype="txt">
+                <metadata name="name" value="my dynamic name" />
+                <metadata name="info" value="my dynamic info" />
+                <metadata name="dbkey" value="cust1" />
+            </output>
+        </test>
+    </tests>
     <help>
     </help>
-    <tests>
-      <test>
-        <param name="input1" value="simple_line.txt" />
-        <output name="out1" file="simple_line.txt" ftype="txt">
-          <metadata name="name" value="my dynamic name" />
-          <metadata name="info" value="my dynamic info" />
-          <metadata name="dbkey" value="cust1" />
-        </output>
-      </test>
-    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_6.xml
+++ b/test/functional/tools/tool_provided_metadata_6.xml
@@ -1,10 +1,10 @@
 <tool id="tool_provided_metadata_6" name="tool_provided_metadata_6" profile="17.09" version="1.0.0">
-  <!-- Demonstrate setting discovered dataset metadata via galaxy.json for profile >= 17.09 tools. -->
-  <command>
-    echo "1" > sample1.report.tsv;
-    echo "2" > sample2.report.tsv;
-    cp $c1 galaxy.json;
-  </command>
+    <!-- Demonstrate setting discovered dataset metadata via galaxy.json for profile >= 17.09 tools. -->
+    <command><![CDATA[
+echo '1' > sample1.report.tsv &&
+echo '2' > sample2.report.tsv &&
+cp '$c1' galaxy.json
+  ]]></command>
   <configfiles>
       <configfile name="c1">{"sample": {
 "datasets": [
@@ -13,31 +13,33 @@
 ]
 }}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <metadata name="name" value="cool name 1" />
-          <metadata name="dbkey" value="hg19" />
-          <metadata name="info" value="cool 1 info" />
-        </discovered_dataset>
-        <discovered_dataset designation="sample2" ftype="txt">
-          <assert_contents><has_line line="2" /></assert_contents>
-          <metadata name="name" value="cool name 2" />
-          <metadata name="info" value="cool 2 info" />
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.report\.tsv" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 1" />
+                    <metadata name="dbkey" value="hg19" />
+                    <metadata name="info" value="cool 1 info" />
+                </discovered_dataset>
+                <discovered_dataset designation="sample2" ftype="txt">
+                    <assert_contents>
+                        <has_line line="2" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 2" />
+                    <metadata name="info" value="cool 2 info" />
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_7.xml
+++ b/test/functional/tools/tool_provided_metadata_7.xml
@@ -1,43 +1,45 @@
 <tool id="tool_provided_metadata_7" name="tool_provided_metadata_7" profile="17.09" version="1.0.0">
-  <!-- Demonstrate setting discovered dataset metadata via galaxy.json for profile >= 17.09 tools. -->
-  <command>
-    echo "1" > sample1.report.tsv;
-    echo "2" > sample2.report.tsv;
-    cp $c1 galaxy.json;
-  </command>
-  <configfiles>
-      <configfile name="c1">{"sample": {
+    <!-- Demonstrate setting discovered dataset metadata via galaxy.json for profile >= 17.09 tools. -->
+    <command><![CDATA[
+echo '1' > sample1.report.tsv &&
+echo '2' > sample2.report.tsv &&
+cp '$c1' galaxy.json
+    ]]></command>
+    <configfiles>
+        <configfile name="c1">{"sample": {
 "datasets": [
 {"filename": "sample1.report.tsv", "designation": "sample1", "name": "cool name 1", "ext": "txt", "info": "cool 1 info", "dbkey": "hg19"},
 {"filename": "sample2.report.tsv", "designation": "sample2", "name": "cool name 2", "ext": "txt", "info": "cool 2 info", "dbkey": "hg19"}
 ]
 }}
 </configfile>
-  </configfiles>
-  <inputs>
-    <param name="input" type="data" />
-  </inputs>
-  <outputs>
-    <data name="sample">
-      <discover_datasets from_provided_metadata="true" visible="true" />
-    </data>
-  </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
-      <output name="sample">
-        <discovered_dataset designation="sample1" ftype="txt">
-          <assert_contents><has_line line="1" /></assert_contents>
-          <metadata name="name" value="cool name 1" />
-          <metadata name="dbkey" value="hg19" />
-          <metadata name="info" value="cool 1 info" />
-        </discovered_dataset>
-        <discovered_dataset designation="sample2" ftype="txt">
-          <assert_contents><has_line line="2" /></assert_contents>
-          <metadata name="name" value="cool name 2" />
-          <metadata name="info" value="cool 2 info" />
-        </discovered_dataset>
-      </output>
-    </test>
-  </tests>
+    </configfiles>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="sample">
+            <discover_datasets from_provided_metadata="true" visible="true" />
+        </data>
+    </outputs>
+    <tests>
+        <test>
+            <output name="sample">
+                <discovered_dataset designation="sample1" ftype="txt">
+                    <assert_contents>
+                        <has_line line="1" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 1" />
+                    <metadata name="dbkey" value="hg19" />
+                    <metadata name="info" value="cool 1 info" />
+                </discovered_dataset>
+                <discovered_dataset designation="sample2" ftype="txt">
+                    <assert_contents>
+                        <has_line line="2" />
+                    </assert_contents>
+                    <metadata name="name" value="cool name 2" />
+                    <metadata name="info" value="cool 2 info" />
+                </discovered_dataset>
+            </output>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_8.xml
+++ b/test/functional/tools/tool_provided_metadata_8.xml
@@ -1,31 +1,29 @@
 <tool id="tool_provided_metadata_8" name="tool_provided_metadata_8" version="1.0.0" profile="17.09">
     <!-- Demonstrate reverting tools with new profiles to older galaxy.json style
          using provided_metadata_style attribute on outputs. -->
-    <command>
-      echo "This is a line of text." > $out1;
-      cp $c1 galaxy.json;
-    </command>
+    <command><![CDATA[
+echo 'This is a line of text.' > '$out1' &&
+cp '$c1' galaxy.json;
+    ]]></command>
     <configfiles>
-      <configfile name="c1">{"type": "dataset", "dataset_id": $out1.dataset.dataset.id, "name": "my dynamic name", "ext": "txt", "info": "my dynamic info", "dbkey": "cust1"}</configfile>
+        <configfile name="c1">{"type": "dataset", "dataset_id": $out1.dataset.dataset.id, "name": "my dynamic name", "ext": "txt", "info": "my dynamic info", "dbkey": "cust1"}</configfile>
     </configfiles>
     <inputs>
-        <param name="input1" type="data" label="Input Dataset"/>
     </inputs>
     <outputs provided_metadata_style="legacy">
         <!-- Set format="auto" to read from galaxy.json, use auto_format="true"
              to sniff. -->
         <data name="out1" format="auto" />
     </outputs>
+    <tests>
+        <test>
+            <output name="out1" file="simple_line.txt" ftype="txt">
+                <metadata name="name" value="my dynamic name" />
+                <metadata name="info" value="my dynamic info" />
+                <metadata name="dbkey" value="cust1" />
+            </output>
+        </test>
+    </tests>
     <help>
     </help>
-    <tests>
-      <test>
-        <param name="input1" value="simple_line.txt" />
-        <output name="out1" file="simple_line.txt" ftype="txt">
-          <metadata name="name" value="my dynamic name" />
-          <metadata name="info" value="my dynamic info" />
-          <metadata name="dbkey" value="cust1" />
-        </output>
-      </test>
-    </tests>
 </tool>

--- a/test/functional/tools/tool_provided_metadata_9.xml
+++ b/test/functional/tools/tool_provided_metadata_9.xml
@@ -1,12 +1,12 @@
 <tool id="tool_provided_metadata_9" name="tool_provided_metadata_9" profile="17.09" version="1.0.0">
     <!-- Demonstrate overriding the location of the tool provided metadata file to
          be something other than galaxy.json. -->
-    <command>
-      echo "This is a line of text." > $out1;
-      cp $c1 not_galaxy.json;
-    </command>
+    <command><![CDATA[
+echo 'This is a line of text.' > '$out1' &&
+cp '$c1' not_galaxy.json
+    ]]></command>
     <configfiles>
-      <configfile name="c1">{"out1": {
+        <configfile name="c1">{"out1": {
   "name": "my dynamic name",
   "ext": "txt",
   "info": "my dynamic info",
@@ -16,22 +16,20 @@
 </configfile>
     </configfiles>
     <inputs>
-        <param name="input1" type="data" label="Input Dataset"/>
     </inputs>
     <outputs provided_metadata_file="not_galaxy.json">
         <data name="out1" format="auto" />
     </outputs>
+    <tests>
+        <test>
+            <output name="out1" file="simple_line.txt" ftype="txt">
+                <metadata name="name" value="my dynamic name" />
+                <metadata name="info" value="my dynamic info" />
+                <metadata name="dbkey" value="cust1" />
+                <metadata name="created_from_basename" value="my name.txt" />
+            </output>
+        </test>
+    </tests>
     <help>
     </help>
-    <tests>
-      <test>
-        <param name="input1" value="simple_line.txt" />
-        <output name="out1" file="simple_line.txt" ftype="txt">
-          <metadata name="name" value="my dynamic name" />
-          <metadata name="info" value="my dynamic info" />
-          <metadata name="dbkey" value="cust1" />
-          <metadata name="created_from_basename" value="my name.txt" />
-        </output>
-      </test>
-    </tests>
 </tool>

--- a/test/functional/tools/top_level_data.xml
+++ b/test/functional/tools/top_level_data.xml
@@ -1,34 +1,34 @@
 <tool id="top_level_data" name="top_level_data" version="0.1.0">
-  <command>
-    cat '${f1}' >> $out1;
-    echo '${library.f2}' >> $out2; <!-- cannot use just f2 here -->
-  </command>
-  <inputs>
-    <conditional name="library">
-      <param name="type" type="select" label="Parameter Settings">
-        <option value="no">Use defaults</option>
-        <option value="yes">Full parameter list</option>
-      </param>
-      <when value="yes">
-        <param name="f1" type="data" format="txt" label="Data 1" />
-        <param name="f2" type="text" label="Text 1" />
-      </when>
-      <when value="no">
-        <param name="f1" type="data" format="txt" label="Data 1" />
-        <param name="f2" type="text" label="TExt 1" />
-      </when>
-    </conditional>
-  </inputs>
-  <outputs>
-    <data format="txt" name="out1" />
-    <data format="txt" name="out2" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="f1" value="simple_line.txt" />
-      <param name="f2" value="This is a line of text." />
-      <output name="out1" file="simple_line.txt" />
-      <output name="out2" file="simple_line.txt" />
-    </test>
-  </tests>
+    <command><![CDATA[
+cat '${f1}' >> '$out1' &&
+echo '${library.f2}' >> '$out2' ## cannot use just f2 here
+    ]]></command>
+    <inputs>
+        <conditional name="library">
+            <param name="type" type="select" label="Parameter Settings">
+                <option value="no">Use defaults</option>
+                <option value="yes">Full parameter list</option>
+            </param>
+            <when value="yes">
+                <param name="f1" type="data" format="txt" label="Data 1" />
+                <param name="f2" type="text" label="Text 1" />
+            </when>
+            <when value="no">
+                <param name="f1" type="data" format="txt" label="Data 1" />
+                <param name="f2" type="text" label="Text 1" />
+            </when>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="out1" format="txt" />
+        <data name="out2" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="f1" value="simple_line.txt" />
+            <param name="f2" value="This is a line of text." />
+            <output name="out1" file="simple_line.txt" />
+            <output name="out2" file="simple_line.txt" />
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/unicode_stream.xml
+++ b/test/functional/tools/unicode_stream.xml
@@ -1,23 +1,25 @@
 <tool id="unicode_stream" name="unicode_stream" version="0.1.0">
     <description>
     </description>
-    <version_command>echo "\x00"</version_command>
+    <version_command><![CDATA[
+echo "\x00"
+    ]]></version_command>
     <command detect_errors="exit_code"><![CDATA[
 #if $include_null:
-    echo "\x00" > $out_file1;
+    echo "\x00" > '$out_file1' &&
 #end if
-echo '$input1' >> '$out_file1';
-cat '$cf';
-echo "\x00";
->&2 cat '$cf';
-sh -c "exit $exit"
+echo '$input1' >> '$out_file1' &&
+cat '$cf' &&
+echo "\x00" &&
+>&2 cat '$cf' &&
+sh -c 'exit $exit'
     ]]></command>
     <configfiles>
         <configfile name="cf">ვეპხის ტყაოსანი შოთა რუსთაველი</configfile>
     </configfiles>
     <inputs>
         <param name="input1" type="text" label="Input">
-            <sanitizer sanitize="False" />
+            <sanitizer sanitize="false" />
         </param>
         <param name="exit" type="integer" value="0" label="Exit Code" />
         <param name="include_null" type="boolean" label="Include unicode null in output?"/>

--- a/test/functional/tools/validation_default.xml
+++ b/test/functional/tools/validation_default.xml
@@ -1,39 +1,39 @@
 <tool id="validation_default" name="Validation (default)" version="0.1">
-  <command>
-    echo '$input1' > out1;
-    echo $float_param > out2;
-    echo $select_param > out3;
-  </command>
-  <inputs>
-    <param name="input1" type="text" label="text input" />
-    <param name="float_param" type="float" label="float input" value="8.0" />
-    <param name="select_param" type="select" label="select_param">
-      <option value="opt1">Option 1</option>
-      <option value="opt2">Option 2</option>
-    </param>
-  </inputs>
-  <outputs>
-    <data name="out_file1" from_work_dir="out1" />
-    <data name="out_file2" from_work_dir="out2" />
-    <data name="out_file3" from_work_dir="out3" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="input1" value="&quot; ; echo &quot;moo" />
-      <param name="float_param" value="5" />
-      <param name="select_param" value="opt1" />
-      <output name="out_file1">
-         <assert_contents>
-            <has_line line="__dq__ X echo __dq__moo" />
-            <has_line line="__dq__ X echo __dq__moo" n="1" />
-            <has_text text="o" n="3" />
-            <has_n_lines n="1" />
-            <has_size value="24"/>
-            <has_size value="20" delta="5"/>
-         </assert_contents>
-      </output>
-    </test>
-  </tests>
-  <help>
-  </help>
+    <command><![CDATA[
+echo '$input1' > out1 &&
+echo $float_param > out2 &&
+echo $select_param > out3
+    ]]></command>
+    <inputs>
+        <param name="input1" type="text" label="text input" />
+        <param name="float_param" type="float" label="float input" value="8.0" />
+        <param name="select_param" type="select" label="select_param">
+            <option value="opt1">Option 1</option>
+            <option value="opt2">Option 2</option>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" from_work_dir="out1" />
+        <data name="out_file2" from_work_dir="out2" />
+        <data name="out_file3" from_work_dir="out3" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="&quot; ; echo &quot;moo" />
+            <param name="float_param" value="5" />
+            <param name="select_param" value="opt1" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="__dq__ X echo __dq__moo" />
+                    <has_line line="__dq__ X echo __dq__moo" n="1" />
+                    <has_text text="o" n="3" />
+                    <has_n_lines n="1" />
+                    <has_size value="24"/>
+                    <has_size value="20" delta="5"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/validation_empty_dataset.xml
+++ b/test/functional/tools/validation_empty_dataset.xml
@@ -1,17 +1,17 @@
-<tool id="validation_empty_dataset" name="validation_empty_dataset">
-  <command>
-    echo "Hello World" > out1;
-  </command>
-  <inputs>
-    <param name="input1" type="data" label="non-empty input">
-      <validator type="empty_dataset" />
-    </param>
-  </inputs>
-  <outputs>
-    <data name="out_file1" from_work_dir="out1" />
-  </outputs>
-  <tests>
-  </tests>
-  <help>
-  </help>
+<tool id="validation_empty_dataset" name="validation_empty_dataset" version="1.0.0">
+    <command><![CDATA[
+echo 'Hello World' > out1
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" label="non-empty input">
+            <validator type="empty_dataset" />
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" from_work_dir="out1" />
+    </outputs>
+    <tests>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/validation_hdf5.xml
+++ b/test/functional/tools/validation_hdf5.xml
@@ -1,7 +1,7 @@
 <tool id="validation_hdf5" name="Validation (hdf5)" version="1.0">
-    <command>
-        cp '$input' '$output'
-    </command>
+    <command><![CDATA[
+cp '$input' '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" format="cool" />
     </inputs>

--- a/test/functional/tools/validation_metadata_in_range.xml
+++ b/test/functional/tools/validation_metadata_in_range.xml
@@ -1,30 +1,30 @@
 <tool id="validation_metadata_in_range" name="validation_metadata_in_range" profile="19.05" version="0.1">
-  <command>
-    echo "Hello World" > out1;
-  </command>
-  <inputs>
-    <param name="input1" type="data" format="fasta" label="fasta file with more than one sequence">
-      <validator type="dataset_metadata_in_range" metadata_name="sequences" min="2"/>
-    </param>
-  </inputs>
-  <outputs>
-    <data name="out_file1" from_work_dir="out1" format="txt"/>
-  </outputs>
-  <tests>
-    <test expect_failure="true">
-    <!-- fails because 1.fasta has just a single sequence -->
-      <param name="input1" value="1.fasta" ftype="fasta"/>
-    </test>
-    <test expect_failure="false">
-    <!-- works because 4.fasta has more than 1 sequence -->
-      <param name="input1" value="4.fasta" ftype="fasta"/>
-      <output name="out_file1">
-         <assert_contents>
-            <has_line line="Hello World" />
-         </assert_contents>
-      </output>
-    </test>
-  </tests>
-  <help>
-  </help>
+    <command><![CDATA[
+echo 'Hello World' > out1
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" format="fasta" label="fasta file with more than one sequence">
+            <validator type="dataset_metadata_in_range" metadata_name="sequences" min="2"/>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" from_work_dir="out1"/>
+    </outputs>
+    <tests>
+        <test expect_failure="true">
+            <!-- fails because 1.fasta has just a single sequence -->
+            <param name="input1" value="1.fasta" ftype="fasta"/>
+        </test>
+        <test expect_failure="false">
+            <!-- works because 4.fasta has more than 1 sequence -->
+            <param name="input1" value="4.fasta" ftype="fasta"/>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Hello World" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/validation_repeat.xml
+++ b/test/functional/tools/validation_repeat.xml
@@ -1,57 +1,57 @@
-<tool id="validation_repeat" name="Validation (default)">
-  <command>
-    #for $r in $r1
-    echo "${r.text}" >> out1;
-    #end for
-    #for $r in $r2
-    echo "${r.text}" >> out2;
-    #end for
-  </command>
-  <inputs>
-    <repeat name="r1" title="Repeat 1">
-      <param name="text" type="text" label="text input" />
-    </repeat>
-    <repeat name="r2" title="Repeat 2">
-      <param name="text" type="text" label="text input">
-        <validator type="empty_field" />
-        <sanitizer>
-          <valid initial="none">
-            <add value="a"/>
-            <add value="b"/>
-            <add value="d"/>
-            <add value="e"/>
-          </valid>
-          <mapping initial="none">
-            <add source="@" target="c"/>
-          </mapping>
-        </sanitizer>
-      </param>
-    </repeat>
-  </inputs>
-  <outputs>
-    <data name="out_file1" from_work_dir="out1" />
-    <data name="out_file2" from_work_dir="out2" />
-  </outputs>
-  <tests>
-    <test>
-      <repeat name="r1">
-        <param name="text" value="&quot; ; echo &quot;moo" />
-      </repeat>
-      <repeat name="r2">
-        <param name="text" value="ab@de" />
-      </repeat>
-      <output name="out_file1">
-         <assert_contents>
-            <has_line line="__dq__ X echo __dq__moo" />
-         </assert_contents>
-      </output>
-      <output name="out_file2">
-         <assert_contents>
-            <has_line line="abcde" />
-         </assert_contents>
-      </output>
-    </test>
-  </tests>
-  <help>
-  </help>
+<tool id="validation_repeat" name="Validation (default)" version="1.0.0">
+    <command><![CDATA[
+#for $r in $r1
+    echo '${r.text}' >> out1;
+#end for
+#for $r in $r2
+    echo '${r.text}' >> out2;
+#end for
+    ]]></command>
+    <inputs>
+        <repeat name="r1" title="Repeat 1">
+            <param name="text" type="text" label="text input" />
+        </repeat>
+        <repeat name="r2" title="Repeat 2">
+            <param name="text" type="text" label="text input">
+                <validator type="empty_field" />
+                <sanitizer>
+                    <valid initial="none">
+                        <add value="a"/>
+                        <add value="b"/>
+                        <add value="d"/>
+                        <add value="e"/>
+                    </valid>
+                    <mapping initial="none">
+                        <add source="@" target="c"/>
+                    </mapping>
+                </sanitizer>
+            </param>
+        </repeat>
+    </inputs>
+    <outputs>
+        <data name="out_file1" from_work_dir="out1" />
+        <data name="out_file2" from_work_dir="out2" />
+    </outputs>
+    <tests>
+        <test>
+            <repeat name="r1">
+                <param name="text" value="&quot; ; echo &quot;moo" />
+            </repeat>
+            <repeat name="r2">
+                <param name="text" value="ab@de" />
+            </repeat>
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="__dq__ X echo __dq__moo" />
+                </assert_contents>
+            </output>
+            <output name="out_file2">
+                <assert_contents>
+                    <has_line line="abcde" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/validation_sanitizer.xml
+++ b/test/functional/tools/validation_sanitizer.xml
@@ -1,35 +1,35 @@
-<tool id="validation_sanitizer" name="Validation (simple sanitizer)">
-  <command>
-    echo "${text}" >> out1;
-  </command>
-  <inputs>
-    <param name="text" type="text" label="text input">
-      <sanitizer>
-        <valid initial="none">
-          <add value="a"/>
-          <add value="b"/>
-          <add value="d"/>
-          <add value="e"/>
-        </valid>
-        <mapping initial="none">
-          <add source="@" target="c"/>
-        </mapping>
-      </sanitizer>
-    </param>
-  </inputs>
-  <outputs>
-    <data name="out_file1" from_work_dir="out1" />
-  </outputs>
-  <tests>
-    <test>
-      <param name="text" value="ab@de" />
-      <output name="out_file1">
-         <assert_contents>
-            <has_line line="abcde" />
-         </assert_contents>
-      </output>
-    </test>
-  </tests>
-  <help>
-  </help>
+<tool id="validation_sanitizer" name="Validation (simple sanitizer)" version="1.0.0">
+    <command><![CDATA[
+echo '${text}' >> out1
+    ]]></command>
+    <inputs>
+        <param name="text" type="text" label="text input">
+            <sanitizer>
+                <valid initial="none">
+                    <add value="a"/>
+                    <add value="b"/>
+                    <add value="d"/>
+                    <add value="e"/>
+                </valid>
+                <mapping initial="none">
+                    <add source="@" target="c"/>
+                </mapping>
+            </sanitizer>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="out_file1" from_work_dir="out1" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="text" value="ab@de" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="abcde" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
 </tool>

--- a/test/functional/tools/validation_tar.xml
+++ b/test/functional/tools/validation_tar.xml
@@ -1,7 +1,7 @@
 <tool id="validation_tar" name="Validation (tar)" version="1.0">
-    <command>
-        cat '$input' > '$output'
-    </command>
+    <command><![CDATA[
+cat '$input' > '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" />
     </inputs>

--- a/test/functional/tools/validation_tar_gz.xml
+++ b/test/functional/tools/validation_tar_gz.xml
@@ -1,7 +1,7 @@
 <tool id="validation_tar_gz" name="Validation (tar.gz)" version="1.0">
-    <command>
-        cat '$input' > '$output'
-    </command>
+    <command><![CDATA[
+cat '$input' > '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" />
     </inputs>

--- a/test/functional/tools/validation_zip.xml
+++ b/test/functional/tools/validation_zip.xml
@@ -1,7 +1,7 @@
 <tool id="validation_zip" name="Validation (zip)" version="1.0">
-    <command>
-        cat '$input' > '$output'
-    </command>
+    <command><![CDATA[
+cat '$input' > '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" format="zip" />
     </inputs>

--- a/test/functional/tools/vcf_bgzip.xml
+++ b/test/functional/tools/vcf_bgzip.xml
@@ -1,18 +1,18 @@
 <tool id="vcf_bgzip_test" name="vcf_bgzip_test" version="0.1.0">
     <command detect_errors="exit_code"><![CDATA[
-      stat '$input.metadata.tabix_index' &&
-      cp '$input' '$output'
+stat '$input.metadata.tabix_index' &&
+cp '$input' '$output'
     ]]></command>
     <inputs>
-        <param name="input" format="vcf_bgzip" type="data" label="Source file"/>
+        <param name="input" type="data" format="vcf_bgzip" label="Source file"/>
     </inputs>
     <outputs>
-        <data format="vcf_bgzip" name="output" />
+        <data name="output" format="vcf_bgzip" />
     </outputs>
-  <tests>
-    <test>
-      <param name="input" ftype="vcf_bgzip" value="test.vcf.gz"/>
-      <output name="output" value="test.vcf.gz" md5="b08896c2d3ed4254e90b9372ef772821"/>
-    </test>
-  </tests>
+    <tests>
+        <test>
+            <param name="input" ftype="vcf_bgzip" value="test.vcf.gz"/>
+            <output name="output" value="test.vcf.gz" md5="b08896c2d3ed4254e90b9372ef772821"/>
+        </test>
+    </tests>
 </tool>

--- a/test/functional/tools/version_command_interpreter.xml
+++ b/test/functional/tools/version_command_interpreter.xml
@@ -1,10 +1,10 @@
 <tool id="version_command_interpreter" name="version_command_interpreter" version="1.0.0">
-    <version_command interpreter="python">
-        version_command.py
-    </version_command>
-    <command>
-        cp $input $output
-    </command>
+    <version_command interpreter="python"><![CDATA[
+version_command.py
+    ]]></version_command>
+    <command><![CDATA[
+cp '$input' '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" format="txt" />
     </inputs>

--- a/test/functional/tools/version_command_plain.xml
+++ b/test/functional/tools/version_command_plain.xml
@@ -1,10 +1,10 @@
 <tool id="version_command_plain" name="version_command_plain" version="1.0.0">
-    <version_command>
-        echo "4.0.0"
-    </version_command>
-    <command>
-        cp $input $output
-    </command>
+    <version_command><![CDATA[
+echo "4.0.0"
+    ]]></version_command>
+    <command><![CDATA[
+cp '$input' '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" format="txt" />
     </inputs>

--- a/test/functional/tools/version_command_tool_dir.xml
+++ b/test/functional/tools/version_command_tool_dir.xml
@@ -1,10 +1,10 @@
 <tool id="version_command_tool_dir" name="version_command_tool_dir" version="1.0.0">
-    <version_command>
-        python $__tool_directory__/version_command.py
-    </version_command>
-    <command>
-        cp $input $output
-    </command>
+    <version_command><![CDATA[
+python '$__tool_directory__/version_command.py'
+    ]]></version_command>
+    <command><![CDATA[
+cp '$input' '$output'
+    ]]></command>
     <inputs>
         <param name="input" type="data" format="txt" />
     </inputs>


### PR DESCRIPTION
Test tool linting (not all of them yet):
- added CDATA to command and help
- single-quote variables for text and dataset params and outputs in Cheetah
- add tool version
- XML element and attribute order per IUC standard
- fixed indentation

Also:
- Fix API tests failing when usegalaxy.org is down