### PR TITLE
[20.09] fix saving FileSource parameter in a workflow

### DIFF
--- a/client/src/mvc/ui/ui-file-source.js
+++ b/client/src/mvc/ui/ui-file-source.js
@@ -45,7 +45,9 @@ var View = Backbone.View.extend({
     render: function () {
         const value = this._value;
         if (value) {
-            if (value.url !== this.$text.text()) {
+            if (typeof value == "string") {
+                this.$text.text(value);
+            } else if (value.url !== this.$text.text()) {
                 this.$text.text(value.url);
             }
         } else {
@@ -86,11 +88,20 @@ var View = Backbone.View.extend({
     _setValue: function (new_value) {
         if (new_value) {
             if (typeof new_value == "string") {
-                new_value = JSON.parse(new_value);
+                let parsed_value;
+                // if new_value is not a JSON, set it as String
+                try {
+                    parsed_value = JSON.parse(new_value);
+                } catch (e) {
+                    parsed_value = new_value;
+                } finally {
+                    new_value = parsed_value;
+                }
             }
             this._value = new_value;
             this.model.trigger("error", null);
             this.model.trigger("change");
+            this.trigger("change");
         }
     },
 });


### PR DESCRIPTION
## What did you do? 
we were loosing entered FileSource parameter if it was used in the workflow context


## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

`ui-file-source` didn't trigger `change` event, so value wasn't saved in a workflow



## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

- [x] Instructions for manual testing are as follows:
  1. Install this tool https://github.com/usegalaxy-eu/temporary-tools/tree/master/test/export
  2. add it in a workflow
  3. choose your directory URI (probably you'd choose an ftp server)
  4. save and reopen your workflow, make sure  `directory URI` is shown

## For UI Components
- [x] I've included a screenshot of the changes
![image](https://user-images.githubusercontent.com/15801412/110860805-e8c00a80-82c5-11eb-8b51-5c258fa377b5.png)

