### PR TITLE
Allow `GET /api/dataset_collections/{hdca_id}` without specifying `instance_type`

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 import routes
 
-from galaxy.exceptions import ObjectNotFound, RequestParameterInvalidException
+from galaxy import exceptions
 from galaxy.managers.base import decode_id
 from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.collections_util import (
@@ -31,8 +31,7 @@ class DatasetCollectionsController(
 
     @expose_api
     def index(self, trans, **kwd):
-        trans.response.status = 501
-        return 'not implemented'
+        raise exceptions.NotImplemented
 
     @expose_api
     def create(self, trans: ProvidesHistoryContext, payload: dict, **kwd):
@@ -63,14 +62,18 @@ class DatasetCollectionsController(
             self.check_user_can_add_to_library_item(trans, library_folder, check_accessible=False)
             create_params["parent"] = library_folder
         else:
-            raise RequestParameterInvalidException()
+            raise exceptions.RequestParameterInvalidException()
 
         dataset_collection_instance = self.__service.create(trans=trans, **create_params)
         return dictify_dataset_collection_instance(dataset_collection_instance,
                                                    security=trans.security, parent=create_params["parent"])
 
     @expose_api
-    def show(self, trans: ProvidesHistoryContext, instance_type, id, **kwds):
+    def show(self, trans: ProvidesHistoryContext, id, instance_type='history', **kwds):
+        """
+        GET /api/dataset_collections/{hdca_id}
+        GET /api/dataset_collections/{ldca_id}?instance_type=library
+        """
         dataset_collection_instance = self.__service.get_dataset_collection_instance(
             trans,
             id=id,
@@ -81,7 +84,7 @@ class DatasetCollectionsController(
         elif instance_type == 'library':
             parent = dataset_collection_instance.folder
         else:
-            raise RequestParameterInvalidException()
+            raise exceptions.RequestParameterInvalidException()
 
         return dictify_dataset_collection_instance(
             dataset_collection_instance,
@@ -121,7 +124,7 @@ class DatasetCollectionsController(
         decoded_parent_id = decode_id(self.app, parent_id)
         if parent_id != hdca_id and not hdca.contains_collection(decoded_parent_id):
             errmsg = 'Requested dataset collection is not contained within indicated history content'
-            raise ObjectNotFound(errmsg)
+            raise exceptions.ObjectNotFound(errmsg)
 
         # retrieve contents
         contents_qry = svc.get_collection_contents_qry(decoded_parent_id, limit=limit, offset=offset)

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -281,7 +281,7 @@ class HistoryContentsController(BaseAPIController, UsesLibraryMixin, UsesLibrary
     @expose_api_raw_anonymous
     def download_dataset_collection(self, trans, id, history_id=None, **kwd):
         """
-        GET /api/histories/{history_id}/contents/{id}/download
+        GET /api/histories/{history_id}/contents/dataset_collections/{id}/download
         GET /api/dataset_collection/{id}/download
 
         Download the content of a HistoryDatasetCollection as a tgz archive

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -248,6 +248,7 @@ def populate_api_routes(webapp, app):
     ]
 
     # Accesss HDA details via histories/{history_id}/contents/datasets/{hda_id}
+    # and HDCA details via histories/{history_id}/contents/dataset_collections/{hdca_id}
     webapp.mapper.resource("content_typed",
                            "{type:%s}s" % "|".join(valid_history_contents_types),
                            name_prefix="history_",

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -311,6 +311,17 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         error_response = self._get(fake_contents_url)
         assert_object_id_error(error_response)
 
+    def test_show_dataset_collection(self):
+        fetch_response = self.dataset_collection_populator.create_list_in_history(self.history_id, direct_upload=True).json()
+        dataset_collection = self.dataset_collection_populator.wait_for_fetched_collection(fetch_response)
+        returned_dce = dataset_collection["elements"]
+        assert len(returned_dce) == 3, dataset_collection
+        hdca_id = dataset_collection['id']
+        dataset_collection_url = f"/api/dataset_collections/{hdca_id}"
+        dataset_collection = self._get(dataset_collection_url).json()
+        assert dataset_collection['id'] == hdca_id
+        assert dataset_collection['collection_type'] == 'list'
+
     def test_show_dataset_collection_contents(self):
         # Get contents_url from history contents, use it to show the first level
         # of collection contents in the created HDCA, then use it again to drill


### PR DESCRIPTION
Also:
- raise `exceptions.NotImplemented` for `GET /api/dataset_collections`
- add/fix API docs