### PR TITLE
fix `test_user_library_import_dir_warning`

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -914,9 +914,8 @@ class NavigatesGalaxy(HasDriver):
         if login:
             self.admin_login()
         self.libraries_open()
-        name = self._get_random_name(prefix="testcontents")
-        self.libraries_index_create(name)
-        return name
+        self.name = self._get_random_name(prefix="testcontents")
+        self.libraries_index_create(self.name)
 
     def libraries_open(self):
         self.home()

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -914,8 +914,9 @@ class NavigatesGalaxy(HasDriver):
         if login:
             self.admin_login()
         self.libraries_open()
-        self.name = self._get_random_name(prefix="testcontents")
-        self.libraries_index_create(self.name)
+        name = self._get_random_name(prefix="testcontents")
+        self.libraries_index_create(name)
+        return name
 
     def libraries_open(self):
         self.home()

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -532,6 +532,10 @@ libraries:
     permission_library_btn: '.permission_library_btn'
     toolbtn_save_permissions: '.toolbtn_save_permissions'
     add_items_permission_field: '.add_perm > ul input'
+    add_items_permission_field_text:
+      type: xpath
+      selector: '//ul/*/div[contains(text(), "${email}")]'
+
     add_items_permission_option: '.select2-result-label[role="option"]'
 
   folder:

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -31,10 +31,10 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         file.close()
 
         # allow user to add new datasets in the newly created library
-        self.create_lib_and_permit_adding(email)
+        name = self.create_lib_and_permit_adding(email)
 
         # test importing functionality
-        self.libraries_open_with_name(self.name)
+        self.libraries_open_with_name(name)
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
         self.select_dataset_from_lib_import_modal(random_text)
@@ -44,9 +44,9 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
     def test_user_library_import_dir_warning(self):
         # do not create email-dir, assert just warning
         email = self.get_logged_in_user()["email"]
-        self.create_lib_and_permit_adding(email)
+        name = self.create_lib_and_permit_adding(email)
 
-        self.libraries_open_with_name(self.name)
+        self.libraries_open_with_name(name)
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
 
@@ -59,7 +59,7 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
     def create_lib_and_permit_adding(self, email):
         # logout of the current user, only admin can create new libraries
         self.logout()
-        self.create_new_library()
+        name = self.create_new_library()
         # open permission manage dialog
         self.components.libraries.permission_library_btn.wait_for_and_click()
         self.components.libraries.add_items_permission_field.wait_for_and_click()
@@ -77,3 +77,5 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         self.logout()
         # login back to the 'regular' user account
         self.submit_login(email=email)
+
+        return name

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -31,10 +31,10 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         file.close()
 
         # allow user to add new datasets in the newly created library
-        name = self.create_lib_and_permit_adding(email)
+        self.create_lib_and_permit_adding(email)
 
         # test importing functionality
-        self.libraries_open_with_name(name)
+        self.libraries_open_with_name(self.name)
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
         self.select_dataset_from_lib_import_modal(random_text)
@@ -44,9 +44,9 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
     def test_user_library_import_dir_warning(self):
         # do not create email-dir, assert just warning
         email = self.get_logged_in_user()["email"]
-        name = self.create_lib_and_permit_adding(email)
+        self.create_lib_and_permit_adding(email)
 
-        self.libraries_open_with_name(name)
+        self.libraries_open_with_name(self.name)
         self.assert_num_displayed_items_is(0)
         self.libraries_dataset_import(self.navigation.libraries.folder.labels.from_user_import_dir)
 
@@ -59,7 +59,8 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
     def create_lib_and_permit_adding(self, email):
         # logout of the current user, only admin can create new libraries
         self.logout()
-        name = self.create_new_library()
+        self.create_new_library()
+        self.libraries_index_search_for(self.name)
         # open permission manage dialog
         self.components.libraries.permission_library_btn.wait_for_and_click()
         self.components.libraries.add_items_permission_field.wait_for_and_click()
@@ -77,5 +78,3 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         self.logout()
         # login back to the 'regular' user account
         self.submit_login(email=email)
-
-        return name

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -64,11 +64,16 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         self.components.libraries.permission_library_btn.wait_for_and_click()
         self.components.libraries.add_items_permission_field.wait_for_and_click()
         # search for created user and add him to permission field
-        print("!!!!")
-        print("!!!!")
         self.components.libraries.add_items_permission_field.wait_for_and_send_keys(email)
         self.components.libraries.add_items_permission_option.wait_for_and_click()
+
+        # assert that the right email has been saved
+        self.components.libraries.add_items_permission_field_text(email=email).wait_for_visible()
+
         self.components.libraries.toolbtn_save_permissions.wait_for_and_click()
+        # assert that toast message is appearing
+        assert self.components.libraries.folder.toast_msg.wait_for_visible()
+
         self.logout()
         # login back to the 'regular' user account
         self.submit_login(email=email)

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -64,6 +64,8 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
         self.components.libraries.permission_library_btn.wait_for_and_click()
         self.components.libraries.add_items_permission_field.wait_for_and_click()
         # search for created user and add him to permission field
+        print("!!!!")
+        print("!!!!")
         self.components.libraries.add_items_permission_field.wait_for_and_send_keys(email)
         self.components.libraries.add_items_permission_option.wait_for_and_click()
         self.components.libraries.toolbtn_save_permissions.wait_for_and_click()

--- a/test/integration_selenium/test_user_library_import_dir.py
+++ b/test/integration_selenium/test_user_library_import_dir.py
@@ -73,7 +73,7 @@ class TestUserLibraryImport(SeleniumIntegrationTestCase):
 
         self.components.libraries.toolbtn_save_permissions.wait_for_and_click()
         # assert that toast message is appearing
-        assert self.components.libraries.folder.toast_msg.wait_for_visible()
+        self.components.libraries.folder.toast_msg.wait_for_visible()
 
         self.logout()
         # login back to the 'regular' user account


### PR DESCRIPTION
This PR fixes the subsequent run of `test_user_library_import_dir.py`, sorry about that

In addition it asserts user corresponding `email` in permission field and waits for visible "saved" toast✌️

Also if we run different tests from the same file, the same instance is actually used for the both. For example `test/integration_selenium/test_user_library_import_dir.py` has 2 methods that create new library each. So when 2nd test runs, another library from the previous test still exists (didn't expect this behavior).