### PR TITLE
Swap 'Analyze Data' to home icon

### DIFF
--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -71,7 +71,7 @@ export function fetchMenu(options = {}) {
     menu.push({
         id: "analysis",
         url: "",
-        tooltip: _l("Analysis home view"),
+        tooltip: _l("Tools and Current History"),
         icon: "fa-home",
     });
     //

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -70,7 +70,6 @@ export function fetchMenu(options = {}) {
     //
     menu.push({
         id: "analysis",
-        title: _l("Analyze Data"),
         url: "",
         tooltip: _l("Analysis home view"),
         icon: "fa-home",

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -73,8 +73,8 @@ export function fetchMenu(options = {}) {
         title: _l("Analyze Data"),
         url: "",
         tooltip: _l("Analysis home view"),
+        icon: "fa-home",
     });
-
     //
     // Workflow tab.
     //

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -360,7 +360,7 @@ body {
                     color: $brand-masthead-text-hover;
                 }
                 &.nav-icon {
-                    font-size: 1.7em;
+                    font-size: 1.3em;
                     .nav-note {
                         @extend .font-weight-bold;
                         @extend .position-absolute;


### PR DESCRIPTION
## What did you do? 
- Swap analyze data to a home icon.
- Make masthead icons somewhat smaller, more consistent with the existing text line height (I think this looks much better)


## Why did you make this change?
#11666 


## How to test the changes? 

- [x] This is a refactoring of components with existing test coverage.


## For UI Components
- [x] I've included a screenshot of the changes

![image](https://user-images.githubusercontent.com/155398/111661424-64014f00-87e5-11eb-9b41-b86bcb2f989d.png)

WIP for a sec while I tinker with spacing and doublecheck selenium tests aren't looking for Analyze Data.