### PR TITLE
[20.09] OIDC Logout+Redirect fix.

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -16,7 +16,7 @@ from galaxy.webapps.base.controller import JSAppLauncher
 
 log = logging.getLogger(__name__)
 
-PROVIDER_COOKIE_NAME = 'oidc-provider'
+PROVIDER_COOKIE_NAME = 'galaxy-oidc-provider'
 
 
 class OIDC(JSAppLauncher):


### PR DESCRIPTION
All galaxy-app / transaction accessed cookies should start with 'galaxy'.  We intentionally toss anything else.