### PR TITLE
lint for checkboxes select

### DIFF
--- a/client/src/mvc/tool/tool-form.js
+++ b/client/src/mvc/tool/tool-form.js
@@ -356,7 +356,7 @@ const View = Backbone.View.extend({
                 continue;
             }
             if (!input_def.optional && input_value == null && input_def.type != "hidden") {
-                this.form.highlight(input_id);
+                this.form.highlight(input_id, "This input requires a value.");
                 return false;
             }
             if (input_field.validate) {

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -44,6 +44,11 @@ def lint_inputs(tool_xml, lint_ctx):
             if dynamic_options is None and len(select_options) == 0:
                 lint_ctx.warn(f"No options defined for select [{param_name}]")
 
+            if param_attrib.get("display") == "checkbockes":
+                if not string_as_bool(param_attrib.get("multiple", "false")):
+                    lint_ctx.error(f'Select [{param_name}] display="checkboxes" is incompatible with multiple="false"')
+                if not string_as_bool(param_attrib.get("optional", "false")):
+                    lint_ctx.error(f'Select [{param_name}] display="checkboxes" is incompatible with optional="false"')
             if param_attrib.get("display") == "radio":
                 if string_as_bool(param_attrib.get("multiple", "false")):
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with multiple="true"')

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -44,7 +44,7 @@ def lint_inputs(tool_xml, lint_ctx):
             if dynamic_options is None and len(select_options) == 0:
                 lint_ctx.warn(f"No options defined for select [{param_name}]")
 
-            if param_attrib.get("display") == "checkbockes":
+            if param_attrib.get("display") == "checkboxes":
                 if not string_as_bool(param_attrib.get("multiple", "false")):
                     lint_ctx.error(f'Select [{param_name}] display="checkboxes" is incompatible with multiple="false"')
                 if not string_as_bool(param_attrib.get("optional", "false")):

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -46,9 +46,9 @@ def lint_inputs(tool_xml, lint_ctx):
 
             if param_attrib.get("display") == "checkboxes":
                 if not string_as_bool(param_attrib.get("multiple", "false")):
-                    lint_ctx.error(f'Select [{param_name}] display="checkboxes" is incompatible with multiple="false"')
+                    lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute')
                 if not string_as_bool(param_attrib.get("optional", "false")):
-                    lint_ctx.error(f'Select [{param_name}] display="checkboxes" is incompatible with optional="false"')
+                    lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute')
             if param_attrib.get("display") == "radio":
                 if string_as_bool(param_attrib.get("multiple", "false")):
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with multiple="true"')

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2888,7 +2888,7 @@ is still the column index. Used only when the ``type`` attribute value is
         <xs:attribute name="display" type="DisplayType">
           <xs:annotation>
             <xs:documentation xml:lang="en">Render a select list as a set of
-checkboxes (``checkboxes``; note this is incompatible with ``multipe="false"``
+checkboxes (``checkboxes``; note this is incompatible with ``multiple="false"``
 and ``optional="false"``) or radio buttons (``radio``; note this is
 incompatible with ``multiple="true"`` and ``optional="true"``). Defaults to a
 drop-down menu select list. Used only when the ``type`` attribute value is

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2888,7 +2888,8 @@ is still the column index. Used only when the ``type`` attribute value is
         <xs:attribute name="display" type="DisplayType">
           <xs:annotation>
             <xs:documentation xml:lang="en">Render a select list as a set of
-checkboxes (``checkboxes``) or radio buttons (``radio``; note this is
+checkboxes (``checkboxes``; note this is incompatible with ``multipe="false"``
+and ``optional="false"``) or radio buttons (``radio``; note this is
 incompatible with ``multiple="true"`` and ``optional="true"``). Defaults to a
 drop-down menu select list. Used only when the ``type`` attribute value is
 ``select``.</xs:documentation>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -31,7 +31,14 @@ RADIO_SELECT_INCOMPATIBILITIES = """
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
-        <param name="radio_select" type="select" display="radio" optional="true" multiple="true"/>
+        <param name="radio_select" type="select" display="radio" optional="true" multiple="true">
+            <option "1">1</option>
+            <option "2">2</option>
+        </param>
+        <param name="radio_checkboxes" type="select" display="checkboxes" optional="false" multiple="false">
+            <option "1">1</option>
+            <option "2">2</option>
+        </param>
     </inputs>
 </tool>
 """
@@ -51,13 +58,35 @@ SELECT_DUPLICATED_OPTIONS = """
 
 TESTS = [
     (NO_SECTIONS_XML, inputs.lint_inputs, lambda x: 'Found no input parameters.' in x.warn_messages),
-    (NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs, lambda x: "Conditional [labels] no <when /> block found for select option 'none'" in x.warn_messages),
-    (RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs, lambda x: 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages),
-    (SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs, lambda x: 'Select [select] has multiple options with the same text content' in x.error_messages and 'Select [select] has multiple options with the same value' in x.error_messages),
+    (
+        NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs,
+        lambda x: "Conditional [labels] no <when /> block found for select option 'none'" in x.warn_messages
+    ),
+    (
+        RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs,
+        lambda x:
+            'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages
+            and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages
+            and 'Select [radio_checkboxes] display="checkboxes" is incompatible with optional="false"' in x.error_messages
+            and 'Select [radio_checkboxes] display="checkboxes" is incompatible with multiple="false"' in x.error_messages
+    ),
+    (
+        SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs,
+        lambda x:
+            'Select [select] has multiple options with the same text content' in x.error_messages
+            and 'Select [select] has multiple options with the same value' in x.error_messages
+    ),
+]
+
+TEST_IDS = [
+    'Lint no sections',
+    'lint no when',
+    'radio select incompatibilities',
+    'select duplicated options'
 ]
 
 
-@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=['Lint no sections', 'lint no when', 'radio select incompatibilities', 'select duplicated options'])
+@pytest.mark.parametrize('tool_xml,lint_func,assert_func', TESTS, ids=TEST_IDS)
 def test_tool_xml(tool_xml, lint_func, assert_func):
     lint_ctx = LintContext('all')
     tree = etree.ElementTree(element=etree.fromstring(tool_xml))

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -32,12 +32,12 @@ RADIO_SELECT_INCOMPATIBILITIES = """
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
         <param name="radio_select" type="select" display="radio" optional="true" multiple="true">
-            <option "1">1</option>
-            <option "2">2</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
         </param>
         <param name="radio_checkboxes" type="select" display="checkboxes" optional="false" multiple="false">
-            <option "1">1</option>
-            <option "2">2</option>
+            <option value="1">1</option>
+            <option value="2">2</option>
         </param>
     </inputs>
 </tool>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -67,8 +67,8 @@ TESTS = [
         lambda x:
             'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages
             and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages
-            and 'Select [radio_checkboxes] display="checkboxes" is incompatible with optional="false"' in x.error_messages
-            and 'Select [radio_checkboxes] display="checkboxes" is incompatible with multiple="false"' in x.error_messages
+            and 'Select [radio_checkboxes] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute' in x.error_messages
+            and 'Select [radio_checkboxes] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute' in x.error_messages
     ),
     (
         SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs,


### PR DESCRIPTION
## What did you do? 

Added a linter for select parameters with `display="checkboxes"` that ensures that neither `multiple` or `optional` are `false`.

## Why did you make this change?

Both cases are not nicely represented in the UI. That is the user can:

- select multiple options and 
- select no option

which will lead to an error when executing the tool. Also the error message is not really helpful `Please verify this parameter` (wondering if we can improve this).

https://github.com/galaxyproteomics/tools-galaxyp/issues/576#issue-834712565

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

I want to say that I really like the new PR form because it nudges me to think about tests and not be to lazy :)

## For UI Components
- [ ] I've included a screenshot of the changes
