### PR TITLE
[21.01] Form definition json fix

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1235,7 +1235,7 @@ model.FormValues.table = Table(
     Column("create_time", DateTime, default=now),
     Column("update_time", DateTime, default=now, onupdate=now),
     Column("form_definition_id", Integer, ForeignKey("form_definition.id"), index=True),
-    Column("content", JSONType))
+    Column("content", SimpleJSONType))
 
 model.Page.table = Table(
     "page", metadata,


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 305, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/users.py", line 346, in get_information
    info_form_models = self.get_all_forms(trans, filter=dict(deleted=False), form_type=trans.app.model.FormDefinition.types.USER_INFO)
  File "lib/galaxy/webapps/base/controller.py", line 1294, in get_all_forms
    return [fdc.latest_form for fdc in fdc_list if fdc.latest_form.type == form_type]
  File "lib/galaxy/webapps/base/controller.py", line 1294, in <listcomp>
    return [fdc.latest_form for fdc in fdc_list if fdc.latest_form.type == form_type]
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/attributes.py", line 287, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/attributes.py", line 723, in get
    value = self.callable_(state, passive)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/strategies.py", line 760, in _load_for_state
    session, state, primary_key_identity, passive
  File "<string>", line 1, in <lambda>
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/strategies.py", line 850, in _emit_lazyload
    session.query(self.mapper), primary_key_identity
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/ext/baked.py", line 615, in _load_on_pk_identity
    result = list(bq.for_session(self.session).params(**params))
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 100, in instances
    cursor.close()
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    with_traceback=exc_tb,
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 80, in instances
    rows = [proc(row) for row in fetch]
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 80, in <listcomp>
    rows = [proc(row) for row in fetch]
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 601, in _instance
    state.manager.dispatch.load(state, context)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/event/attr.py", line 322, in __call__
    fn(*args, **kw)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/ext/mutable.py", line 462, in load
    val = cls.coerce(key, val)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy_json/__init__.py", line 46, in coerce
    return super(cls).coerce(key, value)
AttributeError: 'super' object has no attribute 'coerce'
```