### PR TITLE
Selenium tests for user library import dir

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -900,6 +900,19 @@ class NavigatesGalaxy(HasDriver):
     def admin_open(self):
         self.components.masthead.admin.wait_for_and_click()
 
+
+
+    def select_dataset_from_lib_import_modal(self, name):
+        self.components.libraries.folder.select_import_dir_item(name=name).wait_for_and_click()
+        self.components.libraries.folder.import_dir_btn.wait_for_and_click()
+
+    def create_new_library(self, login=True):
+        if login:
+            self.admin_login()
+        self.libraries_open()
+        self.name = self._get_random_name(prefix="testcontents")
+        self.libraries_index_create(self.name)
+
     def libraries_open(self):
         self.home()
         self.click_masthead_shared_data()
@@ -964,17 +977,9 @@ class NavigatesGalaxy(HasDriver):
         self.wait_for_and_click(self.navigation.libraries.folder.selectors.add_items_button)
         self.wait_for_visible(self.navigation.libraries.folder.selectors.add_items_menu)
 
-    def libraries_dataset_import_from_history(self):
+    def libraries_dataset_import(self, btn):
         self.libraries_click_dataset_import()
-        self.wait_for_and_click(self.navigation.libraries.folder.labels.from_history)
-
-    def libraries_dataset_import_from_path(self):
-        self.libraries_click_dataset_import()
-        self.wait_for_and_click(self.navigation.libraries.folder.labels.from_path)
-
-    def libraries_dataset_import_from_import_dir(self):
-        self.libraries_click_dataset_import()
-        self.wait_for_and_click(self.navigation.libraries.folder.labels.from_import_dir)
+        self.wait_for_and_click(btn)
 
     def libraries_dataset_import_from_history_select(self, to_select_items):
         self.wait_for_visible(self.navigation.libraries.folder.selectors.import_history_content)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -900,8 +900,6 @@ class NavigatesGalaxy(HasDriver):
     def admin_open(self):
         self.components.masthead.admin.wait_for_and_click()
 
-
-
     def select_dataset_from_lib_import_modal(self, name):
         self.components.libraries.folder.select_import_dir_item(name=name).wait_for_and_click()
         self.components.libraries.folder.import_dir_btn.wait_for_and_click()

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -529,6 +529,10 @@ libraries:
 
   selectors:
     _: .library_style_container
+    permission_library_btn: '.permission_library_btn'
+    toolbtn_save_permissions: '.toolbtn_save_permissions'
+    add_items_permission_field: '.add_perm > ul input'
+    add_items_permission_option: '.select2-result-label[role="option"]'
 
   folder:
     selectors:
@@ -563,6 +567,7 @@ libraries:
       download_button: '#download-btn'
       delete_btn: '.toolbtn-bulk-delete'
       toast_msg: '.toast-message'
+      toast_warning: '.toast-warning'
       select_import_dir_item: 'li[full_path="${name}"] .jstree-anchor'
       import_dir_btn:
         type: xpath
@@ -572,6 +577,7 @@ libraries:
       from_history: 'from History'
       from_path: 'from Path'
       from_import_dir: 'from Import Directory'
+      from_user_import_dir: 'from User Directory'
 
   dataset:
     selectors:

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -442,6 +442,15 @@ class SharedStateSeleniumTestCase(SeleniumTestCase):
         """Override this to setup shared data for tests that gets initialized only once."""
 
 
+class UsesLibraryAssertions:
+
+    @retry_assertion_during_transitions
+    def assert_num_displayed_items_is(self, n):
+        self.assertEqual(n, self.num_displayed_items())
+
+    def num_displayed_items(self):
+        return len(self.libraries_table_elements())
+
 class UsesHistoryItemAssertions:
 
     def assert_item_peek_includes(self, hid, expected):

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -451,6 +451,7 @@ class UsesLibraryAssertions:
     def num_displayed_items(self):
         return len(self.libraries_table_elements())
 
+
 class UsesHistoryItemAssertions:
 
     def assert_item_peek_includes(self, hid, expected):

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -6,10 +6,11 @@ from .framework import (
     retry_during_transitions,
     selenium_test,
     SeleniumTestCase,
+    UsesLibraryAssertions
 )
 
 
