### PR TITLE
Lint for duplicated options

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -41,7 +41,7 @@ def lint_inputs(tool_xml, lint_ctx):
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error("Select [%s] has option without value", param_name)
             if len(set([option.text.strip() for option in select_options])) != len(select_options):
-                lint_ctx.error("Select [%s] has duplicated options", param_name)
+                lint_ctx.error(f"Select [{param_name}] has multiple options with the same text content")
 
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -41,7 +41,7 @@ def lint_inputs(tool_xml, lint_ctx):
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error("Select [%s] has option without value", param_name)
             if len(set([option.text.strip() for option in select_options])) != len(select_options):
-                lint_ctx.warn("Select [%s] has duplicated options", param_name)
+                lint_ctx.error("Select [%s] has duplicated options", param_name)
 
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -40,7 +40,7 @@ def lint_inputs(tool_xml, lint_ctx):
             select_options = param.findall('./option')
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error("Select [%s] has option without value", param_name)
-            if len(set([ option.text.strip() for option in select_options])) != len(select_options):
+            if len(set([option.text.strip() for option in select_options])) != len(select_options):
                 lint_ctx.warn("Select [%s] has duplicated options", param_name)
 
             if dynamic_options is None and len(select_options) == 0:

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -40,6 +40,8 @@ def lint_inputs(tool_xml, lint_ctx):
             select_options = param.findall('./option')
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error("Select [%s] has option without value", param_name)
+            if len(set([ option.text.strip() for option in select_options])) != len(select_options):
+                lint_ctx.warn("Select [%s] has duplicated options", param_name)
 
             if dynamic_options is None and len(select_options) == 0:
                 message = "No options defined for select [%s]" % param_name

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -57,7 +57,7 @@ TESTS = [
 ]
 
 
-@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when', 'radio select incompatibilities', 'select duplictaed options'])
+@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when', 'radio select incompatibilities', 'select duplicated options'])
 def test_tool_xml(tool_xml, lint_func, assert_func):
     lint_ctx = LintContext('all')
     tree = etree.ElementTree(element=etree.fromstring(tool_xml))

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -53,7 +53,7 @@ TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
     (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages),
-    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [select] has duplicated options' in x.error_messages),
+    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [select] has multiple options with the same text content' in x.error_messages),
 ]
 
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -36,10 +36,24 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 </tool>
 """
 
+SELECT_DUPLICATED_OPTIONS = """
+<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+    <description>The BWA Mapper</description>
+    <version_command interpreter="python">bwa.py --version</version_command>
+    <inputs>
+        <param name="select" type="select" display="radio" optional="true" multiple="true"/>
+            <option value="a">x</option>
+            <option value="b">x</option>
+        </param>
+    </inputs>
+</tool>
+"""
+
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
     (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages),
+    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [radio_select]  has duplicated options' in x.error_messages),
 ]
 
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -41,7 +41,7 @@ SELECT_DUPLICATED_OPTIONS = """
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
-        <param name="select" type="select" display="radio" optional="true" multiple="true"/>
+        <param name="select" type="select" optional="true" multiple="true">
             <option value="a">x</option>
             <option value="b">x</option>
         </param>
@@ -53,11 +53,11 @@ TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
     (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
     (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages),
-    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [radio_select]  has duplicated options' in x.error_messages),
+    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [select] has duplicated options' in x.error_messages),
 ]
 
 
-@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when', 'radio select incompatibilities'])
+@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when', 'radio select incompatibilities', 'select duplictaed options'])
 def test_tool_xml(tool_xml, lint_func, assert_func):
     lint_ctx = LintContext('all')
     tree = etree.ElementTree(element=etree.fromstring(tool_xml))

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -42,8 +42,8 @@ SELECT_DUPLICATED_OPTIONS = """
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
         <param name="select" type="select" optional="true" multiple="true">
-            <option value="a">x</option>
-            <option value="b">x</option>
+            <option value="v">x</option>
+            <option value="v">x</option>
         </param>
     </inputs>
 </tool>
@@ -51,9 +51,9 @@ SELECT_DUPLICATED_OPTIONS = """
 
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
-    (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: 'No <when /> block found for select option \'none\' inside conditional \'labels\'' in x.warn_messages),
+    (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: "Conditional [labels] no <when /> block found for select option 'none'" in x.warn_messages),
     (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages),
-    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [select] has multiple options with the same text content' in x.error_messages),
+    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [select] has multiple options with the same text content' in x.error_messages and 'Select [select] has multiple options with the same value' in x.error_messages),
 ]
 
 


### PR DESCRIPTION
## What did you do? 

```
<param type="select">
  <option value="a">x</option>
  <option value="b">x</option>
</param>
```

as well as 


```
<param type="select">
  <option value="v">x</option>
  <option value="v">y</option>
</param>
```


will raise a linter error.

## Why did you make this change?

Having a select where the user sees multiple equivalent options leading to potentially different values should not be allowed.

Have seem duplicated `value, text` combinations here https://github.com/bgruening/galaxytools/blob/7f48fa9f0c2ef08ffe621a8215ea307ab780b9b5/tools/uniprot_rest_interface/macros.xml#L49
 and thought that the linter should catch this

We could make this a warning if `multiple="true"`, maybe someone wants to implement something like verbosity switches (`-v`, ..., `-vvv`)?

Also multiple selects with the same value seem unfavorable (at least) since they suggest the user that something different happens, but actually it is not.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

I'm happy to 

## For UI Components
- [ ] I've included a screenshot of the changes
