### PR TITLE
[21.01] Fix 'Method "l" has already been defined as a data property.'

### DIFF
--- a/client/src/components/RuleBuilder/ColumnSelector.vue
+++ b/client/src/components/RuleBuilder/ColumnSelector.vue
@@ -47,11 +47,6 @@ export default {
     components: {
         Select2,
     },
-    data: function () {
-        return {
-            l: _l,
-        };
-    },
     props: {
         target: {
             required: true,


### PR DESCRIPTION
## What did you do? 
- Fixed vue warning

```
[Vue warn]: Method "l" has already been defined as a data property.

found in

---> <ColumnSelector> at src/components/RuleBuilder/ColumnSelector.vue
       <RuleComponent> at src/components/RuleBuilder/RuleComponent.vue
         <RuleModalMiddle> at src/components/RuleBuilder/RuleModalMiddle.vue
           <StateDiv> at src/components/RuleBuilder/StateDiv.vue
             <Root>
```

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate automated tests (https://docs.galaxyproject.org/en/latest/dev/writing_tests.html)
- [x] Instructions for manual testing are as follows:
  1. Open the console and follow the rule builder tutorial (https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/upload-rules-advanced/tutorial.html).
