### PR TITLE
update to cope with impending changes to cwltool internals

### DIFF
--- a/lib/galaxy/tool_util/cwl/cwltool_deps.py
+++ b/lib/galaxy/tool_util/cwl/cwltool_deps.py
@@ -52,9 +52,26 @@ except ImportError:
     load_tool = None  # type: ignore
     resolve_and_validate_document = None  # type: ignore
 
+
+def _has_relax_path_checks_flag():
+    """Return True if cwltool uses a flag to control path checks.
+
+    Old cwltool uses the module global below to control whether
+    it's strict about path checks. New versions use an attribute
+    of LoadingContext.
+
+    Once the version of cwltool required is new enough, we can remove
+    this function and simplify the conditionals where it's used.
+    """
+
+    lc = LoadingContext()
+    return hasattr(lc, "relax_path_checks")
+
+
 try:
     from cwltool import command_line_tool
-    command_line_tool.ACCEPTLIST_RE = command_line_tool.ACCEPTLIST_EN_RELAXED_RE
+    if not _has_relax_path_checks_flag():
+        command_line_tool.ACCEPTLIST_RE = command_line_tool.ACCEPTLIST_EN_RELAXED_RE
 except ImportError:
     command_line_tool = None  # type: ignore
 
@@ -62,12 +79,6 @@ try:
     from cwltool.load_tool import resolve_and_validate_document
 except ImportError:
     resolve_and_validate_document = None  # type: ignore
-
-try:
-    from cwltool import command_line_tool
-    command_line_tool.ACCEPTLIST_RE = command_line_tool.ACCEPTLIST_EN_RELAXED_RE
-except ImportError:
-    command_line_tool = None  # type: ignore
 
 try:
     import shellescape

--- a/lib/galaxy/tool_util/cwl/schema.py
+++ b/lib/galaxy/tool_util/cwl/schema.py
@@ -4,6 +4,7 @@ import tempfile
 from collections import namedtuple
 
 from .cwltool_deps import (
+    _has_relax_path_checks_flag,
     default_loader,
     ensure_cwltool_available,
     load_tool,
@@ -33,6 +34,8 @@ class SchemaLoader:
         loading_context.do_validate = self._validate
         loading_context.loader = self.raw_document_loader
         loading_context.do_update = True
+        if _has_relax_path_checks_flag():
+            loading_context.relax_path_checks = True
         return loading_context
 
     def raw_process_reference(self, path, loading_context=None):


### PR DESCRIPTION
## What did you do? 
- Added a function to test whether the cwltool version available has the new way of specifying strict/relaxed path checks
- If old, no change in behaviour (it globally sets cwltool to be relaxed)
- If new, make galaxy's use of cwltool use relaxed path checks by default


## Why did you make this change?
Cwltool, as currently released, uses a module global (`cwltool.command_line_tool.ACCEPTLIST_RE`) to control whether it's strict about path checks. 

To fix a bug caused by this global state, I removed the global and replaced it with a new attribute of `cwltool.context.LoadingContext`. This is merged to main and will be in the next release. 
https://github.com/common-workflow-language/cwltool/commit/dbde435f8c409fde68139fad896d1a11faa434ec

This will break galaxy's use of cwltool if using this next release.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
