### PR TITLE
Add minimal `msf` datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -576,6 +576,7 @@
     <datatype extension="staden" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="swiss" type="galaxy.datatypes.data:Text" subclass="true"/>
     <!-- Alignment Formats http://emboss.sourceforge.net/docs/themes/AlignFormats.html -->
+    <datatype extension="msf" type="galaxy.datatypes.msa:Msf" />
     <datatype extension="markx0" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="markx1" type="galaxy.datatypes.data:Text" subclass="true"/>
     <datatype extension="markx10" type="galaxy.datatypes.data:Text" subclass="true"/>

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -243,3 +243,13 @@ class MauveXmfa(Text):
 
     def set_meta(self, dataset, **kwd):
         dataset.metadata.number_of_models = generic_util.count_special_lines('^#Sequence([[:digit:]]+)Entry', dataset.file_name)
+
+
+class Msf(Text):
+    """
+    Multiple sequence alignment format produced by the Accelrys GCG suite and
+    other programs.
+    """
+    edam_data = "data_0863"
+    edam_format = "format_1947"
+    file_ext = 'msf'


### PR DESCRIPTION
Missed in https://github.com/galaxyproject/galaxy/pull/148

Used as output format by some EMBOSS tools, and also as optional output by T-Coffee.