### PR TITLE
Replace sqlalchemy-utilities with local implementation

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -29,6 +29,7 @@ from galaxy.config.schema import AppSchema
 from galaxy.containers import parse_containers_config
 from galaxy.exceptions import ConfigurationError
 from galaxy.model import mapping
+from galaxy.model.database_utils import database_exists
 from galaxy.model.tool_shed_install.migrate.check import create_or_verify_database as tsi_create_or_verify_database
 from galaxy.util import (
     ExecutionTimer,
@@ -1270,7 +1271,6 @@ class ConfiguresGalaxyMixin:
             signal.signal(sig, handler)
 
     def _wait_for_database(self, url):
-        from sqlalchemy_utils import database_exists
         attempts = self.config.database_wait_attempts
         pause = self.config.database_wait_sleep
         for i in range(1, attempts):

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -214,7 +214,6 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy-utils==0.36.7
 sqlalchemy==1.3.23; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -169,7 +169,6 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy-utils==0.36.7
 sqlalchemy==1.3.23; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -83,13 +83,19 @@ class SqliteDatabaseManager(DatabaseManager):
         self.database = self.url.database  # use database from db_url
 
     def exists(self):
-        try:
-            sqlite3.connect(f'file:{self.url.database}?mode=ro', uri=True)
-        except sqlite3.OperationalError:
-            return False
-        else:
-            return True
 
-    def create(self, encoding, template):
-        # Don't use encoding and template for sqlite
+        def can_connect_to_dbfile():
+            try:
+                sqlite3.connect(f'file:{db}?mode=ro', uri=True)
+            except sqlite3.OperationalError:
+                return False
+            else:
+                return True
+
+        db = self.url.database
+        # No database or ':memory:' creates an in-memory database
+        return not db or db == ':memory:' or can_connect_to_dbfile()
+
+    def create(self, *args):
+        # Ignore any args (encoding, template)
         sqlite3.connect(f'file:{self.url.database}', uri=True)

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -40,7 +40,7 @@ class DatabaseManager:
 
     @staticmethod
     def make_manager(db_url, database):
-        if db_url.startswith('postgresql'):
+        if db_url.startswith('postgres'):
             return PosgresDatabaseManager(db_url, database)
         elif db_url.startswith('sqlite'):
             return SqliteDatabaseManager(db_url, database)

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -3,7 +3,7 @@ import sqlite3
 from sqlalchemy import create_engine
 from sqlalchemy.sql.expression import text
 from sqlalchemy.sql.compiler import IdentifierPreparer
-from sqlalchemy.engine import make_url
+from sqlalchemy.engine.url import make_url
 
 from contextlib import contextmanager
 
@@ -59,7 +59,7 @@ class PosgresDatabaseManager(DatabaseManager):
 
     def _handle_no_database(self):
         self.database = self.url.database  # use database from db_url
-        self.url = self.url.set(database='postgres')  # use default database to connect
+        self.url.database = 'postgres'
 
     def exists(self):
         with sqlalchemy_engine(self.url) as engine:

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -1,0 +1,96 @@
+import sqlite3
+
+from sqlalchemy import create_engine
+from sqlalchemy.sql.expression import text
+from sqlalchemy.sql.compiler import IdentifierPreparer
+from sqlalchemy.engine import make_url
+
+from contextlib import contextmanager
+
+from galaxy.exceptions import ConfigurationError
+
+
+def database_exists(db_url, database=None):
+    """Check if database exists; connect with db_url.
+
+    If database is None, use the database name from db_url.
+    """
+    dbm = DatabaseManager.make_manager(db_url, database)
+    return dbm.exists()
+
+
+def create_database(db_url, database=None, encoding='utf8', template=None):
+    """Create database; connect with db_url.
+
+    If database is None, use the database name from db_url.
+    """
+    dbm = DatabaseManager.make_manager(db_url, database)
+    dbm.create(encoding, template)
+
+
+@contextmanager
+def sqlalchemy_engine(url):
+    engine = create_engine(url)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+class DatabaseManager:
+
+    @staticmethod
+    def make_manager(db_url, database):
+        if db_url.startswith('postgresql'):
+            return PosgresDatabaseManager(db_url, database)
+        elif db_url.startswith('sqlite'):
+            return SqliteDatabaseManager(db_url, database)
+        else:
+            raise ConfigurationError(f'Invalid database URL: {db_url}')
+
+    def __init__(self, db_url, database):
+        self.url = make_url(db_url)
+        self.database = database
+        if not database:
+            self._handle_no_database()
+
+
+class PosgresDatabaseManager(DatabaseManager):
+
+    def _handle_no_database(self):
+        self.database = self.url.database  # use database from db_url
+        self.url = self.url.set(database='postgres')  # use default database to connect
+
+    def exists(self):
+        with sqlalchemy_engine(self.url) as engine:
+            stmt = text('SELECT 1 FROM pg_database WHERE datname=:database')
+            stmt = stmt.bindparams(database=self.database)
+            with engine.connect() as conn:
+                return bool(conn.scalar(stmt))
+
+    def create(self, encoding, template):
+        with sqlalchemy_engine(self.url) as engine:
+            preparer = IdentifierPreparer(engine.dialect)
+            template = template or 'template1'
+            database, template = preparer.quote(self.database), preparer.quote(template)
+            stmt = f"CREATE DATABASE {database} ENCODING '{encoding}' TEMPLATE {template}"
+            with engine.connect().execution_options(isolation_level='AUTOCOMMIT') as conn:
+                conn.execute(stmt)
+
+
+class SqliteDatabaseManager(DatabaseManager):
+
+    def _handle_no_database(self):
+        self.database = self.url.database  # use database from db_url
+
+    def exists(self):
+        try:
+            sqlite3.connect(f'file:{self.url.database}?mode=ro', uri=True)
+        except sqlite3.OperationalError:
+            return False
+        else:
+            return True
+
+    def create(self, encoding, template):
+        # Don't use encoding and template for sqlite
+        sqlite3.connect(f'file:{self.url.database}', uri=True)

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -1,11 +1,10 @@
 import sqlite3
+from contextlib import contextmanager
 
 from sqlalchemy import create_engine
-from sqlalchemy.sql.expression import text
-from sqlalchemy.sql.compiler import IdentifierPreparer
 from sqlalchemy.engine.url import make_url
-
-from contextlib import contextmanager
+from sqlalchemy.sql.compiler import IdentifierPreparer
+from sqlalchemy.sql.expression import text
 
 from galaxy.exceptions import ConfigurationError
 

--- a/lib/galaxy/model/migrate/check.py
+++ b/lib/galaxy/model/migrate/check.py
@@ -9,9 +9,9 @@ from sqlalchemy import (
     Table
 )
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy_utils import create_database, database_exists
 
 from galaxy.model import mapping
+from galaxy.model.database_utils import create_database, database_exists
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/model/migrate/versions/0166_job_state_summary_view.py
+++ b/lib/galaxy/model/migrate/versions/0166_job_state_summary_view.py
@@ -15,12 +15,13 @@ def upgrade(migrate_engine):
     print(__doc__)
     # drop first because sqlite does not support or_replace
     downgrade(migrate_engine)
-    create_view = CreateView(HistoryDatasetCollectionJobStateSummary)
+    view = HistoryDatasetCollectionJobStateSummary
+    create_view = CreateView(view.name, view.__view__)
     # print(str(create_view.compile(migrate_engine)))
     migrate_engine.execute(create_view)
 
 
 def downgrade(migrate_engine):
-    drop_view = DropView(HistoryDatasetCollectionJobStateSummary)
+    drop_view = DropView(HistoryDatasetCollectionJobStateSummary.name)
     # print(str(drop_view.compile(migrate_engine)))
     migrate_engine.execute(drop_view)

--- a/lib/galaxy/model/tool_shed_install/migrate/check.py
+++ b/lib/galaxy/model/tool_shed_install/migrate/check.py
@@ -12,11 +12,8 @@ from sqlalchemy import (
     Table
 )
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy_utils import (
-    create_database,
-    database_exists,
-)
 
+from galaxy.model.database_utils import create_database, database_exists
 from galaxy.model.tool_shed_install import mapping
 
 

--- a/lib/galaxy/model/view/__init__.py
+++ b/lib/galaxy/model/view/__init__.py
@@ -54,7 +54,7 @@ class HistoryDatasetCollectionJobStateSummary(View):
         column('all_jobs', Integer)
     )
     pkeys = {'hdca_id'}
