### PR TITLE
[21.01] fix exporting datasets from library as collection

### DIFF
--- a/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -123,7 +123,7 @@ var ImportCollectionModal = Backbone.View.extend({
                 }));
                 return this.createHDCA(elements, this.collectionType, name, hideSourceItems, history_id);
             };
-            LIST_CREATOR_MODAL.collectionCreatorModal(
+            LIST_CREATOR_MODAL.listCollectionCreatorModal(
                 collection_elements,
                 { creationFn: creationFn, title: modal_title, defaultHideSourceItems: true },
                 creator_class
@@ -137,7 +137,7 @@ var ImportCollectionModal = Backbone.View.extend({
                 ];
                 return this.createHDCA(elements, this.collectionType, name, hideSourceItems, history_id);
             };
-            PAIR_CREATOR_MODAL.collectionCreatorModal(
+            PAIR_CREATOR_MODAL.listCollectionCreatorModal(
                 collection_elements,
                 { creationFn: creationFn, title: modal_title, defaultHideSourceItems: true },
                 creator_class
@@ -148,7 +148,7 @@ var ImportCollectionModal = Backbone.View.extend({
                 name: element.name,
                 src: "ldda",
             }));
-            PAIRED_CREATOR.pairedCollectionCreatorModal(elements, {
+            PAIRED_CREATOR.pairCollectionCreatorModal(elements, {
                 historyId: history_id,
                 title: modal_title,
                 defaultHideSourceItems: true,

--- a/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -137,7 +137,7 @@ var ImportCollectionModal = Backbone.View.extend({
                 ];
                 return this.createHDCA(elements, this.collectionType, name, hideSourceItems, history_id);
             };
-            PAIR_CREATOR_MODAL.listCollectionCreatorModal(
+            PAIR_CREATOR_MODAL.pairCollectionCreatorModal(
                 collection_elements,
                 { creationFn: creationFn, title: modal_title, defaultHideSourceItems: true },
                 creator_class
@@ -148,7 +148,7 @@ var ImportCollectionModal = Backbone.View.extend({
                 name: element.name,
                 src: "ldda",
             }));
-            PAIRED_CREATOR.pairCollectionCreatorModal(elements, {
+            PAIRED_CREATOR.pairedListCollectionCreatorModal(elements, {
                 historyId: history_id,
                 title: modal_title,
                 defaultHideSourceItems: true,


### PR DESCRIPTION
For others to try, you need to apply changes from 20.09 fix [here](https://github.com/galaxyproject/galaxy/pull/11623). There are 2 lines, could be done by hand untill the PR is merged

@assuntad23, can you please check this out? Is it fine?

## What did you do? 
Continue my https://github.com/galaxyproject/galaxy/pull/11623. Another version, another fix. The same problem, but different cause.

## Why did you make this change?
fixing https://github.com/galaxyproject/galaxy/issues/11610 in 21.01

## How to test the changes? 

- [x] Instructions for manual testing are as follows:
  1. create library
  2. upload 2+ datasets
  3. export as collection
 
## For UI Components
- [x] I've included a screenshot of the changes
![image](https://user-images.githubusercontent.com/15801412/111189933-42268300-85bf-11eb-8bee-0bac98348919.png)
