### PR TITLE
[21.01] Don't use copy when serializing JSON in safe_dumps

### DIFF
--- a/lib/galaxy/util/json.py
+++ b/lib/galaxy/util/json.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import logging
 import math
@@ -70,7 +69,7 @@ def safe_dumps(*args, **kwargs):
     try:
         dumped = json.dumps(*args, allow_nan=False, **kwargs)
     except ValueError:
-        obj = swap_inf_nan(copy.deepcopy(args[0]))
+        obj = swap_inf_nan(args[0])
         dumped = json.dumps(obj, allow_nan=False, **kwargs)
     if kwargs.get('escape_closing_tags', True):
         return dumped.replace('</', '<\\/')


### PR DESCRIPTION
I don't think making a copy is necessary, we don't change values in
place. Also works around:
```
galaxy.web.framework.decorators ERROR 2021-01-18 08:55:45,886 [p:49927,w:1,m:0] [uWSGIWorker1Core2] Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "lib/galaxy/util/json.py", line 71, in safe_dumps
    dumped = json.dumps(*args, allow_nan=False, **kwargs)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 309, in decorator
    rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
  File "lib/galaxy/web/framework/decorators.py", line 343, in format_return_as_json
    json = rval.json()
  File "pydantic/main.py", line 506, in pydantic.main.BaseModel.json
  File "lib/galaxy/util/json.py", line 73, in safe_dumps
    obj = swap_inf_nan(copy.deepcopy(args[0]))
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py", line 230, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py", line 230, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/copy.py", line 153, in deepcopy
    y = copier(memo)
  File "lib/galaxy/model/custom_types.py", line 232, in __deepcopy__
    return MutationList(MutationObj.coerce(self._key, copy.deepcopy(self[:])))
AttributeError: 'MutationList' object has no attribute '_key'
```