### PR TITLE
Allow requesting extra scopes

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -17,6 +17,7 @@ from galaxy import model
 from galaxy.util import (
     asbool,
     etree,
+    listify,
     parse_xml,
     string_as_bool,
     unicodify,
@@ -144,6 +145,8 @@ class AuthnzManager:
             rtv['url'] = config_xml.find('url').text
         if config_xml.find('icon') is not None:
             rtv['icon'] = config_xml.find('icon').text
+        if config_xml.find('extra_scopes') is not None:
+            rtv['extra_scopes'] = listify(config_xml.find('extra_scopes').text)
 
         return rtv
 

--- a/lib/galaxy/authnz/psa_authnz.py
+++ b/lib/galaxy/authnz/psa_authnz.py
@@ -127,6 +127,7 @@ class PSAAuthnz(IdentityProvider):
         self.config['KEY'] = oidc_backend_config.get('client_id')
         self.config['SECRET'] = oidc_backend_config.get('client_secret')
         self.config['redirect_uri'] = oidc_backend_config.get('redirect_uri')
+        self.config['EXTRA_SCOPES'] = oidc_backend_config.get('extra_scopes')
         if oidc_backend_config.get('prompt') is not None:
             self.config[setting_name('AUTH_EXTRA_ARGUMENTS')]['prompt'] = oidc_backend_config.get('prompt')
         if oidc_backend_config.get('api_url') is not None:
@@ -154,6 +155,10 @@ class PSAAuthnz(IdentityProvider):
                 "SOCIAL_AUTH_SECONDARY_AUTH_PROVIDER" in self.config and \
                 "SOCIAL_AUTH_SECONDARY_AUTH_ENDPOINT" in self.config:
             backend.DEFAULT_SCOPE.append("https://www.googleapis.com/auth/cloud-platform")
+
+        if self.config['EXTRA_SCOPES'] is not None:
+            backend.DEFAULT_SCOPE.extend(self.config['EXTRA_SCOPES'])
+
         return do_auth(backend)
 
     def callback(self, state_token, authz_code, trans, login_redirect_url):

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -139,8 +139,6 @@ Please mind `http` and `https`.
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
         <!-- <enable_idp_logout>false</enable_idp_logout> -->
         <!-- <icon>https://path/to/icon</icon>  -->
-        <!-- (Optional) Extra scopes you need to request for your implementation -->
-        <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
     </provider>
 
     <!-- Documentation: https://galaxyproject.org/authnz/config/oidc/idps/elixir-aai  -->

--- a/lib/galaxy/config/sample/oidc_backends_config.xml.sample
+++ b/lib/galaxy/config/sample/oidc_backends_config.xml.sample
@@ -75,6 +75,8 @@ Please mind `http` and `https`.
          login to Galaxy using their Google account.
         -->
         <icon>https://developers.google.com/identity/images/btn_google_signin_light_normal_web.png</icon>
+        <!-- (Optional) Extra scopes you need to request for your implementation -->
+        <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
     </provider>
 
     <!-- Documentation: http://globus-integration-examples.readthedocs.io -->
@@ -96,7 +98,7 @@ Please mind `http` and `https`.
         <!-- (Optional) Override the default Custos well-known URL to point to a different instance -->
         <!-- <well_known_oidc_config_uri>https://.../.well-known/openid-configuration</well_known_oidc_config_uri> -->
         <!-- (Optional) Restrict the list of options available for login using CILogon or Custos by including the EntityID for each institution
-             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/ 
+             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/
              Note: the <allowed_idp>'s for Custos should match those for CILogon if both are enabled.-->
         <!-- <allowed_idp>https://github.com/login/oauth/authorize</allowed_idp> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
@@ -114,7 +116,7 @@ Please mind `http` and `https`.
         <!-- (Optional) Override the default Custos well-known URL to point to a different instance -->
         <!-- <well_known_oidc_config_uri>https://.../.well-known/openid-configuration</well_known_oidc_config_uri> -->
         <!-- (Optional) Restrict the list of options available for login using CILogon or Custos by including the EntityID for each institution
-             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/ 
+             in a separate <allowed_idp> tag. Find the EntityID(s) for your desired institution(s) at https://cilogon.org/idplist/
              Note: the <allowed_idp>'s for CILogon should match those for Custos if both are enabled.-->
         <!-- <allowed_idp>https://github.com/login/oauth/authorize</allowed_idp> -->
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
@@ -137,6 +139,8 @@ Please mind `http` and `https`.
         <!-- (Optional) Enable logging out of the IDP when user logs out of Galaxy -->
         <!-- <enable_idp_logout>false</enable_idp_logout> -->
         <!-- <icon>https://path/to/icon</icon>  -->
+        <!-- (Optional) Extra scopes you need to request for your implementation -->
+        <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
     </provider>
 
     <!-- Documentation: https://galaxyproject.org/authnz/config/oidc/idps/elixir-aai  -->
@@ -146,6 +150,8 @@ Please mind `http` and `https`.
         <redirect_uri>http://localhost:8080/authnz/elixir/callback</redirect_uri>
         <prompt>consent</prompt>
         <icon>https://elixir-europe.org/sites/default/files/images/login-button-orange.png</icon>
+        <!-- (Optional) Extra scopes you need to request for your implementation -->
+        <!-- <extra_scopes>offline_access,something-else</extra_scopes> -->
     </provider>
 
     <provider name="Okta">
@@ -174,7 +180,7 @@ Please mind `http` and `https`.
         <client_id> ... </client_id>
         <client_secret> ... </client_secret>
         <redirect_uri>http://localhost:8080/authnz/azure/callback</redirect_uri>
-        <!-- Azure client_id, client_secret, and api_url can be obtained by folowing the instructions at 
+        <!-- Azure client_id, client_secret, and api_url can be obtained by folowing the instructions at
         https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app
 
         The api_url will typiclly be https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/authorize


### PR DESCRIPTION
## What did you do? 
This expands the `oidc_backends_config` file with the ability to configure custom scopes for @shiltemann 

## Why did you make this change?

By default Galaxy's ELIXIR backend requests the minimal amount of data possible, but for some applications it is desirable to request `offline_access` in order to get a refresh token. This is part of the refactoring of the pyEGA tool to not require user credentials, and instead use the user's already present access_token to make the requests to EGA/GA4GH. @shiltemann 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Be in ELIXIR
  2. Obtain credentials from them through spreg/Perun
  3. Add the new extra_scopes section of the backends config file:
     ```
	 <redirect_uri>....</redirect_uri>
	 <extra_scopes>offline_access</extra_scopes>
	 <prompt>consent</prompt>
	 ```
  4. Consent to grant

     ![image](https://user-images.githubusercontent.com/458683/110313399-a74e0780-8006-11eb-852f-d26d5c05ce39.png)


@VJalili would appreciate your input here if you think this is an ok way to do this, or if you have a different idea in mind. I used listify because I didn't feel like making another nested parameter option and for a text value like this maybe it's ok?