### PR TITLE
[21.01] Add handler name and pid to item grab logging

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -116,7 +116,7 @@ class ItemGrabber:
             try:
                 rows = conn.execute(self._grab_query).fetchall()
                 if rows:
-                    log.debug('Grabbed %s(s): %s', self.grab_type, ', '.join(str(row[0]) for row in rows))
+                    log.debug(f"Handler {self.app.config.server_name} with PID {os.getpid()} grabbed {self.grab_type}(s): {', '.join(str(row[0]) for row in rows)}")
                     trans.commit()
                 else:
                     trans.rollback()


### PR DESCRIPTION
## What did you do? 
- Added additional context logging in the `grab_unhandled_items` method in the job handler.

## Why did you make this change?
xref #11335 

## How to test the changes? 

- [ x ] This is a refactoring of components with existing test coverage.
