### PR TITLE
[21.01] Single User Mode - Disable irrelevant and broken options

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -35,19 +35,18 @@
         @show="open(tab, $event)"
     >
         <template v-for="(item, idx) in tab.menu">
-            <template v-if="item.hidden !== true">
-                <b-dropdown-item
-                    :href="formatUrl(item.url)"
-                    :key="`item-${idx}`"
-                    :target="item.target || '_parent'"
-                    role="menuitem"
-                    @click="open(item, $event)"
-                    :disabled="item.disabled === true"
-                >
-                    {{ item.title }}
-                </b-dropdown-item>
-                <div v-if="item.divider" class="dropdown-divider" :key="`divider-${idx}`" />
-            </template>
+            <div v-if="item.divider" class="dropdown-divider" :key="`divider-${idx}`" />
+            <b-dropdown-item
+                v-else-if="item.hidden !== true"
+                :href="formatUrl(item.url)"
+                :key="`item-${idx}`"
+                :target="item.target || '_parent'"
+                role="menuitem"
+                @click="open(item, $event)"
+                :disabled="item.disabled === true"
+            >
+                {{ item.title }}
+            </b-dropdown-item>
         </template>
     </b-nav-item-dropdown>
 </template>

--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -35,17 +35,19 @@
         @show="open(tab, $event)"
     >
         <template v-for="(item, idx) in tab.menu">
-            <b-dropdown-item
-                :href="formatUrl(item.url)"
-                :key="`item-${idx}`"
-                :target="item.target || '_parent'"
-                role="menuitem"
-                @click="open(item, $event)"
-                :disabled="item.disabled === true"
-            >
-                {{ item.title }}
-            </b-dropdown-item>
-            <div v-if="item.divider" class="dropdown-divider" :key="`divider-${idx}`" />
+            <template v-if="item.hidden !== true">
+                <b-dropdown-item
+                    :href="formatUrl(item.url)"
+                    :key="`item-${idx}`"
+                    :target="item.target || '_parent'"
+                    role="menuitem"
+                    @click="open(item, $event)"
+                    :disabled="item.disabled === true"
+                >
+                    {{ item.title }}
+                </b-dropdown-item>
+                <div v-if="item.divider" class="dropdown-divider" :key="`divider-${idx}`" />
+            </template>
         </template>
     </b-nav-item-dropdown>
 </template>

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -32,43 +32,43 @@
                 </div>
             </div>
         </b-row>
-        <b-row class="ml-3 mb-1">
-            <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
-            <div class="pref-content pr-1">
-                <a href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
-                <div class="form-text text-muted">
-                    Delete your account on this Galaxy server.
+        <ConfigProvider v-slot="{ config }">
+            <b-row v-if="!config.single_user" class="ml-3 mb-1">
+                <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
+                <div class="pref-content pr-1">
+                    <a href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
+                    <div class="form-text text-muted">Delete your account on this Galaxy server.</div>
+                    <b-modal
+                        id="modal-prevent-closing"
+                        centered
+                        ref="modal"
+                        title="Account Deletion"
+                        title-tag="h2"
+                        @show="resetModal"
+                        @hidden="resetModal"
+                        @ok="handleOk"
+                    >
+                        <p>
+                            <b-alert variant="danger" :show="showDeleteError">{{ deleteError }}</b-alert>
+                            <b>
+                                This action cannot be undone. Your account will be permanently deleted, along with the
+                                data contained in it.
+                            </b>
+                        </p>
+                        <b-form ref="form" @submit.prevent="handleSubmit">
+                            <b-form-group
+                                :state="nameState"
+                                label="Enter your user email for this account as confirmation."
+                                label-for="Email"
+                                invalid-feedback="Incorrect email"
+                            >
+                                <b-form-input id="name-input" v-model="name" :state="nameState" required></b-form-input>
+                            </b-form-group>
+                        </b-form>
+                    </b-modal>
                 </div>
