### PR TITLE
[21.01] Another attempt at using pulsar_app_config_path for secure Pulsar K8S parameters.

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -371,13 +371,11 @@ class PulsarJobRunner(AsynchronousJobRunner):
                 metadata_directory = os.path.join(job_wrapper.working_directory, "metadata")
 
             dest_params = job_destination.params
-            remote_pulsar_app_config = dest_params.get("pulsar_app_config", None)
-            if remote_pulsar_app_config is None and "pulsar_app_config_path" in dest_params:
+            remote_pulsar_app_config = dest_params.get("pulsar_app_config", {})
+            if "pulsar_app_config_path" in dest_params:
                 pulsar_app_config_path = dest_params["pulsar_app_config_path"]
                 with open(pulsar_app_config_path, "r") as fh:
-                    remote_pulsar_app_config = yaml.safe_load(fh)
-            elif remote_pulsar_app_config is None:
-                remote_pulsar_app_config = {}
+                    remote_pulsar_app_config.update(yaml.safe_load(fh))
             job_directory_files = []
             config_files = job_wrapper.extra_filenames
             tool_script = os.path.join(job_wrapper.working_directory, "tool_script.sh")


### PR DESCRIPTION
#11191  didn't quite work because this dictionary is pre-populated with some default values by the runner.