### PR TITLE
Copy to Clipboard button next to the tool id in job information

### DIFF
--- a/client/src/components/CopyToClipboard.vue
+++ b/client/src/components/CopyToClipboard.vue
@@ -1,5 +1,5 @@
 <template>
-    <font-awesome-icon :title="title" :icon="['far', 'copy']" @click="copy(text, message)"></font-awesome-icon>
+    <font-awesome-icon :title="title" :icon="['far', 'copy']" @click="copy(text, message)"/>
 </template>
 
 <script>

--- a/client/src/components/CopyToClipboard.vue
+++ b/client/src/components/CopyToClipboard.vue
@@ -1,0 +1,33 @@
+<template>
+    <font-awesome-icon title="Copy Tool ID" icon="copy" @click="copy(text, message)"></font-awesome-icon>
+</template>
+
+<script>
+import { copy } from "utils/clipboard";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+library.add(faCopy);
+
+export default {
+    components: {
+        FontAwesomeIcon,
+    },
+    props: {
+        text: {
+            type: String,
+            required: true,
+        },
+        message: {
+            type: String,
+            required: true,
+        },
+    },
+    methods: {
+        copy(text, message) {
+            copy(text, message);
+        },
+    },
+};
+</script>

--- a/client/src/components/CopyToClipboard.vue
+++ b/client/src/components/CopyToClipboard.vue
@@ -1,5 +1,5 @@
 <template>
-    <font-awesome-icon :title="title" icon="copy" @click="copy(text, message)"></font-awesome-icon>
+    <font-awesome-icon :title="title" :icon="['far', 'copy']" @click="copy(text, message)"></font-awesome-icon>
 </template>
 
 <script>

--- a/client/src/components/CopyToClipboard.vue
+++ b/client/src/components/CopyToClipboard.vue
@@ -1,5 +1,5 @@
 <template>
-    <font-awesome-icon title="Copy Tool ID" icon="copy" @click="copy(text, message)"></font-awesome-icon>
+    <font-awesome-icon :title="title" icon="copy" @click="copy(text, message)"></font-awesome-icon>
 </template>
 
 <script>
@@ -22,6 +22,11 @@ export default {
         message: {
             type: String,
             required: true,
+        },
+        title: {
+            type: String,
+            default: "copy to clipboard",
+            required: false,
         },
     },
     methods: {

--- a/client/src/components/CopyToClipboard.vue
+++ b/client/src/components/CopyToClipboard.vue
@@ -1,5 +1,5 @@
 <template>
-    <font-awesome-icon :title="title" :icon="['far', 'copy']" @click="copy(text, message)"/>
+    <font-awesome-icon :title="title" :icon="['far', 'copy']" @click="copy(text, message)" />
 </template>
 
 <script>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -5,7 +5,14 @@
             <tbody>
                 <tr v-if="job && job.tool_id">
                     <td>Galaxy Tool ID:</td>
-                    <td id="galaxy-tool-id">{{ job.tool_id }}</td>
+                    <td id="galaxy-tool-id">
+                        {{ job.tool_id }}
+                        <font-awesome-icon
+                            title="Copy Tool ID"
+                            icon="copy"
+                            @click="copyToolId(job.tool_id)"
+                        ></font-awesome-icon>
+                    </td>
                 </tr>
                 <tr v-if="job && job.tool_version">
                     <td>Galaxy Tool Version:</td>
@@ -59,12 +66,19 @@ import { getAppRoot } from "onload/loadConfig";
 import DecodedId from "../DecodedId.vue";
 import CodeRow from "./CodeRow.vue";
 import UtcDate from "components/UtcDate";
+import { copy } from "utils/clipboard";
+import { faCopy } from "@fortawesome/free-regular-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+
+library.add(faCopy);
 
 export default {
     components: {
         CodeRow,
         DecodedId,
         UtcDate,
+        FontAwesomeIcon
     },
     props: {
         job_id: {
@@ -89,6 +103,9 @@ export default {
         ...mapCacheActions(["fetchJob"]),
         getAppRoot() {
             return getAppRoot();
+        },
+        copyToolId(id) {
+            return copy(id,  "Tool ID was copied to your clipboard");
         },
     },
 };

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -7,11 +7,7 @@
                     <td>Galaxy Tool ID:</td>
                     <td id="galaxy-tool-id">
                         {{ job.tool_id }}
-                        <font-awesome-icon
-                            title="Copy Tool ID"
-                            icon="copy"
-                            @click="copyToolId(job.tool_id)"
-                        ></font-awesome-icon>
+                        <copy-to-clipboard message="Tool ID was copied to your clipboard" :text="job.tool_id" />
                     </td>
                 </tr>
                 <tr v-if="job && job.tool_version">
@@ -66,19 +62,14 @@ import { getAppRoot } from "onload/loadConfig";
 import DecodedId from "../DecodedId.vue";
 import CodeRow from "./CodeRow.vue";
 import UtcDate from "components/UtcDate";
-import { copy } from "utils/clipboard";
-import { faCopy } from "@fortawesome/free-regular-svg-icons";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-
-library.add(faCopy);
+import CopyToClipboard from "components/CopyToClipboard";
 
 export default {
     components: {
         CodeRow,
         DecodedId,
         UtcDate,
-        FontAwesomeIcon
+        CopyToClipboard,
     },
     props: {
         job_id: {
@@ -103,9 +94,6 @@ export default {
         ...mapCacheActions(["fetchJob"]),
         getAppRoot() {
             return getAppRoot();
-        },
-        copyToolId(id) {
-            return copy(id,  "Tool ID was copied to your clipboard");
         },
     },
 };

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -7,7 +7,11 @@
                     <td>Galaxy Tool ID:</td>
                     <td id="galaxy-tool-id">
                         {{ job.tool_id }}
-                        <copy-to-clipboard message="Tool ID was copied to your clipboard" :text="job.tool_id" />
+                        <copy-to-clipboard
+                            message="Tool ID was copied to your clipboard"
+                            :text="job.tool_id"
+                            title="Copy Tool ID"
+                        />
                     </td>
                 </tr>
                 <tr v-if="job && job.tool_version">

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -10,7 +10,7 @@
                         <copy-to-clipboard
                             message="Tool ID was copied to your clipboard"
                             :text="job.tool_id"
-                            title="copy Tool ID"
+                            title="Copy Tool ID"
                         />
                     </td>
                 </tr>

--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -10,7 +10,7 @@
                         <copy-to-clipboard
                             message="Tool ID was copied to your clipboard"
                             :text="job.tool_id"
-                            title="Copy Tool ID"
+                            title="copy Tool ID"
                         />
                     </td>
                 </tr>


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/11473


Clipboard button next to the tool id:

![image](https://user-images.githubusercontent.com/15801412/109159695-95a26f80-777d-11eb-9457-1c035f1c94f2.png)


Additionaly it brings generic `copy-to-clipboard` component e.g.:

` <copy-to-clipboard message="Tool ID was copied to your clipboard" :text="job.tool_id" />`