### PR TITLE
ignore subdirectories if recurse is false

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -478,7 +478,6 @@ def walk_over_extra_files(target_dir, extra_file_collector, job_working_director
     if os.path.isdir(directory):
         for filename in os.listdir(directory):
             path = os.path.join(directory, filename)
-            log.error("%s isdir %s recurse %s" % (path, os.path.isdir(path), extra_file_collector.recurse))
             if os.path.isdir(path):
                 if extra_file_collector.recurse:
                     # The current directory is already validated, so use that as the next job_working_directory when recursing

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -478,10 +478,12 @@ def walk_over_extra_files(target_dir, extra_file_collector, job_working_director
     if os.path.isdir(directory):
         for filename in os.listdir(directory):
             path = os.path.join(directory, filename)
-            if os.path.isdir(path) and extra_file_collector.recurse:
-                # The current directory is already validated, so use that as the next job_working_directory when recursing
-                for match in walk_over_extra_files(filename, extra_file_collector, directory, matchable):
-                    yield match
+            log.error("%s isdir %s recurse %s" % (path, os.path.isdir(path), extra_file_collector.recurse))
+            if os.path.isdir(path):
+                if extra_file_collector.recurse:
+                    # The current directory is already validated, so use that as the next job_working_directory when recursing
+                    for match in walk_over_extra_files(filename, extra_file_collector, directory, matchable):
+                        yield match
             else:
                 match = extra_file_collector.match(matchable, filename, path=path)
                 if match:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -780,7 +780,7 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
     if expected_collection_type:
         collection_type = data_collection["collection_type"]
         if expected_collection_type != collection_type:
-            template = "Expected output collection [%s] to be of type [%s], was of type [%s]."
+            template = "Output collection '%s': expected to be of type [%s], was of type [%s]."
             message = template % (name, expected_collection_type, collection_type)
             raise AssertionError(message)
 
@@ -788,7 +788,7 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
     if expected_element_count:
         actual_element_count = len(data_collection["elements"])
         if expected_element_count != actual_element_count:
-            template = "Expected output collection [%s] to have %s elements, but it had %s."
+            template = "Output collection '%s': expected to have %s elements, but it had %s."
             message = template % (name, expected_element_count, actual_element_count)
             raise AssertionError(message)
 
@@ -813,7 +813,7 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
 
             element = get_element(element_objects, element_identifier)
             if not element:
-                template = "Failed to find identifier '%s' in the tool generated collection elements %s"
+                template = "Output collection '%s': failed to find identifier '%s' in the tool generated elements %s"
                 message = template % (element_identifier, eo_ids)
                 raise AssertionError(message)
 
@@ -835,8 +835,8 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
                         break
                     i += 1
                 if element is None:
-                    template = "Collection identifier '%s' found out of order, expected order of %s for the tool generated collection elements %s"
-                    message = template % (element_identifier, expected_sort_order, eo_ids)
+                    template = "Output collection '%s': identifier '%s' found out of order, expected order of %s for the tool generated collection elements %s"
+                    message = template % (name, element_identifier, expected_sort_order, eo_ids)
                     raise AssertionError(message)
 
     verify_elements(data_collection["elements"], output_collection_def.element_tests)

--- a/test/functional/tools/discover_sort_by.xml
+++ b/test/functional/tools/discover_sort_by.xml
@@ -4,6 +4,10 @@ for i in \$(seq 1 10);
 do
     echo "\$i" > \$i.txt;
 done
+## create a directory that matches the discovery pattern
+## but must not be discovered because it's a directory which
+## leads to an error https://github.com/galaxyproject/galaxy/pull/11307
+## && mkdir blah.txt
 ]]></command>
   <inputs/>
   <outputs>
@@ -22,7 +26,6 @@ done
   </outputs>
   <tests>
     <test expect_num_outputs="4">
-      <param name="input1" value="tinywga.fam" />
       <output_collection name="collection_numeric_name" type="list" count="10">
         <element name="1">
           <assert_contents><has_text_matching expression="^.*$"/></assert_contents>


### PR DESCRIPTION
if discover outputs has `recurse=true` and the directory contains subdirs that match the pattern then:

```
Traceback (most recent call last):
  File "/home/berntm/projects/galaxy/lib/galaxy/job_execution/output_collect.py", line 160, in collect_dynamic_outputs
    final_job_state=job_context.final_job_state,
  File "/home/berntm/projects/galaxy/lib/galaxy/model/store/discover.py", line 286, in populate_collection_elements
    self.update_object_store_with_datasets(datasets=element_datasets['datasets'], paths=element_datasets['paths'], extra_files=element_datasets['extra_files'])
  File "/home/berntm/projects/galaxy/lib/galaxy/model/store/discover.py", line 309, in update_object_store_with_datasets
    self.object_store.update_from_file(dataset.dataset, file_name=path, create=True)
  File "/home/berntm/projects/galaxy/lib/galaxy/objectstore/__init__.py", line 310, in update_from_file
    return self._invoke('update_from_file', obj, **kwargs)
  File "/home/berntm/projects/galaxy/lib/galaxy/objectstore/__init__.py", line 286, in _invoke
    return self.__getattribute__("_" + delegate)(obj=obj, **kwargs)
  File "/home/berntm/projects/galaxy/lib/galaxy/objectstore/__init__.py", line 625, in _update_from_file
    raise ex
  File "/home/berntm/projects/galaxy/lib/galaxy/objectstore/__init__.py", line 621, in _update_from_file
    shutil.copy(file_name, path)
  File "/home/berntm/miniconda3/envs/_galaxy_/lib/python3.6/shutil.py", line 245, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/home/berntm/miniconda3/envs/_galaxy_/lib/python3.6/shutil.py", line 120, in copyfile
    with open(src, 'rb') as fsrc:
IsADirectoryError: [Errno 21] Is a directory: '/tmp/tmpdzmsmkv0/job_working_directory/000/3/working/rt_concat_trafo_out/dataset_37a0ef0f-a082-4bd4-9a60-6ca444a818b6'
```

Note that the changed functional tool test is failing for me locally (because of the collection sort order .. which shouldn't be the case). But integration tests do not run here at the moment successfully.