### PR TITLE
[20.09] Fix ``metadata_bcf`` framework test

### DIFF
--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -371,4 +371,4 @@ def files_contains(file1, file2, attributes=None):
         if contains not in history_data:
             line_diff_count += 1
         if line_diff_count > lines_diff:
-            raise AssertionError("Failed to find '%s' in history data. (lines_diff=%i):\n" % (contains, lines_diff))
+            raise AssertionError("Failed to find '%s' in history data. (lines_diff=%i)" % (contains, lines_diff))

--- a/packages/test.sh
+++ b/packages/test.sh
@@ -14,6 +14,7 @@ TEST_ENV_DIR=${TEST_ENV_DIR:-$(mktemp -d -t gxpkgtestenvXXXXXX)}
 
 virtualenv -p "$TEST_PYTHON" "$TEST_ENV_DIR"
 . "${TEST_ENV_DIR}/bin/activate"
+pip install --upgrade pip setuptools wheel
 
 # ensure ordered by dependency dag
 PACKAGE_DIRS=(

--- a/test-data/bcf_index_metadata_test.txt
+++ b/test-data/bcf_index_metadata_test.txt
@@ -1,1 +1,1 @@
-gzip compressed data, extra field
+Blocked GNU Zip Format (BGZF; gzip compatible)

--- a/test/functional/tools/metadata_bcf.xml
+++ b/test/functional/tools/metadata_bcf.xml
@@ -1,5 +1,10 @@
 <tool id="metadata_bcf" name="metadata_BCF" version="1.0.0">
-    <command>file "${input_bcf.metadata.bcf_index}" &gt; "${output_of_input_metadata}"</command>
+    <requirements>
+        <requirement type="package" version="5.39">file</requirement>
+    </requirements>
+    <command><![CDATA[
+file '${input_bcf.metadata.bcf_index}' > '${output_of_input_metadata}'
+    ]]></command>
     <inputs>
       <param name="input_bcf" type="data" format="bcf" label="BCF File"/>
     </inputs>


### PR DESCRIPTION
## What did you do? 

Add a requirement for the latest `file` version and update the test accordingly.

## Why did you make this change?

Somewhere between file/libmagic 5.36 and 5.39, the output of `file` on a `.csi` file changed, breaking the ``metadata_bcf`` framework test with the following error:

```
        if found_exceptions:
>           raise JobOutputsError(found_exceptions, job_stdio)
E           galaxy.tool_util.verify.interactor.JobOutputsError: Output output_of_input_metadata:  different than expected, difference (using contains):
E           ( /tmp/tmpu1a3dgjcbcf_index_metadata_test.txt v. /tmp/tmpkt78tzggbcf_index_metadata_test.txt )
E           Failed to find 'gzip compressed data, extra field' in history data. (lines_diff=0):

lib/galaxy/tool_util/verify/interactor.py:1222: JobOutputsError
```




## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