-class LibraryContentsTestCase(SeleniumTestCase):
+class LibraryContentsTestCase(SeleniumTestCase, UsesLibraryAssertions):
 
     requires_admin = True
 
@@ -149,7 +150,6 @@ class LibraryContentsTestCase(SeleniumTestCase):
         self.navigate_to_new_library()
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_import_dir)
-        self.libraries_dataset_import_from_import_dir()
         self.select_dataset_from_lib_import_modal("1.axt")
         self.assert_num_displayed_items_is(1)
 

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -26,7 +26,7 @@ class LibraryContentsTestCase(SeleniumTestCase):
         long_description = self._get_random_name(prefix="new_sub_folder_description", len=45)
 
         # create mew folder
-        self._navigate_to_new_library()
+        self.navigate_to_new_library()
         self.assert_num_displayed_items_is(0)
         self.libraries_folder_create(sub_folder_name)
         self.assert_num_displayed_items_is(1)
@@ -56,7 +56,7 @@ class LibraryContentsTestCase(SeleniumTestCase):
         self.admin_login()
         self.perform_upload(self.get_filename("1.txt"))
         self.wait_for_history()
-        self._navigate_to_new_library(login=False)
+        self.navigate_to_new_library(login=False)
         self.assert_num_displayed_items_is(0)
         self.sleep_for(self.wait_types.UX_RENDER)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_history)
@@ -112,7 +112,7 @@ class LibraryContentsTestCase(SeleniumTestCase):
     # for some reason. https://jenkins.galaxyproject.org/job/jmchilton-selenium/79/artifact/79-test-errors/test_import_dataset_from_path2017100413221507137721/
     @selenium_test
     def test_import_dataset_from_path(self):
-        self._navigate_to_new_library()
+        self.navigate_to_new_library()
         self.assert_num_displayed_items_is(0)
         self.sleep_for(self.wait_types.UX_RENDER)
 
@@ -146,7 +146,7 @@ class LibraryContentsTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_import_dataset_from_import_dir(self):
-        self._navigate_to_new_library()
+        self.navigate_to_new_library()
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_import_dir)
         self.libraries_dataset_import_from_import_dir()
@@ -155,7 +155,7 @@ class LibraryContentsTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_show_details(self):
-        self._navigate_to_new_library()
+        self.navigate_to_new_library()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.wait_for_selector_clickable(".toolbtn-show-locinfo").click()
         self.sleep_for(self.wait_types.UX_RENDER)

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -124,7 +124,7 @@ class LibraryContentsTestCase(SeleniumTestCase, UsesLibraryAssertions):
         self.wait_for_absent_or_hidden(self.navigation.libraries.folder.selectors.import_modal)
 
         # Try again... this time actually select some paths.
-        self.libraries_dataset_import_from_path()
+        self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_path)
         textarea = self.wait_for_and_click(self.navigation.libraries.folder.selectors.import_from_path_textarea)
         textarea.send_keys("test-data/1.txt")
         self.sleep_for(self.wait_types.UX_RENDER)

