### PR TITLE
[21.01] Fix upload button tooltip blocking tool search field

### DIFF
--- a/client/src/components/Upload/UploadButton.vue
+++ b/client/src/components/Upload/UploadButton.vue
@@ -2,7 +2,7 @@
     <b-button
         id="tool-panel-upload-button"
         @click="showUploadDialog"
-        v-b-tooltip.hover
+        v-b-tooltip.hover.auto
         :aria-label="title | localize"
         :title="title | localize"
         class="upload-button"


### PR DESCRIPTION
## What did you do? 
- Add auto directive to tooltip (https://bootstrap-vue.org/docs/directives/tooltip)


## Why did you make this change?
tooltip got in the way of the search box, fixes 11493


## How to test the changes? 
Start Galaxy, hover over upload button and see it doesn't block the tool search field

## For UI Components
- [x] I've included a screenshot of the changes
<img width="380" alt="Screenshot 2021-03-09 at 10 50 36" src="https://user-images.githubusercontent.com/6804901/110452838-d7a8ab00-80c5-11eb-8b3c-849165f9b5d3.png">

