### PR TITLE
[21.01] Fix collection mapping over filtered output problem.

### DIFF
--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1440,6 +1440,21 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         self.assertEqual(len(implicit_collections), 3)
         self._check_implicit_collection_populated(create)
 
+    @skip_without_tool("output_filter_with_input_optional")
+    @uses_test_history(require_new=False)
+    def test_map_over_with_output_filter_on_optional_input(self, history_id):
+        hdca_id = self.dataset_collection_populator.create_list_in_history(history_id, contents=["myinputs"]).json()["id"]
+        inputs = {
+            "input_1": {'batch': True, 'values': [{'src': 'hdca', 'id': hdca_id}]},
+        }
+        create = self._run('output_filter_with_input_optional', history_id, inputs).json()
+        jobs = create['jobs']
+        implicit_collections = create['implicit_collections']
+        self.assertEqual(len(jobs), 1)
+        self.dataset_populator.wait_for_job(jobs[0]["id"], assert_ok=True)
+        self.assertEqual(len(implicit_collections), 1)
+        self._check_implicit_collection_populated(create)
+
     @skip_without_tool("output_filter_with_input")
     @uses_test_history(require_new=False)
     def test_map_over_with_output_filter_one_filtered(self, history_id):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2886,6 +2886,37 @@ steps:
             okay_dataset = contents[0]
             assert okay_dataset["state"] == "ok"
 
+    @skip_without_tool("output_filter_with_input_optional")
+    def test_workflow_optional_input_filtering(self):
+        with self.dataset_populator.test_history() as history_id:
+            test_data = """
+input1:
+  type: list
+  elements:
+    - identifier: A
+      content: A
+"""
+            run_object = self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  input1:
+    type: collection
+    collection_type: list
+outputs:
+  wf_output_1:
+    outputSource: output_filter/out_1
+steps:
+  output_filter:
+    tool_id: output_filter_with_input_optional
+    in:
+      input_1: input1
+""", test_data=test_data, history_id=history_id, wait=False)
+            self.wait_for_invocation_and_jobs(history_id, run_object.workflow_id, run_object.invocation_id)
+            contents = self.__history_contents(history_id)
+            assert len(contents) == 1
+            okay_dataset = contents[0]
+            assert okay_dataset["state"] == "ok"
+
     @skip_without_tool("cat")
     def test_run_rename_on_mapped_over_collection(self):
         with self.dataset_populator.test_history() as history_id:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2913,9 +2913,13 @@ steps:
 """, test_data=test_data, history_id=history_id, wait=False)
             self.wait_for_invocation_and_jobs(history_id, run_object.workflow_id, run_object.invocation_id)
             contents = self.__history_contents(history_id)
-            assert len(contents) == 1
-            okay_dataset = contents[0]
-            assert okay_dataset["state"] == "ok"
+            assert len(contents) == 4
+            for content in contents:
+                if content["history_content_type"] == "dataset":
+                    assert content["state"] == "ok"
+                else:
+                    print(content)
+                    assert content["populated_state"] == "ok"
 
     @skip_without_tool("cat")
     def test_run_rename_on_mapped_over_collection(self):

--- a/test/functional/tools/output_filter_with_input_optional.xml
+++ b/test/functional/tools/output_filter_with_input_optional.xml
@@ -1,0 +1,19 @@
+<tool id="output_filter_with_input_optional" name="output_filter_with_input_optional" version="1.0.0">
+    <command><![CDATA[
+echo 'test' > 1 &&
+echo 'test' > 2
+    ]]></command>
+    <inputs>
+        <param name="input_1" type="data" />
+        <param name="input_2" type="data" optional="true" />
+    </inputs>
+    <outputs>
+        <data name="out_1" format="txt" from_work_dir="1">
+        </data>
+        <data name="out_2" format="txt" from_work_dir="2">
+            <filter>input_2</filter>
+        </data>
+    </outputs>
+    <tests>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -97,6 +97,7 @@
   <tool file="output_filter.xml" />
   <tool file="output_empty_work_dir.xml" />
   <tool file="output_filter_with_input.xml" />
+  <tool file="output_filter_with_input_optional.xml" />
   <tool file="output_filter_exception_1.xml" />
   <tool file="output_collection_filter.xml" />
   <tool file="output_auto_format.xml" />


### PR DESCRIPTION
## What did you do? 

- Fix bug described in https://github.com/galaxyproject/galaxy/issues/11510

## Why did you make this change?

https://github.com/galaxyproject/galaxy/issues/11510

This has essentially been a problem since the beginning (resulting in collections with missing elements I assume) but it became a blocker in 21.01 when we started trying to serialize these broken collections.

## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
