### PR TITLE
uvicorn-compatible factory function for fastapi.

### DIFF
--- a/lib/galaxy/main_config.py
+++ b/lib/galaxy/main_config.py
@@ -1,0 +1,36 @@
+"""Utilities for finding Galaxy's configuration file.
+
+This is for use by web framework code and scripts (e.g. scripts/galaxy_main.py).
+"""
+import os
+
+DEFAULT_INIS = ["config/galaxy.yml", "config/galaxy.ini", "universe_wsgi.ini", "config/galaxy.yml.sample"]
+DEFAULT_INI_APP = "main"
+DEFAULT_CONFIG_SECTION = "galaxy"
+
+
+def absolute_config_path(path, galaxy_root):
+    if path and not os.path.isabs(path):
+        path = os.path.join(galaxy_root, path)
+    return path
+
+
+def config_is_ini(config_file):
+    return config_file and (config_file.endswith('.ini') or config_file.endswith('.ini.sample'))
+
+
+def find_config(supplied_config, galaxy_root):
+    if supplied_config:
+        return supplied_config
+
+    if galaxy_root is None:
+        return os.path.abspath('galaxy.yml')
+
+    # If not explicitly supplied an config, check galaxy.ini and then
+    # just resort to sample if that has not been configured.
+    for guess in DEFAULT_INIS:
+        config_path = os.path.join(galaxy_root, guess)
+        if os.path.exists(config_path):
+            return config_path
+
+    return guess

--- a/lib/galaxy/webapps/galaxy/fast_factory.py
+++ b/lib/galaxy/webapps/galaxy/fast_factory.py
@@ -1,0 +1,82 @@
+"""Module containing factory class for building uvicorn app for Galaxy.
+
+Information on uvicorn, its various settings, and how to invoke it can
+be found at https://www.uvicorn.org/.
+
+Galaxy can be launched with uvicorn using the following invocation:
+
+::
+
+    uvicorn --app-dir lib --factory galaxy.webapps.galaxy.fast_factory:factory
+
+Use the environment variable ``GALAXY_CONFIG_FILE`` to specify a Galaxy
+configuration file. Galaxy configuration can be loading from a YAML
+or an .ini file (reads app:main currently but can be overridden with
+GALAXY_CONFIG_SECTION).
+
+::
+
+    GALAXY_CONFIG_FILE=config/galaxy.yml uvicorn --app-dir lib --factory galaxy.webapps.galaxy.fast_factory:factory
+
+.. note::
+
+    Information on additional ways to configure uvicorn can be found at
+    https://www.uvicorn.org/.
+
+.. warning::
+
+    If an ini file is supplied via GALAXY_CONFIG_FILE, the server properties
+    such as host and port are not read from the file like older forms of
+    configuring Galaxy.
+
+`Gunicorn <https://docs.gunicorn.org/en/stable/index.html>`__ is a server with
+more complex management options.
+
+This factory function can be executed as a uvicorn worker managed with gunicorn
+with the following command-line.
+
+::
+
+    gunicorn 'galaxy.webapps.galaxy.fast_factory:factory()' --env GALAXY_CONFIG_FILE=config/galaxy.ini --pythonpath lib -w 4 -k uvicorn.workers.UvicornWorker
+
+"""
+import os
+
+from galaxy.main_config import (
+    absolute_config_path,
+    config_is_ini,
+    DEFAULT_CONFIG_SECTION,
+    DEFAULT_INI_APP,
+    find_config,
+)
+from galaxy.web_stack import get_app_kwds
+from galaxy.webapps.galaxy.buildapp import app_factory
+from .fast_app import initialize_fast_app
+
+
+def factory():
+    kwds = get_app_kwds("galaxy", "galaxy")
+    config_file = kwds.get("config_file")
+    if not config_file and "GALAXY_CONFIG_FILE" in os.environ:
+        config_file = os.path.abspath(os.environ["GALAXY_CONFIG_FILE"])
+    else:
+        galaxy_root = kwds.get("galaxy_root")
+        config_file = find_config(config_file, galaxy_root)
+        config_file = absolute_config_path(config_file, galaxy_root=galaxy_root)
+
+    if "GALAXY_CONFIG_SECTION" in os.environ:
+        config_section = os.environ["GALAXY_CONFIG_SECTION"]
+    elif config_is_ini(config_file):
+        config_section = "app:%s" % DEFAULT_INI_APP
+    else:
+        config_section = DEFAULT_CONFIG_SECTION
+
+    if 'config_file' not in kwds:
+        kwds['config_file'] = config_file
+    if 'config_section' not in kwds:
+        kwds['config_section'] = config_section
+    global_conf = {}
+    if config_is_ini(config_file):
+        global_conf["__file__"] = config_file
+    gx = app_factory(global_conf=global_conf, load_app_kwds=kwds)
+    return initialize_fast_app(gx)

--- a/packages/app/galaxy/main_config.py
+++ b/packages/app/galaxy/main_config.py
@@ -1,0 +1,1 @@
+../../../lib/galaxy/main_config.py


### PR DESCRIPTION
Implement https://github.com/galaxyproject/galaxy/issues/10884?

I'm sure we could drop the factory argument and just make app a global... but I do hate that style of code. I think everything in lib should be importable without side effects.

Update: I've rebased this with instructions for running via gunicorn which doesn't expose that factory argument to convince myself this can be done without globals. It seems to work.