### PR TITLE
[21.01] Change Upload button tooltip position

### DIFF
--- a/client/src/components/Upload/UploadButton.vue
+++ b/client/src/components/Upload/UploadButton.vue
@@ -2,7 +2,7 @@
     <b-button
         id="tool-panel-upload-button"
         @click="showUploadDialog"
-        v-b-tooltip.hover.auto
+        v-b-tooltip.hover.bottom
         :aria-label="title | localize"
         :title="title | localize"
         class="upload-button"


### PR DESCRIPTION
## What did you do? 
Moved Upload button tooltip to the bottom


## Why did you make this change?
Auto position doesn't seem to work as expected
![image](https://files.gitter.im/5f6b42c8d73408ce4fefac67/84yD/Screenshot-from-2021-03-16-11-59-18.png)

## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. Move the mouse over the upload button

## For UI Components
- [x] I've included a screenshot of the changes
![image](https://user-images.githubusercontent.com/15801412/111317034-7310c180-866c-11eb-9388-3a24c7776413.png)


ping @mvdbeek 

