### PR TITLE
[21.01] Change some more JSONType fields to non-tracked variant

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1225,9 +1225,9 @@ model.FormDefinition.table = Table(
     Column("name", TrimmedString(255), nullable=False),
     Column("desc", TEXT),
     Column("form_definition_current_id", Integer, ForeignKey("form_definition_current.id", use_alter=True), index=True, nullable=False),
-    Column("fields", JSONType),
+    Column("fields", SimpleJSONType),
     Column("type", TrimmedString(255), index=True),
-    Column("layout", JSONType))
+    Column("layout", SimpleJSONType))
 
 model.FormValues.table = Table(
     "form_values", metadata,


### PR DESCRIPTION
Fixes
```
galaxy.web.framework.decorators ERROR 2021-02-12 16:45:00,808 [p:24875,w:1,m:0] [uWSGIWorker1Core2] Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 305, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/users.py", line 346, in get_information
    info_form_models = self.get_all_forms(trans, filter=dict(deleted=False), form_type=trans.app.model.FormDefinition.types.USER_INFO)
  File "lib/galaxy/webapps/base/controller.py", line 1294, in get_all_forms
    return [fdc.latest_form for fdc in fdc_list if fdc.latest_form.type == form_type]
  File "lib/galaxy/webapps/base/controller.py", line 1294, in <listcomp>
    return [fdc.latest_form for fdc in fdc_list if fdc.latest_form.type == form_type]
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/attributes.py", line 287, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/attributes.py", line 723, in get
    value = self.callable_(state, passive)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/strategies.py", line 760, in _load_for_state
    session, state, primary_key_identity, passive
  File "<string>", line 1, in <lambda>
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/strategies.py", line 850, in _emit_lazyload
    session.query(self.mapper), primary_key_identity
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/ext/baked.py", line 615, in _load_on_pk_identity
    result = list(bq.for_session(self.session).params(**params))
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 100, in instances
    cursor.close()
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    with_traceback=exc_tb,
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 80, in instances
    rows = [proc(row) for row in fetch]
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 80, in <listcomp>
    rows = [proc(row) for row in fetch]
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/orm/loading.py", line 601, in _instance
    state.manager.dispatch.load(state, context)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/event/attr.py", line 322, in __call__
    fn(*args, **kw)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy/ext/mutable.py", line 462, in load
    val = cls.coerce(key, val)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/sqlalchemy_json/__init__.py", line 46, in coerce
    return super(cls).coerce(key, value)
AttributeError: 'super' object has no attribute 'coerce'
```