### PR TITLE
Only return a subset of jobs ready to run per user when querying for jobs ready to run

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -364,9 +364,9 @@
              For documentation on handler assignment methods, see the documentation under:
              https://docs.galaxyproject.org/en/latest/admin/scaling.html#job-handler-assignment-methods
 
-             The <handlers> container tag takes three optional attributes:
+             The <handlers> container tag takes four optional attributes:
 
-               <handlers assign_with="method" max_grab="count" default="id_or_tag"/>
+               <handlers assign_with="method" max_grab="count" ready_window_size="100" default="id_or_tag"/>
 
                - `assign_with` - How jobs should be assigned to handlers. The value can be a single method or a
                  comma-separated list that will be tried in order. The default depends on whether any handlers and a job
@@ -384,6 +384,15 @@
                  iteration. This only applies for methods that cause handlers to self-assign multiple jobs at once
                  (db-skip-locked, db-transaction-isolation) and the value is an integer > 0. Default is to grab as many
                  jobs ready to run as possible.
+
+               - `ready_window_size` - Handlers query for and dispatch jobs ready to run in a loop. If the number of
+                 jobs in the `new` state grows very large but they cannot be dispatched due to user concurrency limits,
+                 checking all of these jobs on every iteration can drastically slow down job throughput as each pending
+                 job is checked and then deferred due to limits. This option limits the number of jobs per user are
+                 returned by the query on each iteration. By default it is set to 100. Setting this lower can improve
+                 throughput for other users when one user submits thousands of independent jobs.
+
+                 Be aware that anonymous users are treated as a single user by this algorithm.
 
                - `default` - An ID or tag of the handler(s) that should handle any jobs not assigned to a specific
                  handler (which is probably most of them). If unset, the default is any untagged handlers plus any

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -281,6 +281,8 @@ class JobConfiguration(ConfiguresHandlers):
 
     DEFAULT_NWORKERS = 4
 
