### PR TITLE
[21.01] Use Modal to show wrong RuntimeValue

### DIFF
--- a/client/src/mvc/tool/tool-form-composite.js
+++ b/client/src/mvc/tool/tool-form-composite.js
@@ -357,6 +357,19 @@ var View = Backbone.View.extend({
                             (!input_def.is_workflow && input_value !== null);
                     }
                     if (!validated) {
+                        if (input_def.type == "hidden") {
+                            this.modal.show({
+                                title: _l("Workflow submission failed"),
+                                body: `Step ${step_index}: ${
+                                    step.step_label || step.step_name
+                                } is in an invalid state. Please remove and re-add this step in the Workflow Editor.`,
+                                buttons: {
+                                    Close: () => {
+                                        this.modal.hide();
+                                    },
+                                },
+                            });
+                        }
                         form.highlight(input_id);
                         break;
                     }

--- a/lib/galaxy/tools/parameters/__init__.py
+++ b/lib/galaxy/tools/parameters/__init__.py
@@ -9,7 +9,14 @@ from boltons.iterutils import remap
 from galaxy.util import unicodify
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.json import safe_loads
-from .basic import DataCollectionToolParameter, DataToolParameter, is_runtime_value, runtime_to_json, SelectToolParameter
+from .basic import (
+    DataCollectionToolParameter,
+    DataToolParameter,
+    is_runtime_value,
+    ParameterValueError,
+    runtime_to_json,
+    SelectToolParameter,
+)
 from .grouping import Conditional, Repeat, Section, UploadDataset
 
 REPLACE_ON_TRUTHY = object()
@@ -221,7 +228,10 @@ def params_from_strings(params, param_values, app, ignore_errors=False):
     for key, value in param_values.items():
         value = safe_loads(value)
         if key in params:
-            value = params[key].value_from_basic(value, app, ignore_errors)
+            try:
+                value = params[key].value_from_basic(value, app, ignore_errors)
+            except ParameterValueError:
+                continue
         rval[key] = value
     return rval
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -209,6 +209,8 @@ class ToolParameter(Dictifiable):
     def value_from_basic(self, value, app, ignore_errors=False):
         # Handle Runtime and Unvalidated values
         if is_runtime_value(value):
+            if isinstance(self, HiddenToolParameter):
+                raise ParameterValueError(message_suffix='Runtime Parameter not valid', parameter_name=self.name)
             return runtime_to_object(value)
         elif isinstance(value, dict) and value.get('__class__') == 'UnvalidatedValue':
             return value['value']


### PR DESCRIPTION
Since these parameters are not visible just highlighting them won't cut
it.

If a user is unlucky enough to have defined a workflow on a server that ran on a commit between https://github.com/galaxyproject/galaxy/pull/11602 and https://github.com/galaxyproject/galaxy/pull/11652 this should at least point them in the right direction. I will also look into a linter and/or fixing this automatically by verifying the tool state.