### PR TITLE
[21.01] Fix "Edit Dataset Tags" button title in Beta History Panel

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -34,7 +34,7 @@
         <PriorityMenuItem
             v-if="expanded"
             key="edit-tags"
-            title="Edit History Tags"
+            title="Edit Dataset Tags"
             :pressed="showTags"
             @click.stop="$emit('update:showTags', !showTags)"
             icon="fas fa-tags"


### PR DESCRIPTION
## What did you do? 
It's in the PR title. I noticed it today and @jmchilton already proposed this fix in https://github.com/galaxyproject/galaxy/issues/10947#issuecomment-747775166


## Why did you make this change?
Because the button title was wrong ;)

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy (the client will be rebuilt)
  2. Enable the Beta History Panel in the History panel (gear icon)
  3. Click on a dataset to expand it
  4. Check that the dataset tags button (4th from left) has the correct title by hovering over it

## For UI Components
- [ ] I've included a screenshot of the changes
