### PR TITLE
Ensure new outputs have correct mapOver state

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -248,6 +248,9 @@ export default {
             delete this.inputTerminals[input.name];
         },
         onAddOutput(output, terminal) {
+            if (this.mapOver) {
+                terminal.setMapOver(this.mapOver);
+            }
             this.outputTerminals[output.name] = terminal;
         },
         onRemoveOutput(output) {

--- a/client/src/components/Workflow/Editor/modules/terminals.js
+++ b/client/src/components/Workflow/Editor/modules/terminals.js
@@ -157,6 +157,7 @@ class Terminal extends EventEmitter {
         }
         if (!this.mapOver.equal(val)) {
             this.mapOver = val;
+            this.node.mapOver = output_val;
             Object.values(this.node.outputTerminals).forEach((outputTerminal) => {
                 outputTerminal.setMapOver(output_val);
             });


### PR DESCRIPTION
by storing the effective mapOver state on the node.


## What did you do? 
- Maintain map over status on the node and apply it when adding new outputs (via conditionals, repeats or filter)


## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/10778


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Create workflows with varying levels of mapping over, and verify that adding outputs through tool options results in the correct noodle type

## For UI Components
- [ ] I've included a screenshot of the changes
