### PR TITLE
Pin SQAlchemy to <1.4.0

### DIFF
--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -12,7 +12,7 @@ pycryptodome
 pydantic
 pysam
 social-auth-core[openidconnect]==3.3.0
-SQLAlchemy
+SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 sqlalchemy-migrate
 sqlalchemy-utils
 WebOb

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -8,5 +8,5 @@ pydantic<1.8
 requests
 Routes
 six
-SQLAlchemy
+SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 WebOb

--- a/packages/web_stack/requirements.txt
+++ b/packages/web_stack/requirements.txt
@@ -1,2 +1,2 @@
-sqlalchemy
+SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 galaxy-util

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = "*"
+SQLAlchemy = "~1.3.22"
 sqlalchemy-migrate = "*"
 SQLAlchemy-Utils = "!=0.36.8"  # https://github.com/kvesteri/sqlalchemy-utils/issues/462
 sqlitedict = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = "~1.3.22"
+SQLAlchemy = "~1.3.22"  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 sqlalchemy-migrate = "*"
 SQLAlchemy-Utils = "!=0.36.8"  # https://github.com/kvesteri/sqlalchemy-utils/issues/462
 sqlitedict = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = "~1.3.22"  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
+SQLAlchemy = ">=1.3.22, <1.4.0"  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 sqlalchemy-migrate = "*"
 SQLAlchemy-Utils = "!=0.36.8"  # https://github.com/kvesteri/sqlalchemy-utils/issues/462
 sqlitedict = "*"


### PR DESCRIPTION
1.4 released; our codebase not compatible yet.

## What did you do? 
Pin SQAlchemy to <1.4.0

## Why did you make this change?
SQLAlchemy 1.4 has been released. Galaxy's code is not fully compatible yet. 
Pin is temporary; will be removed when code is made compatible.

## How to test the changes? 
- [ ] Instructions for manual testing are as follows:
make update-dependencies
Check that sqlalchemy is >= 1.3.22 < 1.4 in requirements.txt

