### PR TITLE
Pin fs.webdavfs requirement to latest version

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -14,7 +14,7 @@ python-pam
 galaxycloudrunner
 
 # For file sources plugins
-fs.webdavfs==0.4.2  # type: webdav
+fs.webdavfs>=0.4.2  # type: webdav
 fs.dropboxfs  # type: dropbox
 fs-s3fs  # type: s3
 s3fs  # type: s3fs

--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -14,7 +14,7 @@ python-pam
 galaxycloudrunner
 
 # For file sources plugins
-fs.webdavfs  # type: webdav
+fs.webdavfs==0.4.2  # type: webdav
 fs.dropboxfs  # type: dropbox
 fs-s3fs  # type: s3
 s3fs  # type: s3fs


### PR DESCRIPTION
## What did you do? 
- Pinned the fs.webdavfs conditional requirement


## Why did you make this change?
I just updated my instance to 21.01 but noticed the fs.webdavfs module didn't get updated as it's not pinned.
Pinning to 0.4.2 as it includes several bug fixes and performance improvement (see https://github.com/galaxyproject/galaxy/issues/11145)


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
