### PR TITLE
Break up dynamic dataset collection into chunks

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3362,6 +3362,20 @@
 :Type: int
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~
+``flush_per_n_datasets``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Maximum number of datasets to create before flushing created
+    datasets to database. This affects tools that create many output
+    datasets. Higher values will lead to fewer database flushes and
+    faster execution, but require more memory. Set to -1 to disable
+    creating datasets in batches.
+:Default: ``1000``
+:Type: int
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``history_local_serial_workflow_scheduling``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1684,6 +1684,13 @@ galaxy:
   # disable any such maximum.
   #maximum_workflow_jobs_per_scheduling_iteration: 1000
 
+  # Maximum number of datasets to create before flushing created
+  # datasets to database. This affects tools that create many output
+  # datasets. Higher values will lead to fewer database flushes and
+  # faster execution, but require more memory. Set to -1 to disable
+  # creating datasets in batches.
+  #flush_per_n_datasets: 1000
+
   # Force serial scheduling of workflows within the context of a
   # particular history
   #history_local_serial_workflow_scheduling: false

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -180,7 +180,18 @@ class BaseJobContext:
 
 class JobContext(ModelPersistenceContext, BaseJobContext):
 
-    def __init__(self, tool, tool_provided_metadata, job, job_working_directory, permission_provider, metadata_source_provider, input_dbkey, object_store, final_job_state):
+    def __init__(
+            self,
+            tool,
+            tool_provided_metadata,
+            job,
+            job_working_directory,
+            permission_provider,
+            metadata_source_provider,
+            input_dbkey,
+            object_store,
+            final_job_state,
+            flush_per_n_datasets=None):
         self.tool = tool
         self.metadata_source_provider = metadata_source_provider
         self.permission_provider = permission_provider
@@ -192,6 +203,7 @@ class JobContext(ModelPersistenceContext, BaseJobContext):
         self.tool_provided_metadata = tool_provided_metadata
         self.object_store = object_store
         self.final_job_state = final_job_state
+        self.flush_per_n_datasets = flush_per_n_datasets
 
     @property
     def work_context(self):
@@ -312,6 +324,7 @@ class SessionlessJobContext(SessionlessModelPersistenceContext, BaseJobContext):
         self.import_store = import_store
         self.input_dbkey = input_dbkey
         self.final_job_state = final_job_state
+        self.flush_per_n_datasets = None
 
     def output_collection_def(self, name):
         tool_as_dict = self.metadata_params["tool"]

--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -254,18 +254,6 @@ class DatasetCollectionManager:
         for _, tag in tags.items():
             dataset_collection_instance.tags.append(tag.copy(cls=model.HistoryDatasetCollectionTagAssociation))
 
-    def set_collection_elements(self, dataset_collection, dataset_instances):
-        if dataset_collection.populated:
-            raise Exception("Cannot reset elements of an already populated dataset collection.")
-
-        collection_type = dataset_collection.collection_type
-        collection_type_description = self.collection_type_descriptions.for_collection_type(collection_type)
-        type_plugin = collection_type_description.rank_type_plugin()
-        builder.set_collection_elements(dataset_collection, type_plugin, dataset_instances)
-        dataset_collection.mark_as_populated()
-
-        return dataset_collection
-
     def collection_builder_for(self, dataset_collection):
         return builder.BoundCollectionBuilder(dataset_collection)
 

--- a/lib/galaxy/model/dataset_collections/builder.py
+++ b/lib/galaxy/model/dataset_collections/builder.py
@@ -14,7 +14,8 @@ def build_collection(type, dataset_instances):
 
 
 def set_collection_elements(dataset_collection, type, dataset_instances):
-    element_index = 0
+    dataset_collection.element_count = dataset_collection.element_count or 0
+    element_index = dataset_collection.element_count
     elements = []
     for element in type.generate_elements(dataset_instances):
         element.element_index = element_index
@@ -79,6 +80,7 @@ class CollectionBuilder:
             for identifier, element in elements.items():
                 new_elements[identifier] = element.build()
             elements = new_elements
+        self._current_elements = {}
         return elements
 
     def build(self):
@@ -107,8 +109,11 @@ class BoundCollectionBuilder(CollectionBuilder):
         collection_type_description = COLLECTION_TYPE_DESCRIPTION_FACTORY.for_collection_type(collection_type)
         super().__init__(collection_type_description)
 
-    def populate(self):
+    def populate_partial(self):
         elements = self.build_elements()
         type_plugin = self._collection_type_description.rank_type_plugin()
         set_collection_elements(self.dataset_collection, type_plugin, elements)
+
+    def populate(self):
+        self.populate_partial()
         self.dataset_collection.mark_as_populated()

--- a/lib/galaxy/model/dataset_collections/builder.py
+++ b/lib/galaxy/model/dataset_collections/builder.py
@@ -1,4 +1,5 @@
 from galaxy import model
+from galaxy.util.oset import OrderedSet
 from .type_description import COLLECTION_TYPE_DESCRIPTION_FACTORY
 
 
