### PR TITLE
[21.01] Fix datatype defined column name display

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3501,7 +3501,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
                     continue
                 val = val.file_name
             # If no value for metadata, look in datatype for metadata.
-            elif val is None and hasattr(hda.datatype, name):
+            elif not hda.metadata.element_is_set(name) and hasattr(hda.datatype, name):
                 val = getattr(hda.datatype, name)
             rval['metadata_' + name] = val
         return rval


### PR DESCRIPTION
## What did you do? 
- Fix column header not shown in center panel
I think this was the intention when checking for None, but this doesn't work when the default type is not None, such as a list for column_names.

This might be another side-effect of https://github.com/galaxyproject/galaxy/commit/335a89772012041538e86835a4e16f3a2e50d51f, which is of course the more correct thing to do.

## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/11443


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- Upload https://github.com/galaxyproject/galaxy/blob/dev/test-data/library/5.bed, check that the header is displayed

## For UI Components
- [x] I've included a screenshot of the changes
![Screenshot 2021-03-18 at 12 55 51](https://user-images.githubusercontent.com/6804901/111622287-46ce7f80-87e9-11eb-8e9c-2cf922685d93.png)

