### PR TITLE
Update bam.iobio interactive tool wrapper

### DIFF
--- a/tools/interactive/interactivetool_bam_iobio.xml
+++ b/tools/interactive/interactivetool_bam_iobio.xml
@@ -1,6 +1,6 @@
 <tool id="interactive_tool_bam_iobio" tool_type="interactive" name="bam.iobio visualisation" version="0.2">
     <requirements>
-        <container type="docker">anderspitman/bam.iobio.io:latest</container>
+        <container type="docker">quay.io/iobio/bam.iobio.io:0.3.0</container>
     </requirements>
     <entry_points>
         <entry_point name="BAM io.bio visualisation of $baminfile.display_name" requires_domain="True">
@@ -12,27 +12,26 @@
         #import re
         mkdir -p /bam/input_files;
         #set $bam_cleaned_name = re.sub('[^\w\-\.]', '_', str($baminfile.element_identifier))
-        #set $bai_cleaned_name = re.sub('[^\w\-\.]', '_', str($baiinfile.element_identifier))
         ln -sf '$baminfile' '/bam/input_files/${bam_cleaned_name}' &&
-        ln -sf '$baiinfile' '/bam/input_files/${bai_cleaned_name}' &&
-        echo '{ "bam": "http://localhost:9999/${bam_cleaned_name}", "bai":"http://localhost:9999/${bai_cleaned_name}"}' >> /bam/config/config.json &&
+        ln -sf '$baminfile.metadata.bam_index' '/bam/input_files/${bam_cleaned_name}.bai' &&
+        echo '{ "bam": "http://localhost:9999/${bam_cleaned_name}", "bai":"http://localhost:9999/${bam_cleaned_name}.bai"}' >> /bam/config/config.json &&
         cd /bam/input_files &&
-        node /iobio-gru-backend/src/static_server.js 9999 &
-        node /iobio-gru-backend/src/index.js --tools-dir=/iobio-gru-backend/tool_bin --app-dir=/bam;
+        node /iobio-gru-backend/src/static_server.js 9999 > /dev/null 2>&1 &
+        node /iobio-gru-backend/src/index.js --tools-dir=/iobio-gru-backend/tool_bin --app-dir=/bam > /dev/null 2>&1;
     ]]>
     </command>
     <inputs>
         <param name="baminfile" type="data" format="bam" label="BAM file"/>
-        <param name="baiinfile" type="data" format="bai" label="BAI file"/>
     </inputs>
+    <outputs>
+        <data name="outfile" format="txt" />
+    </outputs>
     <tests>
     </tests>
     <help>
         Required inputs:
 
         1. BAM file: binary alignment map file
-
-        2. BAI file: corresponding index file
 
         The `iobio project`_ is developed by the `Marth lab`_ at the `University of Utah Center for Genetic Discovery`_.
 

--- a/tools/interactive/interactivetool_bam_iobio.xml
+++ b/tools/interactive/interactivetool_bam_iobio.xml
@@ -1,46 +1,43 @@
-<tool id="interactive_tool_bam_iobio" tool_type="interactive" name="BAM (iobio) Visualisation" version="0.1">
+<tool id="interactive_tool_bam_iobio" tool_type="interactive" name="bam.iobio visualisation" version="0.2">
     <requirements>
-        <container type="docker">qiaoy/iobio-bundle.bam-iobio:1.0-ondemand</container>
+        <container type="docker">anderspitman/bam.iobio.io:latest</container>
     </requirements>
     <entry_points>