-                <b-modal
-                    id="modal-prevent-closing"
-                    centered
-                    ref="modal"
-                    title="Account Deletion"
-                    title-tag="h2"
-                    @show="resetModal"
-                    @hidden="resetModal"
-                    @ok="handleOk"
-                >
-                    <p>
-                        <b-alert variant="danger" :show="showDeleteError">{{ deleteError }}</b-alert>
-                        <b>
-                            This action cannot be undone. Your account will be permanently deleted, along with the data
-                            contained in it.
-                        </b>
-                    </p>
-                    <b-form ref="form" @submit.prevent="handleSubmit">
-                        <b-form-group
-                            :state="nameState"
-                            label="Enter your user email for this account as confirmation."
-                            label-for="Email"
-                            invalid-feedback="Incorrect email"
-                        >
-                            <b-form-input id="name-input" v-model="name" :state="nameState" required></b-form-input>
-                        </b-form-group>
-                    </b-form>
-                </b-modal>
-            </div>
-        </b-row>
+            </b-row>
+        </ConfigProvider>
         <p class="mt-2">
             You are using <strong>{{ diskUsage }}</strong> of disk space in this Galaxy instance.
             <span v-html="quotaUsageString"></span>
@@ -88,6 +88,7 @@ import _l from "utils/localization";
 import axios from "axios";
 import QueryStringParsing from "utils/query-string-parsing";
 import { getUserPreferencesModel } from "components/User/UserPreferencesModel";
+import ConfigProvider from "components/providers/ConfigProvider";
 import { userLogoutAll, userLogoutClient } from "layout/menu";
 import "@fortawesome/fontawesome-svg-core";
 
@@ -103,6 +104,9 @@ export default {
             type: Boolean,
             required: true,
         },
