### PR TITLE
[20.09] Persist scroll/url information, in chrome, firefox

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -1,4 +1,5 @@
 var gtnWebhookLoaded = false;
+var lastUpdate = 0;
 
 function removeOverlay() {
     document.getElementById("gtn-container").style.visibility = "hidden";
@@ -8,9 +9,44 @@ function showOverlay() {
     document.getElementById("gtn-container").style.visibility = "visible";
 }
 
+function getIframeUrl(){
+    var loc;
+    try {
+        loc = document.getElementById("gtn-embed").contentWindow.location.pathname;
+    } catch (e) {
+        loc = null;
+    }
+    return loc
+}
+
+function getIframeScroll() {
+    var loc;
+    try {
+        loc = parseInt(document.getElementById("gtn-embed").contentWindow.scrollY);
+    } catch (e) {
+        loc = 0;
+    }
+    return loc
+}
+
+function restoreLocation() {
+}
+
+function persistLocation() {
+    // Don't save every scroll event.
+    var time = new Date().getTime();
+    if ( time - lastUpdate < 1000 ) {
+        return;
+    }
+    lastUpdate = time;
+    window.localStorage.setItem('gtn-in-galaxy', `${getIframeScroll()} ${getIframeUrl()}`);
+}
+
 function addIframe() {
-    let url, message;
+    let url, message, onloadscroll;
     gtnWebhookLoaded = true;
+    let storedData = false;
+    let safe = false;
 
     // Test for the presence of /training-material/. If that is available we
     // can opt in the fancy click-to-run features. Otherwise we fallback to
@@ -24,7 +60,15 @@ function addIframe() {
                             <a href="https://docs.galaxyproject.org/en/master/admin/special_topics/gtn.html">Click to run</a> unavailable.
                         </span>`;
             } else {
-                url = "/training-material/";
+                safe = true;
+
+                var storedLocation = window.localStorage.getItem('gtn-in-galaxy');
+                if(storedLocation !== null && storedLocation.split(' ')[1] !== undefined && storedLocation.split(' ')[1].startsWith('/training-material/')) {
+                    onloadscroll = storedLocation.split(' ')[0];
+                    url = storedLocation.split(' ')[1];
+                } else {
+                    url = "/training-material/";
+                }
                 message = "";
             }
         })
@@ -48,8 +92,25 @@ function addIframe() {
                 removeOverlay();
             });
 
+            // Only setup the listener if it won't crash things.
+            if(safe) {
+                // Listen to the scroll position
+                document.getElementById("gtn-embed").contentWindow.addEventListener('scroll', () => {
+                    persistLocation();
+                });
+            }
+
             // Depends on the iframe being present
             document.getElementById("gtn-embed").addEventListener("load", () => {
+                // Save our current location when possible
+                if(onloadscroll !== undefined){
+                    document.getElementById('gtn-embed').contentWindow.scrollTo(0, parseInt(onloadscroll));
+                    onloadscroll = undefined;
+                }
+
+                if(safe) {
+                    persistLocation();
+                }
                 var gtn_tools = $("#gtn-embed").contents().find("span[data-tool]");
                 // Buttonify
                 gtn_tools.addClass("galaxy-proxy-active");

--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -9,14 +9,14 @@ function showOverlay() {
     document.getElementById("gtn-container").style.visibility = "visible";
 }
 
-function getIframeUrl(){
+function getIframeUrl() {
     var loc;
     try {
         loc = document.getElementById("gtn-embed").contentWindow.location.pathname;
     } catch (e) {
         loc = null;
     }
-    return loc
+    return loc;
 }
 
 function getIframeScroll() {
@@ -26,20 +26,19 @@ function getIframeScroll() {
     } catch (e) {
         loc = 0;
     }
-    return loc
+    return loc;
 }
 
-function restoreLocation() {
-}
+function restoreLocation() {}
 
 function persistLocation() {
     // Don't save every scroll event.
     var time = new Date().getTime();
-    if ( time - lastUpdate < 1000 ) {
+    if (time - lastUpdate < 1000) {
         return;
     }
     lastUpdate = time;
-    window.localStorage.setItem('gtn-in-galaxy', `${getIframeScroll()} ${getIframeUrl()}`);
+    window.localStorage.setItem("gtn-in-galaxy", `${getIframeScroll()} ${getIframeUrl()}`);
 }
 
 function addIframe() {
@@ -62,10 +61,14 @@ function addIframe() {
             } else {
                 safe = true;
 
-                var storedLocation = window.localStorage.getItem('gtn-in-galaxy');
-                if(storedLocation !== null && storedLocation.split(' ')[1] !== undefined && storedLocation.split(' ')[1].startsWith('/training-material/')) {
-                    onloadscroll = storedLocation.split(' ')[0];
-                    url = storedLocation.split(' ')[1];
+                var storedLocation = window.localStorage.getItem("gtn-in-galaxy");
+                if (
+                    storedLocation !== null &&
+                    storedLocation.split(" ")[1] !== undefined &&
+                    storedLocation.split(" ")[1].startsWith("/training-material/")
+                ) {
+                    onloadscroll = storedLocation.split(" ")[0];
+                    url = storedLocation.split(" ")[1];
                 } else {
                     url = "/training-material/";
                 }
@@ -93,9 +96,9 @@ function addIframe() {
             });
 
             // Only setup the listener if it won't crash things.
-            if(safe) {
+            if (safe) {
                 // Listen to the scroll position
-                document.getElementById("gtn-embed").contentWindow.addEventListener('scroll', () => {
+                document.getElementById("gtn-embed").contentWindow.addEventListener("scroll", () => {
                     persistLocation();
                 });
             }
@@ -103,12 +106,12 @@ function addIframe() {
             // Depends on the iframe being present
             document.getElementById("gtn-embed").addEventListener("load", () => {
                 // Save our current location when possible
-                if(onloadscroll !== undefined){
-                    document.getElementById('gtn-embed').contentWindow.scrollTo(0, parseInt(onloadscroll));
+                if (onloadscroll !== undefined) {
+                    document.getElementById("gtn-embed").contentWindow.scrollTo(0, parseInt(onloadscroll));
                     onloadscroll = undefined;
                 }
 
-                if(safe) {
+                if (safe) {
                     persistLocation();
                 }
                 var gtn_tools = $("#gtn-embed").contents().find("span[data-tool]");


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/10855

This is a backport because it's a bugfix (if you squint at it), and more because of the upcoming Smörgåsbord. I definitely should have fixed it earlier but only got to it now.

The scroll offset + url is listened to, and then persisted in localstorage.

Ping you @martenson because you filed the nice bug report :)
Fyi @shiltemann 