-    View._make_table(name, __view__, pkeys)
+    __table__ = View._make_table(name, __view__, pkeys)
 
 
 mapper(HistoryDatasetCollectionJobStateSummary, HistoryDatasetCollectionJobStateSummary.__table__)

--- a/lib/galaxy/model/view/__init__.py
+++ b/lib/galaxy/model/view/__init__.py
@@ -5,8 +5,7 @@ from sqlalchemy import Integer
 from sqlalchemy.orm import mapper
 from sqlalchemy.sql import column, text
 
-from galaxy.model.view.utils import create_view
-from .utils import View
+from galaxy.model.view.utils import View
 
 AGGREGATE_STATE_QUERY = """
 SELECT
@@ -37,10 +36,9 @@ GROUP BY hdca.id
 
 class HistoryDatasetCollectionJobStateSummary(View):
     name = 'collection_job_state_summary_view'
-    pkey = 'hdca_id'
 
     __view__ = text(AGGREGATE_STATE_QUERY).columns(
-        column(pkey, Integer),
+        column('hdca_id', Integer),
         column('new', Integer),
         column('resubmitted', Integer),
         column('waiting', Integer),
@@ -55,8 +53,8 @@ class HistoryDatasetCollectionJobStateSummary(View):
         column('upload', Integer),
         column('all_jobs', Integer)
     )
-
-    __table__ = create_view(name, __view__, pkey)
+    pkeys = {'hdca_id'}
+    View._make_table(name, __view__, pkeys)
 
 
 mapper(HistoryDatasetCollectionJobStateSummary, HistoryDatasetCollectionJobStateSummary.__table__)

--- a/lib/galaxy/model/view/__init__.py
+++ b/lib/galaxy/model/view/__init__.py
@@ -1,14 +1,12 @@
 """
 Galaxy sql view models
 """
-from sqlalchemy import Integer, MetaData
+from sqlalchemy import Integer
 from sqlalchemy.orm import mapper
 from sqlalchemy.sql import column, text
-from sqlalchemy_utils import create_view
 
 from .utils import View
-
-metadata = MetaData()
+from galaxy.model.view.utils import create_view
 
 AGGREGATE_STATE_QUERY = """
 SELECT
