### PR TITLE
[21.01] Fix setCurrentHistoryId in legacy history panel context

### DIFF
--- a/client/src/components/History/model/syncCurrentHistoryToGalaxy.js
+++ b/client/src/components/History/model/syncCurrentHistoryToGalaxy.js
@@ -30,7 +30,7 @@ export function syncCurrentHistoryToGalaxy(galaxy$, store, cfg = {}) {
     );
 
     return historyId$.subscribe(
-        (id) => store.commit("betaHistory/setCurrentHistoryId", id),
+        (id) => store.dispatch("betaHistory/setCurrentHistoryId", id),
         (err) => console.warn("syncCurrentHistoryToGalaxy error", err),
         () => console.log("syncCurrentHistoryToGalaxy complete")
     );


### PR DESCRIPTION
If we create a new history in the legacy history the store does not get
updated, so
https://github.com/galaxyproject/galaxy/blame/3f47effa087f4049132da65643396d58a2be51d1/client/src/components/History/model/historyStore.js#L48
will always return the most recently used history.
This is a little silly in that we will load the history twice, but we
don't switch the history so often that it should matter.

If you want to test this, open the upload modal, close it, and switch to a new history, then upload a file. The dataset will appear in the old history. This fixes that.