### PR TITLE
Handle the case where column list is a comma-separated string

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1362,9 +1362,9 @@ class ColumnListParameter(SelectToolParameter):
 
         value = other_values.get(self.name)
         if value is not None:
-            # There are cases where 'value' is a string of comma separated values
-            # This ensures that it is converted into a list
-            value = value if isinstance(value, list) else value.split(",")
+            # There are cases where 'value' is a string of comma separated values. This ensures 
+            # that it is converted into a list, with extra whitespace around items removed.
+            value = util.listify(value, do_strip=True)
             if not set(value).issubset(set(legal_values)) and self.is_file_empty(trans, other_values):
                 legal_values.extend(value)
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1362,7 +1362,7 @@ class ColumnListParameter(SelectToolParameter):
 
         value = other_values.get(self.name)
         if value is not None:
-            # There are cases where 'value' is a string of comma separated values. This ensures 
+            # There are cases where 'value' is a string of comma separated values. This ensures
             # that it is converted into a list, with extra whitespace around items removed.
             value = util.listify(value, do_strip=True)
             if not set(value).issubset(set(legal_values)) and self.is_file_empty(trans, other_values):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1361,9 +1361,12 @@ class ColumnListParameter(SelectToolParameter):
         legal_values = self.get_column_list(trans, other_values)
 
         value = other_values.get(self.name)
-        if value is not None and value not in legal_values and self.is_file_empty(trans, other_values):
-            value = value if isinstance(value, list) else [value]
-            legal_values.extend(value)
+        if value is not None:
+            # There are cases where 'value' is a string of comma separated values
+            # This ensures that it is converted into a list
+            value = value if isinstance(value, list) else value.split(",")
+            if not set(value).issubset(set(legal_values)) and self.is_file_empty(trans, other_values):
+                legal_values.extend(value)
 
         return set(legal_values)
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1193,6 +1193,26 @@ steps:
             invocation_id = self.__invoke_workflow(history_id, workflow_id, inputs)
             self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
 
+    @skip_without_tool('column_param')
+    def test_empty_file_data_column_specified(self):
+        # Regression test for https://github.com/galaxyproject/galaxy/pull/10981
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""class: GalaxyWorkflow
+steps:
+  empty_output:
+    tool_id: empty_output
+    outputs:
+      out_file1:
+        change_datatype: tabular
+  column_param:
+    tool_id: column_param
+    in:
+      input1: empty_output/out_file1
+    state:
+      col: 2
+      col_names: 'B'
+""", history_id=history_id)
+
     @skip_without_tool("mapper")
     @skip_without_tool("pileup")
     def test_workflow_metadata_validation_0(self):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1213,6 +1213,26 @@ steps:
       col_names: 'B'
 """, history_id=history_id)
 
+    @skip_without_tool('column_param_list')
+    def test_comma_separated_columns(self):
+        # Regression test for https://github.com/galaxyproject/galaxy/pull/10981
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""class: GalaxyWorkflow
+steps:
+  empty_output:
+    tool_id: empty_output
+    outputs:
+      out_file1:
+        change_datatype: tabular
+  column_param_list:
+    tool_id: column_param_list
+    in:
+      input1: empty_output/out_file1
+    state:
+      col: '2,3'
+      col_names: 'B'
+""", history_id=history_id)
+
     @skip_without_tool("mapper")
     @skip_without_tool("pileup")
     def test_workflow_metadata_validation_0(self):

--- a/test/functional/tools/column_param_list.xml
+++ b/test/functional/tools/column_param_list.xml
@@ -6,7 +6,7 @@ echo "col_names $col_names" >> '$output2'
     ]]></command>
     <inputs>
         <param name="input1" type="data" format="tabular" label="Input 1" />
-        <param name="col" type="data_column" multiple="true" data_ref="input1" label="Column to Use" />
+        <param name="col" type="data_column" multiple="true" value="1" data_ref="input1" label="Column to Use" />
         <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
     </inputs>
     <outputs>

--- a/test/functional/tools/column_param_list.xml
+++ b/test/functional/tools/column_param_list.xml
@@ -1,0 +1,50 @@
+<tool id="column_param_list" name="Column Param List" version="1.0.0">
+    <command><![CDATA[
+cut -f '$col' '$input1' > '$output1' &&
+echo "col $col" > '$output2' &&
+echo "col_names $col_names" >> '$output2'
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" format="tabular" label="Input 1" />
+        <param name="col" type="data_column" multiple="true" data_ref="input1" label="Column to Use" />
+        <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
+    </inputs>
+    <outputs>
+        <data name="output1" format="tabular" />
+        <data name="output2" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="2.tabular" />
+            <param name="col" value="2" />
+            <param name="col_names" value="2" />
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="68" />
+                </assert_contents>
+            </output>
+            <output name="output2">
+                <assert_contents>
+                    <has_line line="col 2" />
+                    <has_line line="col_names 2" />
+                </assert_contents>
+            </output>
+        </test>
+        <!-- test if non tabular data also creates entries by using the default
+            value (which is the 1st column, but empty if filling the options fails) -->
+        <test>
+            <param name="input1" value="1.bed" />
+            <output name="output1">
+                <assert_contents>
+                    <has_line line="chr1" />
+                </assert_contents>
+            </output>
+            <output name="output2">
+                <assert_contents>
+                    <has_line line="col 1" />
+                    <has_line line="col_names 1" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -114,6 +114,7 @@
   <tool file="param_text_option.xml" />
   <tool file="column_param.xml" />
   <tool file="column_param_configfile.xml" />
+  <tool file="column_param_list.xml" />
   <tool file="column_multi_param.xml" />
   <tool file="hidden_param.xml" />
   <tool file="special_params.xml" />


### PR DESCRIPTION
This is a fix for https://github.com/galaxyproject/galaxy/issues/11502

When the list of columns is a comma-separated string, it need to be broken down into a list. Also, we must check whether the set of columns is a subset of legal values.