### PR TITLE
Read cgroups from cgroup filesystem mount rather than cgget, which is not always installed

### DIFF
--- a/lib/galaxy/job_metrics/instrumenters/cgroup.py
+++ b/lib/galaxy/job_metrics/instrumenters/cgroup.py
@@ -54,6 +54,7 @@ class CgroupPlugin(InstrumentPlugin):
 
     def __init__(self, **kwargs):
         self.verbose = asbool(kwargs.get("verbose", False))
+        self.cgroup_mount = kwargs.get("cgroup_mount", "/sys/fs/cgroup")
         params_str = kwargs.get("params", None)
         if params_str:
             params = [v.strip() for v in params_str.split(",")]
@@ -72,64 +73,49 @@ class CgroupPlugin(InstrumentPlugin):
         return metrics
 
     def __record_cgroup_cpu_usage(self, job_directory):
-        return """if [ `command -v cgget` ] && [ -e /proc/$$/cgroup ]; then cat /proc/$$/cgroup | awk -F':' '$2=="cpuacct,cpu"{{print $2":"$3}}' | xargs -I{{}} cgget -g {{}} > {metrics} ; else echo "" > {metrics}; fi""".format(metrics=self.__cgroup_metrics_file(job_directory))
+        # comounted cgroups (which cpu and cpuacct are on the supported Linux distros) can appear in any order (cpu,cpuacct or cpuacct,cpu)
+        return """if [ -e "/proc/$$/cgroup" -a -d "{cgroup_mount}" ]; then cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '($2=="cpuacct,cpu")||($2=="cpu,cpuacct"){{print $3}}'); for f in {cgroup_mount}/{{cpu\,cpuacct,cpuacct\,cpu}}$cgroup_path/{{cpu,cpuacct}}.*; do if [ -f "$f" ]; then echo "__$(basename $f)__" >> {metrics}; cat "$f" >> {metrics} 2>/dev/null; fi; done; fi""".format(metrics=self.__cgroup_metrics_file(job_directory), cgroup_mount=self.cgroup_mount)  # noqa: W605
 
     def __record_cgroup_memory_usage(self, job_directory):
-        return """if [ `command -v cgget` ] && [ -e /proc/$$/cgroup ]; then cat /proc/$$/cgroup | awk -F':' '$2=="memory"{{print $2":"$3}}' | xargs -I{{}} cgget -g {{}} >> {metrics} ; else echo "" > {metrics}; fi""".format(metrics=self.__cgroup_metrics_file(job_directory))
+        return """if [ -e "/proc/$$/cgroup" -a -d "{cgroup_mount}" ]; then cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '$2=="memory"{{print $3}}'); for f in {cgroup_mount}/memory$cgroup_path/memory.*; do echo "__$(basename $f)__" >> {metrics}; cat "$f" >> {metrics} 2>/dev/null; done; fi""".format(metrics=self.__cgroup_metrics_file(job_directory), cgroup_mount=self.cgroup_mount)
 
     def __cgroup_metrics_file(self, job_directory):
         return self._instrument_file_path(job_directory, "_metrics")
 
     def __read_metrics(self, path):
         metrics = {}
-        prev_metric = None
+        key = None
         with open(path) as infile:
             for line in infile:
                 try:
-                    metric, prev_metric = self.__read_key_value(line, prev_metric)
+                    metric, key = self.__read_key_value(line.strip(), key)
                 except Exception:
                     log.exception("Caught exception attempting to read metric from cgroup line: %s", line)
                     metric = None
                 if not metric:
                     continue
-                self.__add_metric(metrics, prev_metric)
-                prev_metric = metric
-        self.__add_metric(metrics, prev_metric)
+                self.__add_metric(metrics, metric)
         return metrics
 
     def __add_metric(self, metrics, metric):
         if metric and (metric.subkey in self.params or self.verbose):
             metrics[metric.subkey] = metric.value
 
-    def __read_key_value(self, line, prev_metric):
-        if not line.startswith('\t'):
-            # line is a single-line param or the first line of a multi-line param
-            try:
-                subkey, value = line.strip().split(": ", 1)
-                key = subkey
-            except ValueError:
-                # or not a param line at all, ignore
-                return None, prev_metric
-        else:
-            # line is a subsequent line of a multi-line param
-            subkey, value = line.strip().split(" ", 1)
-            key = prev_metric.key
+    def __read_key_value(self, line, key):
+        if line.startswith('__') and line.endswith('__'):
+            # line is the beginning of a new param
+            key = line[2:][:-2]
+            return (None, key)
+        elif line.count(" ") == 1:
+            # line has a subkey
+            subkey, value = line.split(" ", 1)
             subkey = ".".join((key, subkey))
-            prev_metric = self.__fix_prev_metric(prev_metric)
+        else:
+            # line does not have a subkey
+            subkey = key
+            value = line
         value = self.__type_value(value)
-        return (Metric(key, subkey, value), prev_metric)
-
-    def __fix_prev_metric(self, metric):
-        # we can't determine whether a param is single-line or multi-line until we read the second line, after which, we
-        # must go back and fix the first param to be subkeyed
-        if metric.key == metric.subkey:
-            try:
-                subkey, value = metric.value.split(" ", 1)
-                subkey = ".".join((metric.key, subkey))
-                metric = Metric(metric.key, subkey, self.__type_value(value))
-            except ValueError:
-                pass
-        return metric
+        return (Metric(key, subkey, value), key)
 
     def __type_value(self, value):
         try:


### PR DESCRIPTION
The shell for these comes out to the following (reformatted for readability) and extra eyes here would be appreciated. For cpu and cpuacct, because they are comounted, I found that depending on the system cpu and cpuacct appeared in different orders (and even differed between their order in `/proc/$$/cgroup` and the entry in `/sys/fs/cgroup`:

```bash
if [ -e "/proc/$$/cgroup" -a -d "/sys/fs/cgroup" ]; then
    cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '($2=="cpuacct,cpu")||($2=="cpu,cpuacct"){print $3}');
    for f in /sys/fs/cgroup/{cpu\,cpuacct,cpuacct\,cpu}$cgroup_path/{cpu,cpuacct}.*; do
        if [ -f "$f" ]; then
            echo "__$(basename $f)__" >> /tmp/foo; cat "$f" >> /tmp/foo 2>/dev/null;
        fi;
    done;
fi
```

Memory is thankfully simpler:

```bash
if [ -e "/proc/$$/cgroup" -a -d "/sys/fs/cgroup" ]; then
    cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '$2=="memory"{print $3}');
    for f in /sys/fs/cgroup/memory$cgroup_path/memory.*; do
        echo "__$(basename $f)__" >> /tmp/foo; cat "$f" >> /tmp/foo 2>/dev/null;
    done;
fi
```

This will break metrics for any jobs running during upgrade, but that's not worth accounting for (the jobs will complete fine, they just won't have cgroup metrics, which plenty of jobs are already missing).