### PR TITLE
[21.01] Fix bug to prevent workflow refactor indices from being wrong.

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -342,7 +342,7 @@ export default {
         },
         async onRefactor(response) {
             await fromSimple(this, response.workflow);
-            this._loadEditorData(response);
+            this._loadEditorData(response.workflow);
         },
         onAdd(node) {
             this.nodes[node.id] = node;

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -242,6 +242,7 @@ export default {
             hasChanges: false,
             nodeIndex: 0,
             nodes: {},
+            requiresReindex: false, // track if node has been added or remove and backend may re-index nodes (hasChanges tracks a much more broad set of changes)
             datatypesMapper: null,
             datatypes: [],
             report: {},
@@ -346,6 +347,7 @@ export default {
         },
         onAdd(node) {
             this.nodes[node.id] = node;
+            this.requiresReindex = true;
         },
         onUpdate(node) {
             getModule({
@@ -366,6 +368,7 @@ export default {
             this.canvasManager.drawOverview();
             this.activeNode = null;
             this.hasChanges = true;
+            this.requiresReindex = true;
             showAttributes();
         },
         onEditSubworkflow(contentId) {
@@ -428,10 +431,20 @@ export default {
             node.onUnhighlight();
         },
         onLint() {
-            this._ensureParametersSet();
-            // See notes in Lint.vue about why refresh is needed.
-            this.$refs.lint.refresh();
-            showLint();
+            if (this.requiresReindex) {
+                const r = window.confirm(
+                    "Workflow steps have been added or removed since last save, the workflow needs to be saved before best practices can be analzyed. Save workflow?"
+                );
+                if (r == false) {
+                    return;
+                }
+                this.onSave(true);
+            } else {
+                this._ensureParametersSet();
+                // See notes in Lint.vue about why refresh is needed.
+                this.$refs.lint.refresh();
+                showLint();
+            }
         },
         onEdit() {
             this.isCanvas = true;

--- a/client/src/components/Workflow/Editor/Options.vue
+++ b/client/src/components/Workflow/Editor/Options.vue
@@ -92,6 +92,9 @@ export default {
         hasChanges: {
             type: Boolean,
         },
+        requiredReindex: {
+            type: Boolean,
+        },
     },
 };
 </script>

--- a/client/src/components/Workflow/Editor/modules/services.js
+++ b/client/src/components/Workflow/Editor/modules/services.js
@@ -55,6 +55,7 @@ export async function saveWorkflow(workflow) {
             const { data } = await axios.put(`${getAppRoot()}api/workflows/${workflow.id}`, requestData);
             workflow.name = data.name;
             workflow.hasChanges = false;
+            workflow.requiresReindex = false;
             workflow.stored = true;
             workflow.version = data.version;
             workflow.annotation = data.annotation;


### PR DESCRIPTION
Don't let the workflow linting page build refactor actions with step indices that will be broken after the the prompt to save. 