### PR TITLE
Remove filter from list:paired element names when filter is not _1

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -964,8 +964,8 @@ export default {
             };
         },
         changeFilters: function (filter) {
-            this.forwardFilter = this.commonFilters[filter][0];
-            this.reverseFilter = this.commonFilters[filter][1];
+            this.filters[0] = this.forwardFilter = this.commonFilters[filter][0];
+            this.filters[1] = this.reverseFilter = this.commonFilters[filter][1];
         },
         clickedCreate: function (collectionName) {
             this.checkForDuplicates();


### PR DESCRIPTION
The code was removing `this.filters[0..1]` from the dataset names, but the `changeFilters` method was updating `this.forwardFilter` and `this.reverseFilter`

This PR resolves #11487 