### PR TITLE
[21.01] Add ffindex and ffdata database file types

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -831,6 +831,8 @@
     <!-- speech datatypes -->
     <datatype extension="textgrid" type="galaxy.datatypes.speech:TextGrid" display_in_upload="true" mimetype="text/plain"/>
     <datatype extension="par" type="galaxy.datatypes.speech:BPF" display_in_upload="true" mimetype="text/plain-bas"/>
+    <datatype extension="ffindex" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description="https://github.com/soedinglab/ffindex_soedinglab"/>
+    <datatype extension="ffdata" type="galaxy.datatypes.data:Data" display_in_upload="true" subclass="true" description="https://github.com/soedinglab/ffindex_soedinglab"/>
   </registration>
   <sniffers>
     <!--

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -831,8 +831,8 @@
     <!-- speech datatypes -->
     <datatype extension="textgrid" type="galaxy.datatypes.speech:TextGrid" display_in_upload="true" mimetype="text/plain"/>
     <datatype extension="par" type="galaxy.datatypes.speech:BPF" display_in_upload="true" mimetype="text/plain-bas"/>
-    <datatype extension="ffindex" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description="https://github.com/soedinglab/ffindex_soedinglab"/>
-    <datatype extension="ffdata" type="galaxy.datatypes.data:Data" display_in_upload="true" subclass="true" description="https://github.com/soedinglab/ffindex_soedinglab"/>
+    <datatype extension="ffindex" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description_url="https://github.com/soedinglab/ffindex_soedinglab"/>
+    <datatype extension="ffdata" type="galaxy.datatypes.data:Data" display_in_upload="true" subclass="true" description_url="https://github.com/soedinglab/ffindex_soedinglab"/>
   </registration>
   <sniffers>
     <!--


### PR DESCRIPTION
Adds ffindex/ffdata datatypes to Galaxy. This is a simple index/database format for huge amounts of small files. The files are concatenated into one big data file (ffdata), the byte number at which the file is stored is tracked in the index file (ffindex) together with the size of the file.