### PR TITLE
Allow any extra field in Pages API

### DIFF
--- a/lib/galaxy/managers/pages.py
+++ b/lib/galaxy/managers/pages.py
@@ -18,6 +18,7 @@ from typing import (
 
 from pydantic import (
     BaseModel,
+    Extra,
     Field,
 )
 
@@ -117,6 +118,7 @@ class CreatePagePayload(PageSummaryBase):
 
     class Config:
         use_enum_values = True  # When using .dict()
+        extra = Extra.allow  # Allow any other extra fields
 
 
 class PageSummary(PageSummaryBase):
@@ -166,6 +168,19 @@ class PageSummary(PageSummaryBase):
 class PageDetails(PageSummary):
     content_format: PageContentFormat = ContentFormatField
     content: Optional[str] = ContentField
+    generate_version: Optional[str] = Field(
+        None,
+        title="Galaxy Version",
+        description="The version of Galaxy this page was generated with.",
+    )
+    generate_time: Optional[str] = Field(
+        None,
+        title="Generate Date",
+        description="The date this page was generated.",
+    )
+
+    class Config:
+        extra = Extra.allow  # Allow any other extra fields
 
 
 class PageSummaryList(BaseModel):


### PR DESCRIPTION
## What did you do? 
- Allow to include any other optional field in `CreatePagePayload` and `PageDetails`.


## Why did you make this change?
Bug detected by @guerler, see comment here: https://github.com/galaxyproject/galaxy/pull/11262#issuecomment-795562504


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. See: https://github.com/galaxyproject/galaxy/pull/11262#issuecomment-795870497
