### PR TITLE
[21.01] Improve feedback for remote file listing exceptions.

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -68,7 +68,15 @@ class RemoteFilesAPIController(BaseAPIController):
 
         file_source_path = file_sources.get_file_source_path(uri)
         file_source = file_source_path.file_source
-        index = file_source.list(file_source_path.path, recursive=recursive, user_context=user_context)
+        try:
+            index = file_source.list(file_source_path.path, recursive=recursive, user_context=user_context)
+        except exceptions.MessageException:
+            log.warning(f"Problem listing file source path {file_source_path}", exc_info=True)
+            raise
+        except Exception:
+            message = f"Problem listing file source path {file_source_path}"
+            log.warning(message, exc_info=True)
+            raise exceptions.InternalServerError(message)
         if format == "flat":
             # rip out directories, ensure sorted by path
             index = [i for i in index if i["class"] == "File"]


### PR DESCRIPTION
## What did you do? 
- Added more verbose exception handling and more correct status code exception handling to the remote files API endpoint.

## Why did you make this change?

Proposing an alternative to part of https://github.com/galaxyproject/galaxy/pull/11580.

## How to test the changes? 

- [x] Instructions for manual testing are as follows:
  1. See notes from @abretaud below about how he tested this.