+    DEFAULT_HANDLER_READY_WINDOW_SIZE = 100
+
     JOB_RESOURCE_CONDITIONAL_XML = """<conditional name="__job_resource">
         <param name="__job_resource__select" type="select" label="Job Resource Parameters">
             <option value="no">Use default job resource parameters</option>
@@ -302,6 +304,7 @@ class JobConfiguration(ConfiguresHandlers):
         self.handler_assignment_methods = None
         self.handler_assignment_methods_configured = False
         self.handler_max_grab = None
+        self.handler_ready_job_window = None
         self.destinations = {}
         self.destination_tags = {}
         self.default_destination_id = None
@@ -392,6 +395,8 @@ class JobConfiguration(ConfiguresHandlers):
         log.info("Job handler assignment methods set to: %s", ', '.join(self.handler_assignment_methods))
         for tag, handlers in [(t, h) for t, h in self.handlers.items() if isinstance(h, list)]:
             log.info("Tag [%s] handlers: %s", tag, ', '.join(handlers))
+        self.handler_ready_window_size = int(handling_config_dict.get(
+            'ready_window_size', JobConfiguration.DEFAULT_HANDLER_READY_WINDOW_SIZE))
 
         # Parse environments
         job_metrics = self.app.job_metrics

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -304,7 +304,7 @@ class JobConfiguration(ConfiguresHandlers):
         self.handler_assignment_methods = None
         self.handler_assignment_methods_configured = False
         self.handler_max_grab = None
-        self.handler_ready_job_window = None
+        self.handler_ready_window_size = None
         self.destinations = {}
         self.destination_tags = {}
         self.default_destination_id = None

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -551,6 +551,7 @@ class JobConfiguration(ConfiguresHandlers):
             self._set_default_handler_assignment_methods()
         else:
             self.app.application_stack.init_job_handling(self)
+        self.handler_ready_window_size = JobConfiguration.DEFAULT_HANDLER_READY_WINDOW_SIZE
         # Set the destination
         self.default_destination_id = 'local'
         self.destinations['local'] = [JobDestination(id='local', runner='local')]

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -341,7 +341,7 @@ class JobHandlerQueue(Monitors):
                 .order_by(model.Job.id).subquery()
             jobs_to_check = self.sa_session.query(model.Job) \
                 .join(ranked, model.Job.id == ranked.c.id) \
-                .filter(ranked.c.rank <= 1).all()
+                .filter(ranked.c.rank <= self.app.job_config.handler_ready_window_size).all()
             # Filter jobs with invalid input states
             jobs_to_check = self.__filter_jobs_with_invalid_input_states(jobs_to_check)
             # Fetch all "resubmit" jobs

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -325,22 +325,18 @@ class JobHandlerQueue(Monitors):
                 .join(model.Dataset) \
                 .filter(and_(model.Job.state == model.Job.states.NEW,
                              model.Dataset.state.in_(model.Dataset.non_ready_states))).subquery()
+            job_filter_conditions = (
+                (model.Job.state == model.Job.states.NEW),
+                (model.Job.handler == self.app.config.server_name),
+                ~model.Job.table.c.id.in_(hda_not_ready),
+                ~model.Job.table.c.id.in_(ldda_not_ready))
             if self.app.config.user_activation_on:
-                jobs_to_check = self.sa_session.query(model.Job).enable_eagerloads(False) \
-                    .outerjoin(model.User) \
-                    .filter(and_((model.Job.state == model.Job.states.NEW),
-                                 or_((model.Job.user_id == null()), (model.User.active == true())),
-                                 (model.Job.handler == self.app.config.server_name),
-                                 ~model.Job.table.c.id.in_(hda_not_ready),
-                                 ~model.Job.table.c.id.in_(ldda_not_ready))) \
-                    .order_by(model.Job.id).all()
-            else:
-                jobs_to_check = self.sa_session.query(model.Job).enable_eagerloads(False) \
-                    .filter(and_((model.Job.state == model.Job.states.NEW),
-                                 (model.Job.handler == self.app.config.server_name),
-                                 ~model.Job.table.c.id.in_(hda_not_ready),
-                                 ~model.Job.table.c.id.in_(ldda_not_ready))) \
-                    .order_by(model.Job.id).all()
+                job_filter_conditions = job_filter_conditions + (
+                    or_((model.Job.user_id == null()), (model.User.active == true())),)
+            jobs_to_check = self.sa_session.query(model.Job).enable_eagerloads(False) \
+                .outerjoin(model.User) \
+                .filter(and_(*job_filter_conditions)) \
+                .order_by(model.Job.id).all()
             # Filter jobs with invalid input states
             jobs_to_check = self.__filter_jobs_with_invalid_input_states(jobs_to_check)
             # Fetch all "resubmit" jobs

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -339,7 +339,9 @@ class JobHandlerQueue(Monitors):
                 .outerjoin(model.User) \
                 .filter(and_(*job_filter_conditions)) \
                 .order_by(model.Job.id).subquery()
-            jobs_to_check = self.sa_session.query(ranked).filter(ranked.c.rank <= 1).all()
+            jobs_to_check = self.sa_session.query(model.Job) \
+                .join(ranked, model.Job.id == ranked.c.id) \
+                .filter(ranked.c.rank <= 1).all()
             # Filter jobs with invalid input states
             jobs_to_check = self.__filter_jobs_with_invalid_input_states(jobs_to_check)
             # Fetch all "resubmit" jobs

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -86,6 +86,9 @@ class ConfiguresHandlers:
             max_grab_str = config_element.attrib.get('max_grab', None)
             if max_grab_str:
                 handling_config_dict["max_grab"] = int(max_grab_str)
+            ready_window_size_str = config_element.attrib.get("ready_window_size", None)
+            if ready_window_size_str:
+                handling_config_dict["ready_window_size"] = int(ready_window_size_str)
 
         return handling_config_dict
 

--- a/test/unit/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/jobs/job_conf.sample_advanced.yml
@@ -327,11 +327,44 @@ runners:
     #app: {}
     #pulsar_config: path/to/pulsar/app.yml
 
+# Job handler configuration - for a full discussion of job handlers, see the documentation at:
+#     https://docs.galaxyproject.org/en/latest/admin/scaling.html
 handling:
+  # For more documentation on handler assignment methods, see the documentation under:
+  #     https://docs.galaxyproject.org/en/latest/admin/scaling.html#job-handler-assignment-methods
+  #
+  # How jobs should be assigned to handlers. The value is a list that will be tried in order. The default depends on
+  # whether any handlers and a job handler "pool" (such as uWSGI mules in a `job-handlers` farm) are configured. Valid
+  # methods are explained in detail in the documentation referenced above and have the values:
+  #
+  # - `mem-self` - In-memory Self Assignment
+  # - `db-self`- Database Self Assignment
+  # - `db-preassign` - Database Preassignment
+  # - `uwsgi-mule-message` - uWSGI Mule Messaging
+  # - `db-transaction-isolation` - Database Transaction Isolation
+  # - `db-skip-locked` - Database SKIP LOCKED
+  #
   #assign:
   #  - db-skip-locked
+
+  # Limit the number of jobs that a handler will self-assign per jobs-ready-to-run check loop iteration. This only
+  # applies for methods that cause handlers to self-assign multiple jobs at once (db-skip-locked,
+  # db-transaction-isolation) and the value is an integer > 0. Default is to grab as many jobs ready to run as possible.
   #max_grab: 8
+
+  # Handlers query for and dispatch jobs ready to run in a loop. If the number of jobs in the `new` state grows very
+  # large but they cannot be dispatched due to user concurrency limits, checking all of these jobs on every iteration
+  # can drastically slow down job throughput as each pending job is checked and then deferred due to limits. This option
+  # limits the number of jobs per user are returned by the query on each iteration. By default it is set to 100. Setting
+  # this lower can improve throughput for other users when one user submits thousands of independent jobs.
+  #
+  # Be aware that anonymous users are treated as a single user by this algorithm.
   #ready_window_size: 100
+
+  # An ID or tag of the handler(s) that should handle any jobs not assigned to a specific handler (which is probably
+  # most of them). If unset, the default is any untagged handlers plus any handlers in the `job-handlers` (no tag) pool.
+  #default: handler0
+
   processes:
     handler0:
     handler1:

--- a/test/unit/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/jobs/job_conf.sample_advanced.yml
@@ -328,6 +328,10 @@ runners:
     #pulsar_config: path/to/pulsar/app.yml
 
 handling:
+  #assign:
+  #  - db-skip-locked
+  #max_grab: 8
+  #ready_window_size: 100
   processes:
     handler0:
     handler1:


### PR DESCRIPTION
Observing a problem we currently have on usegalaxy.org, where there are 21,000 jobs in the `new` state, but very few of them are dispatched on each iteration of the handler monitor thread because those jobs are mostly owned by a small number of users and the concurrency limits are preventing their new jobs from dispatching. Every iteration of the loop the monitor thread will resolve destinations (i.e. run them through your dynamic rules...), check limits, etc. for all 21k of these jobs and then defer the overwhelming majority of them until the next loop. All of that takes a lot of time. In the meantime, any new jobs submitted by other users will not even be dispatched to a runner plugin until the end of the *next* iteration of the loop.

So this change uses windowing/partitioning to only return the top `ready_window_size` (default: 100) jobs *per user* on each iteration of the monitor thread. 

A few things to be aware of:

- Anonymous users are treated as a single user by this algorithm. This is probably fixable by having a separate query for anonymous jobs if this becomes a problem (we could even do the rank/window by session) since one extra query is unlikely to be problematic from a performance standpoint. 
- This applies to jobs whose inputs are terminal - jobs whose inputs are not terminal are already filtered out of the query.
- If you are using per-destination (or per-destination-tag) limits, small window sizes could prevent a user's jobs on destinations where they are under the limit from running if their oldest jobs are on destinations where they are over the limit. For example let's say you have set the window size to 20, you have configured 2 job destinations, `multicore` and `singlecore` each with a limit of 10 concurrent jobs per user, and you have 10 jobs running on the `multicore` destination but 0 jobs running on `singlecore`. You also have 100 independent jobs in the `new` state whose inputs are all ready, the first 40 of which are destined for `multicore` and the last 60 of which are destined for `singlecore`.

  Your `singlecore` jobs will have to wait until there are only 19 `multicore` jobs waiting to be dispatched before any of the `singlecore` jobs will start being dispatched, even though you are under your limits there.

  You can mitigate this by not setting `ready_window_size` too low, or avoid it entirely by having separate job handlers (see the `handler` attrib for `<tool>` tags in the job conf) for these destinations.
- Although you can use this as a form of concurrency limits, I think it's better to use this as a safety measure so one person having 10k pending jobs doesn't destroy that handler for everyone else. If you need concurrency limits,  Galaxy already does that in a much more fine-grained manner.

I thought about making this configurable such that the old non-windowed query would be the default but this seems to work fine even with SQLite.

As for performance: the regular job readiness query for one handler on usegalaxy.org currently returns 6902 rows, with this query and `ready_window_size` set to 20, it returns 374 rows, with no hit on query performance (both run in ~320ms).