### PR TITLE
also auto install mulled containers

### DIFF
--- a/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/mulled.py
@@ -460,7 +460,7 @@ class MulledDockerContainerResolver(CliContainerResolver):
                 shell=self.shell,
             )
             if self.can_list_containers:
-                if install and not self.cached_container_description(
+                if (install or self.auto_install) and not self.cached_container_description(
                         targets,
                         namespace=self.namespace,
                         hash_func=self.hash_func,


### PR DESCRIPTION


## What did you do? 

mulled containers are currently pulled only if `install=True`, but they should be pulled if `auto_install=True`

## Why did you make this change?

https://gitter.im/galaxyproject/dev?at=6053720633346c16275e5079

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

No idea, @mvdbeek indicated on gitter that there may be tests already.

## For UI Components
- [ ] I've included a screenshot of the changes
