### PR TITLE
Use galaxy Router instead of InferringRouter

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/genomes.py
+++ b/lib/galaxy/webapps/galaxy/api/genomes.py
@@ -8,8 +8,6 @@ from fastapi import (
     Query,
 )
 from fastapi.responses import Response
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.genomes import GenomesManager
@@ -18,10 +16,15 @@ from galaxy.web import (
     expose_api_raw_anonymous,
 )
 from galaxy.web.framework.helpers import is_true
-from . import BaseGalaxyAPIController, depends, DependsOnTrans
+from . import (
+    BaseGalaxyAPIController,
+    depends,
+    DependsOnTrans,
+    Router,
+)
 
 
-router = APIRouter(tags=['genomes'])
+router = Router(tags=['genomes'])
 
 IdPathParam: str = Path(
     ...,
@@ -84,7 +87,7 @@ def get_id(base, format):
     return base
 
 
-@cbv(router)
+@router.cbv
 class FastAPIGenomes:
     manager: GenomesManager = depends(GenomesManager)
 

--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -10,8 +10,6 @@ from fastapi import (
     Query,
     status,
 )
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 from starlette.responses import StreamingResponse
 
 from galaxy.managers.context import ProvidesUserContext
@@ -29,11 +27,16 @@ from galaxy.web import (
     expose_api_anonymous_and_sessionless,
     expose_api_raw_anonymous_and_sessionless
 )
-from . import BaseGalaxyAPIController, depends, DependsOnTrans
+from . import (
+    BaseGalaxyAPIController,
+    depends,
+    DependsOnTrans,
+    Router,
+)
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=['pages'])
+router = Router(tags=['pages'])
 
 DeletedQueryParam: bool = Query(
     default=False,
@@ -48,7 +51,7 @@ PageIdPathParam: EncodedDatabaseIdField = Path(
 )
 
 
-@cbv(router)
+@router.cbv
 class FastAPIPages:
     manager: PagesManager = depends(PagesManager)
 

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -7,9 +7,6 @@ from fastapi import (
     Body,
     status,
 )
-# TODO: replace with Router after merging #11219
-from fastapi_utils.cbv import cbv
-from fastapi_utils.inferring_router import InferringRouter as APIRouter
 
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.tags import (
@@ -21,14 +18,15 @@ from . import (
     BaseGalaxyAPIController,
     depends,
     DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
 
-router = APIRouter(tags=['tags'])
+router = Router(tags=['tags'])
 
 
-@cbv(router)
+@router.cbv
 class FastAPITags:
     manager: TagsManager = depends(TagsManager)
 


### PR DESCRIPTION
## What did you do? 
- Replace the `InferringRouter` with the new galaxy `Router` in `genomes`, `pages`, and `tags` APIs.

## Why did you make this change?
To unify existing FastAPI routers to use the galaxy tailored `Router` after #11219 was merged.

## How to test the changes? 
- [x] This is a refactoring of components with existing test coverage.
