### PR TITLE
Mark some tool reload tests as expected to fail

### DIFF
--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -190,7 +190,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         assert tool is not None
         assert len(tool._macro_paths) == 1
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(raises=AssertionError)
     def test_tool_reload_when_macro_is_altered(self):
         self._init_tool(filename="tool_with_macro.xml",
                         tool_contents=SIMPLE_TOOL_WITH_MACRO,
@@ -211,7 +211,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
         self._try_until_no_errors(check_tool_macro)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(raises=AssertionError)
     def test_tool_reload_for_broken_tool(self):
         self._init_tool(filename="simple_tool.xml", version="1.0")
         self._add_config("""<toolbox><tool file="simple_tool.xml"/></toolbox>""")

--- a/test/unit/tools/test_toolbox.py
+++ b/test/unit/tools/test_toolbox.py
@@ -6,6 +6,7 @@ import string
 import time
 import unittest
 
+import pytest
 import routes
 
 from galaxy import model
@@ -189,6 +190,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
         assert tool is not None
         assert len(tool._macro_paths) == 1
 
+    @pytest.mark.xfail
     def test_tool_reload_when_macro_is_altered(self):
         self._init_tool(filename="tool_with_macro.xml",
                         tool_contents=SIMPLE_TOOL_WITH_MACRO,
@@ -209,6 +211,7 @@ class ToolBoxTestCase(BaseToolBoxTestCase):
 
         self._try_until_no_errors(check_tool_macro)
 
+    @pytest.mark.xfail
     def test_tool_reload_for_broken_tool(self):
         self._init_tool(filename="simple_tool.xml", version="1.0")
         self._add_config("""<toolbox><tool file="simple_tool.xml"/></toolbox>""")


### PR DESCRIPTION
The unit tests `ToolBoxTestCase::test_tool_reload_for_broken_tool` and `ToolBoxTestCase::test_tool_reload_when_macro_is_altered` were failing or passing transiently.
Marked as [expected to fail](https://docs.pytest.org/en/latest/skipping.html#xfail-mark-test-functions-as-expected-to-fail) as @mvdbeek suggested.