### PR TITLE
FastAPI route for tags (Disabled)

### DIFF
--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -36,6 +36,9 @@ class ItemTagsPayload(BaseModel):
         description="The list of tags that will replace the current tags associated with the item.",
     )
 
+    class Config:
+        use_enum_values = True
+
 
 class TagsManager:
     """Interface/service object shared by controllers for interacting with tags."""

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -10,17 +10,13 @@ from pydantic import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.model import ItemTagAssociation
 from galaxy.schema.fields import EncodedDatabaseIdField
 
-
-class TaggableItemClass(str, Enum):
-    History = "History"
-    HistoryDatasetAssociation = "HistoryDatasetAssociation"
-    HistoryDatasetCollectionAssociation = "HistoryDatasetCollectionAssociation"
-    LibraryDatasetDatasetAssociation = "LibraryDatasetDatasetAssociation"
-    Page = "Page"
-    StoredWorkflow = "StoredWorkflow"
-    Visualization = "Visualization"
+taggable_item_names = {item: item for item in ItemTagAssociation.associated_item_names}
+# This Enum is generated dynamically and mypy can not statically infer it's real type
+# so it should be ignored. See:https://github.com/python/mypy/issues/4865#issuecomment-592560696
+TaggableItemClass = Enum('TaggableItemClass', taggable_item_names)  # type: ignore
 
 
 class ItemTagsPayload(BaseModel):

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -8,7 +8,6 @@ from pydantic import (
     Field,
 )
 
-from galaxy.app import StructuredApp
 from galaxy.managers.context import ProvidesUserContext
 
 
@@ -33,14 +32,7 @@ class ItemTagsPayload(BaseModel):
 class TagsManager:
     """Interface/service object shared by controllers for interacting with tags."""
 
