### PR TITLE
Refactor library folder contents api

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -44,30 +44,25 @@ class FolderContentsAPIView(UsesLibraryMixinItems):
 
     def index(self, trans, folder_id, limit=None, offset=None, search_text=None, include_deleted=False):
         """
-        Displays a collection (list) of a folder's contents
-        (files and folders). Encoded folder ID is prepended
-        with 'F' if it is a folder as opposed to a data set
-        which does not have it. Full path is provided in
-        response as a separate object providing data for
-        breadcrumb path building.
+        Displays a collection (list) of a folder's contents (files and folders). Encoded folder ID is prepended
+        with 'F' if it is a folder as opposed to a data set which does not have it. Full path is provided in
+        response as a separate object providing data for breadcrumb path building.
 
         ..example:
             limit and offset can be combined. Skip the first two and return five:
-                '?limit=3&offset=5'
+                '?offset=2&limit=5'
 
-        :param  folder_id: encoded ID of the folder which
-            contents should be library_dataset_dict
+        :param  folder_id: encoded ID of the folder which contents should be library_dataset_dict
         :type   folder_id: encoded string
 
-        :param  offset: offset for returned library folder datasets
-        :type   folder_id: encoded string
+        :param  offset: number of folder contents to skip
+        :type   offset: optional int
 
-        :param  limit: limit   for returned library folder datasets
-            contents should be library_dataset_dict
-        :type   folder_id: encoded string
+        :param  limit: maximum number of folder contents to return
+        :type   limit: optional int
 
-        :param kwd: keyword dictionary with other params
-        :type  kwd: dict
+        :param  include_deleted: whether to include deleted items in the results
+        :type   include_deleted: optional bool (default False)
 
         :returns: dictionary containing all items and metadata
         :type:    dict
@@ -231,8 +226,7 @@ class FolderContentsAPIView(UsesLibraryMixinItems):
 
     def __decode_library_content_id(self, trans, encoded_folder_id):
         """
