### PR TITLE
[21.01] update the cellxgene IT container

### DIFF
--- a/tools/interactive/interactivetool_cellxgene.xml
+++ b/tools/interactive/interactivetool_cellxgene.xml
@@ -1,6 +1,6 @@
 <tool id="interactive_tool_cellxgene" tool_type="interactive" name="Interactive CellXgene Environment" version="0.1">
     <requirements>
-        <container type="docker">quay.io/galaxy/cellxgene-galaxy-ie:ie2</container>
+         <container type="docker">quay.io/biocontainers/cellxgene:0.16.2--py_0</container>
     </requirements>
     <entry_points>
         <entry_point name="Cellxgene Single Cell Visualisation on $infile.display_name" requires_domain="True">

--- a/tools/interactive/interactivetool_cellxgene.xml
+++ b/tools/interactive/interactivetool_cellxgene.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_cellxgene" tool_type="interactive" name="Interactive CellXgene Environment" version="0.1">
+<tool id="interactive_tool_cellxgene" tool_type="interactive" name="Interactive CellXgene Environment" version="0.16.2">
     <requirements>
         <container type="docker">quay.io/biocontainers/cellxgene:0.16.2--py_0</container>
     </requirements>

--- a/tools/interactive/interactivetool_cellxgene.xml
+++ b/tools/interactive/interactivetool_cellxgene.xml
@@ -1,6 +1,6 @@
 <tool id="interactive_tool_cellxgene" tool_type="interactive" name="Interactive CellXgene Environment" version="0.1">
     <requirements>
-         <container type="docker">quay.io/biocontainers/cellxgene:0.16.2--py_0</container>
+        <container type="docker">quay.io/biocontainers/cellxgene:0.16.2--py_0</container>
     </requirements>
     <entry_points>
         <entry_point name="Cellxgene Single Cell Visualisation on $infile.display_name" requires_domain="True">


### PR DESCRIPTION
## What did you do? 

Use the upstream and more up-to-date cellxgene container.

## Why did you make this change?

Using the plain Biocontainer is always better than a hand-crafted one. It is also more recent and this brings back changes
that have been running on usegalaxy.eu for a while.

## How to test the changes? 

You can go to https://live.usegalaxy.eu and test it.