### PR TITLE
FastAPI routes for Pages (Disabled)

### DIFF
--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -74,7 +74,7 @@ class PageContentFormat(str, Enum):
 
 
 ContentFormatField: PageContentFormat = Field(
-    default=PageContentFormat.markdown,
+    default=PageContentFormat.html,
     title="Content format",
     description="Either `markdown` or `html`.",
 )

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -3,14 +3,9 @@ API for updating Galaxy Pages
 """
 import logging
 
-from galaxy.exceptions import RequestParameterInvalidException
-from galaxy.managers.base import get_object
-from galaxy.managers.markdown_util import internal_galaxy_markdown_to_pdf
 from galaxy.managers.pages import (
-    PageManager,
-    PageSerializer
+    PagesManager,
 )
-from galaxy.model.item_attrs import UsesAnnotations
 from galaxy.web import (
     expose_api,
     expose_api_anonymous_and_sessionless,
@@ -18,22 +13,19 @@ from galaxy.web import (
 )
 from galaxy.webapps.base.controller import (
     BaseAPIController,
-    SharableItemSecurityMixin,
-    SharableMixin
 )
 
 log = logging.getLogger(__name__)
 
 
-class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotations, SharableMixin):
+class PagesController(BaseAPIController):
     """
     RESTful controller for interactions with pages.
     """
 
     def __init__(self, app):
         super().__init__(app)
-        self.manager = PageManager(app)
-        self.serializer = PageSerializer(app)
+        self.manager = PagesManager(app)
 
     @expose_api_anonymous_and_sessionless
     def index(self, trans, deleted=False, **kwd):
@@ -47,30 +39,7 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         :rtype:     list
         :returns:   dictionaries containing summary or detailed Page information
         """
-        out = []
-
-        if trans.user_is_admin:
-            r = trans.sa_session.query(trans.app.model.Page)
-            if not deleted:
-                r = r.filter_by(deleted=False)
-            for row in r:
-                out.append(self.encode_all_ids(trans, row.to_dict(), True))
-        else:
-            # Transaction user's pages (if any)
-            user = trans.get_user()
-            r = trans.sa_session.query(trans.app.model.Page).filter_by(user=user)
-            if not deleted:
-                r = r.filter_by(deleted=False)
-            for row in r:
-                out.append(self.encode_all_ids(trans, row.to_dict(), True))
-            # Published pages from other users
-            r = trans.sa_session.query(trans.app.model.Page).filter(trans.app.model.Page.user != user).filter_by(published=True)
-            if not deleted:
-                r = r.filter_by(deleted=False)
-            for row in r:
-                out.append(self.encode_all_ids(trans, row.to_dict(), True))
-
-        return out
+        return self.manager.index(trans, deleted)
 
     @expose_api
     def create(self, trans, payload, **kwd):
@@ -89,11 +58,7 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         :rtype:     dict
         :returns:   Dictionary return of the Page.to_dict call
         """
-        page = self.manager.create(trans, payload)
-        rval = self.encode_all_ids(trans, page.to_dict(), True)
-        rval['content'] = page.latest_revision.content
-        self.manager.rewrite_content_for_export(trans, rval)
-        return rval
+        return self.manager.create(trans, payload)
 
     @expose_api
     def delete(self, trans, id, **kwd):
@@ -107,12 +72,7 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         :rtype:     dict
         :returns:   Dictionary with 'success' or 'error' element to indicate the result of the request
         """
-        page = get_object(trans, id, 'Page', check_ownership=True)
-
-        # Mark a page as deleted
-        page.deleted = True
-        trans.sa_session.flush()
-        return ''  # TODO: Figure out what to return on DELETE, document in guidelines!
+        self.manager.delete(trans, id)
 
     @expose_api_anonymous_and_sessionless
     def show(self, trans, id, **kwd):
@@ -126,12 +86,7 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         :rtype:     dict
         :returns:   Dictionary return of the Page.to_dict call with the 'content' field populated by the most recent revision
         """
-        page = get_object(trans, id, 'Page', check_ownership=False, check_accessible=True)
-        rval = self.encode_all_ids(trans, page.to_dict(), True)
-        rval['content'] = page.latest_revision.content
-        rval['content_format'] = page.latest_revision.content_format
-        self.manager.rewrite_content_for_export(trans, rval)
-        return rval
+        return self.manager.show(trans, id)
 
     @expose_api_raw_anonymous_and_sessionless
     def show_pdf(self, trans, id, **kwd):
@@ -145,9 +100,4 @@ class PagesController(BaseAPIController, SharableItemSecurityMixin, UsesAnnotati
         :rtype: dict
         :returns: Dictionary return of the Page.to_dict call with the 'content' field populated by the most recent revision
         """
