### PR TITLE
[PROCEDURES] Add Nuwan Goonasekera to the committers group

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -52,6 +52,7 @@ Members
 - Nate Coraor (@natefoo)
 - Jeremy Goecks (@jgoecks)
 - Sergey Golitsynskiy (@ic4f)
+- Nuwan Goonasekera (@nuwang)
 - Björn Grüning (@bgruening)
 - Aysam Guerler (@guerler)
 - Jennifer Hillman Jackson (@jennaj)


### PR DESCRIPTION
Nuwan Goonasekera (@nuwang) has been an active member of the Galaxy community for nearly a decade. He has made numerous and significant contributions across the spectrum of Galaxy Project repositories: [bioblend](https://github.com/galaxyproject/bioblend/commits?author=nuwang), [ansible-galaxy](https://github.com/galaxyproject/ansible-galaxy/commits?author=nuwang), [galaxy-helm](https://github.com/galaxyproject/galaxy-helm/commits?author=nuwang), and others. 

He actively helps users and other team members by answering questions via chat and issues on GitHuh, providing constructive feedback and dedicating time to follow up, eg. https://gitter.im/galaxyproject/wg-deployment?at=601ae0a655359c58bf1c8ff7, https://gitter.im/galaxyproject/FederatedGalaxy?at=6019abed428d9727dd4ebacb, https://github.com/CloudVE/cloudbridge/issues/258. 

He has made a number of improvements to the Galaxy codebase demonstrating his grasp and commitment to the core project:
- https://github.com/galaxyproject/galaxy/pulls?page=2&q=is%3Apr+author%3Anuwang
The following pull requests exemplify his contributions over the years:
- https://github.com/galaxyproject/galaxy/pull/10681
- https://github.com/galaxyproject/galaxy/pull/9738
- https://github.com/galaxyproject/galaxy/pull/1814

I propose we add Nuwan to the Galaxy committers group to both recognize his contributions and benefit more directly from his expertise. 

@galaxyproject/core please vote.