### PR TITLE
[21.01] allow format attribute in output collections

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -38,7 +38,7 @@ def lint_output(tool_xml, lint_ctx):
                 lint_ctx.warn("Collection output with undefined 'type' found.")
             if "structured_like" in output.attrib and "inherit_format" in output.attrib:
                 format_set = True
-        if "format_source" in output.attrib:
+        if "format" in output.attrib or "format_source" in output.attrib:
             format_set = True
         for sub in output:
             if __check_pattern(sub):

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -27,10 +27,10 @@ def lint_output(tool_xml, lint_ctx):
                 lint_ctx.warn("Tool output name [%s] is not a valid Cheetah placeholder.", output.attrib["name"])
 
         format_set = False
+        if __check_format(output, lint_ctx):
+            format_set = True
         if output.tag == "data":
-            if __check_format(output, lint_ctx):
-                format_set = True
-            elif "auto_format" in output.attrib and output.attrib["auto_format"]:
+            if "auto_format" in output.attrib and output.attrib["auto_format"]:
                 format_set = True
 
         elif output.tag == "collection":
@@ -38,12 +38,12 @@ def lint_output(tool_xml, lint_ctx):
                 lint_ctx.warn("Collection output with undefined 'type' found.")
             if "structured_like" in output.attrib and "inherit_format" in output.attrib:
                 format_set = True
-        if "format" in output.attrib or "format_source" in output.attrib:
+        if "format_source" in output.attrib:
             format_set = True
         for sub in output:
             if __check_pattern(sub):
                 format_set = True
-            elif __check_format(sub, lint_ctx):
+            elif __check_format(sub, lint_ctx, allow_ext=True):
                 format_set = True
 
         if not format_set:
@@ -52,13 +52,18 @@ def lint_output(tool_xml, lint_ctx):
     lint_ctx.info("%d outputs found.", num_outputs)
 
 
-def __check_format(node, lint_ctx):
+def __check_format(node, lint_ctx, allow_ext=False):
     """
     check if format/ext attribute is set in a given node
     issue a warning if the value is input
     return true (node defines format/ext) / false (else)
     """
-    fmt = node.attrib.get("format", node.attrib.get("ext", None))
+    fmt = None
+    # if allowed (e.g. for discover_datasets), ext takes precedence over format
+    if allow_ext:
+        fmt = node.attrib.get("ext")
+    if fmt is None:
+        fmt = node.attrib.get("format")
     if fmt == "input":
         lint_ctx.warn("Using format='input' on %s, format_source attribute is less ambiguous and should be used instead." % node.tag)
     return fmt is not None

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4229,6 +4229,14 @@ The default is ``galaxy.json``.
   </xs:group>
 
   <xs:attributeGroup name="OutputCommon">
+    <xs:attribute name="format" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">The short name for the output datatype.
+The valid values for format can be found in
+[/config/datatypes_conf.xml.sample](https://github.com/galaxyproject/galaxy/blob/dev/config/datatypes_conf.xml.sample)
+(e.g. ``format="pdf"`` or ``format="fastqsanger"``).</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="format_source" type="xs:string">
       <xs:annotation>
         <xs:documentation xml:lang="en">This sets the data type of the output dataset(s) to be the same format as that of the specified tool input.</xs:documentation>
@@ -4264,14 +4272,6 @@ pipes or periods (e.g. ``.``).]]></xs:documentation>
 If ``true``, this output will sniffed and its format determined automatically by Galaxy.
 
 ]]></xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="format" type="xs:string">
