### PR TITLE
[21.01] Fix command line building when using interpreter

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -495,12 +495,10 @@ class ToolEvaluator:
             raise
         if interpreter:
             # TODO: path munging for cluster/dataset server relocatability
-            command_line_tokens = shlex.split(command_line)
-            executable = command_line_tokens[0]
+            executable = command_line.split()[0]
             tool_dir = os.path.abspath(self.tool.tool_dir)
             abs_executable = os.path.join(tool_dir, executable)
-            command_line_tokens[0:1] = [interpreter, abs_executable]
-            command_line = ' '.join(map(shlex.quote, command_line_tokens))
+            command_line = command_line.replace(executable, f"{interpreter} {shlex.quote(abs_executable)}", 1)
         self.command_line = command_line
 
     def __build_config_files(self):


### PR DESCRIPTION
Partially revert commit efa9e0fdd1d11d58f4a504a3e8242cc59f3f1416 which broke tools which use `interpreter` and `&&` or environment variables in the `<command />`.

xref.: https://github.com/galaxyproject/galaxy/pull/10674/commits/efa9e0fdd1d11d58f4a504a3e8242cc59f3f1416#r573844945