+    },
+    components: {
+        ConfigProvider,
     },
     data() {
         return {

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -33,7 +33,7 @@
             </div>
         </b-row>
         <ConfigProvider v-slot="{ config }">
-            <b-row v-if="!config.single_user" class="ml-3 mb-1">
+            <b-row v-if="config && !config.single_user" class="ml-3 mb-1">
                 <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
                 <div class="pref-content pr-1">
                     <a href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -42,12 +42,14 @@ export const getUserPreferencesModel = () => {
             icon: "fa-users",
             submit_title: "Save Permissions",
             redirect: "user",
+            shouldRender: !config.single_user,
         },
         make_data_private: {
             title: _l("Make All Data Private"),
             id: "edit-preferences-make-data-private",
             description: _l("Click here to make all data private."),
             icon: "fa-lock",
+            shouldRender: !config.single_user,
         },
         api_key: {
             title: _l("Manage API Key"),

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -86,7 +86,7 @@ export const getUserPreferencesModel = () => {
             id: "edit-preferences-sign-out",
             description: _l("Click here to sign out of all sessions."),
             icon: "fa-sign-out",
-            shouldRender: !!Galaxy.session_csrf_token,
+            shouldRender: !!Galaxy.session_csrf_token && !config.single_user,
         },
     };
 };

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -115,38 +115,49 @@ export function fetchMenu(options = {}) {
     //
     // 'Shared Items' or Libraries tab.
     //
-    menu.push({
-        id: "shared",
-        title: _l("Shared Data"),
-        url: "javascript:void(0)",
-        tooltip: _l("Access published resources"),
-        menu: [
-            {
-                title: _l("Data Libraries"),
-                url: "library/list",
-            },
-            {
-                title: _l("Histories"),
-                url: "histories/list_published",
-                target: "__use_router__",
-            },
-            {
-                title: _l("Workflows"),
-                url: "workflows/list_published",
-                target: "__use_router__",
-            },
-            {
-                title: _l("Visualizations"),
-                url: "visualizations/list_published",
-                target: "__use_router__",
-            },
-            {
-                title: _l("Pages"),
-                url: "pages/list_published",
-                target: "__use_router__",
-            },
-        ],
-    });
+    if (Galaxy.config.single_user) {
+        // Single user can still use libraries, especially as we may grow that
+        // functionality as a representation for external data.  The rest is
+        // hidden though.
+        menu.push({
+            title: _l("Data Libraries"),
+            url: "library/list",
+            id: "libraries",
+        });
+    } else {
+        menu.push({
+            id: "shared",
+            title: _l("Shared Data"),
+            url: "javascript:void(0)",
+            tooltip: _l("Access published resources"),
+            menu: [
+                {
+                    title: _l("Data Libraries"),
+                    url: "library/list",
+                },
+                {
+                    title: _l("Histories"),
+                    url: "histories/list_published",
+                    target: "__use_router__",
+                },
+                {
+                    title: _l("Workflows"),
+                    url: "workflows/list_published",
+                    target: "__use_router__",
+                },
+                {
+                    title: _l("Visualizations"),
+                    url: "visualizations/list_published",
+                    target: "__use_router__",
+                },
+                {
+                    title: _l("Pages"),
+                    url: "pages/list_published",
+                    target: "__use_router__",
+                },
+            ],
+        });
+    }
 
     //
     // Admin.
@@ -292,6 +303,7 @@ export function fetchMenu(options = {}) {
                     title: _l("Histories shared with me"),
                     url: "histories/list_shared",
                     target: "__use_router__",
+                    hidden: Galaxy.config.single_user,
                 },
                 {
                     title: _l("Pages"),

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -272,10 +272,11 @@ export function fetchMenu(options = {}) {
                     url: "custom_builds",
                     target: "__use_router__",
                 },
+                { divider: true },
                 {
                     title: _l("Logout"),
-                    divider: true,
                     onclick: userLogout,
+                    hidden: Galaxy.config.single_user,
                 },
                 {
                     title: _l("Datasets"),
@@ -312,7 +313,7 @@ export function fetchMenu(options = {}) {
             });
         }
         if (Galaxy.config.interactivetools_enable) {
-            userTab.menu[userTab.menu.length - 1].divider = true;
+            userTab.menu.push({ divider: true });
             userTab.menu.push({
                 title: _l("Active InteractiveTools"),
                 url: "interactivetool_entry_points/list",
@@ -321,6 +322,5 @@ export function fetchMenu(options = {}) {
         }
     }
     menu.push(userTab);
-
     return menu;
 }

--- a/client/src/mvc/history/options-menu.js
+++ b/client/src/mvc/history/options-menu.js
@@ -56,6 +56,7 @@ var menu = [
                 Galaxy.router.push(`/histories/permissions?id=${Galaxy.currHistoryPanel.model.id}`);
             }
         },
+        singleUserDisable: true,
     },
     {
         html: _l("Make Private"),

--- a/client/src/mvc/history/options-menu.js
+++ b/client/src/mvc/history/options-menu.js
@@ -32,6 +32,7 @@ var menu = [
                 Galaxy.router.push(`/histories/sharing?id=${Galaxy.currHistoryPanel.model.id}`);
             }
         },
+        singleUserDisable: true,
     },
     {
         html: _l("Show Structure"),
@@ -200,7 +201,11 @@ Webhooks.load({
 });
 
 function buildMenu(isAnon, purgeAllowed, urlRoot) {
+    const Galaxy = getGalaxyInstance();
     return _.clone(menu).filter((menuOption) => {
+        if (Galaxy.config.single_user && menuOption.singleUserDisable) {
+            return false;
+        }
         if (isAnon && !menuOption.anon) {
             return false;
         }

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -38,6 +38,9 @@ class ConfigSerializer(base.ModelSerializer):
             assert hasattr(config, key)
             return getattr(config, key)
 
+        def _config_is_truthy(config, key, **context):
+            return True if config.get(key) else False
+
         self.serializers = {
             # TODO: this is available from user data, remove
             'is_admin_user'                     : lambda *a, **c: False,
@@ -67,7 +70,7 @@ class ConfigSerializer(base.ModelSerializer):
             'allow_user_impersonation'          : _use_config,
             'allow_user_creation'               : _defaults_to(False),  # schema default is True
             'use_remote_user'                   : _defaults_to(None),  # schema default is False; or config.single_user
-            'single_user'                       : lambda config, key, **context: True if config.get(key) else False,
+            'single_user'                       : _config_is_truthy,
             'enable_oidc'                       : _use_config,
             'oidc'                              : _use_config,
             'enable_quotas'                     : _use_config,

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -67,6 +67,7 @@ class ConfigSerializer(base.ModelSerializer):
             'allow_user_impersonation'          : _use_config,
             'allow_user_creation'               : _defaults_to(False),  # schema default is True
             'use_remote_user'                   : _defaults_to(None),  # schema default is False; or config.single_user
+            'single_user'                       : lambda config, key, **context: True if config.get(key) else False,
             'enable_oidc'                       : _use_config,
             'oidc'                              : _use_config,
             'enable_quotas'                     : _use_config,


### PR DESCRIPTION
## What did you do? 
- Assorted enhancements to generally hide interface options that are either broken or pointless in single user mode.

## Why did you make this change?
- #11413 


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. set `single_user` in galaxy.yml; observe UI and note 'sharing' and other options are gone.  Also, please look for things I missed that still don't make sense.

## For UI Components
- [x] I've included a screenshot of the changes

![image](https://user-images.githubusercontent.com/155398/111629917-2b9f4800-87c8-11eb-9977-10eeb5ed08f2.png)

