### PR TITLE
FastAPI: deprecate url attribute

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -30,7 +30,6 @@ import logging
 import re
 from typing import Callable, Dict, List, Optional, Set, Type
 
-import routes
 import sqlalchemy
 from sqlalchemy.orm.scoping import scoped_session
 
@@ -39,6 +38,7 @@ from galaxy import model
 from galaxy.model import tool_shed_install
 from galaxy.structured_app import BasicApp, MinimalManagerApp
 from galaxy.util import namedtuple
+from galaxy.web import url_for as gx_url_for
 
 log = logging.getLogger(__name__)
 
@@ -538,7 +538,7 @@ class ModelSerializer(HasAModelManager):
         item_dict = MySerializer.serialize( my_item, keys_to_serialize )
     """
     #: 'service' to use for getting urls - use class var to allow overriding when testing
-    url_for = staticmethod(routes.url_for)
+    url_for = staticmethod(gx_url_for)
     default_view: Optional[str]
     views: Dict[str, List[str]]
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -781,10 +781,10 @@ class BaseURLToolParameter(HiddenToolParameter):
 
     >>> from galaxy.util.bunch import Bunch
     >>> trans = Bunch(app=None, history=Bunch())
-    >>> p = BaseURLToolParameter(None, XML('<param name="_name" type="base_url" value="_value"/>'))
+    >>> p = BaseURLToolParameter(None, XML('<param name="_name" type="baseurl" value="_value"/>'))
     >>> print(p.name)
     _name
-    >>> assert sorted(p.to_dict(trans).items()) == [('argument', None), ('help', ''), ('hidden', True), ('is_dynamic', False), ('label', ''), ('model_class', 'BaseURLToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'base_url'), ('value', u'_value')]
+    >>> assert sorted(p.to_dict(trans).items()) == [('argument', None), ('help', ''), ('hidden', True), ('is_dynamic', False), ('label', ''), ('model_class', 'BaseURLToolParameter'), ('name', '_name'), ('optional', False), ('refresh_on_change', False), ('type', 'baseurl'), ('value', u'_value')]
     """
 
     def __init__(self, tool, input_source):
@@ -1106,6 +1106,7 @@ class SelectTagParameter(SelectToolParameter):
     """
     Select set that is composed of a set of tags available for an input.
     """
+
     def __init__(self, tool, input_source):
         input_source = ensure_input_source(input_source)
         super().__init__(tool, input_source)

--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -4,4 +4,12 @@ Galaxy web application framework
 
 from . import base
 
-url_for = base.routes.url_for
+
+def handle_url_for(*args, **kargs) -> str:
+    try:
+        return base.routes.url_for(*args, **kargs)
+    except AttributeError:
+        return "*deprecated attribute not filled in by FastAPI server*"
+
+
+url_for = handle_url_for

--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -9,6 +9,8 @@ def handle_url_for(*args, **kargs) -> str:
     try:
         return base.routes.url_for(*args, **kargs)
     except AttributeError:
+        if len(args) > 0:
+            return args[0]
         return "*deprecated attribute not filled in by FastAPI server*"
 
 

--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -44,10 +44,7 @@ class RoleListModel(BaseModel):
 def role_to_model(trans, role):
     item = role.to_dict(view='element', value_mapper={'id': trans.security.encode_id})
     role_id = trans.security.encode_id(role.id)
-    try:
-        item['url'] = url_for('role', id=role_id)
-    except AttributeError:
-        item['url'] = "*deprecated attribute not filled in by FastAPI server*"
+    item['url'] = url_for('role', id=role_id)
     return RoleModel(**item)
 
 


### PR DESCRIPTION
## What did you do? 
Handle the `router.url_for` function to return a deprecation message when using FastAPI like the `roles` API is currently doing.

## Why did you make this change?

See [this comment in the wg-backend Gitter channel](https://gitter.im/galaxyproject/wg-backend?at=600258d281c55b09c70ef782).
The initial decision seems to be deprecating this `url` field in the response models after migrating to FastAPI but there may be some alternative that could be worth discussing as Marius suggested [here](https://gitter.im/galaxyproject/wg-backend?at=604a7238d1aee44e2ddd871b)

## How to test the changes? 

- [x] This is a refactoring of components with existing test coverage.
