### PR TITLE
Small rule builder refactorings.

### DIFF
--- a/client/src/components/RuleBuilder/IdentifierDisplayPreview.vue
+++ b/client/src/components/RuleBuilder/IdentifierDisplayPreview.vue
@@ -1,0 +1,34 @@
+<template>
+    <li class="rule" :title="help">Set {{ columnsLabel }} as {{ typeDisplay }}</li>
+</template>
+
+<script>
+import RuleDefs from "mvc/rules/rule-definitions";
+
+export default {
+    props: {
+        type: {
+            type: String,
+            required: true,
+        },
+        columns: {
+            required: true,
+        },
+        colHeaders: {
+            type: Array,
+            required: true,
+        },
+    },
+    computed: {
+        typeDisplay() {
+            return RuleDefs.MAPPING_TARGETS[this.type].label;
+        },
+        help() {
+            return RuleDefs.MAPPING_TARGETS[this.type].help || "";
+        },
+        columnsLabel() {
+            return RuleDefs.columnDisplay(this.columns, this.colHeaders);
+        },
+    },
+};
+</script>

--- a/client/src/components/RuleBuilder/RuleDisplayPreview.vue
+++ b/client/src/components/RuleBuilder/RuleDisplayPreview.vue
@@ -1,0 +1,34 @@
+<template>
+    <li class="rule">
+        <span class="rule-display">{{ title }} </span>
+        <span class="rule-warning" v-if="rule.warn">
+            {{ rule.warn }}
+        </span>
+        <span class="rule-error" v-if="rule.error">
+            <span class="alert-message">{{ rule.error }}</span>
+        </span>
+    </li>
+</template>
+
+<script>
+import RuleDefs from "mvc/rules/rule-definitions";
+
+export default {
+    props: {
+        rule: {
+            required: true,
+            type: Object,
+        },
+        colHeaders: {
+            type: Array,
+            required: false,
+        },
+    },
+    computed: {
+        title() {
+            const ruleType = this.rule.type;
+            return RuleDefs.RULES[ruleType].display(this.rule, this.colHeaders);
+        },
+    },
+};
+</script>

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -122,7 +122,7 @@
                             <regular-expression-input :target.sync="addColumnRegexExpression" />
                             <label v-if="addColumnRegexType == 'groups'">
                                 {{ l("Number of Groups") }}
-                                <input type="number" v-model="addColumnRegexGroupCount" min="1" />
+                                <input type="number" v-model.number="addColumnRegexGroupCount" min="1" />
                             </label>
                             <label v-if="addColumnRegexType == 'replacement'">
                                 {{ l("Replacement Expression") }}

--- a/client/src/components/RulesDisplay.vue
+++ b/client/src/components/RulesDisplay.vue
@@ -20,76 +20,10 @@
 </template>
 <script>
 import RuleDefs from "mvc/rules/rule-definitions";
-
-// read-only variants of the components for displaying these rules and mappings in builder widget.
-const RuleDisplayPreview = {
-    template: `
-        <li class="rule">
-            <span class="rule-display">{{ title }}
-            </span>
-            <span class="rule-warning" v-if="rule.warn">
-                {{ rule.warn }}
-            </span>
-            <span class="rule-error" v-if="rule.error">
-                <span class="alert-message">{{ rule.error }}</span>
-            </span>
-        </li>
-    `,
-    props: {
-        rule: {
-            required: true,
-            type: Object,
-        },
-        colHeaders: {
-            type: Array,
-            required: false,
-        },
-    },
-    computed: {
-        title() {
-            const ruleType = this.rule.type;
-            return RuleDefs.RULES[ruleType].display(this.rule, this.colHeaders);
-        },
-    },
-    methods: {},
-};
-
-const IdentifierDisplayPreview = {
-    template: `
-      <li class="rule" :title="help">
-        Set {{ columnsLabel }} as {{ typeDisplay }}
-      </li>
-    `,
-    props: {
-        type: {
-            type: String,
-            required: true,
-        },
-        columns: {
-            required: true,
-        },
-        colHeaders: {
-            type: Array,
-            required: true,
-        },
-    },
-    computed: {
-        typeDisplay() {
-            return RuleDefs.MAPPING_TARGETS[this.type].label;
-        },
-        help() {
-            return RuleDefs.MAPPING_TARGETS[this.type].help || "";
-        },
-        columnsLabel() {
-            return RuleDefs.columnDisplay(this.columns, this.colHeaders);
-        },
-    },
-};
+import RuleDisplayPreview from "components/RuleBuilder/RuleDisplayPreview";
+import IdentifierDisplayPreview from "components/RuleBuilder/IdentifierDisplayPreview";
 
 export default {
-    data: function () {
-        return {};
-    },
     computed: {
         mapping: function () {
             return this.inputRules ? this.inputRules.mapping : [];

--- a/client/src/mvc/rules/rule-definitions.js
+++ b/client/src/mvc/rules/rule-definitions.js
@@ -270,7 +270,7 @@ const RULES = {
                 rule.replacement = component.addColumnRegexReplacement;
             }
             if (component.addColumnRegexGroupCount) {
-                rule.group_count = parseInt(component.addColumnRegexGroupCount);
+                rule.group_count = component.addColumnRegexGroupCount;
             }
         },
         apply: (rule, data, sources, columns) => {


### PR DESCRIPTION
## What did you do? 

- Use v-model.number instead of hack from #11553 / c7f5274
- Move two embedded components from RulesDisplay into component files.

## Why did you make this change?

xref conversation https://github.com/galaxyproject/galaxy/pull/11553#discussion_r588522054

Generally we're preferring stand-alone Vue components so this continues the refactoring in that direction (ala #9619).

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/upload-rules-advanced/tutorial.html
