### PR TITLE
[20.09] Don't attempt to use docker cli if it is not available

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -325,6 +325,8 @@ def targets_to_mulled_name(targets, hash_func, namespace, resolution_cache=None,
 
 class DockerContainerResolver(ContainerResolver):
 
+    container_type = 'docker'
+
     def __init__(self, *args, **kwargs):
         self._docker_cli_available = bool(which('docker'))
         super().__init__(*args, **kwargs)
@@ -343,7 +345,6 @@ class DockerContainerResolver(ContainerResolver):
 class CachedMulledDockerContainerResolver(DockerContainerResolver):
 
     resolver_type = "cached_mulled"
-    container_type = "docker"
     shell = '/bin/bash'
 
     def __init__(self, app_info=None, namespace="biocontainers", hash_func="v2", **kwds):
@@ -389,7 +390,6 @@ class MulledDockerContainerResolver(DockerContainerResolver):
     """Look for mulled images matching tool dependencies."""
 
     resolver_type = "mulled"
-    container_type = "docker"
     shell = '/bin/bash'
     protocol = None
 
@@ -405,8 +405,8 @@ class MulledDockerContainerResolver(DockerContainerResolver):
         except subprocess.CalledProcessError:
             # We should only get here if a docker binary is available, but command quits with a non-zero exit code,
             # e.g if the docker daemon is not available
-            log.exception('An error occured while listing cached docker images. Disabling docker image cache.')
-            self.docker_cli_available = False
+            log.exception('An error occured while listing cached docker image. Docker daemon may need to be restarted.')
+            return None
 
     def pull(self, container):
         if self.docker_cli_available:
@@ -493,7 +493,6 @@ class BuildMulledDockerContainerResolver(DockerContainerResolver):
     """Build for Docker mulled images matching tool dependencies."""
 
     resolver_type = "build_mulled"
-    container_type = "docker"
     shell = '/bin/bash'
     builds_on_resolution = True
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -9,6 +9,7 @@ import subprocess
 from galaxy.util import (
     string_as_bool,
     unicodify,
+    which,
 )
 from galaxy.util.commands import shell
 from ..container_classes import CONTAINER_CLASSES
@@ -322,7 +323,24 @@ def targets_to_mulled_name(targets, hash_func, namespace, resolution_cache=None,
     return name
 
 
-class CachedMulledDockerContainerResolver(ContainerResolver):
+class DockerContainerResolver(ContainerResolver):
+
+    def __init__(self, *args, **kwargs):
+        self._docker_cli_available = bool(which('docker'))
+        super().__init__(*args, **kwargs)
+
+    @property
+    def docker_cli_available(self):
+        return self._docker_cli_available
+
+    @docker_cli_available.setter
+    def docker_cli_available(self, value):
+        if not value:
+            log.info('Docker CLI not available, cannot list or pull images in Galaxy process. Does not impact kubernetes.')
+        self._docker_cli_available = value
+
+
+class CachedMulledDockerContainerResolver(DockerContainerResolver):
 
     resolver_type = "cached_mulled"
     container_type = "docker"
@@ -334,7 +352,7 @@ class CachedMulledDockerContainerResolver(ContainerResolver):
         self.hash_func = hash_func
 
     def resolve(self, enabled_container_types, tool_info, **kwds):
-        if tool_info.requires_galaxy_python_environment or self.container_type not in enabled_container_types:
+        if not self.docker_cli_available or tool_info.requires_galaxy_python_environment or self.container_type not in enabled_container_types:
             return None
 
         targets = mulled_targets(tool_info)
@@ -367,7 +385,7 @@ class CachedMulledSingularityContainerResolver(ContainerResolver):
         return "CachedMulledSingularityContainerResolver[cache_directory=%s]" % self.cache_directory
 
 
-class MulledDockerContainerResolver(ContainerResolver):
+class MulledDockerContainerResolver(DockerContainerResolver):
     """Look for mulled images matching tool dependencies."""
 
     resolver_type = "mulled"
@@ -382,11 +400,18 @@ class MulledDockerContainerResolver(ContainerResolver):
         self.auto_install = string_as_bool(auto_install)
 
     def cached_container_description(self, targets, namespace, hash_func, resolution_cache):
-        return docker_cached_container_description(targets, namespace, hash_func, resolution_cache)
+        try:
+            return docker_cached_container_description(targets, namespace, hash_func, resolution_cache)
+        except subprocess.CalledProcessError:
+            # We should only get here if a docker binary is available, but command quits with a non-zero exit code,
+            # e.g if the docker daemon is not available
+            log.exception('An error occured while listing cached docker images. Disabling docker image cache.')
+            self.docker_cli_available = False
 
     def pull(self, container):
-        command = container.build_pull_command()
-        shell(command)
+        if self.docker_cli_available:
+            command = container.build_pull_command()
+            shell(command)
 
     def resolve(self, enabled_container_types, tool_info, install=False, session=None, **kwds):
         resolution_cache = kwds.get("resolution_cache")
@@ -407,30 +432,31 @@ class MulledDockerContainerResolver(ContainerResolver):
                 type=self.container_type,
                 shell=self.shell,
             )
-            if install and not self.cached_container_description(
-                    targets,
-                    namespace=self.namespace,
-                    hash_func=self.hash_func,
-                    resolution_cache=resolution_cache,
-            ):
-                destination_info = {}
-                destination_for_container_type = kwds.get('destination_for_container_type')
-                if destination_for_container_type:
-                    destination_info = destination_for_container_type(self.container_type)
-                container = CONTAINER_CLASSES[self.container_type](container_description.identifier,
-                                                                   self.app_info,
-                                                                   tool_info,
-                                                                   destination_info,
-                                                                   {},
-                                                                   container_description)
-                self.pull(container)
-            if not self.auto_install:
-                container_description = self.cached_container_description(
-                    targets,
-                    namespace=self.namespace,
-                    hash_func=self.hash_func,
-                    resolution_cache=resolution_cache,
-                )
+            if self.docker_cli_available:
+                if install and not self.cached_container_description(
+                        targets,
+                        namespace=self.namespace,
+                        hash_func=self.hash_func,
+                        resolution_cache=resolution_cache,
+                ):
+                    destination_info = {}
+                    destination_for_container_type = kwds.get('destination_for_container_type')
+                    if destination_for_container_type:
+                        destination_info = destination_for_container_type(self.container_type)
+                    container = CONTAINER_CLASSES[self.container_type](container_description.identifier,
+                                                                       self.app_info,
+                                                                       tool_info,
+                                                                       destination_info,
+                                                                       {},
+                                                                       container_description)
+                    self.pull(container)
+                if not self.auto_install:
+                    container_description = self.cached_container_description(
+                        targets,
+                        namespace=self.namespace,
+                        hash_func=self.hash_func,
+                        resolution_cache=resolution_cache,
+                    )
             return container_description
 
     def __str__(self):
@@ -463,7 +489,7 @@ class MulledSingularityContainerResolver(MulledDockerContainerResolver):
         return "MulledSingularityContainerResolver[namespace=%s]" % self.namespace
 
 
-class BuildMulledDockerContainerResolver(ContainerResolver):
+class BuildMulledDockerContainerResolver(DockerContainerResolver):
     """Build for Docker mulled images matching tool dependencies."""
 
     resolver_type = "build_mulled"
@@ -488,7 +514,7 @@ class BuildMulledDockerContainerResolver(ContainerResolver):
         self.auto_init = self._get_config_option("involucro_auto_init", True)
 
     def resolve(self, enabled_container_types, tool_info, install=False, **kwds):
-        if tool_info.requires_galaxy_python_environment or self.container_type not in enabled_container_types:
+        if not self.docker_cli_available or tool_info.requires_galaxy_python_environment or self.container_type not in enabled_container_types:
             return None
 
         targets = mulled_targets(tool_info)

--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -514,7 +514,7 @@ class BuildMulledDockerContainerResolver(DockerContainerResolver):
         self.auto_init = self._get_config_option("involucro_auto_init", True)
 
     def resolve(self, enabled_container_types, tool_info, install=False, **kwds):
-        if not self.docker_cli_available or tool_info.requires_galaxy_python_environment or self.container_type not in enabled_container_types:
+        if tool_info.requires_galaxy_python_environment or self.container_type not in enabled_container_types:
             return None
 
         targets = mulled_targets(tool_info)

--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -222,9 +222,15 @@ class ContainerRegistry:
                 CachedMulledSingularityContainerResolver(self.app_info, namespace="local"),
                 MulledDockerContainerResolver(self.app_info, namespace="biocontainers"),
                 MulledSingularityContainerResolver(self.app_info, namespace="biocontainers"),
-                BuildMulledDockerContainerResolver(self.app_info),
-                BuildMulledSingularityContainerResolver(self.app_info),
             ])
