### PR TITLE
[21.01] Don't log handled exceptions when filling cheetah template

### DIFF
--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1015,7 +1015,7 @@ def roundify(amount, sfs=2):
         return amount[0:sfs] + '0' * (len(amount) - sfs)
 
 
-def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', strip_null=False):
+def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', strip_null=False, log_exception=True):
     """
     Returns a Unicode string or None.
 
@@ -1041,8 +1041,9 @@ def unicodify(value, encoding=DEFAULT_ENCODING, error='replace', strip_null=Fals
         if not isinstance(value, str):
             value = str(value, encoding, error)
     except Exception as e:
-        msg = "Value '{}' could not be coerced to Unicode: {}('{}')".format(repr(value), type(e).__name__, e)
-        log.exception(msg)
+        if log_exception:
+            msg = "Value '{}' could not be coerced to Unicode: {}('{}')".format(repr(value), type(e).__name__, e)
+            log.exception(msg)
         raise
     if strip_null:
         return value.replace('\0', '')

--- a/lib/galaxy/util/template.py
+++ b/lib/galaxy/util/template.py
@@ -77,7 +77,7 @@ def fill_template(template_text,
         raise first_exception or e
     t = klass(searchList=[context])
     try:
-        return unicodify(t)
+        return unicodify(t, log_exception=False)
     except NotFound as e:
         if first_exception is None:
             first_exception = e


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/commit/5176a67a71a655845323ef9b37876901aa20f138
added a log.exception statement which is too noisy when handling Python
2 cheetah templates (and confused me at
first in https://sentry.galaxyproject.org/sentry/main/issues/1325262/).
This for instance appears in the logs:
```
galaxy.tools INFO 2021-02-12 09:48:49,968 Validated and populated state for tool request (20.957 ms)
galaxy.util ERROR 2021-02-12 09:48:50,004 Value '<DynamicallyCompiledCheetahTemplate.DynamicallyCompiledCheetahTemplate object at 0x173a0cbe0>' could not be coerced to Unicode: NotFound('cannot find 'reorder' while searching for 'sam_options.reorder'')
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/__init__.py", line 1039, in unicodify
    value = str(value)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "DynamicallyCompiledCheetahTemplate.py", line 86, in respond
NameMapper.NotFound: cannot find 'reorder' while searching for 'sam_options.reorder'
galaxy.util ERROR 2021-02-12 09:49:37,923 Value '<cheetah_DynamicallyCompiledCheetahTemplate_1613119560_966509_95726.DynamicallyCompiledCheetahTemplate object at 0x109385550>' could not be coerced to Unicode: NotFound('cannot find 'sam_opt' while searching for 'sam_options.sam_opt'')
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/__init__.py", line 1039, in unicodify
    value = str(value)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.8/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1613119560_966509_95726.py", line 86, in respond
NameMapper.NotFound: cannot find 'sam_opt' while searching for 'sam_options.sam_opt'
```
Even though everything is fine.