### PR TITLE
[20.09] Fix regression of 'disabled' masthead items.  

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -42,6 +42,7 @@
                 :target="item.target || '_parent'"
                 role="menuitem"
                 @click="open(item, $event)"
+                :disabled="item.disabled === true"
             >
                 {{ item.title }}
             </b-dropdown-item>

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -250,7 +250,7 @@ export function fetchMenu(options = {}) {
             menu: [
                 {
                     title: `${_l("Logged in as")} ${Galaxy.user.get("email")}`,
-                    class: "dropdown-item disabled",
+                    disabled: true,
                 },
                 {
                     title: _l("Preferences"),


### PR DESCRIPTION
Looks like this functionality (was manual class addition) never made it to the new-ish masthead.
Fixes #11208 

![image](https://user-images.githubusercontent.com/155398/105534362-5fc02600-5cbb-11eb-906c-2fe05a136c49.png)
