### PR TITLE
[21.01] Various fixes for copying workflow nodes 

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -289,6 +289,15 @@ export default {
                 this.hasChanges = true;
             }
         },
+        steps: function (newSteps, oldSteps) {
+            this.hasChanges = true;
+        },
+        nodes: function (newNodes, oldNodes) {
+            this.hasChanges = true;
+            if (newNodes.length != oldNodes.length) {
+                this.requiresReindex = true;
+            }
+        },
     },
     methods: {
         onActivate(node) {
@@ -347,7 +356,6 @@ export default {
         },
         onAdd(node) {
             this.nodes[node.id] = node;
-            this.requiresReindex = true;
         },
         onUpdate(node) {
             getModule({
@@ -367,8 +375,6 @@ export default {
             Vue.delete(this.steps, node.id);
             this.canvasManager.drawOverview();
             this.activeNode = null;
-            this.hasChanges = true;
-            this.requiresReindex = true;
             showAttributes();
         },
         onEditSubworkflow(contentId) {

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -397,6 +397,11 @@ export default {
                 tool_state: JSON.parse(JSON.stringify(node.tool_state)),
                 post_job_actions: JSON.parse(JSON.stringify(node.postJobActions)),
             });
+            Vue.nextTick().then(() => {
+                this.canvasManager.drawOverview();
+                node = this.nodes[newId];
+                this.onActivate(node);
+            });
         },
         onInsertTool(tool_id, tool_name) {
             this._insertStep(tool_id, tool_name, "tool");

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -377,13 +377,14 @@ export default {
         },
         onClone(node) {
             const newId = this.nodeIndex++;
-            const stepCopy = JSON.parse(JSON.stringify(node.step))
+            const stepCopy = JSON.parse(JSON.stringify(node.step));
+            const configFormCopy = JSON.parse(JSON.stringify(node.config_form));
             Vue.set(this.steps, newId, {
                 ...stepCopy,
                 id: newId,
                 config_form: {
-                    ...stepCopy.config_form,
-                    inputs: stepCopy.config_form.inputs.filter((input) => !!!input.skipOnClone),
+                    ...configFormCopy,
+                    inputs: configFormCopy.inputs.filter((input) => !input.skipOnClone),
                 },
                 uuid: null,
                 annotation: JSON.parse(JSON.stringify(node.annotation)),

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -393,6 +393,7 @@ export default {
                     inputs: configFormCopy.inputs.filter((input) => !input.skipOnClone),
                 },
                 uuid: null,
+                label: null,
                 annotation: JSON.parse(JSON.stringify(node.annotation)),
                 tool_state: JSON.parse(JSON.stringify(node.tool_state)),
                 post_job_actions: JSON.parse(JSON.stringify(node.postJobActions)),

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -376,12 +376,19 @@ export default {
             this.onNavigate(editUrl);
         },
         onClone(node) {
-            Vue.set(this.steps, this.nodeIndex++, {
-                ...node.step,
+            const newId = this.nodeIndex++;
+            const stepCopy = JSON.parse(JSON.stringify(node.step))
+            Vue.set(this.steps, newId, {
+                ...stepCopy,
+                id: newId,
+                config_form: {
+                    ...stepCopy.config_form,
+                    inputs: stepCopy.config_form.inputs.filter((input) => !!!input.skipOnClone),
+                },
                 uuid: null,
-                annotation: node.annotation,
-                tool_state: node.tool_state,
-                post_job_actions: node.postJobActions,
+                annotation: JSON.parse(JSON.stringify(node.annotation)),
+                tool_state: JSON.parse(JSON.stringify(node.tool_state)),
+                post_job_actions: JSON.parse(JSON.stringify(node.postJobActions)),
             });
         },
         onInsertTool(tool_id, tool_name) {

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -323,7 +323,6 @@ export default {
         },
         setData(data) {
             this.config_form = data.config_form;
-            this.config_form.raw_inputs = [...data.config_form.inputs];
             this.content_id = data.config_form?.id || data.content_id;
             this.tool_state = data.tool_state;
             this.errors = data.errors;

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -331,21 +331,19 @@ export default {
             this.postJobActions = data.post_job_actions || {};
             this.label = data.label;
             this.uuid = data.uuid;
+            this.inputs = data.inputs ? data.inputs.slice() : [];
+            this.outputs = data.outputs ? data.outputs.slice() : [];
         },
         initData(data) {
             this.setData(data);
-            this.inputs = data.inputs ? data.inputs.slice() : [];
-            this.outputs = data.outputs ? data.outputs.slice() : [];
             this.activeOutputs.initialize(this.outputs, data.workflow_outputs);
-            this.$emit("onChange");
+            this.showLoading = false;
         },
         updateData(data) {
             this.setData(data);
             // Create array of new output names
-            const outputNames = data.outputs.map((output) => output.name);
+            const outputNames = this.outputs.map((output) => output.name);
             this.activeOutputs.filterOutputs(outputNames);
-            this.inputs = data.inputs;
-            this.outputs = data.outputs;
             // emit change completion event
             this.showLoading = false;
             this.$emit("onChange");

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -323,6 +323,7 @@ export default {
         },
         setData(data) {
             this.config_form = data.config_form;
+            this.config_form.raw_inputs = [...data.config_form.inputs];
             this.content_id = data.config_form?.id || data.content_id;
             this.tool_state = data.tool_state;
             this.errors = data.errors;

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -272,7 +272,7 @@ export default {
             Object.values(this.outputTerminals).forEach((t) => {
                 t.destroy();
             });
-            this.activeOutputs.filterOutputs({});
+            this.activeOutputs.filterOutputs([]);
             this.$emit("onRemove", this);
         },
         onRedraw() {

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -203,7 +203,6 @@ export default {
         this.$emit("onAdd", this);
         if (this.step._complete) {
             this.initData(this.step);
-            this.updateData(this.step);
         } else {
             this.$emit("onUpdate", this);
         }

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -51,11 +51,14 @@ export default {
             if (Array.isArray(extensions)) {
                 extensions = extensions.join(", ");
             }
-            const activeLabel = this.output.activeLabel || this.output.label || this.output.name;
+            const activeLabel = this.activeOutput?.activeLabel || this.output.label || this.output.name;
             return `${activeLabel} (${extensions})`;
         },
+        activeOutput() {
+            return this.getNode().activeOutputs.outputsIndex[this.output.name];
+        },
         activeClass() {
-            return this.output.activeOutput && "mark-terminal-active";
+            return this.activeOutput?.activeOutput && "mark-terminal-active";
         },
         showCallout() {
             const node = this.getNode();

--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -267,7 +267,6 @@ function _makeSection(self, node, output) {
         flat: true,
         inputs: [
             {
-                skipOnClone: true,
                 label: "Label",
                 name: `__label__${output.name}`,
                 type: "text",
@@ -289,7 +288,6 @@ function _makeSection(self, node, output) {
                 },
             },
             {
-                skipOnClone: true,
                 action: "RenameDatasetAction",
                 pja_arg: "newname",
                 label: "Rename dataset",
@@ -299,7 +297,6 @@ function _makeSection(self, node, output) {
                 help: renameHelp,
             },
             {
-                skipOnClone: true,
                 action: "ChangeDatatypeAction",
                 pja_arg: "newtype",
                 label: "Change datatype",
@@ -313,7 +310,6 @@ function _makeSection(self, node, output) {
                 },
             },
             {
-                skipOnClone: true,
                 action: "TagDatasetAction",
                 pja_arg: "tags",
                 label: "Add Tags",
@@ -323,7 +319,6 @@ function _makeSection(self, node, output) {
                 help: "This action will set tags for the dataset.",
             },
             {
-                skipOnClone: true,
                 action: "RemoveTagDatasetAction",
                 pja_arg: "tags",
                 label: "Remove Tags",
@@ -333,7 +328,6 @@ function _makeSection(self, node, output) {
                 help: "This action will remove tags for the dataset.",
             },
             {
-                skipOnClone: true,
                 title: _l("Assign columns"),
                 type: "section",
                 flat: true,

--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -138,6 +138,7 @@ function _addLabelAnnotation(self, node) {
     const workflow = self.workflow;
     const inputs = node.config_form.inputs;
     inputs.unshift({
+        skipOnClone: true,
         type: "text",
         name: "__annotation",
         label: "Step Annotation",
@@ -150,6 +151,7 @@ function _addLabelAnnotation(self, node) {
         help: "Add an annotation or notes to this step. Annotations are available when a workflow is viewed.",
     });
     inputs.unshift({
+        skipOnClone: true,
         type: "text",
         name: "__label",
         label: "Label",
@@ -259,11 +261,13 @@ function _makeSection(self, node, output) {
     const activeOutput = node.activeOutputs.get(output.name);
     const inputTitle = output.label || output.name;
     const inputConfig = {
+        skipOnClone: true,
         title: `Configure Output: '${inputTitle}'`,
         type: "section",
         flat: true,
         inputs: [
             {
+                skipOnClone: true,
                 label: "Label",
                 name: `__label__${output.name}`,
                 type: "text",
@@ -285,6 +289,7 @@ function _makeSection(self, node, output) {
                 },
             },
             {
+                skipOnClone: true,
                 action: "RenameDatasetAction",
                 pja_arg: "newname",
                 label: "Rename dataset",
@@ -294,6 +299,7 @@ function _makeSection(self, node, output) {
                 help: renameHelp,
             },
             {
+                skipOnClone: true,
                 action: "ChangeDatatypeAction",
                 pja_arg: "newtype",
                 label: "Change datatype",
@@ -307,6 +313,7 @@ function _makeSection(self, node, output) {
                 },
             },
             {
+                skipOnClone: true,
                 action: "TagDatasetAction",
                 pja_arg: "tags",
                 label: "Add Tags",
@@ -316,6 +323,7 @@ function _makeSection(self, node, output) {
                 help: "This action will set tags for the dataset.",
             },
             {
+                skipOnClone: true,
                 action: "RemoveTagDatasetAction",
                 pja_arg: "tags",
                 label: "Remove Tags",
@@ -325,6 +333,7 @@ function _makeSection(self, node, output) {
                 help: "This action will remove tags for the dataset.",
             },
             {
+                skipOnClone: true,
                 title: _l("Assign columns"),
                 type: "section",
                 flat: true,
@@ -394,6 +403,7 @@ function _addSections(self, node) {
             payload: {
                 host: window.location.host,
             },
+            skipOnClone: true,
         });
         inputs.push({
             name: `pja__${outputFirst.name}__DeleteIntermediatesAction`,
@@ -403,6 +413,7 @@ function _addSections(self, node) {
             ignore: "false",
             help:
                 "Upon completion of this step, delete non-starred outputs from completed workflow steps if they are no longer required as inputs.",
+            skipOnClone: true,
         });
         for (const output of node.outputs) {
             inputs.push(_makeSection(self, node, output));

--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -108,7 +108,7 @@ export class ToolForm {
         const inputs = node.config_form.inputs;
         Utils.deepeach(inputs, (input) => {
             if (input.type) {
-                if (["data", "data_collection"].indexOf(input.type) != -1) {
+                if (["data", "data_collection", "hidden"].indexOf(input.type) != -1) {
                     input.type = "hidden";
                     input.info = `Data input '${input.name}' (${Utils.textify(input.extensions)})`;
                     input.value = { __class__: "RuntimeValue" };

--- a/client/src/components/Workflow/Editor/modules/outputs.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.js
@@ -104,7 +104,7 @@ export class ActiveOutputs {
     /** Removes all entries which are not in the parsed dictionary of names */
     filterOutputs(names) {
         this.getAll().forEach((wf_output) => {
-            if (!names[wf_output.output_name]) {
+            if (!names.includes(wf_output.output_name)) {
                 this.remove(wf_output.output_name);
             }
         });

--- a/client/src/components/Workflow/Editor/modules/outputs.test.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.test.js
@@ -48,7 +48,7 @@ describe("Workflow Outputs", () => {
         expect(activeOutputs_1.count()).toBe(3);
 
         // Test output filtering
-        activeOutputs.filterOutputs({ output_0: true, output_2: true });
+        activeOutputs.filterOutputs(["output_0", "output_2"]);
         expect(activeOutputs.count()).toBe(2);
         expect(activeOutputs.entries["output_0"].label).toBe("label_0");
         expect(activeOutputs.entries["output_1"]).toBe(undefined);
@@ -63,7 +63,7 @@ describe("Workflow Outputs", () => {
         expect(activeOutputs.entries["output_0"].label).toBe("label_3");
 
         // Test output removal
-        activeOutputs.filterOutputs({});
+        activeOutputs.filterOutputs([]);
         expect(Object.keys(allLabels).length).toBe(1);
     });
 });

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -412,9 +412,46 @@ workflow_editor:
 
     connect_icon: 'div.ui-form-element[tour_id="${name}"] .ui-form-connected-icon'
     collapse_icon: 'div.ui-form-element[tour_id="${name}"] .ui-form-collapsible-icon'
+    node_title:
+      type: xpath
+      selector: '//span[@class="node-title" and text()="${title}"]'
 
-    label_input: "[tour_id='__label'] input"
-    annotation_input: "[tour_id='__annotation'] textarea"
+    label_input:
+      type: xpath
+      selector: >
+        //div[@tour_id='__label' and not(ancestor::div[contains(@style,'display: none')])]//input
+    annotation_input:
+      type: xpath
+      selector: >
+        //div[@tour_id='__annotation' and not(ancestor::div[contains(@style,'display: none')])]//textarea
+    configure_output:
+      type: xpath
+      selector: >
+        //span[text()="Configure Output: '${output}'" and not(ancestor::div[contains(@style,'display: none')])]
+    label_output:
+      type: xpath
+      selector: >
+        //div[@tour_id='__label__${output}' and not(ancestor::div[contains(@style,'display: none')])]//input
+    rename_output:
+      type: xpath
+      selector: >
+        //div[@data-label='Rename dataset' and not(ancestor::div[contains(@style,'display: none')])]//input
+    change_datatype:
+      type: xpath
+      selector: >
+        //div[@data-label='Change datatype' and not(ancestor::div[contains(@style,'display: none')])]//span[contains(@class, 'select2-chosen')]
+    select_datatype:
+      type: xpath
+      selector: >
+        //div[@class="select2-result-label" and contains(text(), "${datatype}") and not(ancestor::div[contains(@style,'display: none')])]
+    add_tags:
+      type: xpath
+      selector: >
+        //div[@data-label='Add Tags' and not(ancestor::div[contains(@style,'display: none')])]//input
+    remove_tags:
+      type: xpath
+      selector: >
+        //div[@data-label='Remove Tags' and not(ancestor::div[contains(@style,'display: none')])]//input
     tool_version_button: ".tool-versions"
 
     connector_for: "div[output-handle-id='${source_id}'][input-handle-id='${sink_id}']"
@@ -422,6 +459,7 @@ workflow_editor:
     connector_destroy_callout: '.delete-terminal'
     save_button: '.editor-button-save'
     state_modal_body: '.state-upgrade-modal'
+    modal_button_continue: '.modal-footer .btn'
 
 tour:
   popover:

--- a/lib/galaxy/selenium/smart_components.py
+++ b/lib/galaxy/selenium/smart_components.py
@@ -96,5 +96,5 @@ class SmartTarget:
     def has_class(self, class_name):
         return class_name in self._has_driver.driver.find_element(*self._target.element_locator).get_attribute("class")
 
-    def wait_for_and_send_keys(self, text):
-        self.wait_for_visible().send_keys(text)
+    def wait_for_and_send_keys(self, *text):
+        self.wait_for_visible().send_keys(*text)

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -1,5 +1,7 @@
 import json
 
+from selenium.webdriver.common.keys import Keys
+
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_NESTED_SIMPLE,
     WORKFLOW_OPTIONAL_TRUE_INPUT_COLLECTION,
@@ -358,6 +360,55 @@ steps:
         self.workflow_index_click_option("Edit")
         self.assert_modal_has_text("Using version '0.2' instead of version '0.0.1'")
         self.screenshot("workflow_editor_tool_upgrade")
+        self.components.workflow_editor.modal_button_continue.wait_for_and_click()
+        self.assert_has_changes_and_save()
+
+    @staticmethod
+    def set_text_element(element, value):
+        # Try both, no harm here
+        element.wait_for_and_send_keys(Keys.CONTROL, 'a')
+        element.wait_for_and_send_keys(Keys.COMMAND, 'a')
+        element.wait_for_and_send_keys(Keys.BACKSPACE)
+        element.wait_for_and_send_keys(value)
+
+    @selenium_test
+    def test_editor_duplicate_node(self):
+        workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
+        self.workflow_index_open()
+        self.workflow_index_click_option("Edit")
+        editor = self.components.workflow_editor
+        cat_node = editor.node._(label="first_cat")
+        cat_node.wait_for_and_click()
+        self.set_text_element(editor.label_input, 'source label')
+        # Select node using new label, ensures labels are synced between side panel and node
+        cat_node = editor.node._(label="source label")
+        self.assert_has_changes_and_save()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        editor.annotation_input.wait_for_and_send_keys("source annotation")
+        self.assert_has_changes_and_save()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        editor.configure_output(output='out_file1').wait_for_and_click()
+        output_label = editor.label_output(output='out_file1')
+        self.set_text_element(output_label, 'workflow output label')
+        self.set_text_element(editor.rename_output, 'renamed_output')
+        editor.change_datatype.wait_for_and_click()
+        editor.select_datatype(datatype='bam').wait_for_and_click()
+        self.set_text_element(editor.add_tags, '#crazynewtag')
+        self.set_text_element(editor.remove_tags, '#oldboringtag')
+        cat_node.clone.wait_for_and_click()
+        editor.label_input.wait_for_and_send_keys('cloned label')
+        output_label = editor.label_output(output='out_file1')
+        self.set_text_element(output_label, 'cloned output label')
+        self.assert_has_changes_and_save()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        edited_workflow = self.workflow_populator.download_workflow(workflow_id)
+        source_step = next(iter(step for step in edited_workflow['steps'].values() if step['label'] == 'source label'))
+        cloned_step = next(iter(step for step in edited_workflow['steps'].values() if step['label'] == 'cloned label'))
+        assert source_step['annotation'] == cloned_step['annotation'] == "source annotation"
+        assert source_step['workflow_outputs'][0]['label'] == 'workflow output label'
+        assert cloned_step['workflow_outputs'][0]['label'] == 'cloned output label'
+        assert len(source_step['post_job_actions']) == len(cloned_step['post_job_actions']) == 4
+        assert source_step['post_job_actions'] == cloned_step['post_job_actions']
 
     @selenium_test
     def test_editor_embed_workflow(self):


### PR DESCRIPTION
- Fixes https://github.com/galaxyproject/galaxy/issues/10979 (duplicated label, annotation and Configure output sections)
- Fixes https://github.com/galaxyproject/galaxy/issues/11565 (after copying a node you may still be editing the source node values)
- Fixes outdated state getting copied when cloning node (the wrong config form was passed into onClone)
- Fixes hasChanges (which control the enabled status of the save icon) when copying nodes and updating the annotation
- Makes the copied node the active node, which seems like the most likely action you'd take after copying a node.

Includes Selenium tests that exercises all the things this is fixing.

This is working pretty well, the only thing I don't think we can reasonably fix before vue-ifying the tool form is that if we manipulate the state of the label in vue by removing the checkbox that makes a output a workflow output the output label in the tool form doesn't get removed until we re-render the tool form (which is so slow it's not worth the minor inconsistency).