### PR TITLE
Parallelize client and server builds in dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.k8s_ci.Dockerfile
 .venv
 database

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -87,7 +87,6 @@ RUN git rev-parse HEAD > GITREVISION
 RUN rm -rf \
         .ci \
         .git \
-        .venv/bin/node \
         .venv/include/node \
         .venv/src/node* \
         doc \
@@ -108,7 +107,6 @@ WORKDIR $SERVER_DIR
 RUN rm -rf \
         .ci \
         .git \
-        .venv/bin/node \
         .venv/include/node \
         .venv/src/node* \
         doc \

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -1,12 +1,18 @@
 # Stage 1:
 # - base: ubuntu (default) OR prebuilt image0
 # - install build tools
-# - run playbook (image0 avoids rerunning lengthy tasks)
+# - clone playbook
+# Stage 2: build galaxy client and server in parallel
+# Stage 2.1:
+# - run playbook with server build steps only
 # - remove build artifacts + files not needed in container
-# Stage 2:
+# Stage 2.2:
+# - run playbook with client build steps only
+# - remove build artifacts + files not needed in container
+# Stage 3:
 # - install python-virtualenv
 # - create galaxy user + group + directory
-# - copy galaxy files from stage 1
+# - copy galaxy files from stage 2.1 and 2.2
 # - finalize container (set path, user...)
 
 # Init ARGs
@@ -16,12 +22,14 @@ ARG SERVER_DIR=$ROOT_DIR/server
 # For much faster build time override this with image0 (Dockerfile.0 build):
 #   docker build --build-arg BASE=<image0 name>...
 ARG STAGE1_BASE=ubuntu:20.04
-ARG STAGE2_BASE=$STAGE1_BASE
+ARG FINAL_STAGE_BASE=$STAGE1_BASE
 # NOTE: the value of GALAXY_USER must be also hardcoded in COPY in final stage
 ARG GALAXY_USER=galaxy
 ARG GALAXY_PLAYBOOK_REPO=https://github.com/galaxyproject/galaxy-docker-k8s
 
-# Stage-1
+#======================================================
+# Stage 1 - Setup common requirements for build
+#======================================================
 FROM $STAGE1_BASE AS stage1
 ARG DEBIAN_FRONTEND=noninteractive
 ARG SERVER_DIR
@@ -61,7 +69,14 @@ RUN ansible-galaxy install -r requirements.yml -p roles --force-with-deps
 
 # Add Galaxy source code
 COPY . $SERVER_DIR/
-RUN ansible-playbook -i localhost, playbook.yml -v
+
+#======================================================
+# Stage 2.1 - Build galaxy server
+#======================================================
+FROM stage1 AS server_build
+ARG SERVER_DIR
+
+RUN ansible-playbook -i localhost, playbook.yml -v -e galaxy_build_client=False
 
 RUN cat /galaxy/server/lib/galaxy/dependencies/conditional-requirements.txt | grep psycopg2-binary | xargs /galaxy/server/.venv/bin/pip install
 
@@ -81,8 +96,31 @@ RUN rm -rf \
 # Clean up *all* node_modules, including plugins.  Everything is already built+staged.
 RUN find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 
-# Stage-2
-FROM $STAGE2_BASE
+#======================================================
+# Stage 2.2 - Build galaxy client
+#======================================================
+FROM stage1 AS client_build
+ARG SERVER_DIR
+
+RUN ansible-playbook -i localhost, playbook.yml -v --tags "galaxy_build_client"
+
+WORKDIR $SERVER_DIR
+RUN rm -rf \
+        .ci \
+        .git \
+        .venv/bin/node \
+        .venv/include/node \
+        .venv/src/node* \
+        doc \
+        test \
+        test-data
+# Clean up *all* node_modules, including plugins.  Everything is already built+staged.
+RUN find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
+
+#======================================================
+# Stage 3 - Build final image based on previous stages
+#======================================================
+FROM $FINAL_STAGE_BASE
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ROOT_DIR
 ARG SERVER_DIR
@@ -115,7 +153,8 @@ RUN set -xe; \
 WORKDIR $ROOT_DIR
 # Copy galaxy files to final image
 # The chown value MUST be hardcoded (see #35018 at github.com/moby/moby)
-COPY --chown=galaxy:galaxy --from=stage1 $ROOT_DIR .
+COPY --chown=galaxy:galaxy --from=server_build $ROOT_DIR .
+COPY --chown=galaxy:galaxy --from=client_build $SERVER_DIR/static ./server/static
 
 WORKDIR $SERVER_DIR
 EXPOSE 8080

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+DOCKER_BUILDKIT=1 docker build -f $DOCKERFILE_PATH -t $IMAGE_NAME --build-arg GIT_USERNAME=$GIT_USERNAME --build-arg GIT_PASSWORD=$GIT_PASSWORD .


### PR DESCRIPTION
This PR modifies the k8s docker file so that client and server build stages are built in parallel, reducing total build time.

The uncached build time prior to this is ~18.5 minutes locally, which reduces to ~12.5 minutes, a ~33% reduction.
On dockerhub, there appears to be no benefit, as the builds don't seem to be parallelised in the free version.

This PR is dependent on: https://github.com/galaxyproject/ansible-galaxy/pull/120
