### PR TITLE
[21.01] Small tweaks to invocations display

### DIFF
--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -81,10 +81,10 @@ describe("Invocations.vue with invocation", () => {
     it("toggles detail rendering", async () => {
         let rows = wrapper.findAll("tbody > tr").wrappers;
         expect(rows.length).toBe(1);
-        await wrapper.find("#toggle-invocation-details").trigger("click");
+        await wrapper.find(".toggle-invocation-details").trigger("click");
         rows = wrapper.findAll("tbody > tr").wrappers;
         expect(rows.length).toBe(3);
-        await wrapper.find("#toggle-invocation-details").trigger("click");
+        await wrapper.find(".toggle-invocation-details").trigger("click");
         rows = wrapper.findAll("tbody > tr").wrappers;
         expect(rows.length).toBe(1);
     });

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -35,7 +35,7 @@
                 </template>
                 <template v-slot:cell(workflow_id)="data">
                     <b-link
-                        id="toggle-invocation-details"
+                        class="toggle-invocation-details"
                         v-b-tooltip
                         title="Show Invocation details"
                         href="#"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
@@ -33,13 +33,13 @@ describe("WorkflowInvocationState.vue with terminal invocation", () => {
     });
 
     it("displays report links", async () => {
-        expect(wrapper.find("#invocation-pdf-link").exists()).toBeTruthy();
-        expect(wrapper.find("#invocation-link").exists()).toBeTruthy();
-        expect(wrapper.find("#bco-json").exists()).toBeTruthy();
+        expect(wrapper.find(".invocation-pdf-link").exists()).toBeTruthy();
+        expect(wrapper.find(".invocation-report-link").exists()).toBeTruthy();
+        expect(wrapper.find(".bco-json").exists()).toBeTruthy();
     });
 
     it("doesn't show cancel invocation button", async () => {
-        expect(wrapper.find("#cancel-workflow-scheduling").exists()).toBeFalsy();
+        expect(wrapper.find(".cancel-workflow-scheduling").exists()).toBeFalsy();
     });
 });
 
@@ -75,12 +75,12 @@ describe("WorkflowInvocationState.vue with no invocation", () => {
     });
 
     it("does not display report links", async () => {
-        expect(wrapper.find("#invocation-pdf-link").exists()).toBeFalsy();
-        expect(wrapper.find("#invocation-link").exists()).toBeFalsy();
-        expect(wrapper.find("#bco-json").exists()).toBeFalsy();
+        expect(wrapper.find(".invocation-pdf-link").exists()).toBeFalsy();
+        expect(wrapper.find(".invocation-report-link").exists()).toBeFalsy();
+        expect(wrapper.find(".bco-json").exists()).toBeFalsy();
     });
 
     it("shows cancel invocation button", async () => {
-        expect(wrapper.find("#cancel-workflow-scheduling").exists()).toBeTruthy();
+        expect(wrapper.find(".cancel-workflow-scheduling").exists()).toBeTruthy();
     });
 });

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -2,12 +2,11 @@
     <div class="mb-3">
         <div v-if="invocationAndJobTerminal">
             <span>
-                <a id="invocation-link" :href="invocationLink"
-                    ><b>View Report {{ index + 1 }}</b></a
+                <a class="invocation-report-link" :href="invocationLink"
+                    ><b>View Report {{ indexStr }}</b></a
                 >
                 <a
-                    id="invocation-pdf-link"
-                    class="fa fa-print ml-1"
+                    class="fa fa-print ml-1 invocation-pdf-link"
                     :href="invocationPdfLink"
                     v-b-tooltip
                     title="Download PDF"
@@ -18,11 +17,10 @@
             <span class="fa fa-spinner fa-spin" />
             <span>Invocation {{ index + 1 }}...</span>
             <span
-                id="cancel-workflow-scheduling"
+                class="fa fa-times cancel-workflow-scheduling"
                 v-if="!invocationSchedulingTerminal"
                 v-b-tooltip.hover
                 title="Cancel scheduling of workflow invocation"
-                class="fa fa-times"
                 @click="cancelWorkflowScheduling"
             ></span>
         </div>
@@ -54,7 +52,7 @@
             :loading="!invocationAndJobTerminal"
         />
         <span v-if="invocationAndJobTerminal">
-            <a id="bco-json" :href="bcoJSON"><b>Download BioCompute Object</b></a>
+            <a class="bco-json" :href="bcoJSON"><b>Download BioCompute Object</b></a>
         </span>
         <workflow-invocation-details
             v-if="invocation"

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.vue
@@ -15,7 +15,7 @@
         </div>
         <div v-else>
             <span class="fa fa-spinner fa-spin" />
-            <span>Invocation {{ index + 1 }}...</span>
+            <span>Invocation {{ indexStr }}...</span>
             <span
                 class="fa fa-times cancel-workflow-scheduling"
                 v-if="!invocationSchedulingTerminal"
@@ -87,7 +87,7 @@ export default {
         },
         index: {
             type: Number,
-            default: 0,
+            optional: true,
         },
     },
     data() {
@@ -102,6 +102,13 @@ export default {
     },
     computed: {
         ...mapGetters(["getInvocationById", "getInvocationJobsSummaryById"]),
+        indexStr() {
+            if (this.index == null) {
+                return "";
+            } else {
+                return `${this.index + 1}`;
+            }
+        },
         invocation: function () {
             return this.getInvocationById(this.invocationId);
         },


### PR DESCRIPTION
Small change to backport from testing which I think I'll need to target at dev. The extra "View Report 1" on each invocation in a list doesn't make sense - only makes sense in context of run response I think. Also I think a bunch of ids added should be classes. id was added to a bunch a components that may appear multiple places on a page I believe and so should be class (https://www.w3schools.com/html/html_id.asp).
