### PR TITLE
[21.01] Fix workflow labelling

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -272,7 +272,7 @@ export default {
             Object.values(this.outputTerminals).forEach((t) => {
                 t.destroy();
             });
-            this.activeOutputs.filterOutputs({});
+            this.activeOutputs.filterOutputs([]);
             this.$emit("onRemove", this);
         },
         onRedraw() {

--- a/client/src/components/Workflow/Editor/modules/outputs.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.js
@@ -104,7 +104,7 @@ export class ActiveOutputs {
     /** Removes all entries which are not in the parsed dictionary of names */
     filterOutputs(names) {
         this.getAll().forEach((wf_output) => {
-            if (!names[wf_output.output_name]) {
+            if (!names.includes(wf_output.output_name)) {
                 this.remove(wf_output.output_name);
             }
         });

--- a/client/src/components/Workflow/Editor/modules/outputs.test.js
+++ b/client/src/components/Workflow/Editor/modules/outputs.test.js
@@ -48,7 +48,7 @@ describe("Workflow Outputs", () => {
         expect(activeOutputs_1.count()).toBe(3);
 
         // Test output filtering
-        activeOutputs.filterOutputs({ output_0: true, output_2: true });
+        activeOutputs.filterOutputs(["output_0", "output_2"]);
         expect(activeOutputs.count()).toBe(2);
         expect(activeOutputs.entries["output_0"].label).toBe("label_0");
         expect(activeOutputs.entries["output_1"]).toBe(undefined);
@@ -63,7 +63,7 @@ describe("Workflow Outputs", () => {
         expect(activeOutputs.entries["output_0"].label).toBe("label_3");
 
         // Test output removal
-        activeOutputs.filterOutputs({});
+        activeOutputs.filterOutputs([]);
         expect(Object.keys(allLabels).length).toBe(1);
     });
 });


### PR DESCRIPTION
This broke in https://github.com/galaxyproject/galaxy/pull/11542


## How to test the changes? 
Try labelling a workflow output in the workflow editor. This really needs a selenium test ...
