### PR TITLE
Add ready-to-go gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,34 @@
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
+    addComment: false
+    # add a "Review in Gitpod" button to pull requests (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false
+image: gitpod/workspace-postgres
+tasks:
+  - init: >
+      cp .vscode/settings_gitpod.json .vscode/settings.json &&
+      cp .vscode/launch_gitpod.json .vscode/launch.json &&
+      pip install psycopg2 &&
+      pip install -r lib/galaxy/dependencies/dev-requirements.txt &&
+      createdb galaxy &&
+      make client
+  - command: cp config/galaxy.yml.sample config/galaxy.yml
+  - command: make client-watch
+# Ports to expose on workspace startup (optional)
+ports:
+  - port: 8000
+vscode:
+  extensions:
+    - ms-python.python
+    - ms-python.vscode-pylance

--- a/.vscode/.test.env
+++ b/.vscode/.test.env
@@ -1,0 +1,1 @@
+GALAXY_TEST_TOOL_CONF="lib/galaxy/config/sample/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml"

--- a/.vscode/launch_gitpod.json
+++ b/.vscode/launch_gitpod.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "GalaxyFastAPI uvicorn",
+            "type": "python",
+            "request": "launch",
+            "module": "uvicorn",
+            "args": ["--app-dir", "lib",  "--factory", "galaxy.webapps.galaxy.fast_factory:factory"],
+            "env": {
+                "GALAXY_CONFIG_FILE": "${workspaceFolder}/config/galaxy.yml",
+                "GALAXY_CONDA_AUTO_INIT": "false",
+                "GALAXY_CONFIG_TOOL_CONFIG_FILE": "lib/galaxy/config/sample/tool_conf.xml.sample,test/functional/tools/samples_tool_conf.xml",
+                "GALAXY_CONFIG_DATABASE_CONNECTION": "postgresql://localhost/galaxy"
+            }
+        },
+        {
+            "name": "Tool test framework",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/.venv/bin/pytest",
+            "args": [
+                "test/functional/test_toolbox_pytest.py",
+                "-m",
+                "tool",
+                "-k",
+                "job_properties_test_2"
+            ]
+        }
+    ]
+}
+

--- a/.vscode/settings_gitpod.json
+++ b/.vscode/settings_gitpod.json
@@ -1,0 +1,13 @@
+{
+    "python.testing.pytestArgs": [
+        "--doctest-modules",
+        "lib/galaxy_test/api/",
+        "lib/galaxy/datatypes",
+        "test/unit",
+        "test/integration",
+        "lib/galaxy_test/selenium/"
+    ],
+    "python.testing.pytestEnabled": true,
+    "python.envFile": "${workspaceFolder}/.vscode/.test.env"
+}
+

--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -14,6 +14,7 @@ from importlib import import_module
 
 import routes
 import webob.compat
+import webob.cookies
 import webob.exc
 import webob.exc as httpexceptions  # noqa: F401
 # We will use some very basic HTTP/wsgi utilities from the paste library
@@ -383,7 +384,8 @@ class Request(webob.Request):
         cookies = SimpleCookie()
         cookie_header = self.environ.get("HTTP_COOKIE")
         if cookie_header:
-            galaxy_cookies = "; ".join(x.strip() for x in cookie_header.split('; ') if x.startswith('galaxy'))
+            all_cookies = webob.cookies.parse_cookie(cookie_header)
+            galaxy_cookies = {k.decode(): v.decode() for k, v in all_cookies if k.startswith(b'galaxy')}
             if galaxy_cookies:
                 try:
                     cookies.load(galaxy_cookies)


### PR DESCRIPTION
Once the workspace is pre-built it takes about 30-60 seconds to start the [Gitpod](https://www.gitpod.io/) environment, which gives you the option to start Galaxy within vscode in the browser, or run the tests, or do whatever you want in the terminal. We're also automatically starting `make client-watch`, so you can start changing the client and see the results in the browser.

If you start Galaxy in the debug configuration you'll be asked if you want to open the port, and then you can interact with a live Galaxy instance.

This is great for working on multiple branches, you don't need to switch branches, install dependencies and build the client ... just switch to a new tab in your browser.

Here's the Galaxy interface served in gitpod
![Screenshot 2021-02-28 at 21 43 18](https://user-images.githubusercontent.com/6804901/109432951-0495f780-7a0e-11eb-9a30-58f1da25d322.png)
And here are the tests:
![Screenshot 2021-02-28 at 21 45 39](https://user-images.githubusercontent.com/6804901/109433011-53dc2800-7a0e-11eb-88bc-2c5fb15f276e.png)

To get this to work I had to fix the cookie parsing in https://github.com/galaxyproject/galaxy/commit/61cefb35525d399971b216d778f71740119c19fa

We could also setup cvmfs, and this might also be really cool for IUC and IWC.
