### PR TITLE
[21.01] Remote user logout redirect fix

### DIFF
--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -14,7 +14,7 @@ export function userLogout(logoutAll = false) {
     const url = `${galaxy.root}user/logout?session_csrf_token=${session_csrf_token}&logout_all=${logoutAll}`;
     axios
         .get(url)
-        .then(() => {
+        .then((response) => {
             if (galaxy.user) {
                 galaxy.user.clearSessionStorage();
             }
@@ -22,7 +22,8 @@ export function userLogout(logoutAll = false) {
             if (galaxy.config.enable_oidc) {
                 return axios.get(`${galaxy.root}authnz/logout`);
             } else {
-                return {};
+                // Otherwise pass through the initial logout response
+                return response;
             }
         })
         .then((response) => {

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -227,7 +227,10 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
         # Since logging an event requires a session, we'll log prior to ending the session
         trans.log_event("User logged out")
         trans.handle_user_logout(logout_all=logout_all)
-        return {"message": "Success."}
+        success_response = {"message": "Success."}  # This is a little weird as a response.
+        if trans.app.config.use_remote_user and trans.app.config.remote_user_logout_href:
+            success_response["redirect_uri"] = trans.app.config.remote_user_logout_href
+        return success_response
 
     @expose_api_anonymous_and_sessionless
     def create(self, trans, payload=None, **kwd):

--- a/lib/galaxy/webapps/galaxy/controllers/user.py
+++ b/lib/galaxy/webapps/galaxy/controllers/user.py
@@ -214,6 +214,7 @@ class User(BaseUIController, UsesFormDefinitionsMixin, CreatesApiKeysMixin):
         return (time_difference > delta or activation_grace_period == 0)
 
     @web.expose
+    @web.json
     def logout(self, trans, logout_all=False, **kwd):
         message = trans.check_csrf_token(kwd)
         if message:


### PR DESCRIPTION
## What did you do? 
- Fix logout redirects when using remote user, fix logout response type to json.  (was just a dict as a string before).

## Why did you make this change?

xref: https://github.com/galaxyproject/galaxy/pull/10951
The client really shouldn't have to know anything about server auth internals like 'use_remote_user' being on or off, and I'd like to remove those from the exposed configuration, so this handles redirect_uri in a single consistent way on the client without extra conditionals.

## How to test the changes? 

Set up galaxy REMOTE_USER configuration.  Specify `remote_user_logout_url` to something.  Log out.  Observe redirect.