### PR TITLE
WIP: moving to alembic

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1235,8 +1235,8 @@ class ConfiguresGalaxyMixin:
         if check_migrate_databases:
             # Initialize database / check for appropriate schema version.  # If this
             # is a new installation, we'll restrict the tool migration messaging.
-            from galaxy.model.migrate.check import create_or_verify_database
-            create_or_verify_database(db_url, config_file, self.config.database_engine_options, app=self, map_install_models=combined_install_database)
+            from galaxy.model.migrations import run
+            run(db_url, mapping.metadata, self.config.database_engine_options, app=self, map_install_models=combined_install_database)
             if not combined_install_database:
                 tsi_create_or_verify_database(install_db_url, install_database_options, app=self)
 

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -1,9 +1,10 @@
 --extra-index-url https://wheels.galaxyproject.org/simple
 
-adal==1.2.5
+adal==1.2.6
 aiofiles==0.6.0
 alabaster==0.7.12; python_version >= "3.5"
-amqp==5.0.3; python_version >= "3.6"
+alembic==1.5.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+amqp==5.0.5; python_version >= "3.6"
 appdirs==1.4.4; python_version >= "3.6"
 argcomplete==1.12.2; python_version >= "3.6" and python_version < "4"
 async-exit-stack==1.0.1; python_version >= "3.6" and python_version < "3.7"
@@ -12,34 +13,35 @@ atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" a
 attmap==0.12.11
 attrs==20.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 babel==2.9.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-bagit==1.7.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.4.0" and python_version < "4" and python_version >= "3.6"
+bagit-profile==1.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
+bagit==1.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 bcrypt==3.2.0; python_version >= "3.6"
-bdbag==1.5.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0" and python_version < "4")
+bdbag==1.6.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
 beaker==1.11.0
-bioblend==0.14.0; python_version >= "3.5"
-bleach==3.2.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+bioblend==0.15.0; python_version >= "3.6"
+bleach==3.3.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 boltons==20.2.1
-boto3==1.16.57
+boto3==1.16.63
 boto==2.49.0
-botocore==1.19.57
+botocore==1.19.63
 bx-python==0.8.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 cachecontrol==0.11.7; python_version >= "3.6" and python_version < "4"
 cached-property==1.5.2; python_version < "3.8" and python_version >= "3.6"
-cachetools==4.2.0; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+cachetools==4.2.1; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 certifi==2020.12.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-cffi==1.14.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+cffi==1.14.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 chardet==4.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 cheetah3==3.2.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 click==7.1.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-cliff==3.6.0; python_version >= "3.6"
+cliff==3.7.0; python_version >= "3.6"
 cloudauthz==0.6.0
 cloudbridge==2.1.0
-cmd2==1.4.0; python_version >= "3.6"
+cmd2==1.5.0; python_version >= "3.6"
 colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 coloredlogs==15.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0"
 commonmark==0.9.1
-coverage==5.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-cryptography==3.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+coverage==5.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
+cryptography==3.4.6; python_version >= "3.6"
 cwltool==3.0.20201109103151; python_version >= "3.6" and python_version < "4"
 dataclasses==0.8; python_version >= "3.6" and python_version < "3.7"
 debtcollector==2.2.0; python_version >= "3.6"
@@ -50,7 +52,7 @@ deprecation==2.1.0
 dictobj==0.4
 docopt==0.6.2
 docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-dogpile.cache==1.1.1; python_version >= "3.6"
+dogpile.cache==1.1.2; python_version >= "3.6"
 ecdsa==0.14.1; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 fabric3==1.14.post1
 fastapi-utils==0.2.1; python_version >= "3.6" and python_version < "4.0"
@@ -58,16 +60,16 @@ fastapi==0.63.0; python_version >= "3.6"
 funcsigs==1.0.2
 future==0.18.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 galaxy-sequence-utils==1.1.5
-google-api-core==1.25.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+google-api-core==1.26.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 google-api-python-client==1.12.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth-httplib2==0.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-google-auth==1.24.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+google-auth==1.27.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 googleapis-common-protos==1.52.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 gunicorn==20.0.4; python_version >= "3.4"
 gxformat2==0.15.0
 h11==0.12.0; python_version >= "3.6"
 h5py==3.1.0; python_version >= "3.6"
-httplib2==0.18.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+httplib2==0.19.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 humanfriendly==9.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0"
 idna==2.10; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 imagesize==1.2.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
@@ -75,9 +77,9 @@ importlib-metadata==3.4.0; python_version < "3.8" and python_version >= "3.6" an
 importlib-resources==5.1.0; python_version < "3.7" and python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 isa-rwval==0.10.9
-iso8601==0.1.13; python_version >= "3.6"
+iso8601==0.1.14; python_version >= "3.6"
 isodate==0.6.0; python_version >= "3.6" and python_version < "4"
-jinja2==2.11.2; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
+jinja2==2.11.3; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"
 jmespath==0.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 jsonpatch==1.28; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 jsonpointer==2.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
@@ -86,10 +88,10 @@ kombu==5.0.2; python_version >= "3.6"
 lockfile==0.12.2; python_version >= "3.6" and python_version < "4"
 lxml==4.6.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 mako==1.1.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-markdown==3.3.3; python_version >= "3.6"
 markdown-it-reporter==0.0.2
+markdown==3.3.3; python_version >= "3.6"
 markupsafe==1.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-mercurial==5.6.1
+mercurial==5.7
 mirakuru==2.3.0; python_version >= "3.6"
 mistune==0.8.4; python_version >= "3.6" and python_version < "4"
 msgpack==1.0.2; python_version >= "3.6"
@@ -112,15 +114,14 @@ oslo.config==8.4.0; python_version >= "3.6"
 oslo.context==3.1.1; python_version >= "3.6"
 oslo.i18n==5.0.1; python_version >= "3.6"
 oslo.log==4.4.0; python_version >= "3.6"
-oslo.serialization==4.0.1; python_version >= "3.6"
-oslo.utils==4.7.0; python_version >= "3.6"
+oslo.serialization==4.1.0; python_version >= "3.6"
+oslo.utils==4.8.0; python_version >= "3.6"
 oyaml==1.0
-packaging==20.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+packaging==20.9; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 paramiko==2.7.2
 parsley==1.3
 paste==3.5.0
 pastedeploy==2.1.1
-pastescript==3.2.0
 pbr==5.5.1; python_version >= "3.6"
 pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 port-for==0.4; python_version >= "3.6"
