### PR TITLE
enhance the dopbox file_source example to work for anonymous user

### DIFF
--- a/lib/galaxy/config/sample/file_sources_conf.yml.sample
+++ b/lib/galaxy/config/sample/file_sources_conf.yml.sample
@@ -2,7 +2,7 @@
   id: dropbox1
   label: Dropbox files (configure access in user preferences)
   doc: Your Dropbox files - configure an access token via the user preferences
-  accessToken: ${user.preferences['dropbox|access_token']}
+  accessToken: ${user.preferences.get('dropbox|access_token', '') if $user.preferences else ''}
 
 - type: webdav
   id: owncloud1


### PR DESCRIPTION
## What did you do? 

Enhancing the dropbox file_source example given in the file_source_conf.yml.sample file.


## Why did you make this change?

On EU we had a few users still not able to upload files, due to key errors (''dropbox|access_token'').

This fixes various errors for various configurations that we tried.

```
Traceback (most recent call last):
  File "/opt/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 237, in prepare_job
    job_wrapper.prepare()
  File "/opt/galaxy/server/lib/galaxy/jobs/__init__.py", line 1120, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 451, in build
    raise e
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 447, in build
    self.__build_config_files()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 511, in __build_config_files
    config_text, is_template = self.__build_config_file_text(content)
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 599, in __build_config_file_text
    file_sources_dict = self.app.file_sources.to_dict(for_serialization=True, user_context=user_context)
  File "/opt/galaxy/server/lib/galaxy/files/__init__.py", line 155, in to_dict
    'file_sources': self.plugins_to_dict(for_serialization=for_serialization, user_context=user_context),
  File "/opt/galaxy/server/lib/galaxy/files/__init__.py", line 149, in plugins_to_dict
    el = file_source.to_dict(for_serialization=for_serialization, user_context=user_context)
  File "/opt/galaxy/server/lib/galaxy/files/sources/__init__.py", line 94, in to_dict
    rval.update(self._serialization_props(user_context=user_context))
  File "/opt/galaxy/server/lib/galaxy/files/sources/_pyfilesystem2.py", line 69, in _serialization_props
    effective_props[key] = self._evaluate_prop(val, user_context=user_context)
  File "/opt/galaxy/server/lib/galaxy/files/sources/__init__.py", line 129, in _evaluate_prop
    rval = fill_template(prop_val, context=template_context, futurized=True)
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 126, in fill_template
    raise first_exception or e
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 80, in fill_template
    return unicodify(t, log_exception=False)
  File "/opt/galaxy/server/lib/galaxy/util/__init__.py", line 1039, in unicodify
    value = str(value)
  File "/opt/galaxy/venv/lib/python3.6/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1616493300_6586313_83117.py", line 86, in respond
TypeError: 'NoneType' object is not callable
```

or

```
Traceback (most recent call last):
  File "/opt/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 237, in prepare_job
    job_wrapper.prepare()
  File "/opt/galaxy/server/lib/galaxy/jobs/__init__.py", line 1120, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 451, in build
    raise e
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 447, in build
    self.__build_config_files()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 511, in __build_config_files
    config_text, is_template = self.__build_config_file_text(content)
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 599, in __build_config_file_text
    file_sources_dict = self.app.file_sources.to_dict(for_serialization=True, user_context=user_context)
  File "/opt/galaxy/server/lib/galaxy/files/__init__.py", line 155, in to_dict
    'file_sources': self.plugins_to_dict(for_serialization=for_serialization, user_context=user_context),
  File "/opt/galaxy/server/lib/galaxy/files/__init__.py", line 149, in plugins_to_dict
    el = file_source.to_dict(for_serialization=for_serialization, user_context=user_context)
  File "/opt/galaxy/server/lib/galaxy/files/sources/__init__.py", line 94, in to_dict
    rval.update(self._serialization_props(user_context=user_context))
  File "/opt/galaxy/server/lib/galaxy/files/sources/_pyfilesystem2.py", line 69, in _serialization_props
    effective_props[key] = self._evaluate_prop(val, user_context=user_context)
  File "/opt/galaxy/server/lib/galaxy/files/sources/__init__.py", line 129, in _evaluate_prop
    rval = fill_template(prop_val, context=template_context, futurized=True)
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 126, in fill_template
    raise first_exception or e
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 80, in fill_template
    return unicodify(t, log_exception=False)
  File "/opt/galaxy/server/lib/galaxy/util/__init__.py", line 1039, in unicodify
    value = str(value)
  File "/opt/galaxy/venv/lib/python3.6/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1616466651_5473886_18756.py", line 86, in respond
KeyError: 'dropbox|access_token'
```


## How to test the changes? 

Enable the dropbox option in the file_source plugin and try to upload random files, does not need to be upload from dropbox. All uploads have been broken before.