### PR TITLE
[20.09] Add logging if installable tool config file not found

### DIFF
--- a/lib/galaxy/tools/toolbox/base.py
+++ b/lib/galaxy/tools/toolbox/base.py
@@ -264,9 +264,13 @@ class AbstractToolBox(Dictifiable, ManagesIntegratedToolPanelMixin):
 
     def get_shed_config_dict_by_filename(self, filename):
         filename = os.path.abspath(filename)
+        dynamic_tool_conf_paths = []
         for shed_config_dict in self._dynamic_tool_confs:
-            if shed_config_dict['config_filename'] == filename:
+            dynamic_tool_conf_path = os.path.abspath(shed_config_dict['config_filename'])
+            dynamic_tool_conf_paths.append(dynamic_tool_conf_path)
+            if dynamic_tool_conf_path == filename:
                 return shed_config_dict
+        log.warning("'{}' not among installable tool config files ({})".format(filename, ', '.join(dynamic_tool_conf_paths)))
         return None
 
     def update_shed_config(self, shed_conf):


### PR DESCRIPTION
Should make it easier to debug failing installations like this:
```
Mar 02 09:39:41 svvm0085 uwsgi[2626501]: galaxy.tool_shed.galaxy_install.install_manager ERROR 2021-03-02 09:39:41,329 [p:2626501,w:1,m:0] [uWSGIWorker1Core0] Error installing repository 'data_manager_fetch_genome_dbkeys_all_fasta'
Mar 02 09:39:41 svvm0085 uwsgi[2626501]: Traceback (most recent call last):
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:   File "/data/galaxy/galaxy//server/lib/galaxy/tool_shed/galaxy_install/install_manager.py", line 848, in install_repositories
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:     self.install_tool_shed_repository(tool_shed_repository,
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:   File "/data/galaxy/galaxy//server/lib/galaxy/tool_shed/galaxy_install/install_manager.py", line 926, in install_tool_shed_repository
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:     self.__handle_repository_contents(tool_shed_repository=tool_shed_repository,
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:   File "/data/galaxy/galaxy//server/lib/galaxy/tool_shed/galaxy_install/install_manager.py", line 574, in __handle_repository_contents
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:     dmh.install_data_managers(self.app.config.shed_data_manager_config_file,
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:   File "/data/galaxy/galaxy//server/lib/galaxy/tool_shed/galaxy_install/tools/data_manager.py", line 81, in install_data_managers
Mar 02 09:39:41 svvm0085 uwsgi[2626501]:     relative_repo_data_manager_dir = os.path.join(shed_config_dict.get('tool_path', ''), relative_install_dir)
Mar 02 09:39:41 svvm0085 uwsgi[2626501]: AttributeError: 'NoneType' object has no attribute 'get'
```
In this case there was an extra slash in the tool_path section in the `tool_path` attribute of the `shed_tool_config_file`. Includes a small fix where we check both paths to be compared using the abspath value.