@@ -133,39 +134,41 @@ py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_
 pyasn1-modules==0.2.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyasn1==0.4.8; python_version >= "3.5" and python_version < "4"
 pycparser==2.20; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-pycryptodome==3.9.9; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+pycryptodome==3.10.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pydantic==1.7.3; python_version >= "3.6" and python_version < "4.0"
-pydot==1.4.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.4.0"
+pydot==1.4.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.4.0"
 pyeventsystem==0.1.0
 pyfaidx==0.5.9.2
 pygithub==1.54.1; python_version >= "3.6"
-pygments==2.7.4; python_version >= "3.5"
+pygments==2.8.0; python_version >= "3.5"
 pyinotify==0.9.6; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "sunos5" and python_version >= "3.6"
 pyjwt==1.7.1; python_version >= "3.6"
 pykwalify==1.8.0
 pynacl==1.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 pyparsing==2.4.7; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 pyperclip==1.8.1; python_version >= "3.6"
-pyreadline==2.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" and sys_platform == "win32" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0" and sys_platform == "win32"
+pyreadline3==3.3; sys_platform == "win32" and python_version >= "3.8"
+pyreadline==2.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" and sys_platform == "win32" or python_version >= "3.6" and python_version < "3.8" and python_full_version >= "3.5.0" and sys_platform == "win32"
 pysam==0.16.0.1
 pytest-cov==2.11.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pytest-html==3.1.1; python_version >= "3.6"
+pytest-json-report==1.2.4
 pytest-metadata==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pytest-mock==3.5.1; python_version >= "3.5"
-pytest-postgresql==2.5.2; python_version >= "3.6"
+pytest-postgresql==2.6.0; python_version >= "3.6"
 pytest-pythonpath==0.7.3
 pytest-shard==0.1.2; python_version >= "3.6"
-pytest==6.2.1; python_version >= "3.6"
-python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.3.0"
-python-irodsclient==0.8.5
-pytest-json-report==1.2.1
+pytest==6.2.2; python_version >= "3.6"
+python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.6.0"
+python-editor==1.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+python-irodsclient==0.8.6
 python-jose==3.2.0
 python-keystoneclient==4.1.1; python_version >= "3.6"
 python-neutronclient==7.2.1; python_version >= "3.6"
 python-novaclient==17.2.1; python_version >= "3.6"
 python-swiftclient==3.10.1
 python3-openid==3.2.0; python_version >= "3.0"
-pytz==2020.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
+pytz==2021.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 pyuwsgi==2.0.19.1.post0
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 rdflib-jsonld==0.5.0; python_version >= "3.6" and python_version < "4"
@@ -174,17 +177,17 @@ recommonmark==0.7.1
 refgenconf==0.9.3
 repoze.lru==0.7
 requests-oauthlib==1.3.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-requests-toolbelt==0.9.1; python_version >= "3.5"
+requests-toolbelt==0.9.1; python_version >= "3.6"
 requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 requestsexceptions==1.4.0; python_version >= "3.6"
 responses==0.12.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 rfc3986==1.4.0; python_version >= "3.6"
 routes==2.5.1
-rsa==4.7; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
+rsa==4.7.1; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.8" and python_version >= "3.6"
 ruamel.yaml==0.16.5; python_version >= "3.6" and python_version < "4"
 s3transfer==0.3.4
-schema-salad==7.0.20201119201711; python_version >= "3.6" and python_version < "4"
+schema-salad==7.0.20210124093443; python_version >= "3.6" and python_version < "4"
 selenium==3.141.0
 setuptools-scm==5.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 shellescape==3.4.1; python_version >= "3.6" and python_version < "4"
@@ -195,7 +198,7 @@ social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sphinx-markdown-tables==0.0.15
 sphinx-rtd-theme==0.5.1
-sphinx==3.4.3; python_version >= "3.5"
+sphinx==3.5.1; python_version >= "3.5"
 sphinxcontrib-applehelp==1.0.2; python_version >= "3.5"
 sphinxcontrib-devhelp==1.0.2; python_version >= "3.5"
 sphinxcontrib-htmlhelp==1.0.3; python_version >= "3.5"
@@ -204,27 +207,28 @@ sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
 sqlalchemy-utils==0.36.7
-sqlalchemy==1.3.22; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+sqlalchemy==1.3.23; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette==0.13.6; python_version >= "3.6" and python_version < "4.0"
+statsd==3.3.0
 stevedore==3.3.0; python_version >= "3.6"
 svgwrite==1.4.1; python_version >= "3.6"
 tempita==0.5.2
 tenacity==6.3.1
 testfixtures==6.17.1
 toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-tqdm==4.56.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-twill==2.0.1
+tqdm==4.56.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+twill==2.0.2
 typing-extensions==3.7.4.3; python_version >= "3.6" and python_version < "3.8"
-tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version < "4"
+tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 ubiquerg==0.6.1
-unidecode==1.1.2; python_version >= "3.0" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.0"
+unidecode==1.2.0; python_version >= "3.0" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.0"
 uritemplate==3.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-urllib3==1.26.2; python_version >= "2.7" and python_full_version < "3.0.0" and python_version != "3.4" or python_full_version >= "3.5.0" and python_version < "4" and python_version != "3.4"
+urllib3==1.26.3; python_version >= "2.7" and python_full_version < "3.0.0" and python_version != "3.4" or python_full_version >= "3.5.0" and python_version < "4" and python_version != "3.4"
 uvicorn==0.13.3
 vine==5.0.0; python_version >= "3.6"
-watchdog==1.0.2; python_version >= "3.6"
+watchdog==2.0.1; python_version >= "3.6"
 wcwidth==0.2.5; python_version >= "3.6"
 webencodings==0.5.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 webob==1.8.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")

--- a/lib/galaxy/dependencies/pinned-lint-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-lint-requirements.txt
@@ -3,7 +3,7 @@ flake8==3.8.4
 flake8-bugbear==20.11.1
 flake8-import-order==0.18.1
 mccabe==0.6.1
-mypy==0.790
+mypy==0.800
 mypy-extensions==0.4.3
 pycodestyle==2.6.0
 pyflakes==2.2.0

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -1,8 +1,9 @@
 --extra-index-url https://wheels.galaxyproject.org/simple
 
-adal==1.2.5
+adal==1.2.6
 aiofiles==0.6.0
-amqp==5.0.3; python_version >= "3.6"
+alembic==1.5.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+amqp==5.0.5; python_version >= "3.6"
 appdirs==1.4.4; python_version >= "3.6"
 argcomplete==1.12.2; python_version >= "3.6" and python_version < "4"
 async-exit-stack==1.0.1; python_version >= "3.6" and python_version < "3.7"
