### PR TITLE
[21.01] Expose command line if expose_dataset_path is set

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -387,6 +387,8 @@ class JobSearch:
 def view_show_job(trans, job, full: bool) -> typing.Dict:
     is_admin = trans.user_is_admin
     job_dict = trans.app.security.encode_all_ids(job.to_dict('element', system_details=is_admin), True)
+    if trans.app.config.expose_dataset_path and 'command_line' not in job_dict:
+        job_dict['command_line'] = job.command_line
     if full:
         job_dict.update(dict(
             tool_stdout=job.tool_stdout,

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -38,7 +38,7 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
         self.__history_with_new_dataset(history_id)
         jobs = self.__jobs_index(admin=False)
         job = jobs[0]
-        self._assert_not_has_keys(job, "command_line", "external_id")
+        self._assert_not_has_keys(job, "external_id")
 
         jobs = self.__jobs_index(admin=True)
         job = jobs[0]
@@ -142,7 +142,7 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
         assert not job_lock_response.json()["active"]
 
         show_jobs_response = self._get("jobs/%s" % job_id, admin=False)
-        self._assert_not_has_keys(show_jobs_response.json(), "command_line", "external_id")
+        self._assert_not_has_keys(show_jobs_response.json(), "external_id")
 
         # TODO: Re-activate test case when API accepts privacy settings
         # with self._different_user():


### PR DESCRIPTION
## What did you do? 
This restores what templates/show_params.mako used to do prior to https://github.com/galaxyproject/galaxy/pull/10980/

## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/11651

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] Instructions for manual testing are as follows:
Set up an instance with expose_dataset_path and check that you can see the command line when looking at any of the job info pages.
