### PR TITLE
[21.01] Fix reconnecting terminals

### DIFF
--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -107,7 +107,6 @@ export default {
             this.$emit("onChange");
         },
         onRemove() {
-            this.$emit("onRemove", this.input);
             this.terminal.destroy();
         },
         mouseOver(e) {
@@ -120,6 +119,7 @@ export default {
         },
     },
     beforeDestroy() {
+        this.$emit("onRemove", this.input);
         this.onRemove();
     },
 };

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -231,6 +231,19 @@ steps:
         self.assert_connected("input1#output", "first_cat#input1")
 
     @selenium_test
+    def test_reconnecting_nodes(self):
+        name = self.open_in_workflow_editor(WORKFLOW_SIMPLE_CAT_TWICE)
+        self.assert_connected("input1#output", "first_cat#input1")
+        self.workflow_editor_destroy_connection("first_cat#input1")
+        self.assert_not_connected("input1#output", "first_cat#input1")
+        self.workflow_editor_connect("input1#output", "first_cat#input1")
+        self.assert_connected("input1#output", "first_cat#input1")
+        self.assert_has_changes_and_save()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_index_open_with_name(name)
+        self.assert_connected("input1#output", "first_cat#input1")
+
+    @selenium_test
     def test_rendering_output_collection_connections(self):
         self.open_in_workflow_editor(WORKFLOW_WITH_OUTPUT_COLLECTION)
         self.workflow_editor_maximize_center_pane()
@@ -535,6 +548,7 @@ steps:
         self.workflow_index_open()
         self.workflow_index_open_with_name(name)
         self.workflow_editor_click_option("Auto Layout")
+        return name
 
     def workflow_editor_source_sink_terminal_ids(self, source, sink):
         editor = self.components.workflow_editor


### PR DESCRIPTION
## What did you do? 
Don't emit onRemove when disconnecting an input terminal.
We only need to remove the inputTerminal from the Node when the
NodeInput is removed, not when the connection is destroyed.
This mirrors what we do for the NodeOutput now.
https://github.com/mvdbeek/galaxy/blame/d03c7af02a0ac456a3e22d3fbc90e434debb43fe/client/src/components/Workflow/Editor/NodeOutput.vue#L153
now.

## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/11658.
Broken in e49d6a3c461bae843bb40877a321d15922306842.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## For UI Components
- [ ] I've included a screenshot of the changes
