### PR TITLE
Fix transiently failing roles API test.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -100,8 +100,8 @@ class RoleAPIController(BaseAPIController):
         role = self._role_manager.get(trans, role_id)
         return role_to_model(trans, role)
 
-    @web.require_admin
     @web.expose_api
+    @web.require_admin
     def create(self, trans: ProvidesUserContext, payload, **kwd):
         """
         POST /api/roles

--- a/lib/galaxy_test/api/test_roles.py
+++ b/lib/galaxy_test/api/test_roles.py
@@ -134,6 +134,9 @@ class RolesApiTestCase(ApiTestCase):
     def test_create_only_admin(self):
         response = self._post("roles", json=True)
         assert_status_code_is(response, 403)
+        response_err = response.json()
+        assert response_err["err_code"] == 403006
+        assert "administrator" in response_err["err_msg"]
 
     @staticmethod
     def check_role_dict(role_dict, assert_id=None):


### PR DESCRIPTION
I was able to get it to fail very rarely locally and I noticed some bugs (not returning a json response for instance even though it was annotated as such, decorators in the wrong order) - I don't know which error actually caused the connection reset error but these changes seem to maybe fix it.