### PR TITLE
Augment PR template for refactorings with existing 100% test coverage.

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -10,7 +10,7 @@
 
 ## How to test the changes? 
 (select the most appropriate option; if the latter, provide steps for testing below)
-- [ ] I've included appropriate automated tests (https://docs.galaxyproject.org/en/latest/dev/writing_tests.html)
+- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
 - [ ] This is a refactoring of components with existing test coverage.
 - [ ] Instructions for manual testing are as follows:
   1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -11,9 +11,9 @@
 ## How to test the changes? 
 (select the most appropriate option; if the latter, provide steps for testing below)
 - [ ] I've included appropriate automated tests (https://docs.galaxyproject.org/en/latest/dev/writing_tests.html)
+- [ ] This is a refactoring of components with existing test coverage.
 - [ ] Instructions for manual testing are as follows:
-
-1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
+  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
 
 ## For UI Components
 - [ ] I've included a screenshot of the changes


### PR DESCRIPTION
## What did you do? 

- Augments PR template to acknowledge PRs that refactor code with 100% test coverage don't need additional tests.

## Why did you make this change?

I opened a PR that was awkward with the existing the template and I thought this option would feel more natural in that situation.

## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. Copy the template out of the markdown file and view it in Github
  2. Check for spelling mistakes (and find them if you are 🦅 👁️), decide that this makes sense in addition to rendering properly.
  3. Comment "Awesome, makes a lot of sense @jmchilton. Have a great Friday!"
