### PR TITLE
Adding GALAXY_MEMORY_MB_PER_SLOT to k8s runner

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -307,16 +307,24 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             envs = []
             if 'requests' in resources:
                 requests = resources['requests']
-                if 'memory' in requests:
-                    envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(ByteSize(requests['memory']).to_unit('M', as_string=False))})
                 if 'cpu' in requests:
-                    envs.append({'name': 'GALAXY_SLOTS', 'value': str(int(math.ceil(float(requests['cpu']))))})
+                    cpu_val = int(math.ceil(float(requests['cpu'])))
+                    envs.append({'name': 'GALAXY_SLOTS', 'value': str(cpu_val)})
+                if 'memory' in requests:
+                    mem_val = ByteSize(requests['memory']).to_unit('M', as_string=False)
+                    envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(mem_val)})
+                    if cpu_val:
+                        envs.append({'name': 'GALAXY_MEMORY_MB_PER_SLOT', 'value': str(math.floor(mem_val/cpu_val))})
             elif 'limits' in resources:
                 limits = resources['limits']
-                if 'memory' in limits:
-                    envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(ByteSize(limits['memory']).to_unit('M', as_string=False))})
                 if 'cpu' in limits:
-                    envs.append({'name': 'GALAXY_SLOTS', 'value': str(int(math.ceil(float(limits['cpu']))))})
+                    cpu_val = int(math.floor(float(limits['cpu'])))
+                    envs.append({'name': 'GALAXY_SLOTS', 'value': str(cpu_val)})
+                if 'memory' in limits:
+                    mem_val = ByteSize(limits['memory']).to_unit('M', as_string=False)
+                    envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(mem_val)})
+                    if cpu_val:
+                        envs.append({'name': 'GALAXY_MEMORY_MB_PER_SLOT', 'value': str(math.floor(mem_val/cpu_val))})
             k8s_container['resources'] = resources
             k8s_container['env'] = envs
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -314,7 +314,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                     mem_val = ByteSize(requests['memory']).to_unit('M', as_string=False)
                     envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(mem_val)})
                     if cpu_val:
-                        envs.append({'name': 'GALAXY_MEMORY_MB_PER_SLOT', 'value': str(math.floor(mem_val/cpu_val))})
+                        envs.append({'name': 'GALAXY_MEMORY_MB_PER_SLOT', 'value': str(math.floor(mem_val / cpu_val))})
             elif 'limits' in resources:
                 limits = resources['limits']
                 if 'cpu' in limits:
@@ -325,7 +325,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                     mem_val = ByteSize(limits['memory']).to_unit('M', as_string=False)
                     envs.append({'name': 'GALAXY_MEMORY_MB', 'value': str(mem_val)})
                     if cpu_val:
-                        envs.append({'name': 'GALAXY_MEMORY_MB_PER_SLOT', 'value': str(math.floor(mem_val/cpu_val))})
+                        envs.append({'name': 'GALAXY_MEMORY_MB_PER_SLOT', 'value': str(math.floor(mem_val / cpu_val))})
             k8s_container['resources'] = resources
             k8s_container['env'] = envs
 

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -319,6 +319,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 limits = resources['limits']
                 if 'cpu' in limits:
                     cpu_val = int(math.floor(float(limits['cpu'])))
+                    cpu_val = cpu_val or 1
                     envs.append({'name': 'GALAXY_SLOTS', 'value': str(cpu_val)})
                 if 'memory' in limits:
                     mem_val = ByteSize(limits['memory']).to_unit('M', as_string=False)

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -305,6 +305,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         resources = self.__get_resources(ajs.job_wrapper)
         if resources:
             envs = []
+            cpu_val = None
             if 'requests' in resources:
                 requests = resources['requests']
                 if 'cpu' in requests:


### PR DESCRIPTION
Some tools eg: https://github.com/galaxyproject/tools-iuc/blob/master/tools/rgrnastar/rg_rnaStarSolo.xml#L113 ignore `GALAXY_MEMORY_MB` and require `GALAXY_MEMORY_MB_PER_SLOT`. This is an attempt at adding both envs to each kubernetes job, rather than only the former. 