### PR TITLE
add sshfs plugin to the new file infrastructure

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -16,6 +16,7 @@ galaxycloudrunner
 # For file sources plugins
 fs.webdavfs  # type: webdav
 fs.dropboxfs  # type: dropbox
+fs.fs.sshfs  # type: ssh
 fs-s3fs  # type: s3
 s3fs  # type: s3fs
 

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -16,7 +16,7 @@ galaxycloudrunner
 # For file sources plugins
 fs.webdavfs  # type: webdav
 fs.dropboxfs  # type: dropbox
-fs.fs.sshfs  # type: ssh
+fs.sshfs  # type: ssh
 fs-s3fs  # type: s3
 s3fs  # type: s3fs
 

--- a/lib/galaxy/files/sources/ssh.py
+++ b/lib/galaxy/files/sources/ssh.py
@@ -1,0 +1,20 @@
+try:
+    from fs.sshfs import SSHFS
+except ImportError:
+    SSHFS = None
+
+from ._pyfilesystem2 import PyFilesystem2FilesSource
+
+
+class SshFilesSource(PyFilesystem2FilesSource):
+    plugin_type = "ssh"
+    required_module = SSHFS
+    required_package = "fs.sshfs"
+
+    def _open_fs(self, user_context):
+        props = self._serialization_props(user_context)
+        handle = SSHFS(**props)
+        return handle
+
+
+__all__ = ("SshFilesSource",)


### PR DESCRIPTION
This can be configured with something like in the files_sources_conf.yml

```
- type: ssh
  id: ssh-to-host-x
  doc: "SSH share on X"
  host: gruenings.eu
  user: bag
  passwd: None
  pkey: /home/user/.ssh/id_rsa
  timeout: 10
  port: 22
  keepalive: 10
  compress: False
  config_path: "~/.ssh/config"

- type: ssh
  id: local-ssh
  doc: "local ssh"
  host: localhost
  user: bag
```

@jmchilton should we add a files_sources_conf.yml.sample file with example configs?

fs.sshfs is needed to make it work.
