### PR TITLE
Add missing ssl keyword in nginx example [docs]

### DIFF
--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -112,8 +112,8 @@ http {
     }
 
     server {
-        listen 443 default_server;
-        listen [::]:443 default_server;
+        listen 443 ssl default_server;
+        listen [::]:443 ssl default_server;
         server_name _;
 
         # use a variable for convenience


### PR DESCRIPTION
Otherwise it will use the http protocol instead of https.

Not using `ssl` will give a lot of SSL record too long erros which are very hard to debug. It took me a while to spot the error.