--- a/test/integration_selenium/framework.py
+++ b/test/integration_selenium/framework.py
@@ -6,7 +6,7 @@ from galaxy_test.selenium import (
 selenium_test = framework.selenium_test
 
 
-class SeleniumIntegrationTestCase(integration_util.IntegrationTestCase, framework.TestWithSeleniumMixin):
+class SeleniumIntegrationTestCase(integration_util.IntegrationTestCase, framework.TestWithSeleniumMixin, framework.UsesLibraryAssertions):
 
     def setUp(self):
         super().setUp()

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -30,8 +30,10 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         file.write(random_text)
         file.close()
 
+        # allow user to add new datasets in the newly created library
         self.create_lib_and_permit_adding(email)
 
+        # test importing functionality
         self.libraries_open_with_name(self.name)
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
@@ -40,23 +42,31 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
 
     @selenium_test
     def test_user_library_import_dir_warning(self):
-        # do not create email-dir, assert warning
+        # do not create email-dir, assert just warning
         email = self.get_logged_in_user()["email"]
         self.create_lib_and_permit_adding(email)
 
         self.libraries_open_with_name(self.name)
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
+
+        # importing modal should be hidden
         self.wait_for_selector_absent_or_hidden(self.modal_body_selector())
+
+        # assert 'user import folder was not created' warning
         self.components.libraries.folder.toast_warning.wait_for_visible()
 
     def create_lib_and_permit_adding(self, email):
+        # logout of the current user, only admin can create new libraries
         self.logout()
         self.create_new_library()
+        # open permission manage dialog
         self.components.libraries.permission_library_btn.wait_for_and_click()
         self.components.libraries.add_items_permission_field.wait_for_and_click()
+        # search for created user and add him to permission field
         self.components.libraries.add_items_permission_field.wait_for_and_send_keys(email)
         self.components.libraries.add_items_permission_option.wait_for_and_click()
         self.components.libraries.toolbtn_save_permissions.wait_for_and_click()
         self.logout()
+        # login back to a 'regular' user account
         self.submit_login(email=email)

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -68,5 +68,5 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         self.components.libraries.add_items_permission_option.wait_for_and_click()
         self.components.libraries.toolbtn_save_permissions.wait_for_and_click()
         self.logout()
-        # login back to a 'regular' user account
+        # login back to the 'regular' user account
         self.submit_login(email=email)

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -60,6 +60,3 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         self.components.libraries.toolbtn_save_permissions.wait_for_and_click()
         self.logout()
         self.submit_login(email=email)
-
-
-

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -1,0 +1,65 @@
+import os
+
+from .framework import (
+    selenium_test,
+    SeleniumIntegrationTestCase,
+)
+
+
+class TestUserLibraryImport(SeleniumIntegrationTestCase):
+    requires_admin = True
+    ensure_registered = True
+
+    @classmethod
+    def user_import_dir(cls):
+        return cls.temp_config_dir("user_library_import_dir")
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        user_import_dir = cls.user_import_dir()
+        config["user_library_import_dir"] = user_import_dir
+
+    @selenium_test
+    def test_user_library_import_dir(self):
+        # create new user, create user_library_import_dir, create new email-dir, insert a random text file
+        email = self.get_logged_in_user()["email"]
+        current_user_import_dir = os.path.join(self.user_import_dir(), email)
+        os.makedirs(current_user_import_dir)
+        random_text = self._get_random_name()
+        file = open(f'{current_user_import_dir}/{random_text}', "w")
+        file.write(random_text)
+        file.close()
+
+        self.create_lib_and_permit_adding(email)
+
+        self.libraries_open_with_name(self.name)
+        self.assert_num_displayed_items_is(0)
+        self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
+        self.select_dataset_from_lib_import_modal(random_text)
+        self.assert_num_displayed_items_is(1)
+
+    @selenium_test
+    def test_user_library_import_dir_warning(self):
+        # do not create email-dir, assert warning
+        email = self.get_logged_in_user()["email"]
+        self.create_lib_and_permit_adding(email)
+
+        self.libraries_open_with_name(self.name)
+        self.assert_num_displayed_items_is(0)
+        self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
+        self.wait_for_selector_absent_or_hidden(self.modal_body_selector())
+        self.components.libraries.folder.toast_warning.wait_for_visible()
+
+    def create_lib_and_permit_adding(self, email):
+        self.logout()
+        self.create_new_library()
+        self.components.libraries.permission_library_btn.wait_for_and_click()
+        self.components.libraries.add_items_permission_field.wait_for_and_click()
+        self.components.libraries.add_items_permission_field.wait_for_and_send_keys(email)
+        self.components.libraries.add_items_permission_option.wait_for_and_click()
+        self.components.libraries.toolbtn_save_permissions.wait_for_and_click()
+        self.logout()
+        self.submit_login(email=email)
+
+
+


### PR DESCRIPTION
So we don't have this problem https://github.com/galaxyproject/galaxy/pull/11137 again, this PR introduces user library import selenium test.

It creates new user-import directory for the user, changes permission to allow this user to add new datasets, asserts import
Also asserts warning, if user has permission but the folder wasn't created.
In addition, there's a slight refactoring.