### PR TITLE
[21.01] Fix tags not included when importing shared workflow

### DIFF
--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -1249,6 +1249,7 @@ class UsesStoredWorkflowMixin(SharableItemSecurityMixin, UsesAnnotations):
         workflow.stored_workflow = imported_stored
         imported_stored.latest_workflow = workflow
         imported_stored.user = trans.user
+        imported_stored.copy_tags_from(stored.user, stored)
         # Save new workflow.
         session = trans.sa_session
         session.add(imported_stored)


### PR DESCRIPTION
## What did you do? 
Copy the existing tags associated with a published workflow when it is imported by another user.


## Why did you make this change?
To fix #11505


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  - Go to `https://<your_galaxy>/workflows/list_published`
  - Choose a workflow **with tags** and then select `import` from the dropdown menu
      ![image](https://user-images.githubusercontent.com/46503462/111611516-d6216600-87dc-11eb-867f-4550979e137f.png)
  - Go to `https://<your_galaxy>/workflows/list` and check that the tags are displayed
