### PR TITLE
[20.09] Fix import of histories with collections copied from another history

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -627,7 +627,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             if input_key in object_import_tracker.hdcas_by_key:
                 hdca = object_import_tracker.hdcas_by_key[input_key]
             if input_key in object_import_tracker.hdca_copied_from_sinks:
-                hdca = object_import_tracker.hdca_copied_from_sinks[input_key]
+                hdca = object_import_tracker.hdcas_by_key[object_import_tracker.hdca_copied_from_sinks[input_key]]
             return hdca
 
         def _find_dce(input_key):


### PR DESCRIPTION
This looks like the right thing to do given what _find_hda does, and it
works for the case I encountered, but oddly I wasn't able to setup a
unit test that uses hdca_copied_from_sinks.

Fixes https://github.com/galaxyproject/galaxy/issues/11164