### PR TITLE
Allow workflow imports in pages

### DIFF
--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -15,6 +15,17 @@
                     >
                         <span class="fa fa-download" />
                     </b-button>
+                    <b-button
+                        :href="importUrl"
+                        role="button"
+                        variant="link"
+                        title="Import Workflow"
+                        type="button"
+                        class="py-0 px-1"
+                        v-b-tooltip.hover
+                    >
+                        <span class="fa fa-file-import" />
+                    </b-button>
                 </span>
                 <span>
                     <span>Workflow:</span>
@@ -77,6 +88,9 @@ export default {
         },
         downloadUrl() {
             return `${getAppRoot()}api/workflows/${this.args.workflow_id}/download?format=json-download`;
+        },
+        importUrl() {
+            return `${getAppRoot()}workflow/imp?id=${this.args.workflow_id}`;
         },
         itemUrl() {
             return `${getAppRoot()}api/workflows/${this.args.workflow_id}/download?style=preview`;


### PR DESCRIPTION
This PR adds a button to workflows embedded in markdown pages/reports, enabling users to import the workflow into their own workspace. In order for this feature to work the workflow has to be shared by the owner of the workflow. To test this: Share a workflow through url, create a page and insert the workflow, then view the page and select the import button attached to the header of the shown workflow to import the workflow into your workspace.

<img width="575" alt="image" src="https://user-images.githubusercontent.com/2105447/111063362-70537800-8484-11eb-832c-fe7c4029e920.png">
