### PR TITLE
[20.09] Fix mule job messaging

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -110,10 +110,11 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
     else:
         # Make sure collections, implicit jobs etc are flushed even if there are no precreated output datasets
         trans.sa_session.flush()
+    tool_id = tool.id
     for job in execution_tracker.successful_jobs:
         # Put the job in the queue if tracking in memory
         tool.app.job_manager.enqueue(job, tool=tool, flush=False)
-        trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
+        trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=tool_id)
     trans.sa_session.flush()
 
     if has_remaining_jobs:

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -418,7 +418,7 @@ class ConfiguresHandlers:
             log.debug("(%s) No handler pool (uWSGI farm) for '%s' found", obj.log_str(), tag)
             raise HandlerAssignmentSkip()
         else:
-            if flush:
+            if flush or not obj.id:
                 _timed_flush_obj(obj)
             message = message_callback()
             self.app.application_stack.send_message(pool, message)


### PR DESCRIPTION
Handler assignment via mule messaging passes around the job id, so we need to flush before we can assign.
Should fix https://github.com/galaxyproject/galaxy/issues/11146.