### PR TITLE
Don't fail silently in `User.system_user_pwent()`

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2227,7 +2227,7 @@ class JobWrapper(HasResourceParameters):
     def change_ownership_for_run(self):
         job = self.get_job()
         external_chown_script = self.get_destination_configuration("external_chown_script", None)
-        if job.user is not None and external_chown_script is not None:
+        if job.user is not None and external_chown_script:
             ret = external_chown(self.working_directory, self.user_system_pwent,
                            external_chown_script, description="working directory")
             if not ret:
@@ -2236,7 +2236,7 @@ class JobWrapper(HasResourceParameters):
     def reclaim_ownership(self):
         job = self.get_job()
         external_chown_script = self.get_destination_configuration("external_chown_script", None)
-        if job.user is not None:
+        if job.user is not None and external_chown_script:
             external_chown(self.working_directory, self.galaxy_system_pwent,
                            external_chown_script, description="working directory")
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -437,24 +437,17 @@ class User(Dictifiable, RepresentById):
         Gives the system user pwent entry based on e-mail or username depending
         on the value in real_system_username
         """
-        system_user_pwent = None
         if real_system_username == 'user_email':
-            try:
-                system_user_pwent = pwd.getpwnam(self.email.split('@')[0])
-            except KeyError:
-                pass
+            username = self.email.split('@')[0]
         elif real_system_username == 'username':
-            try:
-                system_user_pwent = pwd.getpwnam(self.username)
-            except KeyError:
-                pass
+            username = self.username
         else:
-            try:
-                system_user_pwent = pwd.getpwnam(real_system_username)
-            except KeyError:
-                log.warning("invalid configuration of real_system_username")
-                system_user_pwent = None
-        return system_user_pwent
+            username = real_system_username
+        try:
+            return pwd.getpwnam(username)
+        except Exception:
+            log.exception(f"Error getting the password database entry for user {username}")
+            raise
 
     def all_roles(self):
         """

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -377,7 +377,7 @@ def create_paramfile(trans, uploaded_datasets):
             # TODO: This will have to change when we start bundling inputs.
             # Also, in_place above causes the file to be left behind since the
             # user cannot remove it unless the parent directory is writable.
-            if link_data_only == 'copy_files' and trans.user:
+            if link_data_only == 'copy_files' and trans.user and trans.app.config.external_chown_script:
                 external_chown(uploaded_dataset.path,
                                trans.user.system_user_pwent(trans.app.config.real_system_username),
                                trans.app.config.external_chown_script, description="uploaded file")

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -23,11 +23,20 @@ class JobImportHistoryArchiveWrapper:
         self.sa_session = self.app.model.context
 
     def setup_job(self, jiha, archive_source, archive_type):
-        if archive_type != "url":
-            external_chown(archive_source, jiha.job.user.system_user_pwent(self.app.config.real_system_username),
-                           self.app.config.external_chown_script, "history import archive")
-        external_chown(jiha.archive_dir, jiha.job.user.system_user_pwent(self.app.config.real_system_username),
-                       self.app.config.external_chown_script, "history import archive directory")
+        if self.app.config.external_chown_script:
+            if archive_type != "url":
+                external_chown(
+                    archive_source,
+                    jiha.job.user.system_user_pwent(self.app.config.real_system_username),
+                    self.app.config.external_chown_script,
+                    "history import archive"
+                )
+            external_chown(
+                jiha.archive_dir,
+                jiha.job.user.system_user_pwent(self.app.config.real_system_username),
+                self.app.config.external_chown_script,
+                "history import archive directory"
+            )
 
     def cleanup_after_job(self):
         """ Set history, datasets, collections and jobs' attributes
@@ -46,8 +55,13 @@ class JobImportHistoryArchiveWrapper:
         new_history = None
         try:
             archive_dir = jiha.archive_dir
-            external_chown(archive_dir, jiha.job.user.system_user_pwent(getpass.getuser()),
-                           self.app.config.external_chown_script, "history import archive directory")
+            if self.app.config.external_chown_script:
+                external_chown(
+                    archive_dir,
+                    jiha.job.user.system_user_pwent(getpass.getuser()),
+                    self.app.config.external_chown_script,
+                    "history import archive directory"
+                )
             model_store = store.get_import_model_store_for_directory(archive_dir, app=self.app, user=user)
             job = jiha.job
             with model_store.target_history(default_history=job.history) as new_history:

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -343,22 +343,18 @@ extensions = Extensions({
 
 def external_chown(path, pwent, external_chown_script, description="file"):
     """
-    call the external chown script (if not None) to change
+    call the external chown script to change
     the user and group of the given path, and additional description
     of the file/path for the log message can be given
 
-    return
-    - None if external_chown_script is None
-    - True in case of success
-    - False in case of failure
+    return True in case of success
     """
-    if not external_chown_script:
-        return None
-
     try:
+        if not external_chown_script:
+            raise ValueError('external_chown_script is not defined')
         cmd = shlex.split(external_chown_script)
         cmd.extend([path, pwent[0], str(pwent[3])])
-        log.debug('Changing ownership of {} with: {}'.format(path, ' '.join(cmd)))
+        log.debug('Changing ownership of {} with: {}'.format(path, ' '.join(map(shlex.quote, cmd))))
         galaxy.util.commands.execute(cmd)
         return True
     except galaxy.util.commands.CommandLineException as e:

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -352,7 +352,7 @@ def external_chown(path, pwent, external_chown_script, description="file"):
     - True in case of success
     - False in case of failure
     """
-    if external_chown_script is None:
+    if not external_chown_script:
         return None
 
     try:


### PR DESCRIPTION
When the exception is not re-raised, `external_chown()` (in `lib/galaxy/util/path/__init__.py`) fails with:
```
  File "lib/galaxy/util/path/__init__.py", line 360, in external_chown
    cmd.extend([path, pwent[0], str(pwent[3])])
TypeError: 'NoneType' object is not subscriptable
```

xref https://github.com/galaxyproject/galaxy/issues/11270