### PR TITLE
[20.09] Fix assertion error

### DIFF
--- a/lib/galaxy/datatypes/display_applications/parameters.py
+++ b/lib/galaxy/datatypes/display_applications/parameters.py
@@ -83,7 +83,7 @@ class DisplayApplicationDataParameter(DisplayApplicationParameter):
             data = data.value
         if self.metadata:
             rval = getattr(data.metadata, self.metadata, None)
-            assert rval, 'Unknown metadata name ({}) provided for dataset type ({}).'.format(self.metadata, data.datatype.__class__.name)
+            assert rval, 'Unknown metadata name "{}" provided for datatype "{}".'.format(self.metadata, data.ext)
             return Bunch(file_name=rval.file_name, state=data.state, states=data.states, extension='data')
         elif self.extensions and (self.force_conversion or not isinstance(data.datatype, self.formats)):
             for ext in self.extensions:


### PR DESCRIPTION
Fixes
```
AttributeError: type object 'Vcf' has no attribute 'name'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 33, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 136, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 215, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/web/framework/decorators.py", line 125, in set_nocache_headers
    return func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 702, in display_application
    display_link.prepare_display()
  File "galaxy/datatypes/display_applications/application.py", line 232, in prepare_display
    value = param.prepare(other_values, self.dataset_hash, self.user_hash, self.trans)
  File "galaxy/datatypes/display_applications/parameters.py", line 106, in prepare
    data = self._get_dataset_like_object(other_values)
  File "galaxy/datatypes/display_applications/parameters.py", line 86, in _get_dataset_like_object
    assert rval, f'Unknown metadata name ({self.metadata}) provided for dataset type ({data.datatype.__class__.name}).'
```
... but not the underlying problem that normal VCFs can't be displayed
currently. This currently only works with vcf.gz files.