### PR TITLE
Fix mypy error with Union in response_model

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -13,8 +13,8 @@ from fastapi import (
     Depends,
     Query,
 )
-from fastapi.routing import APIRouter
 from fastapi_utils.cbv import cbv
+from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.app import UniverseApplication
 from galaxy.datatypes.registry import Registry
@@ -61,11 +61,11 @@ def get_datatypes_registry(app: UniverseApplication = Depends(get_app)) -> Regis
 class FastAPIDatatypes:
     datatypes_registry: Registry = Depends(get_datatypes_registry)
 
-    # mypy does not like the use of Union in the response_model but it must be used to support
-    # the two possible types of response for this endpoint.
-    # Please see: https://stackoverflow.com/questions/62264787/mypy-fastapi-response-model
-    # Aparently this may be related to the Python version
-    @router.get('/api/datatypes', summary="Lists all available data types", response_model=Union[List[DatatypeDetails], List[str]], response_description="List of data types")  # type: ignore
+    @router.get(
+        '/api/datatypes',
+        summary="Lists all available data types",
+        response_description="List of data types",
+    )
     async def index(
         self,
         extension_only: Optional[bool] = ExtensionOnlyQueryParam,
@@ -77,7 +77,6 @@ class FastAPIDatatypes:
     @router.get(
         '/api/datatypes/mapping',
         summary="Returns mappings for data types and their implementing classes",
-        response_model=DatatypesMap,
         response_description="Dictionary to map data types with their classes"
     )
     async def mapping(self) -> DatatypesMap:
@@ -87,7 +86,6 @@ class FastAPIDatatypes:
     @router.get(
         '/api/datatypes/types_and_mapping',
         summary="Returns all the data types extensions and their mappings",
-        response_model=DatatypesCombinedMap,
         response_description="Dictionary to map data types with their classes"
     )
     async def types_and_mapping(
@@ -106,7 +104,6 @@ class FastAPIDatatypes:
     @router.get(
         '/api/datatypes/sniffers',
         summary="Returns the list of all installed sniffers",
-        response_model=List[str],
         response_description="List of datatype sniffers"
     )
     async def sniffers(self) -> List[str]:
@@ -116,7 +113,6 @@ class FastAPIDatatypes:
     @router.get(
         '/api/datatypes/converters',
         summary="Returns the list of all installed converters",
-        response_model=DatatypeConverterList,
         response_description="List of all datatype converters"
     )
     async def converters(self) -> DatatypeConverterList:
@@ -126,7 +122,6 @@ class FastAPIDatatypes:
     @router.get(
         '/api/datatypes/edam_formats',
         summary="Returns a dictionary/map of datatypes and EDAM formats",
-        response_model=Dict[str, str],
         response_description="Dictionary/map of datatypes and EDAM formats"
     )
     async def edam_formats(self) -> Dict[str, str]:
@@ -136,7 +131,6 @@ class FastAPIDatatypes:
     @router.get(
         '/api/datatypes/edam_data',
         summary="Returns a dictionary/map of datatypes and EDAM data",
-        response_model=Dict[str, str],
         response_description="Dictionary/map of datatypes and EDAM data"
     )
     async def edam_data(self) -> Dict[str, str]:

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -61,12 +61,11 @@ def get_datatypes_registry(app: UniverseApplication = Depends(get_app)) -> Regis
 class FastAPIDatatypes:
     datatypes_registry: Registry = Depends(get_datatypes_registry)
 
-    @router.get(
-        '/api/datatypes',
-        summary="Lists all available data types",
-        response_model=Union[List[DatatypeDetails], List[str]],
-        response_description="List of data types",
-    )
+    # mypy does not like the use of Union in the response_model but it must be used to support
+    # the two possible types of response for this endpoint.
+    # Please see: https://stackoverflow.com/questions/62264787/mypy-fastapi-response-model
+    # Aparently this may be related to the Python version
+    @router.get('/api/datatypes', summary="Lists all available data types", response_model=Union[List[DatatypeDetails], List[str]], response_description="List of data types")  # type: ignore
     async def index(
         self,
         extension_only: Optional[bool] = ExtensionOnlyQueryParam,

--- a/lib/galaxy/webapps/galaxy/api/licenses.py
+++ b/lib/galaxy/webapps/galaxy/api/licenses.py
@@ -4,8 +4,8 @@ from fastapi import (
     Depends,
     Path
 )
-from fastapi.routing import APIRouter
 from fastapi_utils.cbv import cbv
+from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.managers.licenses import (
     LicenseMetadataModel,
@@ -34,7 +34,6 @@ class FastAPILicenses:
 
     @router.get('/api/licenses',
         summary="Lists all available SPDX licenses",
-        response_model=List[LicenseMetadataModel],
         response_description="List of SPDX licenses")
     async def index(self) -> List[LicenseMetadataModel]:
         """Returns an index with all the available [SPDX licenses](https://spdx.org/licenses/)."""
@@ -42,7 +41,6 @@ class FastAPILicenses:
 
     @router.get('/api/licenses/{id}',
         summary="Gets the SPDX license metadata associated with the short identifier",
-        response_model=LicenseMetadataModel,
         response_description="SPDX license metadata")
     async def get(self, id=LicenseIdPath) -> LicenseMetadataModel:
         """Returns the license metadata associated with the given


### PR DESCRIPTION
Apparently, in some versions of Python, `mypy` does not like the `Union` type in the FastAPI response_model declaration and will output this error:
````python
Argument "response_model" to "get" of "APIRouter" has incompatible type "object"; expected "Optional[Type[Any]]"
````
Since this endpoint needs to return different types of responses depending on its query parameters, this Union can not be removed.

Note: I had to 'unwrap' the line in order to use the `# type: ignore` otherwise no matter where I put it the error was still showing 😕 