@@ -38,9 +36,11 @@ GROUP BY hdca.id
 
 
 class HistoryDatasetCollectionJobStateSummary(View):
+    name = 'collection_job_state_summary_view'
+    pkey = 'hdca_id'
 
     __view__ = text(AGGREGATE_STATE_QUERY).columns(
-        column('hdca_id', Integer),
+        column(pkey, Integer),
         column('new', Integer),
         column('resubmitted', Integer),
         column('waiting', Integer),
@@ -56,7 +56,8 @@ class HistoryDatasetCollectionJobStateSummary(View):
         column('all_jobs', Integer)
     )
 
-    __table__ = create_view('collection_job_state_summary_view', __view__, metadata)
+    __table__ = create_view(name, __view__, pkey)
 
 
 mapper(HistoryDatasetCollectionJobStateSummary, HistoryDatasetCollectionJobStateSummary.__table__)
+

--- a/lib/galaxy/model/view/__init__.py
+++ b/lib/galaxy/model/view/__init__.py
@@ -5,8 +5,8 @@ from sqlalchemy import Integer
 from sqlalchemy.orm import mapper
 from sqlalchemy.sql import column, text
 
-from .utils import View
 from galaxy.model.view.utils import create_view
+from .utils import View
 
 AGGREGATE_STATE_QUERY = """
 SELECT
@@ -60,4 +60,3 @@ class HistoryDatasetCollectionJobStateSummary(View):
 
 
 mapper(HistoryDatasetCollectionJobStateSummary, HistoryDatasetCollectionJobStateSummary.__table__)
-

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -15,8 +15,8 @@ from sqlalchemy.schema import DDLElement
 class View:
     """Base class for Views."""
 
-    @classmethod
-    def _make_table(cls, name, selectable, pkeys):
+    @staticmethod
+    def _make_table(name, selectable, pkeys):
         """ Create a view.
 
         :param name: The name of the view.
@@ -39,7 +39,7 @@ class View:
 
         # The metadata object passed to Table() should be empty: this table is internal to a View
         # object and is not intended to be created in the database.
-        cls.__table__ = Table(name, MetaData(), *columns)
+        return Table(name, MetaData(), *columns)
 
 
 class CreateView(DDLElement):

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -64,7 +64,7 @@ def create_view(name, selectable, pkey):
             c.type,
             primary_key=(c.name == pkey)
         )
