### PR TITLE
More Sphinx Work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,8 +162,6 @@ client/galaxy
 doc/build
 doc/schema.md
 doc/source/admin/config_logging_default_yaml.rst
-doc/source/api/api.rst
-doc/source/api/ts_api.rst
 doc/source/dev/schema.md
 doc/source/dev/schema.rst
 client/styleguide

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ docs: ## Generate HTML documentation.
 	$(IN_VENV) $(MAKE) -C doc clean
 	$(IN_VENV) $(MAKE) -C doc html
 
+rebuild-docs: ## Re-generate HTML documentation without clean step.
+	$(IN_VENV) $(MAKE) -C doc html
+
 setup-venv:
 	if [ ! -f $(VENV)/bin/activate ]; then bash scripts/common_startup.sh --dev-wheels; fi
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,7 +15,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sou
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
-GENERATED_RST = source/api/api.rst source/api/ts_api.rst source/dev/schema.md source/admin/config_logging_default_yaml.rst
+GENERATED_RST = source/dev/schema.md source/admin/config_logging_default_yaml.rst
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext updaterst
 
@@ -47,18 +47,6 @@ source/dev/run_tests_help.txt:
 
 source/dev/schema.md: parse_gx_xsd.py schema_template.md ../lib/galaxy/tool_util/xsd/galaxy.xsd ## Build Github-flavored Markdown from Galaxy Tool XSD (expects lxml in environment)
 	python parse_gx_xsd.py schema_template.md ../lib/galaxy/tool_util/xsd/galaxy.xsd > $@
-
-source/api/api.rst: source/lib/galaxy.webapps.galaxy.api.rst
-	printf "Galaxy API\n==========\n" > $@
-	tail -n +11 source/lib/galaxy.webapps.galaxy.api.rst >> $@
-	sed -i.bak -e 's/^galaxy\\\.webapps\\\.galaxy\\\.api\\\.//' $@
-	rm -f $@.bak
-
-source/api/ts_api.rst: source/lib/tool_shed.webapp.api.rst
-	printf "Tool Shed API\n=============\n" > $@
-	tail -n +11 source/lib/tool_shed.webapp.api.rst >> $@
-	sed -i.bak -e 's/^tool_shed\\\.webapp\\\.api\\\.//' $@
-	rm -f $@.bak
 
 source/admin/config_logging_default_yaml.rst: ../lib/galaxy/config/__init__.py
 	printf '.. code-block:: yaml\n\n' > $@

--- a/doc/source/admin/cluster.md
+++ b/doc/source/admin/cluster.md
@@ -2,7 +2,7 @@
 
 Galaxy is designed to run jobs on your local system by default, but it can be configured to run jobs on a cluster.  The front-end Galaxy application runs on a single server as usual, but tools are run on cluster nodes instead.
 
-A [general reference for the job configuration file](jobs.md) is also available.
+A [general reference for the job configuration file](./jobs.md) is also available.
 
 ## Distributed Resources Managers
 
@@ -70,7 +70,7 @@ You may also find that attribute caching in your filesystem causes problems with
 
 ## Runner Configuration
 
-**This documentation covers configuration of the various runner plugins, not how to distribute jobs to the various plugins.** Consult the [job configuration file documentation](jobs.md) for full details on the correct syntax, and for instructions on how to configure tools to actually use the runners explained below.
+**This documentation covers configuration of the various runner plugins, not how to distribute jobs to the various plugins.** Consult the [job configuration file documentation](./jobs.md) for full details on the correct syntax, and for instructions on how to configure tools to actually use the runners explained below.
 
 ### Local
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -677,8 +677,8 @@
 :Description:
     involucro is a tool used to build Docker or Singularity containers
     for tools from Conda dependencies referenced in tools as
-    `requirement`s. The following path is the location of involucro on
-    the Galaxy host. This is ignored if the relevant container
+    `requirement` s. The following path is the location of involucro
+    on the Galaxy host. This is ignored if the relevant container
     resolver isn't enabled, and will install on demand unless
     involucro_auto_init is set to false.
     The value of this option will be resolved with respect to
@@ -3709,7 +3709,7 @@
     you can separate Galaxy into multiple processes.  There are more
     than one way to do this, and they are explained in detail in the
     documentation:
-      https://docs.galaxyproject.org/en/master/admin/scaling.html
+    https://docs.galaxyproject.org/en/master/admin/scaling.html
     By default, Galaxy manages and executes jobs from within a single
     process and notifies itself of new jobs via in-memory queues.
     Jobs are run locally on the system on which Galaxy is started.
