### PR TITLE
[WIP][20.09] Record explicit HDCAs as invocation outputs

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -612,6 +612,7 @@ class DefaultToolAction:
                 # Dispatch to a job handler. enqueue() is responsible for flushing the job
                 app.job_manager.enqueue(job, tool=tool)
                 trans.log_event("Added job to the job queue, id: %s" % str(job.id), tool_id=job.tool_id)
+            out_data.update(output_collections.out_collection_instances)
             return job, out_data, history
 
     def _remap_job_on_rerun(self, trans, galaxy_session, rerun_remap_job_id, current_job, out_data):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1776,7 +1776,8 @@ class ToolModule(WorkflowModule):
         else:
             step_outputs = dict(execution_tracker.output_datasets)
             step_outputs.update(execution_tracker.output_collections)
-        progress.set_step_outputs(invocation_step, step_outputs, already_persisted=not invocation_step.is_new)
+        if complete:
+            progress.set_step_outputs(invocation_step, step_outputs, already_persisted=False)
 
         if collection_info:
             step_inputs = mapping_params.param_template


### PR DESCRIPTION
and set invocation outputs only when all jobs have been scheduled.

This is like https://github.com/galaxyproject/galaxy/pull/11498, but ensures that we also correctly set invocation workflow outputs.