### PR TITLE
Copy only dataset tags in Extract Dataset tool

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -198,6 +198,7 @@ WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
     'Filter1': safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.1.1")),
     '__BUILD_LIST__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     '__APPLY_RULES__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.1.0")),
+    '__EXTRACT_DATASET__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
 }
 
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2887,7 +2887,7 @@ class ExtractDatasetCollectionTool(DatabaseOperationTool):
         else:
             raise Exception("Invalid tool parameters.")
         extracted = extracted_element.element_object
-        extracted_o = extracted.copy(copy_tags=tags, new_name=extracted_element.element_identifier)
+        extracted_o = extracted.copy(copy_tags=extracted.tags, new_name=extracted_element.element_identifier)
         self._add_datasets_to_history(history, [extracted_o], datasets_visible=True)
 
         out_data["output"] = extracted_o

--- a/lib/galaxy/tools/extract_dataset.xml
+++ b/lib/galaxy/tools/extract_dataset.xml
@@ -1,6 +1,6 @@
 <tool id="__EXTRACT_DATASET__"
       name="Extract Dataset"
-      version="1.0.0"
+      version="1.0.1"
       tool_type="extract_element">
   <description>from a list</description>
   <type class="ExtractDatasetCollectionTool" module="galaxy.tools" />


### PR DESCRIPTION
This addresses the bug reported in #11199. Instead of taking a list of tags as input, it only copies the tags from the dataset being extracted.