### PR TITLE
[21.01] Add input step data label when extracting workflow

### DIFF
--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -75,6 +75,7 @@ def extract_steps(trans, history=None, job_ids=None, dataset_ids=None, dataset_c
             name = dataset_names[i]
         else:
             name = "Input Dataset"
+        step.label = name
         step.tool_inputs = dict(name=name)
         hid_to_output_pair[hid] = (step, 'output')
         steps.append(step)
@@ -88,6 +89,7 @@ def extract_steps(trans, history=None, job_ids=None, dataset_ids=None, dataset_c
             name = dataset_collection_names[i]
         else:
             name = "Input Dataset Collection"
+        step.label = name
         step.tool_inputs = dict(name=name, collection_type=collection_type)
         hid_to_output_pair[hid] = (step, 'output')
         steps.append(step)

--- a/lib/galaxy/workflow/extract.py
+++ b/lib/galaxy/workflow/extract.py
@@ -66,6 +66,7 @@ def extract_steps(trans, history=None, job_ids=None, dataset_ids=None, dataset_c
     summary = WorkflowSummary(trans, history)
     jobs = summary.jobs
     steps = []
+    step_labels = set()
     hid_to_output_pair = {}
     # Input dataset steps
     for i, hid in enumerate(dataset_ids):
@@ -75,7 +76,9 @@ def extract_steps(trans, history=None, job_ids=None, dataset_ids=None, dataset_c
             name = dataset_names[i]
         else:
             name = "Input Dataset"
-        step.label = name
+        if name not in step_labels:
+            step.label = name
+            step_labels.add(name)
         step.tool_inputs = dict(name=name)
         hid_to_output_pair[hid] = (step, 'output')
         steps.append(step)
@@ -89,7 +92,9 @@ def extract_steps(trans, history=None, job_ids=None, dataset_ids=None, dataset_c
             name = dataset_collection_names[i]
         else:
             name = "Input Dataset Collection"
-        step.label = name
+        if name not in step_labels:
+            step.label = name
+            step_labels.add(name)
         step.tool_inputs = dict(name=name, collection_type=collection_type)
         hid_to_output_pair[hid] = (step, 'output')
         steps.append(step)


### PR DESCRIPTION
Editing the extracted workflow would add the label, but if you chose to run the workflow immediately the step label would just be the step index.