### PR TITLE
Change two vue-routers to plain javascript modules

### DIFF
--- a/client/src/components/LibraryFolder/LibraryFolderRouter.js
+++ b/client/src/components/LibraryFolder/LibraryFolderRouter.js
@@ -1,4 +1,3 @@
-<script>
 import { getAppRoot } from "onload/loadConfig";
 import Vue from "vue";
 import VueRouter from "vue-router";
@@ -32,4 +31,3 @@ export default new VueRouter({
         },
     ],
 });
-</script>

--- a/client/src/components/admin/DataManager/DataManagerRouter.js
+++ b/client/src/components/admin/DataManager/DataManagerRouter.js
@@ -1,4 +1,3 @@
-<script>
 import { getAppRoot } from "onload/loadConfig";
 import Vue from "vue";
 import VueRouter from "vue-router";
@@ -42,4 +41,3 @@ export default new VueRouter({
         },
     ],
 });
-</script>

--- a/client/src/entry/admin/AdminRouter.js
+++ b/client/src/entry/admin/AdminRouter.js
@@ -12,7 +12,7 @@ import ActiveInvocations from "components/admin/ActiveInvocations.vue";
 import Landing from "components/admin/Dependencies/Landing.vue";
 import AdminHome from "components/admin/Home.vue";
 import DataManagerView from "components/admin/DataManager/DataManagerView.vue";
-import DataManagerRouter from "components/admin/DataManager/DataManagerRouter.vue";
+import DataManagerRouter from "components/admin/DataManager/DataManagerRouter.js";
 import Register from "components/login/Register.vue";
 import ErrorStack from "components/admin/ErrorStack.vue";
 import DisplayApplications from "components/admin/DisplayApplications.vue";

--- a/client/src/entry/admin/AdminRouter.js
+++ b/client/src/entry/admin/AdminRouter.js
@@ -12,7 +12,7 @@ import ActiveInvocations from "components/admin/ActiveInvocations.vue";
 import Landing from "components/admin/Dependencies/Landing.vue";
 import AdminHome from "components/admin/Home.vue";
 import DataManagerView from "components/admin/DataManager/DataManagerView.vue";
-import DataManagerRouter from "components/admin/DataManager/DataManagerRouter.js";
+import DataManagerRouter from "components/admin/DataManager/DataManagerRouter";
 import Register from "components/login/Register.vue";
 import ErrorStack from "components/admin/ErrorStack.vue";
 import DisplayApplications from "components/admin/DisplayApplications.vue";

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -48,7 +48,7 @@ import DisplayStructure from "components/DisplayStructured.vue";
 import { CloudAuth } from "components/User/CloudAuth";
 import { ExternalIdentities } from "components/User/ExternalIdentities";
 import Confirmation from "components/login/Confirmation.vue";
-import LibraryFolderRouter from "components/LibraryFolder/LibraryFolderRouter.js";
+import LibraryFolderRouter from "components/LibraryFolder/LibraryFolderRouter";
 import Vue from "vue";
 import store from "store";
 import VueRouterMain from "./VueRouterMain.vue";

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -48,7 +48,7 @@ import DisplayStructure from "components/DisplayStructured.vue";
 import { CloudAuth } from "components/User/CloudAuth";
 import { ExternalIdentities } from "components/User/ExternalIdentities";
 import Confirmation from "components/login/Confirmation.vue";
-import LibraryFolderRouter from "components/LibraryFolder/LibraryFolderRouter.vue";
+import LibraryFolderRouter from "components/LibraryFolder/LibraryFolderRouter.js";
 import Vue from "vue";
 import store from "store";
 import VueRouterMain from "./VueRouterMain.vue";


### PR DESCRIPTION
## What did you do? 

Refactor two vue-routers from being .vue SFCs to regular .js modules, which they are.

## Why did you make this change?

This appeared to be causing errors in the styleguide, xref commentary in https://github.com/galaxyproject/galaxy/pull/11423.  Also, this is more correct.


## How to test the changes? 

Run data manager interface, and/or browse a library and ensure it still navigates.