### PR TITLE
[21.01] Refactor default mounting of $tmp_directory in containers

### DIFF
--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -218,6 +218,12 @@ class HasDockerLikeVolumes:
                     defaults += ",$job_directory/configs:rw"
             if self.job_info.tmp_directory is not None:
                 defaults += ",$tmp_directory:rw"
+                # If a tool definitely has a temp directory available set it to /tmp in container for compat.
+                # with CWL. This is part of that spec and should make it easier to share containers between CWL
+                # and Galaxy.
+                defaults += ",$tmp_directory:/tmp:rw"
+            else:
+                defaults += ",$_GALAXY_JOB_TMP_DIR:rw"
             if self.job_info.home_directory is not None:
                 defaults += ",$home_directory:rw"
             if self.app_info.outputs_to_working_directory:
@@ -294,11 +300,6 @@ class DockerContainer(Container, HasDockerLikeVolumes):
         preprocessed_volumes_list = preprocess_volumes(volumes_raw, self.container_type)
         # TODO: Remove redundant volumes...
         volumes = [DockerVolume.from_str(v) for v in preprocessed_volumes_list]
-        # If a tool definitely has a temp directory available set it to /tmp in container for compat.
-        # with CWL. This is part of that spec and should make it easier to share containers between CWL
-        # and Galaxy.
-        if self.job_info.tmp_directory is not None:
-            volumes.append(DockerVolume.from_str("%s:/tmp:rw" % self.job_info.tmp_directory))
         volumes_from = self.destination_info.get("docker_volumes_from", docker_util.DEFAULT_VOLUMES_FROM)
 
         docker_host_props = self.docker_host_props

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -200,6 +200,7 @@ class HasDockerLikeVolumes:
         add_var("library_import_dir", self.app_info.library_import_dir)
         add_var('tool_data_path', self.app_info.tool_data_path)
         add_var('shed_tool_data_path', self.app_info.shed_tool_data_path)
+
         if self.job_info.job_directory and self.job_info.job_directory_type == "pulsar":
             # We have a Pulsar job directory, so everything needed (excluding index
             # files) should be available in job_directory...
@@ -247,6 +248,7 @@ class HasDockerLikeVolumes:
             if end_index < 0:
                 end_index = len(volumes_str)
             volumes_str = volumes_str[0:tool_directory_index] + volumes_str[end_index:len(volumes_str)]
+
         return volumes_str
 
 
@@ -297,9 +299,8 @@ class DockerContainer(Container, HasDockerLikeVolumes):
         # and Galaxy.
         if self.job_info.tmp_directory is not None:
             volumes.append(DockerVolume.from_str("%s:/tmp:rw" % self.job_info.tmp_directory))
-        else:
-            volumes.append(DockerVolume.from_str("$_GALAXY_JOB_TMP_DIR:$_GALAXY_JOB_TMP_DIR:rw"))
         volumes_from = self.destination_info.get("docker_volumes_from", docker_util.DEFAULT_VOLUMES_FROM)
+
         docker_host_props = self.docker_host_props
 
         cached_image_file = self.__get_cached_image_file()


### PR DESCRIPTION
## What did you do? 
- Refactored default mounting of $tmp_directory in containers
- Reverted e9f2b3a051ae98fa7b14531b7425fc16635c0ca8

## Why did you make this change?
e9f2b3a051ae98fa7b14531b7425fc16635c0ca8 forced Galaxy to erroneously mount the host filesystem. In my case the path that $_GALAXY_JOB_TMP_DIR resolves to is in a docker volume. If multiple instances of Galaxy are running, they would mount the same path.

The issue is that $_GALAXY_JOB_TMP_DIR:$_GALAXY_JOB_TMP_DIR:rw assumes that $_GALAXY_JOB_TMP_DIR exists on the host.

The better solution is to add '$_GALAXY_JOB_TMP_DIR' to the $default value in docker_volumes runner spec.

The $tmp_directory variable can then resolve to self.job_info.tmp_directory or '$_GALAXY_JOB_TMP_DIR'.
I can then omit $tmp_directory from the docker_volumes config as the data volume where the job folder exists is already in the spec and the $_GALAXY_JOB_TMP_DIR path remains valid.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## For UI Components
- [ ] I've included a screenshot of the changes
