### PR TITLE
Document min, max, and optional for data parameters

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2503,11 +2503,6 @@ $attribute_list:checked,truevalue,falsevalue:5
 
 A dataset from the current history. Multiple types might be used for the param form.
 
-#### ``group_tag``
-
-$attribute_list:multiple,date_ref:5
-
-
 ##### Examples
 
 The following will find all "coordinate interval files" contained within the
@@ -2556,6 +2551,10 @@ the [Planemo Documentation](https://planemo.readthedocs.io/en/latest/writing_adv
 on this topic.
 
 $attribute_list:format,multiple:5
+
+#### ``group_tag``
+
+$attribute_list:multiple,date_ref:5
 
 #### ``select``
 

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2550,7 +2550,7 @@ Additionally, a detailed discussion of handling multiple homogenous files can be
 the [Planemo Documentation](https://planemo.readthedocs.io/en/latest/writing_advanced.html#consuming-collections)
 on this topic.
 
-$attribute_list:format,multiple:5
+$attribute_list:format,multiple,optional,min,max:5
 
 #### ``group_tag``
 
@@ -2746,13 +2746,13 @@ it will be a RGB value e.g. 0,0,255. This attribute is only valid when ``type`` 
         <xs:attribute name="min" type="xs:float">
           <xs:annotation>
             <xs:documentation xml:lang="en">Minimum valid parameter value - only
-valid when ``type`` is ``integer`` or ``float``.</xs:documentation>
+valid when ``type`` is ``integer``, ``float``, or ``data``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="max" type="xs:float">
           <xs:annotation>
             <xs:documentation xml:lang="en">Maximum valid parameter value - only
-valid when ``type`` is ``integer`` or ``float``.</xs:documentation>
+valid when ``type`` is ``integer``, ``float``, or ``data``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="format" type="xs:string">


### PR DESCRIPTION
Found that min and max work for data parameters while studying the code: 

https://github.com/galaxyproject/galaxy/blob/594f826a86f169ddb238567ddb61ce4260d2f25c/lib/galaxy/tools/parameters/basic.py#L1937

There are even tests: https://github.com/galaxyproject/galaxy/blob/594f826a86f169ddb238567ddb61ce4260d2f25c/test/functional/tools/multi_data_param.xml#L9

So I thought that it might be worthwhile to document this.

Also fixes:

- add undocumented `optional`
- fix position of `group_tag` docs