### PR TITLE
[21.01] Fix ToolShed link in Admin->Local Data

### DIFF
--- a/client/src/components/admin/DataManager/DataManagerView.vue
+++ b/client/src/components/admin/DataManager/DataManagerView.vue
@@ -4,7 +4,7 @@
             <h2 id="data-managers-title">Local Data</h2>
             <p>
                 Data Managers are used to manage Galaxy's local data. They can be installed manually, or via the
-                <b-link :href="toolShedLink" target="galaxy_main">ToolShed</b-link>. For more comprehensive information
+                <b-link :href="toolShedLink">ToolShed</b-link>. For more comprehensive information
                 <b-link href="https://galaxyproject.org/admin/tools/data-managers/" target="_blank">See the Wiki</b-link
                 >.
             </p>
@@ -18,7 +18,7 @@ import { getAppRoot } from "onload/loadConfig";
 export default {
     computed: {
         toolShedLink() {
-            return `${getAppRoot()}admin_toolshed/browse_tool_sheds`;
+            return `${getAppRoot()}admin/toolshed`;
         },
     },
 };


### PR DESCRIPTION
## What did you do? 
- Fix a broken link to the ToolShed in the Local Data section of the Admin panel.


## Why did you make this change?
To fix #11110


## How to test the changes? 
- [x] Instructions for manual testing are as follows:

1. Go to the Admin panel.
2. Go to  `Server -> Local Data` section.
3. Click on the `ToolShed` link in the description.
4. You should navigate to the ToolShed page.
