### PR TITLE
[21.01] Revert sqlalachemy-json, add unit tests, fix 'MutationList' object has no attribute '_key'

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -164,7 +164,6 @@ simplejson==3.17.2; python_version >= '2.5' and python_version not in '3.0, 3.1,
 six==1.15.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 social-auth-core[openidconnect]==3.3.0
 sortedcontainers==2.3.0
-sqlalchemy-json==0.4.0
 sqlalchemy-migrate==0.13.0
 sqlalchemy-utils==0.36.7
 sqlalchemy==1.3.20

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -205,6 +205,16 @@ class MutationDict(MutationObj, dict):
     def __setstate__(self, state):
         self.update(state)
 
+    def pop(self, *args, **kw):
+        value = super().pop(*args, **kw)
+        self.changed()
+        return value
+
+    def update(self, *args, **kwargs):
+        value = super().update(*args, **kwargs)
+        self.changed()
+        return value
+
 
 class MutationList(MutationObj, list):
     @classmethod

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -125,9 +125,9 @@ class MutationObj(Mutable):
     """
 
     def __new__(cls, *args, **kwds):
-        tracked = super().__new__(cls, *args, **kwds)
-        tracked._key = None
-        return tracked
+        self = super().__new__(cls, *args, **kwds)
+        self._key = None
+        return self
 
     @classmethod
     def coerce(cls, key, value):
@@ -191,13 +191,12 @@ class MutationDict(MutationObj, dict):
         return self
 
     def __setitem__(self, key, value):
-        if hasattr(self, '_key'):
-            value = MutationObj.coerce(self._key, value)
-        dict.__setitem__(self, key, value)
+        value = MutationObj.coerce(self._key, value)
+        super().__setitem__(key, value)
         self.changed()
 
     def __delitem__(self, key):
-        dict.__delitem__(self, key)
+        super().__delitem__(key)
         self.changed()
 
     def __getstate__(self):
@@ -216,19 +215,19 @@ class MutationList(MutationObj, list):
         return self
 
     def __setitem__(self, idx, value):
-        list.__setitem__(self, idx, MutationObj.coerce(self._key, value))
+        super().__setitem__(idx, MutationObj.coerce(self._key, value))
         self.changed()
 
     def __setslice__(self, start, stop, values):
-        list.__setslice__(self, start, stop, (MutationObj.coerce(self._key, v) for v in values))
+        super().__setslice__(start, stop, (MutationObj.coerce(self._key, v) for v in values))
         self.changed()
 
     def __delitem__(self, idx):
-        list.__delitem__(self, idx)
+        super().__delitem__(idx)
         self.changed()
 
     def __delslice__(self, start, stop):
-        list.__delslice__(self, start, stop)
+        super().__delslice__(start, stop)
         self.changed()
 
     def __copy__(self):
@@ -238,26 +237,25 @@ class MutationList(MutationObj, list):
         return MutationList(MutationObj.coerce(self._key, copy.deepcopy(self[:])))
 
     def append(self, value):
-        list.append(self, MutationObj.coerce(self._key, value))
+        super().append(MutationObj.coerce(self._key, value))
         self.changed()
 
     def insert(self, idx, value):
-        list.insert(self, idx, MutationObj.coerce(self._key, value))
+        super().insert(self, idx, MutationObj.coerce(self._key, value))
         self.changed()
 
     def extend(self, values):
-        if hasattr(self, '_key'):
-            values = (MutationObj.coerce(self._key, value) for value in values)
-        list.extend(self, values)
+        values = (MutationObj.coerce(self._key, value) for value in values)
+        super().extend(values)
         self.changed()
 
     def pop(self, *args, **kw):
-        value = list.pop(self, *args, **kw)
+        value = super().pop(*args, **kw)
         self.changed()
         return value
 
     def remove(self, value):
-        list.remove(self, value)
+        super().remove(value)
         self.changed()
 
 

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -123,6 +123,12 @@ class MutationObj(Mutable):
 
     And other minor changes to make it work for us.
     """
