### PR TITLE
Multi-character strings shouldn't be split

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1363,7 +1363,7 @@ class ColumnListParameter(SelectToolParameter):
 
         value = other_values.get(self.name)
         if value is not None and value not in legal_values and self.is_file_empty(trans, other_values):
-            value = value if isinstance(value, list) is list else [value]
+            value = value if isinstance(value, list) else [value]
             legal_values.extend(value)
 
         return set(legal_values)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1363,6 +1363,7 @@ class ColumnListParameter(SelectToolParameter):
 
         value = other_values.get(self.name)
         if value is not None and value not in legal_values and self.is_file_empty(trans, other_values):
+            value = value if type(value) is list else [value]
             legal_values.extend(value)
 
         return set(legal_values)

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1363,7 +1363,7 @@ class ColumnListParameter(SelectToolParameter):
 
         value = other_values.get(self.name)
         if value is not None and value not in legal_values and self.is_file_empty(trans, other_values):
-            value = value if type(value) is list else [value]
+            value = value if isinstance(value, list) is list else [value]
             legal_values.extend(value)
 
         return set(legal_values)


### PR DESCRIPTION
When Galaxy determines the column values and there is a string with multiple characters using extend would split the string into 2 list entries. This shouldn't happen as a tab-separated file can have more than 10 columns. This causes issues when scheduling workflows with optional parameters only.