### PR TITLE
[21.01] Fix metadataspec attribute access again

### DIFF
--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -113,8 +113,12 @@ class MetadataCollection(Mapping):
             return self.spec[name].wrap(self.spec[name].default, object_session(self.parent))
         if name in self.parent._metadata:
             return self.parent._metadata[name]
-        # Instead of raising an AttributeError for non-existing metadata, we return None
-        return None
+        try:
+            attr = Mapping.__getattribute__(self, name)
+        except AttributeError:
+            # Instead of raising an AttributeError for non-existing metadata, we return None
+            return None
+        return attr
 
     def __setattr__(self, name, value):
         if name == "parent":

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -384,6 +384,7 @@ class MappingTests(BaseModelTestCase):
         d = self.model.HistoryDatasetAssociation(extension="interval", metadata=metadata, sa_session=self.model.session)
         assert d.metadata.chromCol == 1
         assert d.metadata.anyAttribute is None
+        assert d.metadata.items()
 
     def test_jobs(self):
         model = self.model


### PR DESCRIPTION
This is similar to https://github.com/galaxyproject/galaxy/pull/11353, except it would fail for instance methods such as `.items()`