### PR TITLE
Decrease verbosity of messages in poetry

### DIFF
--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -15,7 +15,7 @@ pip install --upgrade pip setuptools poetry
 if [ $# -gt 0 ]; then
     poetry add --lock "$@"
 else
-    poetry update -vv --lock
+    poetry update -v --lock
 fi
 poetry export -f requirements.txt --without-hashes --output "$THIS_DIRECTORY/pinned-requirements.txt"
 poetry export --dev -f requirements.txt --without-hashes --output "$THIS_DIRECTORY/dev-requirements.txt"


### PR DESCRIPTION
Poetry's `Provider:debug()` method appears to be broken (also see https://github.com/python-poetry/poetry/issues/3663). Running `make update-dependencies` causes this:
```
  AttributeError

  'NoneType' object has no attribute 'group'

  at .venv/lib/python3.8/site-packages/poetry/puzzle/provider.py:699 in debug
      695│ 
      696│         if message.startswith("fact:"):
      697│             if "depends on" in message:
      698│                 m = re.match(r"fact: (.+?) depends on (.+?) \((.+?)\)", message)
    → 699│                 m2 = re.match(r"(.+?) \((.+?)\)", m.group(1))
      700│                 if m2:
      701│                     name = m2.group(1)
      702│                     version = " ({})".format(m2.group(2))
      703│                 else:
```



Running `poetry` with `-v` instead of `-vv` exits that method early, which solves the problem.
