### PR TITLE
add copy tooldID btn

### DIFF
--- a/client/src/mvc/tool/tool-form-base.js
+++ b/client/src/mvc/tool/tool-form-base.js
@@ -195,6 +195,13 @@ export default FormBase.extend({
                 );
             },
         });
+        menu_button.addMenu({
+            icon: "fa-files-o",
+            title: _l("Copy tool ID"),
+            onclick: function () {
+                copy(`${options.id}`, "Tool ID was copied to your clipboard");
+            },
+        });
 
         // add admin operations
         if (Galaxy.user && Galaxy.user.get("is_admin")) {

--- a/client/src/mvc/tool/tool-form-base.js
+++ b/client/src/mvc/tool/tool-form-base.js
@@ -197,7 +197,7 @@ export default FormBase.extend({
         });
         menu_button.addMenu({
             icon: "fa-files-o",
-            title: _l("Copy tool ID"),
+            title: _l("Copy Tool ID"),
             onclick: function () {
                 copy(`${options.id}`, "Tool ID was copied to your clipboard");
             },


### PR DESCRIPTION
as a part of papercuts...

fix for https://github.com/galaxyproject/galaxy/issues/11472
It adds button that puts toold-Id in clibboard. 
****
![image](https://user-images.githubusercontent.com/15801412/109142675-d3949900-7767-11eb-9338-3fd75fbcc67c.png)

