### PR TITLE
Remove `folder_up` button from data folder

### DIFF
--- a/client/src/components/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/LibraryFolder/LibraryFolder.vue
@@ -17,12 +17,6 @@
                 :unselected="unselected"
                 :isAllSelectedMode="isAllSelectedMode"
             />
-            <a
-                class="btn btn-secondary btn-sm btn_open_folder"
-                v-if="folder_metadata && folder_metadata.full_path"
-                @click="moveToParentFolder()"
-                >..</a
-            >
 
             <b-table
                 id="folder_list_body"
@@ -341,14 +335,6 @@ export default {
         this.fetchFolderContents();
     },
     methods: {
-        moveToParentFolder() {
-            const path = this.folder_metadata.full_path;
-            if (path.length === 1) {
-                window.location = `${this.root}library/list/`;
-            } else {
-                return this.changeFolderId(path[path.length - 2][0]);
-            }
-        },
         fetchFolderContents(include_deleted = false) {
             this.include_deleted = include_deleted;
             this.setBusy(true);

--- a/client/src/components/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -1,21 +1,5 @@
 <template>
     <div>
-        <b-breadcrumb>
-            <b-breadcrumb-item title="Return to the list of libraries" :href="getHomeUrl">
-                Libraries
-            </b-breadcrumb-item>
-            <template v-for="path_item in this.metadata.full_path">
-                <b-breadcrumb-item
-                    :key="path_item[0]"
-                    :title="isCurrentFolder(path_item[0]) ? `You are in this folder` : `Return to this folder`"
-                    :active="isCurrentFolder(path_item[0])"
-                    @click="changeFolderId(path_item[0])"
-                    href="#"
-                    >{{ path_item[1] }}</b-breadcrumb-item
-                >
-            </template>
-        </b-breadcrumb>
-
         <div class="form-inline d-flex align-items-center mb-2">
             <a class="mr-1 btn btn-secondary" :href="getHomeUrl" data-toggle="tooltip" title="Go to first page">
                 <font-awesome-icon icon="home" />
@@ -140,6 +124,22 @@
                 </div>
             </div>
         </div>
+
+        <b-breadcrumb>
+            <b-breadcrumb-item title="Return to the list of libraries" :href="getHomeUrl">
+                Libraries
+            </b-breadcrumb-item>
+            <template v-for="path_item in this.metadata.full_path">
+                <b-breadcrumb-item
+                    :key="path_item[0]"
+                    :title="isCurrentFolder(path_item[0]) ? `You are in this folder` : `Return to this folder`"
+                    :active="isCurrentFolder(path_item[0])"
+                    @click="changeFolderId(path_item[0])"
+                    href="#"
+                    >{{ path_item[1] }}</b-breadcrumb-item
+                >
+            </template>
+        </b-breadcrumb>
     </div>
 </template>
 <script>

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -561,7 +561,9 @@ libraries:
       select_all: '#select-all-checkboxes'
       select_one: '.lib-folder-checkbox'
       empty_folder_message: '.empty-folder-message'
-      btn_open_upper_folder: '.btn_open_folder'
+      btn_open_parent_folder:
+        type: xpath
+        selector: '//a[contains(text(), "${folder_name}")]'
       edit_folder_btn: '.edit_folder_btn'
       description_field: '.description-field > div'
       description_field_shrinked: '.shrinked-description'

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -38,8 +38,9 @@ class LibraryContentsTestCase(SeleniumTestCase, UsesLibraryAssertions):
 
         # assert that 'empty folder message' is present
         self.components.libraries.folder.empty_folder_message.wait_for_present()
+
         # go one folder up
-        self.components.libraries.folder.btn_open_upper_folder.wait_for_and_click()
+        self.components.libraries.folder.btn_open_parent_folder(folder_name=self.name).wait_for_and_click()
         # assert empty description
         self.components.libraries.folder.description_field.assert_absent_or_hidden()
         # change description


### PR DESCRIPTION
A minor cosmetic proposal. It removes `folder_up` button and moves breadcrumb path under the top bar
 Resolves https://github.com/galaxyproject/galaxy/issues/10800


After PR

![image](https://user-images.githubusercontent.com/15801412/105873869-3a555400-5ffc-11eb-872c-081b93e26fe7.png)


Before:


![image](https://user-images.githubusercontent.com/15801412/105875141-b7cd9400-5ffd-11eb-8885-fa8af89837aa.png)
