### PR TITLE
[21.01] Reduce authnz exception exposure

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -300,9 +300,8 @@ class AuthnzManager:
             return success, message, backend.callback(state_token, authz_code, trans, login_redirect_url)
         except exceptions.AuthenticationFailed:
             raise
-        except Exception as e:
-            msg = 'The following error occurred when handling callback from `{}` identity provider: ' \
-                  '{}'.format(provider, str(e))
+        except Exception:
+            msg = f'An error occurred when handling callback from `{provider}` identity provider.  Please contact an administrator for assistance.'
             log.exception(msg)
             return False, msg, (None, None)
 
@@ -315,9 +314,8 @@ class AuthnzManager:
         except exceptions.AuthenticationFailed:
             log.exception("Error creating user")
             raise
-        except Exception as e:
-            msg = 'The following error occurred when handling callback from `{}` identity provider: ' \
-                  '{}'.format(provider, str(e))
+        except Exception:
+            msg = f'An error occurred when creating a user with `{provider}` identity provider.  Please contact an administrator for assistance.'
             log.exception(msg)
             return False, msg, (None, None)
 
@@ -344,9 +342,8 @@ class AuthnzManager:
             if success is False:
                 return False, message, None
             return True, message, backend.logout(trans, post_logout_redirect_url)
-        except Exception as e:
-            msg = 'The following error occurred when logging out from `{}` identity provider: ' \
-                  '{}'.format(provider, str(e))
+        except Exception:
+            msg = f'An error occurred when logging out from `{provider}` identity provider.  Please contact an administrator for assistance.'
             log.exception(msg)
             return False, msg, None
 


### PR DESCRIPTION
 Prevent leaking of raw exception, suggest contacting an admin (who can find the log if need be) in authnz controller.  
These definitely shouldn't go to the end user, as suggested.

fixes #11207 