### PR TITLE
replaced global vue with test vue in unit tests

### DIFF
--- a/client/src/components/DatasetInformation/DatasetInformation.test.js
+++ b/client/src/components/DatasetInformation/DatasetInformation.test.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import DatasetInformation from "./DatasetInformation";
 import datasetResponse from "./testData/datasetResponse";
 import flushPromises from "flush-promises";
@@ -17,6 +18,8 @@ const mockDatasetProvider = {
         });
     },
 };
+
+const localVue = getLocalVue();
 
 describe("DatasetInformation/DatasetInformation.vue", () => {
     let wrapper;
@@ -42,6 +45,7 @@ describe("DatasetInformation/DatasetInformation.vue", () => {
             stubs: {
                 DatasetProvider: mockDatasetProvider,
             },
+            localVue,
         });
         datasetInfoTable = wrapper.find("#dataset-details");
         await flushPromises();

--- a/client/src/components/HistoryExport/Index.vue
+++ b/client/src/components/HistoryExport/Index.vue
@@ -25,20 +25,20 @@
 </template>
 
 <script>
-import Vue from "vue";
-import BootstrapVue from "bootstrap-vue";
+import { BCard, BTabs, BTab } from "bootstrap-vue";
 import ToLink from "./ToLink.vue";
 import ToRemoteFile from "./ToRemoteFile.vue";
 import { Services } from "components/FilesDialog/services";
 import LoadingSpan from "components/LoadingSpan";
-
-Vue.use(BootstrapVue);
 
 export default {
     components: {
         LoadingSpan,
         ToLink,
         ToRemoteFile,
+        BCard,
+        BTabs,
+        BTab,
     },
     props: {
         historyId: {
@@ -59,7 +59,7 @@ export default {
         async initialize() {
             const fileSources = await new Services().getFileSources();
             this.hasWritableFileSources = fileSources.some((fs) => fs.writable);
-            console.log(fileSources);
+            // console.log(fileSources);
             this.initializing = false;
         },
     },

--- a/client/src/components/ToolsView/ToolsSchemaJson/ToolsJson.test.js
+++ b/client/src/components/ToolsView/ToolsSchemaJson/ToolsJson.test.js
@@ -3,7 +3,10 @@ import ToolsJson from "./ToolsJson";
 import testToolsListResponse from "../testData/toolsList";
 import MockAdapter from "axios-mock-adapter";
 import axios from "axios";
-import { mount } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+
+const localVue = getLocalVue();
 
 describe("ToolsView/ToolsView.vue", () => {
     let wrapper;
@@ -12,7 +15,7 @@ describe("ToolsView/ToolsView.vue", () => {
 
     beforeEach(async () => {
         axiosMock = new MockAdapter(axios);
-        wrapper = mount(ToolsJson);
+        wrapper = shallowMount(ToolsJson, { localVue });
         axiosMock.onGet("/api/tools?tool_help=True").reply(200, testToolsListResponse);
         await wrapper.vm.$nextTick();
     });

--- a/client/src/components/Toolshed/InstalledList/Index.test.js
+++ b/client/src/components/Toolshed/InstalledList/Index.test.js
@@ -1,4 +1,5 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import Index from "./Index";
 
 jest.mock("app");
@@ -9,6 +10,8 @@ getAppRoot.mockImplementation(() => "/");
 
 import { Services } from "../services";
 jest.mock("../services");
+
+const localVue = getLocalVue();
 
 Services.mockImplementation(() => {
     return {
@@ -42,6 +45,7 @@ describe("InstalledList", () => {
             stubs: {
                 RepositoryDetails: true,
             },
+            localVue,
         });
         expect(wrapper.find(".loading-message").text()).toBe("Loading installed repositories...");
         await wrapper.vm.$nextTick();

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationButton.test.js
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationButton.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import InstallationButton from "./InstallationButton";
+
+const localVue = getLocalVue();
 
 describe("InstallationButton", () => {
     it("test installed repository revision", () => {
@@ -8,6 +11,7 @@ describe("InstallationButton", () => {
                 installed: true,
                 status: "Installed",
             },
+            localVue,
         });
         const $el = wrapper.find("button");
         expect($el.classes()).toEqual(expect.arrayContaining(["btn-danger"]));

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.test.js
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.test.js
@@ -1,7 +1,10 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import InstallationSettings from "./InstallationSettings";
 
 jest.mock("app");
+
+const localVue = getLocalVue();
 
 describe("InstallationSettings", () => {
     it("test tool repository installer interface", () => {
@@ -18,6 +21,7 @@ describe("InstallationSettings", () => {
                 requiresPanel: true,
                 toolshedUrl: "toolshedUrl",
             },
+            localVue,
         });
         expect(wrapper.find(".title").text()).toBe("Installing 'name'");
         expect(wrapper.find(".description").text()).toBe("long_description");

--- a/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.test.js
+++ b/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import RepositoryTools from "./RepositoryTools";
+
+const localVue = getLocalVue();
 
 describe("RepositoryTools", () => {
     it("test tool version list in repository details", () => {
@@ -13,6 +16,7 @@ describe("RepositoryTools", () => {
                     },
                 ],
             },
+            localVue,
         });
         const $el = wrapper.findAll("td");
         const $first = $el.at(0);

--- a/client/src/components/Toolshed/SearchList/ServerSelection.test.js
+++ b/client/src/components/Toolshed/SearchList/ServerSelection.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import ServerSelection from "./ServerSelection";
+
+const localVue = getLocalVue();
 
 describe("ServerSelection", () => {
     it("test server selection dropdown", () => {
@@ -10,6 +13,7 @@ describe("ServerSelection", () => {
                 loading: false,
                 total: "total",
             },
+            localVue,
         });
         expect(wrapper.find(".description").text()).toBe("total repositories available at");
         const $options = wrapper.findAll("a");

--- a/client/src/components/Upload/UploadModal.test.js
+++ b/client/src/components/Upload/UploadModal.test.js
@@ -3,7 +3,6 @@ import axios from "axios";
 import UploadModal from "./UploadModal.vue";
 import store from "../../store";
 import { shallowMount, createLocalVue } from "@vue/test-utils";
-import BootstrapVue from "bootstrap-vue";
 
 jest.mock("app");
 jest.mock("../History/caching");
@@ -39,7 +38,6 @@ describe("UploadModal.vue", () => {
         axiosMock.onGet(`/api/genomes`).reply(200, genomesResponse);
 
         const localVue = createLocalVue();
-        localVue.use(BootstrapVue);
 
         wrapper = await shallowMount(UploadModal, {
             store,

--- a/client/src/components/User/CloudAuth/CloudAuth.test.js
+++ b/client/src/components/User/CloudAuth/CloudAuth.test.js
@@ -5,9 +5,6 @@ import { getLocalVue } from "jest/helpers";
 import { default as CloudAuth } from "./CloudAuth";
 import CloudAuthItem from "./CloudAuthItem";
 
-import _l from "utils/localization";
-import BootstrapVue from "bootstrap-vue";
-
 jest.mock("./model/service", () => ({
     listCredentials: async () => {
         const listCredentials = require("./testdata/listCredentials.json");
@@ -17,8 +14,6 @@ jest.mock("./model/service", () => ({
 }));
 
 const localVue = getLocalVue();
-localVue.use(BootstrapVue);
-localVue.filter("localize", (value) => _l(value));
 
 describe("CloudAuth component", () => {
     let wrapper;

--- a/client/src/components/User/RecentInvocations.test.js
+++ b/client/src/components/User/RecentInvocations.test.js
@@ -1,5 +1,6 @@
 import Invocations from "../Workflow/Invocations";
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import flushPromises from "flush-promises";
 
 import RecentInvocations from "./RecentInvocations.vue";
@@ -7,13 +8,15 @@ import RecentInvocations from "./RecentInvocations.vue";
 jest.mock("../History/caching");
 jest.mock("./UserServices");
 
+const localVue = getLocalVue();
+
 describe("RecentInvocations.vue", () => {
     let wrapper;
     let fetchInvocationsSpy;
 
     beforeEach(async () => {
         fetchInvocationsSpy = jest.spyOn(RecentInvocations.methods, "fetchRecentInvocations");
-        wrapper = mount(RecentInvocations);
+        wrapper = mount(RecentInvocations, { localVue });
         await flushPromises();
     });
 

--- a/client/src/components/Workflow/Editor/RefactorConfirmationModal.test.js
+++ b/client/src/components/Workflow/Editor/RefactorConfirmationModal.test.js
@@ -1,11 +1,12 @@
 jest.mock("./modules/services");
 
-import { shallowMount, createLocalVue } from "@vue/test-utils";
+import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import RefactorConfirmationModal from "./RefactorConfirmationModal";
 import { refactor } from "./modules/services";
 import flushPromises from "flush-promises";
 
-const localVue = createLocalVue();
+const localVue = getLocalVue();
 const TEST_WORKFLOW_ID = "test123";
 const TEST_ACTION_TYPE = "upgrade_subworkflow";
 

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -1,9 +1,12 @@
 import Invocations from "../Workflow/Invocations";
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import invocationData from "./test/json/invocation.json";
 import moment from "moment";
 
 jest.mock("../History/caching");
+
+const localVue = getLocalVue();
 
 describe("Invocations.vue without invocation", () => {
     let wrapper;
@@ -16,6 +19,7 @@ describe("Invocations.vue without invocation", () => {
         };
         wrapper = mount(Invocations, {
             propsData,
+            localVue,
         });
     });
 
@@ -62,6 +66,7 @@ describe("Invocations.vue with invocation", () => {
                     template: "<span/>",
                 },
             },
+            localVue,
         });
     });
 

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
@@ -1,5 +1,6 @@
 import WorkflowInvocationState from "./WorkflowInvocationState";
 import { shallowMount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import Vuex from "vuex";
 import invocationData from "../Workflow/test/json/invocation.json";
 
@@ -10,6 +11,8 @@ const invocationJobsSummaryById = {
     populated_state: "ok",
 };
 jest.mock("../History/caching");
+
+const localVue = getLocalVue();
 
 describe("WorkflowInvocationState.vue with terminal invocation", () => {
     let wrapper;
@@ -25,6 +28,7 @@ describe("WorkflowInvocationState.vue with terminal invocation", () => {
                 invocation: () => invocationData,
                 getInvocationJobsSummaryById: () => () => invocationJobsSummaryById,
             },
+            localVue,
         });
     });
 
@@ -67,6 +71,7 @@ describe("WorkflowInvocationState.vue with no invocation", () => {
                 invocation: () => null,
                 getInvocationJobsSummaryById: () => () => invocationJobsSummaryById,
             },
+            localVue,
         });
     });
 

--- a/client/src/components/admin/BaseList.test.js
+++ b/client/src/components/admin/BaseList.test.js
@@ -1,5 +1,8 @@
 import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import BaseList from "./BaseList";
+
+const localVue = getLocalVue();
 
 describe("Categories", () => {
     const getter = async () => {
@@ -30,6 +33,7 @@ describe("Categories", () => {
                 getter: getter,
                 setter: setter,
             },
+            localVue,
         });
         await wrapper.vm.$nextTick();
         expect(wrapper.find(".card-header").text()).toContain("There are 2");


### PR DESCRIPTION
Noticed a lot of client-side tests are continuing to use global Vue instead of our curated Vue instance.

Right now, it's just an annoyance with the eye-spam during test runs with the BootstrapVue components blithely trying to access a non-existent document.

But the problem is that component authors are not using [the standard mount function](https://github.com/galaxyproject/galaxy/blob/dev/client/src/utils/mountVueComponent.js) which means they are unit testing in a Vue environment that is unlikely to match the one in which the component actually runs.

The [helper we wrote](https://github.com/galaxyproject/galaxy/blob/bbd325527cf691258bab7989fbd4787f3160aa2d/client/tests/jest/helpers.js#L60) is intended to generate a Vue instance that matches the one in the client in terms of plugins, filters, directive overrides, etc.
