### PR TITLE
[21.01] Fix selecting datasets from workflow & tool form upload

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -49,7 +49,7 @@ import { UrlTracker } from "./utilities";
 import { Model } from "./model";
 import { Services } from "./services";
 import { getAppRoot } from "onload/loadConfig";
-import { openUploadModal } from "components/Upload";
+import { mountUploadModal } from "components/Upload";
 
 Vue.use(BootstrapVue);
 
@@ -134,8 +134,9 @@ export default {
                 format: this.format,
                 callback: this.callback,
                 modalShow: true,
+                selectable: true,
             };
-            openUploadModal(propsData);
+            mountUploadModal(propsData);
             this.modalShow = false;
         },
         /** Called when selection is complete, values are formatted and parsed to external callback **/

--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -43,7 +43,7 @@
         </template>
         <template v-slot:buttons>
             <b-button ref="btnClose" class="ui-button-default" id="btn-close" @click="$emit('dismiss')">
-                {{ btnCloseTitle }}
+                {{ btnCloseTitle | localize }}
             </b-button>
             <b-button
                 ref="btnReset"
@@ -157,7 +157,6 @@ export default {
             btnBuildTitle: _l("Build"),
             btnStopTitle: _l("Pause"),
             btnResetTitle: _l("Reset"),
-            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
         };
     },
     created() {
@@ -262,7 +261,7 @@ export default {
             this.counterRunning = 0;
             this._updateStateForCounters();
             this._eventReset();
-            this.$emit("hide");
+            this.$emit("dismiss");
         },
 
         /** Start upload process */

--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -35,7 +35,7 @@
         </template>
         <template v-slot:buttons>
             <b-button ref="btnClose" class="ui-button-default" @click="$emit('dismiss')">
-                {{ btnCloseTitle }}
+                {{ btnCloseTitle | localize }}
             </b-button>
             <b-button
                 ref="btnStart"
@@ -74,7 +74,6 @@ export default {
             showHelper: true,
             btnResetTitle: _l("Reset"),
             btnStartTitle: _l("Start"),
-            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
             readyStart: false,
         };
     },

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -133,7 +133,6 @@ export default {
             showHelper: true,
             extension: this.app.defaultExtension,
             genome: this.app.defaultGenome,
-            callback: this.app.callback,
             listExtensions: [],
             listGenomes: [],
             running: false,
@@ -153,7 +152,6 @@ export default {
             btnStartTitle: _l("Start"),
             btnStopTitle: _l("Pause"),
             btnResetTitle: _l("Reset"),
-            btnCloseTitle: this.app.callback ? _l("Cancel") : _l("Close"),
             btnSelectTitle: _l("Select"),
         };
     },
@@ -234,8 +232,7 @@ export default {
                     src: model.src,
                 };
             });
-            this.callback(asDict);
-            this.$emit("cancel");
+            this.$emit("dismiss", asDict);
         },
         _newUploadModelProps: function (index, file) {
             return {

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -1,6 +1,6 @@
 <template>
     <upload-wrapper ref="wrapper" :top-info="topInfo | l">
-        <span style="width: 25%; display: inline; height: 100%;" class="float-left">
+        <span style="width: 25%; display: inline; height: 100%" class="float-left">
             <div class="upload-rule-option">
                 <div class="upload-rule-option-title">{{ "Upload data as" | l }}</div>
                 <div class="rule-data-type">
@@ -33,10 +33,10 @@
                 </div>
             </div>
         </span>
-        <span style="display: inline; float: right; width: 75%; height: 300px;">
+        <span style="display: inline; float: right; width: 75%; height: 300px">
             <textarea
                 class="upload-rule-source-content form-control"
-                style="height: 100%;"
+                style="height: 100%"
                 v-model="sourceContent"
                 :disabled="selectionType != 'paste'"
             ></textarea>
@@ -101,11 +101,6 @@ export default {
             btnBuildTitle: "Build",
             btnResetTitle: "Reset",
         };
-    },
-    computed: {
-        btnCloseTitle() {
-            return this.app.callback ? "Cancel" : "Close";
-        },
     },
     created() {
         this.initCollection();
@@ -194,7 +189,7 @@ export default {
             }
             selection.dataType = this.dataType;
             Galaxy.currHistoryPanel.buildCollection("rules", selection, true);
-            this.$emit("hide");
+            this.$emit("dismiss");
         },
     },
 };

