### PR TITLE
[WIP][20.09] Record explicit dataset collection instances as invocation outputs

### DIFF
--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -427,6 +427,8 @@ class WorkflowStepExecutionTracker(ExecutionTracker):
         if not self.collection_info:
             for output_name, output in outputs:
                 self.invocation_step.add_output(output_name, output)
+            for jtodca in job.output_dataset_collection_instances:
+                self.invocation_step.add_output(jtodca.name, jtodca.dataset_collection_instance)
             self.invocation_step.job = job
 
     def new_collection_execution_slices(self):


### PR DESCRIPTION
This is needed for consuming outputs from tools that generate dataset collections that are not mapped over ... under certain conditions, that is why no tests are included here, but this is needed for https://github.com/galaxyproject/iwc/pull/23 to schedule successfully.