### PR TITLE
[21.01] cleanup the supported filestypes for Nora

### DIFF
--- a/config/plugins/visualizations/nora/config/nora.xml
+++ b/config/plugins/visualizations/nora/config/nora.xml
@@ -5,14 +5,15 @@
     <data_sources>
         <data_source>
             <model_class>HistoryDatasetAssociation</model_class>
+            <test test_attr="ext" result_type="datatype">analyze75</test>
             <test test_attr="ext" result_type="datatype">nrrd</test>
             <test test_attr="ext" result_type="datatype">stl</test>
             <test test_attr="ext" result_type="datatype">nii1</test>
             <test test_attr="ext" result_type="datatype">nii1.gz</test>
+            <test test_attr="ext" result_type="datatype">nii2</test>
+            <test test_attr="ext" result_type="datatype">nii2.gz</test>
             <test test_attr="ext" result_type="datatype">gii</test>
             <test test_attr="ext" result_type="datatype">gii.gz</test>
-            <test test_attr="ext" result_type="datatype">png</test>
-            <test test_attr="ext" result_type="datatype">jpg</test>
             <to_param param_attr="id">dataset_id</to_param>
         </data_source>
     </data_sources>


### PR DESCRIPTION
## What did you do? 

Nora is a biomedical image viewer. It does not make much sense to display png, jpg files. Instead, Nora has added support for other filetypes in this domain.

## Why did you make this change?

Adjust to upstream Nora changes and bring back changes from usegalaxy.eu.

## How to test the changes? 

You can upload a test dataset from the Galaxy internal datatype tests and load them into the Nora visualization.
