### PR TITLE
[20.09] ITs with multiple entrypoints each linked to first entry, now link individually

### DIFF
--- a/client/src/components/ToolEntryPoints/ToolEntryPoints.vue
+++ b/client/src/components/ToolEntryPoints/ToolEntryPoints.vue
@@ -17,7 +17,7 @@
             <ul>
                 <li v-for="entryPoint of entryPoints" :key="entryPoint.id">
                     {{ entryPoint.name }}
-                    <span v-if="entryPoint.active"> (<a :href="entryPoints[0].target">click here to display</a>) </span>
+                    <span v-if="entryPoint.active"> (<a :href="entryPoint.target">click here to display</a>) </span>
                     <span v-else>
                         (waiting to become active...)
                     </span>


### PR DESCRIPTION
In the ITs dialogue box that opens in the middle panel, the links to various entrypoints were all the same, despite there being different <url> tags; this fixes that.