@@ -4085,7 +4085,7 @@
 :Description:
     Prologue Markdown/HTML to apply to markdown exports to PDF.
     Allowing branded headers.
-:Default: ````
+:Default: ``""``
 :Type: str
 
 
@@ -4096,7 +4096,7 @@
 :Description:
     Prologue Markdown/HTML to apply to markdown exports to PDF.
     Allowing branded footers.
-:Default: ````
+:Default: ``""``
 :Type: str
 
 
@@ -4107,7 +4107,7 @@
 :Description:
     Alternative to markdown_export_prologue that applies just to page
     exports.
-:Default: ````
+:Default: ``""``
 :Type: str
 
 
@@ -4118,7 +4118,7 @@
 :Description:
     Alternative to markdown_export_prologue that applies just to
     invocation report exports.
-:Default: ````
+:Default: ``""``
 :Type: str
 
 
@@ -4129,7 +4129,7 @@
 :Description:
     Alternative to markdown_export_epilogue that applies just to page
     exports.
-:Default: ````
+:Default: ``""``
 :Type: str
 
 
@@ -4140,7 +4140,7 @@
 :Description:
     Alternative to markdown_export_epilogue that applies just to
     invocation report exports.
-:Default: ````
+:Default: ``""``
 :Type: str
 
 

--- a/doc/source/admin/mq.md
+++ b/doc/source/admin/mq.md
@@ -1,3 +1,7 @@
+```eval_rst
+:orphan:
+```
+
 # Message queue
 
 Galaxy uses a message queue internally for communicating between processes. 

