### PR TITLE
Add more filtering options to api/jobs endpoint

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -175,15 +175,17 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
                 query = query.filter(Job.table.c.history_id == decoded_history_id)
             if workflow_id is not None:
                 decoded_workflow_id = self.decode_id(workflow_id)
+                query = query.filter(and_(
+                    model.WorkflowInvocationStep.table.c.workflow_invocation_id == model.WorkflowInvocation.table.c.id,
+                    model.WorkflowInvocation.table.c.workflow_id == model.Workflow.table.c.id,
+                    model.Workflow.table.c.stored_workflow_id == decoded_workflow_id
+                ))
                 query1 = query.filter(Job.table.c.id == model.WorkflowInvocationStep.table.c.job_id)
                 query2 = query.filter(and_(
                     Job.table.c.id == model.ImplicitCollectionJobsJobAssociation.table.c.job_id,
                     model.ImplicitCollectionJobsJobAssociation.table.c.implicit_collection_jobs_id == model.WorkflowInvocationStep.table.c.implicit_collection_jobs_id,
                 ))
-                query = query1.union_all(query2).filter(and_(
-                    model.WorkflowInvocationStep.table.c.workflow_invocation_id == model.WorkflowInvocation.table.c.id,
-                    model.WorkflowInvocation.table.c.workflow_id == decoded_workflow_id
-                ))
+                query = query1.union_all(query2)
             if invocation_id is not None:
                 decoded_invocation_id = self.decode_id(invocation_id)
                 query = query.filter(and_(

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -175,8 +175,12 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
                 query = query.filter(Job.table.c.history_id == decoded_history_id)
             if workflow_id is not None:
                 decoded_workflow_id = self.decode_id(workflow_id)
-                query = query.filter(and_(
-                    Job.table.c.id == model.WorkflowInvocationStep.table.c.job_id,
+                query1 = query.filter(Job.table.c.id == model.WorkflowInvocationStep.table.c.job_id)
+                query2 = query.filter(and_(
+                    Job.table.c.id == model.ImplicitCollectionJobsJobAssociation.table.c.job_id,
+                    model.ImplicitCollectionJobsJobAssociation.table.c.implicit_collection_jobs_id == model.WorkflowInvocationStep.table.c.implicit_collection_jobs_id,
+                ))
+                query = query1.union_all(query2).filter(and_(
                     model.WorkflowInvocationStep.table.c.workflow_invocation_id == model.WorkflowInvocation.table.c.id,
                     model.WorkflowInvocation.table.c.workflow_id == decoded_workflow_id
                 ))

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -80,7 +80,7 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     hda_manager = depends(hdas.HDAManager)
 
     @expose_api
-    def index(self, trans: ProvidesUserContext, limit=500, **kwd):
+    def index(self, trans: ProvidesUserContext, limit=500, offset=0, **kwd):
         """
         GET /api/jobs
 
@@ -195,9 +195,7 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
             order_by = Job.table.c.update_time.desc()
         query = query.order_by(order_by)
 
-        offset = kwd.get('offset', None)
-        if offset is not None:
-            query = query.offset(offset)
+        query = query.offset(offset)
         query = query.limit(limit)
 
         out = []

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -80,7 +80,7 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
     hda_manager = depends(hdas.HDAManager)
 
     @expose_api
-    def index(self, trans: ProvidesUserContext, **kwd):
+    def index(self, trans: ProvidesUserContext, limit=500, **kwd):
         """
         GET /api/jobs
 
@@ -196,11 +196,9 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
         query = query.order_by(order_by)
 
         offset = kwd.get('offset', None)
-        limit = kwd.get('limit', None)
         if offset is not None:
             query = query.offset(offset)
-        if limit is not None:
-            query = query.limit(limit)
+        query = query.limit(limit)
 
         out = []
         for job in query.all():

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -144,7 +144,13 @@ steps:
         self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
         jobs1 = self.__jobs_index(data={"workflow_id": workflow_id})
         jobs2 = self.__jobs_index(data={"invocation_id": invocation_id})
-        assert len(jobs1) > len(jobs2)
+        assert len(jobs1) == len(jobs2) == 1
+        second_invocation_id = self.workflow_populator.invoke_workflow(history_id, workflow_id, inputs)
+        self.workflow_populator.wait_for_invocation(workflow_id, second_invocation_id)
+        workflow_jobs = self.__jobs_index(data={"workflow_id": workflow_id})
+        second_invocation_jobs = self.__jobs_index(data={"invocation_id": second_invocation_id})
+        assert len(workflow_jobs) == 2
+        assert len(second_invocation_jobs) == 1
 
     @uses_test_history(require_new=True)
     def test_index_limit_and_offset_filter(self, history_id):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -114,8 +114,8 @@ steps:
       input1: input1
 """
         summary = self.workflow_populator.run_workflow(workflow_simple, history_id=history_id, test_data={"input1": "hello world"},)
-        workflow_id = summary.workflow_id
         invocation_id = summary.invocation_id
+        workflow_id = self._get(f"invocations/{invocation_id}").json()['workflow_id']
         self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
         jobs1 = self.__jobs_index(data={"workflow_id": workflow_id})
         assert len(jobs1) == 1

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -15,6 +15,7 @@ from galaxy_test.base.populators import (
     uses_test_history,
     wait_on,
     wait_on_state,
+    WorkflowPopulator
 )
 from ._framework import ApiTestCase
 
@@ -23,6 +24,7 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
 
     def setUp(self):
         super().setUp()
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
@@ -94,6 +96,59 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
         with self.dataset_populator.test_history() as other_history_id:
             jobs = self.__jobs_index(data={"history_id": other_history_id})
             assert len(jobs) == 0
+
+    @uses_test_history(require_new=True)
+    def test_index_workflow_and_invocation_filter(self, history_id):
+        workflow_simple = """
+class: GalaxyWorkflow
+name: Simple Workflow
+inputs:
+  input1: data
+outputs:
+  wf_output_1:
+    outputSource: first_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat1
+    in:
+      input1: input1
+"""
+        summary = self.workflow_populator.run_workflow(workflow_simple, history_id=history_id, test_data={"input1": "hello world"},)
+        workflow_id = summary.workflow_id
+        invocation_id = summary.invocation_id
+        self.workflow_populator.wait_for_invocation(workflow_id, invocation_id)
+        jobs1 = self.__jobs_index(data={"workflow_id": workflow_id})
+        assert len(jobs1) == 1
+        jobs2 = self.__jobs_index(data={"invocation_id": invocation_id})
+        assert len(jobs2) == 1
+        assert jobs1 == jobs2
+
+    @uses_test_history(require_new=True)
+    def test_index_limit_and_offset_filter(self, history_id):
+        self.__history_with_new_dataset(history_id)
+        jobs = self.__jobs_index(data={"history_id": history_id})
+        assert len(jobs) > 0
+        length = len(jobs)
+        jobs = self.__jobs_index(data={"history_id": history_id, "offset": 1})
+        assert len(jobs) == length - 1
+        jobs = self.__jobs_index(data={"history_id": history_id, "limit": 0})
+        assert len(jobs) == 0
+
+    @uses_test_history(require_new=True)
+    def test_index_user_filter(self, history_id):
+        test_user_email = "user_for_jobs_index_test@bx.psu.edu"
+        user = self._setup_user(test_user_email)
+        with self._different_user(email=test_user_email):
+            # User should be able to jobs for their own ID.
+            jobs = self.__jobs_index(data={"user_id": user["id"]})
+            assert jobs == []
+        # Admin should be able to see jobs of another user.
+        jobs = self.__jobs_index(data={"user_id": user["id"]}, admin=True)
+        assert jobs == []
+        # Normal user should not be able to see jobs of another user.
+        jobs_response = self._get("jobs", data={"user_id": user["id"]})
+        self._assert_status_code_is(jobs_response, 403)
+        assert jobs_response.json() == {"err_msg": "Only admins can index the jobs of others", "err_code": 403006}
 
     @uses_test_history(require_new=True)
     def test_index_multiple_states_filter(self, history_id):


### PR DESCRIPTION
## What did you do? 
- Added new parameters to the `galaxy.webapps.galaxy.api.JobsController.index()` API method:
  - `user_id`
  - `limit`
  - `offset`
  - `workflow_id`
  - `invocation_id`

- Added three tests in `lib/galaxy_test/webapps/galaxy/api/test_jobs.py`:
  - `test_index_limit_and_offset_filter`
  - `test_index_workflow_and_invocation_filter`
  - `test_index_user_filter`


## Why did you make this change?
Currently this filtering has to be performed by the user of the API. It would be good if the server could do the filtering.
See also this issue from bioblend: galaxyproject/bioblend#373, and related comments: https://github.com/galaxyproject/bioblend/pull/376#issuecomment-790961541


## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
