### PR TITLE
[21.01] Fix upload button tooltip

### DIFF
--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -540,6 +540,7 @@
                 class="creator-reset-btn rule-btn-reset"
                 >{{ l("Reset") }}</b-button
             >
+            <!--https://github.com/bootstrap-vue/bootstrap-vue/issues/2937#issuecomment-478577527-->
             <b-button
                 v-b-tooltip.hover.d50
                 @click="createCollection"

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -524,32 +524,30 @@
                     </div>
                 </div>
             </template>
+            <b-row class="mx-auto">
+                <b-button
+                    :help="titleCancel"
+                    @click="cancel"
+                    class="creator-cancel-btn rule-btn-cancel"
+                    tabindex="-1"
+                    >{{ l("Cancel") }}</b-button
+                >
 
-            <b-button
-                v-b-tooltip.hover
-                :help="titleCancel"
-                @click="cancel"
-                class="creator-cancel-btn rule-btn-cancel"
-                tabindex="-1"
-                >{{ l("Cancel") }}</b-button
-            >
-            <b-button
-                v-b-tooltip.hover
-                @click="resetRulesAndState"
-                :title="titleReset"
-                class="creator-reset-btn rule-btn-reset"
-                >{{ l("Reset") }}</b-button
-            >
-            <!--https://github.com/bootstrap-vue/bootstrap-vue/issues/2937#issuecomment-478577527-->
-            <b-button
-                v-b-tooltip.hover.d50
-                @click="createCollection"
-                :title="titleFinish"
-                class="create-collection rule-btn-okay"
-                variant="primary"
-                :disabled="!validInput"
-                >{{ finishButtonTitle }}</b-button
-            >
+                <tooltip-on-hover class="menu-option" :title="titleReset">
+                    <b-button @click="resetRulesAndState" class="creator-reset-btn rule-btn-reset">{{
+                        l("Reset")
+                    }}</b-button>
+                </tooltip-on-hover>
+                <tooltip-on-hover class="menu-option" :disabled="!validInput" :title="titleFinish">
+                    <b-button
+                        @click="createCollection"
+                        class="create-collection rule-btn-okay"
+                        variant="primary"
+                        :disabled="!validInput"
+                        >{{ finishButtonTitle }}</b-button
+                    >
+                </tooltip-on-hover>
+            </b-row>
         </rule-modal-footer>
     </state-div>
     <state-div v-else-if="state == 'wait'">
@@ -614,6 +612,7 @@ import RuleModalFooter from "components/RuleBuilder/RuleModalFooter";
 import StateDiv from "components/RuleBuilder/StateDiv";
 import SavedRulesSelector from "components/RuleBuilder/SavedRulesSelector";
 import SaveRules from "components/RuleBuilder/SaveRules";
+import TooltipOnHover from "components/TooltipOnHover.vue";
 
 Vue.use(BootstrapVue);
 
@@ -1684,6 +1683,7 @@ export default {
         },
     },
     components: {
+        TooltipOnHover,
         HotTable,
         RuleComponent,
         RuleTargetComponent,
@@ -1849,5 +1849,8 @@ export default {
 }
 .fa-history {
     cursor: pointer;
+}
+.menu-option {
+    padding-left: 5px;
 }
 </style>

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -541,7 +541,7 @@
                 >{{ l("Reset") }}</b-button
             >
             <b-button
-                v-b-tooltip.hover
+                v-b-tooltip.hover.d50
                 @click="createCollection"
                 :title="titleFinish"
                 class="create-collection rule-btn-okay"

--- a/client/src/components/TooltipOnHover.vue
+++ b/client/src/components/TooltipOnHover.vue
@@ -1,0 +1,18 @@
+<template>
+    <div :disabled="disabled" v-b-tooltip.hover.d50 :title="title"><slot /></div>
+</template>
+<script>
+export default {
+    props: {
+        title: {
+            type: String,
+            required: true,
+        },
+        disabled: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
+    },
+};
+</script>

--- a/client/src/components/TooltipOnHover.vue
+++ b/client/src/components/TooltipOnHover.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :disabled="disabled" v-b-tooltip.hover.d50 :title="title"><slot /></div>
+    <div :disabled="disabled" v-b-tooltip.hover :title="title"><slot /></div>
 </template>
 <script>
 export default {


### PR DESCRIPTION
## What did you do? 
fix tool-tip of Upload button in rule-based upload


## Why did you make this change?
The tooltip of Upload button didn't disappear, even thought it's disabled. We probably don't want to have it on our screenshots. The problem is well described here https://github.com/galaxyproject/training-material/pull/2271#issuecomment-784013278

Our Tooltip issue is appears to be a known bug https://github.com/bootstrap-vue/bootstrap-vue/issues/2937#issuecomment-478577527

## For UI Components
- [x] I've included a screenshot of the changes
![image](https://user-images.githubusercontent.com/15801412/109995954-6eb4e200-7d17-11eb-9100-9d119cb89c94.png)




how it was before PR 



![image](https://camo.githubusercontent.com/49a6b28de96c4a92171bb5133c5bf451799bf4344359e724ff8152a10c559602/68747470733a2f2f67616c6178792d74657374732e73332e616d617a6f6e6177732e636f6d2f67616c6178792d67746e2d73637265656e73686f74732f6c6f63616c2f72756c65735f6578616d706c655f355f375f73706c69745f636f6c756d6e732e706e67)