--- a/client/src/components/Upload/RulesInput.vue
+++ b/client/src/components/Upload/RulesInput.vue
@@ -1,6 +1,6 @@
 <template>
     <upload-wrapper ref="wrapper" :top-info="topInfo | l">
-        <span style="width: 25%; display: inline; height: 100%" class="float-left">
+        <span style="width: 25%; display: inline; height: 100%;" class="float-left">
             <div class="upload-rule-option">
                 <div class="upload-rule-option-title">{{ "Upload data as" | l }}</div>
                 <div class="rule-data-type">
@@ -33,10 +33,10 @@
                 </div>
             </div>
         </span>
-        <span style="display: inline; float: right; width: 75%; height: 300px">
+        <span style="display: inline; float: right; width: 75%; height: 300px;">
             <textarea
                 class="upload-rule-source-content form-control"
-                style="height: 100%"
+                style="height: 100%;"
                 v-model="sourceContent"
                 :disabled="selectionType != 'paste'"
             ></textarea>

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -31,6 +31,10 @@ export default {
             type: Boolean,
             default: false,
         },
+        hasCallback: {
+            type: Boolean,
+            default: false,
+        },
     },
     computed: {
         btnFilesTitle() {
@@ -43,6 +47,9 @@ export default {
         remoteFiles() {
             // this needs to be true for the tests to pass
             return !!this.fileSourcesConfigured || !!this.ftpUploadSite;
+        },
+        btnCloseTitle() {
+            return this.hasCallback ? "Cancel" : "Close";
         },
     },
     methods: {

--- a/client/src/components/Upload/UploadButton.vue
+++ b/client/src/components/Upload/UploadButton.vue
@@ -29,7 +29,7 @@ import { VBTooltip } from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faUpload } from "@fortawesome/free-solid-svg-icons";
-import { openUploadModal } from "./mount";
+import { openGlobalUploadModal } from "./mount";
 library.add(faUpload);
 
 export default {
@@ -48,7 +48,7 @@ export default {
     },
     methods: {
         showUploadDialog(e) {
-            openUploadModal();
+            openGlobalUploadModal();
         },
         setStatus(val) {
             this.status = val;

--- a/client/src/components/Upload/UploadModal.vue
+++ b/client/src/components/Upload/UploadModal.vue
@@ -7,10 +7,8 @@ Provides user and current history to modal because it currently has initializati
     <CurrentUser v-slot="{ user }">
         <UserHistories v-if="user" :user="user" v-slot="{ currentHistoryId }">
             <b-modal
-                :id="id"
                 v-model="modalShow"
                 :static="modalStatic"
-                ref="uploadModal"
                 header-class="no-separator"
                 modal-class="ui-modal"
                 dialog-class="upload-dialog"
@@ -28,8 +26,6 @@ Provides user and current history to modal because it currently has initializati
                     :current-history-id="currentHistoryId"
                     v-bind="{ ...$props, ...$attrs }"
                     @dismiss="dismiss"
-                    @hide="hide"
-                    @cancel="cancel"
                 />
             </b-modal>
         </UserHistories>
@@ -55,36 +51,27 @@ export default {
     },
     data() {
         return {
-            id: null,
             modalShow: false,
         };
     },
     methods: {
         show() {
             this.modalShow = true;
-            this.$nextTick(this.tryMountingTabs);
         },
         hide() {
             this.modalShow = false;
         },
-        cancel() {
-            this.hide();
-            this.$nextTick(() => {
-                this.$bvModal.hide(this.id, "cancel");
-            });
-        },
-        dismiss() {
-            // hide or cancel based on whether this is a singleton
-            if (this.callback) {
-                this.cancel();
-            } else {
-                this.hide();
+        dismiss(result) {
+            if (undefined !== result) {
+                this.$root.$emit("uploadResult", result);
             }
+            this.hide();
         },
     },
     mounted() {
-        this.eventHub.$on("upload:open", this.show);
-        this.id = String(this._uid);
+        this.show();
+        // handles subsequent external requests to re-open a re-used modal
+        this.$root.$on("openUpload", this.show);
     },
 };
 </script>

--- a/client/src/components/Upload/UploadModalContent.vue
+++ b/client/src/components/Upload/UploadModalContent.vue
@@ -1,16 +1,23 @@
 <template>
     <b-tabs v-if="ready">
         <b-tab title="Regular" id="regular" button-id="tab-title-link-regular" v-if="showRegular">
-            <default :app="this" :lazy-load-max="50" :multiple="multiple" :selectable="selectable" v-on="$listeners" />
+            <default
+                :app="this"
+                :lazy-load-max="50"
+                :multiple="multiple"
+                :has-callback="hasCallback"
+                :selectable="selectable"
+                v-on="$listeners"
+            />
         </b-tab>
         <b-tab title="Composite" id="composite" button-id="tab-title-link-composite" v-if="showComposite">
-            <composite :app="this" :selectable="selectable" v-on="$listeners" />
+            <composite :app="this" :has-callback="hasCallback" :selectable="selectable" v-on="$listeners" />
         </b-tab>
         <b-tab title="Collection" id="collection" button-id="tab-title-link-collection" v-if="showCollection">
-            <collection :app="this" :selectable="selectable" v-on="$listeners" />
+            <collection :app="this" :has-callback="hasCallback" :selectable="selectable" v-on="$listeners" />
         </b-tab>
         <b-tab title="Rule-based" id="rule-based" button-id="tab-title-link-rule-based" v-if="showRules">
-            <rules-input :app="this" :selectable="selectable" v-on="$listeners" />
+            <rules-input :app="this" :has-callback="hasCallback" :selectable="selectable" v-on="$listeners" />
         </b-tab>
     </b-tabs>
     <div v-else>
@@ -43,7 +50,6 @@ export default {
     props: {
         currentHistoryId: { type: String, required: true },
         currentUserId: { type: String, default: "" },
-        selectable: { type: Boolean, required: false, default: false },
         ...commonProps,
     },
     data: function () {

--- a/client/src/components/Upload/config.js
+++ b/client/src/components/Upload/config.js
@@ -12,6 +12,7 @@ export function initializeUploadDefaults(propsData = {}) {
         ftpUploadSite: Galaxy.config.ftp_upload_site,
         defaultGenome: Galaxy.config.default_genome,
         defaultExtension: Galaxy.config.default_extension,
+        selectable: false,
     };
     return Object.assign({}, defaults, propsData);
 }

--- a/client/src/components/Upload/helpers.js
+++ b/client/src/components/Upload/helpers.js
@@ -38,10 +38,15 @@ export const commonProps = {
         type: Boolean,
         default: true,
     },
-    callback: {
+    hasCallback: {
         // Return uploads when done if supplied.
-        type: Function,
-        default: null,
+        type: Boolean,
+        default: false,
+    },
+    selectable: {
+        type: Boolean,
+        required: false,
+        default: false,
     },
     auto: {
         type: Object,

--- a/client/src/components/Upload/index.js
+++ b/client/src/components/Upload/index.js
@@ -3,5 +3,5 @@
  */
 export { default as UploadModal } from "./UploadModal";
 export { initializeUploadDefaults } from "./config";
-export { mountUploadModal, openUploadModal } from "./mount";
+export { openGlobalUploadModal, mountUploadModal } from "./mount";
 export { default as UploadButton } from "./UploadButton";

--- a/client/src/utils/data.js
+++ b/client/src/utils/data.js
@@ -4,7 +4,7 @@ import Vue from "vue";
 import DataDialog from "components/DataDialog/DataDialog.vue";
 import { FilesDialog } from "components/FilesDialog";
 import DatasetCollectionDialog from "components/SelectionDialog/DatasetCollectionDialog.vue";
-import { openUploadModal } from "components/Upload";
+import { mountUploadModal } from "components/Upload";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
 
@@ -41,7 +41,7 @@ export function dialog(callback, options = {}) {
             history: history_id,
         });
         if (options.new) {
-            openUploadModal(options);
+            mountUploadModal(options);
         } else {
             _mountSelectionDialog(DataDialog, options);
         }


### PR DESCRIPTION
Addresses:
https://github.com/galaxyproject/galaxy/issues/11432

selectable and callback props were not capable of being re-assigned upon successive openings of the upload dialog, because the author imperatively re-assigned all properties to internal non-reactive variables instead of using Vue properties

Edit: Marius was nice enough to locate the issue with a lilttle video

![second upload button](https://files.gitter.im/5cfabae8d73408ce4fc278e7/1O1i/upload-button.gif)


