### PR TITLE
Better webpack-dev-server handling.

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -48,43 +48,40 @@ for inspection of live javascript to facilitate debugging, use:
 Important Note: The Galaxy repository does not include client script artifacts,
 and these should not be committed.
 
-## Automatic Rebuilding (Watch Mode)
+## Automatic Rebuilding
 
-When you're actively developing, it is sometimes convenient to have the client
+When you're actively developing, it is convenient to have the client
 automatically rebuild every time you save a file. You can do this using:
 
     make client-watch
 
-This will first stage any dependencies (yarn-installed packages like jquery,
-etc), and then will watch for changes in any of the galaxy client source files.
-When a file is changed, the client will automatically rebuild, after which you
-can usually force refresh your browser to see changes. Note that it is still
-recommended to run `make client` after you are finished actively developing
-using `make client-watch`.
+This will first stage client dependencies, initiate a build, and then will
+watch for changes in any of the galaxy client source files.  When a file is
+changed, the client will automatically rebuild, after which you can refresh
+your browser to see changes.
 
-Note that there's a new, better option described in the next section. This
-method of building will likely be deprecated as HMR is more widely tested.
+For even more rapid development you can use the webpack development server,
+which takes advantage of hot module replacement (HMR). This technique allows
+swapping out of javascript modules while the application is running without
+requiring a full page reload most of the time, at least in the more modern
+parts of the application.
 
-## Even Better Automatic Rebuilding (HMR)
-
-For even more rapid development you can use the webpack development server for
-Hot Module Replacement (HMR). This technique allows swapping out of modules
-while the application is running without requiring a full page reload most of
-the time.
-
-Setting this up is a little more involved, but it is the fastest possible way
-to iterate when developing the client. You'll need to start two separate
-processes here. The first command below starts a special webpack dev server
-after a client build, and the second starts a Galaxy server like usual, but
-with extra mappings that redirect client artifact requests to the mentioned
-webpack dev server.
+The command below starts a special webpack dev server after a client
+build.
 
     make client-dev-server
-    GALAXY_CLIENT_DEV_SERVER=1 sh run.sh
 
-Note that this only works under uWSGI due to the extra internal routing rules
-employed. If you're using the older Paste-based galaxy webserver you'll need to
-swap it over to take advantage of this functionality.
+This will start up an extra client development server running on port 8081.
+Open your browser to http://localhost:8081 (instead of the default 8080 that
+Galaxy would run on), and you should see Galaxy like normal.  Except now, when
+you change client code it'll automatically rebuild *and* reload the relevant
+portion of the application for you.  Note that unlike previous versions of this
+functionality, it is no longer required to use uWSGI for this.  Lastly, if you
+are running Galaxy at a location other than the default, you can specify a
+different proxy target (in this example, port 8000) using the GALAXY_URL
+environment variable:
+
+    GALAXY_URL="http://localhost:8000" make client-dev-server
 
 ## Changing Styles/CSS
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -231,7 +231,7 @@ module.exports = (env = {}, argv = {}) => {
             // someday, this can be a more limited set -- e.g. `/api`, `/auth`
             proxy: {
                 "/": {
-                    target: process.env.GALAXY_SERVER || "http://localhost:8080",
+                    target: process.env.GALAXY_URL || "http://localhost:8080",
                 },
             },
         },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -231,7 +231,7 @@ module.exports = (env = {}, argv = {}) => {
             // someday, this can be a more limited set -- e.g. `/api`, `/auth`
             proxy: {
                 "/": {
-                    target: "http://localhost:8080",
+                    target: process.env.GALAXY_SERVER || "http://localhost:8080",
                 },
             },
         },

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -67,9 +67,9 @@ module.exports = (env = {}, argv = {}) => {
                     loader: "vue-loader",
                 },
                 {
-                         test: /\.mjs$/,
-                         include: /node_modules/,
-                         type: 'javascript/auto'
+                    test: /\.mjs$/,
+                    include: /node_modules/,
+                    type: "javascript/auto",
                 },
                 {
                     test: /\.js$/,
@@ -185,7 +185,7 @@ module.exports = (env = {}, argv = {}) => {
                 },
                 {
                     test: /\.worker\.js$/,
-                    use: { loader: 'worker-loader' },
+                    use: { loader: "worker-loader" },
                 },
             ],
         },
