### PR TITLE
[21.01] Fix unhandled error when creating tags with multiple dots

### DIFF
--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -216,22 +216,25 @@ class TagHandler:
             return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name.lower()).first()
         return None
 
-    def _create_tag(self, tag_str):
+    def _create_tag(self, tag_str: str):
         """Create a Tag object from a tag string."""
         tag_hierarchy = tag_str.split(self.hierarchy_separator)
         tag_prefix = ""
         parent_tag = None
+        tag = None
         for sub_tag in tag_hierarchy:
             # Get or create subtag.
-            tag_name = tag_prefix + self._scrub_tag_name(sub_tag)
-            tag = self._get_tag(tag_name)
-            if not tag:
-                tag = self._create_tag_instance(tag_name)
-            # Set tag parent.
-            tag.parent = parent_tag
-            # Update parent and tag prefix.
-            parent_tag = tag
-            tag_prefix = tag.name + self.hierarchy_separator
+            sub_tag_name = self._scrub_tag_name(sub_tag)
+            if sub_tag_name:
+                tag_name = tag_prefix + sub_tag_name
+                tag = self._get_tag(tag_name)
+                if not tag:
+                    tag = self._create_tag_instance(tag_name)
+                # Set tag parent.
+                tag.parent = parent_tag
+                # Update parent and tag prefix.
+                parent_tag = tag
+                tag_prefix = tag.name + self.hierarchy_separator
         return tag
 
     def _get_tag(self, tag_name):
@@ -379,6 +382,7 @@ class GalaxyTagHandler(TagHandler):
 
 class GalaxyTagHandlerSession(GalaxyTagHandler):
     """Like GalaxyTagHandler, but avoids one flush per created tag."""
+
     def __init__(self, sa_session):
         super().__init__(sa_session)
         self.created_tags = {}

--- a/test/unit/managers/test_TagHandler.py
+++ b/test/unit/managers/test_TagHandler.py
@@ -48,6 +48,8 @@ class TagHandlerTestCase(BaseTestCase):
             'tag1:\x00value1',
             'tag1,tag2',
             '...',
+            '.test',
+            'test.a.b',
         ]
         expected_tags = [
             ['tag1'],
@@ -57,6 +59,8 @@ class TagHandlerTestCase(BaseTestCase):
             ['tag1:value1'],
             ['tag1', 'tag2'],
             [],
+            ['test'],
+            ['test.a.b'],
         ]
         for tag_string, expected_tag in zip(tag_strings, expected_tags):
             hda = self._create_vanilla_hda()

--- a/test/unit/managers/test_TagHandler.py
+++ b/test/unit/managers/test_TagHandler.py
@@ -46,7 +46,8 @@ class TagHandlerTestCase(BaseTestCase):
             'tag1:value1:value11',
             '\x00tag1',
             'tag1:\x00value1',
-            'tag1,tag2'
+            'tag1,tag2',
+            '...',
         ]
         expected_tags = [
             ['tag1'],
@@ -54,7 +55,8 @@ class TagHandlerTestCase(BaseTestCase):
             ['tag1:value1:value11'],
             ['tag1'],
             ['tag1:value1'],
-            ['tag1', 'tag2']
+            ['tag1', 'tag2'],
+            [],
         ]
         for tag_string, expected_tag in zip(tag_strings, expected_tags):
             hda = self._create_vanilla_hda()


### PR DESCRIPTION
This fixes #11451

Added a couple of tests using `.` (dots) in the tag name.