### PR TITLE
[21.01] Fix importing collections to new history and import correct elements

### DIFF
--- a/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -155,12 +155,12 @@ var ImportCollectionModal = Backbone.View.extend({
                         {
                             name: "forward",
                             id: pair.forward.id,
-                            src: pair.forward.src || "hda",
+                            src: "ldda",
                         },
                         {
                             name: "reverse",
                             id: pair.reverse.id,
-                            src: pair.reverse.src || "hda",
+                            src: "ldda",
                         },
                     ],
                 }));

--- a/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -34,8 +34,9 @@ var ImportCollectionModal = Backbone.View.extend({
         this.histories = new mod_library_model.GalaxyHistories();
         return this.histories.fetch();
     },
-    createNewHistory: function (new_history_name) {
-        return axios.post(`${getAppRoot()}api/histories`, { name: new_history_name });
+    async createNewHistory(new_history_name) {
+        const { data } = await axios.post(`${getAppRoot()}api/histories`, { name: new_history_name });
+        return data;
     },
     showCollectionSelect: function (e) {
         const Galaxy = getGalaxyInstance();

--- a/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
+++ b/client/src/components/LibraryFolder/TopToolbar/import-to-history/import-collection.js
@@ -36,6 +36,7 @@ var ImportCollectionModal = Backbone.View.extend({
     },
     async createNewHistory(new_history_name) {
         const { data } = await axios.post(`${getAppRoot()}api/histories`, { name: new_history_name });
+        getGalaxyInstance().currHistoryPanel.switchToHistory(data.id);
         return data;
     },
     showCollectionSelect: function (e) {


### PR DESCRIPTION
## What did you do? 
- Fix importing collections to new history
- Fix importing correct elements

## Why did you make this change?
https://github.com/galaxyproject/galaxy/issues/11699#issuecomment-805307522


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
Import a collection to history from the library and select "create a new history" (this was broken for all creator types). Verify that the collection ended up in the new history and verify the correct element had been imported (this was only broken for the list:paired creator)
