### PR TITLE
Front-end Library Routing refactor

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -92,7 +92,6 @@
                     <div v-else-if="!row.item.deleted">
                         <b-link
                             v-if="row.item.type === 'folder'"
-                            :key="$route.fullPath"
                             :to="{ name: `LibraryFolder`, params: { folder_id: `${row.item.id}` } }"
                             >{{ row.item.name }}</b-link
                         >

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -8,7 +8,6 @@
                 @fetchFolderContents="fetchFolderContents($event)"
                 @deleteFromTable="deleteFromTable"
                 @setBusy="setBusy($event)"
-                @changeFolderId="initFolder($event)"
                 :folderContents="folderContents"
                 :include_deleted="include_deleted"
                 :folder_id="current_folder_id"

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -8,7 +8,7 @@
                 @fetchFolderContents="fetchFolderContents($event)"
                 @deleteFromTable="deleteFromTable"
                 @setBusy="setBusy($event)"
-                @changeFolderId="changeFolderId($event)"
+                @changeFolderId="initFolder($event)"
                 :folderContents="folderContents"
                 :include_deleted="include_deleted"
                 :folder_id="current_folder_id"
@@ -91,10 +91,15 @@
                         />
                     </div>
                     <div v-else-if="!row.item.deleted">
-                        <a v-if="row.item.type === 'folder'" href="#" @click="changeFolderId(row.item.id)">{{
+                        <b-link
+                            v-if="row.item.type === 'folder'"
+                            :key="$route.fullPath"
+                            :to="{ name: `LibraryFolder`, params: { folder_id: `${row.item.id}` } }"
+                            >{{ row.item.name }}</b-link
+                        >
+                        <a v-else :href="`${root}library/list#folders/${current_folder_id}/datasets/${row.item.id}`">{{
                             row.item.name
                         }}</a>
-                        <a v-else :href="createContentLink(row.item)">{{ row.item.name }}</a>
                     </div>
                     <!-- Deleted Item-->
                     <div v-else>
@@ -325,15 +330,19 @@ export default {
             isAllSelectedMode: false,
             total_rows: 0,
             deselectedDatasets: [],
+            root: getAppRoot(),
         };
     },
     created() {
-        this.current_folder_id = this.folder_id;
-        this.root = getAppRoot();
         this.services = new Services({ root: this.root });
-        this.fetchFolderContents();
+        this.initFolder(this.folder_id);
     },
     methods: {
+        initFolder(folder_id) {
+            this.current_folder_id = folder_id;
+            this.folderContents = [];
+            this.fetchFolderContents(this.include_deleted);
+        },
         fetchFolderContents(include_deleted = false) {
             this.include_deleted = include_deleted;
             this.setBusy(true);
@@ -367,11 +376,6 @@ export default {
         },
         updateSearchValue(value) {
             this.search_text = value;
-            this.folderContents = [];
-            this.fetchFolderContents(this.include_deleted);
-        },
-        changeFolderId(id) {
-            this.current_folder_id = id;
             this.folderContents = [];
             this.fetchFolderContents(this.include_deleted);
         },
@@ -453,11 +457,6 @@ export default {
         },
         bytesToString(raw_size) {
             return Utils.bytesToString(raw_size);
-        },
-        createContentLink(element) {
-            if (element.type === "file")
-                return `${this.root}library/list#folders/${this.current_folder_id}/datasets/${element.id}`;
-            else if (element.type === "folder") return `${this.root}library/folders/${element.id}`;
         },
         navigateToPermission(element) {
             if (element.type === "file")
@@ -601,6 +600,10 @@ export default {
                 this.fetchFolderContents(this.include_deleted);
             },
         },
+    },
+    beforeRouteUpdate(to, from, next) {
+        this.initFolder(to.params.folder_id);
+        next();
     },
 };
 </script>

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
@@ -3,7 +3,7 @@
         <b-container fluid>
             <div v-if="dataset">
                 <b-breadcrumb>
-                    <b-breadcrumb-item title="Return to the list of libraries" :href="`${root}library/list`">
+                    <b-breadcrumb-item title="Return to the list of libraries" :href="`${root}libraries`">
                         Libraries
                     </b-breadcrumb-item>
                     <template v-for="path_item in this.dataset.full_path">
@@ -206,9 +206,6 @@ export default {
                     console.error(error);
                 }
             );
