### PR TITLE
Avoid appending imported source on workflow name multiple times.

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -361,8 +361,9 @@ class WorkflowContentsManager(UsesAnnotations):
             raise exceptions.RequestParameterInvalidException(f"Invalid workflow format detected [{data}]")
 
         workflow_input_name = data['name']
-        if source:
-            name = f"{workflow_input_name} (imported from {source})"
+        imported_sufix = f"(imported from {source})"
+        if source and imported_sufix not in workflow_input_name:
+            name = f"{workflow_input_name} {imported_sufix}"
         else:
             name = workflow_input_name
         workflow, missing_tool_tups = self._workflow_from_raw_description(


### PR DESCRIPTION
## What did you do? 
Avoid appending `imported form <source>` to the imported workflow name if it is already there. But if the `source` is different it may be appended.

Happy to hear other suggestions here on how to deal with the imported name.

## Why did you make this change?
This addresses #10931


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. Download a workflow file.
  2. Import the workflow file you just downloaded.
  3. Repeat from 1. with the imported workflow.
  4. Observe the `imported form <source>` on the name will not be appended more than once.