-        page = get_object(trans, id, 'Page', check_ownership=False, check_accessible=True)
-        if page.latest_revision.content_format != "markdown":
-            raise RequestParameterInvalidException("PDF export only allowed for Markdown based pages")
-        internal_galaxy_markdown = page.latest_revision.content
-        trans.response.set_content_type("application/pdf")
-        return internal_galaxy_markdown_to_pdf(trans, internal_galaxy_markdown, 'page')
+        return self.manager.show_pdf(trans, id)

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -1,21 +1,139 @@
 """
 API for updating Galaxy Pages
 """
+import io
 import logging
 
-from galaxy.managers.pages import (
-    PagesManager,
+from fastapi import (
+    Body,
+    Depends,
+    Path,
+    Query,
+    status,
 )
+from fastapi_utils.cbv import cbv
+from fastapi_utils.inferring_router import InferringRouter as APIRouter
+from starlette.responses import StreamingResponse
+
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.pages import (
+    CreatePagePayload, PageDetails,
+    PagesManager,
+    PageSummary,
+    PageSummaryList,
+)
+from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.web import (
     expose_api,
     expose_api_anonymous_and_sessionless,
     expose_api_raw_anonymous_and_sessionless
 )
-from galaxy.webapps.base.controller import (
-    BaseAPIController,
-)
+from galaxy.webapps.base.controller import BaseAPIController
+from . import get_app, get_trans
 
 log = logging.getLogger(__name__)
+
+
+router = APIRouter(tags=['pages'])
+
+DeletedQueryParam: bool = Query(
+    default=False,
+    title="Display deleted",
+    description="Whether to include deleted pages in the result."
+)
+
+PageIdPathParam: EncodedDatabaseIdField = Path(
+    ...,  # Required
+    title="Page ID",
+    description="The encoded indentifier of the Page."
+)
+
+
+def get_pages_manager(app=Depends(get_app)) -> PagesManager:
+    return PagesManager(app)
+
+
+@cbv(router)
+class FastAPIPages:
+    manager: PagesManager = Depends(get_pages_manager)
+
+    @router.get(
+        '/api/pages',
+        summary="Lists all Pages viewable by the user.",
+        response_description="A list with summary page information.",
+    )
+    async def index(
+        self,
+        trans: ProvidesUserContext = Depends(get_trans),
+        deleted: bool = DeletedQueryParam,
+    ) -> PageSummaryList:
+        """Get a list with summary information of all Pages available to the user."""
+        return self.manager.index(trans, deleted)
+
+    @router.post(
+        '/api/pages',
+        summary="Create a page and return summary information.",
+        response_description="The page summary information.",
+    )
+    def create(
+        self,
+        trans: ProvidesUserContext = Depends(get_trans),
+        payload: CreatePagePayload = Body(...),
+    ) -> PageSummary:
+        """Get a list with details of all Pages available to the user."""
+        return self.manager.create(trans, payload)
+
+    @router.delete(
+        '/api/pages/{id}',
+        summary="Marks the specific Page as deleted.",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def delete(
+        self,
+        trans: ProvidesUserContext = Depends(get_trans),
+        id: EncodedDatabaseIdField = PageIdPathParam,
+    ):
+        """Marks the Page with the given ID as deleted."""
+        self.manager.delete(trans, id)
+
+    @router.get(
+        '/api/pages/{id}',
+        summary="Return a page summary and the content of the last revision.",
+        response_description="The page summary information.",
+    )
+    async def show(
+        self,
+        trans=Depends(get_trans),
+        id: EncodedDatabaseIdField = PageIdPathParam,
+    ) -> PageDetails:
+        """Return summary information about a specific Page and the content of the last revision."""
+        return self.manager.show(trans, id)
+
+    @router.get(
+        '/api/pages/{id}.pdf',
+        summary="Return a PDF document of the last revision of the Page.",
+        response_class=StreamingResponse,
+        responses={
+            200: {
+                "description": "PDF document with the last revision of the page.",
+                "content": {"application/pdf": {}},
+            },
+            400: {
+                "description": "PDF conversion service not available."
+            }
+        },
+    )
+    async def show_pdf(
+        self,
+        trans: ProvidesUserContext = Depends(get_trans),
+        id: EncodedDatabaseIdField = PageIdPathParam,
+    ):
+        """Return a PDF document of the last revision of the Page.
+
+        This feature may not be available in this Galaxy.
+        """
+        pdf_bytes = self.manager.show_pdf(trans, id)
+        return StreamingResponse(io.BytesIO(pdf_bytes), media_type="application/pdf")
 
 
 class PagesController(BaseAPIController):
@@ -58,7 +176,7 @@ class PagesController(BaseAPIController):
         :rtype:     dict
         :returns:   Dictionary return of the Page.to_dict call
         """
-        return self.manager.create(trans, payload)
+        return self.manager.create(trans, CreatePagePayload(**payload))
 
     @expose_api
     def delete(self, trans, id, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -33,8 +33,8 @@ from . import get_app, get_trans
 
 log = logging.getLogger(__name__)
 
-
-router = APIRouter(tags=['pages'])
+# TODO: This FastAPI router is disabled. Please rename it to `router` when the database session issues are fixed.
+_router = APIRouter(tags=['pages'])
 
 DeletedQueryParam: bool = Query(
     default=False,
@@ -53,11 +53,11 @@ def get_pages_manager(app=Depends(get_app)) -> PagesManager:
     return PagesManager(app)
 
 
-@cbv(router)
+@cbv(_router)
 class FastAPIPages:
     manager: PagesManager = Depends(get_pages_manager)
 
-    @router.get(
+    @_router.get(
         '/api/pages',
         summary="Lists all Pages viewable by the user.",
         response_description="A list with summary page information.",
@@ -70,7 +70,7 @@ class FastAPIPages:
         """Get a list with summary information of all Pages available to the user."""
         return self.manager.index(trans, deleted)
 
-    @router.post(
+    @_router.post(
         '/api/pages',
         summary="Create a page and return summary information.",
         response_description="The page summary information.",
@@ -83,7 +83,7 @@ class FastAPIPages:
         """Get a list with details of all Pages available to the user."""
         return self.manager.create(trans, payload)
 
-    @router.delete(
+    @_router.delete(
         '/api/pages/{id}',
         summary="Marks the specific Page as deleted.",
         status_code=status.HTTP_204_NO_CONTENT,
@@ -96,7 +96,7 @@ class FastAPIPages:
         """Marks the Page with the given ID as deleted."""
         self.manager.delete(trans, id)
 
-    @router.get(
+    @_router.get(
         '/api/pages/{id}',
         summary="Return a page summary and the content of the last revision.",
         response_description="The page summary information.",
@@ -109,7 +109,7 @@ class FastAPIPages:
         """Return summary information about a specific Page and the content of the last revision."""
         return self.manager.show(trans, id)
 
-    @router.get(
+    @_router.get(
         '/api/pages/{id}.pdf',
         summary="Return a PDF document of the last revision of the Page.",
         response_class=StreamingResponse,

--- a/lib/galaxy_test/api/test_pages.py
+++ b/lib/galaxy_test/api/test_pages.py
@@ -9,7 +9,7 @@ class BasePageApiTestCase(ApiTestCase):
 
     def _create_valid_page_with_slug(self, slug):
         page_request = self._test_page_payload(slug=slug)
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 200)
         return page_response.json()
 
@@ -17,7 +17,7 @@ class BasePageApiTestCase(ApiTestCase):
         run_as_user = self._setup_user(other_email)
         page_request = self._test_page_payload(slug=slug)
         page_request["run_as"] = run_as_user["id"]
-        page_response = self._post("pages", page_request, admin=True)
+        page_response = self._post("pages", page_request, admin=True, json=True)
         self._assert_status_code_is(page_response, 200)
         return page_response.json()
 
@@ -79,7 +79,7 @@ steps:
                 title="Invocation Report",
                 invocation_id=invocation_id,
             )
-            page_response = self._post("pages", page_request)
+            page_response = self._post("pages", page_request, json=True)
             self._assert_status_code_is(page_response, 200)
             page_response = page_response.json()
             show_response = self._get("pages/%s" % page_response['id'])
@@ -104,30 +104,35 @@ steps:
 
     def test_cannot_create_pages_with_same_slug(self):
         page_request = self._test_page_payload(slug="mypage1")
-        page_response_1 = self._post("pages", page_request)
+        page_response_1 = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response_1, 200)
-        page_response_2 = self._post("pages", page_request)
+        page_response_2 = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response_2, 400)
         self._assert_error_code_is(page_response_2, error_codes.USER_SLUG_DUPLICATE)
+
+    def test_cannot_create_pages_with_invalid_slug(self):
+        page_request = self._test_page_payload(slug="invalid slug!")
+        page_response = self._post("pages", page_request, json=True)
+        self._assert_status_code_is(page_response, 400)
 
     def test_cannot_create_page_with_invalid_content_format(self):
         page_request = self._test_page_payload(slug="mypageinvalidformat")
         page_request["content_format"] = "xml"
-        page_response_1 = self._post("pages", page_request)
+        page_response_1 = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response_1, 400)
         self._assert_error_code_is(page_response_1, error_codes.USER_REQUEST_INVALID_PARAMETER)
 
     def test_page_requires_name(self):
         page_request = self._test_page_payload(slug="requires-name")
         del page_request['title']
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 400)
-        self._assert_error_code_is(page_response, error_codes.USER_OBJECT_ATTRIBUTE_MISSING)
+        self._assert_error_code_is(page_response, error_codes.USER_REQUEST_MISSING_PARAMETER)
 
     def test_page_requires_slug(self):
         page_request = self._test_page_payload()
         del page_request['slug']
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 400)
 
     def test_delete(self):
@@ -149,14 +154,14 @@ steps:
     def test_400_on_invalid_id_encoding(self):
         page_request = self._test_page_payload(slug="invalid-id-encding")
         page_request["content"] = '''<p>Page!<div class="embedded-item" id="History-invaidencodedid"></div></p>'''
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 400)
         self._assert_error_code_is(page_response, error_codes.MALFORMED_ID)
 
     def test_400_on_invalid_id_encoding_markdown(self):
         page_request = self._test_page_payload(slug="invalid-id-encding-markdown", content_format="markdown")
         page_request["content"] = '''```galaxy\nhistory_dataset_display(history_dataset_id=badencoding)\n```\n'''
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 400)
         self._assert_error_code_is(page_response, error_codes.MALFORMED_ID)
 
@@ -165,7 +170,7 @@ steps:
         valid_id = dataset_populator.new_history()
         page_request = self._test_page_payload(slug="invalid-embed-content")
         page_request["content"] = '''<p>Page!<div class="embedded-item" id="CoolObject-%s"></div></p>''' % valid_id
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 400)
         self._assert_error_code_is(page_response, error_codes.USER_REQUEST_INVALID_PARAMETER)
         assert "embedded HTML content" in page_response.text
@@ -173,7 +178,7 @@ steps:
     def test_400_on_invalid_markdown_call(self):
         page_request = self._test_page_payload(slug="invalid-markdown-call", content_format="markdown")
         page_request["content"] = '''```galaxy\njob_metrics(job_id)\n```\n'''
-        page_response = self._post("pages", page_request)
+        page_response = self._post("pages", page_request, json=True)
         self._assert_status_code_is(page_response, 400)
         self._assert_error_code_is(page_response, error_codes.MALFORMED_CONTENTS)
 
@@ -193,6 +198,22 @@ steps:
         show_response = self._get("pages/%s" % response_json['id'])
         self._assert_status_code_is(show_response, 403)
         self._assert_error_code_is(show_response, error_codes.USER_CANNOT_ACCESS_ITEM)
+
+    def test_400_on_download_pdf_when_service_unavailable(self):
+        page_request = self._test_page_payload(slug="md-page-to-pdf", content_format="markdown")
+        page_response = self._post("pages", page_request, json=True)
+        self._assert_status_code_is(page_response, 200)
+        page_id = page_response.json()['id']
+        pdf_response = self._get(f"pages/{page_id}.pdf")
+        self._assert_status_code_is(pdf_response, 400)
+
+    def test_400_on_download_pdf_when_unsupported_content_format(self):
+        page_request = self._test_page_payload(slug="html-page-to-pdf", content_format="html")
+        page_response = self._post("pages", page_request, json=True)
+        self._assert_status_code_is(page_response, 200)
+        page_id = page_response.json()['id']
+        pdf_response = self._get(f"pages/{page_id}.pdf")
+        self._assert_status_code_is(pdf_response, 400)
 
     def _users_index_has_page_with_id(self, id):
         index_response = self._get("pages")


### PR DESCRIPTION
Ref #10889

## Summary
- Legacy controller logic refactored into `PagesManager`.
- Added some more tests for edge cases.

## Additional comments
- Once more I placed the pydantic models in the manager module because I wasn't sure where to place the equivalent `_schema.py`.
- The empty JSON response in the `delete` endpoint now returns a `204`.
- The legacy controller was declared with some mixins (``SharableItemSecurityMixin``, ``UsesAnnotations``, ``SharableMixin``) but, apparently, they were not used so I removed them (the tests are passing), the same for the `PageSerializer`. Let me know if that was a bad idea 😅 
- When trying to download a PDF version of the page, I've added a method to raise an exception (early in the request) if `weasyprint` is not installed. I wonder if with some integration tests we can actually test if this works when the package is present.
- Forced the tests to send the payload as JSON to make them compatible with FastAPI.
- Most of the tests for the FastAPI endpoints are failing because of the issues with the database session 😓 