@@ -10,32 +11,33 @@ async-generator==1.10; python_version >= "3.6" and python_version < "3.7"
 attmap==0.12.11
 attrs==20.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 babel==2.9.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-bagit==1.7.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.4.0" and python_version < "4" and python_version >= "3.6"
+bagit-profile==1.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
+bagit==1.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 bcrypt==3.2.0; python_version >= "3.6"
-bdbag==1.5.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0" and python_version < "4")
+bdbag==1.6.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
 beaker==1.11.0
-bioblend==0.14.0; python_version >= "3.5"
-bleach==3.2.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+bioblend==0.15.0; python_version >= "3.6"
+bleach==3.3.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 boltons==20.2.1
-boto3==1.16.57
+boto3==1.16.63
 boto==2.49.0
-botocore==1.19.57
+botocore==1.19.63
 bx-python==0.8.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 cachecontrol==0.11.7; python_version >= "3.6" and python_version < "4"
 cached-property==1.5.2; python_version < "3.8" and python_version >= "3.6"
-cachetools==4.2.0; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+cachetools==4.2.1; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 certifi==2020.12.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-cffi==1.14.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+cffi==1.14.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 chardet==4.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 cheetah3==3.2.6; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 click==7.1.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
-cliff==3.6.0; python_version >= "3.6"
+cliff==3.7.0; python_version >= "3.6"
 cloudauthz==0.6.0
 cloudbridge==2.1.0
-cmd2==1.4.0; python_version >= "3.6"
+cmd2==1.5.0; python_version >= "3.6"
 colorama==0.4.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 coloredlogs==15.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0"
-cryptography==3.3.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+cryptography==3.4.6; python_version >= "3.6"
 cwltool==3.0.20201109103151; python_version >= "3.6" and python_version < "4"
 dataclasses==0.8; python_version >= "3.6" and python_version < "3.7"
 debtcollector==2.2.0; python_version >= "3.6"
@@ -45,7 +47,7 @@ deprecation==2.1.0
 dictobj==0.4
 docopt==0.6.2
 docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
-dogpile.cache==1.1.1; python_version >= "3.6"
+dogpile.cache==1.1.2; python_version >= "3.6"
 ecdsa==0.14.1; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 fabric3==1.14.post1
 fastapi-utils==0.2.1; python_version >= "3.6" and python_version < "4.0"
@@ -53,21 +55,21 @@ fastapi==0.63.0; python_version >= "3.6"
 funcsigs==1.0.2
 future==0.18.2; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 galaxy-sequence-utils==1.1.5
-google-api-core==1.25.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+google-api-core==1.26.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 google-api-python-client==1.12.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth-httplib2==0.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-google-auth==1.24.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+google-auth==1.27.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 googleapis-common-protos==1.52.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 gxformat2==0.15.0
 h11==0.12.0; python_version >= "3.6"
 h5py==3.1.0; python_version >= "3.6"
-httplib2==0.18.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+httplib2==0.19.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 humanfriendly==9.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0"
 idna==2.10; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 importlib-metadata==3.4.0; python_version < "3.8" and python_version >= "3.6" and (python_version == "3.6" or python_version == "3.7")
 importlib-resources==5.1.0; python_version < "3.7" and python_version >= "3.6"
 isa-rwval==0.10.9
-iso8601==0.1.13; python_version >= "3.6"
+iso8601==0.1.14; python_version >= "3.6"
 isodate==0.6.0; python_version >= "3.6" and python_version < "4"
 jmespath==0.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 jsonpatch==1.28; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
