### PR TITLE
[20.09] fix exporting datasets from library as collection

### DIFF
--- a/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -91,11 +91,12 @@ var ImportCollectionModal = Backbone.View.extend({
         const new_history_name = this.modal.$("input[name=history_name]").val();
         if (new_history_name !== "") {
             this.createNewHistory(new_history_name)
-                .done((new_history) => {
+                .then((new_history) => {
                     Toast.success("History created");
                     this.collectionImport(collection_elements, new_history.id, new_history.name);
                 })
-                .fail((xhr, status, error) => {
+                .catch((error) => {
+                    console.error(error);
                     Toast.error("An error occurred.");
                 });
         } else {


### PR DESCRIPTION
## What did you do? 
FIxed collection creation from library datasets 

## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/11610

## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. create library
  2. upload 2+ datasets
  3. import as collection


thanks a lot @martenson for reporting!
