### PR TITLE
[21.01] Removedreference to remove-extensions

### DIFF
--- a/client/src/components/Collections/PairCollectionCreator.vue
+++ b/client/src/components/Collections/PairCollectionCreator.vue
@@ -81,7 +81,6 @@
                     :hideSourceItems="hideSourceItems"
                     @onUpdateHideSourceItems="onUpdateHideSourceItems"
                     @clicked-create="clickedCreate"
-                    @remove-extensions-toggle="removeExtensionsToggle"
                     :creationFn="creationFn"
                 >
                     <template v-slot:help-content>


### PR DESCRIPTION
## What did you do? 
- removed unused reference to remove extensions
- 


## Why did you make this change?
#11722 


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [X] Instructions for manual testing are as follows:
  1. open the pair collection creator
  2. open the console
  3. there are no longer errors regarding the remove-extensions toggle


## For UI Components
- [X] I've included a screenshot of the changes
![Screenshot from 2021-03-24 12-28-41](https://user-images.githubusercontent.com/26912553/112346668-8b9c5f80-8c9c-11eb-8f61-3bb4bd9ced04.png)