### PR TITLE
[21.01] Fix conditional, section and hidden parameters becoming runtime parameters

### DIFF
--- a/client/src/components/Workflow/Editor/modules/forms.js
+++ b/client/src/components/Workflow/Editor/modules/forms.js
@@ -108,8 +108,8 @@ export class ToolForm {
         const inputs = node.config_form.inputs;
         Utils.deepeach(inputs, (input) => {
             if (input.type) {
-                if (["data", "data_collection", "hidden"].indexOf(input.type) != -1) {
-                    input.type = "hidden";
+                if (["data", "data_collection"].indexOf(input.type) != -1) {
+                    input.hiddenInWorkflow = true;
                     input.info = `Data input '${input.name}' (${Utils.textify(input.extensions)})`;
                     input.value = { __class__: "RuntimeValue" };
                 } else if (!input.fixed) {

--- a/client/src/mvc/form/form-parameters.js
+++ b/client/src/mvc/form/form-parameters.js
@@ -45,7 +45,7 @@ export default Backbone.Model.extend({
     /** Returns an input field for a given field type */
     create: function (input_def) {
         const Galaxy = getGalaxyInstance();
-        var fieldClass = this.types[input_def.type];
+        var fieldClass = this.types[input_def.hiddenInWorkflow ? "hidden" : input_def.type];
         var field = typeof this[fieldClass] === "function" ? this[fieldClass].call(this, input_def) : null;
         if (!field) {
             field = input_def.options ? this._fieldSelect(input_def) : this._fieldText(input_def);


### PR DESCRIPTION
## What did you do? 
Fix the state of Conditional and Section parameters.

## Why did you make this change?
This broke in 526fb05d5c7d0e154f7df2f622045059105451e5, which fixed
cloned data inputs missing from the tool form.
The problem with this commit is that we now add the runtime value state
to non-data hidden inputs, which is not correct and breaks execution
of workflows with these inputs.

This fix is better since it does not change the input type, and instead
adds a new attribute. The tool form and its variants need to be
rewritten in vue ASAP, so we can stop these hacks.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
Add a tool that contains a conditional or a section in the workflow editor and change the state. Download the workflow and verify that there is no entry for the conditional in the steps' inputs.