@@ -15,7 +16,7 @@ def build_collection(type, dataset_instances, collection=None, associated_identi
 
 
 def set_collection_elements(dataset_collection, type, dataset_instances, associated_identifiers):
-    new_element_keys = dataset_instances.keys() - associated_identifiers
+    new_element_keys = OrderedSet(dataset_instances.keys()) - associated_identifiers
     new_dataset_instances = {k: dataset_instances[k] for k in new_element_keys}
     dataset_collection.element_count = dataset_collection.element_count or 0
     element_index = dataset_collection.element_count

--- a/lib/galaxy/model/dataset_collections/types/paired.py
+++ b/lib/galaxy/model/dataset_collections/types/paired.py
@@ -4,8 +4,6 @@ from ..types import BaseDatasetCollectionType
 FORWARD_IDENTIFIER = "forward"
 REVERSE_IDENTIFIER = "reverse"
 
-INVALID_IDENTIFIERS_MESSAGE = f"Paired instance must define '{FORWARD_IDENTIFIER}' and '{REVERSE_IDENTIFIER}' datasets ."
-
 
 class PairedDatasetCollectionType(BaseDatasetCollectionType):
     """
@@ -17,20 +15,20 @@ class PairedDatasetCollectionType(BaseDatasetCollectionType):
         pass
 
     def generate_elements(self, elements):
-        forward_dataset = elements.get(FORWARD_IDENTIFIER, None)
-        reverse_dataset = elements.get(REVERSE_IDENTIFIER, None)
-        if not forward_dataset or not reverse_dataset:
-            self._validation_failed(INVALID_IDENTIFIERS_MESSAGE)
-        left_association = DatasetCollectionElement(
-            element=forward_dataset,
-            element_identifier=FORWARD_IDENTIFIER,
-        )
-        right_association = DatasetCollectionElement(
-            element=reverse_dataset,
-            element_identifier=REVERSE_IDENTIFIER,
-        )
-        yield left_association
-        yield right_association
+        forward_dataset = elements.get(FORWARD_IDENTIFIER)
+        reverse_dataset = elements.get(REVERSE_IDENTIFIER)
+        if forward_dataset:
+            left_association = DatasetCollectionElement(
+                element=forward_dataset,
+                element_identifier=FORWARD_IDENTIFIER,
+            )
+            yield left_association
+        if reverse_dataset:
+            right_association = DatasetCollectionElement(
+                element=reverse_dataset,
+                element_identifier=REVERSE_IDENTIFIER,
+            )
+            yield right_association
 
     def prototype_elements(self):
         left_association = DatasetCollectionElement(

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1936,6 +1936,7 @@ class Tool(Dictifiable):
             input_dbkey,
             object_store=tool.app.object_store,
             final_job_state=final_job_state,
+            flush_per_n_datasets=tool.app.config.flush_per_n_datasets,
         )
         collected = output_collect.collect_primary_datasets(
             job_context,

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -7,6 +7,7 @@ import binascii
 import collections
 import errno
 import importlib
+import itertools
 import json
 import os
 import random
@@ -20,6 +21,7 @@ import tempfile
 import textwrap
 import threading
 import time
+import typing
 import unicodedata
 import xml.dom.minidom
 from datetime import datetime
@@ -210,6 +212,21 @@ def file_reader(fp, chunk_size=CHUNK_SIZE):
             break
         yield data
     fp.close()
+
+
+def chunk_iterable(it: typing.Iterable, size: int = 1000):
+    """
+    Break an iterable into chunks of ``size`` elements.
+
+    >>> list(chunk_iterable([1, 2, 3, 4, 5, 6, 7], 3))
+    [(1, 2, 3), (4, 5, 6), (7,)]
+    """
+    it = iter(it)
+    while True:
+        p = tuple(itertools.islice(it, size))
+        if not p:
+            break
+        yield p
 
 
 def unique_id(KEY_SIZE=128):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2465,6 +2465,16 @@ mapping:
           are expunged from the SQL alchemy session between workflow invocation scheduling iterations.
           Set to -1 to disable any such maximum.
 
+      flush_per_n_datasets:
+        type: int
+        default: 1000
+        required: false
+        desc: |
+          Maximum number of datasets to create before flushing created datasets to database.
+          This affects tools that create many output datasets.
+          Higher values will lead to fewer database flushes and faster execution, but require
+          more memory. Set to -1 to disable creating datasets in batches.
+
       history_local_serial_workflow_scheduling:
         type: bool
         default: false

--- a/test/integration/test_flush_per_n_datasets.py
+++ b/test/integration/test_flush_per_n_datasets.py
@@ -13,4 +13,7 @@ class FlushPerNDatasetsTestCase(integration_util.IntegrationInstance):
 
 
 instance = integration_util.integration_module_instance(FlushPerNDatasetsTestCase)
-test_tools = integration_util.integration_tool_runner(['collection_creates_dynamic_nested'])
+test_tools = integration_util.integration_tool_runner([
+    'collection_creates_dynamic_nested',
+    'collection_creates_dynamic_list_of_pairs'
+])

--- a/test/integration/test_flush_per_n_datasets.py
+++ b/test/integration/test_flush_per_n_datasets.py
@@ -1,0 +1,16 @@
+"""Integration tests for the flush_per_n_datasets setting."""
+from galaxy_test.driver import integration_util
+
+
+class FlushPerNDatasetsTestCase(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with embedded pulsar configured."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["flush_per_n_datasets"] = 1
+
+
+instance = integration_util.integration_module_instance(FlushPerNDatasetsTestCase)
+test_tools = integration_util.integration_tool_runner(['collection_creates_dynamic_nested'])

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -166,6 +166,7 @@ class MockAppConfig(Bunch):
         self.password_expiration_period = 0
 
         self.umask = 0o77
+        self.flush_per_n_datasets = 0
 
         # Compliance related config
         self.redact_email_in_job_name = False


### PR DESCRIPTION
One drawback here is that if multiple jobs are concurrently creating datasets in a history the HID is not guaranteed to be sequential between chunks. We can address this, but this is also a problem when breaking workflow executions at ``maximum_workflow_jobs_per_scheduling_iteration``.
If we consider this to be a problem (personally I don't think it is, but I could be convinced otherwise) I would work on this in a different PR.

On the upside the history panel will display an increasing amount of datasets created during the dataset discovery.

## What did you do? 
- Break up dynamic dataset collection into chunks


## Why did you make this change?
Addresses https://github.com/galaxyproject/galaxy/issues/11488.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).