### PR TITLE
Don't check for missing `kind/` label for `minor` merged PRs

### DIFF
--- a/.github/workflows/labels-verifier.yaml
+++ b/.github/workflows/labels-verifier.yaml
@@ -12,7 +12,8 @@ jobs:
         if: |
           github.event.pull_request.merged == true &&
           ! contains(join(github.event.pull_request.labels.*.name, ', '), 'kind/') &&
-          ! contains(github.event.pull_request.labels.*.name, 'merge')
+          ! contains(github.event.pull_request.labels.*.name, 'merge') &&
+          ! contains(github.event.pull_request.labels.*.name, 'minor')
         uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What did you do? 
- Modified `.github/workflows/labels-verifier.yaml` to not check for missing `kind/` label for `minor` merged PRs, as we already do with those labelled `merge`.


## Why did you make this change?
PRs labelled `minor` and `merge` are skipped by `scripts/bootstrap_history.py` when generating the release notes.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
