### PR TITLE
[20.09] Fix Workflow report markdown lost upon renaming WF

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4835,6 +4835,7 @@ class Workflow(Dictifiable, RepresentById):
         copied_workflow.name = self.name
         copied_workflow.has_cycles = self.has_cycles
         copied_workflow.has_errors = self.has_errors
+        copied_workflow.reports_config = self.reports_config
 
         # Map old step ids to new steps
         step_mapping = {}


### PR DESCRIPTION
Fixes #11280

When renaming a workflow from the popup-menu in the workflows list page...

![image](https://user-images.githubusercontent.com/46503462/107266278-903aea80-6a45-11eb-9509-f2f353cafe55.png)

The markdown report was not copied from the previous workflow version and the default markdown report was displayed instead.

I am not 100% sure this is the best way of keeping the markdown report from previous versions after a rename, but it seems to work :)
