### PR TITLE
[21.01] Return None on unknown metadata attribute access

### DIFF
--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -113,7 +113,7 @@ class MetadataCollection(Mapping):
             return self.spec[name].wrap(self.spec[name].default, object_session(self.parent))
         if name in self.parent._metadata:
             return self.parent._metadata[name]
-        raise AttributeError
+        return None
 
     def __setattr__(self, name, value):
         if name == "parent":

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -113,6 +113,7 @@ class MetadataCollection(Mapping):
             return self.spec[name].wrap(self.spec[name].default, object_session(self.parent))
         if name in self.parent._metadata:
             return self.parent._metadata[name]
+        # Instead of raising an AttributeError for non-existing metadata, we return None
         return None
 
     def __setattr__(self, name, value):

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -379,6 +379,12 @@ class MappingTests(BaseModelTestCase):
         assert hist1.name == "History 2b"
         # gvk TODO need to ad test for GalaxySessions, but not yet sure what they should look like.
 
+    def test_metadata_spec(self):
+        metadata = dict(chromCol=1, startCol=2, endCol=3)
+        d = self.model.HistoryDatasetAssociation(extension="interval", metadata=metadata, sa_session=self.model.session)
+        assert d.metadata.chromCol == 1
+        assert d.metadata.anyAttribute is None
+
     def test_jobs(self):
         model = self.model
         u = model.User(email="jobtest@foo.bar.baz", password="password")


### PR DESCRIPTION
The AttributeError was added in https://github.com/galaxyproject/galaxy/pull/11293, but I think `if data.metadata.anyAttribute:` is something tool authors probably use.