### PR TITLE
[20.09] Fix pulling of  singularity images if docker cli not available

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -462,7 +462,7 @@ class MulledDockerContainerResolver(CliContainerResolver):
                         namespace=self.namespace,
                         hash_func=self.hash_func,
                         resolution_cache=resolution_cache,
-                    )
+                    ) or container_description
             return container_description
 
     def __str__(self):

--- a/lib/galaxy/tool_util/deps/containers.py
+++ b/lib/galaxy/tool_util/deps/containers.py
@@ -226,7 +226,7 @@ class ContainerRegistry:
             # BuildMulledDockerContainerResolver and BuildMulledSingularityContainerResolver both need the docker daemon to build images.
             # If docker is not available, we don't load them.
             build_mulled_docker_container_resolver = BuildMulledDockerContainerResolver(self.app_info)
-            if build_mulled_docker_container_resolver.docker_cli_available:
+            if build_mulled_docker_container_resolver.cli_available:
                 default_resolvers.extend([
                     build_mulled_docker_container_resolver,
                     BuildMulledSingularityContainerResolver(self.app_info),

--- a/test/unit/tool_util/test_container_resolution.py
+++ b/test/unit/tool_util/test_container_resolution.py
@@ -11,26 +11,26 @@ from galaxy.tool_util.deps.requirements import ToolRequirement
 def test_docker_container_resolver_detects_docker_cli_absent(mocker):
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value=None)
     resolver = CachedMulledDockerContainerResolver()
-    assert resolver.docker_cli_available is False
+    assert resolver._cli_available is False
 
 
 def test_docker_container_resolver_detects_docker_cli(mocker):
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled', return_value='/bin/docker')
     resolver = CachedMulledDockerContainerResolver()
-    assert resolver.docker_cli_available
+    assert resolver.cli_available
 
 
 def test_cached_docker_container_docker_cli_absent_resolve(mocker):
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value=None)
     resolver = CachedMulledDockerContainerResolver()
-    assert resolver.docker_cli_available is False
+    assert resolver.cli_available is False
     assert resolver.resolve(enabled_container_types=[], tool_info={}) is None
 
 
 def test_docker_container_docker_cli_absent_resolve(mocker):
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value=None)
     resolver = MulledDockerContainerResolver()
-    assert resolver.docker_cli_available is False
+    assert resolver.cli_available is False
     requirement = ToolRequirement(name="samtools", version="1.10", type="package")
     tool_info = ToolInfo(requirements=[requirement])
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.targets_to_mulled_name', return_value='samtools:1.10--h2e538c0_3')
@@ -42,12 +42,12 @@ def test_docker_container_docker_cli_absent_resolve(mocker):
 def test_docker_container_docker_cli_exception_resolve(mocker):
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.which', return_value='/bin/docker')
     resolver = MulledDockerContainerResolver()
-    assert resolver.docker_cli_available is True
+    assert resolver.cli_available is True
     requirement = ToolRequirement(name="samtools", version="1.10", type="package")
     tool_info = ToolInfo(requirements=[requirement])
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.targets_to_mulled_name', return_value='samtools:1.10--h2e538c0_3')
     mocker.patch('galaxy.tool_util.deps.container_resolvers.mulled.docker_cached_container_description', side_effect=CalledProcessError(1, 'bla'))
     container_description = resolver.resolve(enabled_container_types=['docker'], tool_info=tool_info, install=True)
-    assert resolver.docker_cli_available is True
+    assert resolver.cli_available is True
     assert container_description.type == 'docker'
     assert container_description.identifier == 'quay.io/biocontainers/samtools:1.10--h2e538c0_3'


### PR DESCRIPTION
That broke in https://github.com/galaxyproject/galaxy/pull/11134, since the singularity container resolve() inherits from docker container resolution it'd also check to see if `docker` was on path.

Should fix https://github.com/galaxyproject/galaxy/issues/11174 .