@@ -79,7 +81,7 @@ lxml==4.6.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (pyt
 mako==1.1.4; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 markdown==3.3.3; python_version >= "3.6"
 markupsafe==1.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-mercurial==5.6.1
+mercurial==5.7
 mistune==0.8.4; python_version >= "3.6" and python_version < "4"
 msgpack==1.0.2; python_version >= "3.6"
 munch==2.5.0; python_version >= "3.6"
@@ -100,15 +102,14 @@ oslo.config==8.4.0; python_version >= "3.6"
 oslo.context==3.1.1; python_version >= "3.6"
 oslo.i18n==5.0.1; python_version >= "3.6"
 oslo.log==4.4.0; python_version >= "3.6"
-oslo.serialization==4.0.1; python_version >= "3.6"
-oslo.utils==4.7.0; python_version >= "3.6"
+oslo.serialization==4.1.0; python_version >= "3.6"
+oslo.utils==4.8.0; python_version >= "3.6"
 oyaml==1.0
-packaging==20.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+packaging==20.9; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 paramiko==2.7.2
 parsley==1.3
 paste==3.5.0
 pastedeploy==2.1.1
-pastescript==3.2.0
 pbr==5.5.1; python_version >= "3.6"
 prettytable==0.7.2; python_version >= "3.6"
 protobuf==3.14.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
@@ -118,9 +119,9 @@ pulsar-galaxy-lib==0.14.2
 pyasn1-modules==0.2.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyasn1==0.4.8; python_version >= "3.5" and python_version < "4"
 pycparser==2.20; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
-pycryptodome==3.9.9; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+pycryptodome==3.10.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pydantic==1.7.3; python_version >= "3.6" and python_version < "4.0"
-pydot==1.4.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.4.0"
+pydot==1.4.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.4.0"
 pyeventsystem==0.1.0
 pyfaidx==0.5.9.2
 pyinotify==0.9.6; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "sunos5" and python_version >= "3.6"
@@ -129,16 +130,18 @@ pykwalify==1.8.0
 pynacl==1.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 pyparsing==2.4.7; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 pyperclip==1.8.1; python_version >= "3.6"
-pyreadline==2.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" and sys_platform == "win32" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0" and sys_platform == "win32"
+pyreadline3==3.3; sys_platform == "win32" and python_version >= "3.8"
+pyreadline==2.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" and sys_platform == "win32" or python_version >= "3.6" and python_version < "3.8" and python_full_version >= "3.5.0" and sys_platform == "win32"
 pysam==0.16.0.1
-python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.3.0"
+python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.6.0"
+python-editor==1.0.4; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 python-jose==3.2.0
 python-keystoneclient==4.1.1; python_version >= "3.6"
 python-neutronclient==7.2.1; python_version >= "3.6"
 python-novaclient==17.2.1; python_version >= "3.6"
 python-swiftclient==3.10.1
 python3-openid==3.2.0; python_version >= "3.0"
-pytz==2020.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
+pytz==2021.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 pyuwsgi==2.0.19.1.post0
 pyyaml==5.4.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 rdflib-jsonld==0.5.0; python_version >= "3.6" and python_version < "4"
@@ -146,16 +149,16 @@ rdflib==4.2.2; python_version >= "3.6" and python_version < "4"
 refgenconf==0.9.3
 repoze.lru==0.7
 requests-oauthlib==1.3.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-requests-toolbelt==0.9.1; python_version >= "3.5"
+requests-toolbelt==0.9.1; python_version >= "3.6"
 requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 requestsexceptions==1.4.0; python_version >= "3.6"
 rfc3986==1.4.0; python_version >= "3.6"
 routes==2.5.1
-rsa==4.7; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
+rsa==4.7.1; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.8" and python_version >= "3.6"
 ruamel.yaml==0.16.5; python_version >= "3.6" and python_version < "4"
 s3transfer==0.3.4
-schema-salad==7.0.20201119201711; python_version >= "3.6" and python_version < "4"
+schema-salad==7.0.20210124093443; python_version >= "3.6" and python_version < "4"
 setuptools-scm==5.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 shellescape==3.4.1; python_version >= "3.6" and python_version < "4"
 simplejson==3.17.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
@@ -164,7 +167,7 @@ social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
 sqlalchemy-utils==0.36.7
-sqlalchemy==1.3.22; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+sqlalchemy==1.3.23; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette==0.13.6; python_version >= "3.6" and python_version < "4.0"
@@ -172,13 +175,13 @@ stevedore==3.3.0; python_version >= "3.6"
 svgwrite==1.4.1; python_version >= "3.6"
 tempita==0.5.2
 tenacity==6.3.1
-tqdm==4.56.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+tqdm==4.56.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 typing-extensions==3.7.4.3; python_version >= "3.6" and python_version < "3.8"
-tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version < "4"
+tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 ubiquerg==0.6.1
-unidecode==1.1.2; python_version >= "3.0" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.0"
+unidecode==1.2.0; python_version >= "3.0" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.0"
 uritemplate==3.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-urllib3==1.26.2; python_version >= "2.7" and python_full_version < "3.0.0" and python_version != "3.4" or python_full_version >= "3.5.0" and python_version < "4" and python_version != "3.4"
+urllib3==1.26.3; python_version >= "2.7" and python_full_version < "3.0.0" and python_version != "3.4" or python_full_version >= "3.5.0" and python_version < "4" and python_version != "3.4"
 uvicorn==0.13.3
 vine==5.0.0; python_version >= "3.6"
 wcwidth==0.2.5; python_version >= "3.6"

--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -15,7 +15,7 @@ pip install --upgrade pip setuptools poetry
 if [ $# -gt 0 ]; then
     poetry add --lock "$@"
 else
-    poetry update -vv --lock
+    poetry update -v --lock
 fi
 poetry export -f requirements.txt --without-hashes --output "$THIS_DIRECTORY/pinned-requirements.txt"
 poetry export --dev -f requirements.txt --without-hashes --output "$THIS_DIRECTORY/dev-requirements.txt"

--- a/lib/galaxy/model/migrations/__init__.py
+++ b/lib/galaxy/model/migrations/__init__.py
@@ -1,0 +1,253 @@
+import logging
+import os
+
+from alembic import command
+from alembic.config import Config
+from alembic.migration import MigrationContext
+from alembic.script import ScriptDirectory
+
+from sqlalchemy import MetaData, Unicode
+
+from sqlalchemy.types import TypeDecorator
+
+from sqlalchemy_utils import (
+    create_database,
+    database_exists,
+)
+
+from galaxy.model.orm.engine_factory import build_engine
+
+
+log = logging.getLogger(__name__)
+
+
+ALEMBIC_TABLE = 'alembic_version'
+MIGRATE_TABLE = 'migrate_version'
+# sqlite does not work with 'default', 'key', 'unique', 'index', 'onupdate' column attributes
+COLUMN_ATTRIBUTES_TO_VERIFY = ('name', 'primary_key', 'nullable')
+TYPE_ATTRIBUTES_TO_VERIFY = ('length', 'precision', 'scale')
+ALEMBIC_CONFIG_FILE = 'alembic.ini'
+ALEMBIC_DIR = 'lib/galaxy/model/migrations/alembic'
+
+
+def run(url, metadata, alembic_dir=None, engine_options=None, app=None,
+        map_install_models=False, auto_migrate=False):
+    """Handles the logic of verifying and modifying the database."""
+
+    # Case 1: no database.
+    if not database_exists(url):
+        create_galaxy_database(url, app)
+
+    # prevent redundant call to model.mapping.init()
+    ts_metadata = None
+    if map_install_models:
+        from galaxy.model.tool_shed_install.mapping import metadata as ts_metadata  # noqa: F401
+
+    alembic_dir = alembic_dir or ALEMBIC_DIR  # quick fix: pass dir to enable testing
+    dbm = DBManager(url, metadata, ts_metadata, alembic_dir, engine_options)
+
+    # Case 2: Database exists but not initialized.
+    if not dbm.is_initialized():
+        dbm.initialize_schema()
+        dbm.initialize_alembic()
+        if app:
+            app.new_installation = True  # Skips the tool migration process.
+        return
+
+    # Case 3: Initialized, but no alembic.
+    if not dbm.is_alembic_versioned():
+        if not dbm.is_migrate_versioned():
+            # TODO construct proper error message (no auto-migrate support here)
+            raise NoMigrateVersioningError()
+        else:
+            if auto_migrate:
+                # TODO auto_migrate is true when this is called from the db management script,
+                #      or (TODO) when database_auto_migrate is set.
+                # migrate_upgrade()  # to revision where alembic was introduced
+                # init_alembic()
+                # alembic_upgrade()
+                return
+            # TODO construct proper error message
+            raise NoAlembicVersioningError()
+
+    # Case 4. Initialized, has alembic, outdated.
+    if not dbm.is_current():
+        # if auto_migrate: # TODO
+        #     alembic_upgrade()
+        #     return
+        # TODO construct proper error message
+        raise DBOutdatedError()
+
+    log.info('Database is up-to-date')  # add revision # to msg
+
+
+def create_galaxy_database(url, app):
+    template = app and getattr(app.config, "database_template", None)
+    encoding = app and getattr(app.config, "database_encoding", None)
+    create_kwds = {}
+
+    message = "Creating database for URI [%s]" % url
+    if template:
+        message += " from template [%s]" % template
+        create_kwds["template"] = template
+    if encoding:
+        message += " with encoding [%s]" % encoding
+        create_kwds["encoding"] = encoding
+    log.info(message)
+    create_database(url, **create_kwds)
+
+    create_database(url)
+    assert database_exists(url)
+
+
+class DBManager:
+    """
+    Handles all interactions w/db (except creating it) and alembic.
+    Used by app at startup (and tests) + by db management script.
+    """
+    def __init__(self, url, metadata, ts_metadata, alembic_dir, engine_options):  # TODO do not pass alembic_dir; find better way
+        self.url = url
+        self.metadata = metadata        # loaded from galaxy mapping module
+        self.ts_metadata = ts_metadata  # loaded from TS mapping module
+        self.db_metadata = MetaData()   # to be loaded from database
+
+        engine_options = engine_options or {}
+        self.engine = build_engine(url, engine_options)
+
+        with self.engine.connect() as conn:
+            self._load_db_metadata(conn)
+        alembic_dir = alembic_dir or ALEMBIC_DIR
+        self._load_alembic_config(alembic_dir)
+
+    def is_initialized(self):
+        """Assume database is initialized if 'dataset' table exists."""
+        return 'dataset' in self.db_metadata.tables
+
+    def is_alembic_versioned(self):
+        """Database is under Alembic version control if 'alembic_version' table exists."""
+        return ALEMBIC_TABLE in self.db_metadata.tables
+
+    def is_migrate_versioned(self):
+        """Database is under SQLAlchemy version control if 'migrate_version' table exists."""
+        return MIGRATE_TABLE in self.db_metadata.tables
+
+    def is_current(self):
+        script = ScriptDirectory.from_config(self.alembic_cfg)
+        app_version = script.get_current_head()
+        with self.engine.connect() as conn:
+            context = MigrationContext.configure(conn)
+            db_version = context.get_current_revision()
+        return db_version == app_version
+
+    def initialize_schema(self):
+        log.info('Initializing database schema')
+        with self.engine.connect() as conn:
+            self.metadata.bind = conn
+            self.metadata.create_all()
+            self._load_db_metadata(conn)  # load again to get the updated metadata
+
+            if self.ts_metadata:
+                self.ts_metadata.bind = conn
+                self.ts_metadata.create_all()
+                self._load_db_metadata(conn)  # load again to get the updated metadata
+
+    def initialize_alembic(self):
+        log.info('Placing database under Alembic version control')
+        command.stamp(self.alembic_cfg, "head")  # create alembic table in db; insert latest revision id.
+
+    def _load_db_metadata(self, conn):
+        self.db_metadata.bind = conn
+        self.db_metadata.reflect()
+
+    def _load_alembic_config(self, alembic_dir):
+        config_file = os.path.join(alembic_dir, ALEMBIC_CONFIG_FILE)
+        self.alembic_cfg = Config(config_file)
+        self.alembic_cfg.set_main_option('script_location', alembic_dir)
+        self.alembic_cfg.set_main_option('sqlalchemy.url', self.url)
+
+    def alembic_upgrade(self):  # TODO this should work, but we also need to upgrade/downgrade to a specific revision
+        log.info('Upgrading database / alembic head')
+        command.upgrade(self.alembic_cfg, 'head')
+
+
+def get_metadata_tables(metadata):
+    tables = [table for table in metadata.sorted_tables if table.name != ALEMBIC_TABLE]
+    return sorted(tables, key=lambda t: t.name)  # sort by table name
+
+
+class MetaDataComparator:
+    """Compares 2 SQLAlchemy MetaData objects."""
+    # (This is hacky, but it's better than nothing, for now)
+
+    def compare(self, metadata1, metadata2, column_attributes, type_attributes=None):
+        tables1, tables2 = get_metadata_tables(metadata1), get_metadata_tables(metadata2)
+        assert len(tables1) == len(tables2), 'Number of tables not the same'
+        for (t1, t2) in zip(tables1, tables2):
+            self.compare_indexes(t1, t2)
+            assert len(t1.columns) == len(t2.columns), 'Different number of columns in table %s' % t1.name
+            for (c1, c2) in zip(t1.columns, t2.columns):
+                self.compare_types(c1, c2, type_attributes)
+                self.compare_foreignkeys(c1, c2)
+                self.compare_column_attributes(c1, c2, column_attributes)
+
+    def compare_indexes(self, table1, table2):
+        assert len(table1.indexes) == len(table2.indexes), \
+            'Different number of indexes on table %s' % table1.name
+        indexes1 = {i.name: i for i in table1.indexes}
+        indexes2 = {i.name: i for i in table2.indexes}
+        for (name1, name2) in zip(sorted(indexes1), sorted(indexes2)):
+            assert name1 == name2, 'Different index names'
+            assert indexes1[name1].unique == indexes2[name2].unique
+            for (c1, c2) in zip(indexes1[name1].columns, indexes2[name2].columns):
+                assert c1.name == c2.name
+
+    def compare_types(self, column1, column2, type_attributes=None):
+        type1, type2 = column1.type, column2.type
+
+        if isinstance(type2, TypeDecorator) or isinstance(type2, Unicode):
+            return  # handling these cases requires much pain and suffering
+
+        assert isinstance(column1.type, type(type2)) or isinstance(column2.type, type(type1)), \
+            'Different types on column %s: %s, %s' % (column1.name, type1, type2)
+
+        if type_attributes:
+            for key in type_attributes:
+                if hasattr(type1, key) or hasattr(type2, key):
+                    assert getattr(type1, key) == getattr(type2, key), \
+                        "Type %s attributes don't match on attribute %s " % (type1, key)
+
+    def compare_column_attributes(self, column1, column2, column_attributes):
+        for key in column_attributes:
+            attr1, attr2 = getattr(column1, key), getattr(column2, key)
+            assert hasattr(attr1, 'arg') == hasattr(attr2, 'arg')
+            if not hasattr(attr1, 'arg'):
+                assert attr1 == attr2
+            else:
+                assert attr1.is_callable == attr2.is_callable
+                if attr1.is_callable:
+                    assert attr1.arg.__name__ == attr2.arg.__name__
+                else:
+                    assert attr1.arg == attr2.arg
+
+    def compare_foreignkeys(self, c1, c2):
+        assert len(c1.foreign_keys) == len(c2.foreign_keys)
+        for (fk1, fk2) in zip(c1.foreign_keys, c2.foreign_keys):
+            assert fk1.column.name == fk2.column.name
+            assert fk1.column.table.name == fk2.column.table.name
+            assert fk1.onupdate == fk2.onupdate
+            assert fk1.ondelete == fk2.ondelete
+
+
+class NoMigrateVersioningError(Exception):
+    def __init__(self):
+        super().__init__('not alembic, not migrate: upgrade manually')  # msg is tmp
+
+
+class NoAlembicVersioningError(Exception):
+    def __init__(self):
+        super().__init__('not alembic, migrate: run migrate+alembic script')  # msg is tmp
+
+
+class DBOutdatedError(Exception):
+    def __init__(self):
+        super().__init__('database is outdated: run alembic script')  # msg is tmp

--- a/lib/galaxy/model/migrations/alembic.ini
+++ b/lib/galaxy/model/migrations/alembic.ini
@@ -1,0 +1,85 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = alembic
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to alembic/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat alembic/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks=black
+# black.type=console_scripts
+# black.entrypoint=black
+# black.options=-l 79
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/lib/galaxy/model/migrations/alembic/README
+++ b/lib/galaxy/model/migrations/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/lib/galaxy/model/migrations/alembic/env.py
+++ b/lib/galaxy/model/migrations/alembic/env.py
@@ -1,8 +1,6 @@
-from logging.config import fileConfig
-
+# from logging.config import fileConfig
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
 from alembic import context
 
 # this is the Alembic Config object, which provides

--- a/lib/galaxy/model/migrations/alembic/env.py
+++ b/lib/galaxy/model/migrations/alembic/env.py
@@ -1,0 +1,77 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+# fileConfig(config.config_file_name) TODO: this is NOT needed if created programmatically!
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/lib/galaxy/model/migrations/alembic/script.py.mako
+++ b/lib/galaxy/model/migrations/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ url = "https://wheels.galaxyproject.org/simple"
 
 [tool.poetry.dependencies]
 aiofiles = "*"
+alembic = "*"
 async-generator = {version = "*", python = "~3.6"}
 async-exit-stack = {version = "*", python = "~3.6"}
 Babel = "*"

--- a/test/unit/migrations/states/state1.py
+++ b/test/unit/migrations/states/state1.py
@@ -1,0 +1,18 @@
+import sqlalchemy as sa
+
+metadata = sa.MetaData()
+
+# 1. initialized, no versioning
+dataset = sa.Table(
+    'dataset', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+
+data = {
+    'dataset': [
+        (1, 'dataset1'),
+        (2, 'dataset2'),
+    ],
+}

--- a/test/unit/migrations/states/state2.py
+++ b/test/unit/migrations/states/state2.py
@@ -1,0 +1,52 @@
+import sqlalchemy as sa
+
+metadata = sa.MetaData()
+
+dataset = sa.Table(
+    'dataset', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+# added in 2
+history = sa.Table(
+    'history', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+hda = sa.Table(
+    'hda', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column("history_id", sa.Integer, sa.ForeignKey("history.id"), index=True),
+    sa.Column("dataset_id", sa.Integer, sa.ForeignKey("dataset.id"), index=True),
+    sa.Column('name', sa.String(40)),
+)
+
+# this table similates placing db under SA Migrate version control
+migrate_version = sa.Table(
+    'migrate_version', metadata,
+    sa.Column('repository_id', sa.String(250), primary_key=True),
+    sa.Column('repository_path', sa.Text),
+    sa.Column('version', sa.Integer),
+)
+
+
+data = {
+    'dataset': [
+        (1, 'dataset1'),
+        (2, 'dataset2'),
+    ],
+    'history': [
+        (1, 'history1'),
+        (2, 'history2'),
+    ],
+    'hda': [
+        (1, 1, 1, 'hda1'),
+        (2, 1, 2, 'hda2'),
+        (3, 2, 1, 'hda3'),
+    ],
+    'migrate_version': [
+        ('repo1', 'repo path', 1),
+    ],
+}

--- a/test/unit/migrations/states/state3.py
+++ b/test/unit/migrations/states/state3.py
@@ -1,0 +1,61 @@
+import sqlalchemy as sa
+
+metadata = sa.MetaData()
+
+dataset = sa.Table(
+    'dataset', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+history = sa.Table(
+    'history', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+hda = sa.Table(
+    'hda', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column("history_id", sa.Integer, sa.ForeignKey("history.id"), index=True),
+    sa.Column("dataset_id", sa.Integer, sa.ForeignKey("dataset.id"), index=True),
+    sa.Column('name', sa.String(40)),
+)
+
+migrate_version = sa.Table(
+    'migrate_version', metadata,
+    sa.Column('repository_id', sa.String(250), primary_key=True),
+    sa.Column('repository_path', sa.Text),
+    sa.Column('version', sa.Integer),
+)
+
+# added in 3
+foo1 = sa.Table(
+    'foo1', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+
+data = {
+    'dataset': [
+        (1, 'dataset1'),
+        (2, 'dataset2'),
+    ],
+    'history': [
+        (1, 'history1'),
+        (2, 'history2'),
+    ],
+    'hda': [
+        (1, 1, 1, 'hda1'),
+        (2, 1, 2, 'hda2'),
+        (3, 2, 1, 'hda3'),
+    ],
+    'migrate_version': [
+        ('repo1', 'repo path', 1),
+    ],
+    'foo1': [
+        (1, 'foo1-1'),
+        (2, 'foo1-2'),
+    ],
+}

--- a/test/unit/migrations/states/state4.py
+++ b/test/unit/migrations/states/state4.py
@@ -1,0 +1,71 @@
+import sqlalchemy as sa
+
+metadata = sa.MetaData()
+
+dataset = sa.Table(
+    'dataset', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+history = sa.Table(
+    'history', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+hda = sa.Table(
+    'hda', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column("history_id", sa.Integer, sa.ForeignKey("history.id"), index=True),
+    sa.Column("dataset_id", sa.Integer, sa.ForeignKey("dataset.id"), index=True),
+    sa.Column('name', sa.String(40)),
+)
+
+migrate_version = sa.Table(
+    'migrate_version', metadata,
+    sa.Column('repository_id', sa.String(250), primary_key=True),
+    sa.Column('repository_path', sa.Text),
+    sa.Column('version', sa.Integer),
+)
+
+foo1 = sa.Table(
+    'foo1', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+# added in 4
+foo2 = sa.Table(
+    'foo2', metadata,
+    sa.Column('id', sa.Integer, primary_key=True),
+    sa.Column('name', sa.String(40)),
+)
+
+
+data = {
+    'dataset': [
+        (1, 'dataset1'),
+        (2, 'dataset2'),
+    ],
+    'history': [
+        (1, 'history1'),
+        (2, 'history2'),
+    ],
+    'hda': [
+        (1, 1, 1, 'hda1'),
+        (2, 1, 2, 'hda2'),
+        (3, 2, 1, 'hda3'),
+    ],
+    'migrate_version': [
+        ('repo1', 'repo path', 1),
+    ],
+    'foo1': [
+        (1, 'foo1-1'),
+        (2, 'foo1-2'),
+    ],
+    'foo2': [
+        (1, 'foo2-1'),
+        (2, 'foo2-2'),
+    ],
+}

--- a/test/unit/migrations/test_check.py
+++ b/test/unit/migrations/test_check.py
@@ -1,0 +1,315 @@
+import os
+import tempfile
+
+import pytest
+from sqlalchemy import (
+    create_engine,
+    MetaData,
+)
+from sqlalchemy_utils import (
+    create_database,
+    database_exists,
+)
+from alembic import command
+from alembic.config import Config
+
+from galaxy.model.mapping import metadata as galaxy_metadata
+
+from galaxy.model.migrations import (
+    ALEMBIC_CONFIG_FILE,
+    ALEMBIC_TABLE,
+    COLUMN_ATTRIBUTES_TO_VERIFY,
+    DBOutdatedError,
+    MetaDataComparator,
+    NoAlembicVersioningError,
+    NoMigrateVersioningError,
+    TYPE_ATTRIBUTES_TO_VERIFY,
+    get_metadata_tables,
+    run,
+)
+
+from states import state1, state2, state3, state4 as state_current
+
+
+"""
+DATABASE STATES:
+1. dataset
+2. state1 + history, hda, migrate_version
+3. state2 + foo1
+4. state3 + foo2
+
+CASES:
+1. no db >> create, initialize, add alembic
+2. empty db >> initialize, add alembic
+3. nonempty db, alembic, up-to-date, w/data >> do nothing
+4. nonempty db, no migrate, no alembic >> fail, error message: manual upgrade
+4a. same + automigrate >> same: fail, error message: manual upgrade
+5. nonempty db, has migrate, no alembic >> fail, error message: run migrate+alembic upgrade script
+5a. same + automigrate >> (use migrate to upgrade to alembic-0, add alembic, upgrade)
+6. nonempty db, has alembic >> fail, error message: run alembic upgrade script
+6a. same + automigrate >> upgrade
+"""
+
+
+@pytest.fixture
+def db_url():
+    with tempfile.NamedTemporaryFile() as f:
+        yield 'sqlite:///%s' % f.name
+
+
+@pytest.fixture
+def metadata():
+    return state_current.metadata
+
+
+def test_case_1(db_url, metadata):
+    """No database."""
+    assert not database_exists(db_url)
+
+    run(db_url, metadata)
+    assert database_exists(db_url)
+    with create_engine(db_url).connect() as conn:
+        assert_metadata(conn)
+        assert_alembic(conn)
+
+
+def test_case_2(db_url, metadata):
+    """Empty database."""
+    assert not database_exists(db_url)
+    create_database(db_url)
+
+    run(db_url, metadata)
+    with create_engine(db_url).connect() as conn:
+        assert_metadata(conn)
+        assert_alembic(conn)
+
+
+def test_case_2_galaxy_metadata(db_url):
+    """Empty database, galaxy metadada."""
+    assert not database_exists(db_url)
+    create_database(db_url)
+
+    run(db_url, galaxy_metadata)
+    with create_engine(db_url).connect() as conn:
+        assert_metadata(conn, metadata=galaxy_metadata)
+        assert_alembic(conn)
+
+
+def test_case_3(db_url, metadata):
+    """Everything is up-to-date."""
+    assert not database_exists(db_url)
+    create_database(db_url)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        alembic_cfg = init_alembic(db_url, tmpdir)
+        command.stamp(alembic_cfg, 'head')
+
+        with create_engine(db_url).connect() as conn:
+            load_metadata(conn, metadata)
+            load_data(conn, state_current)
+
+            run(db_url, metadata, tmpdir)
+            assert_metadata(conn)
+            assert_alembic(conn)
+            assert_data(conn, state_current)
+
+
+def test_case_3_galaxy_metadata(db_url):
+    """Everything is up-to-date, galaxy metadata."""
+    assert not database_exists(db_url)
+    create_database(db_url)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        alembic_cfg = init_alembic(db_url, tmpdir)
+        command.stamp(alembic_cfg, 'head')
+
+        with create_engine(db_url).connect() as conn:
+            load_metadata(conn, galaxy_metadata)
+
+            run(db_url, galaxy_metadata, tmpdir)
+            assert_metadata(conn, metadata=galaxy_metadata)
+            assert_alembic(conn)
+
+
+def test_case_4(db_url, metadata):
+    """Nonempty database, no migrate, no alembic."""
+    state_to_load = state1  # what we're loading into the db
+    create_database(db_url)
+    with create_engine(db_url).connect() as conn:
+        load_metadata(conn, state_to_load.metadata)
+        load_data(conn, state_to_load)
+
+    with pytest.raises(NoMigrateVersioningError):
+        run(db_url, metadata)
+
+
+def test_case_4_galaxy_metadata(db_url):
+    """Nonempty database, no migrate, no alembic, galaxy metadata."""
+    create_database(db_url)
+    with create_engine(db_url).connect() as conn:
+        load_metadata(conn, galaxy_metadata)
+
+    with pytest.raises(NoMigrateVersioningError):
+        run(db_url, galaxy_metadata)
+
+
+def test_case_4_automigrate(db_url, metadata):
+    """Same as 4 + auto-migrate."""
+    state_to_load = state1  # what we're loading into the db
+    create_database(db_url)
+    with create_engine(db_url).connect() as conn:
+        load_metadata(conn, state_to_load.metadata)
+        load_data(conn, state_to_load)
+
+    with pytest.raises(NoMigrateVersioningError):
+        run(db_url, metadata, auto_migrate=True)
+
+
+def test_case_4_automigrate_galaxy_metadata(db_url):
+    """Same as 4 + auto-migrate, galaxy metadata."""
+    create_database(db_url)
+    with create_engine(db_url).connect() as conn:
+        load_metadata(conn, galaxy_metadata)
+
+    with pytest.raises(NoMigrateVersioningError):
+        run(db_url, galaxy_metadata, auto_migrate=True)
+
+
+def test_case_5(db_url, metadata):
+    """Nonempty database, has migrate, no alembic."""
+    state_to_load = state2  # what we're loading into the db
+    create_database(db_url)
+    with create_engine(db_url).connect() as conn:
+        load_metadata(conn, state_to_load.metadata)
+        load_data(conn, state_to_load)
+
+    with pytest.raises(NoAlembicVersioningError):
+        run(db_url, metadata)
+
+
+# TODO: add case 5 w/galaxy metadata (mock migrate_version table)
+
+
+# def test_case_5_automigrate(db_url, metadata):
+#     """Same as 5 + auto-migrate."""
+# TODO
+#    state_to_load = state2  # what we're loading into the db
+#    create_database(db_url)
+#    with tempfile.TemporaryDirectory() as tmpdir:
+#
+#        with create_engine(db_url).connect() as conn:
+#            load_metadata(conn, state_to_load.metadata)
+#            load_data(conn, state_to_load)
+#
+#            run(db_url, metadata, tmpdir, auto_migrate=True)
+#            assert_metadata(conn)
+#            assert_alembic(conn)
+#            assert_data(conn, state2)
+
+
+def test_case_6(db_url, metadata):
+    """Nonempty database, alembic-versioned, out-of-date."""
+    create_database(db_url)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        alembic_cfg = init_alembic(db_url, tmpdir)
+        command.stamp(alembic_cfg, 'head')
+        command.revision(alembic_cfg)  # new revision makes db outdated
+
+        with create_engine(db_url).connect() as conn:
+            load_metadata(conn, metadata)
+            load_data(conn, state_current)
+
+            with pytest.raises(DBOutdatedError):
+                run(db_url, metadata, tmpdir)
+
+
+def test_case_6_galaxy_metadata(db_url):
+    """Nonempty database, alembic-versioned, out-of-date, galaxy metadata."""
+    create_database(db_url)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        alembic_cfg = init_alembic(db_url, tmpdir)
+        command.stamp(alembic_cfg, 'head')
+        command.revision(alembic_cfg)  # new revision makes db outdated
+
+        with create_engine(db_url).connect() as conn:
+            load_metadata(conn, galaxy_metadata)
+
+            with pytest.raises(DBOutdatedError):
+                run(db_url, galaxy_metadata, tmpdir)
+
+
+# def test_case_6_automigrate(db_url, metadata):
+#     """Same as 6 + auto-migrate."""
+# TODO
+#    create_database(db_url)
+#    with tempfile.TemporaryDirectory() as tmpdir:
+#        alembic_cfg = init_alembic(db_url, tmpdir)
+#        command.stamp(alembic_cfg, 'head')
+#        command.revision(alembic_cfg)  # new revision makes db outdated
+#
+#        with create_engine(db_url).connect() as conn:
+#            load_metadata(conn, metadata)
+#            load_data(conn, state_current)
+#            run(db_url, metadata, tmpdir, auto_migrate=True)
+#            assert_metadata(conn)
+#            assert_alembic(conn)
+#            assert_data(conn, state2)
+
+
+def init_alembic(url, alembic_dir):
+    config_file = os.path.join(alembic_dir, ALEMBIC_CONFIG_FILE)
+    config = Config(config_file)
+    config.set_main_option('sqlalchemy.url', url)
+    config.set_main_option('script_location', alembic_dir)
+    command.init(config, alembic_dir)
+    return config
+
+
+def load_metadata(conn, metadata):
+    metadata.bind = conn
+    metadata.create_all()
+    assert_metadata(conn, metadata)
+
+
+def load_data(conn, state):
+    db_metadata = MetaData(bind=conn)
+    db_metadata.reflect()
+    for table in get_metadata_tables(db_metadata):
+        table_data = state.data[table.name]
+        ins = table.insert().values(table_data)
+        conn.execute(ins)
+    assert_data(conn, state)
+
+
+def assert_metadata(conn, metadata=state_current.metadata):
+    """Metadata loaded from the database is the same as the `metadata` argument."""
+    db_metadata = MetaData(bind=conn)
+    db_metadata.reflect()
+
+    MetaDataComparator().compare(
+        db_metadata, metadata, COLUMN_ATTRIBUTES_TO_VERIFY, TYPE_ATTRIBUTES_TO_VERIFY)
+
+
+def assert_alembic(conn):
+    """Database is under alembic version control."""
+    metadata = MetaData(bind=conn)
+    metadata.reflect()
+    assert ALEMBIC_TABLE in metadata.tables, 'Database is not under alembic version control'
+
+
+def assert_data(conn, state):
+    """Assert that data in db is the same as defined in state.data."""
+
+    def assert_table_data(table_name):
+        db_data = conn.execute('select * from %s' % table_name).fetchall()
+        # Assert that data in database is the same as the data defined in state* module.
+        assert db_data == state.data[table_name]
+
+    if state in (state1, state2, state3, state_current):
+        assert_table_data('dataset')
+    if state in (state2, state3, state_current):
+        assert_table_data('history')
+        assert_table_data('hda')
+        assert_table_data('migrate_version')
+    if state in (state3, state_current):
+        assert_table_data('foo1')
+    if state == state_current:
+        assert_table_data('foo2')


### PR DESCRIPTION
Ref #10369

Very much WIP. First steps towards moving us to alembic. The new tests in the PR pass, the rest breaks, for now.

The alembic stuff is in `model/migrations`. There's a `run` function that handles the basic logic + a `DBManager` class that takes care of all db/alembic interactions. The steps are as follows:

1. no database >> create, initialize, add alembic
1. empty database >> initialize, add alembic
1. nonempty database, alembic, up-to-date >> do nothing
1. nonempty database, no migrate, no alembic >> fail, error message: require manual upgrade
1. same + automigrate >> same: fail, error message: require manual upgrade
1. nonempty database, has migrate, no alembic >> fail, error message: run db_manage script
1. same + automigrate >> (we use SQLAlchemy migrate to upgrade to alembic revision#0 (when alembic was added), add alembic, upgrade to current revision)
1. nonempty database, has alembic >> fail, error message: run db_manage script
1. same + automigrate >> (upgrade to current revision)

My idea is to provide an automated upgrade path for db versions that already have SQLAlchemy Migrate, but not prior to that (I assume there's no reason to go that far back). This will be simpler than the [current logic](https://github.com/galaxyproject/galaxy/blob/release_20.09/lib/galaxy/model/migrate/check.py#L102). I think we can phase out this path in 1-2 releases - that way we'll gradually remove SQLAlchemy Migrate from the code base.

The current implementation is far from complete. Also, I did not include views and triggers intentionally - I think it will make more sense to let alembic handle them (as a revision). Or maybe not. 