-        for c in selectable.subquery().c
+        for c in selectable.c
     ]
     table = Table(name, metadata, *columns)
 

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -5,12 +5,12 @@ from inspect import getmembers
 
 from sqlalchemy import (
     Column,
+    event,
     MetaData,
     Table,
-    event
 )
-from sqlalchemy.schema import DDLElement
 from sqlalchemy.ext import compiler
+from sqlalchemy.schema import DDLElement
 
 
 class View:
@@ -72,4 +72,3 @@ def create_view(name, selectable, pkey):
     event.listen(metadata, 'before_drop', DropView(name))
 
     return table
-

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -3,32 +3,40 @@ View wrappers, currently using sqlalchemy_views
 """
 from inspect import getmembers
 
+from sqlalchemy import (
+    Column,
+    MetaData,
+    Table,
+    event
+)
+from sqlalchemy.schema import DDLElement
 from sqlalchemy.ext import compiler
-from sqlalchemy_utils import view
 
 
 class View:
     is_view = True
 
 
-class DropView(view.DropView):
-    def __init__(self, ViewModel, **kwargs):
-        super().__init__(str(ViewModel.__table__.name), **kwargs)
+class CreateView(DDLElement):
+    def __init__(self, name, selectable):
+        self.name = name
+        self.selectable = selectable
 
 
-@compiler.compiles(DropView, "sqlite")
-def compile_drop_materialized_view(element, compiler, **kw):
-    # modified because sqlalchemy_utils adds a cascade for
-    # sqlite even though sqlite does not support cascade keyword
-    return 'DROP {}VIEW IF EXISTS {}'.format(
-        'MATERIALIZED ' if element.materialized else '',
-        element.name
-    )
+@compiler.compiles(CreateView)
+def compile_create_view(element, compiler, **kw):
+    compiled_selectable = compiler.sql_compiler.process(element.selectable, literal_binds=True)
+    return f'CREATE VIEW {element.name} AS {compiled_selectable}'
 
 
-class CreateView(view.CreateView):
-    def __init__(self, ViewModel, **kwargs):
-        super().__init__(str(ViewModel.__table__.name), ViewModel.__view__, **kwargs)
+class DropView(DDLElement):
+    def __init__(self, name):
+        self.name = name
+
+
+@compiler.compiles(DropView)
+def compile_drop_view(element, compiler, **kw):
+    return f'DROP VIEW IF EXISTS {element.name}'
 
 
 def is_view_model(o):
@@ -38,10 +46,30 @@ def is_view_model(o):
 def install_views(engine):
     import galaxy.model.view
     views = getmembers(galaxy.model.view, is_view_model)
-    for _name, ViewModel in views:
+    for _, view in views:
         # adding DropView here because our unit-testing calls this function when
         # it mocks the app and CreateView will attempt to rebuild an existing
         # view in a database that is already made, the right answer is probably
         # to change the sql that gest emitted when CreateView is rendered.
-        engine.execute(DropView(ViewModel))
-        engine.execute(CreateView(ViewModel))
+        engine.execute(DropView(view.name))
+        engine.execute(CreateView(view.name, view.__view__))
+
+
+def create_view(name, selectable, pkey):
+    metadata = MetaData()
+
+    columns = [
+        Column(
+            c.name,
+            c.type,
+            primary_key=(c.name == pkey)
+        )
+        for c in selectable.subquery().c
+    ]
+    table = Table(name, metadata, *columns)
+
+    event.listen(metadata, 'after_create', CreateView(name, selectable))
+    event.listen(metadata, 'before_drop', DropView(name))
+
+    return table
+

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -22,14 +22,11 @@ import nose.loader
 import nose.plugins.manager
 import yaml
 from paste import httpserver
-from sqlalchemy_utils import (
-    create_database,
-    database_exists,
-)
 
 from galaxy.app import UniverseApplication as GalaxyUniverseApplication
 from galaxy.config import LOGGING_CONFIG_DEFAULT
 from galaxy.model import mapping
+from galaxy.model.database_utils import create_database, database_exists
 from galaxy.model.tool_shed_install import mapping as toolshed_mapping
 from galaxy.tool_util.verify.interactor import GalaxyInteractorApi, verify_tool
 from galaxy.util import asbool, download_to_file, galaxy_directory

--- a/lib/tool_shed/webapp/model/migrate/check.py
+++ b/lib/tool_shed/webapp/model/migrate/check.py
@@ -5,10 +5,8 @@ import sys
 from migrate.versioning import repository, schema
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.exc import NoSuchTableError
-from sqlalchemy_utils import (
-    create_database,
-    database_exists,
-)
+
+from galaxy.model.database_utils import create_database, database_exists
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
 SQLAlchemy = ">=1.3.22, <1.4.0"  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 sqlalchemy-migrate = "*"
-SQLAlchemy-Utils = "!=0.36.8"  # https://github.com/kvesteri/sqlalchemy-utils/issues/462
 sqlitedict = "*"
 sqlparse = "*"
 starlette = "*"

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -8,8 +8,8 @@ from sqlalchemy import inspect
 
 import galaxy.datatypes.registry
 import galaxy.model
-from galaxy.model.database_utils import create_database
 import galaxy.model.mapping as mapping
+from galaxy.model.database_utils import create_database
 from galaxy.model.security import GalaxyRBACAgent
 
 datatypes_registry = galaxy.datatypes.registry.Registry()

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -5,10 +5,10 @@ import uuid
 
 import pytest
 from sqlalchemy import inspect
-from sqlalchemy_utils import create_database
 
 import galaxy.datatypes.registry
 import galaxy.model
+from galaxy.model.database_utils import create_database
 import galaxy.model.mapping as mapping
 from galaxy.model.security import GalaxyRBACAgent
 

--- a/test/unit/model/common.py
+++ b/test/unit/model/common.py
@@ -1,9 +1,27 @@
 import os
 
+import pytest
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.sql.compiler import IdentifierPreparer
 
 from galaxy.model.database_utils import sqlalchemy_engine
+
+# GALAXY_TEST_CONNECT_POSTGRES_URI='postgresql://postgres@localhost:5432/postgres' pytest test/unit/util/test_database.py
+skip_if_not_postgres_uri = pytest.mark.skipif(
+    not os.environ.get('GALAXY_TEST_CONNECT_POSTGRES_URI'),
+    reason="GALAXY_TEST_CONNECT_POSTGRES_URI not set"
+)
+
+
+def replace_database_in_url(url, database_name):
+    """
+    Substitute the database part of url for database_name.
+
+    Example: replace_database_in_url('foo/db1', 'db2') returns 'foo/db2'
+    This will not work for unix domain connections.
+    """
+    i = url.rfind('/')
+    return f'{url[:i]}/{database_name}'
 
 
 def drop_database(db_url, database):

--- a/test/unit/model/common.py
+++ b/test/unit/model/common.py
@@ -6,10 +6,16 @@ from sqlalchemy.sql.compiler import IdentifierPreparer
 
 from galaxy.model.database_utils import sqlalchemy_engine
 
-# GALAXY_TEST_CONNECT_POSTGRES_URI='postgresql://postgres@localhost:5432/postgres' pytest test/unit/util/test_database.py
+# GALAXY_TEST_CONNECT_POSTGRES_URI='postgresql://postgres@localhost:5432/postgres' pytest test/unit/model
 skip_if_not_postgres_uri = pytest.mark.skipif(
     not os.environ.get('GALAXY_TEST_CONNECT_POSTGRES_URI'),
     reason="GALAXY_TEST_CONNECT_POSTGRES_URI not set"
+)
+
+# GALAXY_TEST_CONNECT_MYSQL_URI='mysql+mysqldb://root@localhost/mysql' pytest test/unit/model
+skip_if_not_mysql_uri = pytest.mark.skipif(
+    not os.environ.get('GALAXY_TEST_CONNECT_MYSQL_URI'),
+    reason="GALAXY_TEST_CONNECT_MYSQL_URI not set"
 )
 
 
@@ -29,7 +35,7 @@ def drop_database(db_url, database):
 
     Used only for test purposes to cleanup after creating a test database.
     """
