### PR TITLE
Lint for optional or multiple selects with radio display

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -45,11 +45,12 @@ def lint_inputs(tool_xml, lint_ctx):
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
 
-            if param_attrib["display"] == "radio":
-                if param_attrib["optional"] == "true":
-                    lint_ctx.error('Select [%s] display="radio" is incompatible with optional="true"', param_name)
-                if param_attrib["multiple"] == "true":
+            if param_attrib.get("display", "checkboxes") == "radio":
+                multiple = string_as_bool(param_attrib.get("multiple", False))
+                if multiple:
                     lint_ctx.error('Select [%s] display="radio" is incompatible with multiple="true"', param_name)
+                if string_as_bool(param_attrib.get("optional", multiple)):
+                    lint_ctx.error('Select [%s] display="radio" is incompatible with optional="true"', param_name)
         # TODO: Validate type, much more...
 
     conditional_selects = tool_xml.findall("./inputs//conditional")

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -46,10 +46,9 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.warn(message)
 
             if param_attrib.get("display", "checkboxes") == "radio":
-                multiple = string_as_bool(param_attrib.get("multiple", False))
-                if multiple:
+                if string_as_bool(param_attrib.get("multiple", "false")):
                     lint_ctx.error('Select [%s] display="radio" is incompatible with multiple="true"', param_name)
-                if string_as_bool(param_attrib.get("optional", multiple)):
+                if string_as_bool(param_attrib.get("optional", "false")):
                     lint_ctx.error('Select [%s] display="radio" is incompatible with optional="true"', param_name)
         # TODO: Validate type, much more...
 

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -44,6 +44,12 @@ def lint_inputs(tool_xml, lint_ctx):
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
+
+            if param_attrib["display"] == "radio":
+                if param_attrib["optional"] == "true":
+                    lint_ctx.error('Select [%s] display="radio" is incompatible with optional="true"', param_name)
+                if param_attrib["multiple"] == "true":
+                    lint_ctx.error('Select [%s] display="radio" is incompatible with multiple="true"', param_name)
         # TODO: Validate type, much more...
 
     conditional_selects = tool_xml.findall("./inputs//conditional")

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -45,7 +45,7 @@ def lint_inputs(tool_xml, lint_ctx):
                 message = "No options defined for select [%s]" % param_name
                 lint_ctx.warn(message)
 
-            if param_attrib.get("display", "checkboxes") == "radio":
+            if param_attrib.get("display") == "radio":
                 if string_as_bool(param_attrib.get("multiple", "false")):
                     lint_ctx.error('Select [%s] display="radio" is incompatible with multiple="true"', param_name)
                 if string_as_bool(param_attrib.get("optional", "false")):

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2889,12 +2889,14 @@ the column index.
           <xs:annotation>
             <xs:documentation xml:lang="en">This attribute is used only if
 ``type`` attribute value is ``select`` - render a select list as a set of check
-boxes or radio buttons. Defaults to a drop-down menu select list.</xs:documentation>
+boxes (``display="checkboxes"``) or radio buttons (``display="radio"``, note this
+is incompatible with ``multiple="true"`` and ``optional="true"``).
+Defaults to a drop-down menu select list.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="multiple" type="PermissiveBoolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Allow multiple valus to be selected.
+            <xs:documentation xml:lang="en">Allow multiple values to be selected.
 Valid with ``data`` and ``select`` parameters. ``select`` parameters with ``multiple="true"`` are optional by default.</xs:documentation>
           </xs:annotation>
         </xs:attribute>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2887,11 +2887,11 @@ the column index.
         </xs:attribute>
         <xs:attribute name="display" type="DisplayType">
           <xs:annotation>
