### PR TITLE
[21.01] Fix displaying data column parameters in workflow editor

### DIFF
--- a/client/src/mvc/form/form-parameters.js
+++ b/client/src/mvc/form/form-parameters.js
@@ -141,7 +141,10 @@ export default Backbone.Model.extend({
     /** Text input field */
     _fieldText: function (input_def) {
         // field replaces e.g. a select field
-        if (input_def.model_class === "SelectTagParameter" || (input_def.options && input_def.data)) {
+        if (
+            ["SelectTagParameter", "ColumnListParameter"].includes(input_def.model_class) ||
+            (input_def.options && input_def.data)
+        ) {
             input_def.area = input_def.multiple;
             if (Utils.isEmpty(input_def.value)) {
                 input_def.value = null;

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -360,6 +360,7 @@ tool_form:
     options: '#options [data-toggle="dropdown"]'
     execute: 'button#execute'
     parameter_div: 'div.ui-form-element[tour_id="${parameter}"]'
+    parameter_textarea: 'div.ui-form-element[tour_id="${parameter}"] textarea'
     reference: '.formatted-reference'
     about: '.tool-footer'
 

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -138,6 +138,34 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         self.screenshot("workflow_editor_data_collection_input_deleted")
 
     @selenium_test
+    def test_data_column_input_editing(self):
+        self.open_in_workflow_editor("""
+class: GalaxyWorkflow
+steps:
+  column_param_list:
+    tool_id: column_param_list
+    state:
+      col: ["1","2","3"]
+      col_names: ["a", "b", "c"]
+      """)
+        editor = self.components.workflow_editor
+        node = editor.node._(label="column_param_list")
+        node.title.wait_for_and_click()
+        columns = self.components.tool_form.parameter_textarea(parameter='col')
+        textarea_columns = columns.wait_for_visible()
+        assert textarea_columns.get_attribute('value') == '1\n2\n3\n'
+        column_names = self.components.tool_form.parameter_textarea(parameter='col_names')
+        textarea_column_names = column_names.wait_for_visible()
+        assert textarea_column_names.get_attribute('value') == 'a\nb\nc\n'
+        self.set_text_element(columns, '4\n5\n6\n')
+        self.assert_has_changes_and_save()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.driver.refresh()
+        node.title.wait_for_and_click()
+        textarea_columns = columns.wait_for_visible()
+        assert textarea_columns.get_attribute('value') == '4\n5\n6\n'
+
+    @selenium_test
     def test_integer_input(self):
         editor = self.components.workflow_editor
 

--- a/test/functional/tools/column_param_list.xml
+++ b/test/functional/tools/column_param_list.xml
@@ -30,21 +30,5 @@ echo "col_names $col_names" >> '$output2'
                 </assert_contents>
             </output>
         </test>
-        <!-- test if non tabular data also creates entries by using the default
-            value (which is the 1st column, but empty if filling the options fails) -->
-        <test>
-            <param name="input1" value="1.bed" />
-            <output name="output1">
-                <assert_contents>
-                    <has_line line="chr1" />
-                </assert_contents>
-            </output>
-            <output name="output2">
-                <assert_contents>
-                    <has_line line="col 1" />
-                    <has_line line="col_names 1" />
-                </assert_contents>
-            </output>
-        </test>
     </tests>
 </tool>

--- a/test/functional/tools/column_param_list.xml
+++ b/test/functional/tools/column_param_list.xml
@@ -6,8 +6,8 @@ echo "col_names $col_names" >> '$output2'
     ]]></command>
     <inputs>
         <param name="input1" type="data" format="tabular" label="Input 1" />
-        <param name="col" type="data_column" multiple="true" value="1" data_ref="input1" label="Column to Use" />
-        <param name="col_names" type="data_column" data_ref="input1" use_header_names="true" label="Column to Use" />
+        <param name="col" type="data_column" multiple="true" value="1" data_ref="input1" label="Columns to use" />
+        <param name="col_names" type="data_column" multiple="true" data_ref="input1" use_header_names="true" label="Column names to use" />
     </inputs>
     <outputs>
         <data name="output1" format="tabular" />


### PR DESCRIPTION
## What did you do? 
- Add DataColumnListParameter to model_class that should be displayed as a text field

## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/11672

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## For UI Components
- [x] I've included a screenshot of the changes
<img width="287" alt="Screenshot 2021-03-19 at 19 12 40" src="https://user-images.githubusercontent.com/6804901/111824914-18cf6500-88e7-11eb-9ac5-6a03591c5e6c.png">
