### PR TITLE
Check for binary files at the middle of the file instead of at the beginning

### DIFF
--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -58,7 +58,8 @@ def check_binary(name, file_path=True):
         # Read 1024 from the middle of the file if this is not
         # a gzip or zip compressed file (bzip are indexed),
         # to avoid issues with long txt headers on binary files.
-        if not is_gzip(file_path) and not is_zip(file_path):
+        if file_path and not is_gzip(name) and not is_zip(name) and not is_bz2(name):
+            # file_path=False doesn't seem to be used in the codebase
             temp.seek(read_start)
         return util.is_binary(temp.read(1024))
     finally:

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -60,14 +60,17 @@ def check_binary(name, file_path=True):
         read_start = int(length / 2)
         read_length = min(1024, int(length / 2) - 1)
     try:
+        if util.is_binary(temp.read(1024)):
+            return True
+        # Some binary files have text only within the first 1024
         # Read 1024 from the middle of the file if this is not
         # a gzip or zip compressed file (bzip are indexed),
         # to avoid issues with long txt headers on binary files.
         if file_path and not is_gzip(name) and not is_zip(name) and not is_bz2(name):
             # file_path=False doesn't seem to be used in the codebase
             temp.seek(read_start)
-            read_length = 1024
-        return util.is_binary(temp.read(read_length))
+            return util.is_binary(temp.read(read_length))
+        return False
     finally:
         temp.close()
 

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -50,10 +50,15 @@ def check_binary(name, file_path=True):
     # Handles files if file_path is True or text if file_path is False
     if file_path:
         temp = open(name, "rb")
-        read_start = int(os.stat(name).st_size / 2)
+        file_size = os.stat(name).st_size
+        read_start = int(file_size / 2)
+        # avoid reading beyond the end of the file
+        read_length = min(1024, int(file_size / 2) - 1)
     else:
         temp = BytesIO(name)
-        read_start = int(len(name) / 2)
+        length = len(name)
+        read_start = int(length / 2)
+        read_length = min(1024, int(length / 2) - 1)
     try:
         # Read 1024 from the middle of the file if this is not
         # a gzip or zip compressed file (bzip are indexed),
@@ -61,7 +66,8 @@ def check_binary(name, file_path=True):
         if file_path and not is_gzip(name) and not is_zip(name) and not is_bz2(name):
             # file_path=False doesn't seem to be used in the codebase
             temp.seek(read_start)
-        return util.is_binary(temp.read(1024))
+            read_length = 1024
+        return util.is_binary(temp.read(read_length))
     finally:
         temp.close()
 

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -1,5 +1,6 @@
 import bz2
 import gzip
+import os
 import re
 import tarfile
 import zipfile
@@ -49,9 +50,14 @@ def check_binary(name, file_path=True):
     # Handles files if file_path is True or text if file_path is False
     if file_path:
         temp = open(name, "rb")
+        read_start = int(os.stat(name).st_size/2)
     else:
         temp = BytesIO(name)
+        read_start = int(len(name)/2)
     try:
+        # Read 1024 from the middle of the file,
+        # to avoid issues with long txt headers on binary files.
+        temp.seek(read_start)
         return util.is_binary(temp.read(1024))
     finally:
         temp.close()

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -50,17 +50,14 @@ def check_binary(name, file_path=True):
     # Handles files if file_path is True or text if file_path is False
     if file_path:
         temp = open(name, "rb")
-        file_size = os.stat(name).st_size
-        read_start = int(file_size / 2)
-        # avoid reading beyond the end of the file
-        read_length = min(1024, int(file_size / 2) - 1)
+        size = os.stat(name).st_size
     else:
         temp = BytesIO(name)
-        length = len(name)
-        read_start = int(length / 2)
-        read_length = min(1024, int(length / 2) - 1)
+        size = len(name)
+    read_start = int(size / 2)
+    read_length = 1024
     try:
-        if util.is_binary(temp.read(1024)):
+        if util.is_binary(temp.read(read_length)):
             return True
         # Some binary files have text only within the first 1024
         # Read 1024 from the middle of the file if this is not

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -55,9 +55,11 @@ def check_binary(name, file_path=True):
         temp = BytesIO(name)
         read_start = int(len(name) / 2)
     try:
-        # Read 1024 from the middle of the file,
+        # Read 1024 from the middle of the file if this is not
+        # a gzip or zip compressed file (bzip are indexed),
         # to avoid issues with long txt headers on binary files.
-        temp.seek(read_start)
+        if not is_gzip(file_path) and not is_zip(file_path):
+            temp.seek(read_start)
         return util.is_binary(temp.read(1024))
     finally:
         temp.close()

--- a/lib/galaxy/util/checkers.py
+++ b/lib/galaxy/util/checkers.py
@@ -50,10 +50,10 @@ def check_binary(name, file_path=True):
     # Handles files if file_path is True or text if file_path is False
     if file_path:
         temp = open(name, "rb")
-        read_start = int(os.stat(name).st_size/2)
+        read_start = int(os.stat(name).st_size / 2)
     else:
         temp = BytesIO(name)
-        read_start = int(len(name)/2)
+        read_start = int(len(name) / 2)
     try:
         # Read 1024 from the middle of the file,
         # to avoid issues with long txt headers on binary files.


### PR DESCRIPTION
This PR aims to deal with #11420, where certain binary files are not recognised as such because the have long text headers (>1024 bytes). Here we read the same 1024 bytes but from the middle of the file. I'm not sure if this could produce a delay for when Galaxy processes very long files: I'm not sure how expensive it is to move the byte reader to half of the file, I presume that if this behaves like a random access reader, it should be fine.

I have checked all test datatype files available in Galaxy and seems to be fine telling apart all binary from non binary examples, left the result in this gist: https://gist.github.com/pcm32/856c86308b9ee71ac58b16e07737e4b7