### PR TITLE
[21.01] Disable tool document cache by default

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1054,13 +1054,13 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Set this to false to disable the tool document cache. This cache
-    stores expanded xml strings. Disabling the tool cache results in
-    slower startup times. The tool cache is backed by sqlite database,
-    which cannot be stored on certain network disks. The cache
-    location is configurable using the ``tool_cache_data_dir``
+    Set this to true to enable the tool document cache. This cache
+    stores expanded xml strings. Enabling the tool cache results in
+    slightly faster startup times. The tool cache is backed by sqlite
+    database, which cannot be stored on certain network disks. The
+    cache location is configurable using the ``tool_cache_data_dir``
     setting, but can be disabled completely here.
-:Default: ``true``
+:Default: ``false``
 :Type: bool
 
 

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1054,9 +1054,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Set this to true to enable the tool document cache. This cache
-    stores expanded xml strings. Enabling the tool cache results in
-    slightly faster startup times. The tool cache is backed by sqlite
+    Whether to enable the tool document cache. This cache stores
+    expanded XML strings. Enabling the tool cache results in slightly
+    faster startup times. The tool cache is backed by a SQLite
     database, which cannot be stored on certain network disks. The
     cache location is configurable using the ``tool_cache_data_dir``
     setting, but can be disabled completely here.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -617,13 +617,13 @@ galaxy:
   # generated commands run in sh.
   #default_job_shell: /bin/bash
 
-  # Set this to false to disable the tool document cache. This cache
-  # stores expanded xml strings. Disabling the tool cache results in
-  # slower startup times. The tool cache is backed by sqlite database,
-  # which cannot be stored on certain network disks. The cache location
-  # is configurable using the ``tool_cache_data_dir`` setting, but can
-  # be disabled completely here.
-  #enable_tool_document_cache: true
+  # Set this to true to enable the tool document cache. This cache
+  # stores expanded xml strings. Enabling the tool cache results in
+  # slightly faster startup times. The tool cache is backed by sqlite
+  # database, which cannot be stored on certain network disks. The cache
+  # location is configurable using the ``tool_cache_data_dir`` setting,
+  # but can be disabled completely here.
+  #enable_tool_document_cache: false
 
   # Tool related caching. Fully expanded tools and metadata will be
   # stored at this path. Per tool_conf cache locations can be configured

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -617,12 +617,12 @@ galaxy:
   # generated commands run in sh.
   #default_job_shell: /bin/bash
 
-  # Set this to true to enable the tool document cache. This cache
-  # stores expanded xml strings. Enabling the tool cache results in
-  # slightly faster startup times. The tool cache is backed by sqlite
-  # database, which cannot be stored on certain network disks. The cache
-  # location is configurable using the ``tool_cache_data_dir`` setting,
-  # but can be disabled completely here.
+  # Whether to enable the tool document cache. This cache stores
+  # expanded XML strings. Enabling the tool cache results in slightly
+  # faster startup times. The tool cache is backed by a SQLite database,
+  # which cannot be stored on certain network disks. The cache location
+  # is configurable using the ``tool_cache_data_dir`` setting, but can
+  # be disabled completely here.
   #enable_tool_document_cache: false
 
   # Tool related caching. Fully expanded tools and metadata will be

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -770,9 +770,9 @@ mapping:
         default: false
         required: false
         desc: |
-          Set this to true to enable the tool document cache. This cache stores
-          expanded xml strings. Enabling the tool cache results in slightly faster startup
-          times. The tool cache is backed by sqlite database, which cannot
+          Whether to enable the tool document cache. This cache stores
+          expanded XML strings. Enabling the tool cache results in slightly faster startup
+          times. The tool cache is backed by a SQLite database, which cannot
           be stored on certain network disks. The cache location is configurable
           using the ``tool_cache_data_dir`` setting, but can be disabled completely here.
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -767,11 +767,11 @@ mapping:
 
       enable_tool_document_cache:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
-          Set this to false to disable the tool document cache. This cache stores
-          expanded xml strings. Disabling the tool cache results in slower startup
+          Set this to true to enable the tool document cache. This cache stores
+          expanded xml strings. Enabling the tool cache results in slightly faster startup
           times. The tool cache is backed by sqlite database, which cannot
           be stored on certain network disks. The cache location is configurable
           using the ``tool_cache_data_dir`` setting, but can be disabled completely here.


### PR DESCRIPTION
It's kind of brittle, and https://github.com/galaxyproject/galaxy/pull/10804
has improved the parsing so much that it doesn't add much benefit.
Instances on Anvil start up in ~ 32 seconds, with all of main's toolbox.