### PR TITLE
Fix SLURM runner for real user setups and avoid uneccesary chowns

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -153,6 +153,7 @@ class SlurmJobRunner(DRMAAJobRunner):
                     self.work_queue.put((self.fail_job, ajs))
                     return
             if drmaa_state == self.drmaa_job_states.DONE:
+                ajs.job_wrapper.reclaim_ownership()
                 with open(ajs.error_file) as rfh:
                     _remove_spurious_top_lines(rfh, ajs)
                 with open(ajs.error_file, 'r+') as f:

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -32,6 +32,7 @@ from os.path import (
     relpath,
     sep as separator,
 )
+from pathlib import Path
 try:
     from pwd import getpwuid
 except ImportError:
@@ -352,6 +353,9 @@ def external_chown(path, pwent, external_chown_script, description="file"):
     try:
         if not external_chown_script:
             raise ValueError('external_chown_script is not defined')
+        if Path(path).owner() == pwent[0]:
+            return True
+
         cmd = shlex.split(external_chown_script)
         cmd.extend([path, pwent[0], str(pwent[3])])
         log.debug('Changing ownership of {} with: {}'.format(path, ' '.join(map(shlex.quote, cmd))))


### PR DESCRIPTION
for finished jobs (state DONE) the SLURM runner modifies the job's stderr file. for real user setups this does not work because the job dir is still owned by the real user. 

solution: just add a reclaim ownership before writing

I observed that for one finished job chown is now called 3x. Therefore the 2nd commit.


The change survived 1 successful job and 1 successful job with resubmission