-    if db_url.startswith('postgresql'):
+    if db_url.startswith('postgresql') or db_url.startswith('mysql'):
         with sqlalchemy_engine(db_url) as engine:
             preparer = IdentifierPreparer(engine.dialect)
             database = preparer.quote(database)

--- a/test/unit/model/conftest.py
+++ b/test/unit/model/conftest.py
@@ -1,0 +1,19 @@
+import os
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def database_name():
+    return f'galaxytest_{uuid.uuid4().hex}'
+
+
+@pytest.fixture
+def postgres_url():
+    return os.environ.get('GALAXY_TEST_CONNECT_POSTGRES_URI')
+
+
+@pytest.fixture
+def sqlite_memory_url():
+    return 'sqlite:///:memory:'

--- a/test/unit/model/conftest.py
+++ b/test/unit/model/conftest.py
@@ -15,5 +15,10 @@ def postgres_url():
 
 
 @pytest.fixture
+def mysql_url():
+    return os.environ.get('GALAXY_TEST_CONNECT_MYSQL_URI')
+
+
+@pytest.fixture
 def sqlite_memory_url():
     return 'sqlite:///:memory:'

--- a/test/unit/model/test_database_utils.py
+++ b/test/unit/model/test_database_utils.py
@@ -1,0 +1,85 @@
+import os
+import pytest
+import tempfile
+import uuid
+
+from galaxy.model.database_utils import database_exists, create_database
+from ..unittest_utils.database_helpers import drop_database
+
+
+# GALAXY_TEST_CONNECT_POSTGRES_URI='postgresql://postgres@localhost:5432/postgres' pytest test/unit/util/test_database.py
+skip_if_not_postgres_uri = pytest.mark.skipif(
+    not os.environ.get('GALAXY_TEST_CONNECT_POSTGRES_URI'),
+    reason="GALAXY_TEST_CONNECT_POSTGRES_URI not set"
+)
+
+
+@pytest.fixture
+def database_name():
+    return f'galaxytest_{uuid.uuid4().hex}'
+
+
+@pytest.fixture
+def postgres_url():
+    return os.environ.get('GALAXY_TEST_CONNECT_POSTGRES_URI')
+
+
+@pytest.fixture
+def sqlite_memory_url():
+    return 'sqlite:///:memory:'
+
+
+@skip_if_not_postgres_uri
+def test_postgres_create_exists_drop_database(database_name, postgres_url):
+    assert not database_exists(postgres_url, database_name)
+    create_database(postgres_url, database_name)
+    assert database_exists(postgres_url, database_name)
+    drop_database(postgres_url, database_name)
+    assert not database_exists(postgres_url, database_name)
+
+
+@skip_if_not_postgres_uri
+def test_postgres_create_exists_drop_database__pass_one_argument(database_name, postgres_url):
+    # Substitute the database part of postgres_url for database_name:
+    # url: 'foo/db1', database: 'db2' => url: 'foo/db2' (will not work for unix domain connections)
+    url = postgres_url
+    i = url.rfind('/')
+    url = f'{url[:i]}/{database_name}'
+
+    assert not database_exists(url)
+    create_database(url)
+    assert database_exists(url)
+    drop_database(postgres_url, database_name)
+    assert not database_exists(url)
+
+
+def test_sqlite_create_exists_drop_database(database_name):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        url = _make_sqlite_url(tmp_dir, database_name)
+
+        assert not database_exists(url, database_name)
+        create_database(url, database_name)
+        assert database_exists(url, database_name)
+        drop_database(url, database_name)
+        assert not database_exists(url, database_name)
+
+
+def test_sqlite_create_exists_drop_database__pass_one_argument(database_name):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        url = _make_sqlite_url(tmp_dir, database_name)
+
+        assert not database_exists(url)
+        create_database(url)
+        assert database_exists(url)
+        drop_database(url, database_name)
+        assert not database_exists(url)
+
+
+def test_sqlite_create_exists_drop_in_memory_database(database_name, sqlite_memory_url):
+    assert database_exists(sqlite_memory_url)
+
+
+def _make_sqlite_url(tmp_dir, database_name):
+    path = os.path.join(tmp_dir, database_name)
+    return f'sqlite:///{path}?isolation_level=IMMEDIATE'
+

