### PR TITLE
Refactor group_roles API logic into GroupRolesManager

### DIFF
--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -1,0 +1,115 @@
+import logging
+
+from galaxy.util import unicodify
+from galaxy.web import url_for
+
+log = logging.getLogger(__name__)
+
+
+class GroupRolesManager:
+    """Interface/service object shared by controllers for interacting with group roles."""
+
+    def __init__(self, app) -> None:
+        self._app = app
+
+    def index(self, trans, group_id):
+        """
+        Returns a collection (list) of roles.
+        """
+        decoded_group_id = trans.security.decode_id(group_id)
+        try:
+            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
+        except Exception:
+            group = None
+        if not group:
+            trans.response.status = 400
+            return "Invalid group id ( %s ) specified." % str(group_id)
+        rval = []
+        try:
+            for gra in group.roles:
+                role = gra.role
+                encoded_id = trans.security.encode_id(role.id)
+                rval.append(dict(id=encoded_id,
+                                 name=role.name,
+                                 url=url_for('group_role', group_id=group_id, id=encoded_id, )))
+        except Exception as e:
+            rval = "Error in group API at listing roles"
+            log.error(rval + ": %s", unicodify(e))
+            trans.response.status = 500
+        return rval
+
+    def show(self, trans, id, group_id):
+        """
+        Returns information about a group role.
+        """
+        role_id = id
+        decoded_group_id = trans.security.decode_id(group_id)
+        decoded_role_id = trans.security.decode_id(role_id)
+        item = None
+        try:
+            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
+            role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
+            for gra in group.roles:
+                if gra.role == role:
+                    item = dict(id=role_id,
+                                name=role.name,
+                                url=url_for('group_role', group_id=group_id, id=role_id))  # TODO Fix This
+            if not item:
+                item = f"role {role.name} not in group {group.name}"
+        except Exception as e:
+            item = f"Error in group_role API group {group.name} role {role.name}"
+            log.error(item + ": %s", unicodify(e))
+        return item
+
+    def update(self, trans, id, group_id):
+        """
+        Adds a role to a group
+        """
+        role_id = id
+        decoded_group_id = trans.security.decode_id(group_id)
+        decoded_role_id = trans.security.decode_id(role_id)
+        item = None
+        try:
+            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
+            role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
+            for gra in group.roles:
+                if gra.role == role:
+                    item = dict(id=role_id,
+                                name=role.name,
+                                url=url_for('group_role', group_id=group_id, id=role_id))
+            if not item:
+                gra = trans.app.model.GroupRoleAssociation(group, role)
+                # Add GroupRoleAssociation
+                trans.sa_session.add(gra)
+                trans.sa_session.flush()
+                item = dict(id=role_id,
+                            name=role.name,
+                            url=url_for('group_role', group_id=group_id, id=role_id))
+        except Exception as e:
+            item = f"Error in group_role API Adding role {role.name} to group {group.name}"
+            log.error(item + ": %s", unicodify(e))
+        return item
+
+    def delete(self, trans, id, group_id):
+        """
+        Removes a role from a group
+        """
+        role_id = id
+        decoded_group_id = trans.security.decode_id(group_id)
+        decoded_role_id = trans.security.decode_id(role_id)
+        try:
+            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
+            role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
+            for gra in group.roles:
+                if gra.role == role:
+                    trans.sa_session.delete(gra)
+                    trans.sa_session.flush()
+                    item = dict(id=role_id,
+                                name=role.name,
+                                url=url_for('group_role', group_id=group_id, id=role_id))
+            if not item:
+                item = f"role {role.name} not in group {group.name}"
+        except Exception as e:
+            item = f"Error in group_role API Removing role {role.name} from group {group.name}"
+            log.error(item + ": %s", unicodify(e))
+        return item

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -3,17 +3,21 @@ API operations on Group objects.
 """
 import logging
 
-from galaxy.util import unicodify
+from galaxy.managers.group_roles import GroupRolesManager
 from galaxy.web import (
     expose_api,
     require_admin,
 )
-from galaxy.webapps.base.controller import BaseAPIController, url_for
+from galaxy.webapps.base.controller import BaseAPIController
 
 log = logging.getLogger(__name__)
 
 
 class GroupRolesAPIController(BaseAPIController):
+
+    def __init__(self, app):
+        super().__init__(app)
+        self.manager = GroupRolesManager(app)
 
     @require_admin
     @expose_api
@@ -22,27 +26,7 @@ class GroupRolesAPIController(BaseAPIController):
         GET /api/groups/{encoded_group_id}/roles
         Displays a collection (list) of groups.
         """
