### PR TITLE
Pin mypy to 0.790 to prevent linting errors when running v 0.8

### DIFF
--- a/lib/galaxy/dependencies/lint-requirements.txt
+++ b/lib/galaxy/dependencies/lint-requirements.txt
@@ -1,4 +1,4 @@
 flake8
 flake8-bugbear
 flake8-import-order
-mypy
+mypy==0.790


### PR DESCRIPTION
Running `make update-dependencies` will update mypy to version 0.8, which will cause the following error:

```
mypy run-test: commands[0] | mypy test lib
lib/galaxy/tools/bundled/data_source/data_source.py: error: Duplicate module named 'data_source' (also at 'test/functional/tools/data_source.py')
lib/galaxy/tools/bundled/data_source/data_source.py: error: Are you missing an __init__.py?
Found 2 errors in 1 file (errors prevented further checking)
ERROR: InvocationError for command /home/runner/work/galaxy/galaxy/.tox/mypy/bin/mypy test lib (exited with code 2)
```
I'm looking into the error, but for now I think it's reasonable to just pin it. 