### PR TITLE
Don't toggle code row

### DIFF
--- a/client/src/components/JobInformation/CodeRow.vue
+++ b/client/src/components/JobInformation/CodeRow.vue
@@ -3,22 +3,15 @@
         <td>
             {{ codeLabel }}
         </td>
-        <td v-if="expanded">
-            <pre class="code">{{ codeItem }}</pre>
-        </td>
-        <td v-else-if="codeItem">
-            <pre class="code preview">{{ codeItem }}</pre>
-            <b>(Click to expand)</b>
+        <td v-if="codeItem">
+            <pre @click.stop :class="codeClass">{{ codeItem }}</pre>
+            <i :class="iconClass" />
+            <b>Click to {{ action }}</b>
         </td>
         <td v-else><i>empty</i></td>
     </tr>
 </template>
 <script>
-import Vue from "vue";
-import BootstrapVue from "bootstrap-vue";
-
-Vue.use(BootstrapVue);
-
 export default {
     props: {
         codeLabel: String,
@@ -26,6 +19,17 @@ export default {
     },
     data() {
         return { expanded: false };
+    },
+    computed: {
+        action() {
+            return this.expanded ? "collapse" : "expand";
+        },
+        codeClass() {
+            return this.expanded ? "code" : "code preview";
+        },
+        iconClass() {
+            return this.expanded ? "fa fa-minus" : "fa fa-plus";
+        },
     },
     methods: {
         toggleExpanded() {


### PR DESCRIPTION
## What did you do? 
To exand/toggle you need to click anywhere within the tr, but not in the
code row. I tried placing an icon next to the pre element, but couldn't
make it work while maintaining the ellipsis. 



## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/11723



## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## For UI Components
- [x] I've included a screenshot of the changes

![clicktoexpand](https://user-images.githubusercontent.com/6804901/112480816-acd17e80-8d76-11eb-8401-c8d176929ba2.gif)