-        decoded_group_id = trans.security.decode_id(group_id)
-        try:
-            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
-        except Exception:
-            group = None
-        if not group:
-            trans.response.status = 400
-            return "Invalid group id ( %s ) specified." % str(group_id)
-        rval = []
-        try:
-            for gra in group.roles:
-                role = gra.role
-                encoded_id = trans.security.encode_id(role.id)
-                rval.append(dict(id=encoded_id,
-                                 name=role.name,
-                                 url=url_for('group_role', group_id=group_id, id=encoded_id, )))
-        except Exception as e:
-            rval = "Error in group API at listing roles"
-            log.error(rval + ": %s", unicodify(e))
-            trans.response.status = 500
-        return rval
+        return self.manager.index(trans, group_id)
 
     @require_admin
     @expose_api
@@ -51,24 +35,7 @@ class GroupRolesAPIController(BaseAPIController):
         GET /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Displays information about a group role.
         """
-        role_id = id
-        decoded_group_id = trans.security.decode_id(group_id)
-        decoded_role_id = trans.security.decode_id(role_id)
-        item = None
-        try:
-            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
-            role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
-            for gra in group.roles:
-                if gra.role == role:
-                    item = dict(id=role_id,
-                                name=role.name,
-                                url=url_for('group_role', group_id=group_id, id=role_id))  # TODO Fix This
-            if not item:
-                item = f"role {role.name} not in group {group.name}"
-        except Exception as e:
-            item = f"Error in group_role API group {group.name} role {role.name}"
-            log.error(item + ": %s", unicodify(e))
-        return item
+        return self.manager.show(trans, id, group_id)
 
     @require_admin
     @expose_api
@@ -77,30 +44,7 @@ class GroupRolesAPIController(BaseAPIController):
         PUT /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Adds a role to a group
         """
-        role_id = id
-        decoded_group_id = trans.security.decode_id(group_id)
-        decoded_role_id = trans.security.decode_id(role_id)
-        item = None
-        try:
-            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
-            role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
-            for gra in group.roles:
-                if gra.role == role:
-                    item = dict(id=role_id,
-                                name=role.name,
-                                url=url_for('group_role', group_id=group_id, id=role_id))
-            if not item:
-                gra = trans.app.model.GroupRoleAssociation(group, role)
-                # Add GroupRoleAssociation
-                trans.sa_session.add(gra)
-                trans.sa_session.flush()
-                item = dict(id=role_id,
-                            name=role.name,
-                            url=url_for('group_role', group_id=group_id, id=role_id))
-        except Exception as e:
-            item = f"Error in group_role API Adding role {role.name} to group {group.name}"
-            log.error(item + ": %s", unicodify(e))
-        return item
+        return self.manager.update(trans, id, group_id)
 
     @require_admin
     @expose_api
@@ -109,22 +53,4 @@ class GroupRolesAPIController(BaseAPIController):
         DELETE /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Removes a role from a group
         """
-        role_id = id
-        decoded_group_id = trans.security.decode_id(group_id)
-        decoded_role_id = trans.security.decode_id(role_id)
-        try:
-            group = trans.sa_session.query(trans.app.model.Group).get(decoded_group_id)
-            role = trans.sa_session.query(trans.app.model.Role).get(decoded_role_id)
-            for gra in group.roles:
-                if gra.role == role:
-                    trans.sa_session.delete(gra)
-                    trans.sa_session.flush()
-                    item = dict(id=role_id,
-                                name=role.name,
-                                url=url_for('group_role', group_id=group_id, id=role_id))
-            if not item:
-                item = f"role {role.name} not in group {group.name}"
-        except Exception as e:
-            item = f"Error in group_role API Removing role {role.name} from group {group.name}"
-            log.error(item + ": %s", unicodify(e))
-        return item
+        return self.manager.delete(trans, id, group_id)

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -3,7 +3,9 @@ API operations on Group objects.
 """
 import logging
 