@@ -227,6 +227,13 @@ module.exports = (env = {}, argv = {}) => {
         ],
         devServer: {
             hot: true,
+            // proxy *everything* to the galaxy server
+            // someday, this can be a more limited set -- e.g. `/api`, `/auth`
+            proxy: {
+                "/": {
+                    target: "http://localhost:8080",
+                },
+            },
         },
     };
 

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -18,7 +18,6 @@ CREATE_VENV=1
 REPLACE_PIP=$SET_VENV
 COPY_SAMPLE_FILES=1
 SKIP_CLIENT_BUILD=${GALAXY_SKIP_CLIENT_BUILD:-0}
-CLIENT_DEV_SERVER=${GALAXY_CLIENT_DEV_SERVER:-0}
 NODE_VERSION=${GALAXY_NODE_VERSION:-"$(cat client/.node_version)"}
 
 for arg in "$@"; do
@@ -32,11 +31,6 @@ for arg in "$@"; do
     [ "$arg" = "--skip-samples" ] && COPY_SAMPLE_FILES=0
     [ "$arg" = "--skip-client-build" ] && SKIP_CLIENT_BUILD=1
 done
-
-# If a client dev server is being configured, skip the client build.
-if [ $CLIENT_DEV_SERVER -ne 0 ]; then
-    SKIP_CLIENT_BUILD=1
-fi
 
 SAMPLES="
     lib/tool_shed/scripts/bootstrap_tool_shed/user_info.xml.sample

--- a/scripts/get_uwsgi_args.py
+++ b/scripts/get_uwsgi_args.py
@@ -107,14 +107,6 @@ def _get_uwsgi_args(cliargs, kwargs):
     if not __arg_set('virtualenv', uwsgi_kwargs) and ('VIRTUAL_ENV' in os.environ or os.path.exists('.venv')):
         __add_arg(args, 'virtualenv', os.environ.get('VIRTUAL_ENV', '.venv'))
 
-    # Client dev server for HMR
-    hmr_server = os.environ.get('GALAXY_CLIENT_DEV_SERVER', None)
-    if hmr_server:
-        # Something like this, which is the default in the package scripts
-        # route: ^/static/scripts/bundled/ http:127.0.0.1:8081
-        if hmr_server.lower() in ['1', 'true', 'default']:
-            hmr_server = "http:127.0.0.1:8081"
-        __add_arg(args, 'route', f'^/static/dist/ {hmr_server}')
     # We always want to append client/src/assets as static-safe.
     __add_arg(args, 'static-safe', f'{os.getcwd()}/client/src/assets')
 


### PR DESCRIPTION
## What did you do? 
Overhauled webpack-dev-server approach.  Now, you can, in two shells do something like:

```
GALAXY_CONFIG_FILE=config/galaxy.yml uvicorn --factory 'galaxy.webapps.galaxy.fast_factory:factory' --reload --reload-dir lib --app-dir lib --port 8080
```

And (from client)
```
yarn run webpack-dev-server
```

And both the galaxy client *and* server will watch for and reload on any change.  Previously we had to pick one or the other.

TODO:  Update vscode launch targets to have 'one true way to run dev locally, with all the perks'.


## Why did you make this change?
Previously using webpack-dev-server with HMR required use of uWSGI routing.  This separation allows us to run uWSGI, gunicorn, uvicorn, whatever as the backend without relying on server internals or routing.

This has many benefits over the previous approach where the galaxy server had to know about and route to the webpack-dev-server.

## How to test the changes? 
- [ x ] Instructions for manual testing are as follows:
  1. Try commands above.
