### PR TITLE
Fix job filtering by `date_range_max` / `date_range_mix`

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -755,8 +755,11 @@ class Job(JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         self.state_history = []
         self.imported = False
         self.handler = None
+        self.create_time = None
         self.exit_code = None
+        self.history_id = None
         self.job_messages = None
+        self.update_time = None
         self._init_metrics()
         self.state_history.append(JobStateHistory(self))
 
@@ -5323,6 +5326,7 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         self.subworkflow_invocations = []
         self.step_states = []
         self.steps = []
+        self.workflow_id = None
 
     def create_subworkflow_invocation_for_step(self, step):
         assert step.type == "subworkflow"
@@ -5674,6 +5678,11 @@ class WorkflowInvocationStep(Dictifiable, RepresentById):
         SCHEDULED = 'scheduled'  # Workflow invocation step has been scheduled.
         # CANCELLED = 'cancelled',  TODO: implement and expose
         # FAILED = 'failed',  TODO: implement and expose
+
+    def __init__(self):
+        self.implicit_collection_jobs_id = None
+        self.job_id = None
+        self.workflow_invocation_id = None
 
     @property
     def is_new(self):

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -162,8 +162,8 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
         query = build_and_apply_filters(query, kwd.get('tool_id', None), lambda t: job_alias.tool_id == t)
         query = build_and_apply_filters(query, kwd.get('tool_id_like', None), lambda t: job_alias.tool_id.like(t))
 
-        query = build_and_apply_filters(query, kwd.get('date_range_min', None), lambda dmin: job_alias.table.c.update_time >= dmin)
-        query = build_and_apply_filters(query, kwd.get('date_range_max', None), lambda dmax: job_alias.table.c.update_time <= dmax)
+        query = build_and_apply_filters(query, kwd.get('date_range_min', None), lambda dmin: job_alias.update_time >= dmin)
+        query = build_and_apply_filters(query, kwd.get('date_range_max', None), lambda dmax: job_alias.update_time <= dmax)
 
         history_id = kwd.get('history_id', None)
         workflow_id = kwd.get('workflow_id', None)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -71,7 +71,7 @@ class JobsApiTestCase(ApiTestCase, TestsTools):
     @uses_test_history(require_new=True)
     def test_index_date_filter(self, history_id):
         self.__history_with_new_dataset(history_id)
-        two_weeks_ago = (datetime.datetime.utcnow() - datetime.timedelta(7)).isoformat()
+        two_weeks_ago = (datetime.datetime.utcnow() - datetime.timedelta(14)).isoformat()
         last_week = (datetime.datetime.utcnow() - datetime.timedelta(7)).isoformat()
         next_week = (datetime.datetime.utcnow() + datetime.timedelta(7)).isoformat()
         today = datetime.datetime.utcnow().isoformat()


### PR DESCRIPTION
## What did you do? 
1) Fix query broken in commit 889280240058cf6a6e2d32cad8744a7118234772 .
2) Removed unnecessary use of SQLAlchemy `aliased`. Fix resulting mypy issues by initialising attributes in `galaxy.model` .


## Why did you make this change?
1) To fix https://github.com/galaxyproject/galaxy/issues/11706 .
2) `aliased` is normally used "as an alternate within a SQL statement generated by the ORM, such that an existing mapped entity can be used in multiple contexts", i.e. for something like:

   ```
   my_alias = aliased(MyClass)

   session.query(MyClass, my_alias).filter(MyClass.id > my_alias.id)
   ```


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## For UI Components
- [ ] I've included a screenshot of the changes
