### PR TITLE
Allow anonymous access to S3 buckets via file sources plugins.

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -219,6 +219,14 @@ class ConditionalDependencies:
     def check_fs_webdavfs(self):
         return 'webdav' in self.file_sources
 
+    def check_fs_s3fs(self):
+        # pyfilesystem plugin access to s3
+        return 's3' in self.file_sources
+
+    def check_s3fs(self):
+        # use s3fs directly (skipping pyfilesystem) for direct access to more options
+        return 's3fs' in self.file_sources
+
     def check_watchdog(self):
         install_set = {'auto', 'True', 'true', 'polling'}
         return (self.config['watch_tools'] in install_set

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -13,8 +13,11 @@ python-ldap==3.2.0
 python-pam
 galaxycloudrunner
 
-fs.webdavfs
-fs.dropboxfs
+# For file sources plugins
+fs.webdavfs  # type: webdav
+fs.dropboxfs  # type: dropbox
+fs-s3fs  # type: s3
+s3fs  # type: s3fs
 
 # Chronos client
 chronos-python==1.2.1

--- a/test/unit/files/_util.py
+++ b/test/unit/files/_util.py
@@ -74,6 +74,20 @@ def assert_realizes_as(file_sources, uri, expected, user_context=None):
             raise AssertionError(message)
 
 
+def assert_realizes_contains(file_sources, uri, expected, user_context=None):
+    file_source_path = file_sources.get_file_source_path(uri)
+    with tempfile.NamedTemporaryFile(mode='r') as temp:
+        file_source_path.file_source.realize_to(file_source_path.path, temp.name, user_context=user_context)
+        realized_contents = temp.read()
+        if expected not in realized_contents:
+            message = "Expected to realize contents at [{}] to contain [{}], instead found [{}]".format(
+                uri,
+                expected,
+                realized_contents,
+            )
+            raise AssertionError(message)
+
+
 def write_from(file_sources, uri, content, user_context=None):
     file_source_path = file_sources.get_file_source_path(uri)
     with tempfile.NamedTemporaryFile(mode='w') as f:

--- a/test/unit/files/s3.py
+++ b/test/unit/files/s3.py
@@ -1,0 +1,38 @@
+import os
+
+import pytest
+
+from galaxy.files import ConfiguredFileSources, ConfiguredFileSourcesConfig
+from ._util import (
+    assert_realizes_contains,
+    find,
+    user_context_fixture,
+)
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+FILE_SOURCES_CONF = os.path.join(SCRIPT_DIRECTORY, "s3_file_sources_conf.yml")
+
+skip_if_not_slow = pytest.mark.skipif(
+    not os.environ.get('GALAXY_TEST_INCLUDE_SLOW'),
+    reason="GALAXY_TEST_INCLUDE_SLOW not set"
+)
+
+
+@skip_if_not_slow
+def test_file_source():
+    user_context = user_context_fixture()
+    file_sources = _configured_file_sources()
+    file_source_pair = file_sources.get_file_source_path("gxfiles://test1")
+
+    assert file_source_pair.path == "/"
+    file_source = file_source_pair.file_source
+    res = file_source.list("/", recursive=False, user_context=user_context)
+    print(res)
+    dup = find(res, "File", "data_use_policies.txt")
+    assert dup
+
+    assert_realizes_contains(file_sources, "gxfiles://test1/data_use_policies.txt", "DATA USE POLICIES", user_context=user_context)
+
+
+def _configured_file_sources(conf_file=FILE_SOURCES_CONF):
+    file_sources_config = ConfiguredFileSourcesConfig()
+    return ConfiguredFileSources(file_sources_config, conf_file=conf_file)

--- a/test/unit/files/s3_file_sources_conf.yml
+++ b/test/unit/files/s3_file_sources_conf.yml
@@ -1,0 +1,5 @@
+- type: s3fs
+  id: test1
+  doc: Test anonymous access to an AWS S3 bucket.
+  bucket: genomeark
+  anon: true


### PR DESCRIPTION
The fs-s3fs PyFileSystem plugin (integrated in #10523) does not allow anonymous access to buckets as far as I can tell. s3fs (ironically not actually used by fs-s3fs) seems more mature and better maintained and does allow easy anonymous access to buckets.

I was able to access Genome Ark (for #11435) from my laptop without any configured credentials using the following definition and this PR.

```yaml
- type: s3fs
  label: Genome Ark
  id: genomeark
  doc: Access to Genome Ark open data on AWS.
  bucket: genomeark
  anon: true
```
