### PR TITLE
FastAPI/ASGI CORS handling.

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -38,9 +38,12 @@ def app_factory(*args, **kwargs):
     return app_pair(*args, **kwargs)[0]
 
 
-def app_pair(global_conf, load_app_kwds=None, **kwargs):
+def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     """
     Return a wsgi application serving the root object and the Galaxy application.
+
+    When creating an app for asgi, set wsgi_preflight to False to allow FastAPI
+    middleware to handle CORS options, etc..
     """
     load_app_kwds = load_app_kwds or {}
     kwargs = load_app_properties(
@@ -107,6 +110,15 @@ def app_pair(global_conf, load_app_kwds=None, **kwargs):
     # TODO: Refactor above routes into external method to allow testing in
     # isolation as well.
     populate_api_routes(webapp, app)
+    if wsgi_preflight:
+        # API OPTIONS RESPONSE
+        webapp.mapper.connect(
+            'options',
+            '/api/{path_info:.*?}',
+            controller='authenticate',
+            action='options',
+            conditions={'method': ['OPTIONS']},
+        )
 
     # CLIENTSIDE ROUTES
     # The following are routes that are handled completely on the clientside.
@@ -455,8 +467,8 @@ def populate_api_routes(webapp, app):
     webapp.mapper.connect('/api/workflows/menu', action='set_workflow_menu', controller="workflows", conditions=dict(method=["PUT"]))
     webapp.mapper.connect('/api/workflows/{id}/refactor', action='refactor', controller="workflows", conditions=dict(method=["PUT"]))
     webapp.mapper.resource('workflow', 'workflows', path_prefix='/api')
-    webapp.mapper.connect('/api/licenses', controller='licenses', action='index')
-    webapp.mapper.connect('/api/licenses/{id}', controller='licenses', action='get')
+    webapp.mapper.connect('/api/licenses', controller='licenses', action='index', conditions=dict(method="GET"))
+    webapp.mapper.connect('/api/licenses/{id}', controller='licenses', action='get', conditions=dict(method="GET"))
     webapp.mapper.resource_with_deleted('history', 'histories', path_prefix='/api')
     webapp.mapper.connect('/api/histories/{history_id}/citations', action='citations', controller="histories")
     webapp.mapper.connect('/api/histories/{id}/sharing', action='sharing', controller="histories", conditions=dict(method=["GET", "POST"]))
@@ -707,13 +719,6 @@ def populate_api_routes(webapp, app):
                           controller='authenticate',
                           action='get_api_key',
                           conditions=dict(method=["GET"]))
-
-    # API OPTIONS RESPONSE
-    webapp.mapper.connect('options',
-                          '/api/{path_info:.*?}',
-                          controller='authenticate',
-                          action='options',
-                          conditions={'method': ['OPTIONS']})
 
     # ======================================
     # ====== DISPLAY APPLICATIONS API ======

--- a/lib/galaxy/webapps/galaxy/fast_factory.py
+++ b/lib/galaxy/webapps/galaxy/fast_factory.py
@@ -78,5 +78,5 @@ def factory():
     global_conf = {}
     if config_is_ini(config_file):
         global_conf["__file__"] = config_file
-    gx_webapp, gx_app = app_pair(global_conf=global_conf, load_app_kwds=kwds)
+    gx_webapp, gx_app = app_pair(global_conf=global_conf, load_app_kwds=kwds, wsgi_preflight=False)
     return initialize_fast_app(gx_webapp, gx_app)

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -970,6 +970,11 @@ class GalaxyTestDriver(TestDriver):
                 use_uwsgi = True
         self.use_uwsgi = use_uwsgi
 
+        if getattr(config_object, "use_uvicorn", USE_UVICORN):
+            self.else_use_uvicorn = True
+        else:
+            self.else_use_uvicorn = False
+
         # Allow controlling the log format
         log_format = os.environ.get('GALAXY_TEST_LOG_FORMAT', None)
         if not log_format and use_uwsgi:
@@ -1061,11 +1066,11 @@ class GalaxyTestDriver(TestDriver):
                     tempdir=tempdir,
                     config_object=config_object,
                 )
-            elif USE_UVICORN:
+            elif self.else_use_uvicorn:
                 self.app = build_galaxy_app(galaxy_config)
                 server_wrapper = launch_uvicorn(
                     self.app,
-                    buildapp.app_factory,
+                    lambda *args, **kwd: buildapp.app_factory(*args, wsgi_preflight=False, **kwd),
                     galaxy_config,
                     config_object=config_object,
                 )

--- a/test/integration/test_web_framework_config.py
+++ b/test/integration/test_web_framework_config.py
@@ -1,0 +1,84 @@
+"""Integration tests for framework configuration code."""
+from requests import options
+
+from galaxy_test.driver import integration_util
+
+
+class BaseWebFrameworkTestCase(integration_util.IntegrationTestCase):
+
+    def _options(self, headers=None):
+        url = self._api_url("licenses")
+        options_response = options(url, headers=headers or {})
+        return options_response
+
+
+class CorsDefaultIntegrationTestCase(BaseWebFrameworkTestCase):
+    use_uvicorn = True
+
+    def test_options(self):
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "origin": "http://192.168.0.101:8083",
+        }
+        options_response = self._options(headers)
+        assert options_response.status_code == 200
+        assert 'access-control-allow-origin' not in options_response.headers
+
+    def test_origin_not_allowed_default(self):
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "Authorization",
+            "origin": "http://192.168.0.101:8083",
+        }
+        options_response = self._options(headers)
+        assert options_response.status_code == 200
+        assert 'access-control-allow-origin' not in options_response.headers
+
+
+class AllowOriginIntegrationTestCase(BaseWebFrameworkTestCase):
+    use_uvicorn = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["allowed_origin_hostnames"] = "192.168.0.101,/.*.galaxyproject.org/"
+
+    def test_origin_allowed_if_configured(self):
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "origin": "http://192.168.0.101:8083",
+            "Access-Control-Request-Headers": "Authorization",
+        }
+        options_response = self._options(headers)
+        options_response.raise_for_status()
+        assert 'access-control-allow-origin' in options_response.headers
+        assert options_response.headers['access-control-allow-origin'] == "http://192.168.0.101:8083"
+        assert options_response.headers['access-control-max-age'] == "600"
+
+    def test_origin_allowed_if_configured_via_regex(self):
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "origin": "http://rna.galaxyproject.org",
+            "Access-Control-Request-Headers": "Authorization",
+        }
+        options_response = self._options(headers)
+        options_response.raise_for_status()
+        assert 'access-control-allow-origin' in options_response.headers
+        assert options_response.headers['access-control-allow-origin'] == "http://rna.galaxyproject.org"
+        assert options_response.headers['access-control-max-age'] == "600"
+
+    def test_origin_not_allowed_if_not_in_configured_list(self):
+        headers = {
+            "Access-Control-Request-Method": "GET",
+            "origin": "http://192.168.0.102:8083",  # swapped ip by one
+            "Access-Control-Request-Headers": "Authorization",
+        }
+        options_response = self._options(headers)
+        assert options_response.status_code == 400
+
+
+class AllowOriginPasteIntegrationTestCase(AllowOriginIntegrationTestCase):
+    use_uvicorn = False
+
+
+class CorsDefaultPasteIntegrationTestCase(CorsDefaultIntegrationTestCase):
+    use_uvicorn = False


### PR DESCRIPTION
- Some tests to clarify existing behavior (at least where they don't diverge). Including frameworks enhancements to allow integration tests to force on server type or the other.
- In WSGI-land return a 400 if an invalid origin is specified (to bring inline with CORSMiddleware).
- In ASGI-land, override CORSMiddleware to use Galaxy's logic for checking an origin against the config object.
- When building a WSGI webapp for FastAPI, skip CORS handling at that level so it can be handled by FastAPI app.