--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -399,7 +399,7 @@ these paths need to exposed in the same way.
 
 You may find it useful to require authentication for access to certain paths on your server.  For example, Galaxy can
 run a separate reports app which gives useful information about your Galaxy instance. See the [Reports Configuration
-documentation](reports) and [Peter Briggs' blog post on the
+documentation](./reports) and [Peter Briggs' blog post on the
 subject](http://galacticengineer.blogspot.com/2015/06/exposing-galaxy-reports-via-nginx-in.html) for more.
 
 After successfully following the blog post, Galaxy reports should be available at e.g. `https://galaxy.example.org/reports`.

--- a/doc/source/admin/proxy_package_layout.rst
+++ b/doc/source/admin/proxy_package_layout.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Proxy Package Layouts
 ========================================
 

--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -438,8 +438,8 @@ separated,  to the `job-handlers` farm. For example, 3 handlers are defined like
 
 By default, a job will be handled by whatever mule currently has the lock on the mule message queue. After receiving a
 message, it will release the lock, giving other mules a chance to handle future jobs.  Jobs can be explicitly mapped to
-specific mules as described in the [Job configuration documentation](jobs.md) by using the handler IDs
-`main.job-handlers.N`, where `N` is the mule's position in the farm, starting at 1 and incrementing for each mule in the
+specific mules as described in the [Galaxy Job Configuration](./jobs.md) documentation
+by using the handler IDs `main.job-handlers.N`, where `N` is the mule's position in the farm, starting at 1 and incrementing for each mule in the
 farm (this is not necessarily the mule ID, but it will be if you only define one farm and you add mules to that farm in
 sequential order).  Each worker that you wish to explicitly map jobs to should be defined in the `<handlers>` section
 of `job_conf.xml`. *Do not* define a default handler.

--- a/doc/source/admin/special_topics/index.rst
+++ b/doc/source/admin/special_topics/index.rst
@@ -10,6 +10,7 @@ Special Topics
    interactive_environments
    mulled_containers
    grt
+   gtn
    job_metrics
    webhooks
    performance_tracking

--- a/doc/source/api/api.rst
+++ b/doc/source/api/api.rst
@@ -1,0 +1,5 @@
+Galaxy API
+==========
+
+For a detailed description of the of Galaxy API controller please see
+the API module :py:mod:`galaxy.webapps.galaxy.api`.

--- a/doc/source/api/ts_api.rst
+++ b/doc/source/api/ts_api.rst
@@ -1,0 +1,5 @@
+ToolShed API
+=============
+
+For a detailed description of the of Tool Shed API controller please see
+the API module :py:mod:`tool_shed.webapp.api`.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,6 +18,10 @@ import sphinx_rtd_theme
 # Library to make .md to slideshow
 from recommonmark.transform import AutoStructify
 
+# Set GALAXY_DOCS_SKIP_VIEW_CODE=1 to skip embedding highlighted source
+# code into docs.
+SKIP_VIEW_CODE = os.environ.get("GALAXY_DOCS_SKIP_VIEW_CODE", False) == "1"
+
 # Set GALAXY_DOCS_SKIP_SOURCE=1 to skip building source information and
 # just build primary documentation. (Quicker to debug issues in most frequently updated
 # docs).
@@ -43,7 +47,9 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pa
 extensions = ['recommonmark', 'sphinx.ext.intersphinx', 'sphinx_markdown_tables']
 if not SKIP_SOURCE:
     # TODO: Add https://pypi.org/project/sphinx-autodoc-typehints
-    extensions += ['sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.viewcode', 'sphinx.ext.autodoc']
+    extensions += ['sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.autodoc']
+    if not SKIP_VIEW_CODE:
+        extensions.append('sphinx.ext.viewcode')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -140,7 +140,10 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 # Intersphinx mapping to Python documentation
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'requests': ("https://requests.readthedocs.io/en/master/", None),
+}
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/doc/source/lib/galaxy.schema.rst
+++ b/doc/source/lib/galaxy.schema.rst
@@ -1,0 +1,26 @@
+galaxy.schema package
+=====================
+
+.. automodule:: galaxy.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+galaxy.schema.fields module
+---------------------------
+
+.. automodule:: galaxy.schema.fields
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+galaxy.schema.schema module
+---------------------------
+
+.. automodule:: galaxy.schema.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/lib/galaxy.tool_util.client.rst
+++ b/doc/source/lib/galaxy.tool_util.client.rst
@@ -1,0 +1,18 @@
+galaxy.tool\_util.client package
+================================
+
+.. automodule:: galaxy.tool_util.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+galaxy.tool\_util.client.staging module
+---------------------------------------
+
+.. automodule:: galaxy.tool_util.client.staging
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/lib/galaxy.web.legacy_framework.rst
+++ b/doc/source/lib/galaxy.web.legacy_framework.rst
@@ -1,0 +1,18 @@
+galaxy.web.legacy\_framework package
+====================================
+
+.. automodule:: galaxy.web.legacy_framework
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+galaxy.web.legacy\_framework.grids module
+-----------------------------------------
+
+.. automodule:: galaxy.web.legacy_framework.grids
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/lib/galaxy.workflow.refactor.rst
+++ b/doc/source/lib/galaxy.workflow.refactor.rst
@@ -1,0 +1,26 @@
+galaxy.workflow.refactor package
+================================
+
+.. automodule:: galaxy.workflow.refactor
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+galaxy.workflow.refactor.execute module
+---------------------------------------
+
+.. automodule:: galaxy.workflow.refactor.execute
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+galaxy.workflow.refactor.schema module
+--------------------------------------
+
+.. automodule:: galaxy.workflow.refactor.schema
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/releases/20.09-config.rst
+++ b/doc/source/releases/20.09-config.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Configuration Changes
 =====================
 

--- a/doc/source/releases/index.rst
+++ b/doc/source/releases/index.rst
@@ -37,3 +37,15 @@ Releases
    13.02_announce
    13.01_announce
    older_releases
+
+User Announcements
+
+.. toctree::
+   :maxdepth: 1
+
+   20.09_announce_user
+   20.05_announce_user
+   20.01_announce_user
+   19.09_announce_user
+   19.05_announce_user
+   19.01_announce_user

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -426,6 +426,8 @@ def _write_option_rst(args, rst, key, heading_level, option_value):
         default = "true"
     elif default is False:
         default = "false"
+    elif default == "":
+        default = '""'
     rst.write(":Default: ``%s``\n" % default)
     if type:
         rst.write(":Type: %s\n" % type)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -436,7 +436,7 @@ galaxy:
 
   # involucro is a tool used to build Docker or Singularity containers
   # for tools from Conda dependencies referenced in tools as
-  # `requirement`s. The following path is the location of involucro on
+  # `requirement` s. The following path is the location of involucro on
   # the Galaxy host. This is ignored if the relevant container resolver
   # isn't enabled, and will install on demand unless involucro_auto_init
   # is set to false.
@@ -1830,7 +1830,7 @@ galaxy:
   # can separate Galaxy into multiple processes.  There are more than
   # one way to do this, and they are explained in detail in the
   # documentation:
