### PR TITLE
An attempt to improve dependency management

### DIFF
--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -1,21 +1,55 @@
 #!/bin/sh
-set -e
 
-# You can pass one or more package specifications to this script to add only
-# them without updating all the rest of the requirements.
+# This script creates a temporary venv and installs poetry into that venv.
+# The temporary venv should NOT be activated.
+# It then runs poetry inside Galaxy's root directory, potentially updating 
+# pyproject.toml and poetry.lock, and the pinned and dev requirements files.
+
+set -e
 
 if [ -z "$VIRTUAL_ENV" ]; then
     echo "Please run this script inside a virtual environment!"
     exit 1
 fi
 
-THIS_DIRECTORY="$(cd "$(dirname "$0")" > /dev/null && pwd)"
+this_directory="$(cd "$(dirname "$0")" > /dev/null && pwd)"
 
-pip install --upgrade pip setuptools poetry
-if [ $# -gt 0 ]; then
-    poetry add --lock "$@"
-else
-    poetry update -v --lock
+usage() {
+    printf "Usage: %s: [-a] [pkg1] [... pkgN]\n" ${0##*/} >&2
+}
+
+add=
+while getopts 'a' OPTION
+do
+    case $OPTION in
+        a) add=1
+           ;;
+        ?) usage
+           exit 2
+           ;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+if [ -n "$add" ] && [ $# -eq 0 ]; then
+    printf "When adding (-a), you must provide at least one package name.\n" >&2
+    usage
+    exit 2
 fi
-poetry export -f requirements.txt --without-hashes --output "$THIS_DIRECTORY/pinned-requirements.txt"
-poetry export --dev -f requirements.txt --without-hashes --output "$THIS_DIRECTORY/dev-requirements.txt"
+
+# Create poetry-venv in a tmp directory; install poetry and make shortcut to executable.
+poetry_venv=$(mktemp -d "${TMPDIR:-/tmp}/poetry_venv.XXXXXXXXXX")
+python3 -m venv "${poetry_venv}"
+${poetry_venv}/bin/pip install --upgrade pip poetry
+poetry="${poetry_venv}/bin/poetry"
+
+# Run poetry (this may update pyproject.toml and poetry.lock).
+if [ -z "$add" ]; then
+    "$poetry" update --lock "$@"
+else
+    "$poetry" add --lock "$@"
+fi
+
+# Update pinned requirements.
+$poetry export -f requirements.txt --without-hashes --output "$this_directory/pinned-requirements.txt"
+$poetry export --dev -f requirements.txt --without-hashes --output "$this_directory/dev-requirements.txt"

--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -40,7 +40,7 @@ fi
 # Create poetry-venv in a tmp directory; install poetry and make shortcut to executable.
 poetry_venv=$(mktemp -d "${TMPDIR:-/tmp}/poetry_venv.XXXXXXXXXX")
 python3 -m venv "${poetry_venv}"
-${poetry_venv}/bin/pip install --upgrade pip poetry
+${poetry_venv}/bin/python -m pip install --upgrade pip poetry
 poetry="${poetry_venv}/bin/poetry"
 
 # Run poetry (this may update pyproject.toml and poetry.lock).

--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -32,7 +32,7 @@ done
 shift $(($OPTIND - 1))
 
 if [ -n "$add" ] && [ $# -eq 0 ]; then
-    printf "When adding (-a), you must provide at least one package name.\n" >&2
+    printf "When adding (-a), you must provide at least one package specification.\n" >&2
     usage
     exit 2
 fi

--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -15,7 +15,7 @@ fi
 this_directory="$(cd "$(dirname "$0")" > /dev/null && pwd)"
 
 usage() {
-    printf "Usage: %s: [-a] [pkg1] [... pkgN]\n" ${0##*/} >&2
+    printf "Usage: %s: [-a] [pkg_spec...]\n" ${0##*/} >&2
 }
 
 add=

--- a/lib/galaxy/dependencies/update.sh
+++ b/lib/galaxy/dependencies/update.sh
@@ -53,3 +53,4 @@ fi
 # Update pinned requirements.
 $poetry export -f requirements.txt --without-hashes --output "$this_directory/pinned-requirements.txt"
 $poetry export --dev -f requirements.txt --without-hashes --output "$this_directory/dev-requirements.txt"
+rm -rf "${poetry_venv}"


### PR DESCRIPTION
### What did you do? 
~~1. Added `poetry.lock` to version control.~~ (edit: removed as per code review suggestion)
2. Modified script used to update Python dependencies to:
  a) install poetry in a temporary venv;
  b) allow passing an argument for both adding and updating packages.

### Why did you make this change?
This addresses #11618.

### How to test the changes? 
Manual testing:
- Run `make update-dependencies`. Verify that Poetry is not in Galaxy's venv (e.g. `pip list | grep -i poetry`)
- Run the script to add a dependency and update a dependency. Verify it was added and/or updated.
