### PR TITLE
[21.01] Set correct status code in old history route

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1208,7 +1208,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             trans.set_history(history)
             return self.history_data(trans, history)
         except exceptions.MessageException as msg_exc:
-            trans.response.status = msg_exc.err_code.code
+            trans.response.status = msg_exc.status_code
             return {'err_msg': msg_exc.err_msg, 'err_code': msg_exc.err_code.code}
 
     @web.json


### PR DESCRIPTION
`err_code.code` is our internal error, more specific code that looks
like `403003` for instance, while we need to set a standard webob.exc
status code here.

Fixes https://sentry.galaxyproject.org/sentry/test/issues/1216796/:
```
AttributeError: 'NoneType' object has no attribute 'code'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 33, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 136, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 221, in handle_request
    return body_renderer(trans, body, environ, start_response)
  File "galaxy/web/framework/base.py", line 239, in _render_body
    start_response(trans.response.wsgi_status(),
  File "galaxy/web/framework/base.py", line 473, in wsgi_status
    return "%d %s" % (exception.code, exception.title)
```