### PR TITLE
Temporarily turn off integration test

### DIFF
--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -283,8 +283,10 @@ def get_path_data():
 def get_key(option_data):
     return option_data.key
 
-
-@pytest.mark.parametrize('data', get_config_data(), ids=get_key)
+# TODO: commented out due to consistent errors at test collection stage
+# under integration/kubernetes github workflow. Needs to be resolved.
+#@pytest.mark.parametrize('data', get_config_data(), ids=get_key)
+@pytest.mark.skip(reason="Consistent errors due to db n/a at test collection stage under integration/k8s workflow")
 def test_config_option(data, driver):
     assert data.expected == data.loaded
 

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -283,15 +283,17 @@ def get_path_data():
 def get_key(option_data):
     return option_data.key
 
+
 # TODO: commented out due to consistent errors at test collection stage
 # under integration/kubernetes github workflow. Needs to be resolved.
-#@pytest.mark.parametrize('data', get_config_data(), ids=get_key)
+# @pytest.mark.parametrize('data', get_config_data(), ids=get_key)
 @pytest.mark.skip(reason="Consistent errors due to db n/a at test collection stage under integration/k8s workflow")
 def test_config_option(data, driver):
     assert data.expected == data.loaded
 
 
-@pytest.mark.parametrize('data', get_path_data())
+# @pytest.mark.parametrize('data', get_path_data())
+@pytest.mark.skip(reason="Consistent errors due to db n/a at test collection stage under integration/k8s workflow")
 def test_is_path_absolute(data, driver):
     path = getattr(DRIVER.app.config, data)
     if path:


### PR DESCRIPTION
This test appears to be consistently causing an error under the integration/kubernetes github workflow. The error happens due to the database being not available at test collection state. This has not happened until now and is *not* related to the content (what is tested) of the test.

Given the above, it seems reasonable to temporarily turn off the test and investigate it offline.