### PR TITLE
Warns that build_mulled_singularity requires docker

### DIFF
--- a/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
+++ b/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
@@ -52,7 +52,7 @@
        or more package requirements listed as part of the tool's definition.
        Set auto_install to False if Galaxy should build container images
        through the admin interface or API, but not automatically when
-       a tool is run.
+       a tool is run. WARNING: requires docker to be installed.
 
   -->
 


### PR DESCRIPTION
Minor warning on documentation for those trying to use the build mulled singularity resolver in settings where docker is not available (very likely if you are trying to use singularity). Details in #11175.