### PR TITLE
[20.09] Deploy postgresql and rabbitmq in kubernetes

### DIFF
--- a/.ci/minikube-test-setup/deployment.yaml
+++ b/.ci/minikube-test-setup/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: testing
+  name: testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test
+    spec:
+      containers:
+      - image: postgres:12
+        name: postgres
+        ports:
+        - containerPort: 5432
+        env:
+          - name: POSTGRES_DB
+            value: postgres
+          - name: POSTGRES_USER
+            value:  postgres
+          - name: POSTGRES_PASSWORD
+            value: postgres
+      - image: rabbitmq
+        name: rabbitmq
+        ports:
+        - containerPort: 5672

--- a/.ci/minikube-test-setup/start_services.sh
+++ b/.ci/minikube-test-setup/start_services.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+kubectl apply -f "$SCRIPTDIR/deployment.yaml"
+kubectl expose deployment testing --type=LoadBalancer --name=testing-service
+
+CLUSTER_IP=$(kubectl get service testing-service -o jsonpath='{.spec.clusterIP}')
+GALAXY_TEST_DBURI="postgresql://postgres:postgres@${CLUSTER_IP}:5432/galaxy?client_encoding=utf-8"
+GALAXY_TEST_AMQP_URL="amqp://${CLUSTER_IP}:5672)//"
+export GALAXY_TEST_DBURI
+export GALAXY_TEST_AMQP_URL

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -6,14 +6,15 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [3.7]
-        subset: ['upload_datatype', 'extended_metadata', 'kubernetes', 'not (upload_datatype or extended_metadata or kubernetes)']
+        python-version: ['3.7']
+        subset: ['kubernetes']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -25,39 +26,49 @@ jobs:
         ports:
           - 5672:5672
     steps:
-    - name: Prune unused docker image, volumes and containers
-      run: docker system prune -a -f
-    - name: Clean dotnet folder for space
-      if: matrix.subset == 'kubernetes'
-      run: rm -Rf /usr/share/dotnet
-    - name: Setup Minikube
-      if: matrix.subset == 'kubernetes'
-      id: minikube
-      uses: CodingNagger/minikube-setup-action@v1.0.3
-      with:
-        minikube-version: "1.9.0-0_amd64"
-    - name: Launch Minikube
-      if: matrix.subset == 'kubernetes'
-      run: eval ${{ steps.minikube.outputs.launcher }}
-    - name: Check pods
-      if: matrix.subset == 'kubernetes'
-      run: |
-        kubectl get pods
-    - uses: actions/checkout@v2
-      with:
-        path: 'galaxy root'
-    - uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Cache pip dir
-      uses: actions/cache@v1
-      id: pip-cache
-      with:
-        path: ~/.cache/pip
-        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-    - name: Install ffmpeg
-      run: sudo apt-get update && sudo apt-get install ffmpeg -y
-      if: matrix.subset == 'upload_datatype'
-    - name: Run tests
-      run: './run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'
-      working-directory: 'galaxy root'
+      - name: Prune unused docker image, volumes and containers
+        run: docker system prune -a -f
+      - name: Clean dotnet folder for space
+        if: matrix.subset == 'kubernetes'
+        run: rm -Rf /usr/share/dotnet
+      - name: Setup Minikube
+        if: matrix.subset == 'kubernetes'
+        id: minikube
+        uses: CodingNagger/minikube-setup-action@v1.0.3
+        with:
+          minikube-version: "1.9.0-0_amd64"
+      - name: Launch Minikube
+        if: matrix.subset == 'kubernetes'
+        run: eval ${{ steps.minikube.outputs.launcher }}
+      - name: Check pods
+        if: matrix.subset == 'kubernetes'
+        run: |
+          kubectl get pods
+      - uses: actions/checkout@v2
+        with:
+          path: 'galaxy root'
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dir
+        uses: actions/cache@v1
+        id: pip-cache
+        with:
+          path: ~/.cache/pip
+          key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install ffmpeg -y
+        if: matrix.subset == 'upload_datatype'
+      - name: Run tests
+        if: matrix.subset != 'kubernetes'
+        run: './run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'
+        working-directory: 'galaxy root'
+      - name: Run tests
+        if: matrix.subset == 'kubernetes'
+        run: 'source .ci/minikube-test-setup/start_services.sh && ./run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'
+        working-directory: 'galaxy root'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Integration test results (${{ matrix.python-version }}, ${{ matrix.subset }})
+          path: 'galaxy root/run_integration_tests.html'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7']
-        subset: ['kubernetes']
+        subset: ['upload_datatype', 'extended_metadata', 'kubernetes', 'not (upload_datatype or extended_metadata or kubernetes)']
     services:
       postgres:
         image: postgres:13

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -65,7 +65,9 @@ jobs:
         working-directory: 'galaxy root'
       - name: Run tests
         if: matrix.subset == 'kubernetes'
-        run: 'source .ci/minikube-test-setup/start_services.sh && ./run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'
+        run: |
+          . .ci/minikube-test-setup/start_services.sh
+          ./run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
Setting up minikube stops the postgres and rabbitmq containers that are
set up by the workflow. These are setup with custom docker networks, so
it isn't trivial to restart them. Instead we just deploy them to
minikube.