### PR TITLE
[21.01] Fix DefaultQuotaAssociation access to Enum values

### DIFF
--- a/lib/galaxy/actions/admin.py
+++ b/lib/galaxy/actions/admin.py
@@ -32,7 +32,7 @@ class AdminActions:
             raise ActionInputError("Unable to parse the provided amount.")
         elif params.operation not in self.app.model.Quota.valid_operations:
             raise ActionInputError("Enter a valid operation.")
-        elif params.default != 'no' and params.default not in self.app.model.DefaultQuotaAssociation.types.__dict__.values():
+        elif params.default != 'no' and params.default not in self.app.model.DefaultQuotaAssociation.types.__members__.values():
             raise ActionInputError("Enter a valid default type.")
         elif params.default != 'no' and params.operation != '=':
             raise ActionInputError("Operation for a default quota must be '='.")
@@ -117,7 +117,7 @@ class AdminActions:
             return message
 
     def _set_quota_default(self, quota, params):
-        if params.default != 'no' and params.default not in self.app.model.DefaultQuotaAssociation.types.__dict__.values():
+        if params.default != 'no' and params.default not in self.app.model.DefaultQuotaAssociation.types.__members__.values():
             raise ActionInputError('Enter a valid default type.')
         else:
             if params.default != 'no':

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2296,7 +2296,7 @@ class DefaultQuotaAssociation(Quota, Dictifiable, RepresentById):
         REGISTERED = 'registered'
 
     def __init__(self, type, quota):
-        assert type in self.types.__dict__.values(), 'Invalid type'
+        assert type in self.types.__members__.values(), 'Invalid type'
         self.type = type
         self.quota = quota
 
@@ -2660,6 +2660,7 @@ class DatasetSourceHash(RepresentById):
 
 class DatasetHash(RepresentById):
     """ """
+
     def serialize(self, id_encoder, serialization_options):
         # serialize Dataset objects only for jobs that can actually modify these models.
         rval = dict_for(

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -809,7 +809,7 @@ class AdminGalaxy(controller.JSAppLauncher, AdminActions, UsesQuotaMixin, QuotaP
         if trans.request.method == 'GET':
             default_value = quota.default[0].type if quota.default else 'no'
             default_options = [('No', 'no')]
-            for typ in trans.app.model.DefaultQuotaAssociation.types.__dict__.values():
+            for typ in trans.app.model.DefaultQuotaAssociation.types.__members__.values():
                 default_options.append(('Yes, ' + typ, typ))
             return {
                 'title': 'Set quota default for \'%s\'' % util.sanitize_text(quota.name),


### PR DESCRIPTION
Follow up to #11277

Fixes some quota operation from the Admin panel:
- Set an existing quota as default
- Create a new quota as default with the `Yes` option and one of the supported types.