### PR TITLE
[21.01] Add server name, PID and thread name to each handler log message

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -116,7 +116,7 @@ class ItemGrabber:
             try:
                 rows = conn.execute(self._grab_query).fetchall()
                 if rows:
-                    log.debug(f"Handler {self.app.config.server_name} with PID {os.getpid()} grabbed {self.grab_type}(s): {', '.join(str(row[0]) for row in rows)}")
+                    log.debug(f"Grabbed {self.grab_type}(s): {', '.join(str(row[0]) for row in rows)}")
                     trans.commit()
                 else:
                     trans.rollback()


### PR DESCRIPTION
## What did you do? 
- Added the server name, PID and thread name to each handler log message.
- Added the server name to each uWSGI log message (and moved thread name in the same "section" of the message).
- Updated the process name to the configured server name.

## Why did you make this change?

Follow-up on https://github.com/galaxyproject/galaxy/pull/11598#issuecomment-796961045

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] Instructions for manual testing are as follows:
  1. start a uWSGI process with `./run.sh` or a handler process with `./scripts/galaxy-main --server-name handler0`
  2. Check that the log messages contain the server name, process ID and thread name
