### PR TITLE
Pin refgenconf to <0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ pysam = "*"
 python = "^3.6"
 pyuwsgi = "*"
 PyYAML = "*"
-refgenconf = ">=0.7.0"
+refgenconf = ">=0.7.0, <0.10.0"  # https://github.com/galaxyproject/galaxy/issues/11601
 requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}


### PR DESCRIPTION
## What did you do? 
Pin refgenconf to <0.10.0 in `pyproject.toml`

## Why did you make this change?
refgenconf 0.10.0 contains breaking changes, see https://github.com/galaxyproject/galaxy/issues/11601


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `make update-dependencies`
  2. Check that refgenconf is `==0.9.3` in `requirements.txt`