### PR TITLE
[21.01] Fix name and hid when selecting uploaded datasets

### DIFF
--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -230,6 +230,8 @@ export default {
                 return {
                     id: model.attributes.id, // model.id has datatype prefix
                     src: model.src,
+                    hid: model.attributes.hid,
+                    name: model.attributes.name,
                 };
             });
             this.$emit("dismiss", asDict);


### PR DESCRIPTION
in tool form or workflow form. Otherwise this would just display
`Selected: <hda_id>`.

## What did you do? 
- pass name and hid to the values that are passed to the handleDropValues callback

## How to test the changes? 
- [ ] Instructions for manual testing are as follows:

Upload a dataset from the workflow run form and select it

## For UI Components
- [x] I've included a screenshot of the changes

<img width="377" alt="Screenshot 2021-03-09 at 12 17 49" src="https://user-images.githubusercontent.com/6804901/110462837-7c7cb580-80d1-11eb-9fc0-f2e7e2016c96.png">
