### PR TITLE
[20.09] Fix Mtx unbound error

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -1272,6 +1272,7 @@ class MatrixMarket(TabularData):
     def set_meta(self, dataset, overwrite=True, skip=None, max_data_lines=5, **kwd):
         if dataset.has_data():
             with open(dataset.file_name) as dataset_fh:
+                l = ''
                 comment_lines = 0
                 for i, l in enumerate(dataset_fh):
                     if l.startswith('%'):


### PR DESCRIPTION
If the dataset is empty ... not a big issue, but there was some refactoring in 21.01 where this became an actual bug. Will open another PR for that one.