### PR TITLE
[21.01] Nora visualization version bump incorporating a few upstream bugfixes

### DIFF
--- a/config/plugins/visualizations/nora/package.json
+++ b/config/plugins/visualizations/nora/package.json
@@ -9,7 +9,7 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "@galaxyproject/nora": "^1.1.0",
+    "@galaxyproject/nora": "1.1.2",
     "cpy-cli": "^3.1.1"
   },
   "scripts": {


### PR DESCRIPTION
Should hopefully fix #11468 

I incorporated upstream changes and rebuilt and published a new nora-galaxy viz at https://www.npmjs.com/package/@galaxyproject/nora, which this uses.

Fixes include protocol handling to support https, which was noticed on on usegalaxy.org