### PR TITLE
[21.01] Unpin pulsar-galaxy-lib in packages

### DIFF
--- a/packages/app/requirements.txt
+++ b/packages/app/requirements.txt
@@ -8,7 +8,7 @@ galaxy-web-stack
 kombu
 Beaker
 pykwalify
-pulsar-galaxy-lib==0.14.0.dev4
+pulsar-galaxy-lib
 gxformat2
 Mako
 sqlitedict


### PR DESCRIPTION
It's pinned to 0.14.1 in relevant files, so it needs to change from .0.dev4 in any event.