-        Identify whether the id provided is properly encoded
-        LibraryFolder.
+        Identify whether the id provided is properly encoded LibraryFolder.
 
         :param  encoded_folder_id:  encoded id of Galaxy LibraryFolder
         :type   encoded_folder_id:  encoded string

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -430,17 +430,3 @@ class FolderContentsController(BaseGalaxyAPIController):
             InternalServerError
         """
         return self.view.create(trans, encoded_folder_id, payload)
-
-    @expose_api
-    def show(self, trans, id, library_id, **kwd):
-        """
-        GET /api/folders/{encoded_folder_id}/
-        """
-        raise exceptions.NotImplemented('Showing the library folder content is not implemented here.')
-
-    @expose_api
-    def update(self, trans, id, library_id, payload, **kwd):
-        """
-        PUT /api/folders/{encoded_folder_id}/contents
-        """
-        raise exceptions.NotImplemented('Updating the library folder content is not implemented here.')

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -11,9 +11,6 @@ from galaxy_test.base.populators import (
 )
 from ._framework import ApiTestCase
 
-OWNNER_USER = 'owner@user.com'
-ANOTHER_USER = 'another@user.com'
-
 
 class FolderContentsApiTestCase(ApiTestCase):
 
@@ -141,8 +138,6 @@ class FolderContentsApiTestCase(ApiTestCase):
             assert len(contents) == len(matching_names)
 
     def test_index_permissions_include_deleted(self):
-        self._setup_user(ANOTHER_USER)
-        self._setup_user(OWNNER_USER)
 
         folder_name = "Test Folder Contents Index permissions include deteleted"
         folder_id = self._create_folder_in_library(folder_name)
@@ -195,12 +190,12 @@ class FolderContentsApiTestCase(ApiTestCase):
         assert len(contents) == num_total_contents
 
         # Users with access but no modify permission can't see deleted
-        with self._different_user(ANOTHER_USER):
+        with self._different_user():
             different_user_role_id = self.dataset_populator.user_private_role_id()
 
         self._allow_library_access_to_user_role(different_user_role_id)
 
-        with self._different_user(ANOTHER_USER):
+        with self._different_user():
             response = self._get(f"folders/{folder_id}/contents?include_deleted={include_deleted}")
             self._assert_status_code_is(response, 200)
             contents = response.json()["folder_contents"]

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -11,6 +11,9 @@ from galaxy_test.base.populators import (
 )
 from ._framework import ApiTestCase
 
+OWNNER_USER = 'owner@user.com'
+ANOTHER_USER = 'another@user.com'
+
 
 class FolderContentsApiTestCase(ApiTestCase):
 
@@ -22,8 +25,7 @@ class FolderContentsApiTestCase(ApiTestCase):
 
         self.history_id = self.dataset_populator.new_history()
         self.library = self.library_populator.new_private_library("FolderContentsTestsLibrary")
-        self.root_folder = self._create_folder_in_library("Test Folder Contents")
-        self.root_folder_id = self.root_folder["id"]
+        self.root_folder_id = self._create_folder_in_library("Test Folder Contents")
 
     def test_create_hda_with_ldda_message(self):
         hda_id = self._create_hda()
@@ -47,8 +49,7 @@ class FolderContentsApiTestCase(ApiTestCase):
         assert len(contents) == len(lddas)
 
     def test_index(self):
-        folder = self._create_folder_in_library("Test Folder Contents Index")
-        folder_id = folder["id"]
+        folder_id = self._create_folder_in_library("Test Folder Contents Index")
 
         self._create_dataset_in_folder(folder_id)
 
@@ -59,8 +60,7 @@ class FolderContentsApiTestCase(ApiTestCase):
 
     def test_index_include_deleted(self):
         folder_name = "Test Folder Contents Index include deleted"
-        folder = self._create_folder_in_library(folder_name)
-        folder_id = folder["id"]
+        folder_id = self._create_folder_in_library(folder_name)
 
         hda_id = self._create_dataset_in_folder(folder_id)
         self._delete_library_dataset(hda_id)
@@ -79,8 +79,7 @@ class FolderContentsApiTestCase(ApiTestCase):
 
     def test_index_limit_offset(self):
         folder_name = "Test Folder Contents Index limit"
-        folder = self._create_folder_in_library(folder_name)
-        folder_id = folder["id"]
+        folder_id = self._create_folder_in_library(folder_name)
 
         num_subfolders = 5
         for index in range(num_subfolders):
@@ -121,8 +120,7 @@ class FolderContentsApiTestCase(ApiTestCase):
 
     def test_index_search_text(self):
         folder_name = "Test Folder Contents Index search text"
-        folder = self._create_folder_in_library(folder_name)
-        folder_id = folder["id"]
+        folder_id = self._create_folder_in_library(folder_name)
 
         dataset_names = ["AB", "BC", "ABC"]
         for name in dataset_names:
@@ -142,11 +140,77 @@ class FolderContentsApiTestCase(ApiTestCase):
             matching_names = [name for name in all_names if search_text in name]
             assert len(contents) == len(matching_names)
 
+    def test_index_permissions_include_deleted(self):
+        self._setup_user(ANOTHER_USER)
+        self._setup_user(OWNNER_USER)
+
+        folder_name = "Test Folder Contents Index permissions include deteleted"
+        folder_id = self._create_folder_in_library(folder_name)
+
+        num_subfolders = 5
+        subfolder_ids: List[str] = []
+        deleted_subfolder_ids: List[str] = []
+        for index in range(num_subfolders):
+            id = self._create_subfolder_in(folder_id, name=f"Folder_{index}")
+            subfolder_ids.append(id)
+
+        for index, subfolder_id in enumerate(subfolder_ids):
+            if index % 2 == 0:
+                self._delete_subfolder(subfolder_id)
+                deleted_subfolder_ids.append(subfolder_id)
+
+        num_datasets = 5
+        datasets_ids: List[str] = []
+        deleted_datasets_ids: List[str] = []
+        for _ in range(num_datasets):
+            id = self._create_dataset_in_folder(folder_id)
+            datasets_ids.append(id)
+
+        for index, ldda_id in enumerate(datasets_ids):
+            if index % 2 == 0:
+                self._delete_library_dataset(ldda_id)
+                deleted_datasets_ids.append(ldda_id)
+
+        num_total_contents = num_subfolders + num_datasets
+        num_non_deleted = num_total_contents - len(deleted_subfolder_ids) - len(deleted_datasets_ids)
+
+        # Verify deleted contents are not listed
+        include_deleted = False
+        response = self._get(f"folders/{folder_id}/contents?include_deleted={include_deleted}")
+        self._assert_status_code_is(response, 200)
+        contents = response.json()["folder_contents"]
+        assert len(contents) == num_non_deleted
+
+        include_deleted = True
+        # Admins can see everything...
+        response = self._get(f"folders/{folder_id}/contents?include_deleted={include_deleted}", admin=True)
+        self._assert_status_code_is(response, 200)
+        contents = response.json()["folder_contents"]
+        assert len(contents) == num_total_contents
+
+        # Owner can see everything too
+        response = self._get(f"folders/{folder_id}/contents?include_deleted={include_deleted}")
+        self._assert_status_code_is(response, 200)
+        contents = response.json()["folder_contents"]
+        assert len(contents) == num_total_contents
+
+        # Users with access but no modify permission can't see deleted
+        with self._different_user(ANOTHER_USER):
+            different_user_role_id = self.dataset_populator.user_private_role_id()
+
+        self._allow_library_access_to_user_role(different_user_role_id)
+
+        with self._different_user(ANOTHER_USER):
+            response = self._get(f"folders/{folder_id}/contents?include_deleted={include_deleted}")
+            self._assert_status_code_is(response, 200)
+            contents = response.json()["folder_contents"]
+            assert len(contents) == num_non_deleted
+
     def _create_folder_in_library(self, name: str) -> Any:
         root_folder_id = self.library["root_folder_id"]
         return self._create_subfolder_in(root_folder_id, name)
 
-    def _create_subfolder_in(self, folder_id: str, name: str) -> Any:
+    def _create_subfolder_in(self, folder_id: str, name: str) -> str:
         data = {
             "name": name,
             "description": f"The description of {name}",
@@ -154,7 +218,7 @@ class FolderContentsApiTestCase(ApiTestCase):
         create_response = self._post(f"folders/{folder_id}", data=data)
         self._assert_status_code_is(create_response, 200)
         folder = create_response.json()
-        return folder
+        return folder["id"]
 
     def _create_dataset_in_folder(self, folder_id: str, name: Optional[str] = None) -> str:
         hda_id = self._create_hda(name)
@@ -180,5 +244,18 @@ class FolderContentsApiTestCase(ApiTestCase):
         return hdca_id
 
     def _delete_library_dataset(self, ldda_id: str) -> None:
-        delete_response = self._delete(f"libraries/datasets/{ldda_id}", admin=True)
+        delete_response = self._delete(f"libraries/datasets/{ldda_id}")
         self._assert_status_code_is(delete_response, 200)
+
+    def _delete_subfolder(self, folder_id: str) -> None:
+        delete_response = self._delete(f"folders/{folder_id}")
+        self._assert_status_code_is(delete_response, 200)
+
+    def _allow_library_access_to_user_role(self, role_id: str):
+        library_id = self.library["id"]
+        action = "set_permissions"
+        data = {
+            "access_ids[]": role_id,
+        }
+        response = self._post(f"libraries/{library_id}/permissions?action={action}", data=data, admin=True)
+        self._assert_status_code_is(response, 200)


### PR DESCRIPTION
## What did you do? 
- Refactor the `folder_contents` controller logic to simplify it a bit.
- Add more tests for the access permission when including deleted items.
- Move the legacy controller logic to a `FolderContentsAPIView` class that will be shared with the future FastAPI controller.

### Additional details
This time, instead of creating a corresponding `FolderContentsManager` in `lib/galaxy/managers/folder_contents.py`, I have tried a new approach creating the analogous [FolderContentsAPIView](https://github.com/galaxyproject/galaxy/compare/dev...davelopez:refactor_library_folder_contents_api?expand=1#diff-4d8a61dd287e53dffb1e6cc4fd5f8986674b61782a45b95ff85d43c4c08c5d68R29) class beside the legacy controller to keep the UsesLibraryMixinItems until it can be removed. I didn't want to remove it yet since is used across various places and will require much more changes.
Anyway, I'm still struggling a bit with how to layout managers, controllers, views, etc. so any advice or recommendations are really appreciated :)

## Why did you make this change?
This is part of the efforts to migrate the existing API to FastAPI in relatively small steps.


## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
