### PR TITLE
Github workfow + run_tests.sh option to run marked tests with uwsgi instead of uvicorn

### DIFF
--- a/.github/workflows/api_legacy.yaml
+++ b/.github/workflows/api_legacy.yaml
@@ -1,0 +1,43 @@
+name: API (legacy endpoints) tests
+on: [push, pull_request]
+env:
+  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: 'galaxy root'
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dir
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Run tests
+        env:
+          GALAXY_TEST_USE_UVICORN: 0
+        run: ./run_tests.sh --skip_flakey_fails -api lib/galaxy_test/api --legacy-api
+        working-directory: 'galaxy root'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: API test results (${{ matrix.python-version }})
+          path: 'galaxy root/run_api_tests_legacy.html'
+

--- a/lib/galaxy_test/api/test_configuration.py
+++ b/lib/galaxy_test/api/test_configuration.py
@@ -1,3 +1,5 @@
+import pytest
+
 from galaxy_test.base.api_asserts import (
     assert_has_keys,
     assert_not_has_keys,
@@ -22,6 +24,7 @@ TEST_KEYS_FOR_ADMIN_ONLY = [
 ]
 
 
+@pytest.mark.legacy_api
 class ConfigurationApiTestCase(ApiTestCase):
 
     def test_whoami(self):

--- a/lib/galaxy_test/api/test_licenses.py
+++ b/lib/galaxy_test/api/test_licenses.py
@@ -1,6 +1,9 @@
+import pytest
+
 from ._framework import ApiTestCase
 
 
+@pytest.mark.legacy_api
 class LicensesApiTestCase(ApiTestCase):
 
     def test_index(self):

--- a/lib/galaxy_test/api/test_tours.py
+++ b/lib/galaxy_test/api/test_tours.py
@@ -1,6 +1,9 @@
+import pytest
+
 from ._framework import ApiTestCase
 
 
+@pytest.mark.legacy_api
 class TourApiTestCase(ApiTestCase):
 
     def test_index(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,6 @@ markers =
   data_manager: marks test as a data_manager test
   tool: marks test as a tool test
   gtn_screenshot: marks test as a screenshot producer for galaxy training network
-  local: mark indicates, that it's sufficient to run test locally to get relevant artifacts (e.g. screenshots)
-  external: mark indicates, that test has to be run against external production server to get relevant artifacts (e.g. screenshots)
+  local: mark indicates that it's sufficient to run test locally to get relevant artifacts (e.g. screenshots)
+  external: mark indicates that test has to be run against external production server to get relevant artifacts (e.g. screenshots)
+  legacy_api: test should be run twice: (1) with uvicorn (by default) to test fastapi endpoints, and (2) with uwsgi to test legacy endpoints

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -171,8 +171,12 @@ Extra options:
  --external_master_key Master API key used to configure external tests.
  --external_user_key   User API used for external tests - not required if
                        external_master_key is specified.
-  --skip_flakey_fails  Skip flakey tests on error (sets
+ --skip_flakey_fails   Skip flakey tests on error (sets
                        GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR=1).
+ --legacy_api          Run tests marked as 'legacy_api'. Tests are run using
+                       uvicorn by default, which tests FastAPI endpoints.
+                       Setting GALAXY_TEST_USE_UVICORN=0 will run them with
+                       uwsgi, which tests Galaxy's legacy API.
 
 Environment Variables:
 
@@ -250,6 +254,8 @@ TOOL_SHED_TEST_TMP_DIR          Defaults to random /tmp directory - place for
                                 tool shed test server files to be placed.
 TOOL_SHED_TEST_OMIT_GALAXY      Do not launch a Galaxy server for tool shed
                                 testing.
+GALAXY_TEST_USE_UVICORN         Tests use uvicorn by default. Unset this option (set to 0)
+                                to use uwsgi instead.
 
 Unit Test Environment Variables
 
@@ -575,6 +581,10 @@ do
           # Don't run ./scripts/common_startup.sh (presumably it has already
           # been done, or you know what you're doing).
           skip_common_startup=1
+          shift
+          ;;
+      --legacy-api)
+          marker="legacy_api"
           shift
           ;;
       --)


### PR DESCRIPTION
Addresses #11302.
Will this work?
I've marked configuration, tours and licences only. If this is an acceptable solution, we'll need to mark all the other migrated controllers. (we can mark at the module level, but I think marking each controller class is better - more explicit).