--- a/test/unit/model/test_database_utils.py
+++ b/test/unit/model/test_database_utils.py
@@ -1,9 +1,13 @@
 import os
-import pytest
 import tempfile
 import uuid
 
-from galaxy.model.database_utils import database_exists, create_database
+import pytest
+
+from galaxy.model.database_utils import (
+    create_database,
+    database_exists,
+)
 from ..unittest_utils.database_helpers import drop_database
 
 
@@ -82,4 +86,3 @@ def test_sqlite_create_exists_drop_in_memory_database(database_name, sqlite_memo
 def _make_sqlite_url(tmp_dir, database_name):
     path = os.path.join(tmp_dir, database_name)
     return f'sqlite:///{path}?isolation_level=IMMEDIATE'
-

--- a/test/unit/model/test_database_utils.py
+++ b/test/unit/model/test_database_utils.py
@@ -8,6 +8,7 @@ from galaxy.model.database_utils import (
 from .common import (
     drop_database,
     replace_database_in_url,
+    skip_if_not_mysql_uri,
     skip_if_not_postgres_uri,
 )
 
@@ -58,6 +59,15 @@ def test_create_exists_sqlite_database__pass_as_url(database_name):
 
 def test_exists_sqlite_in_memory_database(database_name, sqlite_memory_url):
     assert database_exists(sqlite_memory_url)
+
+
+@skip_if_not_mysql_uri
+def test_create_exists_mysql_database(database_name, mysql_url):
+    assert not database_exists(mysql_url, database_name)
+    create_database(mysql_url, database_name)
+    assert database_exists(mysql_url, database_name)
+    drop_database(mysql_url, database_name)
+    assert not database_exists(mysql_url, database_name)
 
 
 def make_sqlite_url(tmp_dir, database_name):

--- a/test/unit/model/test_views.py
+++ b/test/unit/model/test_views.py
@@ -1,0 +1,81 @@
+import pytest
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+)
+from sqlalchemy.sql import (
+    column,
+    text,
+)
+
+from galaxy.model.database_utils import (
+    create_database,
+    sqlalchemy_engine,
+)
+from galaxy.model.view.utils import (
+    CreateView,
+    View,
+)
+from .common import (
+    drop_database,
+    replace_database_in_url,
+    skip_if_not_postgres_uri,
+)
+
+
+@pytest.fixture
+def view():
+    # A View class we would add to galaxy.model.view
+    class TestView(View):
+        name = 'testview'
+        __view__ = text('select id, first_name from testusers').columns(
+            column('id', Integer),
+            column('first_name', String)
+        )
+        pkeys = {'id'}
+        View._make_table(name, __view__, pkeys)
+
+    return TestView
+
+
+@skip_if_not_postgres_uri
+def test_postgres_create_view(database_name, postgres_url, view):
+    metadata = MetaData()
+    make_table(metadata)  # table from which the view will select
+    create_database(postgres_url, database_name)
+
+    url = replace_database_in_url(postgres_url, database_name)
+    with sqlalchemy_engine(url) as engine:
+        with engine.connect() as conn:
+            metadata.create_all(conn)  # create table in database
+            conn.execute(CreateView(view.name, view.__view__))  # create view in database
+            query = f"select * from information_schema.tables where table_name = '{view.name}' and table_type = 'VIEW'"
+            result = conn.execute(query)
+            assert result.rowcount == 1  # assert that view exists in database
+
+    drop_database(postgres_url, database_name)
+
+
+def test_sqlite_create_view(sqlite_memory_url, view):
+    metadata = MetaData()
+    make_table(metadata)  # table from which the view will select
+
+    with sqlalchemy_engine(sqlite_memory_url) as engine:
+        with engine.connect() as conn:
+            metadata.create_all(conn)  # create table in database
+            conn.execute(CreateView(view.name, view.__view__))  # create view in database
+            query = f"SELECT name FROM sqlite_master WHERE type='view' AND name='{view.name}'"
+            result = conn.execute(query).fetchall()
+            assert len(result) == 1  # assert that view exists in database
+
+
+def make_table(metadata):
+    users = Table('testusers', metadata,
+        Column('id', Integer, primary_key=True),
+        Column('first_name', String),
+        Column('last_name', String)
+    )
+    return users

--- a/test/unit/unittest_utils/database_helpers.py
+++ b/test/unit/unittest_utils/database_helpers.py
@@ -1,0 +1,24 @@
+import os
+
+from sqlalchemy.sql.compiler import IdentifierPreparer
+from sqlalchemy.engine import make_url
+
+from galaxy.model.database_utils import sqlalchemy_engine
+
+
+def drop_database(db_url, database):
+    """Drop database; connect with db_url.
+
+    Used only for test purposes to cleanup after creating a test database.
+    """
+    if db_url.startswith('postgresql'):
+        with sqlalchemy_engine(db_url) as engine:
+            preparer = IdentifierPreparer(engine.dialect)
+            database = preparer.quote(database)
+            stmt = f'DROP DATABASE IF EXISTS {database}'
+            with engine.connect().execution_options(isolation_level='AUTOCOMMIT') as conn:
+                conn.execute(stmt)
+    else:
+        url = make_url(db_url)
+        os.remove(url.database)
+

--- a/test/unit/unittest_utils/database_helpers.py
+++ b/test/unit/unittest_utils/database_helpers.py
@@ -1,7 +1,7 @@
 import os
 
-from sqlalchemy.sql.compiler import IdentifierPreparer
 from sqlalchemy.engine.url import make_url
+from sqlalchemy.sql.compiler import IdentifierPreparer
 
 from galaxy.model.database_utils import sqlalchemy_engine
 
@@ -21,4 +21,3 @@ def drop_database(db_url, database):
     else:
         url = make_url(db_url)
         os.remove(url.database)
-

--- a/test/unit/unittest_utils/database_helpers.py
+++ b/test/unit/unittest_utils/database_helpers.py
@@ -1,7 +1,7 @@
 import os
 
 from sqlalchemy.sql.compiler import IdentifierPreparer
-from sqlalchemy.engine import make_url
+from sqlalchemy.engine.url import make_url
 
 from galaxy.model.database_utils import sqlalchemy_engine
 


### PR DESCRIPTION
## What did you do? 
Replaced dependency on sqlalchemy_utils with a local implementation of the functionality we actually need.

## Why did you make this change?
The main goal of this is to get this dependency out of the way and move on with migrating Galaxy to SA 1.4. It is designed as a temporary or permanent replacement for sqlalchemy-utils for reasons outlined in #11459. This may be replaced with sqlalchemy-utils once that library supports SA 1.4 (effort is underway).

To do: (lower priority; after this is merged)
1. Postgresql and MySQL tests have been run locally (they passed); however they will be skipped within the unit test workflow, since it doens't include postgres and mysql services. Since these (and `unit/data/test_galaxy_mapping`) are the only unit tests that require a database, I'm not sure what's the best way to handle this: add the serivces or setup a separate workflow.

2. Handling of views can be improved: we have setup a DIY mechanism for installing them in the database; however, SQLAlchemy provides a simple way to do it via `after_create`/`before_drop` hooks: we would just need to use `event.listen(metadata, 'after_create', [our DDLElement])`. This is the approach taken by sqlalchemy-utils; however, we don't use it and pass an empty metadata object instead ([see comment](https://github.com/ic4f/galaxy/blob/dev_no_sqlalchemy_utils/lib/galaxy/model/view/utils.py#L34)). I did not modify this as this to keep the PR focused on one thing.

Implementation Notes

1. I considered using mocks for tests (sqlalchemy-utils does that), but decided that for testing the creation of a database or a database object such as a view it makes sense to use a real database for increased test fidelity (because this is outside the context of what SA already does and what's covered by SA's internal tests). So, technically, this makes them integration tests. However, in the context of Galaxy's testing frameworks integration tests run Galaxy in different configurations, which is not what these tests are. So I left them under unit tests (they are also fast, so that's fitting).

