### PR TITLE
[21.01] Don't flush for each failed output dataset

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1310,8 +1310,6 @@ class JobWrapper(HasResourceParameters):
                 # Pause any dependent jobs (and those jobs' outputs)
                 for dep_job_assoc in dataset.dependent_jobs:
                     self.pause(dep_job_assoc.job, "Execution of this dataset's job is paused because its input datasets are in an error state.")
-                self.sa_session.add(dataset)
-                self.sa_session.flush()
             job.set_final_state(job.states.ERROR)
             job.command_line = unicodify(self.command_line)
             job.info = message


### PR DESCRIPTION
I noticed that main's job handler is spending a lot of time here:
```
Thread 21942 (active+gil): "SlurmRunner.work_thread-1"
    _remove_snapshot (sqlalchemy/orm/session.py:396)
    commit (sqlalchemy/orm/session.py:514)
    _flush (sqlalchemy/orm/session.py:2674)
    flush (sqlalchemy/orm/session.py:2536)
    do (sqlalchemy/orm/scoping.py:163)
    fail (galaxy/jobs/__init__.py:1314)
    fail_job (galaxy/jobs/runners/__init__.py:474)
    run_next (galaxy/jobs/runners/__init__.py:136)
    run (threading.py:864)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
```
We flush just a few lines below anyway, so this flush shouldn't be needed
and could have a big impact if there are a lot of output datasets.