### PR TITLE
[21.01] Sharing component bugfixes

### DIFF
--- a/client/src/components/Common/SlugInput.vue
+++ b/client/src/components/Common/SlugInput.vue
@@ -18,7 +18,7 @@ export default {
     props: {
         slug: {
             type: String,
-            required: true
+            required: true,
         },
     },
     data() {

--- a/client/src/components/Common/SlugInput.vue
+++ b/client/src/components/Common/SlugInput.vue
@@ -18,6 +18,7 @@ export default {
     props: {
         slug: {
             type: String,
+            required: true
         },
     },
     data() {

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -12,7 +12,7 @@
         </div>
         <div v-else>
             <b-form-checkbox switch class="make-accessible" v-model="item.importable" @change="onImportable">
-                Make {{ model_class }} accessible.
+                Make {{ model_class }} accessible
             </b-form-checkbox>
             <b-form-checkbox
                 v-if="item.importable"
@@ -22,38 +22,38 @@
                 @change="onPublish"
             >
                 Make {{ model_class }} publicly available in
-                <a :href="published_url" target="_top">Published {{ plural_name }}</a> section.
+                <a :href="published_url" target="_top">Published {{ plural_name }}</a>
             </b-form-checkbox>
             <br />
-            <div>
-                <div v-if="item.importable">
-                    <div>
-                        This {{ model_class }} is currently <strong>{{ itemStatus }}</strong
-                        >.
-                    </div>
-                    <p>Anyone can view and import this {{ model_class }} by visiting the following URL:</p>
-                    <blockquote>
-                        <b-button title="Edit URL" @click="onEdit" v-b-tooltip.hover variant="link" size="sm">
-                            <font-awesome-icon icon="edit" />
-                        </b-button>
-                        <b-button id="tooltip-clipboard" @click="onCopy" @mouseout="onCopyOut" variant="link" size="sm">
-                            <font-awesome-icon icon="link" />
-                        </b-button>
-                        <b-tooltip target="tooltip-clipboard" triggers="hover">
-                            {{ tooltipClipboard }}
-                        </b-tooltip>
-                        <a v-if="showUrl" id="item-url" :href="itemUrl" target="_top" class="ml-2">
-                            {{ itemUrl }}
-                        </a>
-                        <span v-else id="item-url-text">
-                            {{ itemUrlParts[0] }}<SlugInput class="ml-1" :slug="itemUrlParts[1]" @onChange="onChange" />
-                        </span>
-                    </blockquote>
+            <div v-if="item.importable">
+                <div>
+                    This {{ model_class }} is currently <strong>{{ itemStatus }}</strong
+                    >.
                 </div>
-                <div v-else>
-                    Access to this {{ model_class }} is currently restricted so that only you and the users listed below
-                    can access it. Note that sharing a History will also allow access to all of its datasets.
-                </div>
+                <p>Anyone can view and import this {{ model_class }} by visiting the following URL:</p>
+                <blockquote>
+                    <b-button title="Edit URL" @click="onEdit" v-b-tooltip.hover variant="link" size="sm">
+                        <font-awesome-icon icon="edit" />
+                    </b-button>
+                    <b-button id="tooltip-clipboard" @click="onCopy" @mouseout="onCopyOut" variant="link" size="sm">
+                        <font-awesome-icon icon="link" />
+                    </b-button>
+                    <b-tooltip target="tooltip-clipboard" triggers="hover">
+                        {{ tooltipClipboard }}
+                    </b-tooltip>
+                    <a v-if="showUrl" id="item-url" :href="itemUrl" target="_top" class="ml-2">
+                        url:
+                        {{ itemUrl }}
+                    </a>
+                    <span v-else id="item-url-text">
+                        slug:
+                        {{ itemUrlParts[0] }}<SlugInput class="ml-1" :slug="itemUrlParts[1]" @onChange="onChange" />
+                    </span>
+                </blockquote>
+            </div>
+            <div v-else>
+                Access to this {{ model_class }} is currently restricted so that only you and the users listed below can
+                access it. Note that sharing a History will also allow access to all of its datasets.
             </div>
             <br />
             <h4>Share {{ model_class }} with Individual Users</h4>

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -127,7 +127,7 @@ export default {
             errMsg: null,
             item: {
                 title: "title",
-                username_and_slug: "username_and_slug",
+                username_and_slug: "username/slug",
                 importable: false,
                 published: false,
                 users_shared_with: [],
@@ -205,16 +205,19 @@ export default {
         },
         onImportable(importable) {
             if (importable) {
-                this.setSharing("make_accessible_via_link");
-                if (this.item.published) {
-                    this.setSharing("publish");
-                } else {
-                    this.setSharing("unpublish");
-                }
+                const alsoPublish = this.item.published;
+                this.setSharing("make_accessible_via_link").then(() => {
+                    if (alsoPublish) {
+                        this.setSharing("publish");
+                    } else {
+                        this.setSharing("unpublish");
+                    }
+                });
             } else {
                 this.item.published = false;
-                this.setSharing("disable_link_access");
-                this.setSharing("unpublish");
+                this.setSharing("disable_link_access").then(() => {
+                    this.setSharing("unpublish");
+                });
             }
         },
         onPublish(published) {
@@ -248,18 +251,19 @@ export default {
                 })
                 .catch((error) => (this.errMsg = error.response.data.err_msg));
         },
-        setSharing(action, user_id) {
+        async setSharing(action, user_id) {
             const data = {
                 action: action,
                 user_id: user_id,
             };
-            axios
+            return axios
                 .post(`${getAppRoot()}api/${this.pluralNameLower}/${this.id}/sharing`, data)
                 .then((response) => {
                     if (response.data.skipped) {
                         this.errMsg = "Some of the items within this object were not published due to an error.";
                     }
                     this.item = response.data;
+                    this.ready = true;
                 })
                 .catch((error) => (this.errMsg = error.response.data.err_msg));
         },

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -259,6 +259,7 @@ export default {
                     if (response.data.skipped) {
                         this.errMsg = "Some of the items within this object were not published due to an error.";
                     }
+                    this.item = response.data;
                 })
                 .catch((error) => (this.errMsg = error.response.data.err_msg));
         },

--- a/client/src/components/Sharing.vue
+++ b/client/src/components/Sharing.vue
@@ -205,19 +205,10 @@ export default {
         },
         onImportable(importable) {
             if (importable) {
-                const alsoPublish = this.item.published;
-                this.setSharing("make_accessible_via_link").then(() => {
-                    if (alsoPublish) {
-                        this.setSharing("publish");
-                    } else {
-                        this.setSharing("unpublish");
-                    }
-                });
+                this.setSharing(`make_accessible_via_link-${this.item.published ? "publish" : "unpublish"}`);
             } else {
                 this.item.published = false;
-                this.setSharing("disable_link_access").then(() => {
-                    this.setSharing("unpublish");
-                });
+                this.setSharing("disable_link_access-unpublish");
             }
         },
         onPublish(published) {
@@ -251,7 +242,7 @@ export default {
                 })
                 .catch((error) => (this.errMsg = error.response.data.err_msg));
         },
-        async setSharing(action, user_id) {
+        setSharing(action, user_id) {
             const data = {
                 action: action,
                 user_id: user_id,

--- a/client/src/onload/standardInit.js
+++ b/client/src/onload/standardInit.js
@@ -45,7 +45,7 @@ export function standardInit(label = "Galaxy", appFactory = defaultAppFactory) {
     // will not remake a the existing Galaxy or config objects, it'll just run
     // the new batch of freshly registered init functions
     combineLatest(config$, galaxy$, initializations$).subscribe(([config, galaxy, inits]) => {
-        console.groupCollapsed(`runInitializations`, label, serverPath());
+        console.group(`runInitializations`, label, serverPath());
         inits.forEach((fn) => fn(galaxy, config));
         clearInitQueue();
         console.groupEnd();

--- a/client/src/onload/standardInit.js
+++ b/client/src/onload/standardInit.js
@@ -44,7 +44,7 @@ export function standardInit(label = "Galaxy", appFactory = defaultAppFactory) {
     // functions even if they are registered super-late because combineLatest
     // will not remake a the existing Galaxy or config objects, it'll just run
     // the new batch of freshly registered init functions
-    combineLatest(config$, galaxy$, initializations$).subscribe(([config, galaxy, inits]) => {
+    combineLatest([config$, galaxy$, initializations$]).subscribe(([config, galaxy, inits]) => {
         console.group(`runInitializations`, label, serverPath());
         inits.forEach((fn) => fn(galaxy, config));
         clearInitQueue();

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1411,8 +1411,10 @@ class SharableMixin:
         skipped = False
         class_name = self.manager.model_class.__name__
         item = self.get_object(trans, id, class_name, check_ownership=True, check_accessible=True, deleted=False)
-        if payload and payload.get("action"):
-            action = payload.get("action")
+        actions = []
+        if payload:
+            actions += payload.get("action").split("-")
+        for action in actions:
             if action == "make_accessible_via_link":
                 self._make_item_accessible(trans.sa_session, item)
                 if hasattr(item, "has_possible_members") and item.has_possible_members:


### PR DESCRIPTION
The driver for this was fixing the `null` username/slug that @jennaj noted, shown in the screenshot here:
![image](https://user-images.githubusercontent.com/155398/107064494-8f862800-67a9-11eb-8fbe-bb29e9a8fb68.png)


I did work in a little cleanup and a couple enhancements though.  The biggest change (that I can work around if we don't want to do it) is to allow the sharing endpoint to take compound actions.  So, for the sharing component, instead of making multiple requests to `make_accessible_via_link` and `publish` (sequential requests, both replying with an updated payload that without extra workarounds causes a 'flash' on the client side rendering), now we can do a single `make_accessible_via_link-publish`, or whatever combination.  This seemed more sensible than making compound actions on the backend for it all.
