### PR TITLE
[21.01] Fix markdown tag for history dataset collections

### DIFF
--- a/client/src/components/Markdown/MarkdownToolBox.vue
+++ b/client/src/components/Markdown/MarkdownToolBox.vue
@@ -81,7 +81,7 @@ export default {
                         emitter: "onHistoryId",
                     },
                     {
-                        id: "history_collection_display",
+                        id: "history_dataset_collection_display",
                         name: "Collection",
                         emitter: "onHistoryCollectionId",
                     },


### PR DESCRIPTION
Fixes markdown tag for history dataset collections. When inserting a collection into a markdown page the client inserts the tag: `history_collection_display` which is incorrect and leads to an error when attempting to save the page. The correct tag is `history_dataset_collection_display`.
