### PR TITLE
[21.01] Fix workflow rename dropping metadata. 

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4996,6 +4996,8 @@ class Workflow(Dictifiable, RepresentById):
         copied_workflow.has_cycles = self.has_cycles
         copied_workflow.has_errors = self.has_errors
         copied_workflow.reports_config = self.reports_config
+        copied_workflow.license = self.license
+        copied_workflow.creator_metadata = self.creator_metadata
 
         # Map old step ids to new steps
         step_mapping = {}

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -472,6 +472,23 @@ class WorkflowsApiTestCase(BaseWorkflowsApiTestCase, ChangeDatatypeTestCase):
         update_response = self._update_workflow(workflow['id'], workflow).json()
         assert update_response['tags'] == []
 
+    def test_update_name(self):
+        original_name = "test update name"
+        workflow_object = self.workflow_populator.load_workflow(name=original_name)
+        workflow_object["license"] = "AAL"
+        upload_response = self.__test_upload(workflow=workflow_object, name=original_name)
+        workflow = upload_response.json()
+        workflow_id = workflow['id']
+        assert workflow['name'] == original_name
+        workflow_dict = self.workflow_populator.download_workflow(workflow_id)
+        assert workflow_dict["license"] == "AAL"
+
+        data = {"name": "my cool new name"}
+        update_response = self._update_workflow(workflow['id'], data).json()
+        assert update_response['name'] == "my cool new name"
+        workflow_dict = self.workflow_populator.download_workflow(workflow_id)
+        assert workflow_dict["license"] == "AAL"
+
     def test_refactor(self):
         workflow_id = self.workflow_populator.upload_yaml_workflow("""
 class: GalaxyWorkflow


### PR DESCRIPTION
## What did you do? 
- Preserved metadata for author and license when doing a workflow model copy.

## Why did you make this change?

xref https://github.com/galaxyproject/galaxy/issues/11668

## How to test the changes? 

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