+from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_roles import GroupRolesManager
+from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.web import (
     expose_api,
     require_admin,
@@ -21,7 +23,7 @@ class GroupRolesAPIController(BaseAPIController):
 
     @require_admin
     @expose_api
-    def index(self, trans, group_id, **kwd):
+    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField, **kwd):
         """
         GET /api/groups/{encoded_group_id}/roles
         Displays a collection (list) of groups.
@@ -30,7 +32,7 @@ class GroupRolesAPIController(BaseAPIController):
 
     @require_admin
     @expose_api
-    def show(self, trans, id, group_id, **kwd):
+    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
         """
         GET /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Displays information about a group role.
@@ -39,7 +41,7 @@ class GroupRolesAPIController(BaseAPIController):
 
     @require_admin
     @expose_api
-    def update(self, trans, id, group_id, **kwd):
+    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
         """
         PUT /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Adds a role to a group
@@ -48,7 +50,7 @@ class GroupRolesAPIController(BaseAPIController):
 
     @require_admin
     @expose_api
-    def delete(self, trans, id, group_id, **kwd):
+    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField, **kwd):
         """
         DELETE /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Removes a role from a group

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -3,8 +3,11 @@ API operations on Group objects.
 """
 import logging
 
-from galaxy import web
 from galaxy.util import unicodify
+from galaxy.web import (
+    expose_api,
+    require_admin,
+)
 from galaxy.webapps.base.controller import BaseAPIController, url_for
 
 log = logging.getLogger(__name__)
@@ -12,8 +15,8 @@ log = logging.getLogger(__name__)
 
 class GroupRolesAPIController(BaseAPIController):
 
-    @web.require_admin
-    @web.legacy_expose_api
+    @require_admin
+    @expose_api
     def index(self, trans, group_id, **kwd):
         """
         GET /api/groups/{encoded_group_id}/roles
@@ -41,8 +44,8 @@ class GroupRolesAPIController(BaseAPIController):
             trans.response.status = 500
         return rval
 
-    @web.require_admin
-    @web.legacy_expose_api
+    @require_admin
+    @expose_api
     def show(self, trans, id, group_id, **kwd):
         """
         GET /api/groups/{encoded_group_id}/roles/{encoded_role_id}
@@ -67,8 +70,8 @@ class GroupRolesAPIController(BaseAPIController):
             log.error(item + ": %s", unicodify(e))
         return item
 
-    @web.require_admin
-    @web.legacy_expose_api
+    @require_admin
+    @expose_api
     def update(self, trans, id, group_id, **kwd):
         """
         PUT /api/groups/{encoded_group_id}/roles/{encoded_role_id}
@@ -99,8 +102,8 @@ class GroupRolesAPIController(BaseAPIController):
             log.error(item + ": %s", unicodify(e))
         return item
 