-        <entry_point name="BAM io.bio visualisation of $infile.display_name" requires_domain="True">
-            <port>80</port>
-            <url><![CDATA[/?bam=http://localhost/tmp/bamfile.bam&region=1]]></url>
+        <entry_point name="BAM io.bio visualisation of $baminfile.display_name" requires_domain="True">
+            <port>9001</port>
+            <url>/</url>
         </entry_point>
     </entry_points>
     <command><![CDATA[
-    ## ToDo: websocket could not be found
-    ## WebSocket connection to 'ws://localhost/bamreaddepther/' failed: Error in connection establishment: net::ERR_CONNECTION_REFUSED
-
-    #set $PUB_HOSTNAME = 'localhost'
-    #set $PUB_HTTP_PORT = '80'
-
-    cd /var/www/html &&
-    sed -i "s@\"wss://services.iobio.io/samtools/\"@((window.location.protocol === \"https:\") ? \"wss://\" : \"ws://\") + window.location.host + \"/samtools/\"@" js/bam.iobio.js/bam.iobio.js &&
-    sed -i "s@\"wss://services.iobio.io/bamreaddepther/\"@((window.location.protocol === \"https:\") ? \"wss://\" : \"ws://\") + window.location.host + \"/bamreaddepther/\"@" js/bam.iobio.js/bam.iobio.js &&
-    sed -i "s@\"wss://services.iobio.io/bamstatsalive/\"@((window.location.protocol === \"https:\") ? \"wss://\" : \"ws://\") + window.location.host + \"/bamstatsalive/\"@" js/bam.iobio.js/bam.iobio.js &&
-    sed -i "s@\"wss://services.iobio.io/samheader/\"@((window.location.protocol === \"https:\") ? \"wss://\" : \"ws://\") + window.location.host + \"/samheader/\"@" js/bam.iobio.js/bam.iobio.js &&
-
-    sed -i 's/deny all;//g' /etc/nginx/nginx.conf &&
-
-        cp '${infile}' /input/bamfile.bam &&
-        cp '${infile.metadata.bam_index}' /input/bamfile.bam.bai &&
-        mkdir /var/log/supervisor/ &&
-        head -n -2  /etc/supervisor.d/app.conf > /tmp/app.conf &&
-        mv /tmp/app.conf /etc/supervisor.d/app.conf &&
-
-        /usr/bin/supervisord -c /etc/supervisord.conf
+        #import re
+        mkdir -p /bam/input_files;
+        #set $bam_cleaned_name = re.sub('[^\w\-\.]', '_', str($baminfile.element_identifier))
+        #set $bai_cleaned_name = re.sub('[^\w\-\.]', '_', str($baiinfile.element_identifier))
+        ln -sf '$baminfile' '/bam/input_files/${bam_cleaned_name}' &&
+        ln -sf '$baiinfile' '/bam/input_files/${bai_cleaned_name}' &&
+        echo '{ "bam": "http://localhost:9999/${bam_cleaned_name}", "bai":"http://localhost:9999/${bai_cleaned_name}"}' >> /bam/config/config.json &&
+        cd /bam/input_files &&
+        node /iobio-gru-backend/src/static_server.js 9999 &
+        node /iobio-gru-backend/src/index.js --tools-dir=/iobio-gru-backend/tool_bin --app-dir=/bam;
     ]]>
     </command>
     <inputs>
-        <param name="infile" type="data" format="bam" label="BAM file"/>
+        <param name="baminfile" type="data" format="bam" label="BAM file"/>
+        <param name="baiinfile" type="data" format="bai" label="BAI file"/>
     </inputs>
-    <outputs>
-        <data name="outfile" format="txt" />
-    </outputs>
     <tests>
     </tests>
     <help>
-        BAM iobio visualisation.
+        Required inputs:
+
+        1. BAM file: binary alignment map file
+
+        2. BAI file: corresponding index file
+
+        The `iobio project`_ is developed by the `Marth lab`_ at the `University of Utah Center for Genetic Discovery`_.
+
+        .. _iobio project: https://iobio.io
+        .. _Marth lab: https://marthlab.org/
+        .. _University of Utah Center for Genetic Discovery: https://ucgd.genetics.utah.edu/
     </help>
 </tool>

--- a/tools/interactive/interactivetool_bam_iobio.xml
+++ b/tools/interactive/interactivetool_bam_iobio.xml
@@ -1,9 +1,9 @@
-<tool id="interactive_tool_bam_iobio" tool_type="interactive" name="bam.iobio visualisation" version="0.2">
+<tool id="interactive_tool_bam_iobio" tool_type="interactive" name="bam.iobio visualisation" version="0.4.0">
     <requirements>
-        <container type="docker">quay.io/iobio/bam.iobio.io:0.3.0</container>
+        <container type="docker">quay.io/iobio/bam.iobio.io:0.4.0</container>
     </requirements>
     <entry_points>
-        <entry_point name="BAM io.bio visualisation of $baminfile.display_name" requires_domain="True">
+        <entry_point name="BAM io.bio visualisation of $baminfile.element_identifier" requires_domain="True">
             <port>9001</port>
             <url>/</url>
         </entry_point>


### PR DESCRIPTION
> Why you made the changes (e.g. references to GitHub issues being fixed).

A new bam.iobio image was created by the iobio team; this updates the wrapper to use it.

> A description of the implementation of the changes.

This wrapper:
- symlinks user-specified BAM and BAI files from the history within the container
- starts a localhost byte-range server to serve (potentially protected) files to their app (which requires byte-range-accessible URLs)
- creates a `config.json` file with links to the files for the app to ingest, so that it skips the landing page and goes directly to the visualization of the desired files
- starts the actual app on the exposed port using the created `config.json` file

> How to test the changes, if you haven't included specific tests already.
In a Galaxy instance configured to run Interactive Tools, run this tool when there is a bam file and complementary bai index file in your history, select them in their respective input forms, execute, visualize