-  #   https://docs.galaxyproject.org/en/master/admin/scaling.html
+  # https://docs.galaxyproject.org/en/master/admin/scaling.html
   # By default, Galaxy manages and executes jobs from within a single
   # process and notifies itself of new jobs via in-memory queues.  Jobs
   # are run locally on the system on which Galaxy is started.  Advanced

--- a/lib/galaxy/containers/__init__.py
+++ b/lib/galaxy/containers/__init__.py
@@ -14,8 +14,7 @@ from abc import (
     abstractmethod,
     abstractproperty
 )
-from collections import namedtuple
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, NamedTuple, Optional, Type
 
 import yaml
 
@@ -29,18 +28,12 @@ DEFAULT_CONF = {'_default_': {'type': DEFAULT_CONTAINER_TYPE}}
 log = logging.getLogger(__name__)
 
 
-class ContainerPort(namedtuple('ContainerPort', ('port', 'protocol', 'hostaddr', 'hostport'))):
-    """Named tuple representing ports published by a container, with attributes:
-
-    :ivar       port:       Port number (inside the container)
-    :vartype    port:       int
-    :ivar       protocol:   Port protocol, either ``tcp`` or ``udp``
-    :vartype    protocol:   str
-    :ivar       hostaddr:   Address or hostname where the published port can be accessed
-    :vartype    hostaddr:   str
-    :ivar       hostport:   Published port number on which the container can be accessed
-    :vartype    hostport:   int
-    """
+class ContainerPort(NamedTuple):
+    """Named tuple representing ports published by a container, with attributes"""
+    port: int  # Port number (inside the container)
+    protocol: str  # Port protocol, either ``tcp`` or ``udp``
+    hostaddr: str  # Address or hostname where the published port can be accessed
+    hostport: int  # Published port number on which the container can be accessed
 
 
 class ContainerVolume(metaclass=ABCMeta):

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -174,7 +174,7 @@ class LibraryManager:
         :type   check_accessible:        bool
 
         :returns:   the original library
-        :rtype:     Library
+        :rtype:     galaxy.model.Library
         """
         # all libraries are accessible to an admin
         if trans.user_is_admin:

--- a/lib/galaxy/visualization/plugins/registry.py
+++ b/lib/galaxy/visualization/plugins/registry.py
@@ -51,7 +51,7 @@ class VisualizationsRegistry:
         """
         Set up the manager and load all visualization plugins.
 
-        :type   app:        UniverseApplication
+        :type   app:        galaxy.app.UniverseApplication
         :param  app:        the application (and its configuration) using this manager
         :type   base_url:   string
         :param  base_url:   url to prefix all plugin urls with

--- a/lib/galaxy/web/framework/middleware/batch.py
+++ b/lib/galaxy/web/framework/middleware/batch.py
@@ -2,6 +2,7 @@
 Batch API middleware
 
 Adds a single route to the installation that:
+
   1. accepts a POST call containing a JSON array of 'http-like' JSON
      dictionaries.
   2. Each dictionary describes a single API call within the batch and is routed

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -350,6 +350,7 @@ class JSAppLauncher(BaseUIController):
         `masthead` (boolean): (optional, default=True) include masthead elements in
             the initial page dom.
         `additional_options` (kwargs): update to the options sent to the app.
+
         """
         options = options or self._get_js_options(trans)
         options.update(additional_options)

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -70,8 +70,9 @@ class WebApplication(base.WebApplication):
     Base WSGI application instantiated for all Galaxy webapps.
 
     A web application that:
+
         * adds API and UI controllers by scanning given directories and
-        importing all modules found there.
+          importing all modules found there.
         * has a security object.
         * builds mako template lookups.
         * generates GalaxyWebTransactions.
@@ -765,8 +766,10 @@ class GalaxyWebTransaction(base.DefaultWebTransaction,
     def get_history(self, create=False, most_recent=False):
         """
         Load the current history.
+
             - If that isn't available, we find the most recently updated history.
             - If *that* isn't available, we get or create the default history.
+
         Transactions will not always have an active history (API requests), so
         None is a valid response.
         """

--- a/lib/galaxy/webapps/galaxy/api/authenticate.py
+++ b/lib/galaxy/webapps/galaxy/api/authenticate.py
@@ -8,7 +8,6 @@ Sample usage
 
 Returns
 
-.. highlight:: json
 .. code-block:: json
 
     {

--- a/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
+++ b/lib/galaxy/webapps/galaxy/api/tool_shed_repositories.py
@@ -420,10 +420,9 @@ class ToolShedRepositoriesController(BaseAPIController):
         """
         GET /api/tool_shed_repositories/{encoded_tool_shed_repsository_id}
 
