### PR TITLE
[21.01] Allow injecting environment variables and config parameters into YAML job config

### DIFF
--- a/test/unit/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/jobs/job_conf.sample_advanced.yml
@@ -16,6 +16,14 @@ runners:
     load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
     # Override the $DRMAA_LIBRARY_PATH environment variable
     drmaa_library_path: /sge/lib/libdrmaa.so
+  sge2:
+    load: galaxy.jobs.runners.drmaa:DRMAAJobRunner
+    # Override the $DRMAA_LIBRARY_PATH environment variable
+    drmaa_library_path:
+      $from_environ: PWD
+    another_runner_param:
+      $from_environ: NOT_A_REAL_VAR_HOPEFULLY
+      $default: 'a very cool default'
   cli: 
     load: galaxy.jobs.runners.cli:ShellJobRunner
   condor: 

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -395,6 +395,14 @@ class AdvancedJobConfXmlParserTestCase(BaseJobConfXmlParserTestCase):
 class AdvancedJobConfYamlParserTestCase(AdvancedJobConfXmlParserTestCase):
     extension = "yml"
 
+    def test_env(self):
+        self._with_advanced_config()
+        # self.drmaa_library_path
+        env_example = [r for r in self.job_config.runner_plugins if r["id"] == "sge2"][0]
+        assert "drmaa_library_path" in env_example["kwds"]
+        assert env_example["kwds"]["drmaa_library_path"] == os.environ["PWD"]
+        assert env_example["kwds"]["another_runner_param"] == "a very cool default", env_example
+
 
 def test_yaml_advanced_validation():
     schema = os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib", "galaxy", "webapps", "galaxy", "job_config_schema.yml")


### PR DESCRIPTION
Similar dynamic options were available to XML job config (though only at the top-level of each config tag type). Calling it a bug because it is missing for YAML and because @natefoo reasonably doesn't want to store AMQP credentials in the database.