-            <xs:documentation xml:lang="en">This attribute is used only if
-``type`` attribute value is ``select`` - render a select list as a set of check
-boxes (``display="checkboxes"``) or radio buttons (``display="radio"``, note this
-is incompatible with ``multiple="true"`` and ``optional="true"``).
-Defaults to a drop-down menu select list.</xs:documentation>
+            <xs:documentation xml:lang="en">Render a select list as a set of
+checkboxes (``checkboxes``) or radio buttons (``radio``; note this is
+incompatible with ``multiple="true"`` and ``optional="true"``). Defaults to a
+drop-down menu select list. Used only when the ``type`` attribute value is
+``select``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="multiple" type="PermissiveBoolean">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2896,8 +2896,10 @@ drop-down menu select list. Used only when the ``type`` attribute value is
         </xs:attribute>
         <xs:attribute name="multiple" type="PermissiveBoolean">
           <xs:annotation>
-            <xs:documentation xml:lang="en">Allow multiple values to be selected.
-Valid with ``data`` and ``select`` parameters. ``select`` parameters with ``multiple="true"`` are optional by default.</xs:documentation>
+            <xs:documentation xml:lang="en">Allow multiple values to be
+selected. ``select`` parameters with ``multiple="true"`` are optional by
+default. Used only when the ``type`` attribute value is ``data``, ``group_tag``,
+or ``select``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="numerical" type="PermissiveBoolean">

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -26,13 +26,24 @@ NO_WHEN_IN_CONDITIONAL_XML = """
 </tool>
 """
 
+RADIO_SELECT_INCOMPATIBILITIES = """
+<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+    <description>The BWA Mapper</description>
+    <version_command interpreter="python">bwa.py --version</version_command>
+    <inputs>
+        <param name="select" display="radio" multiple="true" optional="true"/>
+    </inputs>
+</tool>
+"""
+
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
+    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [select] display="radio" is incompatible with optional="true"\nSelect [%s] display="radio" is incompatible with multiple="true"' in x.error_messages),
 ]
 
 
-@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when'])
+@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when', 'radio select incompatibilities'])
 def test_tool_xml(tool_xml, lint_func, assert_func):
     lint_ctx = LintContext('all')
     tree = etree.ElementTree(element=etree.fromstring(tool_xml))

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -31,7 +31,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
-        <param name="select" display="radio" multiple="true" optional="true"/>
+        <param name="select" display="radio" optional="true"/>
     </inputs>
 </tool>
 """
@@ -39,7 +39,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
-    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [select] display="radio" is incompatible with optional="true"\nSelect [%s] display="radio" is incompatible with multiple="true"' in x.error_messages),
+    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [select] display="radio" is incompatible with optional="true"' in x.error_messages),
 ]
 
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -31,7 +31,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
-        <param name="select" display="radio" optional="true"/>
+        <param name="radio_select" type="select" display="radio" optional="true"/>
     </inputs>
 </tool>
 """
@@ -39,7 +39,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
-    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [select] display="radio" is incompatible with optional="true"' in x.error_messages),
+    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages),
 ]
 
 
@@ -48,4 +48,4 @@ def test_tool_xml(tool_xml, lint_func, assert_func):
     lint_ctx = LintContext('all')
     tree = etree.ElementTree(element=etree.fromstring(tool_xml))
     lint_ctx.lint(name="test_lint", lint_func=lint_func, lint_target=tree)
-    assert assert_func(lint_ctx)
+    assert assert_func(lint_ctx), f"Warnings: {lint_ctx.warn_messages}\nErrors: {lint_ctx.error_messages}"

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -31,7 +31,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
-        <param name="radio_select" type="select" display="radio" optional="true"/>
+        <param name="radio_select" type="select" display="radio" optional="true" multiple="true"/>
     </inputs>
 </tool>
 """
@@ -39,7 +39,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
-    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages),
+    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages),
 ]
 
 


### PR DESCRIPTION
select with `display="radio"` one can not be unselected once an options was chosen.
also radio style selects do not allow to select multiple options.

both might as well be considered bugs. but I think the idea of radio buttons could
as well be considered incompatible with multiple=true or optional
https://en.wikipedia.org/wiki/Radio_button

Are there already tests for this piece of code that might be extended? Or would is be
worth setting some up?