-        Display a dictionary containing information about a specified tool_shed_repository
+        Display a dictionary containing information about a specified tool_shed_repository.
 
-        .. highlight:: json
-        .. code-block:: json
+        .. code-block::
 
             {
                 id: (string) Galaxy ID

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -38,17 +38,17 @@ class ToolsController(BaseAPIController, UsesVisualizationMixin):
     @expose_api_anonymous_and_sessionless
     def index(self, trans, **kwds):
         """
-        GET /api/tools: returns a list of tools defined by parameters::
+        GET /api/tools
 
-            parameters:
+        returns a list of tools defined by parameters
 
-                in_panel  - if true, tools are returned in panel structure,
-                            including sections and labels
-                trackster - if true, only tools that are compatible with
-                            Trackster are returned
-                q         - if present search on the given query will be performed
-                tool_id   - if present the given tool_id will be searched for
-                            all installed versions
+        :param in_panel: if true, tools are returned in panel structure,
+                         including sections and labels
+        :param trackster: if true, only tools that are compatible with
+                          Trackster are returned
+        :param q: if present search on the given query will be performed
+        :param tool_id: if present the given tool_id will be searched for
+                        all installed versions
         """
 
         # Read params.

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -505,7 +505,7 @@ mapping:
         required: false
         desc: |
           involucro is a tool used to build Docker or Singularity containers for tools from Conda
-          dependencies referenced in tools as `requirement`s. The following path is
+          dependencies referenced in tools as `requirement` s. The following path is
           the location of involucro on the Galaxy host. This is ignored if the relevant
           container resolver isn't enabled, and will install on demand unless
           involucro_auto_init is set to false.
@@ -2704,7 +2704,7 @@ mapping:
           separate Galaxy into multiple processes.  There are more than one way to do
           this, and they are explained in detail in the documentation:
 
-            https://docs.galaxyproject.org/en/master/admin/scaling.html
+          https://docs.galaxyproject.org/en/master/admin/scaling.html
 
           By default, Galaxy manages and executes jobs from within a single process and
           notifies itself of new jobs via in-memory queues.  Jobs are run locally on

--- a/lib/galaxy_test/base/api_asserts.py
+++ b/lib/galaxy_test/base/api_asserts.py
@@ -1,50 +1,72 @@
-""" Utility methods for making assertions about Galaxy API responses, etc...
+"""Utility methods for making assertions about Galaxy API responses, etc...
 """
+from typing import Any, cast, Dict, Union
+
+from requests import Response
+
 ASSERT_FAIL_ERROR_CODE = "Expected Galaxy error code %d, obtained %d"
 ASSERT_FAIL_STATUS_CODE = "Request status code (%d) was not expected value %s. Body was %s"
 
 
-def assert_status_code_is(response, expected_status_code):
+def assert_status_code_is(response: Response, expected_status_code: int):
+    """Assert that the supplied response has the expect status code."""
     response_status_code = response.status_code
     if expected_status_code != response_status_code:
         _report_status_code_error(response, expected_status_code)
 
 
-def assert_status_code_is_ok(response):
+def assert_status_code_is_ok(response: Response):
+    """Assert that the supplied response is okay.
+
+    The easier alternative ``response.raise_for_status()`` might be
+    perferable generally.
+    """
     response_status_code = response.status_code
     is_two_hundred_status_code = response_status_code >= 200 and response_status_code <= 300
     if not is_two_hundred_status_code:
         _report_status_code_error(response, "2XX")
 
 
-def _report_status_code_error(response, expected_status_code):
+def _report_status_code_error(response: Response, expected_status_code: Union[str, int]):
     try:
         body = response.json()
     except Exception:
-        body = "INVALID JSON RESPONSE <%s>" % response.content
+        body = f"INVALID JSON RESPONSE <{response.text}>"
     assertion_message = ASSERT_FAIL_STATUS_CODE % (response.status_code, expected_status_code, body)
     raise AssertionError(assertion_message)
 
 
-def assert_has_keys(response, *keys):
+def assert_has_keys(response: dict, *keys: str):
+    """Assert that the supplied response (dict) has the supplied keys."""
     for key in keys:
         assert key in response, f"Response [{response}] does not contain key [{key}]"
 
 
-def assert_not_has_keys(response, *keys):
+def assert_not_has_keys(response: dict, *keys: str):
+    """Assert that the supplied response (dict) does not have the supplied keys."""
     for key in keys:
         assert key not in response, f"Response [{response}] contains invalid key [{key}]"
 
 
-def assert_error_code_is(response, error_code):
-    if hasattr(response, "json"):
-        response = response.json()
-    assert_has_keys(response, "err_code")
-    err_code = response["err_code"]
+def assert_error_code_is(response: Union[Response, dict], error_code: int):
+    """Assert that the supplied response has the supplied Galaxy error code.
+
+    Galaxy error codes can be imported from :py:mod:`galaxy.exceptions.error_codes`
+    to test against.
+
+    ::
+
+        from galaxy.exceptions import error_codes
+        assert_error_code_is(response, error_codes.USER_REQUEST_MISSING_PARAMETER)
+
+    """
+    as_dict = _as_dict(response)
+    assert_has_keys(as_dict, "err_code")
+    err_code = as_dict["err_code"]
     assert err_code == int(error_code), ASSERT_FAIL_ERROR_CODE % (err_code, int(error_code))
 
 
-def assert_object_id_error(response):
+def assert_object_id_error(response: Response):
     # for tests that use fake object IDs - API might throw MalformedId (400) or
     # or ObjectNotFound (404) - depending if the ID happens to be parseable with
     # servers API key.
@@ -56,12 +78,20 @@ def assert_object_id_error(response):
         assert_error_code_is(response, 404001)
 
 
-def assert_error_message_contains(response, expected_contains):
-    if hasattr(response, "json"):
-        response = response.json()
-    assert_has_keys(response, "err_msg")
-    err_msg = response["err_msg"]
+def assert_error_message_contains(response: Union[Response, dict], expected_contains: str):
+    as_dict = _as_dict(response)
+    assert_has_keys(as_dict, "err_msg")
+    err_msg = as_dict["err_msg"]
     assert expected_contains in err_msg
+
+
+def _as_dict(response: Union[Response, dict]) -> Dict[str, Any]:
+    as_dict : Dict[str, Any]
+    if isinstance(response, Response):
+        as_dict = cast(dict, response.json())
+    else:
+        as_dict = response
+    return as_dict
 
 
 assert_has_key = assert_has_keys

--- a/lib/galaxy_test/base/api_asserts.py
+++ b/lib/galaxy_test/base/api_asserts.py
@@ -20,6 +20,8 @@ def assert_status_code_is_ok(response: Response):
 
     The easier alternative ``response.raise_for_status()`` might be
     perferable generally.
+
+    .. seealso:: :py:meth:`requests.Response.raise_for_status()`
     """
     response_status_code = response.status_code
     is_two_hundred_status_code = response_status_code >= 200 and response_status_code <= 300

--- a/lib/tool_shed/managers/groups.py
+++ b/lib/tool_shed/managers/groups.py
@@ -34,7 +34,7 @@ class GroupManager:
         :type   decoded_group_id:       int
 
         :returns:   the requested group
-        :rtype:     Group
+        :rtype:     tool_shed.model.Group
         """
         if decoded_group_id is None and name is None:
             raise RequestParameterInvalidException('You must supply either ID or a name of the group.')

--- a/lib/tool_shed/managers/repositories.py
+++ b/lib/tool_shed/managers/repositories.py
@@ -28,7 +28,7 @@ class RepoManager:
         :type   decoded_repo_id:       int
 
         :returns:   the requested repo
-        :rtype:     Repository
+        :rtype:     tool_shed.webapp.model.Repository
         """
         try:
             repo = trans.sa_session.query(trans.app.model.Repository).filter(trans.app.model.Repository.table.c.id == decoded_repo_id).one()

--- a/lib/tool_shed/webapp/api/authenticate.py
+++ b/lib/tool_shed/webapp/api/authenticate.py
@@ -8,11 +8,10 @@ Sample usage:
 
 Returns
 
-.. highlight:: json
 .. code-block:: json
 
     {
-        "api_key": <some api key>
+        "api_key": "<some api key>"
     }
 
 """


### PR DESCRIPTION
- Redo the way API docs are generated - just link to regular pydocs instead of duplicating all of the pydocs.
- Add docstrings to api_asserts.py.
- Allow linking to requests to using intersphinx.
- Some new environment variables to speed up doc building.
- Fix a ton of sphinx warnings.