### PR TITLE
[21.01] Fix history import job done before import complete

### DIFF
--- a/client/src/components/HistoryExport/ToLink.vue
+++ b/client/src/components/HistoryExport/ToLink.vue
@@ -153,10 +153,7 @@ export default {
             waitOnJob(jobId)
                 .then((jobResponse) => {
                     this.waitingOnJob = false;
-                    this.loadingExports = true;
-                    // Race condition, for some reasons the job API returns
-                    // ok before the JEHA...
-                    setTimeout(this.loadExports, 2000);
+                    this.loadExports();
                 })
                 .catch(this.handleError);
         },

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -55,6 +55,7 @@ from galaxy.tools.actions.data_manager import DataManagerToolAction
 from galaxy.tools.actions.data_source import DataSourceToolAction
 from galaxy.tools.actions.model_operations import ModelOperationToolAction
 from galaxy.tools.cache import ToolDocumentCache
+from galaxy.tools.imp_exp import JobImportHistoryArchiveWrapper
 from galaxy.tools.parameters import (
     check_param,
     params_from_strings,
@@ -2648,6 +2649,12 @@ class ExportHistoryTool(Tool):
 
 class ImportHistoryTool(Tool):
     tool_type = 'import_history'
+
+    def exec_after_process(self, app, inp_data, out_data, param_dict, job, final_job_state=None, **kwds):
+        super().exec_after_process(app, inp_data, out_data, param_dict, job=job, **kwds)
+        if final_job_state != DETECTED_JOB_STATE.OK:
+            return
+        JobImportHistoryArchiveWrapper(self.app, job.id).cleanup_after_job()
 
 
 class InteractiveTool(Tool):


### PR DESCRIPTION
By moving history import from job wrapper cleanup to exec_after_process.
That seems like a better location overall, and in particular runs the
actual import before we set the final job state.

Fixes https://github.com/galaxyproject/galaxy/issues/11168