### PR TITLE
[20.09] Fix random-ish workflow error with maximum_workflow_jobs_per_scheduling_iteration

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -495,12 +495,10 @@ class ToolEvaluator:
             raise
         if interpreter:
             # TODO: path munging for cluster/dataset server relocatability
-            command_line_tokens = shlex.split(command_line)
-            executable = command_line_tokens[0]
+            executable = command_line.split()[0]
             tool_dir = os.path.abspath(self.tool.tool_dir)
             abs_executable = os.path.join(tool_dir, executable)
-            command_line_tokens[0:1] = [interpreter, abs_executable]
-            command_line = ' '.join(map(shlex.quote, command_line_tokens))
+            command_line = command_line.replace(executable, "{} {}".format(interpreter, shlex.quote(abs_executable)), 1)
         self.command_line = command_line
 
     def __build_config_files(self):

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shlex
 import tempfile
 
 
@@ -494,11 +495,12 @@ class ToolEvaluator:
             raise
         if interpreter:
             # TODO: path munging for cluster/dataset server relocatability
-            executable = command_line.split()[0]
+            command_line_tokens = shlex.split(command_line)
+            executable = command_line_tokens[0]
             tool_dir = os.path.abspath(self.tool.tool_dir)
             abs_executable = os.path.join(tool_dir, executable)
-            command_line = command_line.replace(executable, abs_executable, 1)
-            command_line = interpreter + " " + command_line
+            command_line_tokens[0:1] = [interpreter, abs_executable]
+            command_line = ' '.join(map(shlex.quote, command_line_tokens))
         self.command_line = command_line
 
     def __build_config_files(self):

--- a/lib/galaxy/tools/execute.py
+++ b/lib/galaxy/tools/execute.py
@@ -34,7 +34,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
     Execute a tool and return object containing summary (output data, number of
     failures, etc...).
     """
-    if max_num_jobs:
+    if max_num_jobs is not None:
         assert invocation_step is not None
     if rerun_remap_job_id:
         assert invocation_step is None
@@ -96,7 +96,7 @@ def execute(trans, tool, mapping_params, history, rerun_remap_job_id=None, colle
     execution_slice = None
 
     for i, execution_slice in enumerate(execution_tracker.new_execution_slices()):
-        if max_num_jobs and jobs_executed >= max_num_jobs:
+        if max_num_jobs is not None and jobs_executed >= max_num_jobs:
             has_remaining_jobs = True
             break
         else:

--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -173,7 +173,12 @@ class WorkflowInvoker:
 
         remaining_steps = self.progress.remaining_steps()
         delayed_steps = False
+        max_jobs_per_iteration_reached = False
         for (step, workflow_invocation_step) in remaining_steps:
+            max_jobs_to_schedule = self.progress.maximum_jobs_to_schedule_or_none
+            if max_jobs_to_schedule is not None and max_jobs_to_schedule <= 0:
+                max_jobs_per_iteration_reached = True
+                break
             step_delayed = False
             step_timer = ExecutionTimer()
             try:
@@ -208,7 +213,7 @@ class WorkflowInvoker:
             if not step_delayed:
                 log.debug("Workflow step {} of invocation {} invoked {}".format(step.id, workflow_invocation.id, step_timer))
 
-        if delayed_steps:
+        if delayed_steps or max_jobs_per_iteration_reached:
             state = model.WorkflowInvocation.states.READY
         else:
             state = model.WorkflowInvocation.states.SCHEDULED

--- a/test/integration/test_workflow_scheduling_options.py
+++ b/test/integration/test_workflow_scheduling_options.py
@@ -61,7 +61,7 @@ class MaximumWorkflowJobsPerSchedulingIterationTestCase(integration_util.Integra
     def handle_galaxy_config_kwds(cls, config):
         config["maximum_workflow_jobs_per_scheduling_iteration"] = 1
 
-    def test(self):
+    def test_collection_explicit_and_implicit(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow("""
 class: GalaxyWorkflow
 steps:
@@ -89,3 +89,40 @@ steps:
             self.workflow_populator.wait_for_workflow(history_id, workflow_id, invocation_id)
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)
             self.assertEqual("a\nc\nb\nd\ne\ng\nf\nh\n", self.dataset_populator.get_history_dataset_content(history_id, hid=0))
+
+    def test_scheduling_rounds(self):
+        with self.dataset_populator.test_history() as history_id:
+            invocation_response = self.workflow_populator.run_workflow("""
+class: GalaxyWorkflow
+inputs:
+  input1: data
+  text_input: text
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+  second_cat:
+    tool_id: cat1
+    in:
+      input1: first_cat/out_file1
+  collection_creates_dynamic_list_of_pairs:
+    tool_id: collection_creates_dynamic_list_of_pairs
+    in:
+      file: second_cat/out_file1
+  count_multi_file:
+    tool_id: count_multi_file
+    in:
+      input1: collection_creates_dynamic_list_of_pairs/list_output
+outputs:
+  wf_output_1:
+    outputSource: collection_creates_dynamic_list_of_pairs/list_output
+""", test_data="""
+input1:
+  value: 1.fasta
+  type: File
+  name: fasta1
+text_input: foo
+""", history_id=history_id)
+            invocation = self._get("/invocations/{}".format(invocation_response.invocation_id)).json()
+            assert 'wf_output_1' in invocation['output_collections']


### PR DESCRIPTION
If we reach `maximum_workflow_jobs_per_scheduling_iteration` in https://github.com/mvdbeek/galaxy/blob/1f82927ace979075dbd1540cad3493700889492a/lib/galaxy/tools/execute.py#L100 without having executed a single job for a new step we write out an empty step_outputs dict, which leads to
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 82, in __invoke
    outputs = invoker.invoke()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 190, in invoke
    incomplete_or_none = self._invoke_step(workflow_invocation_step)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 263, in _invoke_step
    incomplete_or_none = invocation_step.workflow_step.module.execute(self.trans,
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/modules.py", line 1659, in execute
    collection_info = self.compute_collection_info(progress, step, all_inputs)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/modules.py", line 335, in compute_collection_info
    collections_to_match = self._find_collections_to_match(
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/modules.py", line 354, in _find_collections_to_match
    data = progress.replacement_for_input(step, input_dict)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 328, in replacement_for_input
    replacement = [self.replacement_for_connection(c) for c in connection]
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 328, in <listcomp>
    replacement = [self.replacement_for_connection(c) for c in connection]
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 358, in replacement_for_connection
    raise Exception(message)
Exception: Workflow evaluation problem - failed to find output_name list_output in step_outputs {}
galaxy.workflow.scheduling_manager DEBUG 2021-03-01 19:58:59,493 Workflow invocation [1] scheduled
```