### PR TITLE
[Selenium] Test library dataset permissions

### DIFF
--- a/client/src/components/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
+++ b/client/src/components/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
@@ -61,7 +61,7 @@
             <p class="text-center" v-if="is_unrestricted">
                 You can
                 <strong @click="toggleDatasetPrivacy(true)" class="make-private">
-                    <a href="javascript:void(0)">make this dataset private</a>
+                    <a id="make-private" href="javascript:void(0)">make this dataset private</a>
                 </strong>
                 to you.
             </p>

--- a/client/src/components/LibraryFolder/LibraryFolderPermissions/PermissionsInputField.vue
+++ b/client/src/components/LibraryFolder/LibraryFolderPermissions/PermissionsInputField.vue
@@ -5,7 +5,7 @@
         </h4>
         <b-row>
             <b-col>
-                <div v-if="options && value">
+                <div :class="permission_type" v-if="options && value">
                     <multiselect
                         v-model="value"
                         :options="fetched_options"

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -579,6 +579,10 @@ libraries:
       import_dir_btn:
         type: xpath
         selector: '//button[contains(text(), "Import")]'
+      manage_dataset_permissions_btn: 'button[title="Permissions of ${name}"]'
+      make_private_btn: '#make-private'
+      access_dataset_roles: '.access_dataset_roles .multiselect__tag span'
+      private_dataset_icon: '.fa-key'
 
     labels:
       from_history: 'from History'

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -370,6 +370,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
         )
         with self.main_panel():
             self.assert_no_error_message()
+        return GALAXY_TEST_SELENIUM_ADMIN_USER_EMAIL
 
     def workflow_upload_yaml_with_random_name(self, content, **kwds):
         workflow_populator = self.workflow_populator


### PR DESCRIPTION
This PR implements access permissions test in  https://github.com/galaxyproject/galaxy/pull/11347

Obviously it depends on https://github.com/galaxyproject/galaxy/pull/11347 and it would be a draft till the 11347 merge.

It changes permission of a dataset to 'private', verifies icon in lib-folder and makes sure that another user doesn't see it.