### PR TITLE
[21.01] add meryldb datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -266,6 +266,7 @@
     <datatype extension="mztab2" type="galaxy.datatypes.proteomics:MzTab2" display_in_upload="true"/>
     <datatype extension="mzml" type="galaxy.datatypes.proteomics:MzML" mimetype="application/xml" display_in_upload="true"/>
     <datatype extension="nmrml" type="galaxy.datatypes.proteomics:NmrML" mimetype="application/xml" display_in_upload="true" description="nmrML is an open mark-up language for NMR data." description_url="http://nmrml.org/schema/"/>
+    <datatype extension="meryldb" type="galaxy.datatypes.binary:Binary" subclass="true" display_in_upload="true" description="MerylDB is a tar.gz archive containing 64 binaries + 64 indexes."/>
     <datatype extension="mgf" type="galaxy.datatypes.proteomics:Mgf" display_in_upload="true"/>
     <datatype extension="wiff" type="galaxy.datatypes.proteomics:Wiff" display_in_upload="true"/>
     <datatype extension="mzxml" type="galaxy.datatypes.proteomics:MzXML" mimetype="application/xml" display_in_upload="true"/>


### PR DESCRIPTION
## What did you do? 

This adds a new datatype called `meryldb`. MerylDB is a tar.gz containing 128 files, 64 binaries + 64 indexes.


## Why did you make this change?

This is needed for the tool meryl and mercury - both needed inside the VGP workflows.


## How to test the changes? 

* develop/test look at the upcoming meryl tool :)