-    @web.require_admin
-    @web.legacy_expose_api
+    @require_admin
+    @expose_api
     def delete(self, trans, id, group_id, **kwd):
         """
         DELETE /api/groups/{encoded_group_id}/roles/{encoded_role_id}

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -1,0 +1,135 @@
+from typing import List
+
+from galaxy_test.base.populators import DatasetPopulator
+from ._framework import ApiTestCase
+
+
+class GroupRolesApiTestCase(ApiTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_index(self, group_name: str = None):
+        group_name = group_name or "test-group"
+        group = self._create_group(group_name)
+        encoded_group_id = group["id"]
+
+        group_roles = self._get_group_roles(encoded_group_id)
+
+        assert isinstance(group_roles, list)
+        assert len(group_roles) > 0
+        for group_role in group_roles:
+            self._assert_valid_group_role(group_role)
+
+    def test_index_only_admin(self):
+        encoded_group_id = "any-group-id"
+        response = self._get(f"groups/{encoded_group_id}/roles")
+        self._assert_status_code_is(response, 403)
+
+    def test_index_unknown_group_raises_400(self):
+        encoded_group_id = "unknown-group-id"
+        response = self._get(f"groups/{encoded_group_id}/roles", admin=True)
+        self._assert_status_code_is(response, 400)
+
+    def test_show(self):
+        encoded_role_id = self.dataset_populator.user_private_role_id()
+        group = self._create_group("test-group-show-role", encoded_role_ids=[encoded_role_id])
+        encoded_group_id = group["id"]
+        response = self._get(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
+        self._assert_status_code_is(response, 200)
+        group_role = response.json()
+        self._assert_valid_group_role(group_role)
+
+    def test_show_only_admin(self):
+        encoded_group_id = "any-group-id"
+        encoded_role_id = "any-role-id"
+        response = self._get(f"groups/{encoded_group_id}/roles/{encoded_role_id}")
+        self._assert_status_code_is(response, 403)
+
+    def test_show_unknown_raises_400(self):
+        group = self._create_group("test-group-with-unknown-role")
+        encoded_group_id = group["id"]
+        encoded_role_id = "unknown-role-id"
+        response = self._get(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
+        self._assert_status_code_is(response, 400)
+
+    def test_update(self):
+        group_name = "group-without-roles"
+        group = self._create_group(group_name, encoded_role_ids=[])
+        encoded_group_id = group["id"]
+
+        group_roles = self._get_group_roles(encoded_group_id)
+        assert len(group_roles) == 0
+
+        encoded_role_id = self.dataset_populator.user_private_role_id()
+        update_response = self._put(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
+        self._assert_status_code_is_ok(update_response)
+        group_role = update_response.json()
+        self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
+        assert group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}"
+
+    def test_update_only_admin(self):
+        encoded_group_id = "any-group-id"
+        encoded_role_id = "any-role-id"
+        response = self._put(f"groups/{encoded_group_id}/roles/{encoded_role_id}")
+        self._assert_status_code_is(response, 403)
+
+    def test_delete(self):
+        group_name = "group-with-role-to-delete"
+        encoded_role_id = self.dataset_populator.user_private_role_id()
+        group = self._create_group(group_name, encoded_role_ids=[encoded_role_id])
+        encoded_group_id = group["id"]
+
+        group_roles = self._get_group_roles(encoded_group_id)
+        assert len(group_roles) == 1
+
+        delete_response = self._delete(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
+        self._assert_status_code_is_ok(delete_response)
+        group_role = delete_response.json()
+        self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
+
+        group_roles = self._get_group_roles(encoded_group_id)
+        assert len(group_roles) == 0
+
+    def test_delete_only_admin(self):
+        encoded_group_id = "any-group-id"
+        encoded_role_id = "any-role-id"
+        response = self._delete(f"groups/{encoded_group_id}/roles/{encoded_role_id}")
+        self._assert_status_code_is(response, 403)
+
+    def test_delete_unknown_raises_400(self):
+        group_name = "group-without-role-to-delete"
+        group = self._create_group(group_name, encoded_role_ids=[])
+        encoded_group_id = group["id"]
+
+        group_roles = self._get_group_roles(encoded_group_id)
+        assert len(group_roles) == 0
+
+        encoded_role_id = "unknown-role-id"
+        delete_response = self._delete(f"groups/{encoded_group_id}/roles/{encoded_role_id}", admin=True)
+        self._assert_status_code_is(delete_response, 400)
+
+    def _create_group(self, group_name: str, encoded_role_ids: List[str] = None):
+        if encoded_role_ids is None:
+            encoded_role_ids = [self.dataset_populator.user_private_role_id()]
+        role_ids = encoded_role_ids
+        payload = {
+            "name": group_name,
+            "role_ids": role_ids,
+        }
+        response = self._post("groups", payload, admin=True, json=True)
+        self._assert_status_code_is(response, 200)
+        group = response.json()[0]  # POST /api/groups returns a list
+        return group
+
+    def _get_group_roles(self, encoded_group_id: str):
+        response = self._get(f"groups/{encoded_group_id}/roles", admin=True)
+        self._assert_status_code_is(response, 200)
+        group_roles = response.json()
+        return group_roles
+
+    def _assert_valid_group_role(self, role, assert_id=None):
+        self._assert_has_keys(role, "id", "name", "url")
+        if assert_id is not None:
+            assert role["id"] == assert_id


### PR DESCRIPTION
## Overview
More work to ease the transition to FastAPI.

- Added API tests for all endpoints
- Replaced the old legacy_expose_api decorators. See #11252
- Moved the controller logic to a manager class.
- Refactored the manager to handle errors raising the appropriate exception.