### PR TITLE
SLURM: stop editing job stderr file

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -2,9 +2,6 @@
 SLURM job control via the DRMAA API.
 """
 import os
-import re
-import shutil
-import tempfile
 import time
 
 from galaxy import model
@@ -27,11 +24,6 @@ SLURM_MEMORY_LIMIT_EXCEEDED_MSG = 'slurmstepd: error: Exceeded job memory limit'
 # https://github.com/SchedMD/slurm/
 SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS = [': Exceeded job memory limit at some point.',
                                                 ': Exceeded step memory limit at some point.']
-SLURM_MEMORY_LIMIT_SCAN_SIZE = 16 * 1024 * 1024  # 16MB
-SLURM_CGROUP_RE = re.compile(r"""slurmstepd: .*cgroup.*$""")
-SLURM_TOP_WARNING_RES = (
-    SLURM_CGROUP_RE,
-)
 
 # These messages are returned to the user
 OUT_OF_MEMORY_MSG = 'This job was terminated because it used more memory than it was allocated.'
@@ -152,24 +144,6 @@ class SlurmJobRunner(DRMAAJobRunner):
                     ajs.stop_job = False
                     self.work_queue.put((self.fail_job, ajs))
                     return
-            if drmaa_state == self.drmaa_job_states.DONE:
-                ajs.job_wrapper.reclaim_ownership()
-                with open(ajs.error_file) as rfh:
-                    _remove_spurious_top_lines(rfh, ajs)
-                with open(ajs.error_file, 'r+') as f:
-                    if os.path.getsize(ajs.error_file) > SLURM_MEMORY_LIMIT_SCAN_SIZE:
-                        f.seek(-SLURM_MEMORY_LIMIT_SCAN_SIZE, os.SEEK_END)
-                        f.readline()
-                    pos = f.tell()
-                    lines = f.readlines()
-                    f.seek(pos)
-                    for line in lines:
-                        stripped_line = line.strip()
-                        if any(_ in stripped_line for _ in SLURM_MEMORY_LIMIT_EXCEEDED_PARTIAL_WARNINGS):
-                            log.debug('(%s/%s) Job completed, removing SLURM exceeded memory warning: "%s"', ajs.job_wrapper.get_id_tag(), ajs.job_id, stripped_line)
-                        else:
-                            f.write(line)
-                    f.truncate()
         except Exception:
             log.exception('(%s/%s) Failure in SLURM _complete_terminal_job(), job final state will be: %s', ajs.job_wrapper.get_id_tag(), ajs.job_id, drmaa_state)
         # by default, finish the job with the state from drmaa
@@ -196,32 +170,3 @@ class SlurmJobRunner(DRMAAJobRunner):
             log.exception('Error reading end of %s:', efile_path)
 
         return False
-
-
-def _remove_spurious_top_lines(rfh, ajs, maxlines=3):
-    bad = []
-    putback = None
-    for _ in range(maxlines):
-        line = rfh.readline()
-        log.trace('checking line: %s', line)
-        for pattern in SLURM_TOP_WARNING_RES:
-            if pattern.match(line):
-                bad.append(line)
-                # found a match, stop checking REs and check next line
-                break
-        else:
-            if bad:
-                # no match found on this line so line is now a good line, but previous bad lines are found, so it needs to be put back
-                putback = line
-            # no match on this line, stop looking
-            break
-        # check next line
-    if bad:
-        with tempfile.NamedTemporaryFile('w', delete=False) as wfh:
-            if putback is not None:
-                wfh.write(putback)
-            shutil.copyfileobj(rfh, wfh)
-            wf_name = wfh.name
-        shutil.move(wf_name, ajs.error_file)
-        for line in bad:
-            log.debug('(%s/%s) Job completed, removing SLURM spurious warning: "%s"', ajs.job_wrapper.get_id_tag(), ajs.job_id, line)


### PR DESCRIPTION
## What did you do? 

This PR modifies the SLURM runner such that it does not touch the job stderr file.
Before it removed messages from SLURM.

## Why did you make this change?

With #7095 Galaxy properly separates the output streams of the tool script (`tool_script.sh`) and the job script (`galaxy_JOBID.sh`).

SLURM may write messages into the job stderr (in case of resource limit violations). Before #7095 it was necessary to remove those messages because tools that error on non-empty stderr (legacy tools and aggressive error checking) would interpret this as a tool error.

Since this seems not necessary anymore we should try to remove this.

See also https://github.com/galaxyproject/galaxy/issues/11571

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Use a Galaxy with job resubmission configured
  2. Use a tool like https://github.com/bernt-matthias/mb-galaxy-tools/blob/master/tools/sleepwaste/sleepwaste.xml to violate resources (the tool needs to be adapted to aggressive error checking / legacy behavior)
  3. Check if the job is resubmitted (which would be the positive outcome) or a tool error is reported (which would be the negative outcome)
