### PR TITLE
[20.09] Fix populated state for empty collections

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4012,7 +4012,7 @@ class DatasetCollection(Dictifiable, UsesAnnotations, RepresentById):
                 select_stmt = select(list(map(lambda dc: dc.c.populated_state, collection_depth_aliases))).select_from(select_from).where(dc.c.id == self.id).distinct()
                 for populated_states in db_session.execute(select_stmt).fetchall():
                     for populated_state in populated_states:
-                        if populated_state != DatasetCollection.populated_states.OK:
+                        if populated_state and populated_state != DatasetCollection.populated_states.OK:
                             _populated_optimized = False
 
             self._populated_optimized = _populated_optimized


### PR DESCRIPTION
This matches the non-optimized variant. If there's an empty collection
(because nothing has been discovered for instance)
DatasetCollection.populated would be true and
DatasetCollection.populated_optimized would be false. This is because of
the way we build the query. Noticed this with a workflow that worked
before https://github.com/galaxyproject/galaxy/pull/10917, which
switched the inputs ready check for database colletion tools to use the
populated_optimized method.