### PR TITLE
[21.01] Fix arguments in create_api_key

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -761,7 +761,7 @@ class UserAPIController(BaseAPIController, UsesTagsMixin, BaseUIController, Uses
         """
         payload = payload or {}
         user = self._get_user(trans, id)
-        self.api_key_manager.create_api_key(trans, user)
+        self.api_key_manager.create_api_key(user)
         return self._build_inputs_api_key(user, message='Generated a new web API key.')
 
     def _build_inputs_api_key(self, user, message=''):

--- a/lib/galaxy_test/api/test_users.py
+++ b/lib/galaxy_test/api/test_users.py
@@ -127,6 +127,13 @@ class UsersApiTestCase(ApiTestCase):
         self.assertEqual(len(response["addresses"]), 1)
         self.assertEqual(response["addresses"][0]["desc"], "_desc")
 
+    def test_create_api_key(self):
+        user = self._setup_user(TEST_USER_EMAIL)
+        user_id = user["id"]
+        response = self._put(f"users/{user_id}/api_key/inputs", admin=True)
+        self._assert_status_code_is_ok(response)
+        self.assertEqual(response.json()["inputs"][0]["name"], "api-key")
+
     @skip_without_tool("cat1")
     def test_favorites(self):
         user = self._setup_user(TEST_USER_EMAIL)


### PR DESCRIPTION
This was causing an error when trying to create a new API key:
![error](https://user-images.githubusercontent.com/46503462/106138045-e8cbd700-616b-11eb-980e-033056b75263.png)

````
TypeError: create_api_key() takes 2 positional arguments but 3 were given
````