### PR TITLE
[21.01] Bug fix - cannot set dbkeys in workflow tests.

### DIFF
--- a/lib/galaxy/tool_util/client/staging.py
+++ b/lib/galaxy/tool_util/client/staging.py
@@ -23,6 +23,8 @@ log = logging.getLogger(__name__)
 UPLOAD_TOOL_ID = "upload1"
 LOAD_TOOLS_FROM_PATH = True
 DEFAULT_USE_FETCH_API = True
+DEFAULT_FILE_TYPE = "auto"
+DEFAULT_DBKEY = "?"
 
 
 class StagingInterace(metaclass=abc.ABCMeta):
@@ -74,9 +76,12 @@ class StagingInterace(metaclass=abc.ABCMeta):
             fetch_payload = None
             if isinstance(upload_target, FileUploadTarget):
                 file_path = upload_target.path
+                file_type = upload_target.properties.get('filetype', None) or DEFAULT_FILE_TYPE
+                dbkey = upload_target.properties.get('dbkey', None) or DEFAULT_DBKEY
                 fetch_payload = _fetch_payload(
                     history_id,
-                    file_type=upload_target.properties.get('filetype', None) or "auto",
+                    file_type=file_type,
+                    dbkey=dbkey,
                     to_posix_lines=to_posix_lines,
                 )
                 name = _file_path_to_name(file_path)
@@ -141,10 +146,12 @@ class StagingInterace(metaclass=abc.ABCMeta):
 
             if isinstance(upload_target, FileUploadTarget):
                 file_path = upload_target.path
+                file_type = upload_target.properties.get('filetype', None) or DEFAULT_FILE_TYPE
+                dbkey = upload_target.properties.get('dbkey', None) or DEFAULT_DBKEY
                 upload_payload = _upload_payload(
                     history_id,
-                    file_type=upload_target.properties.get('filetype', None) or "auto",
-                    to_posix_lines=to_posix_lines,
+                    file_type=file_type,
+                    to_posix_lines=dbkey,
                 )
                 name = _file_path_to_name(file_path)
                 upload_payload["inputs"]["files_0|auto_decompress"] = False
@@ -269,7 +276,7 @@ def _file_path_to_name(file_path):
     return name
 
 
-def _upload_payload(history_id, tool_id=UPLOAD_TOOL_ID, file_type="auto", dbkey="?", **kwd):
+def _upload_payload(history_id, tool_id=UPLOAD_TOOL_ID, file_type=DEFAULT_FILE_TYPE, dbkey=DEFAULT_DBKEY, **kwd):
     """Adapted from bioblend tools client."""
     payload = {}
     payload["history_id"] = history_id
@@ -289,9 +296,10 @@ def _upload_payload(history_id, tool_id=UPLOAD_TOOL_ID, file_type="auto", dbkey=
     return payload
 
 
-def _fetch_payload(history_id, file_type="auto", dbkey="?", **kwd):
+def _fetch_payload(history_id, file_type=DEFAULT_FILE_TYPE, dbkey=DEFAULT_DBKEY, **kwd):
     element = {
         "ext": file_type,
+        "dbkey": dbkey,
     }
     for arg in ['to_posix_lines', 'space_to_tab']:
         if arg in kwd:

--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -180,6 +180,8 @@ def galactic_job_json(
         kwd = {}
         if "tags" in value:
             kwd["tags"] = value.get("tags")
+        if "dbkey" in value:
+            kwd["dbkey"] = value.get("dbkey")
         if composite_data_raw:
             composite_data = []
             for entry in composite_data_raw:

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -274,6 +274,7 @@ class ToolsUploadTestCase(ApiTestCase):
                 "class": "File",
                 "format": "txt",
                 "path": "test-data/simple_line_no_newline.txt",
+                "dbkey": "hg19",
             }
         }
         inputs, datasets = stage_inputs(self.galaxy_interactor, history_id, job, use_path_paste=False, to_posix_lines=False)
@@ -284,6 +285,11 @@ class ToolsUploadTestCase(ApiTestCase):
         )
         # By default this appends the newline.
         self.assertEqual(content, "This is a line of text.")
+        details = self.dataset_populator.get_history_dataset_details(
+            history_id=history_id,
+            dataset=dataset
+        )
+        assert details["genome_build"] == "hg19"
 
     @uses_test_history(require_new=False)
     def test_upload_multiple_mixed_success(self, history_id):


### PR DESCRIPTION
## What did you do? 

- Updated the staging functionality leveraged by Planemo workflow testing to allow setting dbkeys on inputs. (See example block for syntax that would be used in workflow test yaml).

## Why did you make this change?

Workflow's leveraging dbkey functionality in Galaxy cannot be tested without this change.

## How to test the changes? 

- [x] I've included appropriate automated tests (https://docs.galaxyproject.org/en/latest/dev/writing_tests.html)
