### PR TITLE
[21.01] Fix workflow best practices panel requiring save when nothing changed

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -538,7 +538,7 @@ export default {
             Vue.nextTick(() => {
                 this.canvasManager.drawOverview();
                 this.canvasManager.scrollToNodes();
-                this.hasChanges = has_changes;
+                this.hasChanges = this.requiresReindex = has_changes;
             });
         },
         _loadCurrent(id, version) {


### PR DESCRIPTION
This is because the nodes that are added on initial load are setting
requiresReindex to true in  https://github.com/mvdbeek/galaxy/blob/45990803eb4953c7baad8b65922b419ebc791e20/client/src/components/Workflow/Editor/Index.vue#L351

## What did you do? 
- Reset `requiresReindex` after initial load

## Why did you make this change?
Required to use the best practices panel just after loading a workflow and before making any changes.

## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. Open a workflow in the workflow editor and click on Options -> Best Practices. You should not be prompted to save the workflow
