### PR TITLE
Various testing framework cleanups.

### DIFF
--- a/lib/galaxy/selenium/context.py
+++ b/lib/galaxy/selenium/context.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from six.moves.urllib.parse import urljoin
 
 from .driver_factory import ConfiguredDriver
@@ -35,7 +36,11 @@ class GalaxySeleniumContext(NavigatesGalaxy):
 
 
 class GalaxySeleniumContextImpl(GalaxySeleniumContext):
-    """Minimal, simplified GalaxySeleniumContext useful outside the context of test cases."""
+    """Minimal, simplified GalaxySeleniumContext useful outside the context of test cases.
+
+    A variant of this concept that can also populate content via the API
+    to then interact with via the Selenium is :class:galaxy_test.selenium.framework:`GalaxySeleniumContextImpl`.
+    """
 
     def __init__(self, from_dict: Optional[dict] = None) -> None:
         from_dict = from_dict or {}

--- a/lib/galaxy/selenium/context.py
+++ b/lib/galaxy/selenium/context.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from six.moves.urllib.parse import urljoin
 
 from .driver_factory import ConfiguredDriver
@@ -36,7 +37,7 @@ class GalaxySeleniumContext(NavigatesGalaxy):
 class GalaxySeleniumContextImpl(GalaxySeleniumContext):
     """Minimal, simplified GalaxySeleniumContext useful outside the context of test cases."""
 
-    def __init__(self, from_dict=None):
+    def __init__(self, from_dict: Optional[dict] = None) -> None:
         from_dict = from_dict or {}
         self.configured_driver = ConfiguredDriver(**from_dict.get("driver", {}))
         self.url = from_dict.get("local_galaxy_url", "http://localhost:8080")

--- a/lib/galaxy/selenium/context.py
+++ b/lib/galaxy/selenium/context.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Optional
 
 from six.moves.urllib.parse import urljoin
@@ -7,8 +8,10 @@ from .navigates_galaxy import NavigatesGalaxy
 
 
 class GalaxySeleniumContext(NavigatesGalaxy):
+    url: str
+    target_url_from_selenium: str
 
-    def build_url(self, url, for_selenium=True):
+    def build_url(self, url: str, for_selenium: bool = True) -> str:
         if for_selenium:
             base = self.target_url_from_selenium
         else:
@@ -19,7 +22,7 @@ class GalaxySeleniumContext(NavigatesGalaxy):
     def driver(self):
         return self.configured_driver.driver
 
-    def screenshot(self, label):
+    def screenshot(self, label: str):
         """If GALAXY_TEST_SCREENSHOTS_DIRECTORY is set create a screenshot there named <label>.png.
 
         Unlike the above "snapshot" feature, this will be written out regardless and not in a per-test
@@ -33,6 +36,10 @@ class GalaxySeleniumContext(NavigatesGalaxy):
 
         self.driver.save_screenshot(target)
         return target
+
+    @abstractmethod
+    def _screenshot_path(self, label: str, extension=".png") -> str:
+        """Path to store screenshots in."""
 
 
 class GalaxySeleniumContextImpl(GalaxySeleniumContext):

--- a/lib/galaxy/selenium/driver_factory.py
+++ b/lib/galaxy/selenium/driver_factory.py
@@ -8,6 +8,7 @@ except ImportError:
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from selenium.webdriver.remote.webdriver import WebDriver
 
 
 DEFAULT_BROWSER = "auto"
@@ -25,6 +26,7 @@ VALID_LOCAL_BROWSERS = ["CHROME", "FIREFOX", "OPERA", "PHANTOMJS"]
 
 
 class ConfiguredDriver:
+    driver: WebDriver
 
     def __init__(
         self,
@@ -75,7 +77,7 @@ def get_local_browser(browser):
     return browser
 
 
-def get_local_driver(browser=DEFAULT_BROWSER, headless=False):
+def get_local_driver(browser=DEFAULT_BROWSER, headless=False) -> WebDriver:
     browser = get_local_browser(browser)
     if browser not in VALID_LOCAL_BROWSERS:
         raise AssertionError(f"{browser} not in VALID_LOCAL_BROWSERS ({VALID_LOCAL_BROWSERS})")
@@ -111,7 +113,7 @@ def get_remote_driver(
     host,
     port,
     browser=DEFAULT_BROWSER
-):
+) -> WebDriver:
     # docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:3.0.1-aluminum
     if browser == "auto":
         browser = "CHROME"

--- a/lib/galaxy/tool_util/verify/wait.py
+++ b/lib/galaxy/tool_util/verify/wait.py
@@ -1,14 +1,16 @@
 """Abstraction for waiting on API conditions to become true."""
 
 import time
+from typing import Callable, Optional, Union
 
 DEFAULT_POLLING_BACKOFF = 0
 DEFAULT_POLLING_DELTA = 0.25
 
 TIMEOUT_MESSAGE_TEMPLATE = "Timed out after {} seconds waiting on {}."
+timeout_type = Union[int, float]
 
 
-def wait_on(function, desc, timeout, delta=DEFAULT_POLLING_DELTA, polling_backoff=DEFAULT_POLLING_BACKOFF, sleep_=None):
+def wait_on(function: Callable, desc: str, timeout: timeout_type, delta: timeout_type = DEFAULT_POLLING_DELTA, polling_backoff: timeout_type = DEFAULT_POLLING_BACKOFF, sleep_: Optional[Callable] = None):
     """Wait for function to return non-None value.
 
     Grow the polling interval (initially ``delta`` defaulting to 0.25 seconds)
