### PR TITLE
Fix TypeError in WorkflowsAPIController.get_versions()

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -258,7 +258,8 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
 
         Lists all versions of this workflow.
         """
-        stored_workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id)
+        instance = util.string_as_bool(kwds.get("instance", "false"))
+        stored_workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id, by_stored_id=not instance)
         return [{'version': i, 'update_time': str(w.update_time), 'steps': len(w.steps)} for i, w in enumerate(reversed(stored_workflow.workflows))]
 
     @expose_api

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -258,7 +258,7 @@ class WorkflowsAPIController(BaseAPIController, UsesStoredWorkflowMixin, UsesAnn
 
         Lists all versions of this workflow.
         """
-        stored_workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id, **kwds)
+        stored_workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id)
         return [{'version': i, 'update_time': str(w.update_time), 'steps': len(w.steps)} for i, w in enumerate(reversed(stored_workflow.workflows))]
 
     @expose_api


### PR DESCRIPTION
Small fix for error

`
galaxy.web.framework.decorators ERROR 2021-02-15 10:36:14,965 [p:61509,w:1,m:0] [uWSGIWorker1Core2] Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 309, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/workflows.py", line 262, in show_versions
    stored_workflow = self.workflow_manager.get_stored_accessible_workflow(trans, workflow_id, **kwds)
TypeError: get_stored_accessible_workflow() got an unexpected keyword argument 'key'
`

when making a GET request to

`/api/workflows/{encoded_workflow_id}/versions`