### PR TITLE
[21.01] Decrease verbosity of urllib connectionpool logging

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -66,6 +66,10 @@ LOGGING_CONFIG_DEFAULT = {
             'level': 'WARN',
             'qualname': 'paste.httpserver.ThreadPool',
         },
+        'urllib3.connectionpool': {
+            'level': 'WARN',
+            'qualname': 'urllib3.connectionpool',
+        },
         'routes.middleware': {
             'level': 'WARN',
             'qualname': 'routes.middleware',


### PR DESCRIPTION
This removes the 2 connectionpool lines seen with planemo for instance:
```
INFO:     127.0.0.1:62188 - "POST /api/users HTTP/1.1" 200 OK
2021-02-01 11:48:41,841 DEBUG [urllib3.connectionpool] http://127.0.0.1:9566 "POST /api/users HTTP/1.1" 200 None
2021-02-01 11:48:41,843 DEBUG [urllib3.connectionpool] Starting new HTTP connection (1): 127.0.0.1:9566
```