### PR TITLE
[21.01] Fix $HOME for some gxit requiring a specific one

### DIFF
--- a/tools/interactive/interactivetool_climate_notebook.xml
+++ b/tools/interactive/interactivetool_climate_notebook.xml
@@ -29,6 +29,7 @@
 
         ## change into the directory where the notebooks are located
         cd ./jupyter/ &&
+        export HOME=/home/jovyan/ &&
         export PATH=/home/jovyan/.local/bin:\$PATH &&
 
         #if $mode.mode_select == 'scratch':
@@ -95,12 +96,12 @@
 
     You can import data into the notebook via a predefined `get()` function and write results back to Galaxy with a `put()` function.
 
-    The Climate version of the Jupyter Notebook offers a lot of preinstalled tools for climate science. The list of packages is based on what is available 
+    The Climate version of the Jupyter Notebook offers a lot of preinstalled tools for climate science. The list of packages is based on what is available
 	on the [Pangeo](http://pangeo.io/) platform and [Pangeo stacks](https://pangeo-data.github.io/pangeo-stacks/).
 
     - **Core scipy packages**: numpy, scipy, matplotlib, pandas, xarray, sparse and sympy
     - **Data science**: scikit-image, scikit-learn, dask-ml, tensorflow, keras, pytorch-cpu, dask_labextension
-    - **Visualization**: holoviews, panel, geoviews, hvplot, geoviews, datashader, seaborn, altair, descartes, folium, vega, 
+    - **Visualization**: holoviews, panel, geoviews, hvplot, geoviews, datashader, seaborn, altair, descartes, folium, vega,
 	                     vega_datasets, palettable, cmocean,plotly, psy-maps, psy-reg, psyplot, psyplot-gui, psy-maps, psy-reg,
 						 geopy, branca
 	- **Geospatial**: iris, cartopy, basemap, basemap-data-hires, geopandas, rasterio, netcdf4, erddapy, pydap, h5py, h5netcdf, regionmask and rio-cogeo

--- a/tools/interactive/interactivetool_ethercalc.xml
+++ b/tools/interactive/interactivetool_ethercalc.xml
@@ -8,7 +8,9 @@
         </entry_point>
     </entry_points>
     <command><![CDATA[
-    
+
+        export HOME=/root &&
+
         forever start `which ethercalc` --cors &
         bash $wait_script
         &&

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -26,6 +26,7 @@
 
         ## change into the directory where the notebooks are located
         cd ./jupyter/ &&
+        export HOME=/home/jovyan/ &&
         export PATH=/home/jovyan/.local/bin:\$PATH &&
 
         #if $mode.mode_select == 'scratch':

--- a/tools/interactive/interactivetool_pyiron.xml
+++ b/tools/interactive/interactivetool_pyiron.xml
@@ -30,6 +30,7 @@
         ## change into the directory where the notebooks are located
         cd ./jupyter/ &&
         cp \${HOME}/examples/* ./ &&
+        export HOME=/home/jovyan/ &&
         export PATH=/home/jovyan/.local/bin:\$PATH &&
 
         #if $mode.mode_select == 'scratch':
@@ -95,4 +96,3 @@
     You can import data into the notebook via a predefined `get()` function and write results back to Galaxy with a `put()` function.
     </help>
 </tool>
-


### PR DESCRIPTION
## What did you do? 
- Force the value of the $HOME env var for some interactive tools

## Why did you make this change?

Fixes #11573

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run the ethercalc/jupyter gxits -> it works now instead of crashing at startup when HOME is not set in the env of the job destination