### PR TITLE
Revert "[20.09] always mount a job tmp rw"

### DIFF
--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -98,9 +98,9 @@ class CondorJobRunner(AsynchronousJobRunner):
 
         galaxy_slots = query_params.get('request_cpus', None)
         if galaxy_slots:
-            galaxy_slots_statement = 'GALAXY_SLOTS="%s"; export GALAXY_SLOTS; GALAXY_SLOTS_CONFIGURED="1"; export GALAXY_SLOTS_CONFIGURED;' % galaxy_slots
+            galaxy_slots_statement = 'GALAXY_SLOTS="%s"; export GALAXY_SLOTS_CONFIGURED="1"' % galaxy_slots
         else:
-            galaxy_slots_statement = 'GALAXY_SLOTS="1"; export GALAXY_SLOTS;'
+            galaxy_slots_statement = 'GALAXY_SLOTS="1"'
 
         # define job attributes
         cjs = CondorJobState(

--- a/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/CLUSTER_SLOTS_STATEMENT.sh
@@ -30,4 +30,3 @@ else
     GALAXY_SLOTS="1"
     unset GALAXY_SLOTS_CONFIGURED
 fi
-export GALAXY_SLOTS

--- a/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/DEFAULT_JOB_FILE_TEMPLATE.sh
@@ -27,14 +27,13 @@ _galaxy_setup_environment() {
 
 $integrity_injection
 $slots_statement
+export GALAXY_SLOTS
 export PYTHONWARNINGS="ignore"
 GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 _GALAXY_VIRTUAL_ENV="$galaxy_virtual_env"
 PRESERVE_GALAXY_ENVIRONMENT="$preserve_python_environment"
 GALAXY_LIB="$galaxy_lib"
 _galaxy_setup_environment "$PRESERVE_GALAXY_ENVIRONMENT"
-export _GALAXY_JOB_HOME_DIR
-export _GALAXY_JOB_TMP_DIR
 GALAXY_PYTHON=`command -v python`
 cd $working_directory
 $memory_statement

--- a/lib/galaxy/jobs/runners/util/job_script/__init__.py
+++ b/lib/galaxy/jobs/runners/util/job_script/__init__.py
@@ -79,7 +79,7 @@ def job_script(template=DEFAULT_JOB_FILE_TEMPLATE, **kwds):
     >>> script.startswith('#!/bin/bash\\n\\n#PBS -test\\n')
     True
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec', slots_statement='GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"')
-    >>> script.find('GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"\\n') > 0
+    >>> script.find('GALAXY_SLOTS="$SLURM_JOB_NUM_NODES"\\nexport GALAXY_SLOTS\\n') > 0
     True
     >>> script = job_script(working_directory='wd', command='uptime', exit_code_path='ec', memory_statement='GALAXY_MEMORY_MB="32768"')
     >>> script.find('GALAXY_MEMORY_MB="32768"\\n') > 0

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -200,6 +200,7 @@ class HasDockerLikeVolumes:
         add_var("library_import_dir", self.app_info.library_import_dir)
         add_var('tool_data_path', self.app_info.tool_data_path)
         add_var('shed_tool_data_path', self.app_info.shed_tool_data_path)
+
         if self.job_info.job_directory and self.job_info.job_directory_type == "pulsar":
             # We have a Pulsar job directory, so everything needed (excluding index
             # files) should be available in job_directory...
@@ -247,6 +248,7 @@ class HasDockerLikeVolumes:
             if end_index < 0:
                 end_index = len(volumes_str)
             volumes_str = volumes_str[0:tool_directory_index] + volumes_str[end_index:len(volumes_str)]
+
         return volumes_str
 
 
@@ -297,9 +299,8 @@ class DockerContainer(Container, HasDockerLikeVolumes):
         # and Galaxy.
         if self.job_info.tmp_directory is not None:
             volumes.append(DockerVolume.from_str("%s:/tmp:rw" % self.job_info.tmp_directory))
-        else:
-            volumes.append(DockerVolume.from_str("$_GALAXY_JOB_TMP_DIR:$_GALAXY_JOB_TMP_DIR:rw"))
         volumes_from = self.destination_info.get("docker_volumes_from", docker_util.DEFAULT_VOLUMES_FROM)
+
         docker_host_props = self.docker_host_props
 
         cached_image_file = self.__get_cached_image_file()

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2865,7 +2865,6 @@ Name | Description
 ``\${GALAXY_SLOTS:-4}`` | Number of cores/threads allocated by the job runner or resource manager to the tool for the given job (here 4 is the default number of threads to use if running via custom runner that does not configure GALAXY_SLOTS or in an older Galaxy runtime).
 ``\$GALAXY_MEMORY_MB`` | Total amount of memory in megabytes (1024^2 bytes) allocated by the administrator (via the resource manager) to the tool for the given job. If unset, tools should not attempt to limit memory usage.
 ``\$GALAXY_MEMORY_MB_PER_SLOT`` | Amount of memory per slot in megabytes (1024^2 bytes) allocated by the administrator (via the resource manager) to the tool for the given job. If unset, tools should not attempt to limit memory usage.
-``\$_GALAXY_JOB_TMP_DIR`` | Path to an empty directory in the job's working directory that can be used as a temporary directory.
 
 See the [Planemo docs](https://planemo.readthedocs.io/en/latest/writing_advanced.html#cluster-usage)
 on the topic of ``GALAXY_SLOTS`` for more information and examples.

--- a/test/functional/tools/job_environment_default.xml
+++ b/test/functional/tools/job_environment_default.xml
@@ -3,16 +3,14 @@
       <container type="docker">busybox:ubuntu-14.04</container>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
-      echo 'Writing environment properties to output files.' &&
-      (>&2 echo 'Example tool stderr output.') &&
-      echo `id -u` > '$user_id' &&
-      echo `id -g` > '$group_id' &&
-      echo `pwd` > '$pwd' &&
-      echo "\$HOME" > '$home' &&
-      echo "\$TMP"  > '$tmp' &&
-      echo "\$SOME_ENV_VAR" > '$some_env_var' &&
-      touch "\$_GALAXY_JOB_TMP_DIR/tmp_test" &&
-      touch "\$HOME/home_test"
+      echo 'Writing environment properties to output files.';
+      (>&2 echo 'Example tool stderr output.');
+      echo `id -u` > '$user_id';
+      echo `id -g` > '$group_id';
+      echo `pwd` > '$pwd';
+      echo "\$HOME" > '$home';
+      echo "\$TMP"  > '$tmp';
+      echo "\$SOME_ENV_VAR" > '$some_env_var';
     ]]></command>
     <inputs>
     </inputs>

--- a/test/integration/chained_dyndest_rules/module3/rules.py
+++ b/test/integration/chained_dyndest_rules/module3/rules.py
@@ -14,6 +14,6 @@ def dyndest_chain_2():
 
 
 def dyndest_chain_3(tmp_dir_prefix_two):
-    tmp_dir = '$(mktemp -d -p $(pwd) %sand3XXXXXXXXXXXX)' % tmp_dir_prefix_two
+    tmp_dir = '$(mktemp %sand3XXXXXXXXXXXX)' % tmp_dir_prefix_two
     return JobDestination(runner="local",
                           params={'tmp_dir': tmp_dir})

--- a/test/integration/sets_tmp_dir_expression_job_conf.xml
+++ b/test/integration/sets_tmp_dir_expression_job_conf.xml
@@ -6,7 +6,7 @@
 
     <destinations>
         <destination id="local_dest" runner="local">
-            <param id="tmp_dir">$(mktemp -d -p $(pwd) cooltmpXXXXXXXXXXXX)</param>
+            <param id="tmp_dir">$(mktemp cooltmpXXXXXXXXXXXX)</param>
         </destination>
     </destinations>
 


### PR DESCRIPTION
Reverts galaxyproject/galaxy#11448

This PR forced Galaxy to erroneously mount the host filesystem. In my case the path that $_GALAXY_JOB_TMP_DIR resolves to is in a docker volume. If multiple instances of Galaxy are running, they would mount the same path.

The issue is that $_GALAXY_JOB_TMP_DIR:$_GALAXY_JOB_TMP_DIR:rw assumes that $_GALAXY_JOB_TMP_DIR exists on the host. 

The better solution is to provide a $tmp_dir variable in the docker_volumes runner spec.

The $tmp_dir variable can then resolve to self.job_info.tmp_directory or '$_GALAXY_JOB_TMP_DIR'.
I can then omit $tmp_dir from the docker_volumes config as the data volume where the job folder exists is already in the spec and the $_GALAXY_JOB_TMP_DIR path remains valid.