-      <xs:annotation>
-        <xs:documentation xml:lang="en">The short name for the output datatype.
-The valid values for format can be found in
-[/config/datatypes_conf.xml.sample](https://github.com/galaxyproject/galaxy/blob/dev/config/datatypes_conf.xml.sample)
-(e.g. ``format="pdf"`` or ``format="fastqsanger"``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="default_identifier_source" type="xs:string">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4234,7 +4234,8 @@ The default is ``galaxy.json``.
         <xs:documentation xml:lang="en">The short name for the output datatype.
 The valid values for format can be found in
 [/config/datatypes_conf.xml.sample](https://github.com/galaxyproject/galaxy/blob/dev/config/datatypes_conf.xml.sample)
-(e.g. ``format="pdf"`` or ``format="fastqsanger"``).</xs:documentation>
+(e.g. ``format="pdf"`` or ``format="fastqsanger"``). For collections this is the default format for all included
+elements. Note that the format specified here is ignored for discovered data sets.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="format_source" type="xs:string">

--- a/test/functional/tools/collection_creates_pair.xml
+++ b/test/functional/tools/collection_creates_pair.xml
@@ -19,14 +19,14 @@
   </outputs>
   <tests>
     <test>
-      <param name="input1" value="simple_lines_interleaved.txt" />
+      <param name="input1" ftype="bed" value="simple_lines_interleaved.txt" />
       <output_collection name="paired_output" type="paired">
-        <element name="forward">
+        <element name="forward" ftype="txt">
           <assert_contents>
             <has_text_matching expression="^This is a line of text.\nThis is a line of text.\n$" />
           </assert_contents>
         </element>
-        <element name="reverse">
+        <element name="reverse" ftype="bed">
           <assert_contents>
             <has_text_matching expression="^This is a different line of text.\nThis is a different line of text.\n$" />
           </assert_contents>

--- a/test/functional/tools/collection_creates_pair_format.xml
+++ b/test/functional/tools/collection_creates_pair_format.xml
@@ -1,0 +1,52 @@
+<tool id="collection_creates_pair_format" name="collection_creates_pair" version="0.1.0">
+  <command>
+    sed 'n;d' $input1 > '$paired_output.forward' ;
+    sed 'n;d' $input1 > '$paired_output_default_format.forward' ;
+    sed 'n;d' $input1 > "forward.txt";
+    sed -n 'g;n;p' $input1 > "reverse.txt";
+  </command>
+  <inputs>
+    <param name="input1" type="data" label="Input" help="Input to be split." />
+  </inputs>
+  <outputs>
+    <!-- format is specified separately for the elements, i.e. default format (fasta in this case) is ignored -->
+    <collection name="paired_output" format="fasta" type="paired" label="Split Pair">
+      <data name="forward" format="txt" />
+      <data name="reverse" format_source="input1" from_work_dir="reverse.txt" />
+    </collection>
+    <!-- no format is specified separately for the elements, i.e. default format (fasta in this case) is used -->
+    <collection name="paired_output_default_format" format="fasta" type="paired" label="Split Pair">
+      <data name="forward" />
+      <data name="reverse" from_work_dir="reverse.txt" />
+    </collection>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1" ftype="bed" value="simple_lines_interleaved.txt" />
+      <output_collection name="paired_output" type="paired">
+        <element name="forward" ftype="txt">
+          <assert_contents>
+            <has_text_matching expression="^This is a line of text.\nThis is a line of text.\n$" />
+          </assert_contents>
+        </element>
+        <element name="reverse" ftype="bed">
+          <assert_contents>
+            <has_text_matching expression="^This is a different line of text.\nThis is a different line of text.\n$" />
+          </assert_contents>
+        </element>
+      </output_collection>
+      <output_collection name="paired_output_default_format" type="paired">
+        <element name="forward" ftype="fasta">
+          <assert_contents>
+            <has_text_matching expression="^This is a line of text.\nThis is a line of text.\n$" />
+          </assert_contents>
+        </element>
+        <element name="reverse" ftype="fasta">
+          <assert_contents>
+            <has_text_matching expression="^This is a different line of text.\nThis is a different line of text.\n$" />
+          </assert_contents>
+        </element>
+      </output_collection>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -155,6 +155,7 @@
   <tool file="collection_mixed_param.xml" />
   <tool file="collection_two_paired.xml" />
   <tool file="collection_creates_pair.xml" />
+  <tool file="collection_creates_pair_format.xml" />
   <tool file="collection_creates_pair_from_type.xml" />
   <tool file="collection_creates_pair_from_work_dir.xml" />
   <tool file="collection_creates_list.xml" />


### PR DESCRIPTION
this works already but xsd does not allow for it and the linter complains.

Needed for instance if one has a paired collection 

```
<collection name="xyz" type="paired"/>
```

and writes to the elements with `> $xyz.forward`.

fixes: https://github.com/galaxyproject/galaxy/issues/7175

Do we want a test, e.g. in `test/functional/tools/` -- if so, where? or a new one?