-        },
-        getParentLink() {
-            return `${this.root}library/folders/${this.folder_id}`;
         },
         setUserPermissionsPreferences(ids, permission_type) {
             this[permission_type] = ids;

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
@@ -127,9 +127,6 @@ export default {
     },
 
     methods: {
-        getParentLink() {
-            return `${this.root}library/folders/${this.folder.parent_id}`;
-        },
         setUserPermissionsPreferences(ids, permission_type) {
             this[permission_type] = ids;
         },

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -3,7 +3,7 @@
         <div class="form-inline d-flex align-items-center mb-2">
             <b-button
                 class="mr-1 btn btn-secondary"
-                :to="{ path: `/libraries-list` }"
+                :to="{ path: `/libraries` }"
                 data-toggle="tooltip"
                 title="Go to libraries list"
             >
@@ -131,7 +131,7 @@
         </div>
 
         <b-breadcrumb>
-            <b-breadcrumb-item title="Return to the list of libraries" :to="{ path: `/libraries-list` }">
+            <b-breadcrumb-item title="Return to the list of libraries" :to="{ path: `/` }">
                 Libraries
             </b-breadcrumb-item>
             <template v-for="path_item in this.metadata.full_path">
@@ -139,7 +139,7 @@
                     :key="path_item[0]"
                     :title="isCurrentFolder(path_item[0]) ? `You are in this folder` : `Return to this folder`"
                     :active="isCurrentFolder(path_item[0])"
-                    @click="changeFolderId(path_item[0])"
+                    :to="{ name: `LibraryFolder`, params: { folder_id: `${path_item[0]}` } }"
                     href="#"
                     >{{ path_item[1] }}</b-breadcrumb-item
                 >

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -258,9 +258,6 @@ export default {
         updateSearch: function (value) {
             this.$emit("updateSearch", value);
         },
-        changeFolderId: function (value) {
-            this.$emit("changeFolderId", value);
-        },
         deleteSelected: function () {
             this.getSelected().then((selected) =>
                 deleteSelectedItems(

--- a/client/src/components/Libraries/LibraryFolderRouter.js
+++ b/client/src/components/Libraries/LibraryFolderRouter.js
@@ -5,17 +5,22 @@ import LibraryFolderPermissions from "components/Libraries/LibraryFolder/Library
 import LibraryFolder from "components/Libraries/LibraryFolder/LibraryFolder.vue";
 import LibraryFolderDatasetPermissions from "components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue";
 import LibrariesList from "components/Libraries/LibrariesList.vue";
+import LibraryPermissions from "components/Libraries/LibraryPermissions/LibraryPermissions.vue";
 
 Vue.use(VueRouter);
 
 export default new VueRouter({
-    mode: "history",
-    base: `${getAppRoot()}library`,
+    base: `${getAppRoot()}libraries`,
     routes: [
         {
-            path: "/libraries-list",
+            path: "/",
             name: "LibrariesList",
             component: LibrariesList,
+        },
+        {
+            path: "/permissions/:library_id",
+            name: "LibraryPermissions",
+            component: LibraryPermissions,
         },
         {
             path: "/folders/:folder_id",

--- a/client/src/components/Libraries/LibraryFolderRouter.js
+++ b/client/src/components/Libraries/LibraryFolderRouter.js
@@ -5,7 +5,6 @@ import LibraryFolderPermissions from "components/Libraries/LibraryFolder/Library
 import LibraryFolder from "components/Libraries/LibraryFolder/LibraryFolder.vue";
 import LibraryFolderDatasetPermissions from "components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue";
 import LibrariesList from "components/Libraries/LibrariesList.vue";
-import LibraryPermissions from "components/Libraries/LibraryPermissions/LibraryPermissions.vue";
 
 Vue.use(VueRouter);
 
@@ -16,11 +15,6 @@ export default new VueRouter({
             path: "/",
             name: "LibrariesList",
             component: LibrariesList,
-        },
-        {
-            path: "/permissions/:library_id",
-            name: "LibraryPermissions",
-            component: LibraryPermissions,
         },
         {
             path: "/folders/:folder_id",

--- a/client/src/components/Libraries/LibraryFolderRouter.js
+++ b/client/src/components/Libraries/LibraryFolderRouter.js
@@ -9,6 +9,7 @@ import LibrariesList from "components/Libraries/LibrariesList.vue";
 Vue.use(VueRouter);
 
 export default new VueRouter({
+    mode: "history",
     base: `${getAppRoot()}libraries`,
     routes: [
         {

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -100,6 +100,9 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)datasets/error": "show_dataset_error",
             "(/)interactivetool_entry_points(/)list": "show_interactivetool_list",
             "(/)libraries": "show_library_folder",
+            "(/)libraries/folders(/)(:folder_id)": "show_library_folder",
+            "(/)libraries/folders/permissions(/)(:folder_id)": "show_library_folder",
+            "(/)libraries/folders/permissions(/)(:folder_id)(/)dataset(/)(:dataset_id)": "show_library_folder",
         },
 
         require_login: ["show_user", "show_user_form", "show_workflows", "show_cloud_auth", "show_external_ids"],

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -99,10 +99,7 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)datasets/edit": "show_dataset_edit_attributes",
             "(/)datasets/error": "show_dataset_error",
             "(/)interactivetool_entry_points(/)list": "show_interactivetool_list",
-            "(/)libraries": "show_library_folder",
-            "(/)libraries/folders(/)(:folder_id)": "show_library_folder",
-            "(/)libraries/folders/permissions(/)(:folder_id)": "show_library_folder",
-            "(/)libraries/folders/permissions(/)(:folder_id)(/)dataset(/)(:dataset_id)": "show_library_folder",
+            "(/)libraries*path": "show_library_folder",
         },
 
         require_login: ["show_user", "show_user_form", "show_workflows", "show_cloud_auth", "show_external_ids"],

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -99,10 +99,7 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)datasets/edit": "show_dataset_edit_attributes",
             "(/)datasets/error": "show_dataset_error",
             "(/)interactivetool_entry_points(/)list": "show_interactivetool_list",
-            "(/)library/folders(/)(:folder_id)": "show_library_folder",
-            "(/)library/libraries-list": "show_library_folder",
-            "(/)library/folders/permissions(/)(:folder_id)": "show_library_folder",
-            "(/)library/folders/permissions(/)(:folder_id)(/)dataset(/)(:dataset_id)": "show_library_folder",
+            "(/)libraries": "show_library_folder",
         },
 
         require_login: ["show_user", "show_user_form", "show_workflows", "show_cloud_auth", "show_external_ids"],

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -123,7 +123,7 @@ export function fetchMenu(options = {}) {
         menu: [
             {
                 title: _l("Data Libraries"),
-                url: "library/libraries-list",
+                url: "libraries",
             },
             {
                 title: _l("Histories"),

--- a/client/src/mvc/library/library-dataset-view.js
+++ b/client/src/mvc/library/library-dataset-view.js
@@ -478,7 +478,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         </button>
                     <% } %>
                     <% if (item.get("can_user_manage")) { %>
-                        <a href="<% rootPath %>/library/folders/permissions/<%- item.get("folder_id") %>/dataset/<%- item.id %>">
+                        <a href="<% rootPath %>/libraries#/folders/permissions/<%- item.get("folder_id") %>/dataset/<%- item.id %>">
                             <button data-toggle="tooltip" data-placement="top" title="Manage permissions"
                                 class="btn btn-secondary toolbtn_change_permissions toolbar-item mr-1"
                                 type="button">
@@ -492,7 +492,7 @@ var LibraryDatasetView = Backbone.View.extend({
                 <!-- BREADCRUMBS -->
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item">
-                        <a title="Return to the list of libraries" href="<% rootPath %>library/libraries-list">Libraries</a>
+                        <a title="Return to the list of libraries" href="<% rootPath %>libraries">Libraries</a>
                     </li>
                     <% _.each(item.get("full_path"), function(path_item) { %>
                         <% if (path_item[0] != item.id) { %>
@@ -679,7 +679,7 @@ var LibraryDatasetView = Backbone.View.extend({
                 <!-- BREADCRUMBS -->
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item">
-                        <a title="Return to the list of libraries"  href="<% rootPath %>library/libraries-list">Libraries</a>
+                        <a title="Return to the list of libraries"  href="<% rootPath %>libraries">Libraries</a>
                     </li>
                     <% _.each(item.get("full_path"), function(path_item) { %>
                         <% if (path_item[0] != item.id) { %>
@@ -812,7 +812,7 @@ var LibraryDatasetView = Backbone.View.extend({
                 <!-- BREADCRUMBS -->
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item">
-                        <a title="Return to the list of libraries" href="<% rootPath %>library/libraries-list">Libraries</a>
+                        <a title="Return to the list of libraries" href="<% rootPath %>libraries">Libraries</a>
                     </li>
                     <% _.each(item.get("full_path"), function(path_item) { %>
                         <% if (path_item[0] != item.id) { %>

--- a/client/src/mvc/library/library-dataset-view.js
+++ b/client/src/mvc/library/library-dataset-view.js
@@ -478,7 +478,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         </button>
                     <% } %>
                     <% if (item.get("can_user_manage")) { %>
-                        <a href="<% rootPath %>/libraries#/folders/permissions/<%- item.get("folder_id") %>/dataset/<%- item.id %>">
+                        <a href="<% rootPath %>/libraries/folders/permissions/<%- item.get("folder_id") %>/dataset/<%- item.id %>">
                             <button data-toggle="tooltip" data-placement="top" title="Manage permissions"
                                 class="btn btn-secondary toolbtn_change_permissions toolbar-item mr-1"
                                 type="button">

--- a/client/src/mvc/library/library-library-view.js
+++ b/client/src/mvc/library/library-library-view.js
@@ -217,7 +217,7 @@ var LibraryView = Backbone.View.extend({
         return _.template(
             `<div class="library_style_container">
                 <div>
-                    <a href="<% rootPath %>libraries-list">
+                    <a href="<% rootPath %>libraries">
                         <button data-toggle="tooltip" data-placement="top"
                             title="Go back to the list of Libraries" class="btn btn-secondary primary-button" type="button">
                             <span class="fa fa-list"></span>&nbsp;Libraries

--- a/client/src/mvc/library/library-libraryrow-view.js
+++ b/client/src/mvc/library/library-libraryrow-view.js
@@ -245,7 +245,7 @@ var LibraryRowView = Backbone.View.extend({
                         <td style="color:grey;"><%- library.get("name") %></td>
                     <% } else { %>
                         <td>
-                            <a href="<%- root_path %>libraries#/folders/<%- library.get("root_folder_id") %>"><%- library.get("name") %></a>
+                            <a href="<%- root_path %>libraries/folders/<%- library.get("root_folder_id") %>"><%- library.get("name") %></a>
                         </td>
                     <% } %>
                     <% if(library.get("description")) { %>

--- a/client/src/mvc/library/library-libraryrow-view.js
+++ b/client/src/mvc/library/library-libraryrow-view.js
@@ -245,7 +245,7 @@ var LibraryRowView = Backbone.View.extend({
                         <td style="color:grey;"><%- library.get("name") %></td>
                     <% } else { %>
                         <td>
-                            <a href="<%- root_path %>library/folders/<%- library.get("root_folder_id") %>"><%- library.get("name") %></a>
+                            <a href="<%- root_path %>libraries#/folders/<%- library.get("root_folder_id") %>"><%- library.get("name") %></a>
                         </td>
                     <% } %>
                     <% if(library.get("description")) { %>

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -191,7 +191,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     # webapp.add_client_route('/workflows/invocations/view_bco')
     webapp.add_client_route('/custom_builds')
     webapp.add_client_route('/interactivetool_entry_points/list')
-    webapp.add_client_route('/libraries')
+    webapp.add_client_route('/libraries{path:.*?}')
 
     # ==== Done
     # Indicate that all configuration settings have been provided

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -191,10 +191,8 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     # webapp.add_client_route('/workflows/invocations/view_bco')
     webapp.add_client_route('/custom_builds')
     webapp.add_client_route('/interactivetool_entry_points/list')
-    webapp.add_client_route('/library/libraries-list')
-    webapp.add_client_route('/library/folders/{folder_id}')
-    webapp.add_client_route('/library/folders/permissions/{folder_id}')
-    webapp.add_client_route('/library/folders/permissions/{folder_id}/dataset/{dataset_id}')
+    webapp.add_client_route('/libraries')
+
 
     # ==== Done
     # Indicate that all configuration settings have been provided

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -193,7 +193,6 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route('/interactivetool_entry_points/list')
     webapp.add_client_route('/libraries')
 
-
     # ==== Done
     # Indicate that all configuration settings have been provided
     webapp.finalize_config()


### PR DESCRIPTION
depends on https://github.com/galaxyproject/galaxy/pull/11485 and will be a draft until 11485 is merged

## What did you do? 
Refactored library Router. 

## Why did you make this change?

The code looks cleaner, we don't need to define each possible library route in `buildapp.py` and `AnalysisRouter.js` anymore, `LibraryFolderRouter` will take care. Also it adds consistency in router naming.

Additionally it fixes a following bug:
 it was not possible to return into upper library folder with the 'back' browser button, this PR will fix this issue


## How to test the changes? 
- [x] This is a refactoring of components with existing test coverage.
   Quite a few selenium tests are already in place
- [x] Instructions for manual testing are as follows:
 Go to libraries and surf, also use back <- and front -> buttons in your browser
