### PR TITLE
Implement abstraction around InferringApiRouter tailored to typical Galaxy usage.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/configuration.py
+++ b/lib/galaxy/webapps/galaxy/api/configuration.py
@@ -11,8 +11,6 @@ from typing import (
 )
 
 from fastapi import Path
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.managers.configuration import ConfigurationManager
 from galaxy.managers.context import (
@@ -30,11 +28,11 @@ from galaxy.web import (
     require_admin
 )
 from . import (
-    AdminUserRequired,
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
     DependsOnUser,
+    Router,
 )
 from .common import (
     parse_serialization_params,
@@ -44,7 +42,7 @@ from .common import (
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=['configuration'])
+router = Router(tags=['configuration'])
 
 
 EncodedIdPathParam: EncodedDatabaseIdField = Path(
@@ -54,7 +52,7 @@ EncodedIdPathParam: EncodedDatabaseIdField = Path(
 )
 
 
-@cbv(router)
+@router.cbv
 class FastAPIConfiguration:
     configuration_manager: ConfigurationManager = depends(ConfigurationManager)
 
@@ -98,7 +96,7 @@ class FastAPIConfiguration:
 
     @router.get(
         '/api/configuration/dynamic_tool_confs',
-        dependencies=[AdminUserRequired],
+        require_admin=True,
         summary="Return dynamic tool configuration files",
         response_description="Dynamic tool configuration files"
     )
@@ -108,7 +106,7 @@ class FastAPIConfiguration:
 
     @router.get(
         '/api/configuration/decode/{encoded_id}',
-        dependencies=[AdminUserRequired],
+        require_admin=True,
         summary="Decode a given id",
         response_description="Decoded id"
     )
@@ -121,7 +119,7 @@ class FastAPIConfiguration:
 
     @router.get(
         '/api/configuration/tool_lineages',
-        dependencies=[AdminUserRequired],
+        require_admin=True,
         summary="Return tool lineages for tools that have them",
         response_description="Tool lineages for tools that have them"
     )
@@ -131,7 +129,7 @@ class FastAPIConfiguration:
 
     @router.put(
         '/api/configuration/toolbox',
-        dependencies=[AdminUserRequired],
+        require_admin=True,
         summary="Reload the Galaxy toolbox (but not individual tools)"
     )
     def reload_toolbox(self):

--- a/lib/galaxy/webapps/galaxy/api/datatypes.py
+++ b/lib/galaxy/webapps/galaxy/api/datatypes.py
@@ -10,8 +10,6 @@ from typing import (
 )
 
 from fastapi import Query
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.datatypes.registry import Registry
 from galaxy.managers.datatypes import (
@@ -32,11 +30,12 @@ from galaxy.web import expose_api_anonymous_and_sessionless
 from . import (
     BaseGalaxyAPIController,
     depends,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=['datatypes'])
+router = Router(tags=['datatypes'])
 
 ExtensionOnlyQueryParam: Optional[bool] = Query(
     default=True,
@@ -51,7 +50,7 @@ UploadOnlyQueryParam: Optional[bool] = Query(
 )
 
 
-@cbv(router)
+@router.cbv
 class FastAPIDatatypes:
     datatypes_registry: Registry = depends(Registry)
 
@@ -133,6 +132,7 @@ class FastAPIDatatypes:
 
 
 class DatatypesController(BaseGalaxyAPIController):
+    datatypes_registry: Registry = depends(Registry)
 
     @expose_api_anonymous_and_sessionless
     def index(self, trans, **kwd):
@@ -142,7 +142,7 @@ class DatatypesController(BaseGalaxyAPIController):
         """
         extension_only = asbool(kwd.get('extension_only', True))
         upload_only = asbool(kwd.get('upload_only', True))
-        return view_index(self._datatypes_registry, extension_only, upload_only)
+        return view_index(self.datatypes_registry, extension_only, upload_only)
 
     @expose_api_anonymous_and_sessionless
     def mapping(self, trans, **kwd):
@@ -150,7 +150,7 @@ class DatatypesController(BaseGalaxyAPIController):
         GET /api/datatypes/mapping
         Return a dictionary of class to class mappings.
         '''
-        return view_mapping(self._datatypes_registry)
+        return view_mapping(self.datatypes_registry)
 
     @expose_api_anonymous_and_sessionless
     def types_and_mapping(self, trans, **kwd):
@@ -163,7 +163,7 @@ class DatatypesController(BaseGalaxyAPIController):
         """
         extension_only = asbool(kwd.get('extension_only', True))
         upload_only = asbool(kwd.get('upload_only', True))
-        return view_types_and_mapping(self._datatypes_registry, extension_only, upload_only)
+        return view_types_and_mapping(self.datatypes_registry, extension_only, upload_only)
 
     @expose_api_anonymous_and_sessionless
     def sniffers(self, trans, **kwd):
@@ -171,20 +171,16 @@ class DatatypesController(BaseGalaxyAPIController):
         GET /api/datatypes/sniffers
         Return a list of sniffers.
         '''
-        return view_sniffers(self._datatypes_registry)
+        return view_sniffers(self.datatypes_registry)
 
     @expose_api_anonymous_and_sessionless
     def converters(self, trans, **kwd):
-        return view_converters(self._datatypes_registry)
+        return view_converters(self.datatypes_registry)
 
     @expose_api_anonymous_and_sessionless
     def edam_formats(self, trans, **kwds):
-        return view_edam_formats(self._datatypes_registry)
+        return view_edam_formats(self.datatypes_registry)
 
     @expose_api_anonymous_and_sessionless
     def edam_data(self, trans, **kwds):
-        return view_edam_data(self._datatypes_registry)
-
-    @property
-    def _datatypes_registry(self):
-        return self.app.datatypes_registry
+        return view_edam_data(self.datatypes_registry)

--- a/lib/galaxy/webapps/galaxy/api/job_lock.py
+++ b/lib/galaxy/webapps/galaxy/api/job_lock.py
@@ -1,21 +1,20 @@
 from fastapi import (
     Body,
 )
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.managers.jobs import JobLock, JobManager
-from . import AdminUserRequired, depends
+from . import depends, Router
 
-router = APIRouter(tags=['job_lock'])
+router = Router(tags=['job_lock'])
 
 
-@router.get('/api/job_lock', dependencies=[AdminUserRequired])
+@router.get('/api/job_lock', require_admin=True)
 def job_lock_status(job_manager: JobManager = depends(JobManager)) -> JobLock:
     """Get job lock status."""
     return job_manager.job_lock()
 
 
-@router.put('/api/job_lock', dependencies=[AdminUserRequired])
+@router.put('/api/job_lock', require_admin=True)
 def update_job_lock(job_manager: JobManager = depends(JobManager), job_lock: JobLock = Body(...)) -> JobLock:
     """Set job lock status."""
     return job_manager.update_job_lock(job_lock)

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -7,8 +7,6 @@ API operations on a jobs.
 import logging
 import typing
 
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 from sqlalchemy import (
     or_,
 )
@@ -46,14 +44,15 @@ from . import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=["jobs"])
+router = Router(tags=["jobs"])
 
 
-@cbv(router)
+@router.cbv
 class FastAPIJobs:
     job_manager: JobManager = depends(JobManager)
     job_search: JobSearch = depends(JobSearch)

--- a/lib/galaxy/webapps/galaxy/api/licenses.py
+++ b/lib/galaxy/webapps/galaxy/api/licenses.py
@@ -3,8 +3,6 @@ from typing import List
 from fastapi import (
     Path
 )
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.managers.licenses import (
     LicenseMetadataModel,
@@ -14,9 +12,10 @@ from galaxy.web import expose_api_anonymous_and_sessionless
 from . import (
     BaseGalaxyAPIController,
     depends,
+    Router,
 )
 
-router = APIRouter(tags=['licenses'])
+router = Router(tags=['licenses'])
 
 LicenseIdPath: str = Path(
     ...,  # Mark this Path parameter as required
@@ -26,7 +25,7 @@ LicenseIdPath: str = Path(
 )
 
 
-@cbv(router)
+@router.cbv
 class FastAPILicenses:
     licenses_manager: LicensesManager = depends(LicensesManager)
 

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -5,8 +5,6 @@ import logging
 from typing import Any, Dict, List, Optional
 
 from fastapi.param_functions import Query
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.files._schema import (
     FilesSourcePluginList,
@@ -21,11 +19,12 @@ from . import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=['remote files'])
+router = Router(tags=['remote files'])
 
 TargetQueryParam: str = Query(
     default=RemoteFilesTarget.ftpdir,
@@ -65,7 +64,7 @@ DisableModeQueryParam: Optional[RemoteFilesDisableMode] = Query(
 )
 
 
-@cbv(router)
+@router.cbv
 class FastAPIRemoteFiles:
     manager: RemoteFilesManager = depends(RemoteFilesManager)
 

--- a/lib/galaxy/webapps/galaxy/api/tours.py
+++ b/lib/galaxy/webapps/galaxy/api/tours.py
@@ -3,9 +3,6 @@ API Controller providing Galaxy Tours
 """
 import logging
 
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
-
 from galaxy.tours import (
     TourDetails,
     TourList,
@@ -17,18 +14,18 @@ from galaxy.web import (
     require_admin
 )
 from . import (
-    AdminUserRequired,
     BaseGalaxyAPIController,
     depends,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
 
-router = APIRouter(tags=['tours'])
+router = Router(tags=['tours'])
 
 
-@cbv(router)
+@router.cbv
 class FastAPITours:
     # ugh - mypy https://github.com/python/mypy/issues/5374
     registry: ToursRegistry = depends(ToursRegistry)  # type: ignore
@@ -43,7 +40,7 @@ class FastAPITours:
         """Return a tour definition."""
         return self.registry.tour_contents(tour_id)
 
-    @router.post('/api/tours/{tour_id}', dependencies=[AdminUserRequired])
+    @router.post('/api/tours/{tour_id}', require_admin=True)
     def update_tour(self, tour_id: str) -> TourDetails:
         """Return a tour definition."""
         return self.registry.load_tour(tour_id)


### PR DESCRIPTION
The new router also allows require_admin as just an argument to the router verbs to avoid needing to import the require admin dependency.

Replaces three common imports with one cleaner one - including replacing two external imports with internal abstractions that protect us from lock in to some degree. I think the following diff demonstrates that this approach is a bit cleaner.

```diff
diff --git a/lib/galaxy/webapps/galaxy/api/roles.py b/lib/galaxy/webapps/galaxy/api/roles.py
index a7a415f6fcf..7275adecb7b 100644
--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -8,8 +8,6 @@
 from fastapi import (
     Body,
 )
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 from pydantic import (
     BaseModel,
 )
@@ -25,10 +23,10 @@
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.webapps.base.controller import url_for
 from . import (
-    AdminUserRequired,
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
@@ -36,7 +34,7 @@
 
 # Empty paths (e.g. /api/roles) only work if a prefix is defined right here.
 # https://github.com/tiangolo/fastapi/pull/415/files
-router = APIRouter(tags=["roles"])
+router = Router(tags=["roles"])
 
 
 class RoleListModel(BaseModel):
@@ -53,7 +51,7 @@ def role_to_model(trans, role):
     return RoleModel(**item)
 
 
-@cbv(router)
+@router.cbv
 class FastAPIRoles:
     role_manager: RoleManager = depends(RoleManager)
 
@@ -68,7 +66,7 @@ def show(self, id: EncodedDatabaseIdField, trans: ProvidesUserContext = DependsO
         role = self.role_manager.get(trans, role_id)
         return role_to_model(trans, role)
 
-    @router.post("/api/roles", dependencies=[AdminUserRequired])
+    @router.post("/api/roles", require_admin=True)
     def create(self, trans: ProvidesUserContext = DependsOnTrans, role_definition_model: RoleDefinitionModel = Body(...)) -> RoleModel:
         role = self.role_manager.create_role(trans, role_definition_model)
         return role_to_model(trans, role)
```