+
+    def __new__(cls, *args, **kwds):
+        tracked = super().__new__(cls, *args, **kwds)
+        tracked._key = None
+        return tracked
+
     @classmethod
     def coerce(cls, key, value):
         if isinstance(value, dict) and not isinstance(value, MutationDict):

--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -9,18 +9,12 @@ from sys import getsizeof
 
 import numpy
 import sqlalchemy
+from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.types import (
     CHAR,
     LargeBinary,
     String,
     TypeDecorator
-)
-# For compatibility with custom yaml dumping in gxformat2
-from sqlalchemy_json import (  # noqa: F401
-    mutable_json_type,
-    NestedMutableDict as MutationDict,
-    NestedMutableList as MutationList,
-    track
 )
 
 from galaxy.util import (
@@ -30,7 +24,6 @@ from galaxy.util import (
 from galaxy.util.aliaspickler import AliasPickleModule
 
 log = logging.getLogger(__name__)
-track.TrackedObject.parent = None  # https://github.com/edelooff/sqlalchemy-json/pull/28
 
 
 class SafeJsonEncoder(json.JSONEncoder):
@@ -84,7 +77,7 @@ class GalaxyLargeBinary(LargeBinary):
         return process
 
 
-class SimpleJSONType(sqlalchemy.types.TypeDecorator):
+class JSONType(sqlalchemy.types.TypeDecorator):
     """
     Represents an immutable structure as a json-encoded string.
 
@@ -119,6 +112,150 @@ class SimpleJSONType(sqlalchemy.types.TypeDecorator):
     def compare_values(self, x, y):
         return (x == y)
 
+
+class MutationObj(Mutable):
+    """
+    Mutable JSONType for SQLAlchemy from original gist:
+    https://gist.github.com/dbarnett/1730610
+
+    Using minor changes from this fork of the gist:
+    https://gist.github.com/miracle2k/52a031cced285ba9b8cd
+
+    And other minor changes to make it work for us.
+    """
+    @classmethod
+    def coerce(cls, key, value):
+        if isinstance(value, dict) and not isinstance(value, MutationDict):
+            return MutationDict.coerce(key, value)
+        if isinstance(value, list) and not isinstance(value, MutationList):
+            return MutationList.coerce(key, value)
+        return value
+
+    @classmethod
+    def _listen_on_attribute(cls, attribute, coerce, parent_cls):
+        key = attribute.key
+        if parent_cls is not attribute.class_:
+            return
+
+        # rely on "propagate" here
+        parent_cls = attribute.class_
+
+        def load(state, *args):
+            val = state.dict.get(key, None)
+            if coerce and key not in state.unloaded:
+                val = cls.coerce(key, val)
+                state.dict[key] = val
+            if isinstance(val, cls):
+                val._parents[state.obj()] = key
+
+        def set(target, value, oldvalue, initiator):
+            if not isinstance(value, cls):
+                value = cls.coerce(key, value)
+            if isinstance(value, cls):
+                value._parents[target.obj()] = key
+            if isinstance(oldvalue, cls):
+                oldvalue._parents.pop(target.obj(), None)
+            return value
+
+        def pickle(state, state_dict):
+            val = state.dict.get(key, None)
+            if isinstance(val, cls):
+                if 'ext.mutable.values' not in state_dict:
+                    state_dict['ext.mutable.values'] = []
+                state_dict['ext.mutable.values'].append(val)
+
+        def unpickle(state, state_dict):
+            if 'ext.mutable.values' in state_dict:
+                for val in state_dict['ext.mutable.values']:
+                    val._parents[state.obj()] = key
+
+        sqlalchemy.event.listen(parent_cls, 'load', load, raw=True, propagate=True)
+        sqlalchemy.event.listen(parent_cls, 'refresh', load, raw=True, propagate=True)
+        sqlalchemy.event.listen(attribute, 'set', set, raw=True, retval=True, propagate=True)
+        sqlalchemy.event.listen(parent_cls, 'pickle', pickle, raw=True, propagate=True)
+        sqlalchemy.event.listen(parent_cls, 'unpickle', unpickle, raw=True, propagate=True)
+
+
+class MutationDict(MutationObj, dict):
+    @classmethod
+    def coerce(cls, key, value):
+        """Convert plain dictionary to MutationDict"""
+        self = MutationDict((k, MutationObj.coerce(key, v)) for (k, v) in value.items())
+        self._key = key
+        return self
+
+    def __setitem__(self, key, value):
+        if hasattr(self, '_key'):
+            value = MutationObj.coerce(self._key, value)
+        dict.__setitem__(self, key, value)
+        self.changed()
+
+    def __delitem__(self, key):
+        dict.__delitem__(self, key)
+        self.changed()
+
+    def __getstate__(self):
+        return dict(self)
+
+    def __setstate__(self, state):
+        self.update(state)
+
+
+class MutationList(MutationObj, list):
+    @classmethod
+    def coerce(cls, key, value):
+        """Convert plain list to MutationList"""
+        self = MutationList(MutationObj.coerce(key, v) for v in value)
+        self._key = key
+        return self
+
+    def __setitem__(self, idx, value):
+        list.__setitem__(self, idx, MutationObj.coerce(self._key, value))
+        self.changed()
+
+    def __setslice__(self, start, stop, values):
+        list.__setslice__(self, start, stop, (MutationObj.coerce(self._key, v) for v in values))
+        self.changed()
+
+    def __delitem__(self, idx):
+        list.__delitem__(self, idx)
+        self.changed()
+
+    def __delslice__(self, start, stop):
+        list.__delslice__(self, start, stop)
+        self.changed()
+
+    def __copy__(self):
+        return MutationList(MutationObj.coerce(self._key, self[:]))
+
+    def __deepcopy__(self, memo):
+        return MutationList(MutationObj.coerce(self._key, copy.deepcopy(self[:])))
+
+    def append(self, value):
+        list.append(self, MutationObj.coerce(self._key, value))
+        self.changed()
+
+    def insert(self, idx, value):
+        list.insert(self, idx, MutationObj.coerce(self._key, value))
+        self.changed()
+
+    def extend(self, values):
+        if hasattr(self, '_key'):
+            values = (MutationObj.coerce(self._key, value) for value in values)
+        list.extend(self, values)
+        self.changed()
+
+    def pop(self, *args, **kw):
+        value = list.pop(self, *args, **kw)
+        self.changed()
+        return value
+
+    def remove(self, value):
+        list.remove(self, value)
+        self.changed()
+
+
+MutationObj.associate_with(JSONType)
 
 metadata_pickler = AliasPickleModule({
     ("cookbook.patterns", "Bunch"): ("galaxy.util.bunch", "Bunch")
@@ -167,7 +304,7 @@ def total_size(o, handlers=None, verbose=False):
     return sizeof(o)
 
 
-class _MetadataType(SimpleJSONType):
+class MetadataType(JSONType):
     """
     Backward compatible metadata type. Can read pickles or JSON, but always
     writes in JSON.
@@ -198,10 +335,6 @@ class _MetadataType(SimpleJSONType):
             except Exception:
                 ret = None
         return ret
-
-
-JSONType = mutable_json_type(dbtype=SimpleJSONType, nested=True)
-MetadataType = mutable_json_type(dbtype=_MetadataType, nested=True)
 
 
 class UUIDType(TypeDecorator):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -41,7 +41,6 @@ from galaxy.model.base import ModelMapping
 from galaxy.model.custom_types import (
     JSONType,
     MetadataType,
-    SimpleJSONType,
     TrimmedString,
     UUIDType,
 )
@@ -864,7 +863,7 @@ model.PostJobAction.table = Table(
     Column("workflow_step_id", Integer, ForeignKey("workflow_step.id"), index=True, nullable=True),
     Column("action_type", String(255), nullable=False),
     Column("output_name", String(255), nullable=True),
-    Column("action_arguments", SimpleJSONType, nullable=True))
+    Column("action_arguments", JSONType, nullable=True))
 
 model.PostJobActionAssociation.table = Table(
     "post_job_action_association", metadata,
@@ -1041,7 +1040,7 @@ model.WorkflowStepInput.table = Table(
     Column("scatter_type", TEXT),
     Column("value_from", JSONType),
     Column("value_from_type", TEXT),
-    Column("default_value", SimpleJSONType),
+    Column("default_value", JSONType),
     Column("default_value_set", Boolean, default=False),
     Column("runtime_value", Boolean, default=False),
     Index('ix_workflow_step_input_workflow_step_id_name_unique', "workflow_step_id", "name", unique=True, mysql_length={'name': 200}),
@@ -1054,7 +1053,7 @@ model.WorkflowRequestStepState.table = Table(
     Column("workflow_invocation_id", Integer,
         ForeignKey("workflow_invocation.id", onupdate="CASCADE", ondelete="CASCADE")),
     Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
-    Column("value", SimpleJSONType))
+    Column("value", JSONType))
 
 model.WorkflowRequestInputParameter.table = Table(
     "workflow_request_input_parameters", metadata,
@@ -1070,7 +1069,7 @@ model.WorkflowRequestInputStepParameter.table = Table(
     Column("id", Integer, primary_key=True),
     Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
     Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
-    Column("parameter_value", SimpleJSONType),
+    Column("parameter_value", JSONType),
 )
 
 model.WorkflowRequestToInputDatasetAssociation.table = Table(
@@ -1129,7 +1128,7 @@ model.WorkflowInvocationStep.table = Table(
     Column("state", TrimmedString(64), index=True),
     Column("job_id", Integer, ForeignKey("job.id"), index=True, nullable=True),
     Column("implicit_collection_jobs_id", Integer, ForeignKey("implicit_collection_jobs.id"), index=True, nullable=True),
-    Column("action", SimpleJSONType, nullable=True))
+    Column("action", JSONType, nullable=True))
 
 model.WorkflowInvocationOutputDatasetAssociation.table = Table(
     "workflow_invocation_output_dataset_association", metadata,
@@ -1155,7 +1154,7 @@ model.WorkflowInvocationOutputValue.table = Table(
     Column("workflow_invocation_id", Integer, ForeignKey("workflow_invocation.id"), index=True),
     Column("workflow_step_id", Integer, ForeignKey("workflow_step.id")),
     Column("workflow_output_id", Integer, ForeignKey("workflow_output.id"), index=True),
-    Column("value", SimpleJSONType),
+    Column("value", JSONType),
 )
 
 model.WorkflowInvocationStepOutputDatasetAssociation.table = Table(
@@ -1225,9 +1224,9 @@ model.FormDefinition.table = Table(
     Column("name", TrimmedString(255), nullable=False),
     Column("desc", TEXT),
     Column("form_definition_current_id", Integer, ForeignKey("form_definition_current.id", use_alter=True), index=True, nullable=False),
-    Column("fields", SimpleJSONType),
+    Column("fields", JSONType),
     Column("type", TrimmedString(255), index=True),
-    Column("layout", SimpleJSONType))
+    Column("layout", JSONType))
 
 model.FormValues.table = Table(
     "form_values", metadata,
@@ -1235,7 +1234,7 @@ model.FormValues.table = Table(
     Column("create_time", DateTime, default=now),
     Column("update_time", DateTime, default=now, onupdate=now),
     Column("form_definition_id", Integer, ForeignKey("form_definition.id"), index=True),
-    Column("content", SimpleJSONType))
+    Column("content", JSONType))
 
 model.Page.table = Table(
     "page", metadata,

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -11,7 +11,6 @@ pycryptodome
 pysam
 social-auth-core[openidconnect]==3.3.0
 SQLAlchemy
-sqlalchemy-json
 sqlalchemy-migrate
 sqlalchemy-utils
 WebOb

--- a/test/unit/data/test_mutable_json_column.py
+++ b/test/unit/data/test_mutable_json_column.py
@@ -1,0 +1,72 @@
+import copy
+
+from .test_galaxy_mapping import BaseModelTestCase
+
+
+class MutableColumnTest(BaseModelTestCase):
+
+    def persist_and_reload(self, item):
+        item_id = item.id
+        self.model.session.flush()
+        self.model.session.expunge_all()
+        return self.model.session.query(self.model.Workflow).get(item_id)
+
+    def test_metadata_mutable_column(self):
+        w = self.model.Workflow()
+        self.model.session.add(w)
+        self.model.session.flush()
+        w.reports_config = {'x': 'z'}
+        persisted = self.persist_and_reload(w)
+        assert persisted.reports_config == {'x': 'z'}
+        persisted.reports_config['x'] = '1'
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config['x'] == '1'
+        # test string
+        persisted.reports_config = 'abcdefg'
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == 'abcdefg'
+        # test int
+        persisted.reports_config = 1
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == 1
+        # test float
+        persisted.reports_config = 1.1
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == 1.1
+        # test bool
+        persisted.reports_config = True
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config is True
+        # Test nested dict/list
+        persisted.reports_config = {'list': [[1, 2, 3]]}
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == {'list': [[1, 2, 3]]}
+        copy.deepcopy(persisted.reports_config)
+        persisted.reports_config.pop('list') == [[1, 2, 3]]
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == {}
+        persisted.reports_config.update({'x': 'z'})
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == {'x': 'z'}
+        del persisted.reports_config['x']
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == {}
+        persisted.reports_config = {'x': {'y': 'z'}}
+        persisted = self.persist_and_reload(persisted)
+        assert persisted.reports_config == {'x': {'y': 'z'}}
+        # These tests are failing ... at least since 20.09,
+        # but nested mutable change tracking might have
+        # never worked
+
+        # persisted.reports_config['x']['y'] = 'x'
+        # persisted = self.persist_and_reload(persisted)
+        # assert persisted.reports_config == {'x': {'y': 'x'}}
+        # persisted.reports_config[0].append(2)
+        # persisted = self.persist_and_reload(persisted)
+        # assert persisted.reports_config[0] == [1, 2]
+        # persisted.reports_config[0].extend([3, 4])
+        # persisted = self.persist_and_reload(persisted)
+        # assert persisted.reports_config[0] == [1, 2, 3, 4]
+        # persisted.reports_config[0].remove(4)
+        # persisted = self.persist_and_reload(persisted)
+        # assert persisted.reports_config[0] == [1, 2, 3]


### PR DESCRIPTION
Unfortunately there are still some places left that use non-dict/non-list values on JSONType columns, and that crashes currently.

We could fix those, but I'm not super-comfortable with making everything a `SimpleJSON` type column, even if we probably only need to keep the `_metadata` column as a nested mutable JSON column. So this reverts custom_types.py to the state in 20.09.
https://github.com/galaxyproject/galaxy/pull/11366/commits/66a5f4414c923d34bc303c200547c158ec8174ce then fixes `AttributeError: 'MutationList' object has no attribute '_key'` that I tried to fix by moving the sqlalchemy-json/sqlalchemy-mutable.
https://github.com/galaxyproject/galaxy/pull/11366/commits/af47800c4969914d6427728aa3160ee277a26b2d adds some unit tests that I used to figure out what is actually currently possible with our JSONType column (which is less than I was assuming ...)