### PR TITLE
Generalise rule helper to detect whether tools can use any container

### DIFF
--- a/lib/galaxy/jobs/rule_helper.py
+++ b/lib/galaxy/jobs/rule_helper.py
@@ -34,7 +34,7 @@ class RuleHelper:
 
         :param job_or_tool:
         :param container_type: either "docker" or "singularity" currently
-        :return:
+        :return: true if the tool supports the specified container type.
         """
         # Not a ton of logic in this method - but the idea is to shield rule
         # developers from the details and they shouldn't have to know how to

--- a/lib/galaxy/jobs/rule_helper.py
+++ b/lib/galaxy/jobs/rule_helper.py
@@ -56,7 +56,6 @@ class RuleHelper:
     def supports_docker(self, job_or_tool):
         return self.supports_container(job_or_tool, container_type="docker")
 
-
     def job_count(
         self,
         **kwds

--- a/lib/galaxy/jobs/rule_helper.py
+++ b/lib/galaxy/jobs/rule_helper.py
@@ -30,7 +30,7 @@ class RuleHelper:
     def supports_container(self, job_or_tool, container_type):
         """
         Job rules can pass this function a job, job_wrapper, or tool and
-        determine if the underlying tool believes it can be containered.
+        determine if the underlying tool believes it can be run with a specific container type.
 
         :param job_or_tool:
         :param container_type: either "docker" or "singularity" currently
@@ -54,7 +54,22 @@ class RuleHelper:
         return container_description is not None
 
     def supports_docker(self, job_or_tool):
+        """
+        Returns true if the tool or job supports running on a singularity container.
+
+        :param job_or_tool: the job or tool to test for.
+        :return: true if the tool/job can run in docker.
+        """
         return self.supports_container(job_or_tool, container_type="docker")
+
+    def supports_singularity(self, job_or_tool):
+        """
+        Returns true if the tool or job supports running on a singularity container.
+
+        :param job_or_tool: the job or tool to test for.
+        :return: true if the tool/job can run in singularity.
+        """
+        return self.supports_container(job_or_tool, container_type="singularity")
 
     def job_count(
         self,

--- a/lib/galaxy/jobs/rule_helper.py
+++ b/lib/galaxy/jobs/rule_helper.py
@@ -27,9 +27,14 @@ class RuleHelper:
     def __init__(self, app):
         self.app = app
 
-    def supports_docker(self, job_or_tool):
-        """ Job rules can pass this function a job, job_wrapper, or tool and
+    def supports_container(self, job_or_tool, container_type):
+        """
+        Job rules can pass this function a job, job_wrapper, or tool and
         determine if the underlying tool believes it can be containered.
+
+        :param job_or_tool:
+        :param container_type: either "docker" or "singularity" currently
+        :return:
         """
         # Not a ton of logic in this method - but the idea is to shield rule
         # developers from the details and they shouldn't have to know how to
@@ -43,9 +48,14 @@ class RuleHelper:
         else:
             # Have a Job object.
             tool = self.app.toolbox.get_tool(job_or_tool.tool_id, tool_version=job_or_tool.tool_version)
-        tool_info = ToolInfo(tool.containers, tool.requirements, tool.requires_galaxy_python_environment, tool.docker_env_pass_through)
-        container_description = self.app.container_finder.find_best_container_description(["docker"], tool_info)
+        tool_info = ToolInfo(tool.containers, tool.requirements, tool.requires_galaxy_python_environment,
+                             tool.docker_env_pass_through)
+        container_description = self.app.container_finder.find_best_container_description([container_type], tool_info)
         return container_description is not None
+
+    def supports_docker(self, job_or_tool):
+        return self.supports_container(job_or_tool, container_type="docker")
+
 
     def job_count(
         self,


### PR DESCRIPTION
This PR adds the ability for the rule_helper to asses whether a tool can use not only docker containers but other types, such as singularity. This is towards dynamic destinations that could decide, like docker dispatch, whether you can dispatch a tool to a singularity destination.