2. I've dropped the things we don't use (creating materialized views, cascade on view drop, using after_create/before_drop hooks). Any of this can be added when needed. Until then, yagni.

3. I've changed the singature for `create_database` and `database_exists` to 2 parameters: the connection URL and an optional database to manipulate. This addresses the issue of some installations not having access to the default `postgres` database and is similar to the solution proposed [here](https://github.com/kvesteri/sqlalchemy-utils/pull/463#issuecomment-668214945).

3. This code is not SA 1.4-compatible. It was first implemented as such, but other parts of Galaxy broke under SA 1.4, so this was downgraded to 1.3. It will be migrated to run under 1.4 with the rest of Galaxy.


## How to test the changes? 
Manually: 
- Your `database_connection` should be unset. Delete local sqlite database, run Galaxy; database should be created.
- Your `database_connection` should be using postgresql; point it to a nonexistant database
- To run the new unit tests: 
  `GALAXY_TEST_CONNECT_POSTGRES_URI='postgresql://postgres@localhost:5432/postgres' pytest test/unit/model/`
- Repeat the postgresql steps for mysql: 
  `GALAXY_TEST_CONNECT_MYSQL_URI='mysql+mysqldb://root@localhost/mysql' pytest test/unit/model/`
  (you'll need to `python -m pip install mysqlclient`; you'll also need a running instance of mysql)
