### PR TITLE
Move docstring linting to GitHub workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,14 +83,6 @@ jobs:
           key: v1-repo-{{ .Environment.CIRCLE_SHA1 }}
           paths:
             - ~/repo
-  py36_docstring:
-    docker:
-      - image: circleci/python:3.6
-    <<: *set_workdir
-    steps:
-      - *restore_repo_cache
-      - *install_tox
-      - run: tox -e py36-lint_docstring_include_list
   py36_unit:
     docker:
       - image: circleci/python:3.6
@@ -159,8 +151,6 @@ workflows:
   get_code_and_test:
     jobs:
       - get_code
-      - py36_docstring:
-          <<: *requires_get_code
       - py36_unit:
           <<: *requires_get_code
       - py36_first_startup:

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7']
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7']
         db: ['postgresql', 'sqlite']
     services:
       postgres:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7']
         subset: ['upload_datatype', 'extended_metadata', 'kubernetes', 'not (upload_datatype or extended_metadata or kubernetes)']
     services:
       postgres:

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7']
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
+        python-version: ['3.6', '3.9']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,10 +16,12 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('lib/galaxy/dependencies/pinned-lint-requirements.txt') }}
     - name: Install tox
       run: pip install tox
-    - name: run tests
+    - name: Run linting
       run: tox -e lint
-    - name: run mypy checks
+    - name: Run docstring linting
+      run: tox -e py36-lint_docstring_include_list
+    - name: Run mypy checks
       run: tox -e mypy

--- a/.github/workflows/maintenance_bot.yaml
+++ b/.github/workflows/maintenance_bot.yaml
@@ -10,6 +10,11 @@ jobs:
     env:
       MILESTONE_NUMBER: 19
     steps:
+      - name: Debug
+        run: |
+          echo "Pull request: ${{ toJSON(github.event.pull_request) }}"
+          echo "Pull request labels: ${{ toJSON(github.event.pull_request.labels.*.name) }}"
+          echo "Joined labels: ${{ join(github.event.pull_request.labels.*.name, ', ') }}"
       - name: Add area labels
         if: ${{ ! contains(join(github.event.pull_request.labels.*.name, ', '), 'area/') }}
         uses: actions/labeler@main

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7']
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7']
     services:
       postgres:
         image: postgres:11


### PR DESCRIPTION
Also:
- Fix pip cache key.
- Quote Python versions in YAML. Treating them as floats will break with Python 3.10 .