### PR TITLE
[20.09] Make extra user preferences behave like defaultdict

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -386,7 +386,7 @@ class User(Dictifiable, RepresentById):
         extra_user_preferences = self.preferences.get('extra_user_preferences')
         if extra_user_preferences:
             try:
-                data = json.loads(extra_user_preferences)
+                data.update(json.loads(extra_user_preferences))
             except Exception:
                 pass
         return data


### PR DESCRIPTION
This was the intention in https://github.com/galaxyproject/galaxy/pull/10747 and is an alternative to https://github.com/galaxyproject/galaxy/pull/11707

To test this, enable the file sources, and make sure you add a plugin you haven't configured in your user preferences, then try to upload a file as a logged-in user.