### PR TITLE
[WIP] Move pysam index to external process

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -28,6 +28,7 @@ from galaxy.datatypes.data import (
 )
 from galaxy.datatypes.metadata import DictParameter, ListParameter, MetadataElement, MetadataParameter
 from galaxy.datatypes.sniff import build_sniff_from_prefix
+from galaxy.datatypes.util.generic_util import call_pysam_index
 from galaxy.util import nice_size, sqlite
 from galaxy.util.checkers import is_bz2, is_gzip
 from . import data, dataproviders
@@ -488,13 +489,8 @@ class Bam(BamNative):
             # If pysam fails to index a file it will write to stderr,
             # and this causes the set_meta script to fail. So instead
             # we start another process and discard stderr.
-            if index_flag == '-b':
-                # IOError: No such file or directory: '-b' if index_flag is set to -b (pysam 0.15.4)
-                cmd = ['python', '-c', f"import pysam; pysam.set_verbosity(0); pysam.index('{file_name}', '{index_name}')"]
-            else:
-                cmd = ['python', '-c', f"import pysam; pysam.set_verbosity(0); pysam.index('{index_flag}', '{file_name}', '{index_name}')"]
-            with open(os.devnull, 'w') as devnull:
-                subprocess.check_call(cmd, stderr=devnull, shell=False)
+            call_pysam_index(file_name, index_name, index_flag=index_flag,
+                             stderr=os.devnull)
             needs_sorting = False
         except subprocess.CalledProcessError:
             needs_sorting = True
@@ -516,11 +512,7 @@ class Bam(BamNative):
             index_file = dataset.metadata.bam_csi_index
         if not index_file:
             index_file = dataset.metadata.spec[spec_key].param.new_file(dataset=dataset)
-        if index_flag == '-b':
-            # IOError: No such file or directory: '-b' if index_flag is set to -b (pysam 0.15.4)
-            pysam.index(dataset.file_name, index_file.file_name)
-        else:
-            pysam.index(index_flag, dataset.file_name, index_file.file_name)
+        call_pysam_index(dataset.file_name, index_file.file_name, index_flag=index_flag)
         dataset.metadata.bam_index = index_file
 
     def sniff(self, file_name):
@@ -691,7 +683,7 @@ class CRAM(Binary):
 
     def set_index_file(self, dataset, index_file):
         try:
-            pysam.index(dataset.file_name, index_file.file_name)
+            call_pysam_index(dataset.file_name, index_file.file_name)
             return True
         except Exception as exc:
             log.warning('%s, set_index_file Exception: %s', self, exc)

--- a/lib/galaxy/datatypes/util/generic_util.py
+++ b/lib/galaxy/datatypes/util/generic_util.py
@@ -16,3 +16,21 @@ def count_special_lines(word, filename, invert=False):
     except commands.CommandLineException:
         return 0
     return int(out)
+
+
+def call_pysam_index(self, file_name, index_name, index_flag=None, stderr=None):
+    """
+    The pysam.index call can block the GIL, which can pause all threads, including
+    the heartbeat thread. Therefore, start it as an external process.
+    """
+    if index_flag == '-b' or not index_flag:
+        # IOError: No such file or directory: '-b' if index_flag is set to -b (pysam 0.15.4)
+        cmd = ['python', '-c', f"import pysam; pysam.set_verbosity(0); pysam.index('{file_name}', '{index_name}')"]
+    else:
+        cmd = ['python', '-c',
+               f"import pysam; pysam.set_verbosity(0); pysam.index('{index_flag}', '{file_name}', '{index_name}')"]
+    if stderr:
+        with open(stderr, 'w') as stderr:
+            subprocess.check_call(cmd, stderr=stderr, shell=False)
+    else:
+        subprocess.check_call(cmd, shell=False)


### PR DESCRIPTION
## What did you do? 
This PR moves all calls to pysam.index to an external process. This had previously been done in one place in the code: https://github.com/galaxyproject/galaxy/blob/e5a95246dbfb22507a93a1cf999b9a5a7e89222f/lib/galaxy/datatypes/binary.py#L493 but this PR extends that to all use cases.

## Why did you make this change?
We ran into an issue in the k8s chart where the job handler would abruptly restart while within pysam.index. The proximate cause was a health check failure. The underlying reason was that pysam.index could potentially take a long time, and being an external c extension, appears to be not releasing the GIL, preventing the heartbeat thread from running. The failure of the heartbeat thread to report liveness causes k8s to restart the job handler.

By externalizing the process, we prevent it from blocking the job handler threads, and has the additional benefit of generally preventing any pysam failures from causing a handler crash.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] This is a refactoring of components with existing test coverage.
