### PR TITLE
sortable columns in Admin->Users

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -107,7 +107,7 @@ class UserListGrid(grids.Grid):
                        key="username",
                        attach_popup=False,
                        filterable="advanced"),
-        LastLoginColumn("Last Login", format=time_ago, key="update_time"),
+        LastLoginColumn("Last Login", format=time_ago),
         DiskUsageColumn("Disk Usage", key="disk_usage", attach_popup=False),
         StatusColumn("Status", attach_popup=False, key="deleted"),
         TimeCreatedColumn("Created", attach_popup=False, key="create_time"),
@@ -400,7 +400,7 @@ class QuotaListGrid(grids.Grid):
                      attach_popup=False),
         UsersColumn("Users", attach_popup=False),
         GroupsColumn("Groups", attach_popup=False),
-        StatusColumn("Status", attach_popup=False, key="deleted"),
+        StatusColumn("Status", attach_popup=False),
         # Columns that are valid for filtering but are not visible.
         grids.DeletedColumn("Deleted", key="deleted", visible=False, filterable="advanced")
     ]

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -107,14 +107,14 @@ class UserListGrid(grids.Grid):
                        key="username",
                        attach_popup=False,
                        filterable="advanced"),
-        LastLoginColumn("Last Login", format=time_ago),
+        LastLoginColumn("Last Login", format=time_ago, key="update_time"),
         DiskUsageColumn("Disk Usage", key="disk_usage", attach_popup=False),
-        StatusColumn("Status", attach_popup=False),
-        TimeCreatedColumn("Created", attach_popup=False),
-        ActivatedColumn("Activated", attach_popup=False),
+        StatusColumn("Status", attach_popup=False, key="deleted"),
+        TimeCreatedColumn("Created", attach_popup=False, key="create_time"),
+        ActivatedColumn("Activated", attach_popup=False, key="active"),
         GroupsColumn("Groups", attach_popup=False),
         RolesColumn("Roles", attach_popup=False),
-        ExternalColumn("External", attach_popup=False),
+        ExternalColumn("External", attach_popup=False, key="groups"),
         # Columns that are valid for filtering but are not visible.
         grids.DeletedColumn("Deleted", key="deleted", visible=False, filterable="advanced"),
         grids.PurgedColumn("Purged", key="purged", visible=False, filterable="advanced")
@@ -400,7 +400,7 @@ class QuotaListGrid(grids.Grid):
                      attach_popup=False),
         UsersColumn("Users", attach_popup=False),
         GroupsColumn("Groups", attach_popup=False),
-        StatusColumn("Status", attach_popup=False),
+        StatusColumn("Status", attach_popup=False, key="deleted"),
         # Columns that are valid for filtering but are not visible.
         grids.DeletedColumn("Deleted", key="deleted", visible=False, filterable="advanced")
     ]

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -114,7 +114,7 @@ class UserListGrid(grids.Grid):
         ActivatedColumn("Activated", attach_popup=False, key="active"),
         GroupsColumn("Groups", attach_popup=False),
         RolesColumn("Roles", attach_popup=False),
-        ExternalColumn("External", attach_popup=False, key="groups"),
+        ExternalColumn("External", attach_popup=False, key="external"),
         # Columns that are valid for filtering but are not visible.
         grids.DeletedColumn("Deleted", key="deleted", visible=False, filterable="advanced"),
         grids.PurgedColumn("Purged", key="purged", visible=False, filterable="advanced")


### PR DESCRIPTION
## What did you do? 
made a little more columns sortable in Admin->Users, specifically:

Created
Activated
External

## Why did you make this change?
We probably should (among many other things) rewrite this table, but for now that fixes https://github.com/galaxyproject/galaxy/issues/11656

## How to test the changes? 
  1. open Admin->Users
  2. try to sort columns

## For UI Components
- [x] I've included a screenshot of the changes
 



![image](https://user-images.githubusercontent.com/15801412/111624605-8fd80100-87f4-11eb-8b6b-8f2169537462.png)

