### PR TITLE
Allow line break html tag in markdown pages

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -52,6 +52,7 @@
     "jquery.cookie": "^1.4.1",
     "linkifyjs": "^2.1.9",
     "markdown-it": "^11.0.0",
+    "markdown-it-regexp": "^0.4.0",
     "moment": "2.26.0",
     "popper.js": "^1.16.1",
     "pouchdb": "^7.2.2",

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -93,6 +93,7 @@ import BootstrapVue from "bootstrap-vue";
 import store from "store";
 import { getGalaxyInstance } from "app";
 import MarkdownIt from "markdown-it";
+import markdownItRegexp from "markdown-it-regexp";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEdit } from "@fortawesome/free-solid-svg-icons";
@@ -116,7 +117,12 @@ const FUNCTION_CALL = `\\s*[\\w\\|]+\\s*=` + FUNCTION_VALUE_REGEX;
 const FUNCTION_CALL_LINE = `\\s*(\\w+)\\s*\\(\\s*(?:(${FUNCTION_CALL})(,${FUNCTION_CALL})*)?\\s*\\)\\s*`;
 const FUNCTION_CALL_LINE_TEMPLATE = new RegExp(FUNCTION_CALL_LINE, "m");
 
+const mdNewline = markdownItRegexp(/<br>/, () => {
+    return "<div style='clear:both;'/><br>";
+});
+
 const md = MarkdownIt();
+md.use(mdNewline);
 
 Vue.use(BootstrapVue);
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9601,6 +9601,11 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
   integrity sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==
 
+markdown-it-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz#d64d713eecec55ce4cfdeb321750ecc099e2c2dc"
+  integrity sha1-1k1xPuzsVc5M/esyF1DswJniwtw=
+
 markdown-it@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-11.0.0.tgz#dbfc30363e43d756ebc52c38586b91b90046b876"


### PR DESCRIPTION
Adds a markdown plugin to specifically allow the html break tag `<br>` within markdown documents. Enabling all html tags by default may lead to xss vulnerabilities. The markdown-it plugin is added using the markdown-it-regexp module. To test this: create a page and insert the `<br>` tag between inserted elements.