### PR TITLE
[21.01] Fix optional workflow parameter inputs not recovered when setting step outputs

### DIFF
--- a/lib/galaxy/workflow/run.py
+++ b/lib/galaxy/workflow/run.py
@@ -431,15 +431,17 @@ class WorkflowProgress:
             outputs[invocation_step.output_value.workflow_output.output_name] = invocation_step.output_value.value
         self.outputs[step.id] = outputs
         if not already_persisted:
+            workflow_outputs_by_name = {wo.output_name: wo for wo in step.workflow_outputs}
             for output_name, output_object in outputs.items():
                 if hasattr(output_object, "history_content_type"):
                     invocation_step.add_output(output_name, output_object)
                 else:
-                    # This is a problem, this non-data, non-collection output
-                    # won't be recovered on a subsequent workflow scheduling
-                    # iteration. This seems to have been a pre-existing problem
-                    # prior to #4584 though.
-                    pass
+                    # Add this non-data, non workflow-output output to the workflow outputs.
+                    # This is required for recovering the output in the next scheduling iteration,
+                    # and should be replaced with a WorkflowInvocationStepOutputValue ASAP.
+                    if not workflow_outputs_by_name.get(output_name) and not output_object == modules.NO_REPLACEMENT:
+                        workflow_output = model.WorkflowOutput(step, output_name=output_name)
+                        step.workflow_outputs.append(workflow_output)
             for workflow_output in step.workflow_outputs:
                 output_name = workflow_output.output_name
                 if output_name not in outputs:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2696,6 +2696,54 @@ test_data:
         assert element_a_content.strip() == 'A'
         assert element_b_content.strip() == 'B'
 
+    @skip_without_tool('create_input_collection')
+    def test_workflow_optional_input_text_parameter_reevaluation(self):
+        with self.dataset_populator.test_history() as history_id:
+            self._run_jobs("""
+class: GalaxyWorkflow
+inputs:
+  text_input:
+    type: text
+    optional: true
+    default: ''
+steps:
+  create_collection:
+    tool_id: create_input_collection
+  nested_workflow:
+    in:
+      inner_input: create_collection/output
+      inner_text_input: text_input
+    run:
+      class: GalaxyWorkflow
+      inputs:
+        inner_input:
+          type: data_collection_input
+        inner_text_input:
+          type: text
+          optional: true
+          default: ''
+      steps:
+        apply:
+          tool_id: __APPLY_RULES__
+          in:
+            input: inner_input
+          state:
+            rules:
+              rules:
+                - type: add_column_metadata
+                  value: identifier0
+              mapping:
+                - type: list_identifiers
+                  columns: [0]
+      echo:
+        cat1:
+          in:
+            input1: apply/output
+          outputs:
+            out_file1:
+              rename: "#{inner_text_input} suffix"
+        """, history_id=history_id)
+
     @skip_without_tool('cat1')
     def test_workflow_rerun_with_use_cached_job(self):
         workflow = self.workflow_populator.load_workflow(name="test_for_run")


### PR DESCRIPTION
I think this should be fine as a fix, although I think we should break up the `WorkflowInvocationOutputValue`
 table and have to value column reference something like  `WorkflowInvocationStepOutputValue`, so that we can have non-data outputs that are not workflow outputs.

Includes a workflow test that fails with
```
galaxy.workflow.run ERROR 2021-03-16 16:27:31,362 [pN:main,p:76342,tN:WorkflowRequestMonitor.monitor_thread] Failed to schedule Workflow[id=2,name=Workflow], problem occurred on WorkflowStep[index=2,type=subworkflow].
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 358, in replacement_for_connection
    replacement = step_outputs[output_name]
KeyError: 'output'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 195, in invoke
    incomplete_or_none = self._invoke_step(workflow_invocation_step)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 268, in _invoke_step
    incomplete_or_none = invocation_step.workflow_step.module.execute(self.trans,
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/modules.py", line 509, in execute
    subworkflow_invoker = progress.subworkflow_invoker(trans, step, use_cached_job=use_cached_job)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 481, in subworkflow_invoker
    subworkflow_progress = self.subworkflow_progress(subworkflow_invocation, step, workflow_run_config.param_map)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 499, in subworkflow_progress
    replacement = self.replacement_for_connection(
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 363, in replacement_for_connection
    raise Exception(message)
Exception: Workflow evaluation problem - failed to find output_name output in step_outputs {}
galaxy.workflow.run ERROR 2021-03-16 16:27:31,365 [pN:main,p:76342,tN:WorkflowRequestMonitor.monitor_thread] Failed to execute scheduled workflow.
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 358, in replacement_for_connection
    replacement = step_outputs[output_name]
KeyError: 'output'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 82, in __invoke
    outputs = invoker.invoke()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 195, in invoke
    incomplete_or_none = self._invoke_step(workflow_invocation_step)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 268, in _invoke_step
    incomplete_or_none = invocation_step.workflow_step.module.execute(self.trans,
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/modules.py", line 509, in execute
    subworkflow_invoker = progress.subworkflow_invoker(trans, step, use_cached_job=use_cached_job)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 481, in subworkflow_invoker
    subworkflow_progress = self.subworkflow_progress(subworkflow_invocation, step, workflow_run_config.param_map)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 499, in subworkflow_progress
    replacement = self.replacement_for_connection(
  File "/Users/mvandenb/src/galaxy/lib/galaxy/workflow/run.py", line 363, in replacement_for_connection
    raise Exception(message)
Exception: Workflow evaluation problem - failed to find output_name output in step_outputs {}
```