### PR TITLE
Fixed sync between legacy galaxy variable and Vuex current history

### DIFF
--- a/client/src/components/History/HistoryTopNav.vue
+++ b/client/src/components/History/HistoryTopNav.vue
@@ -35,7 +35,7 @@
                 key="use-legacy-history"
                 title="Return to legacy history panel"
                 icon="fas fa-exchange-alt"
-                @click="useLegacyHistoryPanel"
+                @click="switchToLegacyHistoryPanel"
             />
         </PriorityMenu>
     </div>
@@ -48,6 +48,7 @@ import HistorySelector from "./HistorySelector";
 import { createNewHistory } from "./model/queries";
 import { wipeDatabase, clearHistoryDateStore } from "./caching";
 import { legacyNavigationMixin } from "components/plugins";
+import { switchToLegacyHistoryPanel } from "./adapters/betaToggle";
 
 export default {
     mixins: [legacyNavigationMixin],
@@ -72,10 +73,7 @@ export default {
     methods: {
         ...mapActions("betaHistory", ["storeHistory"]),
 
-        useLegacyHistoryPanel() {
-            sessionStorage.removeItem("useBetaHistory");
-            location.reload();
-        },
+        switchToLegacyHistoryPanel,
 
         // create new server, store in vuex, switch to it
         async createHistory() {

--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -15,6 +15,7 @@ import Backbone from "backbone";
 import CurrentHistoryView from "mvc/history/history-view-edit-current";
 import { History } from "mvc/history/history-model";
 import "./HistoryPanelProxy.scss";
+import store from "store";
 
 // bypass polling while using the beta panel, skips contents loading
 const FakeHistoryViewModel = CurrentHistoryView.CurrentHistoryView.extend({
@@ -37,6 +38,7 @@ export const HistoryPanelProxy = Backbone.View.extend({
 
         // fake view of the current history
         this.historyView = new FakeHistoryViewModel({
+            fakeHistoryViewModel: true,
             className: `fake ${CurrentHistoryView.CurrentHistoryView.prototype.className} middle`,
             purgeAllowed: this.allow_user_dataset_purge,
             linkTarget: "galaxy_main",
@@ -58,6 +60,14 @@ export const HistoryPanelProxy = Backbone.View.extend({
             Galaxy.user.fetch({
                 url: `${Galaxy.user.urlRoot()}/${Galaxy.user.id || "current"}`,
             });
+        });
+
+        // Watch the store, change the fake history model when it changs
+        store.subscribe(({ type, payload: newId }) => {
+            if (type == "betaHistory/setCurrentHistoryId") {
+                console.log("setCurrentHistoryId", newId);
+                Galaxy.currHistoryPanel.setModel(new History({ id: newId }));
+            }
         });
     },
     render() {

--- a/client/src/components/History/adapters/betaToggle.js
+++ b/client/src/components/History/adapters/betaToggle.js
@@ -1,0 +1,13 @@
+export const isBetaHistoryOpen = () => {
+    return sessionStorage.getItem("useBetaHistory");
+};
+
+export const switchToLegacyHistoryPanel = () => {
+    sessionStorage.removeItem("useBetaHistory");
+    location.reload();
+};
+
+export const switchToBetaHistoryPanel = () => {
+    sessionStorage.setItem("useBetaHistory", 1);
+    location.reload(false);
+};

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -46,6 +46,7 @@ import RulesInput from "./RulesInput";
 import LoadingSpan from "components/LoadingSpan";
 import { mapState } from "vuex";
 import { BModal, BTabs, BTab } from "bootstrap-vue";
+import { isBetaHistoryOpen } from "components/History/adapters/betaToggle";
 
 const UploadModal = {
     components: {
@@ -336,8 +337,7 @@ const UploadModal = {
 };
 
 // Beta history patch
-const useBetaHistory = sessionStorage.getItem("useBetaHistory");
-if (useBetaHistory) {
+if (isBetaHistoryOpen()) {
     UploadModal.computed.currentHistoryId = function () {
         return this.$store.getters["betaHistory/currentHistoryId"];
     };

--- a/client/src/entry/analysis/index.js
+++ b/client/src/entry/analysis/index.js
@@ -6,14 +6,14 @@ import Page from "layout/page";
 
 // Vue adapter emulates current features of backbone history panel
 import { HistoryPanelProxy } from "components/History";
+import { isBetaHistoryOpen } from "components/History/adapters/betaToggle";
 
 addInitialization((Galaxy, { options = {} }) => {
     console.log("Analysis custom page setup");
 
     // Handle beta history panel
     // Need to mock Galaxy.currHistoryPanel
-    const useBeta = sessionStorage.getItem("useBetaHistory");
-    const HistoryPanel = useBeta ? HistoryPanelProxy : MvcHistoryPanel;
+    const HistoryPanel = isBetaHistoryOpen() ? HistoryPanelProxy : MvcHistoryPanel;
 
     const pageOptions = Object.assign({}, options, {
         config: Object.assign({}, options.config, {

--- a/client/src/mvc/history/options-menu.js
+++ b/client/src/mvc/history/options-menu.js
@@ -6,6 +6,7 @@ import _l from "utils/localization";
 import PopupMenu from "mvc/ui/popup-menu";
 import historyCopyDialog from "mvc/history/copy-dialog";
 import Webhooks from "mvc/webhooks";
+import { switchToBetaHistoryPanel } from "../../components/History/adapters/betaToggle";
 
 // ============================================================================
 var menu = [
@@ -165,8 +166,7 @@ var menu = [
         html: _l("Use Beta History Panel"),
         anon: false,
         func: function () {
-            sessionStorage.setItem("useBetaHistory", 1);
-            window.location.reload(false);
+            switchToBetaHistoryPanel();
         },
     },
 ];

--- a/client/src/store/syncVuextoGalaxy.js
+++ b/client/src/store/syncVuextoGalaxy.js
@@ -13,6 +13,7 @@ import { waitForInit } from "utils/observable/waitForInit";
 import { syncUserToGalaxy } from "store/userStore/syncUserToGalaxy";
 import { syncConfigToGalaxy } from "store/configStore/syncConfigToGalaxy";
 import { syncCurrentHistoryToGalaxy } from "components/History/model/syncCurrentHistoryToGalaxy";
+import { isBetaHistoryOpen } from "components/History/adapters/betaToggle";
 
 export const syncVuextoGalaxy = (store) => {
     const globalGalaxy$ = defer(() => {
@@ -25,6 +26,8 @@ export const syncVuextoGalaxy = (store) => {
     // configuration
     syncConfigToGalaxy(globalGalaxy$, store);
 
-    // Current History object (from legacy history panel)
-    syncCurrentHistoryToGalaxy(globalGalaxy$, store);
+    // Update Vuex with legacy galaxy history changes only when beta panel is closed.
+    if (!isBetaHistoryOpen()) {
+        syncCurrentHistoryToGalaxy(globalGalaxy$, store);
+    }
 };


### PR DESCRIPTION
Addresses flaws Marius noted with submitting tool forms and the new syncing to vuex feature. These functions are necessary to keep the Vuex betaHistoryStore in sync with the legacy Galaxy.currHistoryPanel variable so we can rewrite the legacy stuff in piecemeal.

Notably: when a tool form was used that accessed the Galaxy.currHistoryPanel, the ID was either uninitialized or the whole panel object was unavailable. That should be fixed now.


### Fix galaxy -> Vue synchronization

The goal of this sync function is to match the Vuex store to whatever is kept in galaxy.currHistoryPanel, but sometimes that variable is slow to load. This change just retries it for a while then gives up. 

On pages where the load is slower, this should catch it, but on pages where the "currHistoryPanel" variable never is initialized, it'll eventually just fail as it does now, showing with that error, indicating there's nothing to sync to.

I made the errors a little easier to consume so it wasn't so cryptic.


### Fix Vue -> galaxy synchronization

The HistoryPanelProxy facade creates a fake Backbone view for use in the legacy system. Its purpose is to look like what the rest of the legacy galaxy system wants to see when it accesses "Galaxy.currHistoryPanel". I've made some changes to keep it in sync with changes to the store.

The HistoryPanelProxy only runs when the beta panel is open (it's actually the mounter for the beta panel).
