### PR TITLE
Set default USE_UVICORN to true only on python >= 3.7

### DIFF
--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -78,7 +78,8 @@ uwsgi:
 """)
 
 DEFAULT_LOCALES = "en"
-USE_UVICORN = asbool(os.environ.get('GALAXY_TEST_USE_UVICORN', True))
+CAN_BUILD_ASGI_APP = sys.version_info[:2] >= (3, 7)
+USE_UVICORN = asbool(os.environ.get('GALAXY_TEST_USE_UVICORN', CAN_BUILD_ASGI_APP))
 
 log = logging.getLogger("test_driver")
 


### PR DESCRIPTION
Fixes test exception in https://github.com/galaxyproject/planemo/pull/1142#issuecomment-784308435