### PR TITLE
docstrings and type annotations for galaxy.managers.context.

### DIFF
--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -102,8 +102,8 @@ class RoleManager(base.ModelManager):
 
         role = trans.app.model.Role(name=name, description=description, type=role_type)
         trans.sa_session.add(role)
-        users = [trans.sa_session.query(trans.model.User).get(trans.security.decode_id(i)) for i in user_ids]
-        groups = [trans.sa_session.query(trans.model.Group).get(trans.security.decode_id(i)) for i in group_ids]
+        users = [trans.sa_session.query(model.User).get(trans.security.decode_id(i)) for i in user_ids]
+        groups = [trans.sa_session.query(model.Group).get(trans.security.decode_id(i)) for i in group_ids]
 
         # Create the UserRoleAssociations
         for user in users:

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -765,7 +765,9 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         self.sa_session.add(self.galaxy_session)
         self.sa_session.flush()
 
-    history = property(get_history, set_history)
+    @property
+    def history(self):
+        return self.get_history()
 
     def get_or_create_default_history(self):
         """

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -30,10 +30,9 @@ class WorkRequestContext(ProvidesHistoryContext):
     def get_history(self, create=False):
         return self.__history
 
-    def set_history(self, history):
-        raise NotImplementedError("Cannot change histories from a work request context.")
-
-    history = property(get_history, set_history)
+    @property
+    def history(self):
+        return self.get_history()
 
     def get_user(self):
         """Return the current user if logged in or None."""


### PR DESCRIPTION
sphinx isn't rendering the types on the abstract properties - which makes me sad but I'm confident that will be fixed at some point. I did change some dependents around to ensure the type annotations are being used by mypy in this case and and they are.