### PR TITLE
Add empty preferences attribute to BootstrapAdminUser

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -238,7 +238,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         Find a user by API key.
         """
         if self.check_master_api_key(api_key=api_key):
-            return schema.BoostrapAdminUser()
+            return schema.BootstrapAdminUser()
         sa_session = sa_session or self.app.model.session
         try:
             provided_key = sa_session.query(self.app.model.APIKeys).filter(self.app.model.APIKeys.table.c.key == api_key).one()

--- a/lib/galaxy/schema/__init__.py
+++ b/lib/galaxy/schema/__init__.py
@@ -3,9 +3,10 @@ import typing
 from pydantic import BaseModel
 
 
-class BoostrapAdminUser(BaseModel):
+class BootstrapAdminUser(BaseModel):
     id = 0
     email: typing.Optional[str] = None
+    preferences: typing.Dict[str, str] = {}
     bootstrap_admin_user = True
 
     def all_roles(*args) -> list:


### PR DESCRIPTION
Running any planemo command which requires tool installation (e.g. workflow execution) against the dev version of Galaxy currently results in the following traceback:

```
bioblend ERROR: GET: error 500: b'{"err_msg": "Uncaught exception in exposed API method:", "err_code": 0, "traceback": "Traceback (most recent call last):\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/web/framework/decorators.py\\", line 305, in decorator\\n    rval = func(self, trans, *args, **kwargs)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/webapps/galaxy/api/tools.py\\", line 91, in index\\n    return self.app.toolbox.to_dict(trans, in_panel=in_panel, trackster=trackster, tool_help=tool_help)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\\", line 1085, in to_dict\\n    panel_elts = list(self.tool_panel_contents(trans, **kwds))\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\\", line 1050, in tool_panel_contents\\n    filter_method = self._build_filter_method(trans)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\\", line 1134, in _build_filter_method\\n    filters = self._filter_factory.build_filters(trans)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/filters/__init__.py\\", line 36, in build_filters\\n    for name, value in trans.user.preferences.items():\\nAttributeError: \'BoostrapAdminUser\' object has no attribute \'preferences\'\\n"}', 0 attempts left
Traceback (most recent call last):
  File "/home/simon/GitRepos/.planemo_local/bin/planemo", line 33, in <module>
    sys.exit(load_entry_point('planemo', 'console_scripts', 'planemo')())
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/simon/GitRepos/planemo/planemo/cli.py", line 98, in handle_blended_options
    return f(*args, **kwds)
  File "/home/simon/GitRepos/planemo/planemo/commands/cmd_test.py", line 83, in cli
    return_value = test_runnables(ctx, runnables, original_paths=uris, **kwds)
  File "/home/simon/GitRepos/planemo/planemo/engine/test.py", line 25, in test_runnables
    test_data = engine.test(runnables)
  File "/home/simon/GitRepos/planemo/planemo/engine/interface.py", line 80, in test
    test_results = self._collect_test_results(test_cases)
  File "/home/simon/GitRepos/planemo/planemo/engine/interface.py", line 99, in _collect_test_results
    run_response = self._run_test_case(test_case)
  File "/home/simon/GitRepos/planemo/planemo/engine/galaxy.py", line 50, in _run_test_case
    return super(GalaxyEngine, self)._run_test_case(test_case)
  File "/home/simon/GitRepos/planemo/planemo/engine/interface.py", line 126, in _run_test_case
    run_response = self._run(runnable, job_path)
  File "/home/simon/GitRepos/planemo/planemo/engine/galaxy.py", line 35, in _run
    with self.ensure_runnables_served([runnable]) as config:
  File "/usr/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/home/simon/GitRepos/planemo/planemo/engine/galaxy.py", line 104, in ensure_runnables_served
    with serve_daemon(self._ctx, runnables, **self._serve_kwds()) as config:
  File "/usr/lib/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/home/simon/GitRepos/planemo/planemo/galaxy/serve.py", line 109, in serve_daemon
    config = serve(ctx, runnables, **kwds)
  File "/home/simon/GitRepos/planemo/planemo/galaxy/serve.py", line 25, in serve
    return _serve(ctx, runnables, **kwds)
  File "/home/simon/GitRepos/planemo/planemo/galaxy/serve.py", line 65, in _serve
    config.install_workflows()
  File "/home/simon/GitRepos/planemo/planemo/galaxy/config.py", line 762, in install_workflows
    self._install_workflow(runnable)
  File "/home/simon/GitRepos/planemo/planemo/galaxy/config.py", line 771, in _install_workflow
    self._kwds.get("install_repository_dependencies", True))
  File "/home/simon/GitRepos/planemo/planemo/galaxy/workflows.py", line 53, in install_shed_repos
    default_install_repository_dependencies=install_repository_dependencies)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/shed_tools.py", line 162, in install_repositories
    filtered_repos = self.filter_installed_repos(repository_list)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/shed_tools.py", line 97, in filter_installed_repos
    installed_repos = flatten_repo_info(self.installed_repositories())
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/shed_tools.py", line 86, in installed_repositories
    get_all_tools=True
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/get_tool_list_from_galaxy.py", line 141, in tool_list
    repo_list = self.repository_list
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/get_tool_list_from_galaxy.py", line 102, in repository_list
    walk_tools(self.toolbox, record_repo)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/get_tool_list_from_galaxy.py", line 78, in toolbox
    return get_tool_panel(self.gi)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/ephemeris/get_tool_list_from_galaxy.py", line 19, in get_tool_panel
    return tool_client.get_tool_panel()
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/bioblend/galaxy/tools/__init__.py", line 60, in get_tool_panel
    return self._raw_get_tool(in_panel=True)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/bioblend/galaxy/tools/__init__.py", line 66, in _raw_get_tool
    return self._get(params=params)
  File "/home/simon/GitRepos/.planemo_local/lib/python3.7/site-packages/bioblend/galaxy/client.py", line 150, in _get
    status_code=r.status_code)
bioblend.ConnectionError: GET: error 500: b'{"err_msg": "Uncaught exception in exposed API method:", "err_code": 0, "traceback": "Traceback (most recent call last):\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/web/framework/decorators.py\\", line 305, in decorator\\n    rval = func(self, trans, *args, **kwargs)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/webapps/galaxy/api/tools.py\\", line 91, in index\\n    return self.app.toolbox.to_dict(trans, in_panel=in_panel, trackster=trackster, tool_help=tool_help)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\\", line 1085, in to_dict\\n    panel_elts = list(self.tool_panel_contents(trans, **kwds))\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\\", line 1050, in tool_panel_contents\\n    filter_method = self._build_filter_method(trans)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\\", line 1134, in _build_filter_method\\n    filters = self._filter_factory.build_filters(trans)\\n  File \\"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/filters/__init__.py\\", line 36, in build_filters\\n    for name, value in trans.user.preferences.items():\\nAttributeError: \'BoostrapAdminUser\' object has no attribute \'preferences\'\\n"}', 0 attempts left: {"err_msg": "Uncaught exception in exposed API method:", "err_code": 0, "traceback": "Traceback (most recent call last):\n  File \"/home/simon/GitRepos/galaxy/lib/galaxy/web/framework/decorators.py\", line 305, in decorator\n    rval = func(self, trans, *args, **kwargs)\n  File \"/home/simon/GitRepos/galaxy/lib/galaxy/webapps/galaxy/api/tools.py\", line 91, in index\n    return self.app.toolbox.to_dict(trans, in_panel=in_panel, trackster=trackster, tool_help=tool_help)\n  File \"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\", line 1085, in to_dict\n    panel_elts = list(self.tool_panel_contents(trans, **kwds))\n  File \"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\", line 1050, in tool_panel_contents\n    filter_method = self._build_filter_method(trans)\n  File \"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/base.py\", line 1134, in _build_filter_method\n    filters = self._filter_factory.build_filters(trans)\n  File \"/home/simon/GitRepos/galaxy/lib/galaxy/tools/toolbox/filters/__init__.py\", line 36, in build_filters\n    for name, value in trans.user.preferences.items():\nAttributeError: 'BoostrapAdminUser' object has no attribute 'preferences'\n"}

```

This PR just skips the filtering for a `BootstrapAdminUser` which is causing the error.