### PR TITLE
Allow element_identifiers or a manually specified name for datasets in build list tool

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -39,6 +39,7 @@
     <tool file="${model_tools_path}/tag_collection_from_file.xml" />
     <tool file="${model_tools_path}/apply_rules.xml" />
     <tool file="${model_tools_path}/build_list.xml" />
+    <tool file="${model_tools_path}/build_list_1.2.0.xml" />
     <tool file="${model_tools_path}/extract_dataset.xml" />
   </section>
   <section id="expression_tools" name="Expression Tools">

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2955,16 +2955,15 @@ class BuildListCollectionTool(DatabaseOperationTool):
         new_elements = {}
 
         for i, incoming_repeat in enumerate(incoming["datasets"]):
-            if not incoming_repeat["input"]:
-                continue
-            new_dataset = incoming_repeat["input"].copy(copy_tags=tags)
-            if incoming_repeat["id_cond"]["id_select"] == 'idx':
-                identifier = str(i)
-            elif incoming_repeat["id_cond"]["id_select"] == 'identifier':
-                identifier = incoming_repeat["input"].element_identifier
-            elif incoming_repeat["id_cond"]["id_select"] == 'manual':
-                identifier = incoming_repeat["id_cond"]["identifier"]
-            new_elements[identifier] = new_dataset
+            if incoming_repeat["input"]:
+                if incoming_repeat["id_cond"]["id_select"] == 'idx':
+                    identifier = str(i)
+                elif incoming_repeat["id_cond"]["id_select"] == 'identifier':
+                    identifier = incoming_repeat["input"].name
+                elif incoming_repeat["id_cond"]["id_select"] == 'manual':
+                    identifier = incoming_repeat["id_cond"]["identifier"]
+                new_elements[identifier] = incoming_repeat["input"].copy(copy_tags=tags)
+
         self._add_datasets_to_history(history, new_elements.values())
         output_collections.create_collection(
             next(iter(self.outputs.values())), "output", elements=new_elements, propagate_hda_tags=False

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2959,7 +2959,7 @@ class BuildListCollectionTool(DatabaseOperationTool):
                 if incoming_repeat["id_cond"]["id_select"] == 'idx':
                     identifier = str(i)
                 elif incoming_repeat["id_cond"]["id_select"] == 'identifier':
-                    identifier = incoming_repeat["input"].element_identifier
+                    identifier = getattr(incoming_repeat["input"], 'element_identifier', incoming_repeat["input"].name)
                 elif incoming_repeat["id_cond"]["id_select"] == 'manual':
                     identifier = incoming_repeat["id_cond"]["identifier"]
                 new_elements[identifier] = incoming_repeat["input"].copy(copy_tags=incoming_repeat["input"].tags)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2962,7 +2962,7 @@ class BuildListCollectionTool(DatabaseOperationTool):
                     identifier = incoming_repeat["input"].name
                 elif incoming_repeat["id_cond"]["id_select"] == 'manual':
                     identifier = incoming_repeat["id_cond"]["identifier"]
-                new_elements[identifier] = incoming_repeat["input"].copy(copy_tags=tags)
+                new_elements[identifier] = incoming_repeat["input"].copy(copy_tags=incoming_repeat["input"].tags)
 
         self._add_datasets_to_history(history, new_elements.values())
         output_collections.create_collection(

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2956,11 +2956,16 @@ class BuildListCollectionTool(DatabaseOperationTool):
 
         for i, incoming_repeat in enumerate(incoming["datasets"]):
             if incoming_repeat["input"]:
-                if incoming_repeat["id_cond"]["id_select"] == 'idx':
+                try:
+                    id_select = incoming_repeat["id_cond"]["id_select"]
+                except KeyError:
+                    # Prior to tool version 1.2.0
+                    id_select = 'idx'
+                if id_select == 'idx':
                     identifier = str(i)
-                elif incoming_repeat["id_cond"]["id_select"] == 'identifier':
+                elif id_select == 'identifier':
                     identifier = getattr(incoming_repeat["input"], 'element_identifier', incoming_repeat["input"].name)
-                elif incoming_repeat["id_cond"]["id_select"] == 'manual':
+                elif id_select == 'manual':
                     identifier = incoming_repeat["id_cond"]["identifier"]
                 new_elements[identifier] = incoming_repeat["input"].copy(copy_tags=incoming_repeat["input"].tags)
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -216,7 +216,7 @@ class safe_update(NamedTuple):
 # Tool updates that did not change parameters in a way that requires rebuilding workflows
 WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
     'Filter1': safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.1.1")),
-    '__BUILD_LIST__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
+    '__BUILD_LIST__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.1.0")),
     '__APPLY_RULES__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.1.0")),
     '__EXTRACT_DATASET__': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     'Grep1': safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.3")),
@@ -2959,7 +2959,7 @@ class BuildListCollectionTool(DatabaseOperationTool):
                 if incoming_repeat["id_cond"]["id_select"] == 'idx':
                     identifier = str(i)
                 elif incoming_repeat["id_cond"]["id_select"] == 'identifier':
-                    identifier = incoming_repeat["input"].name
+                    identifier = incoming_repeat["input"].element_identifier
                 elif incoming_repeat["id_cond"]["id_select"] == 'manual':
                     identifier = incoming_repeat["id_cond"]["identifier"]
                 new_elements[identifier] = incoming_repeat["input"].copy(copy_tags=incoming_repeat["input"].tags)

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2955,9 +2955,16 @@ class BuildListCollectionTool(DatabaseOperationTool):
         new_elements = {}
 
         for i, incoming_repeat in enumerate(incoming["datasets"]):
-            if incoming_repeat["input"]:
-                new_elements["%d" % i] = incoming_repeat["input"].copy(copy_tags=incoming_repeat["input"].tags)
-
+            if not incoming_repeat["input"]:
+                continue
+            new_dataset = incoming_repeat["input"].copy(copy_tags=tags)
+            if incoming_repeat["id_cond"]["id_select"] == 'idx':
+                identifier = str(i)
+            elif incoming_repeat["id_cond"]["id_select"] == 'identifier':
+                identifier = incoming_repeat["input"].element_identifier
+            elif incoming_repeat["id_cond"]["id_select"] == 'manual':
+                identifier = incoming_repeat["id_cond"]["identifier"]
+            new_elements[identifier] = new_dataset
         self._add_datasets_to_history(history, new_elements.values())
         output_collections.create_collection(
             next(iter(self.outputs.values())), "output", elements=new_elements, propagate_hda_tags=False

--- a/lib/galaxy/tools/build_list.xml
+++ b/lib/galaxy/tools/build_list.xml
@@ -11,7 +11,19 @@
   </edam_operations>
   <inputs>
     <repeat name="datasets" title="Dataset" help="If collections are provided they should contain the same number of items.">
-      <param type="data" name="input" optional="true" label="Input Dataset" help="If providing a collection here the tool will be run in batch and one collection per element is created."/>
+      <param type="data" name="input" optional="true" label="Input Dataset"  help="If providing a collection here the tool will be run in batch and one collection per element is created."/>
+      <conditional name="id_cond">
+          <param name="id_select" type="select" label="Label to use" help="">
+              <option value="idx">Index</option>
+              <option value="identifier">Identifier</option>
+              <option value="manual">Manual</option>
+          </param>
+          <when value="idx"/>
+          <when value="identifier"/>
+          <when value="manual">
+            <param name="identifier" type="text" lable="Identifier"/>
+          </when>
+      </conditional>
     </repeat>
   </inputs>
   <outputs>

--- a/lib/galaxy/tools/build_list.xml
+++ b/lib/galaxy/tools/build_list.xml
@@ -14,7 +14,7 @@
       <param type="data" name="input" optional="true" label="Input Dataset"  help="If providing a collection here the tool will be run in batch and one collection per element is created."/>
       <conditional name="id_cond">
           <param name="id_select" type="select" label="Label to use" help="">
-              <option value="idx">Index</option>
+              <option value="idx" selected="true">Index</option>
               <option value="identifier">Identifier</option>
               <option value="manual">Manual</option>
           </param>
@@ -79,6 +79,37 @@ This tool will create a new collection from your history datasets but your quota
       <repeat name="datasets">
       </repeat>
       <output_collection name="output" type="list" count="0">
+      </output_collection>
+    </test>
+    <test>
+      <repeat name="datasets">
+        <param name="input" value="simple_line.txt" />
+        <conditional name="id_cond">
+          <param name="id_select" value="identifier"/>
+        </conditional>
+      </repeat>
+      <output_collection name="output" type="list">
+        <element name="simple_line.txt">
+          <assert_contents>
+              <has_text_matching expression="^This is a line of text.\n$"/>
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+    <test>
+      <repeat name="datasets">
+        <param name="input" value="simple_line.txt" />
+        <conditional name="id_cond">
+          <param name="id_select" value="manual"/>
+          <param name="identifier" value="identifier"/>
+        </conditional>
+      </repeat>
+      <output_collection name="output" type="list">
+        <element name="identifier">
+          <assert_contents>
+              <has_text_matching expression="^This is a line of text.\n$"/>
+          </assert_contents>
+        </element>
       </output_collection>
     </test>
   </tests>

--- a/lib/galaxy/tools/build_list.xml
+++ b/lib/galaxy/tools/build_list.xml
@@ -98,27 +98,6 @@ This tool will create a new collection from your history datasets but your quota
     </test>
     <test>
       <repeat name="datasets">
-        <param name="input">
-          <collection type="list">
-            <element name="simple_line" value="simple_line.txt"/>
-          </collection>
-        </param>
-        <conditional name="id_cond">
-          <param name="id_select" value="identifier"/>
-        </conditional>
-      </repeat>
-      <output_collection name="output" type="list">
-        <element name="???">
-          <element name="simple_line">
-            <assert_contents>
-              <has_text_matching expression="^This is a line of text.\n$"/>
-            </assert_contents>
-          </element>
-        </element>
-      </output_collection>
-    </test>
-    <test>
-      <repeat name="datasets">
         <param name="input" value="simple_line.txt" />
         <conditional name="id_cond">
           <param name="id_select" value="manual"/>

--- a/lib/galaxy/tools/build_list.xml
+++ b/lib/galaxy/tools/build_list.xml
@@ -98,6 +98,27 @@ This tool will create a new collection from your history datasets but your quota
     </test>
     <test>
       <repeat name="datasets">
+        <param name="input">
+          <collection type="list">
+            <element name="simple_line" value="simple_line.txt"/>
+          </collection>
+        </param>
+        <conditional name="id_cond">
+          <param name="id_select" value="identifier"/>
+        </conditional>
+      </repeat>
+      <output_collection name="output" type="list">
+        <element name="???">
+          <element name="simple_line">
+            <assert_contents>
+              <has_text_matching expression="^This is a line of text.\n$"/>
+            </assert_contents>
+          </element>
+        </element>
+      </output_collection>
+    </test>
+    <test>
+      <repeat name="datasets">
         <param name="input" value="simple_line.txt" />
         <conditional name="id_cond">
           <param name="id_select" value="manual"/>

--- a/lib/galaxy/tools/build_list_1.2.0.xml
+++ b/lib/galaxy/tools/build_list_1.2.0.xml
@@ -1,6 +1,6 @@
 <tool id="__BUILD_LIST__"
       name="Build list"
-      version="1.1.0"
+      version="1.2.0"
       tool_type="build_list">
   <description></description>
   <type class="BuildListCollectionTool" module="galaxy.tools" />
@@ -11,7 +11,19 @@
   </edam_operations>
   <inputs>
     <repeat name="datasets" title="Dataset" help="If collections are provided they should contain the same number of items.">
-      <param type="data" name="input" optional="true" label="Input Dataset" help="If providing a collection here the tool will be run in batch and one collection per element is created."/>
+      <param type="data" name="input" optional="true" label="Input Dataset"  help="If providing a collection here the tool will be run in batch and one collection per element is created."/>
+      <conditional name="id_cond">
+          <param name="id_select" type="select" label="Label to use" help="">
+              <option value="idx" selected="true">Index</option>
+              <option value="identifier">Identifier</option>
+              <option value="manual">Manual</option>
+          </param>
+          <when value="idx"/>
+          <when value="identifier"/>
+          <when value="manual">
+            <param name="identifier" type="text" lable="Identifier"/>
+          </when>
+      </conditional>
     </repeat>
   </inputs>
   <outputs>
@@ -67,6 +79,37 @@ This tool will create a new collection from your history datasets but your quota
       <repeat name="datasets">
       </repeat>
       <output_collection name="output" type="list" count="0">
+      </output_collection>
+    </test>
+    <test>
+      <repeat name="datasets">
+        <param name="input" value="simple_line.txt" />
+        <conditional name="id_cond">
+          <param name="id_select" value="identifier"/>
+        </conditional>
+      </repeat>
+      <output_collection name="output" type="list">
+        <element name="simple_line.txt">
+          <assert_contents>
+              <has_text_matching expression="^This is a line of text.\n$"/>
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+    <test>
+      <repeat name="datasets">
+        <param name="input" value="simple_line.txt" />
+        <conditional name="id_cond">
+          <param name="id_select" value="manual"/>
+          <param name="identifier" value="identifier"/>
+        </conditional>
+      </repeat>
+      <output_collection name="output" type="list">
+        <element name="identifier">
+          <assert_contents>
+              <has_text_matching expression="^This is a line of text.\n$"/>
+          </assert_contents>
+        </element>
       </output_collection>
     </test>
   </tests>

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -3130,6 +3130,10 @@ steps:
   - tool_id: __BUILD_LIST__
     in:
       datasets_0|input: input1
+    state:
+      datasets:
+      - id_cond:
+          id_select: id
     outputs:
       output:
         hide: true
@@ -3155,6 +3159,10 @@ steps:
   - tool_id: __BUILD_LIST__
     in:
       datasets_0|input: input1
+    state:
+      datasets:
+      - id_cond:
+          id_select: id
     outputs:
       output:
         delete_intermediate_datasets: true
@@ -3184,12 +3192,20 @@ steps:
   - tool_id: __BUILD_LIST__
     in:
       datasets_0|input: input1
+    state:
+      datasets:
+      - id_cond:
+          id_select: idx
     outputs:
       output:
         change_datatype: txt
   - tool_id: __BUILD_LIST__
     in:
       datasets_0|input: input1
+    state:
+      datasets:
+      - id_cond:
+          id_select: idx
 """, test_data="""
 input1:
   value: 1.fasta
@@ -3218,6 +3234,10 @@ steps:
   - tool_id: __BUILD_LIST__
     in:
       datasets_0|input: input1
+    state:
+      datasets:
+      - id_cond:
+          id_select: idx
     outputs:
       output:
         rename: "my new name"

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -270,6 +270,7 @@
   <tool file="${model_tools_path}/tag_collection_from_file.xml" />
   <tool file="${model_tools_path}/apply_rules.xml" />
   <tool file="${model_tools_path}/build_list.xml" />
+  <tool file="${model_tools_path}/build_list_1.2.0.xml" />
   <tool file="${model_tools_path}/extract_dataset.xml" />
 
 </toolbox>


### PR DESCRIPTION
allow also element_identifiers or a manually specified name

- [x] add tests to the tool
- [x] implement check for duplicate names?
  - I think it should be fine to allow duplicated names

would fix https://github.com/galaxyproject/galaxy/issues/7946