### PR TITLE
Make OIDC email matching case-insensitive

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -6136,7 +6136,7 @@ class UserAuthnzToken(UserMixin, RepresentById):
 
     @classmethod
     def get_users_by_email(cls, email):
-        return cls.user_query().filter_by(email=email)
+        return cls.user_query().filter(func.lower(User.table.c.email) == email.lower())
 
     @classmethod
     def get_social_auth(cls, provider, uid):


### PR DESCRIPTION
OIDC email matching is currently case-sensitive, in order to not create duplicate accounts when the internal Galaxy database and the OIDC provider do not agree on the case-sensitivity of emails, they should be validated without case-sensitivity. See https://github.com/galaxyproject/galaxy/issues/9981.