### PR TITLE
fixed incorrect javascript import syntax

### DIFF
--- a/client/src/components/LibraryFolder/LibraryFolderRouter.js
+++ b/client/src/components/LibraryFolder/LibraryFolderRouter.js
@@ -1,10 +1,9 @@
-<script>
 import { getAppRoot } from "onload/loadConfig";
 import Vue from "vue";
 import VueRouter from "vue-router";
-import LibraryFolderPermissions from "components/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue";
-import LibraryFolder from "components/LibraryFolder/LibraryFolder.vue";
-import LibraryFolderDatasetPermissions from "components/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue";
+import LibraryFolderPermissions from "components/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions";
+import LibraryFolder from "components/LibraryFolder/LibraryFolder";
+import LibraryFolderDatasetPermissions from "components/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions";
 
 Vue.use(VueRouter);
 
@@ -32,4 +31,3 @@ export default new VueRouter({
         },
     ],
 });
-</script>

--- a/client/src/components/admin/DataManager/DataManagerRouter.js
+++ b/client/src/components/admin/DataManager/DataManagerRouter.js
@@ -1,11 +1,10 @@
-<script>
 import { getAppRoot } from "onload/loadConfig";
 import Vue from "vue";
 import VueRouter from "vue-router";
-import DataManager from "./DataManager.vue";
-import DataManagerJobs from "./DataManagerJobs.vue";
-import DataManagerJob from "./DataManagerJob.vue";
-import DataManagerTable from "./DataManagerTable.vue";
+import DataManager from "./DataManager";
+import DataManagerJobs from "./DataManagerJobs";
+import DataManagerJob from "./DataManagerJob";
+import DataManagerTable from "./DataManagerTable";
 
 Vue.use(VueRouter);
 
@@ -42,4 +41,3 @@ export default new VueRouter({
         },
     ],
 });
-</script>

--- a/client/src/entry/admin/AdminRouter.js
+++ b/client/src/entry/admin/AdminRouter.js
@@ -12,7 +12,7 @@ import ActiveInvocations from "components/admin/ActiveInvocations.vue";
 import Landing from "components/admin/Dependencies/Landing.vue";
 import AdminHome from "components/admin/Home.vue";
 import DataManagerView from "components/admin/DataManager/DataManagerView.vue";
-import DataManagerRouter from "components/admin/DataManager/DataManagerRouter.vue";
+import DataManagerRouter from "components/admin/DataManager/DataManagerRouter";
 import Register from "components/login/Register.vue";
 import ErrorStack from "components/admin/ErrorStack.vue";
 import DisplayApplications from "components/admin/DisplayApplications.vue";

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -48,7 +48,7 @@ import DisplayStructure from "components/DisplayStructured.vue";
 import { CloudAuth } from "components/User/CloudAuth";
 import { ExternalIdentities } from "components/User/ExternalIdentities";
 import Confirmation from "components/login/Confirmation.vue";
-import LibraryFolderRouter from "components/LibraryFolder/LibraryFolderRouter.vue";
+import LibraryFolderRouter from "components/LibraryFolder/LibraryFolderRouter";
 import Vue from "vue";
 import store from "store";
 import VueRouterMain from "./VueRouterMain.vue";


### PR DESCRIPTION
I noticed some of this kind of thing while I was getting the style guide working. 

Including the specific file type like this is often considered bad form since we'll have to refactor in the event that a single-file module turns into a folder.

It's also hosing 3rd party tooling like the styleguide.

I can't tell whether the authors did this because they didn't understand how webpack and javascript modules work or if there is a legitimate but undocumented need for the overly-specific typing. I'm assuming the former unless somebody speaks up.

There's a lot more of this kind of thing, but I figured I'd let the tests run on this small sample to doublecheck that it's just a mistake and not a necessary convention.