-    def __init__(self, app: StructuredApp):
-        self._app = app
-
-    def update(
-            self,
-            trans: ProvidesUserContext,
-            payload: ItemTagsPayload,
-    ) -> None:
+    def update(self, trans: ProvidesUserContext, payload: ItemTagsPayload) -> None:
         """Apply a new set of tags to an item; previous tags are deleted."""
         tag_handler = trans.app.tag_handler
         new_tags: Optional[str] = None

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import (
     List,
     Optional,
@@ -9,18 +10,29 @@ from pydantic import (
 )
 
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.schema.fields import EncodedDatabaseIdField
+
+
+class TaggableItemClass(str, Enum):
+    History = "History"
+    HistoryDatasetAssociation = "HistoryDatasetAssociation"
+    HistoryDatasetCollectionAssociation = "HistoryDatasetCollectionAssociation"
+    LibraryDatasetDatasetAssociation = "LibraryDatasetDatasetAssociation"
+    Page = "Page"
+    StoredWorkflow = "StoredWorkflow"
+    Visualization = "Visualization"
 
 
 class ItemTagsPayload(BaseModel):
-    item_id: str = Field(
+    item_id: EncodedDatabaseIdField = Field(
         ...,  # This field is required
         title="Item ID",
         description="The `encoded identifier` of the item whose tags will be updated.",
     )
-    item_class: str = Field(
+    item_class: TaggableItemClass = Field(
         ...,  # This field is required
         title="Item class",
-        description="The name of the class of the item.",
+        description="The name of the class of the item that will be tagged.",
     )
     item_tags: Optional[List[str]] = Field(
         default=None,

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -15,17 +15,17 @@ class ItemTagsPayload(BaseModel):
     item_id: str = Field(
         ...,  # This field is required
         title="Item ID",
-        description="The identifier of the item whose tags will be updated",
+        description="The `encoded identifier` of the item whose tags will be updated.",
     )
     item_class: str = Field(
         ...,  # This field is required
         title="Item class",
-        description="The name of the class of the item",
+        description="The name of the class of the item.",
     )
     item_tags: Optional[List[str]] = Field(
         default=None,
         title="Item tags",
-        description="The list of tags that will replace the current tags associated with the item",
+        description="The list of tags that will replace the current tags associated with the item.",
     )
 
 

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -1,0 +1,64 @@
+from typing import List, Optional
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+from galaxy.app import StructuredApp
+from galaxy.exceptions import MessageException
+from galaxy.webapps.base.controller import UsesTagsMixin
+from galaxy.webapps.base.webapp import GalaxyWebTransaction
+
+
+class ItemTagsPayload(BaseModel):
+    item_id: str = Field(
+        ...,  # This field is required
+        title="Item ID",
+        description="The identifier of the item whose tags will be updated",
+    )
+    item_class: str = Field(
+        ...,  # This field is required
+        title="Item class",
+        description="The name of the class of the item",
+    )
+    item_tags: Optional[List[str]] = Field(
+        default=None,
+        title="Item tags",
+        description="The list of tags that will replace the current tags associated with the item",
+    )
+
+
+class TagsManager(UsesTagsMixin):
+    """Interface/service object shared by controllers for interacting with tags."""
+
+    def __init__(self, app: StructuredApp):
+        self._app = app
+
+    def update(
+            self,
+            trans: GalaxyWebTransaction,
+            payload: ItemTagsPayload,
+    ) -> None:
+        """Apply a new set of tags to an item; previous tags are deleted."""
+        if payload.item_id is None:
+            raise MessageException("Please provide the item id (item_id).")
+        if payload.item_class is None:
+            raise MessageException("Please provide the item class (item_class).")
+
+        new_tags: Optional[str] = None
+        if payload.item_tags and len(payload.item_tags) > 0:
+            new_tags = ",".join(payload.item_tags)
+        item = self._get_item(trans, payload.item_class, trans.security.decode_id(payload.item_id))
+        user = trans.user
+        self.get_tag_handler(trans).delete_item_tags(user, item)
+        self.get_tag_handler(trans).apply_item_tags(user, item, new_tags)
+        trans.sa_session.flush()
+
+    def _get_item(self, trans: GalaxyWebTransaction, item_class_name: str, id: int):
+        """
+        Get an item based on type and id.
+        """
+        item_class = self.get_tag_handler(trans).item_tag_assoc_info[item_class_name].item_class
+        item = trans.sa_session.query(item_class).filter(item_class.id == id).first()
+        return item

--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -6,7 +6,6 @@ from pydantic import (
 )
 
 from galaxy.app import StructuredApp
-from galaxy.exceptions import MessageException
 from galaxy.webapps.base.controller import UsesTagsMixin
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
 
@@ -41,11 +40,6 @@ class TagsManager(UsesTagsMixin):
             payload: ItemTagsPayload,
     ) -> None:
         """Apply a new set of tags to an item; previous tags are deleted."""
-        if payload.item_id is None:
-            raise MessageException("Please provide the item id (item_id).")
-        if payload.item_class is None:
-            raise MessageException("Please provide the item class (item_class).")
-
         new_tags: Optional[str] = None
         if payload.item_tags and len(payload.item_tags) > 0:
             new_tags = ",".join(payload.item_tags)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from enum import Enum
 from string import Template
-from typing import Optional, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 from uuid import UUID, uuid4
 
 from boltons.iterutils import remap
@@ -6350,6 +6350,11 @@ class Tag(RepresentById):
 class ItemTagAssociation(Dictifiable):
     dict_collection_visible_keys = ['id', 'user_tname', 'user_value']
     dict_element_visible_keys = dict_collection_visible_keys
+    associated_item_names: List[str] = []
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.associated_item_names.append(cls.__name__.replace("TagAssociation", ""))
 
     def __init__(self, id=None, user=None, item_id=None, tag_id=None, user_tname=None, value=None):
         self.id = id

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1515,7 +1515,7 @@ class UsesQuotaMixin:
 
 class UsesTagsMixin(SharableItemSecurityMixin):
 
-    def get_tag_handler(self, trans):
+    def get_tag_handler(self, trans) -> tags.GalaxyTagHandler:
         return trans.app.tag_handler
 
     def _get_user_tags(self, trans, item_class_name, id):

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -3,7 +3,10 @@ API Controller providing Galaxy Tags
 """
 import logging
 
-from fastapi import Body
+from fastapi import (
+    Body,
+    status,
+)
 # TODO: replace with Router after merging #11219
 from fastapi_utils.cbv import cbv
 from fastapi_utils.inferring_router import InferringRouter as APIRouter
@@ -34,6 +37,7 @@ class FastAPITags:
     @router.put(
         '/api/tags',
         summary="Apply a new set of tags to an item; previous tags are deleted.",
+        status_code=status.HTTP_204_NO_CONTENT,
     )
     def update(
         self,

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -36,19 +36,23 @@ class FastAPITags:
 
     @router.put(
         '/api/tags',
-        summary="Apply a new set of tags to an item; previous tags are deleted.",
+        summary="Apply a new set of tags to an item.",
         status_code=status.HTTP_204_NO_CONTENT,
     )
     def update(
         self,
+        trans: GalaxyWebTransaction = Depends(get_trans),
         payload: ItemTagsPayload = Body(
             ...,  # Required
             title="Payload",
             description="Request body containing the item and the tags to be assigned.",
         ),
-        trans: GalaxyWebTransaction = Depends(get_trans),
     ):
-        """Replaces the tags associated with an item with the new ones specified in the payload."""
+        """Replaces the tags associated with an item with the new ones specified in the payload.
+
+        - The previous tags will be __deleted__.
+        - If no tags are provided in the request body, the currently associated tags will also be __deleted__.
+        """
         self.manager.update(trans, payload)
 
 

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -16,12 +16,10 @@ from galaxy.managers.tags import (
     ItemTagsPayload,
     TagsManager,
 )
-from galaxy.structured_app import StructuredApp
 from galaxy.web import expose_api
 from galaxy.webapps.base.controller import BaseAPIController
 from . import (
     Depends,
-    get_app,
     get_trans,
 )
 
@@ -30,8 +28,8 @@ log = logging.getLogger(__name__)
 router = APIRouter(tags=['tags'])
 
 
-def get_tags_manager(app: StructuredApp = Depends(get_app)) -> TagsManager:
-    return TagsManager(app)  # TODO: remove/refactor after merging #11180
+def get_tags_manager() -> TagsManager:
+    return TagsManager()  # TODO: remove/refactor after merging #11180
 
 
 @cbv(router)
@@ -64,7 +62,7 @@ class TagsController(BaseAPIController):
 
     def __init__(self, app):
         super().__init__(app)
-        self.manager = TagsManager(app)
+        self.manager = TagsManager()
 
     # Retag an item. All previous tags are deleted and new tags are applied.
     @expose_api

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -7,7 +7,7 @@ from fastapi import (
     Body,
     status,
 )
-# TODO: replace with Router after merging #11219
+# TODO: replace with _router after merging #11219
 from fastapi_utils.cbv import cbv
 from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
@@ -25,18 +25,19 @@ from . import (
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=['tags'])
+# TODO: This FastAPI router is disabled. Please rename it to `router` when the database session issues are fixed.
+_router = APIRouter(tags=['tags'])
 
 
 def get_tags_manager() -> TagsManager:
     return TagsManager()  # TODO: remove/refactor after merging #11180
 
 
-@cbv(router)
+@cbv(_router)
 class FastAPITags:
     manager: TagsManager = Depends(get_tags_manager)
 
-    @router.put(
+    @_router.put(
         '/api/tags',
         summary="Apply a new set of tags to an item.",
         status_code=status.HTTP_204_NO_CONTENT,

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -7,7 +7,7 @@ from fastapi import (
     Body,
     status,
 )
-# TODO: replace with _router after merging #11219
+# TODO: replace with Router after merging #11219
 from fastapi_utils.cbv import cbv
 from fastapi_utils.inferring_router import InferringRouter as APIRouter
 

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -3,15 +3,56 @@ API Controller providing Galaxy Tags
 """
 import logging
 
-from galaxy.exceptions import MessageException
+from fastapi import Body
+# TODO: replace with Router after merging #11219
+from fastapi_utils.cbv import cbv
+from fastapi_utils.inferring_router import InferringRouter as APIRouter
+
+from galaxy.managers.tags import (
+    ItemTagsPayload,
+    TagsManager,
+)
+from galaxy.structured_app import StructuredApp
 from galaxy.web import expose_api
-from galaxy.webapps.base.controller import BaseAPIController, UsesTagsMixin
+from galaxy.webapps.base.controller import BaseAPIController
 from galaxy.webapps.base.webapp import GalaxyWebTransaction
+from . import Depends, get_app, get_trans
 
 log = logging.getLogger(__name__)
 
+router = APIRouter(tags=['tags'])
 
-class TagsController(BaseAPIController, UsesTagsMixin):
+
+def get_tags_manager(app: StructuredApp = Depends(get_app)) -> TagsManager:
+    return TagsManager(app)  # TODO: remove/refactor after merging #11180
+
+
+@cbv(router)
+class FastAPITags:
+    manager: TagsManager = Depends(get_tags_manager)
+
+    @router.put(
+        '/api/tags',
+        summary="Apply a new set of tags to an item; previous tags are deleted.",
+    )
+    def update(
+        self,
+        payload: ItemTagsPayload = Body(
+            ...,  # Required
+            title="Payload",
+            description="Request body containing the item and the tags to be assigned.",
+        ),
+        trans: GalaxyWebTransaction = Depends(get_trans),
+    ):
+        """Replaces the tags associated with an item with the new ones specified in the payload."""
+        self.manager.update(trans, payload)
+
+
+class TagsController(BaseAPIController):
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.manager = TagsManager(app)
 
     # Retag an item. All previous tags are deleted and new tags are applied.
     @expose_api
@@ -21,25 +62,4 @@ class TagsController(BaseAPIController, UsesTagsMixin):
 
         Apply a new set of tags to an item; previous tags are deleted.
         """
-        item_id = payload.get("item_id")
-        item_class = payload.get("item_class")
-        item_tags = payload.get("item_tags")
-        if item_id is None:
-            raise MessageException("Please provide the item id (item_id).")
-        if item_class is None:
-            raise MessageException("Please provide the item class (item_class).")
-        if item_tags and len(item_tags) > 0:
-            item_tags = ",".join(item_tags)
-        item = self._get_item(trans, item_class, trans.security.decode_id(item_id))
-        user = trans.user
-        self.get_tag_handler(trans).delete_item_tags(user, item)
-        self.get_tag_handler(trans).apply_item_tags(user, item, item_tags)
-        trans.sa_session.flush()
-
-    def _get_item(self, trans: GalaxyWebTransaction, item_class_name, id):
-        """
-        Get an item based on type and id.
-        """
-        item_class = self.get_tag_handler(trans).item_tag_assoc_info[item_class_name].item_class
-        item = trans.sa_session.query(item_class).filter(item_class.id == id).first()
-        return item
+        self.manager.update(trans, ItemTagsPayload(**payload))

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -18,8 +18,12 @@ from galaxy.managers.tags import (
 )
 from galaxy.structured_app import StructuredApp
 from galaxy.web import expose_api
-from galaxy.webapps.base.controller import BaseAPIController, UsesTagsMixin
-from . import Depends, get_app, get_trans
+from galaxy.webapps.base.controller import BaseAPIController
+from . import (
+    Depends,
+    get_app,
+    get_trans,
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +35,7 @@ def get_tags_manager(app: StructuredApp = Depends(get_app)) -> TagsManager:
 
 
 @cbv(router)
-class FastAPITags(UsesTagsMixin):
+class FastAPITags:
     manager: TagsManager = Depends(get_tags_manager)
 
     @router.put(
@@ -53,10 +57,10 @@ class FastAPITags(UsesTagsMixin):
         - The previous tags will be __deleted__.
         - If no tags are provided in the request body, the currently associated tags will also be __deleted__.
         """
-        self.manager.update(trans, payload, self.get_tag_handler(trans))
+        self.manager.update(trans, payload)
 
 
-class TagsController(BaseAPIController, UsesTagsMixin):
+class TagsController(BaseAPIController):
 
     def __init__(self, app):
         super().__init__(app)
@@ -70,4 +74,4 @@ class TagsController(BaseAPIController, UsesTagsMixin):
 
         Apply a new set of tags to an item; previous tags are deleted.
         """
-        self.manager.update(trans, ItemTagsPayload(**payload), self.get_tag_handler(trans))
+        self.manager.update(trans, ItemTagsPayload(**payload))

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -29,6 +29,10 @@ api_tags_metadata = [
         "description": "Operations with [SPDX licenses](https://spdx.org/licenses/).",
     },
     {
+        "name": "tags",
+        "description": "Operations with tags.",
+    },
+    {
         "name": "tool data tables",
         "description": "Operations with tool [Data Tables](https://galaxyproject.org/admin/tools/data-tables/).",
     },

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 
 from galaxy_test.base.populators import (
@@ -122,11 +123,11 @@ class DatasetsApiTestCase(ApiTestCase):
 
     def test_tag_change(self):
         hda_id = self.dataset_populator.new_dataset(self.history_id)['id']
-        payload = {
+        payload = json.dumps({
             'item_id': hda_id,
             'item_class': 'HistoryDatasetAssociation',
             'item_tags': ['cool:tag_a', 'cool:tag_b', 'tag_c', 'name:tag_d', '#tag_e'],
-        }
+        })
         put_response = self._put("tags", payload)
         self._assert_status_code_is_ok(put_response)
         updated_hda = self._get(

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -127,7 +127,8 @@ class DatasetsApiTestCase(ApiTestCase):
             'item_class': 'HistoryDatasetAssociation',
             'item_tags': ['cool:tag_a', 'cool:tag_b', 'tag_c', 'name:tag_d', '#tag_e'],
         }
-        self._put("tags", payload).json()
+        put_response = self._put("tags", payload)
+        self._assert_status_code_is_ok(put_response)
         updated_hda = self._get(
             f"histories/{self.history_id}/contents/{hda_id}").json()
         assert 'cool:tag_a' in updated_hda['tags']


### PR DESCRIPTION
Ref #10889

## Summary
- The legacy controller logic has been refactored into a `TagManager` class shared with the new FastAPI controller.

## Additional comments
- I have placed the pydantic model in the manager module instead of a separate `_schemas.py` file because I wasn't sure where would be a better place.
- Apparently, the endpoint does not return anything. Would be better to return an empty response with a `204` status code so this is documented in the OpenAPI docs properly?
- The only test I found for this endpoint is [here](https://github.com/galaxyproject/galaxy/blob/8521a3afa0af5ff823f5dd1f1cce71136712347e/lib/galaxy_test/api/test_datasets.py#L123). It is currently failing when tested against the new FastAPI endpoint (`Bad Request`). I've been staring at it for a couple of hours but it doesn't fix itself neither I managed to figure out the reason, maybe another pair of trained eyes can help 😄 