@@ -18,7 +20,7 @@ def wait_on(function, desc, timeout, delta=DEFAULT_POLLING_DELTA, polling_backof
     supplied function ever returning a non-None value.
     """
     sleep = sleep_ or time.sleep
-    total_wait = 0
+    total_wait = 0.0
     while True:
         if total_wait > timeout:
             raise TimeoutAssertionError(TIMEOUT_MESSAGE_TEMPLATE.format(total_wait, desc))

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -7,23 +7,22 @@ from galaxy_test.base.populators import (
     DatasetPopulator,
     LibraryPopulator,
     skip_without_tool,
-    TestsDatasets,
 )
 from ._framework import ApiTestCase
 
 
 # TODO: Test anonymous access.
-class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
+class HistoryContentsApiTestCase(ApiTestCase):
 
     def setUp(self):
         super().setUp()
-        self.history_id = self._new_history()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
+        self.history_id = self.dataset_populator.new_history()
 
     def test_index_hda_summary(self):
-        hda1 = self._new_dataset(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
         contents_response = self._get("histories/%s/contents" % self.history_id)
         hda_summary = self.__check_for_hda(contents_response, hda1)
         assert "display_types" not in hda_summary  # Quick summary, not full details
@@ -142,30 +141,30 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
             assert "name" in contents_response.json()
 
     def test_index_hda_all_details(self):
-        hda1 = self._new_dataset(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
         contents_response = self._get("histories/%s/contents?details=all" % self.history_id)
         hda_details = self.__check_for_hda(contents_response, hda1)
         self.__assert_hda_has_full_details(hda_details)
 
     def test_index_hda_detail_by_id(self):
-        hda1 = self._new_dataset(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
         contents_response = self._get("histories/{}/contents?details={}".format(self.history_id, hda1["id"]))
         hda_details = self.__check_for_hda(contents_response, hda1)
         self.__assert_hda_has_full_details(hda_details)
 
     def test_show_hda(self):
-        hda1 = self._new_dataset(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
         show_response = self.__show(hda1)
         self._assert_status_code_is(show_response, 200)
         self.__assert_matches_hda(hda1, show_response.json())
 
     def test_hda_copy(self):
-        hda1 = self._new_dataset(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
         create_data = dict(
             source='hda',
             content=hda1["id"],
         )
-        second_history_id = self._new_history()
+        second_history_id = self.dataset_populator.new_history()
         assert self.__count_contents(second_history_id) == 0
         create_response = self._post("histories/%s/contents" % second_history_id, create_data)
         self._assert_status_code_is(create_response, 200)
@@ -235,8 +234,8 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
         self._assert_status_code_is(update_response, 400)
 
     def _wait_for_new_hda(self):
-        hda1 = self._new_dataset(self.history_id)
-        self._wait_for_history(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id)
         return hda1
 
     def _set_edit_update(self, json):
@@ -263,16 +262,16 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
         return update_response
 
     def test_delete(self):
-        hda1 = self._new_dataset(self.history_id)
-        self._wait_for_history(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id)
         assert str(self.__show(hda1).json()["deleted"]).lower() == "false"
         delete_response = self._delete("histories/{}/contents/{}".format(self.history_id, hda1["id"]))
         assert delete_response.status_code < 300  # Something in the 200s :).
         assert str(self.__show(hda1).json()["deleted"]).lower() == "true"
 
     def test_purge(self):
-        hda1 = self._new_dataset(self.history_id)
-        self._wait_for_history(self.history_id)
+        hda1 = self.dataset_populator.new_dataset(self.history_id)
+        self.dataset_populator.wait_for_history(self.history_id)
         assert str(self.__show(hda1).json()["deleted"]).lower() == "false"
         assert str(self.__show(hda1).json()["purged"]).lower() == "false"
         data = {'purge': True}
@@ -427,7 +426,7 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
     def test_hdca_copy(self):
         hdca = self.dataset_collection_populator.create_pair_in_history(self.history_id).json()
         hdca_id = hdca["id"]
-        second_history_id = self._new_history()
+        second_history_id = self.dataset_populator.new_history()
         create_data = dict(
             source='hdca',
             content=hdca_id,
@@ -444,7 +443,7 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
     def test_hdca_copy_and_elements(self):
         hdca = self.dataset_collection_populator.create_pair_in_history(self.history_id).json()
         hdca_id = hdca["id"]
-        second_history_id = self._new_history()
+        second_history_id = self.dataset_populator.new_history()
         create_data = dict(
             source='hdca',
             content=hdca_id,
@@ -476,7 +475,7 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
         ld = self.library_populator.new_library_dataset("el1")
         ldda_id = ld["ldda_id"]
         element_identifiers = [{"name": "el1", "src": "ldda", "id": ldda_id}]
-        history_id = self._new_history()
+        history_id = self.dataset_populator.new_history()
         create_data = dict(
             history_id=history_id,
             type="dataset_collection",
@@ -506,7 +505,7 @@ class HistoryContentsApiTestCase(ApiTestCase, TestsDatasets):
             collection_type="list",
         )
         with self._different_user():
-            second_history_id = self._new_history()
+            second_history_id = self.dataset_populator.new_history()
             create_response = self._post("histories/%s/contents/dataset_collections" % second_history_id, create_data)
             self._assert_status_code_is(create_response, 403)
 

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -6,7 +6,6 @@ from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
-    TestsDatasets,
 )
 from ._framework import ApiTestCase
 
@@ -14,7 +13,7 @@ FILE_URL = 'https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data
 FILE_MD5 = "37b59762b59fff860460522d271bc111"
 
 
-class LibrariesApiTestCase(ApiTestCase, TestsDatasets):
+class LibrariesApiTestCase(ApiTestCase):
 
     def setUp(self):
         super().setUp()

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -60,10 +60,13 @@ class UsesApiTestCaseMixin:
 
     @contextmanager
     def _different_user(self, email=OTHER_USER):
-        """ Use in test cases to switch get/post operations to act as new user,
+        """ Use in test cases to switch get/post operations to act as new user
+
+        ..code-block:: python
 
             with self._different_user("other_user@bx.psu.edu"):
                 self._get("histories")  # Gets other_user@bx.psu.edu histories.
+
         """
         original_api_key = self.user_api_key
         original_interactor_key = self.galaxy_interactor.api_key

--- a/lib/galaxy_test/base/api.py
+++ b/lib/galaxy_test/base/api.py
@@ -11,7 +11,7 @@ from .api_asserts import (
 )
 from .api_util import (
     ADMIN_TEST_USER,
-    get_master_api_key,
+    get_admin_api_key,
     get_user_api_key,
     OTHER_USER,
     TEST_USER,
@@ -42,7 +42,7 @@ class UsesApiTestCaseMixin:
 
     def _setup_interactor(self):
         self.user_api_key = get_user_api_key()
-        self.master_api_key = get_master_api_key()
+        self.master_api_key = get_admin_api_key()
         self.galaxy_interactor = self._get_interactor()
 
     def _get_interactor(self, api_key=None):

--- a/lib/galaxy_test/base/api_util.py
+++ b/lib/galaxy_test/base/api_util.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 DEFAULT_GALAXY_MASTER_API_KEY = "TEST123"
 DEFAULT_GALAXY_USER_API_KEY = None
@@ -12,10 +13,11 @@ ADMIN_TEST_USER = os.environ.get("GALAXY_TEST_ADMIN_USER_EMAIL", DEFAULT_ADMIN_T
 OTHER_USER = os.environ.get("GALAXY_TEST_OTHER_USER_EMAIL", DEFAULT_OTHER_USER)
 
 
-def get_master_api_key():
-    """ Test master API key to use for functional test. This key should be
-    configured as a master API key and should be able to create additional
-    users and keys.
+def get_admin_api_key() -> str:
+    """Test admin API key to use for functional tests.
+
+    This key should be configured as a admin API key and should be able
+    to create additional users and keys.
     """
     for key in ["GALAXY_CONFIG_MASTER_API_KEY", "GALAXY_CONFIG_OVERRIDE_MASTER_API_KEY"]:
         value = os.environ.get(key, None)
@@ -24,9 +26,10 @@ def get_master_api_key():
     return DEFAULT_GALAXY_MASTER_API_KEY
 
 
-def get_user_api_key():
-    """ Test user API key to use for functional tests. If set, this should drive
-    API based testing - if not set master API key should be used to create a new
-    user and API key for tests.
+def get_user_api_key() -> Optional[str]:
+    """Test user API key to use for functional tests.
+
+    If set, this should drive API based testing - if not set an admin API key will
+    be used to create a new user and API key for tests.
     """
     return os.environ.get("GALAXY_TEST_USER_API_KEY", DEFAULT_GALAXY_USER_API_KEY)

--- a/lib/galaxy_test/base/env.py
+++ b/lib/galaxy_test/base/env.py
@@ -4,11 +4,12 @@ import fcntl
 import os
 import socket
 import struct
+from typing import Optional, Tuple
 
 DEFAULT_WEB_HOST = socket.gethostbyname('localhost')
 
 
-def setup_keep_outdir():
+def setup_keep_outdir() -> str:
     keep_outdir = os.environ.get('GALAXY_TEST_SAVE', '')
     if keep_outdir > '':
         try:
@@ -18,15 +19,18 @@ def setup_keep_outdir():
     return keep_outdir
 
 
-def target_url_parts():
+def target_url_parts() -> Tuple[str, Optional[str], str]:
     host = socket.gethostbyname(os.environ.get('GALAXY_TEST_HOST', DEFAULT_WEB_HOST))
     port = os.environ.get('GALAXY_TEST_PORT')
-    default_url = f"http://{host}:{port}"
+    if port:
+        default_url = f"http://{host}:{port}"
+    else:
+        default_url = f"http://{host}"
     url = os.environ.get('GALAXY_TEST_EXTERNAL', default_url)
     return host, port, url
 
 
-def get_ip_address(ifname):
+def get_ip_address(ifname: str) -> str:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     return socket.inet_ntoa(fcntl.ioctl(
         s.fileno(),

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1,3 +1,42 @@
+"""Abstractions used by the Galaxy testing frameworks for interacting with the Galaxy API.
+
+These abstractions are geared toward testing use cases and populating fixtures.
+For a more general framework for working with the Galaxy API checkout `bioblend
+<https://github.com/galaxyproject/bioblend>`__.
+
+The populators are broken into different categories of data one might want to populate
+and work with (datasets, histories, libraries, and workflows). Within each populator
+type abstract classes describe high-level functionality that depend on abstract
+HTTP verbs executions (e.g. methods for executing GET, POST, DELETE). The abstract
+classes are :class:`galaxy_test.base.populators.BaseDatasetPopulator`,
+:class:`galaxy_test.base.populators.BaseWorkflowPopulator`, and
+:class:`galaxy_test.base.populators.BaseDatasetCollectionPopulator`.
+
+There are a few different concrete ways to supply these low-level verb executions.
+For instance :class:`galaxy_test.base.populators.DatasetPopulator` implements the abstract
+:class:`galaxy_test.base.populators.BaseDatasetPopulator` by leveraging a galaxy interactor
+:class:`galaxy.tool_util.interactor.GalaxyInteractorApi`. It is non-intuitive
+that the Galaxy testing framework uses the tool testing code inside Galaxy's code
+base for a lot of heavy lifting. This is due to the API testing framework organically
+growing from the tool testing framework that predated it and then the tool testing
+framework being extracted for re-use in `Planemo <https://github.com/galaxyproject/planemo>`__, etc..
+
+These other two concrete implementation of the populators are much more
+direct and intuitive. :class:`galaxy_test.base.populators.GiDatasetPopulator`, et. al.
+are populators built based on Bioblend ``gi`` objects to build URLs and describe
+API keys. :class:`galaxy_test.selenium.framework.SeleniumSessionDatasetPopulator`,
+et al. are populators built based on Selenium sessions to leverage Galaxy cookies
+for auth for instance.
+
+All three of these implementations are now effectively light wrappers around
+`requests <https://requests.readthedocs.io/>`__. Not leveraging requests directly
+is a bit ugly and this ugliness again stems from these organically growing from a
+framework that originally didn't use requests at all.
+
+API tests and Selenium tests routinely use requests directly and that is totally fine,
+requests should just be filtered through the verb abstractions if that functionality
+is then added to populators to be shared across tests or across testing frameworks.
+"""
 import contextlib
 import json
 import os

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -43,28 +43,34 @@ import os
 import random
 import string
 import unittest
+from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 from functools import wraps
 from io import StringIO
 from operator import itemgetter
+from typing import Any, Callable, Dict, Optional
 
 import requests
 import yaml
+from bioblend.galaxy import GalaxyClient
 from gxformat2 import (
     convert_and_import_workflow,
     ImporterGalaxyInterface,
 )
 from gxformat2._yaml import ordered_load
 from pkg_resources import resource_string
+from requests.models import Response
 
 from galaxy.tool_util.client.staging import InteractorStaging
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy.tool_util.verify.wait import (
+    timeout_type,
     TimeoutAssertionError,
     wait_on as tool_util_wait_on,
 )
 from galaxy.util import unicodify
 from . import api_asserts
+from .api import ApiTestInteractor
 
 
 # Simple workflow that takes an input and call cat wrapper on it.
@@ -203,17 +209,42 @@ def _raise_skip_if(check, *args):
         raise SkipTest(*args)
 
 
-class BaseDatasetPopulator:
+class BasePopulator(metaclass=ABCMeta):
+
+    @abstractmethod
+    def _post(self, route, data=None, files=None, admin=False, json: bool = False) -> Response:
+        """POST data to target Galaxy instance on specified route."""
+
+    @abstractmethod
+    def _put(self, route, data=None, admin=False) -> Response:
+        """PUT data to target Galaxy instance on specified route."""
+
+    @abstractmethod
+    def _get(self, route, data=None, admin=False) -> Response:
+        """GET data from target Galaxy instance on specified route."""
+
+    @abstractmethod
+    def _delete(self, route, data=None, admin=False) -> Response:
+        """DELETE against target Galaxy instance on specified route."""
+
+
+class BaseDatasetPopulator(BasePopulator):
     """ Abstract description of API operations optimized for testing
     Galaxy - implementations must implement _get, _post and _delete.
     """
 
-    def new_dataset(self, history_id, content=None, wait=False, **kwds):
+    def new_dataset(self, history_id: str, content=None, wait: bool = False, **kwds) -> str:
+        """Create a new history dataset instance (HDA) and return its ID.
+
+        :returns: the HDA id of the new object
+        """
         run_response = self.new_dataset_request(history_id, content=content, wait=wait, **kwds)
-        assert run_response.status_code == 200, "Failed to create new dataset with response: %s" % run_response.content
+        assert run_response.status_code == 200, "Failed to create new dataset with response: %s" % run_response.text
         return run_response.json()["outputs"][0]
 
-    def new_dataset_request(self, history_id, content=None, wait=False, **kwds):
+    def new_dataset_request(self, history_id: str, content=None, wait: bool = False, **kwds) -> requests.Response:
+        """Lower-level dataset creation that returns the upload tool response object.
+        """
         if content is None and "ftp_files" not in kwds:
             content = "TestData123"
         payload = self.upload_payload(history_id, content=content, **kwds)
@@ -222,7 +253,7 @@ class BaseDatasetPopulator:
             self.wait_for_tool_run(history_id, run_response, assert_ok=kwds.get('assert_ok', True))
         return run_response
 
-    def fetch(self, payload, assert_ok=True, timeout=DEFAULT_TIMEOUT, wait=None):
+    def fetch(self, payload: dict, assert_ok: bool = True, timeout: timeout_type = DEFAULT_TIMEOUT, wait: Optional[bool] = None):
         tool_response = self._post("tools/fetch", data=payload)
         if wait is None:
             wait = assert_ok
@@ -236,26 +267,26 @@ class BaseDatasetPopulator:
 
         return tool_response
 
-    def wait_for_tool_run(self, history_id, run_response, timeout=DEFAULT_TIMEOUT, assert_ok=True):
+    def wait_for_tool_run(self, history_id: str, run_response: requests.Response, timeout: timeout_type = DEFAULT_TIMEOUT, assert_ok: bool = True):
         job = self.check_run(run_response)
         self.wait_for_job(job["id"], timeout=timeout)
         self.wait_for_history(history_id, assert_ok=assert_ok, timeout=timeout)
         return run_response
 
-    def check_run(self, run_response):
+    def check_run(self, run_response: requests.Response) -> dict:
         run = run_response.json()
         assert run_response.status_code == 200, run
         job = run["jobs"][0]
         return job
 
-    def wait_for_history(self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
+    def wait_for_history(self, history_id: str, assert_ok: bool = False, timeout: timeout_type = DEFAULT_TIMEOUT) -> str:
         try:
             return wait_on_state(lambda: self._get("histories/%s" % history_id), desc="history state", assert_ok=assert_ok, timeout=timeout)
         except AssertionError:
             self._summarize_history(history_id)
             raise
 
-    def wait_for_history_jobs(self, history_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
+    def wait_for_history_jobs(self, history_id: str, assert_ok: bool = False, timeout: timeout_type = DEFAULT_TIMEOUT):
 
         def has_active_jobs():
             active_jobs = self.active_history_jobs(history_id)
@@ -274,40 +305,40 @@ class BaseDatasetPopulator:
         if assert_ok:
             return self.wait_for_history(history_id, assert_ok=True, timeout=timeout)
 
-    def wait_for_job(self, job_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
+    def wait_for_job(self, job_id: str, assert_ok: bool = False, timeout: timeout_type = DEFAULT_TIMEOUT):
         return wait_on_state(lambda: self.get_job_details(job_id), desc="job state", assert_ok=assert_ok, timeout=timeout)
 
-    def get_job_details(self, job_id, full=False):
+    def get_job_details(self, job_id: str, full: bool = False) -> Response:
         return self._get(f"jobs/{job_id}?full={full}")
 
-    def cancel_history_jobs(self, history_id, wait=True):
+    def cancel_history_jobs(self, history_id: str, wait=True) -> None:
         active_jobs = self.active_history_jobs(history_id)
         for active_job in active_jobs:
             self.cancel_job(active_job["id"])
 
-    def history_jobs(self, history_id):
+    def history_jobs(self, history_id: str) -> dict:
         query_params = {"history_id": history_id, "order_by": "create_time"}
         jobs_response = self._get("jobs", query_params)
         assert jobs_response.status_code == 200
         return jobs_response.json()
 
-    def active_history_jobs(self, history_id):
+    def active_history_jobs(self, history_id: str) -> list:
         all_history_jobs = self.history_jobs(history_id)
         active_jobs = [j for j in all_history_jobs if j["state"] in ["new", "upload", "waiting", "queued", "running"]]
         return active_jobs
 
-    def cancel_job(self, job_id):
+    def cancel_job(self, job_id: str) -> Response:
         return self._delete("jobs/%s" % job_id)
 
-    def delete_history(self, history_id):
+    def delete_history(self, history_id: str) -> None:
         delete_response = self._delete(f"histories/{history_id}")
         delete_response.raise_for_status()
 
-    def delete_dataset(self, history_id, content_id):
+    def delete_dataset(self, history_id: str, content_id: str) -> Response:
         delete_response = self._delete(f"histories/{history_id}/contents/{content_id}")
         return delete_response
 
-    def create_tool_from_path(self, tool_path):
+    def create_tool_from_path(self, tool_path: str) -> Response:
         tool_directory = os.path.dirname(os.path.abspath(tool_path))
         payload = dict(
             src="from_path",
@@ -316,7 +347,7 @@ class BaseDatasetPopulator:
         )
         return self._create_tool_raw(payload)
 
-    def create_tool(self, representation, tool_directory=None):
+    def create_tool(self, representation, tool_directory: Optional[str] = None) -> Response:
         if isinstance(representation, dict):
             representation = json.dumps(representation)
         payload = dict(
@@ -325,7 +356,7 @@ class BaseDatasetPopulator:
         )
         return self._create_tool_raw(payload)
 
-    def _create_tool_raw(self, payload):
+    def _create_tool_raw(self, payload) -> Response:
         try:
             create_response = self._post("dynamic_tools", data=payload, admin=True)
         except TypeError:
@@ -333,35 +364,33 @@ class BaseDatasetPopulator:
         assert create_response.status_code == 200, create_response.text
         return create_response.json()
 
-    def list_dynamic_tools(self):
+    def list_dynamic_tools(self) -> list:
         list_response = self._get("dynamic_tools", admin=True)
         assert list_response.status_code == 200, list_response
         return list_response.json()
 
-    def show_dynamic_tool(self, uuid):
+    def show_dynamic_tool(self, uuid) -> dict:
         show_response = self._get("dynamic_tools/%s" % uuid, admin=True)
         assert show_response.status_code == 200, show_response
         return show_response.json()
 
-    def deactivate_dynamic_tool(self, uuid):
+    def deactivate_dynamic_tool(self, uuid) -> dict:
         delete_response = self._delete("dynamic_tools/%s" % uuid, admin=True)
         return delete_response.json()
 
-    def _summarize_history(self, history_id):
-        pass
+    def _summarize_history(self, history_id: str) -> None:
+        """Abstract method for summarizing a target history - override to provide details."""
 
     @contextlib.contextmanager
-    def test_history(self, **kwds):
+    def test_history(self, cancel_executions: bool = True, require_new: bool = True, **kwds):
         cleanup = "GALAXY_TEST_NO_CLEANUP" not in os.environ
+        history_id = None
 
         def wrap_up():
-            cancel_executions = kwds.get("cancel_executions", True)
             if cleanup and cancel_executions:
                 self.cancel_history_jobs(history_id)
 
-        require_new = kwds.get("require_new", True)
         try:
-            history_id = None
             if not require_new:
                 history_id = kwds.get("GALAXY_TEST_HISTORY_ID", None)
 
@@ -369,18 +398,18 @@ class BaseDatasetPopulator:
             yield history_id
             wrap_up()
         except Exception:
-            self._summarize_history(history_id)
+            if history_id:
+                self._summarize_history(history_id)
             wrap_up()
             raise
 
-    def new_history(self, **kwds):
-        name = kwds.get("name", "API Test History")
+    def new_history(self, name="API Test History", **kwds) -> str:
         create_history_response = self._post("histories", data=dict(name=name))
         assert "id" in create_history_response.json(), create_history_response.text
         history_id = create_history_response.json()["id"]
         return history_id
 
-    def upload_payload(self, history_id, content=None, **kwds):
+    def upload_payload(self, history_id: str, content: str = None, **kwds) -> dict:
         name = kwds.get("name", "Test_Dataset")
         dbkey = kwds.get("dbkey", "?")
         file_type = kwds.get("file_type", 'txt')
@@ -412,10 +441,12 @@ class BaseDatasetPopulator:
             upload_type='upload_dataset'
         )
 
-    def get_remote_files(self, target="ftp"):
-        return self._get("remote_files", data={"target": target}).json()
+    def get_remote_files(self, target: str = "ftp") -> dict:
+        response = self._get("remote_files", data={"target": target})
+        response.raise_for_status()
+        return response.json()
 
-    def run_tool_payload(self, tool_id, inputs, history_id, **kwds):
+    def run_tool_payload(self, tool_id: str, inputs: dict, history_id: str, **kwds) -> dict:
         # Remove files_%d|file_data parameters from inputs dict and attach
         # as __files dictionary.
         for key, value in list(inputs.items()):
@@ -432,7 +463,7 @@ class BaseDatasetPopulator:
             **kwds
         )
 
-    def run_tool(self, tool_id, inputs, history_id, assert_ok=True, **kwds):
+    def run_tool(self, tool_id: str, inputs: dict, history_id: str, assert_ok: bool = True, **kwds):
         payload = self.run_tool_payload(tool_id, inputs, history_id, **kwds)
         tool_response = self.tools_post(payload)
         if assert_ok:
@@ -441,11 +472,11 @@ class BaseDatasetPopulator:
         else:
             return tool_response
 
-    def tools_post(self, payload, url="tools"):
+    def tools_post(self, payload: dict, url="tools") -> Response:
         tool_response = self._post(url, data=payload)
         return tool_response
 
-    def get_history_dataset_content(self, history_id, wait=True, filename=None, type='text', raw=False, **kwds):
+    def get_history_dataset_content(self, history_id: str, wait=True, filename=None, type='text', raw=False, **kwds):
         dataset_id = self.__history_content_id(history_id, wait=wait, **kwds)
         data = {}
         if filename:
@@ -459,36 +490,36 @@ class BaseDatasetPopulator:
         else:
             return display_response.content
 
-    def get_history_dataset_details(self, history_id, **kwds):
+    def get_history_dataset_details(self, history_id: str, **kwds) -> dict:
         dataset_id = self.__history_content_id(history_id, **kwds)
         details_response = self.get_history_dataset_details_raw(history_id, dataset_id)
         details_response.raise_for_status()
         return details_response.json()
 
-    def get_history_dataset_details_raw(self, history_id, dataset_id):
+    def get_history_dataset_details_raw(self, history_id: str, dataset_id: str) -> Response:
         details_response = self._get_contents_request(history_id, f"/datasets/{dataset_id}")
         return details_response
 
-    def get_history_dataset_extra_files(self, history_id, **kwds):
+    def get_history_dataset_extra_files(self, history_id: str, **kwds) -> list:
         dataset_id = self.__history_content_id(history_id, **kwds)
         details_response = self._get_contents_request(history_id, "/%s/extra_files" % dataset_id)
         assert details_response.status_code == 200, details_response.content
         return details_response.json()
 
-    def get_history_collection_details(self, history_id, **kwds):
+    def get_history_collection_details(self, history_id: str, **kwds) -> dict:
         hdca_id = self.__history_content_id(history_id, **kwds)
         details_response = self._get_contents_request(history_id, "/dataset_collections/%s" % hdca_id)
         assert details_response.status_code == 200, details_response.content
         return details_response.json()
 
-    def run_collection_creates_list(self, history_id, hdca_id):
+    def run_collection_creates_list(self, history_id: str, hdca_id: str) -> Response:
         inputs = {
             "input1": {"src": "hdca", "id": hdca_id},
         }
         self.wait_for_history(history_id, assert_ok=True)
         return self.run_tool("collection_creates_list", inputs, history_id)
 
-    def run_exit_code_from_file(self, history_id, hdca_id):
+    def run_exit_code_from_file(self, history_id: str, hdca_id: str) -> dict:
         exit_code_inputs = {
             "input": {'batch': True, 'values': [{"src": "hdca", "id": hdca_id}]},
         }
@@ -496,7 +527,7 @@ class BaseDatasetPopulator:
         self.wait_for_history(history_id, assert_ok=False)
         return response
 
-    def __history_content_id(self, history_id, wait=True, **kwds):
+    def __history_content_id(self, history_id: str, wait=True, **kwds) -> str:
         if wait:
             assert_ok = kwds.get("assert_ok", True)
             self.wait_for_history(history_id, assert_ok=assert_ok)
@@ -523,7 +554,7 @@ class BaseDatasetPopulator:
                 history_content_id = history_contents[-1]["id"]
         return history_content_id
 
-    def _get_contents_request(self, history_id, suffix="", data=None):
+    def _get_contents_request(self, history_id: str, suffix: str = "", data=None) -> Response:
         if data is None:
             data = {}
         url = "histories/%s/contents" % history_id
@@ -531,35 +562,35 @@ class BaseDatasetPopulator:
             url = f"{url}{suffix}"
         return self._get(url, data=data)
 
-    def ds_entry(self, history_content):
+    def ds_entry(self, history_content: dict) -> dict:
         src = 'hda'
         if 'history_content_type' in history_content and history_content['history_content_type'] == "dataset_collection":
             src = 'hdca'
         return dict(src=src, id=history_content["id"])
 
-    def dataset_storage_info(self, dataset_id):
-        storage_response = self.galaxy_interactor.get(f"datasets/{dataset_id}/storage")
+    def dataset_storage_info(self, dataset_id: str) -> dict:
+        storage_response = self._get(f"datasets/{dataset_id}/storage")
         storage_response.raise_for_status()
         return storage_response.json()
 
-    def get_roles(self):
-        roles_response = self.galaxy_interactor.get("roles", admin=True)
+    def get_roles(self) -> list:
+        roles_response = self._get("roles", admin=True)
         assert roles_response.status_code == 200
         return roles_response.json()
 
-    def user_email(self):
-        users_response = self.galaxy_interactor.get("users")
+    def user_email(self) -> str:
+        users_response = self._get("users")
         users = users_response.json()
         assert len(users) == 1
         return users[0]["email"]
 
-    def user_id(self):
-        users_response = self.galaxy_interactor.get("users")
+    def user_id(self) -> str:
+        users_response = self._get("users")
         users = users_response.json()
         assert len(users) == 1
         return users[0]["id"]
 
-    def user_private_role_id(self):
+    def user_private_role_id(self) -> str:
         user_email = self.user_email()
         roles = self.get_roles()
         users_roles = [r for r in roles if r["name"] == user_email]
@@ -568,27 +599,27 @@ class BaseDatasetPopulator:
         assert "id" in role, role
         return role["id"]
 
-    def create_role(self, user_ids, description=None):
+    def create_role(self, user_ids: list, description: str = None) -> dict:
         payload = {
             "name": self.get_random_name(prefix="testpop"),
             "description": description or "Test Role",
             "user_ids": user_ids,
         }
-        role_response = self.galaxy_interactor.post("roles", data=payload, admin=True, json=True)
+        role_response = self._post("roles", data=payload, admin=True, json=True)
         assert role_response.status_code == 200
         return role_response.json()
 
-    def create_quota(self, quota_payload):
-        quota_response = self.galaxy_interactor.post("quotas", data=quota_payload, admin=True)
+    def create_quota(self, quota_payload: dict) -> dict:
+        quota_response = self._post("quotas", data=quota_payload, admin=True)
         quota_response.raise_for_status()
         return quota_response.json()
 
-    def get_quotas(self):
-        quota_response = self.galaxy_interactor.get("quotas", admin=True)
+    def get_quotas(self) -> list:
+        quota_response = self._get("quotas", admin=True)
         quota_response.raise_for_status()
         return quota_response.json()
 
-    def make_private(self, history_id, dataset_id):
+    def make_private(self, history_id: str, dataset_id: str) -> dict:
         role_id = self.user_private_role_id()
         # Give manage permission to the user.
         payload = {
@@ -596,7 +627,7 @@ class BaseDatasetPopulator:
             "manage": json.dumps([role_id]),
         }
         url = f"histories/{history_id}/contents/{dataset_id}/permissions"
-        update_response = self.galaxy_interactor._put(url, payload, admin=True)
+        update_response = self._put(url, payload, admin=True)
         assert update_response.status_code == 200, update_response.content
         return update_response.json()
 
@@ -742,21 +773,22 @@ class BaseDatasetPopulator:
             suffix or '',
         )
 
+    def wait_for_dataset(self, history_id, dataset_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
+        return wait_on_state(lambda: self._get(f"histories/{history_id}/contents/{dataset_id}"), desc="dataset state", assert_ok=assert_ok, timeout=timeout)
 
-class DatasetPopulator(BaseDatasetPopulator):
 
-    def __init__(self, galaxy_interactor):
-        self.galaxy_interactor = galaxy_interactor
+class GalaxyInteractorHttpMixin:
+    galaxy_interactor: ApiTestInteractor
 
     @property
     def _api_key(self):
         return self.galaxy_interactor.api_key
 
-    def _post(self, route, data=None, files=None, admin=False):
-        return self.galaxy_interactor.post(route, data, files=files, admin=admin)
+    def _post(self, route, data=None, files=None, admin=False, json: bool = False) -> Response:
+        return self.galaxy_interactor.post(route, data, files=files, admin=admin, json=json)
 
-    def _put(self, route, data=None):
-        return self.galaxy_interactor.put(route, data)
+    def _put(self, route, data=None, admin=False):
+        return self.galaxy_interactor.put(route, data, admin=admin)
 
     def _get(self, route, data=None, admin=False):
         if data is None:
@@ -770,16 +802,19 @@ class DatasetPopulator(BaseDatasetPopulator):
 
         return self.galaxy_interactor.delete(route, data=data, admin=admin)
 
+
+class DatasetPopulator(GalaxyInteractorHttpMixin, BaseDatasetPopulator):
+
+    def __init__(self, galaxy_interactor):
+        self.galaxy_interactor = galaxy_interactor
+
     def _summarize_history(self, history_id):
         self.galaxy_interactor._summarize_history(history_id)
 
-    def wait_for_dataset(self, history_id, dataset_id, assert_ok=False, timeout=DEFAULT_TIMEOUT):
-        return wait_on_state(lambda: self._get(f"histories/{history_id}/contents/{dataset_id}"), desc="dataset state", assert_ok=assert_ok, timeout=timeout)
 
+class BaseWorkflowPopulator(BasePopulator):
 
-class BaseWorkflowPopulator:
-
-    def load_workflow(self, name, content=workflow_str, add_pja=False):
+    def load_workflow(self, name: str, content: str = workflow_str, add_pja=False) -> dict:
         workflow = json.loads(content)
         workflow["name"] = name
         if add_pja:
@@ -791,20 +826,20 @@ class BaseWorkflowPopulator:
             )
         return workflow
 
-    def load_random_x2_workflow(self, name):
+    def load_random_x2_workflow(self, name: str) -> dict:
         return self.load_workflow(name, content=workflow_random_x2_str)
 
-    def load_workflow_from_resource(self, name, filename=None):
+    def load_workflow_from_resource(self, name: str, filename: Optional[str] = None) -> dict:
         if filename is None:
             filename = "data/%s.ga" % name
         content = unicodify(resource_string(__name__, filename))
         return self.load_workflow(name, content=content)
 
-    def simple_workflow(self, name, **create_kwds):
+    def simple_workflow(self, name: str, **create_kwds) -> str:
         workflow = self.load_workflow(name)
         return self.create_workflow(workflow, **create_kwds)
 
-    def import_workflow_from_path(self, from_path):
+    def import_workflow_from_path(self, from_path: str) -> str:
         data = dict(
             from_path=from_path
         )
@@ -812,12 +847,12 @@ class BaseWorkflowPopulator:
         api_asserts.assert_status_code_is(import_response, 200)
         return import_response.json()["id"]
 
-    def create_workflow(self, workflow, **create_kwds):
+    def create_workflow(self, workflow: dict, **create_kwds) -> str:
         upload_response = self.create_workflow_response(workflow, **create_kwds)
         uploaded_workflow_id = upload_response.json()["id"]
         return uploaded_workflow_id
 
-    def create_workflow_response(self, workflow, **create_kwds):
+    def create_workflow_response(self, workflow: dict, **create_kwds) -> Response:
         data = dict(
             workflow=json.dumps(workflow),
             **create_kwds
@@ -825,7 +860,7 @@ class BaseWorkflowPopulator:
         upload_response = self._post("workflows/upload", data=data)
         return upload_response
 
-    def upload_yaml_workflow(self, has_yaml, **kwds):
+    def upload_yaml_workflow(self, has_yaml, **kwds) -> str:
         round_trip_conversion = kwds.get("round_trip_format_conversion", False)
         client_convert = kwds.pop("client_convert", not round_trip_conversion)
         kwds["convert"] = client_convert
@@ -839,7 +874,7 @@ class BaseWorkflowPopulator:
 
         return workflow_id
 
-    def wait_for_invocation(self, workflow_id, invocation_id, timeout=DEFAULT_TIMEOUT, assert_ok=True):
+    def wait_for_invocation(self, workflow_id: str, invocation_id: str, timeout: timeout_type = DEFAULT_TIMEOUT, assert_ok: bool = True):
         url = f"workflows/{workflow_id}/usage/{invocation_id}"
 
         def workflow_state():
@@ -847,7 +882,7 @@ class BaseWorkflowPopulator:
 
         return wait_on_state(workflow_state, desc="workflow invocation state", timeout=timeout, assert_ok=assert_ok)
 
-    def history_invocations(self, history_id):
+    def history_invocations(self, history_id: str) -> list:
         history_invocations_response = self._get("invocations", {"history_id": history_id})
         api_asserts.assert_status_code_is(history_invocations_response, 200)
         return history_invocations_response.json()
@@ -891,12 +926,12 @@ class BaseWorkflowPopulator:
             api_asserts.assert_has_keys(p, "param", "value", "step")
         api_asserts.assert_has_keys(bco['io_domain'], "input_subdomain", "output_subdomain")
 
-    def invoke_workflow_raw(self, workflow_id, request):
+    def invoke_workflow_raw(self, workflow_id, request: dict) -> Response:
         url = "workflows/%s/usage" % (workflow_id)
         invocation_response = self._post(url, data=request)
         return invocation_response
 
-    def invoke_workflow(self, history_id, workflow_id, inputs=None, request=None, assert_ok=True):
+    def invoke_workflow(self, history_id: str, workflow_id: str, inputs: Optional[dict] = None, request: Optional[dict] = None, assert_ok: bool = True):
         if inputs is None:
             inputs = {}
 
@@ -915,12 +950,12 @@ class BaseWorkflowPopulator:
         else:
             return invocation_response
 
-    def workflow_report_json(self, workflow_id, invocation_id):
+    def workflow_report_json(self, workflow_id: str, invocation_id: str) -> dict:
         response = self._get(f"workflows/{workflow_id}/invocations/{invocation_id}/report")
         api_asserts.assert_status_code_is(response, 200)
         return response.json()
 
-    def download_workflow(self, workflow_id, style=None, history_id=None):
+    def download_workflow(self, workflow_id: str, style: Optional[str] = None, history_id: Optional[str] = None) -> dict:
         params = {}
         if style is not None:
             params["style"] = style
@@ -933,16 +968,16 @@ class BaseWorkflowPopulator:
         else:
             return ordered_load(response.text)
 
-    def update_workflow(self, workflow_id, workflow_object):
+    def update_workflow(self, workflow_id: str, workflow_object: dict) -> Response:
         data = dict(
             workflow=workflow_object
         )
         raw_url = 'workflows/%s' % workflow_id
-        put_response = self.galaxy_interactor._put(raw_url, data=json.dumps(data))
+        put_response = self._put(raw_url, json.dumps(data))
         return put_response
 
-    def refactor_workflow(self, workflow_id, actions, dry_run=None, style=None):
-        data = dict(
+    def refactor_workflow(self, workflow_id: str, actions: list, dry_run: Optional[bool] = None, style: Optional[str] = None) -> Response:
+        data: Dict[str, Any] = dict(
             actions=actions,
         )
         if style is not None:
@@ -950,7 +985,7 @@ class BaseWorkflowPopulator:
         if dry_run is not None:
             data["dry_run"] = dry_run
         raw_url = 'workflows/%s/refactor' % workflow_id
-        put_response = self.galaxy_interactor._put(raw_url, data=json.dumps(data))
+        put_response = self._put(raw_url, json.dumps(data))
         return put_response
 
     @contextlib.contextmanager
@@ -1028,26 +1063,14 @@ class BaseWorkflowPopulator:
 RunJobsSummary = namedtuple('RunJobsSummary', ['history_id', 'workflow_id', 'invocation_id', 'inputs', 'jobs', 'invocation', 'workflow_request'])
 
 
-class WorkflowPopulator(BaseWorkflowPopulator, ImporterGalaxyInterface):
+class WorkflowPopulator(GalaxyInteractorHttpMixin, BaseWorkflowPopulator, ImporterGalaxyInterface):
 
     def __init__(self, galaxy_interactor):
         self.galaxy_interactor = galaxy_interactor
         self.dataset_populator = DatasetPopulator(galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(galaxy_interactor)
 
-    def _post(self, route, data=None, admin=False):
-        if data is None:
-            data = {}
-
-        return self.galaxy_interactor.post(route, data, admin=admin)
-
-    def _get(self, route, data=None):
-        if data is None:
-            data = {}
-
-        return self.galaxy_interactor.get(route, data=data)
-
-    # Required for ImporterGalaxyInterface interface - so we can recurisvely import
+    # Required for ImporterGalaxyInterface interface - so we can recursively import
     # nested workflows.
     def import_workflow(self, workflow, **kwds):
         workflow_str = json.dumps(workflow, indent=4)
@@ -1461,14 +1484,18 @@ class BaseDatasetCollectionPopulator:
             elif element['element_type'] == 'dataset_collection':
                 self.wait_for_dataset_collection(element['object'], assert_ok=assert_ok, timeout=timeout)
 
+    @abstractmethod
+    def _create_collection(self, payload: dict) -> Response:
+        """Create collection from specified payload."""
+
 
 class DatasetCollectionPopulator(BaseDatasetCollectionPopulator):
 
-    def __init__(self, galaxy_interactor):
+    def __init__(self, galaxy_interactor: ApiTestInteractor):
         self.galaxy_interactor = galaxy_interactor
         self.dataset_populator = DatasetPopulator(galaxy_interactor)
 
-    def _create_collection(self, payload):
+    def _create_collection(self, payload: dict) -> Response:
         create_response = self.galaxy_interactor.post("dataset_collections", data=payload)
         return create_response
 
@@ -1570,7 +1597,7 @@ def stage_rules_example(galaxy_interactor, history_id, example):
     return inputs
 
 
-def wait_on_state(state_func, desc="state", skip_states=None, ok_states=None, assert_ok=False, timeout=DEFAULT_TIMEOUT):
+def wait_on_state(state_func: Callable, desc="state", skip_states=None, ok_states=None, assert_ok=False, timeout=DEFAULT_TIMEOUT) -> str:
     def get_state():
         response = state_func()
         assert response.status_code == 200, "Failed to fetch state update while waiting. [%s]" % response.content
@@ -1593,8 +1620,9 @@ def wait_on_state(state_func, desc="state", skip_states=None, ok_states=None, as
         raise TimeoutAssertionError(f"{e} Current response containing state [{response.json()}].")
 
 
-class GiPostGetMixin:
+class GiHttpMixin:
     """Mixin for adapting Galaxy testing populators helpers to bioblend."""
+    _gi: GalaxyClient
 
     @property
     def _api_key(self):
@@ -1608,14 +1636,14 @@ class GiPostGetMixin:
             data = {}
         return self._gi.make_get_request(self._url(route), data=data)
 
-    def _post(self, route, data=None):
+    def _post(self, route, data=None, files=None, admin=False, json: bool = False) -> Response:
         if data is None:
             data = {}
         data = data.copy()
         data['key'] = self._gi.key
         return requests.post(self._url(route), data=data)
 
-    def _put(self, route, data=None):
+    def _put(self, route, data=None, admin=False):
         if data is None:
             data = {}
         data = data.copy()
@@ -1636,7 +1664,7 @@ class GiPostGetMixin:
         return self._api_url() + "/" + route
 
 
-class GiDatasetPopulator(BaseDatasetPopulator, GiPostGetMixin):
+class GiDatasetPopulator(BaseDatasetPopulator, GiHttpMixin):
 
     """Implementation of BaseDatasetPopulator backed by bioblend."""
 
@@ -1645,7 +1673,7 @@ class GiDatasetPopulator(BaseDatasetPopulator, GiPostGetMixin):
         self._gi = gi
 
 
-class GiDatasetCollectionPopulator(BaseDatasetCollectionPopulator, GiPostGetMixin):
+class GiDatasetCollectionPopulator(BaseDatasetCollectionPopulator, GiHttpMixin):
 
     """Implementation of BaseDatasetCollectionPopulator backed by bioblend."""
 
@@ -1660,7 +1688,7 @@ class GiDatasetCollectionPopulator(BaseDatasetCollectionPopulator, GiPostGetMixi
         return create_response
 
 
-class GiWorkflowPopulator(BaseWorkflowPopulator, GiPostGetMixin):
+class GiWorkflowPopulator(BaseWorkflowPopulator, GiHttpMixin):
 
     """Implementation of BaseWorkflowPopulator backed by bioblend."""
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -9,11 +9,6 @@ from functools import wraps
 from io import StringIO
 from operator import itemgetter
 
-try:
-    from nose.tools import nottest
-except ImportError:
-    def nottest(x):
-        return x
 import requests
 import yaml
 from gxformat2 import (
@@ -148,7 +143,6 @@ def summarize_instance_history_on_error(method):
     return wrapped_method
 
 
-@nottest
 def uses_test_history(**test_history_kwd):
     """Can override require_new and cancel_executions using kwds to decorator.
     """

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -170,26 +170,6 @@ def _raise_skip_if(check, *args):
         raise SkipTest(*args)
 
 
-# Deprecated mixin, use dataset populator instead.
-# TODO: Rework existing tests to target DatasetPopulator in a setup method instead.
-class TestsDatasets:
-
-    def _new_dataset(self, history_id, content='TestData123', **kwds):
-        return DatasetPopulator(self.galaxy_interactor).new_dataset(history_id, content=content, **kwds)
-
-    def _wait_for_history(self, history_id, assert_ok=False):
-        return DatasetPopulator(self.galaxy_interactor).wait_for_history(history_id, assert_ok=assert_ok)
-
-    def _new_history(self, **kwds):
-        return DatasetPopulator(self.galaxy_interactor).new_history(**kwds)
-
-    def _upload_payload(self, history_id, content, **kwds):
-        return DatasetPopulator(self.galaxy_interactor).upload_payload(history_id, content, **kwds)
-
-    def _run_tool_payload(self, tool_id, inputs, history_id, **kwds):
-        return DatasetPopulator(self.galaxy_interactor).run_tool_payload(tool_id, inputs, history_id, **kwds)
-
-
 class BaseDatasetPopulator:
     """ Abstract description of API operations optimized for testing
     Galaxy - implementations must implement _get, _post and _delete.

--- a/lib/galaxy_test/base/testcase.py
+++ b/lib/galaxy_test/base/testcase.py
@@ -17,8 +17,14 @@ class FunctionalTestCase(unittest.TestCase):
     server is already running.
     """
     galaxy_driver_class: Optional[type] = None
+    history_id: Optional[str]
+    host: str
+    port: Optional[str]
+    url: str
+    keepOutdir: str
+    test_data_resolver: TestDataResolver
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.history_id = os.environ.get('GALAXY_TEST_HISTORY_ID', None)
         self.host, self.port, self.url = target_url_parts()
         self.test_data_resolver = TestDataResolver()
@@ -39,6 +45,6 @@ class FunctionalTestCase(unittest.TestCase):
         if cls._test_driver:
             cls._test_driver.tear_down()
 
-    def get_filename(self, filename):
+    def get_filename(self, filename: str) -> str:
         # No longer used by tool tests - drop if isn't used else where.
         return self.test_data_resolver.get_filename(filename)

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -35,7 +35,7 @@ from galaxy.tool_util.verify.interactor import GalaxyInteractorApi, verify_tool
 from galaxy.util import asbool, download_to_file, galaxy_directory
 from galaxy.util.properties import load_app_properties
 from galaxy.web import buildapp
-from galaxy_test.base.api_util import get_master_api_key, get_user_api_key
+from galaxy_test.base.api_util import get_admin_api_key, get_user_api_key
 from galaxy_test.base.env import (
     DEFAULT_WEB_HOST,
     target_url_parts,
@@ -188,7 +188,7 @@ def setup_galaxy_config(
     data_manager_config_file = 'test/functional/tools/sample_data_manager_conf.xml'
     if default_data_manager_config is not None:
         data_manager_config_file = f"{default_data_manager_config},{data_manager_config_file}"
-    master_api_key = get_master_api_key()
+    master_api_key = get_admin_api_key()
     cleanup_job = 'never' if ("GALAXY_TEST_NO_CLEANUP" in os.environ or
                               "TOOL_SHED_TEST_NO_CLEANUP" in os.environ) else 'onsuccess'
 
@@ -1126,7 +1126,7 @@ class GalaxyTestDriver(TestDriver):
         test_classes = functional.test_toolbox.build_tests(
             app=self.app,
             testing_shed_tools=testing_shed_tools,
-            master_api_key=get_master_api_key(),
+            master_api_key=get_admin_api_key(),
             user_api_key=get_user_api_key(),
         )
         if return_test_classes:
@@ -1139,7 +1139,7 @@ class GalaxyTestDriver(TestDriver):
         host, port, url = target_url_parts()
         galaxy_interactor_kwds = {
             "galaxy_url": url,
-            "master_api_key": get_master_api_key(),
+            "master_api_key": get_admin_api_key(),
             "api_key": get_user_api_key(),
             "keep_outputs_dir": None,
         }

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -185,7 +185,26 @@ class TestSnapshot:
         write_file_func("%s-stack.txt" % prefix, str(self.stack))
 
 
-class TestWithSeleniumMixin(GalaxySeleniumContext, UsesApiTestCaseMixin):
+class GalaxyTestSeleniumContext(GalaxySeleniumContext):
+    """Extend GalaxySeleniumContext with Selenium-aware galaxy_test.base.populators."""
+
+    @property
+    def dataset_populator(self) -> populators.BaseDatasetPopulator:
+        """A dataset populator connected to the Galaxy session described by Selenium context."""
+        return SeleniumSessionDatasetPopulator(self)
+
+    @property
+    def dataset_collection_populator(self) -> populators.BaseDatasetCollectionPopulator:
+        """A dataset collection populator connected to the Galaxy session described by Selenium context."""
+        return SeleniumSessionDatasetCollectionPopulator(self)
+
+    @property
+    def workflow_populator(self) -> populators.BaseWorkflowPopulator:
+        """A workflow populator connected to the Galaxy session described by Selenium context."""
+        return SeleniumSessionWorkflowPopulator(self)
+
+
+class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
     # If run one-off via nosetests, the next line ensures test
     # tools and datatypes are used instead of configured tools.
     framework_tool_and_types = True
@@ -354,18 +373,6 @@ class TestWithSeleniumMixin(GalaxySeleniumContext, UsesApiTestCaseMixin):
         )
         with self.main_panel():
             self.assert_no_error_message()
-
-    @property
-    def dataset_populator(self):
-        return SeleniumSessionDatasetPopulator(self)
-
-    @property
-    def dataset_collection_populator(self):
-        return SeleniumSessionDatasetCollectionPopulator(self)
-
-    @property
-    def workflow_populator(self):
-        return SeleniumSessionWorkflowPopulator(self)
 
     def workflow_upload_yaml_with_random_name(self, content, **kwds):
         workflow_populator = self.workflow_populator

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -12,10 +12,6 @@ from gxformat2 import (
     convert_and_import_workflow,
     ImporterGalaxyInterface,
 )
-try:
-    from pyvirtualdisplay import Display
-except ImportError:
-    Display = None
 from requests.models import Response
 
 from galaxy.selenium import (

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -20,7 +20,7 @@ import galaxy.model.tool_shed_install as galaxy_model
 import galaxy.util
 from galaxy.security import idencoding
 from galaxy.util import smart_str, unicodify
-from galaxy_test.base.api_util import get_master_api_key
+from galaxy_test.base.api_util import get_admin_api_key
 from galaxy_test.driver.testcase import DrivenFunctionalTestCase
 from tool_shed.util import (
     hg_util,
@@ -529,7 +529,7 @@ class ShedTwillTestCase(DrivenFunctionalTestCase):
 
     def deactivate_repository(self, installed_repository, strings_displayed=None, strings_not_displayed=None):
         encoded_id = self.security.encode_id(installed_repository.id)
-        api_key = get_master_api_key()
+        api_key = get_admin_api_key()
         response = requests.delete(self.galaxy_url + "/api/tool_shed_repositories/" + encoded_id, data={'remove_from_disk': False, 'key': api_key})
         assert response.status_code != 403, response.content
 
@@ -1258,7 +1258,7 @@ class ShedTwillTestCase(DrivenFunctionalTestCase):
 
     def reset_installed_repository_metadata(self, repository):
         encoded_id = self.security.encode_id(repository.id)
-        api_key = get_master_api_key()
+        api_key = get_admin_api_key()
         response = requests.post(self.galaxy_url + "/api/tool_shed_repositories/reset_metadata_on_selected_installed_repositories", data={'repository_ids': [encoded_id], 'key': api_key})
         assert response.status_code != 403, response.content
 
@@ -1268,7 +1268,7 @@ class ShedTwillTestCase(DrivenFunctionalTestCase):
         self.submit_form(button="reset_metadata_on_selected_repositories_button", **kwd)
 
     def reset_metadata_on_selected_installed_repositories(self, repository_ids):
-        api_key = get_master_api_key()
+        api_key = get_admin_api_key()
         response = requests.post(self.galaxy_url + "/api/tool_shed_repositories/reset_metadata_on_selected_installed_repositories", data={'repository_ids': repository_ids, 'key': api_key})
         assert response.status_code != 403, response.content
 
@@ -1375,7 +1375,7 @@ class ShedTwillTestCase(DrivenFunctionalTestCase):
 
     def uninstall_repository(self, installed_repository, strings_displayed=None, strings_not_displayed=None):
         encoded_id = self.security.encode_id(installed_repository.id)
-        api_key = get_master_api_key()
+        api_key = get_admin_api_key()
         response = requests.delete(self.galaxy_url + "/api/tool_shed_repositories/" + encoded_id, data={'remove_from_disk': True, 'key': api_key})
         assert response.status_code != 403, response.content
 
@@ -1390,7 +1390,7 @@ class ShedTwillTestCase(DrivenFunctionalTestCase):
         self.check_for_strings(strings_displayed, strings_not_displayed)
 
     def update_tool_shed_status(self):
-        api_key = get_master_api_key()
+        api_key = get_admin_api_key()
         response = requests.get(self.galaxy_url + "/api/tool_shed_repositories/check_for_updates?key=" + api_key)
         assert response.status_code != 403, response.content
 

--- a/scripts/functional_tests.py
+++ b/scripts/functional_tests.py
@@ -13,7 +13,7 @@ galaxy_root = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pa
 sys.path[1:1] = [os.path.join(galaxy_root, "lib"), os.path.join(galaxy_root, "test")]
 
 from galaxy.util import classproperty
-from galaxy_test.base.api_util import get_master_api_key, get_user_api_key
+from galaxy_test.base.api_util import get_admin_api_key, get_user_api_key
 from galaxy_test.driver import driver_util
 
 log = driver_util.build_logger()
@@ -86,7 +86,7 @@ class DataManagersGalaxyTestDriver(driver_util.GalaxyTestDriver):
         functional.test_data_managers.build_tests(
             tmp_dir=self.galaxy_test_tmp_dir,
             testing_shed_tools=self.testing_shed_tools,
-            master_api_key=get_master_api_key(),
+            master_api_key=get_admin_api_key(),
             user_api_key=get_user_api_key(),
             user_email=self.app.config.admin_users_list[0],
             create_admin=True,

--- a/test/unit/tool_util/test_wait.py
+++ b/test/unit/tool_util/test_wait.py
@@ -42,7 +42,7 @@ def test_timeout_first_call():
         wait_on(condition, "never met condition", 1, delta=2, sleep_=sleeper.sleep)
     except TimeoutAssertionError as e:
         assert "never met condition" in str(e)
-        assert "after 2 seconds" in str(e)
+        assert "after 2.0 seconds" in str(e)
         exception_called = True
     assert len(sleeper.sleeps) == 1
     assert sleeper.sleeps[0] == 2  # delta of 2


### PR DESCRIPTION
- Drop last uses of deprecated testing mixin, drop deprecated nose-ism, drop unused import.
- Big, flushed out module docstring in galaxy_test.base.populators to describe their use and architecture
- Fix a bunch of type issue with various mixins in galaxy_test.base.populators and their descendants 
- Cleanup galaxy_test.base.api_util.
  - Rename get_master_api_key to get_admin_api_key - less offesnive and more accurate since it doesn't need to be the bootstrap key.
   - Add types and cleanup docstrings.
- More work on selenium variant of populators - allow them to be used outside context of test cases and fix up admin key handling inside of them.