+            # BuildMulledDockerContainerResolver and BuildMulledSingularityContainerResolver both need the docker daemon to build images.
+            # If docker is not available, we don't load them.
+            build_mulled_docker_container_resolver = BuildMulledDockerContainerResolver(self.app_info)
+            if build_mulled_docker_container_resolver.docker_cli_available:
+                default_resolvers.extend([
+                    build_mulled_docker_container_resolver,
+                    BuildMulledSingularityContainerResolver(self.app_info),
+                ])
         return default_resolvers
 
     def __resolvers_dict(self):

--- a/packages/tool_util/test-requirements.txt
+++ b/packages/tool_util/test-requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-mock

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -1,0 +1,53 @@
+from subprocess import CalledProcessError
+
+from galaxy.tool_util.deps.container_resolvers.mulled import (
+    CachedMulledDockerContainerResolver,
+    MulledDockerContainerResolver,
+)
+from galaxy.tool_util.deps.dependencies import ToolInfo
+from galaxy.tool_util.deps.requirements import ToolRequirement
+
+
+def test_docker_container_resolver_detects_docker_cli_absent(mocker):
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value=None)
+    resolver = CachedMulledDockerContainerResolver()
+    assert resolver.docker_cli_available is False
+
+
+def test_docker_container_resolver_detects_docker_cli(mocker):
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled', return_value='/bin/docker')
+    resolver = CachedMulledDockerContainerResolver()
+    assert resolver.docker_cli_available
+
+
+def test_cached_docker_container_docker_cli_absent_resolve(mocker):
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value=None)
+    resolver = CachedMulledDockerContainerResolver()
+    assert resolver.docker_cli_available is False
+    assert resolver.resolve(enabled_container_types=[], tool_info={}) is None
+
+
+def test_docker_container_docker_cli_absent_resolve(mocker):
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value=None)
+    resolver = MulledDockerContainerResolver()
+    assert resolver.docker_cli_available is False
+    requirement = ToolRequirement(name="samtools", version="1.10", type="package")
+    tool_info = ToolInfo(requirements=[requirement])
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.targets_to_mulled_name', return_value='samtools:1.10--h2e538c0_3')
+    container_description = resolver.resolve(enabled_container_types=['docker'], tool_info=tool_info)
+    assert container_description.type == 'docker'
+    assert container_description.identifier == 'quay.io/biocontainers/samtools:1.10--h2e538c0_3'
+
+
+def test_docker_container_docker_cli_exception_resolve(mocker):
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value='/bin/docker')
+    resolver = MulledDockerContainerResolver()
+    assert resolver.docker_cli_available is True
+    requirement = ToolRequirement(name="samtools", version="1.10", type="package")
+    tool_info = ToolInfo(requirements=[requirement])
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.targets_to_mulled_name', return_value='samtools:1.10--h2e538c0_3')
+    mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.docker_cached_container_description', side_effect=CalledProcessError(1, 'bla'))
+    container_description = resolver.resolve(enabled_container_types=['docker'], tool_info=tool_info, install=True)
+    assert resolver.docker_cli_available is False
+    assert container_description.type == 'docker'
+    assert container_description.identifier == 'quay.io/biocontainers/samtools:1.10--h2e538c0_3'

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -48,6 +48,6 @@ def test_docker_container_docker_cli_exception_resolve(mocker):
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.targets_to_mulled_name', return_value='samtools:1.10--h2e538c0_3')
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.docker_cached_container_description', side_effect=CalledProcessError(1, 'bla'))
     container_description = resolver.resolve(enabled_container_types=['docker'], tool_info=tool_info, install=True)
-    assert resolver.docker_cli_available is False
+    assert resolver.docker_cli_available is True
     assert container_description.type == 'docker'
     assert container_description.identifier == 'quay.io/biocontainers/samtools:1.10--h2e538c0_3'


### PR DESCRIPTION
This fixes https://github.com/galaxyproject/galaxy/issues/11125, which became a problem with https://github.com/galaxyproject/galaxy/pull/10814 and the recent removal of the docker runtime from kubernetes.

This is the quick fix, but I don't like the guessing and disabling that we do if docker is not available or not functional (but test are included, this should work™️ ).

I'm hesitating between adding a config option for the resolver (`docker_cli_available` or `docker_list_images` + `docker_pull_images`) and adding a `KubernetesContainerResolver` / `RemoteContainerResolver` class that doesn't assume docker is available for listing and pulling images.

Not wanting to list/pull images on the Galaxy node is probably a reasonable thing outside of kubernetes as well, so I tend to go with a `RemoteContainerResolver` class in dev ?