### PR TITLE
Fix images in workflow PDF report

### DIFF
--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
@@ -46,10 +46,7 @@ export default {
                     pathDestination.filepath
                 );
             } else if (this.path === undefined || this.path === "undefined") {
-                this.directoryContent = this.removeParentDirectory(
-                    pathDestination.datasetContent,
-                    pathDestination.datasetRootDir
-                );
+                this.directoryContent = pathDestination.datasetContent
             } else {
                 this.errorMessage = `is not found!`;
             }

--- a/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
+++ b/client/src/components/Dataset/DatasetIndex/DatasetIndex.vue
@@ -46,7 +46,7 @@ export default {
                     pathDestination.filepath
                 );
             } else if (this.path === undefined || this.path === "undefined") {
-                this.directoryContent = pathDestination.datasetContent
+                this.directoryContent = pathDestination.datasetContent;
             } else {
                 this.errorMessage = `is not found!`;
             }

--- a/client/src/components/Dataset/compositeDatasetUtils.js
+++ b/client/src/components/Dataset/compositeDatasetUtils.js
@@ -6,15 +6,11 @@ export const getPathDestination = async (history_dataset_id, path) => {
     const services = new Services({ root: getAppRoot() });
 
     const computePathDestination = (pathDestination) => {
-        if (pathDestination.datasetContent[0].class === "Directory")
-            pathDestination.datasetRootDir = datasetContent[0].path;
-        else return;
-
         if (path === undefined || path === "undefined") {
             return pathDestination;
         }
 
-        const filepath = `${pathDestination.datasetRootDir}/${path}`;
+        const filepath = path;
 
         const datasetEntry = datasetContent.find((datasetEntry) => {
             return filepath === datasetEntry.path;

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -388,8 +388,7 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
     def handle_dataset_as_image(self, line, hda):
         dataset = hda.dataset
         name = hda.name or ''
-        filepath =  re.search(PATH_LABEL_PATTERN, line).group(2)
-
+        filepath = re.search(PATH_LABEL_PATTERN, line).group(2)
 
         if filepath is not None:
             file = os.path.join(hda.extra_files_path, filepath)

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -386,8 +386,22 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
 
     def handle_dataset_as_image(self, line, hda):
         dataset = hda.dataset
+        print("!!!!!!!!!!!")
+        print("!!!!!!!!!!!")    
+        print("!!!!!!!!!!!")
+        print("!!!!!!!!!!!")
+        print("!!!!!!!!!!!")
+        print("!!!!!!!!!!!")
+        print("!!!!!!!!!!!")
+        print(line)
         name = hda.name or ''
-        with open(dataset.file_name, "rb") as f:
+        
+        if "path" in line:
+            file = os.path.join(hda.extra_files_path, 'GSM461178_untreat_paired_subset_1_fastq_fastqc/Images/per_sequence_quality.png')
+        else:
+            file = dataset.file_name
+            
+        with open(file, "rb") as f:
             base64_image_data = base64.b64encode(f.read()).decode("utf-8")
         rval = (f"![{name}](data:image/png;base64,{base64_image_data})", True)
         return rval
@@ -552,6 +566,17 @@ def to_pdf(trans, basic_markdown, css_paths=None) -> bytes:
     css_paths = css_paths or []
     as_html = to_html(basic_markdown)
     directory = tempfile.mkdtemp('gxmarkdown')
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print("!!!!!!!!!!1")
+    print(directory)
     index = os.path.join(directory, "index.html")
     try:
         output_file = codecs.open(index, "w", encoding="utf-8", errors="xmlcharrefreplace")
@@ -568,7 +593,8 @@ def to_pdf(trans, basic_markdown, css_paths=None) -> bytes:
         # font_config = FontConfiguration()
         # stylesheets=[css], font_config=font_config
     finally:
-        shutil.rmtree(directory)
+        print()
+    #     shutil.rmtree(directory)
 
 
 def _check_can_convert_to_pdf_or_raise():

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -388,9 +388,10 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
     def handle_dataset_as_image(self, line, hda):
         dataset = hda.dataset
         name = hda.name or ''
-        filepath = re.search(PATH_LABEL_PATTERN, line).group(2)
+        path_match = re.search(PATH_LABEL_PATTERN, line)
 
-        if filepath is not None:
+        if path_match:
+            filepath = path_match.group(2)
             file = os.path.join(hda.extra_files_path, filepath)
         else:
             file = dataset.file_name

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -391,7 +391,7 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
         filepath =  re.search(PATH_LABEL_PATTERN, line).group(2)
 
 
-        if "path" in line:
+        if filepath is not None:
             file = os.path.join(hda.extra_files_path, filepath)
         else:
             file = dataset.file_name
@@ -561,17 +561,6 @@ def to_pdf(trans, basic_markdown, css_paths=None) -> bytes:
     css_paths = css_paths or []
     as_html = to_html(basic_markdown)
     directory = tempfile.mkdtemp('gxmarkdown')
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print("!!!!!!!!!!1")
-    print(directory)
     index = os.path.join(directory, "index.html")
     try:
         output_file = codecs.open(index, "w", encoding="utf-8", errors="xmlcharrefreplace")
@@ -588,8 +577,7 @@ def to_pdf(trans, basic_markdown, css_paths=None) -> bytes:
         # font_config = FontConfiguration()
         # stylesheets=[css], font_config=font_config
     finally:
-        print()
-    #     shutil.rmtree(directory)
+        shutil.rmtree(directory)
 
 
 def _check_can_convert_to_pdf_or_raise():

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -49,6 +49,7 @@ ARG_VAL_CAPTURED_REGEX = r'''(?:([\w_\-\|]+)|\"([^\"]+)\"|\'([^\']+)\')'''
 OUTPUT_LABEL_PATTERN = re.compile(r'output=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
 INPUT_LABEL_PATTERN = re.compile(r'input=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
 STEP_LABEL_PATTERN = re.compile(r'step=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
+PATH_LABEL_PATTERN = re.compile(r'path=\s*%s\s*' % ARG_VAL_CAPTURED_REGEX)
 # STEP_OUTPUT_LABEL_PATTERN = re.compile(r'step_output=([\w_\-]+)/([\w_\-]+)')
 UNENCODED_ID_PATTERN = re.compile(r'(workflow_id|history_dataset_id|history_dataset_collection_id|job_id|invocation_id)=([\d]+)')
 ENCODED_ID_PATTERN = re.compile(r'(workflow_id|history_dataset_id|history_dataset_collection_id|job_id|invocation_id)=([a-z0-9]+)')
@@ -386,21 +387,15 @@ class ToBasicMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHandler):
 
     def handle_dataset_as_image(self, line, hda):
         dataset = hda.dataset
-        print("!!!!!!!!!!!")
-        print("!!!!!!!!!!!")    
-        print("!!!!!!!!!!!")
-        print("!!!!!!!!!!!")
-        print("!!!!!!!!!!!")
-        print("!!!!!!!!!!!")
-        print("!!!!!!!!!!!")
-        print(line)
         name = hda.name or ''
-        
+        filepath =  re.search(PATH_LABEL_PATTERN, line).group(2)
+
+
         if "path" in line:
-            file = os.path.join(hda.extra_files_path, 'GSM461178_untreat_paired_subset_1_fastq_fastqc/Images/per_sequence_quality.png')
+            file = os.path.join(hda.extra_files_path, filepath)
         else:
             file = dataset.file_name
-            
+
         with open(file, "rb") as f:
             base64_image_data = base64.b64encode(f.read()).decode("utf-8")
         rval = (f"![{name}](data:image/png;base64,{base64_image_data})", True)


### PR DESCRIPTION
Addressing https://github.com/galaxyproject/galaxy/issues/11275. 
From now on, users would have to provide full path e.g. 

```galaxy
 history_dataset_as_image(history_dataset_id=a3ff968b01c9046c, path="GSM461178_untreat_paired_subset_1_fastq_fastqc/Images/per_sequence_quality.png")
```

If a user wants to know, what is the fullpath of composite dataset, he can either run 

```galaxy
history_dataset_index(output="{output_label}")
```
and get  
![image](https://user-images.githubusercontent.com/15801412/106921216-17b5f000-670c-11eb-8033-a3108a878572.png)

or just download dataset and see the full path himself

This PR fixes composite images in report PDF. Example:
[report.pdf](https://github.com/galaxyproject/galaxy/files/5927032/report.pdf)


