### PR TITLE
[21.01] Fix job_destination display if job has no destination params yet

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -610,7 +610,9 @@ def summarize_destination_params(trans, job):
     destination_params = {'Runner': job.job_runner_name,
                           'Runner Job ID': job.job_runner_external_id,
                           'Handler': job.handler}
-    destination_params.update(job.destination_params)
+    job_destination_params = job.destination_params
+    if job_destination_params:
+        destination_params.update(job_destination_params)
     return destination_params
 
 


### PR DESCRIPTION
Fixes
```
TypeError: 'NoneType' object is not iterable
  File "galaxy/web/framework/decorators.py", line 305, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/jobs.py", line 329, in destination_params
    return summarize_destination_params(trans, job)
  File "galaxy/managers/jobs.py", line 613, in summarize_destination_params
    destination_params.update(job.destination_params)
```