### PR TITLE
Migrate to SQLAlchemy 1.4

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.7
+sqlalchemy==1.4.9
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -72,6 +72,7 @@ google-api-python-client==1.12.8; python_version >= "2.7" and python_full_versio
 google-auth-httplib2==0.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth==1.30.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 googleapis-common-protos==1.53.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+greenlet==1.0.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4.0"
 gunicorn==20.1.0; python_version >= "3.5"
 gxformat2==0.15.0
 h11==0.12.0; python_version >= "3.6"
@@ -223,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.3.24; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+sqlalchemy==1.4.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.12
+sqlalchemy==1.4.14
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+sqlalchemy==1.4.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+sqlalchemy==1.4.5
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.9
+sqlalchemy==1.4.10
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.6
+sqlalchemy==1.4.7
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.11
+sqlalchemy==1.4.12
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.5
+sqlalchemy==1.4.6
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.10
+sqlalchemy==1.4.11
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -224,7 +224,7 @@ sphinxcontrib-jsmath==1.0.1; python_version >= "3.5"
 sphinxcontrib-qthelp==1.0.3; python_version >= "3.5"
 sphinxcontrib-serializinghtml==1.1.4; python_version >= "3.5"
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.14
+sqlalchemy==1.4.15
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+sqlalchemy==1.4.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -66,6 +66,7 @@ google-api-python-client==1.12.8; python_version >= "2.7" and python_full_versio
 google-auth-httplib2==0.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth==1.30.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 googleapis-common-protos==1.53.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+greenlet==1.0.0; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4.0"
 gxformat2==0.15.0
 h11==0.12.0; python_version >= "3.6"
 h5py==3.1.0; python_version >= "3.6"
@@ -179,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.3.24; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+sqlalchemy==1.4.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.14
+sqlalchemy==1.4.15
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.5
+sqlalchemy==1.4.6
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.11
+sqlalchemy==1.4.12
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.7
+sqlalchemy==1.4.9
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.10
+sqlalchemy==1.4.11
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.6
+sqlalchemy==1.4.7
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
+sqlalchemy==1.4.5
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.12
+sqlalchemy==1.4.14
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -180,7 +180,7 @@ six==1.15.0; python_version >= "3.6" and python_full_version < "3.0.0" and pytho
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sqlalchemy-migrate==0.13.0
-sqlalchemy==1.4.9
+sqlalchemy==1.4.10
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
 starlette-context==0.3.2; python_version >= "3.7"

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1585,14 +1585,6 @@ class JobWrapper(HasResourceParameters):
 
         self.sa_session.add(dataset)
 
-        # This is a temporary fix for a probem that happens under SQLAlchemy 1.4.
-        # The 'dataset' attribute (which is an HDA) of the JobToOutputDatasetAssociation is expired in SA's instance state.
-        # Thus, upon access, it is reloaded from the database, which erases the metadata that has been loaded but not flushed to the db.
-        # In SA 1.3, the 'dataset' attribute is NOT expired, so accessing it does not trigger database access and the metadata is not erased.
-        # (Specifics: hda._metadata is a populated dict. Under 1.3 it is unchanged, but under 1.4 it becomes None.)
-        # This is NOT a good solution because it deals with the symptom, not the problem. The real cause should be identified before merge.
-        self.sa_session.flush()
-
     def finish(
         self,
         tool_stdout,

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1585,6 +1585,14 @@ class JobWrapper(HasResourceParameters):
 
         self.sa_session.add(dataset)
 
+        # This is a temporary fix for a probem that happens under SQLAlchemy 1.4.
+        # The 'dataset' attribute (which is an HDA) of the JobToOutputDatasetAssociation is expired in SA's instance state.
+        # Thus, upon access, it is reloaded from the database, which erases the metadata that has been loaded but not flushed to the db.
+        # In SA 1.3, the 'dataset' attribute is NOT expired, so accessing it does not trigger database access and the metadata is not erased.
+        # (Specifics: hda._metadata is a populated dict. Under 1.3 it is unchanged, but under 1.4 it becomes None.)
+        # This is NOT a good solution because it deals with the symptom, not the problem. The real cause should be identified before merge.
+        self.sa_session.flush()
+
     def finish(
         self,
         tool_stdout,

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -60,7 +60,7 @@ class PosgresDatabaseManager(DatabaseManager):
 
     def _handle_no_database(self):
         self.database = self.url.database  # use database from db_url
-        self.url.database = 'postgres'
+        self.url = self.url.set(database = 'postgres')
 
     def exists(self):
         with sqlalchemy_engine(self.url) as engine:

--- a/lib/galaxy/model/database_utils.py
+++ b/lib/galaxy/model/database_utils.py
@@ -60,7 +60,7 @@ class PosgresDatabaseManager(DatabaseManager):
 
     def _handle_no_database(self):
         self.database = self.url.database  # use database from db_url
-        self.url = self.url.set(database = 'postgres')
+        self.url = self.url.set(database='postgres')
 
     def exists(self):
         with sqlalchemy_engine(self.url) as engine:

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2188,7 +2188,6 @@ mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.
 ))
 
 mapper(model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetCollectionAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset_collection=relation(model.HistoryDatasetCollectionAssociation,
         lazy=False)
 ))
@@ -2771,7 +2770,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     library_folder=relation(model.LibraryFolder, lazy=True),
     parameters=relation(model.JobParameter, lazy=True),
     input_datasets=relation(model.JobToInputDatasetAssociation, backref="job"),
-    input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, lazy=True),
+    input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, backref="job", lazy=True),
     input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation, lazy=True),
     output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation, lazy=True),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2162,7 +2162,9 @@ mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.ta
 
 mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.table, properties=dict(
     job=relation(model.Job),
-    dataset=relation(model.HistoryDatasetAssociation, lazy=False)
+    dataset=relation(model.HistoryDatasetAssociation,
+        lazy=False,
+        backref="creating_job_associations")
 ))
 
 mapper(model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetCollectionAssociation.table, properties=dict(
@@ -2782,9 +2784,6 @@ mapper(model.DataManagerJobAssociation, model.DataManagerJobAssociation.table, p
         backref=backref('data_manager_association', uselist=False),
         uselist=False)
 ))
-
-class_mapper(model.HistoryDatasetAssociation).add_property(
-    "creating_job_associations", relation(model.JobToOutputDatasetAssociation))
 
 class_mapper(model.HistoryDatasetCollectionAssociation).add_property(
     "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation))

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2377,7 +2377,7 @@ simple_mapping(model.HistoryDatasetCollectionAssociation,
         backref="dataset_collections"),
     ratings=relation(model.HistoryDatasetCollectionRatingAssociation,
         order_by=model.HistoryDatasetCollectionRatingAssociation.table.c.id,
-        backref="dataset_collections")
+        backref="dataset_collection")
 )
 
 simple_mapping(model.LibraryDatasetCollectionAssociation,
@@ -2770,8 +2770,7 @@ rating_mapping(model.HistoryDatasetAssociationRatingAssociation)
 rating_mapping(model.StoredWorkflowRatingAssociation)
 rating_mapping(model.PageRatingAssociation)
 rating_mapping(model.VisualizationRatingAssociation)
-rating_mapping(model.HistoryDatasetCollectionRatingAssociation,
-    history_dataset_collection=model.HistoryDatasetCollectionAssociation)
+rating_mapping(model.HistoryDatasetCollectionRatingAssociation)
 rating_mapping(model.LibraryDatasetCollectionRatingAssociation,
     libary_dataset_collection=model.LibraryDatasetCollectionAssociation)
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2208,7 +2208,6 @@ mapper(model.JobToImplicitOutputDatasetCollectionAssociation, model.JobToImplici
 ))
 
 mapper(model.JobToInputLibraryDatasetAssociation, model.JobToInputLibraryDatasetAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset=relation(model.LibraryDatasetDatasetAssociation,
         lazy=False,
         backref="dependent_jobs")
@@ -2775,7 +2774,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation,
         backref="job", lazy=True),
     post_job_actions=relation(model.PostJobActionAssociation, backref="job", lazy=False),
-    input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation),
+    input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation, backref="job"),
     output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation, lazy=True),
     external_output_metadata=relation(model.JobExternalOutputMetadata, lazy=True, backref='job'),
     tasks=relation(model.Task, backref='job')

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1888,7 +1888,7 @@ mapper(model.History, model.History.table, properties=dict(
         deferred=True
     ),
     update_time=column_property(
-        select([func.max(model.HistoryAudit.table.c.update_time)]).where(model.HistoryAudit.table.c.history_id == model.History.table.c.id),
+        select(func.max(model.HistoryAudit.table.c.update_time)).where(model.HistoryAudit.table.c.history_id == model.History.table.c.id).scalar_subquery(),
     ),
 ))
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2181,6 +2181,7 @@ mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.ta
 ))
 
 mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.table, properties=dict(
+    job=relation(model.Job),
     dataset=relation(model.HistoryDatasetAssociation,
         lazy=False,
         backref="creating_job_associations")
@@ -2766,8 +2767,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, backref="job", lazy=True),
     input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation,
         backref="job", lazy=True),
-    output_datasets=relation(model.JobToOutputDatasetAssociation,
-        backref="job", lazy=True),
+    output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation,
         backref="job", lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1957,13 +1957,11 @@ mapper(model.PasswordResetToken, model.PasswordResetToken.table,
 # <user_obj>.preferences[pref_name] = pref_value
 model.User.preferences = association_proxy('_preferences', 'value', creator=model.UserPreference)  # type: ignore
 
-mapper(model.Group, model.Group.table, properties=dict(
-    users=relation(model.UserGroupAssociation)
-))
+mapper(model.Group, model.Group.table)
 
 mapper(model.UserGroupAssociation, model.UserGroupAssociation.table, properties=dict(
     user=relation(model.User, backref="groups"),
-    group=relation(model.Group, backref="members")
+    group=relation(model.Group, backref="users")
 ))
 
 mapper(model.DefaultUserPermissions, model.DefaultUserPermissions.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2531,7 +2531,7 @@ mapper(model.StoredWorkflowMenuEntry, model.StoredWorkflowMenuEntry.table, prope
 
 mapper(model.WorkflowInvocation, model.WorkflowInvocation.table, properties=dict(
     history=relation(model.History, backref=backref('workflow_invocations', uselist=True)),
-    input_parameters=relation(model.WorkflowRequestInputParameter),
+    input_parameters=relation(model.WorkflowRequestInputParameter, backref='workflow_invocation'),
     step_states=relation(model.WorkflowRequestStepState),
     input_step_parameters=relation(model.WorkflowRequestInputStepParameter),
     input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation),
@@ -2568,8 +2568,7 @@ simple_mapping(model.WorkflowInvocationStep,
 )
 
 
-simple_mapping(model.WorkflowRequestInputParameter,
-    workflow_invocation=relation(model.WorkflowInvocation))
+simple_mapping(model.WorkflowRequestInputParameter)
 
 simple_mapping(model.WorkflowRequestStepState,
     workflow_invocation=relation(model.WorkflowInvocation),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2183,7 +2183,8 @@ mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.ta
 
 mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.table, properties=dict(
     dataset=relation(model.HistoryDatasetAssociation,
-        lazy=False)
+        lazy=False,
+        backref="creating_job_associations")
 ))
 
 mapper(model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetCollectionAssociation.table, properties=dict(
@@ -2807,12 +2808,6 @@ mapper(model.DataManagerJobAssociation, model.DataManagerJobAssociation.table, p
         uselist=False)
 ))
 
-# model.HistoryDatasetAssociation.mapper.add_property( "creating_job_associations",
-#     relation( model.JobToOutputDatasetAssociation ) )
-# model.LibraryDatasetDatasetAssociation.mapper.add_property( "creating_job_associations",
-#     relation( model.JobToOutputLibraryDatasetAssociation ) )
-class_mapper(model.HistoryDatasetAssociation).add_property(
-    "creating_job_associations", relation(model.JobToOutputDatasetAssociation))
 class_mapper(model.LibraryDatasetDatasetAssociation).add_property(
     "creating_job_associations", relation(model.JobToOutputLibraryDatasetAssociation))
 class_mapper(model.HistoryDatasetCollectionAssociation).add_property(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -518,9 +518,11 @@ model.LibraryDatasetDatasetAssociation.table = Table(
     Column("copied_from_history_dataset_association_id", Integer,
         ForeignKey("history_dataset_association.id", use_alter=True, name='history_dataset_association_dataset_id_fkey'),
         nullable=True),
+
     Column("copied_from_library_dataset_dataset_association_id", Integer,
         ForeignKey("library_dataset_dataset_association.id", use_alter=True, name='library_dataset_dataset_association_id_fkey'),
         nullable=True),
+
     Column("name", TrimmedString(255), index=True),
     Column("info", TrimmedString(255)),
     Column("blurb", TrimmedString(255)),
@@ -2134,10 +2136,8 @@ mapper(model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssoci
         primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id),
         remote_side=[model.LibraryDatasetDatasetAssociation.table.c.id],
-        uselist=False),
-    copied_to_library_dataset_dataset_associations=relation(model.LibraryDatasetDatasetAssociation,
-        primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
-                     == model.LibraryDatasetDatasetAssociation.table.c.id)),
+        uselist=False,
+        backref='copied_to_library_dataset_dataset_associations'),
     copied_from_history_dataset_association=relation(model.HistoryDatasetAssociation,
         primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.copied_from_history_dataset_association_id
                      == model.HistoryDatasetAssociation.table.c.id),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2701,7 +2701,7 @@ mapper(model.Visualization, model.Visualization.table, properties=dict(
         backref="visualizations"),
     ratings=relation(model.VisualizationRatingAssociation,
         order_by=model.VisualizationRatingAssociation.table.c.id,
-        backref="visualizations"),
+        backref="visualization"),
     average_rating=column_property(
         select(func.avg(model.VisualizationRatingAssociation.table.c.rating)).where(model.VisualizationRatingAssociation.table.c.visualization_id == model.Visualization.table.c.id).scalar_subquery(),
         deferred=True
@@ -2769,7 +2769,7 @@ rating_mapping(model.HistoryRatingAssociation, history=model.History)
 rating_mapping(model.HistoryDatasetAssociationRatingAssociation, hda=model.HistoryDatasetAssociation)
 rating_mapping(model.StoredWorkflowRatingAssociation, stored_workflow=model.StoredWorkflow)
 rating_mapping(model.PageRatingAssociation)
-rating_mapping(model.VisualizationRatingAssociation, visualizaiton=model.Visualization)
+rating_mapping(model.VisualizationRatingAssociation)
 rating_mapping(model.HistoryDatasetCollectionRatingAssociation,
     history_dataset_collection=model.HistoryDatasetCollectionAssociation)
 rating_mapping(model.LibraryDatasetCollectionRatingAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1886,7 +1886,7 @@ mapper(model.History, model.History.table, properties=dict(
         backref="histories"),
     ratings=relation(model.HistoryRatingAssociation,
         order_by=model.HistoryRatingAssociation.table.c.id,
-        backref="histories"),
+        backref="history"),
     average_rating=column_property(
         select(func.avg(model.HistoryRatingAssociation.table.c.rating)).where(model.HistoryRatingAssociation.table.c.history_id == model.History.table.c.id).scalar_subquery(),
         deferred=True
@@ -2765,7 +2765,7 @@ def rating_mapping(rating_class, **kwds):
     simple_mapping(rating_class, **dict(user=relation(model.User), **kwds))
 
 
-rating_mapping(model.HistoryRatingAssociation, history=model.History)
+rating_mapping(model.HistoryRatingAssociation)
 rating_mapping(model.HistoryDatasetAssociationRatingAssociation, hda=model.HistoryDatasetAssociation)
 rating_mapping(model.StoredWorkflowRatingAssociation, stored_workflow=model.StoredWorkflow)
 rating_mapping(model.PageRatingAssociation)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2029,17 +2029,10 @@ mapper(model.Library, model.Library.table, properties=dict(
 ))
 
 mapper(model.ExtendedMetadata, model.ExtendedMetadata.table, properties=dict(
-    children=relation(model.ExtendedMetadataIndex,
-        primaryjoin=(model.ExtendedMetadataIndex.table.c.extended_metadata_id == model.ExtendedMetadata.table.c.id),
-        backref=backref("parent",
-            primaryjoin=(model.ExtendedMetadataIndex.table.c.extended_metadata_id == model.ExtendedMetadata.table.c.id)))
+    children=relation(model.ExtendedMetadataIndex, backref='extended_metadata')
 ))
 
-mapper(model.ExtendedMetadataIndex, model.ExtendedMetadataIndex.table, properties=dict(
-    extended_metadata=relation(model.ExtendedMetadata,
-        primaryjoin=(model.ExtendedMetadataIndex.table.c.extended_metadata_id == model.ExtendedMetadata.table.c.id))
-))
-
+mapper(model.ExtendedMetadataIndex, model.ExtendedMetadataIndex.table)
 
 mapper(model.LibraryInfoAssociation, model.LibraryInfoAssociation.table, properties=dict(
     library=relation(model.Library,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2534,7 +2534,7 @@ mapper(model.WorkflowInvocation, model.WorkflowInvocation.table, properties=dict
     input_parameters=relation(model.WorkflowRequestInputParameter, backref='workflow_invocation'),
     step_states=relation(model.WorkflowRequestStepState, backref='workflow_invocation'),
     input_step_parameters=relation(model.WorkflowRequestInputStepParameter, backref='workflow_invocation'),
-    input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation),
+    input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation, backref='workflow_invocation'),
     input_dataset_collections=relation(model.WorkflowRequestToInputDatasetCollectionAssociation),
     subworkflow_invocations=relation(model.WorkflowInvocationToSubworkflowInvocationAssociation,
         primaryjoin=(model.WorkflowInvocationToSubworkflowInvocationAssociation.table.c.workflow_invocation_id == model.WorkflowInvocation.table.c.id),
@@ -2577,7 +2577,6 @@ simple_mapping(model.WorkflowRequestInputStepParameter,
     workflow_step=relation(model.WorkflowStep))
 
 simple_mapping(model.WorkflowRequestToInputDatasetAssociation,
-    workflow_invocation=relation(model.WorkflowInvocation),
     workflow_step=relation(model.WorkflowStep),
     dataset=relation(model.HistoryDatasetAssociation))
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2499,6 +2499,7 @@ mapper(model.StoredWorkflow, model.StoredWorkflow.table, properties=dict(
             and_(model.StoredWorkflow.table.c.id == model.StoredWorkflowTagAssociation.table.c.stored_workflow_id,
                  model.StoredWorkflow.table.c.user_id == model.StoredWorkflowTagAssociation.table.c.user_id)
         ),
+        viewonly=True,
         order_by=model.StoredWorkflowTagAssociation.table.c.id),
     annotations=relation(model.StoredWorkflowAnnotationAssociation,
         order_by=model.StoredWorkflowAnnotationAssociation.table.c.id,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2193,7 +2193,6 @@ mapper(model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetColl
 ))
 
 mapper(model.JobToInputDatasetCollectionElementAssociation, model.JobToInputDatasetCollectionElementAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset_collection_element=relation(model.DatasetCollectionElement,
     lazy=False)
 ))
@@ -2771,7 +2770,8 @@ mapper(model.Job, model.Job.table, properties=dict(
     parameters=relation(model.JobParameter, lazy=True),
     input_datasets=relation(model.JobToInputDatasetAssociation, backref="job"),
     input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, backref="job", lazy=True),
-    input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation, lazy=True),
+    input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation,
+        backref="job", lazy=True),
     output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation, lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation, lazy=True),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2392,7 +2392,7 @@ simple_mapping(model.LibraryDatasetCollectionAssociation,
         backref='dataset_collections'),
     annotations=relation(model.LibraryDatasetCollectionAnnotationAssociation,
         order_by=model.LibraryDatasetCollectionAnnotationAssociation.table.c.id,
-        backref="dataset_collections"),
+        backref="dataset_collection"),
     ratings=relation(model.LibraryDatasetCollectionRatingAssociation,
         order_by=model.LibraryDatasetCollectionRatingAssociation.table.c.id,
         backref="dataset_collection"))
@@ -2758,8 +2758,7 @@ annotation_mapping(model.PageAnnotationAssociation)
 annotation_mapping(model.VisualizationAnnotationAssociation)
 annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
     history_dataset_collection=model.HistoryDatasetCollectionAssociation)
-annotation_mapping(model.LibraryDatasetCollectionAnnotationAssociation,
-    library_dataset_collection=model.LibraryDatasetCollectionAssociation)
+annotation_mapping(model.LibraryDatasetCollectionAnnotationAssociation)
 
 
 # Rating tables.

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1782,11 +1782,13 @@ simple_mapping(model.Dataset,
         primaryjoin=(
             (model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id)
             & (model.HistoryDatasetAssociation.table.c.deleted == false())
-            & (model.HistoryDatasetAssociation.table.c.purged == false()))),
+            & (model.HistoryDatasetAssociation.table.c.purged == false())),
+        viewonly=True),
     purged_history_associations=relation(model.HistoryDatasetAssociation,
         primaryjoin=(
             (model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id)
-            & (model.HistoryDatasetAssociation.table.c.purged == true()))),
+            & (model.HistoryDatasetAssociation.table.c.purged == true())),
+        viewonly=True),
     library_associations=relation(model.LibraryDatasetDatasetAssociation,
         primaryjoin=(model.Dataset.table.c.id == model.LibraryDatasetDatasetAssociation.table.c.dataset_id)),
     active_library_associations=relation(model.LibraryDatasetDatasetAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2216,7 +2216,8 @@ mapper(model.JobToInputLibraryDatasetAssociation, model.JobToInputLibraryDataset
 
 mapper(model.JobToOutputLibraryDatasetAssociation, model.JobToOutputLibraryDatasetAssociation.table, properties=dict(
     dataset=relation(model.LibraryDatasetDatasetAssociation,
-        lazy=False)
+        lazy=False,
+        backref="creating_job_associations")
 ))
 
 simple_mapping(model.JobStateHistory,
@@ -2808,8 +2809,6 @@ mapper(model.DataManagerJobAssociation, model.DataManagerJobAssociation.table, p
         uselist=False)
 ))
 
-class_mapper(model.LibraryDatasetDatasetAssociation).add_property(
-    "creating_job_associations", relation(model.JobToOutputLibraryDatasetAssociation))
 class_mapper(model.HistoryDatasetCollectionAssociation).add_property(
     "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation))
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1842,7 +1842,6 @@ mapper(model.ImplicitlyConvertedDatasetAssociation, model.ImplicitlyConvertedDat
 ))
 
 mapper(model.History, model.History.table, properties=dict(
-    galaxy_sessions=relation(model.GalaxySessionToHistoryAssociation),
     datasets=relation(model.HistoryDatasetAssociation,
         backref="history",
         order_by=asc(model.HistoryDatasetAssociation.table.c.hid)),
@@ -2417,7 +2416,7 @@ mapper(model.GalaxySession, model.GalaxySession.table, properties=dict(
 
 mapper(model.GalaxySessionToHistoryAssociation, model.GalaxySessionToHistoryAssociation.table, properties=dict(
     galaxy_session=relation(model.GalaxySession),
-    history=relation(model.History)
+    history=relation(model.History, backref='galaxy_sessions')
 ))
 
 mapper(model.Workflow, model.Workflow.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2182,9 +2182,7 @@ mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.ta
 
 mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.table, properties=dict(
     job=relation(model.Job),
-    dataset=relation(model.HistoryDatasetAssociation,
-        lazy=False,
-        backref="creating_job_associations")
+    dataset=relation(model.HistoryDatasetAssociation, lazy=False)
 ))
 
 mapper(model.JobToInputDatasetCollectionAssociation, model.JobToInputDatasetCollectionAssociation.table, properties=dict(
@@ -2806,6 +2804,9 @@ mapper(model.DataManagerJobAssociation, model.DataManagerJobAssociation.table, p
         backref=backref('data_manager_association', uselist=False),
         uselist=False)
 ))
+
+class_mapper(model.HistoryDatasetAssociation).add_property(
+    "creating_job_associations", relation(model.JobToOutputDatasetAssociation))
 
 class_mapper(model.HistoryDatasetCollectionAssociation).add_property(
     "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation))

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2176,7 +2176,6 @@ mapper(model.LibraryDatasetDatasetInfoAssociation, model.LibraryDatasetDatasetIn
 ))
 
 mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset=relation(model.HistoryDatasetAssociation,
         lazy=False,
         backref="dependent_jobs")
@@ -2771,7 +2770,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     history=relation(model.History, backref="jobs"),
     library_folder=relation(model.LibraryFolder, lazy=True),
     parameters=relation(model.JobParameter, lazy=True),
-    input_datasets=relation(model.JobToInputDatasetAssociation),
+    input_datasets=relation(model.JobToInputDatasetAssociation, backref="job"),
     input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, lazy=True),
     input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation, lazy=True),
     output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1923,6 +1923,7 @@ mapper(model.User, model.User.table, properties=dict(
         viewonly=True,
         order_by=desc(model.History.update_time)),
     galaxy_sessions=relation(model.GalaxySession,
+        backref="user",
         order_by=desc(model.GalaxySession.table.c.update_time)),
     stored_workflow_menu_entries=relation(model.StoredWorkflowMenuEntry,
         primaryjoin=(
@@ -2412,8 +2413,6 @@ mapper(model.Event, model.Event.table, properties=dict(
 mapper(model.GalaxySession, model.GalaxySession.table, properties=dict(
     histories=relation(model.GalaxySessionToHistoryAssociation),
     current_history=relation(model.History),
-    # user=relation( model.User.mapper ) ) )
-    user=relation(model.User)
 ))
 
 mapper(model.GalaxySessionToHistoryAssociation, model.GalaxySessionToHistoryAssociation.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2203,7 +2203,6 @@ mapper(model.JobToOutputDatasetCollectionAssociation, model.JobToOutputDatasetCo
 ))
 
 mapper(model.JobToImplicitOutputDatasetCollectionAssociation, model.JobToImplicitOutputDatasetCollectionAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset_collection=relation(model.DatasetCollection,
         backref="output_dataset_collections")
 ))
@@ -2774,7 +2773,8 @@ mapper(model.Job, model.Job.table, properties=dict(
         backref="job", lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation,
         backref="job", lazy=True),
-    output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation, lazy=True),
+    output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation,
+        backref="job", lazy=True),
     post_job_actions=relation(model.PostJobActionAssociation, lazy=False),
     input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation),
     output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation, lazy=True),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2277,7 +2277,6 @@ simple_mapping(
 mapper(model.JobParameter, model.JobParameter.table)
 
 mapper(model.JobExternalOutputMetadata, model.JobExternalOutputMetadata.table, properties=dict(
-    job=relation(model.Job),
     history_dataset_association=relation(model.HistoryDatasetAssociation, lazy=False),
     library_dataset_dataset_association=relation(model.LibraryDatasetDatasetAssociation, lazy=False)
 ))
@@ -2781,7 +2780,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     post_job_actions=relation(model.PostJobActionAssociation, lazy=False),
     input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation),
     output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation, lazy=True),
-    external_output_metadata=relation(model.JobExternalOutputMetadata, lazy=True),
+    external_output_metadata=relation(model.JobExternalOutputMetadata, lazy=True, backref='job'),
     tasks=relation(model.Task, backref='job')
 ))
 model.Job.any_output_dataset_deleted = column_property(  # type: ignore

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1971,9 +1971,7 @@ mapper(model.DefaultHistoryPermissions, model.DefaultHistoryPermissions.table, p
     role=relation(model.Role)
 ))
 
-mapper(model.Role, model.Role.table, properties=dict(
-    groups=relation(model.GroupRoleAssociation)
-))
+mapper(model.Role, model.Role.table)
 
 mapper(model.UserRoleAssociation, model.UserRoleAssociation.table, properties=dict(
     user=relation(model.User, backref="roles"),
@@ -1991,7 +1989,7 @@ mapper(model.UserRoleAssociation, model.UserRoleAssociation.table, properties=di
 
 mapper(model.GroupRoleAssociation, model.GroupRoleAssociation.table, properties=dict(
     group=relation(model.Group, backref="roles"),
-    role=relation(model.Role)
+    role=relation(model.Role, backref="groups")
 ))
 
 mapper(model.Quota, model.Quota.table)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1922,8 +1922,8 @@ mapper(model.User, model.User.table, properties=dict(
             (model.History.table.c.user_id == model.User.table.c.id)
             & (not_(model.History.table.c.deleted))
         ),
+        viewonly=True,
         order_by=desc(model.History.update_time)),
-
     galaxy_sessions=relation(model.GalaxySession,
         order_by=desc(model.GalaxySession.table.c.update_time)),
     stored_workflow_menu_entries=relation(model.StoredWorkflowMenuEntry,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1749,7 +1749,8 @@ simple_mapping(model.HistoryDatasetAssociation,
         model.LibraryDatasetDatasetAssociation,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id),
-        uselist=False),
+        uselist=False,
+        backref='copied_to_history_dataset_associations'),
     copied_to_library_dataset_dataset_associations=relation(model.LibraryDatasetDatasetAssociation,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id)),
@@ -2140,9 +2141,6 @@ mapper(model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssoci
         primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.copied_from_history_dataset_association_id
                      == model.HistoryDatasetAssociation.table.c.id),
         uselist=False),
-    copied_to_history_dataset_associations=relation(model.HistoryDatasetAssociation,
-        primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
-                     == model.LibraryDatasetDatasetAssociation.table.c.id)),
     implicitly_converted_datasets=relation(model.ImplicitlyConvertedDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.ldda_parent_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2506,7 +2506,7 @@ mapper(model.StoredWorkflow, model.StoredWorkflow.table, properties=dict(
         backref="stored_workflows"),
     ratings=relation(model.StoredWorkflowRatingAssociation,
         order_by=model.StoredWorkflowRatingAssociation.table.c.id,
-        backref="stored_workflows"),
+        backref="stored_workflow"),
     average_rating=column_property(
         select(func.avg(model.StoredWorkflowRatingAssociation.table.c.rating)).where(model.StoredWorkflowRatingAssociation.table.c.stored_workflow_id == model.StoredWorkflow.table.c.id).scalar_subquery(),
         deferred=True
@@ -2767,7 +2767,7 @@ def rating_mapping(rating_class, **kwds):
 
 rating_mapping(model.HistoryRatingAssociation)
 rating_mapping(model.HistoryDatasetAssociationRatingAssociation)
-rating_mapping(model.StoredWorkflowRatingAssociation, stored_workflow=model.StoredWorkflow)
+rating_mapping(model.StoredWorkflowRatingAssociation)
 rating_mapping(model.PageRatingAssociation)
 rating_mapping(model.VisualizationRatingAssociation)
 rating_mapping(model.HistoryDatasetCollectionRatingAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2665,7 +2665,7 @@ mapper(model.Page, model.Page.table, properties=dict(
         backref="pages"),
     annotations=relation(model.PageAnnotationAssociation,
         order_by=model.PageAnnotationAssociation.table.c.id,
-        backref="pages"),
+        backref="page"),
     ratings=relation(model.PageRatingAssociation,
         order_by=model.PageRatingAssociation.table.c.id,
         backref="page"),
@@ -2754,7 +2754,7 @@ annotation_mapping(model.HistoryAnnotationAssociation, history=model.History)
 annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation, hda=model.HistoryDatasetAssociation)
 annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=model.StoredWorkflow)
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
-annotation_mapping(model.PageAnnotationAssociation, page=model.Page)
+annotation_mapping(model.PageAnnotationAssociation)
 annotation_mapping(model.VisualizationAnnotationAssociation, visualization=model.Visualization)
 annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
     history_dataset_collection=model.HistoryDatasetCollectionAssociation)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1733,7 +1733,9 @@ simple_mapping(model.DynamicTool)
 
 simple_mapping(model.HistoryDatasetAssociation,
     dataset=relation(model.Dataset,
-        primaryjoin=(model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id), lazy=False),
+        primaryjoin=(model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id),
+        lazy=False,
+        backref='history_associations'),
     # .history defined in History mapper
     copied_from_history_dataset_association=relation(model.HistoryDatasetAssociation,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_history_dataset_association_id
@@ -1776,8 +1778,6 @@ simple_mapping(model.HistoryDatasetAssociation,
 
 simple_mapping(model.Dataset,
     job=relation(model.Job, primaryjoin=(model.Dataset.table.c.job_id == model.Job.table.c.id)),
-    history_associations=relation(model.HistoryDatasetAssociation,
-        primaryjoin=(model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id)),
     active_history_associations=relation(model.HistoryDatasetAssociation,
         primaryjoin=(
             (model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2377,7 +2377,7 @@ simple_mapping(model.HistoryDatasetCollectionAssociation,
         backref='dataset_collections'),
     annotations=relation(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
         order_by=model.HistoryDatasetCollectionAssociationAnnotationAssociation.table.c.id,
-        backref="dataset_collections"),
+        backref="history_dataset_collection"),
     ratings=relation(model.HistoryDatasetCollectionRatingAssociation,
         order_by=model.HistoryDatasetCollectionRatingAssociation.table.c.id,
         backref="dataset_collection")
@@ -2756,8 +2756,7 @@ annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=mo
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
 annotation_mapping(model.PageAnnotationAssociation)
 annotation_mapping(model.VisualizationAnnotationAssociation)
-annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
-    history_dataset_collection=model.HistoryDatasetCollectionAssociation)
+annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation)
 annotation_mapping(model.LibraryDatasetCollectionAnnotationAssociation)
 
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1993,19 +1993,16 @@ mapper(model.GroupRoleAssociation, model.GroupRoleAssociation.table, properties=
     role=relation(model.Role)
 ))
 
-mapper(model.Quota, model.Quota.table, properties=dict(
-    users=relation(model.UserQuotaAssociation),
-    groups=relation(model.GroupQuotaAssociation)
-))
+mapper(model.Quota, model.Quota.table)
 
 mapper(model.UserQuotaAssociation, model.UserQuotaAssociation.table, properties=dict(
     user=relation(model.User, backref="quotas"),
-    quota=relation(model.Quota)
+    quota=relation(model.Quota, backref="users")
 ))
 
 mapper(model.GroupQuotaAssociation, model.GroupQuotaAssociation.table, properties=dict(
     group=relation(model.Group, backref="quotas"),
-    quota=relation(model.Quota)
+    quota=relation(model.Quota, backref="groups")
 ))
 
 mapper(model.DefaultQuotaAssociation, model.DefaultQuotaAssociation.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2533,9 +2533,12 @@ mapper(model.WorkflowInvocation, model.WorkflowInvocation.table, properties=dict
     history=relation(model.History, backref=backref('workflow_invocations', uselist=True)),
     input_parameters=relation(model.WorkflowRequestInputParameter, backref='workflow_invocation'),
     step_states=relation(model.WorkflowRequestStepState, backref='workflow_invocation'),
-    input_step_parameters=relation(model.WorkflowRequestInputStepParameter, backref='workflow_invocation'),
-    input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation, backref='workflow_invocation'),
-    input_dataset_collections=relation(model.WorkflowRequestToInputDatasetCollectionAssociation),
+    input_step_parameters=relation(model.WorkflowRequestInputStepParameter,
+        backref='workflow_invocation'),
+    input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation,
+        backref='workflow_invocation'),
+    input_dataset_collections=relation(model.WorkflowRequestToInputDatasetCollectionAssociation,
+        backref='workflow_invocation'),
     subworkflow_invocations=relation(model.WorkflowInvocationToSubworkflowInvocationAssociation,
         primaryjoin=(model.WorkflowInvocationToSubworkflowInvocationAssociation.table.c.workflow_invocation_id == model.WorkflowInvocation.table.c.id),
         backref=backref("parent_workflow_invocation", uselist=False),
@@ -2582,7 +2585,6 @@ simple_mapping(model.WorkflowRequestToInputDatasetAssociation,
 
 
 simple_mapping(model.WorkflowRequestToInputDatasetCollectionAssociation,
-    workflow_invocation=relation(model.WorkflowInvocation),
     workflow_step=relation(model.WorkflowStep),
     dataset_collection=relation(model.HistoryDatasetCollectionAssociation))
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2392,7 +2392,7 @@ simple_mapping(model.LibraryDatasetCollectionAssociation,
         backref="dataset_collections"),
     ratings=relation(model.LibraryDatasetCollectionRatingAssociation,
         order_by=model.LibraryDatasetCollectionRatingAssociation.table.c.id,
-        backref="dataset_collections"))
+        backref="dataset_collection"))
 
 simple_mapping(model.DatasetCollectionElement,
     hda=relation(model.HistoryDatasetAssociation,
@@ -2771,8 +2771,7 @@ rating_mapping(model.StoredWorkflowRatingAssociation)
 rating_mapping(model.PageRatingAssociation)
 rating_mapping(model.VisualizationRatingAssociation)
 rating_mapping(model.HistoryDatasetCollectionRatingAssociation)
-rating_mapping(model.LibraryDatasetCollectionRatingAssociation,
-    libary_dataset_collection=model.LibraryDatasetCollectionAssociation)
+rating_mapping(model.LibraryDatasetCollectionRatingAssociation)
 
 mapper(model.Job, model.Job.table, properties=dict(
     # user=relation( model.User.mapper ),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2532,7 +2532,7 @@ mapper(model.StoredWorkflowMenuEntry, model.StoredWorkflowMenuEntry.table, prope
 mapper(model.WorkflowInvocation, model.WorkflowInvocation.table, properties=dict(
     history=relation(model.History, backref=backref('workflow_invocations', uselist=True)),
     input_parameters=relation(model.WorkflowRequestInputParameter, backref='workflow_invocation'),
-    step_states=relation(model.WorkflowRequestStepState),
+    step_states=relation(model.WorkflowRequestStepState, backref='workflow_invocation'),
     input_step_parameters=relation(model.WorkflowRequestInputStepParameter),
     input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation),
     input_dataset_collections=relation(model.WorkflowRequestToInputDatasetCollectionAssociation),
@@ -2571,7 +2571,6 @@ simple_mapping(model.WorkflowInvocationStep,
 simple_mapping(model.WorkflowRequestInputParameter)
 
 simple_mapping(model.WorkflowRequestStepState,
-    workflow_invocation=relation(model.WorkflowInvocation),
     workflow_step=relation(model.WorkflowStep))
 
 simple_mapping(model.WorkflowRequestInputStepParameter,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2197,7 +2197,6 @@ mapper(model.JobToInputDatasetCollectionElementAssociation, model.JobToInputData
 ))
 
 mapper(model.JobToOutputDatasetCollectionAssociation, model.JobToOutputDatasetCollectionAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset_collection_instance=relation(model.HistoryDatasetCollectionAssociation,
         lazy=False,
         backref="output_dataset_collection_instances")
@@ -2773,7 +2772,8 @@ mapper(model.Job, model.Job.table, properties=dict(
         backref="job", lazy=True),
     output_datasets=relation(model.JobToOutputDatasetAssociation,
         backref="job", lazy=True),
-    output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation, lazy=True),
+    output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation,
+        backref="job", lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation, lazy=True),
     post_job_actions=relation(model.PostJobActionAssociation, lazy=False),
     input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1762,7 +1762,7 @@ simple_mapping(model.HistoryDatasetAssociation,
         backref="hdas"),
     ratings=relation(model.HistoryDatasetAssociationRatingAssociation,
         order_by=model.HistoryDatasetAssociationRatingAssociation.table.c.id,
-        backref="hdas"),
+        backref="hda"),
     extended_metadata=relation(model.ExtendedMetadata,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.extended_metadata_id
                      == model.ExtendedMetadata.table.c.id)),
@@ -2766,7 +2766,7 @@ def rating_mapping(rating_class, **kwds):
 
 
 rating_mapping(model.HistoryRatingAssociation)
-rating_mapping(model.HistoryDatasetAssociationRatingAssociation, hda=model.HistoryDatasetAssociation)
+rating_mapping(model.HistoryDatasetAssociationRatingAssociation)
 rating_mapping(model.StoredWorkflowRatingAssociation, stored_workflow=model.StoredWorkflow)
 rating_mapping(model.PageRatingAssociation)
 rating_mapping(model.VisualizationRatingAssociation)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2787,7 +2787,8 @@ mapper(model.DataManagerJobAssociation, model.DataManagerJobAssociation.table, p
 ))
 
 class_mapper(model.HistoryDatasetCollectionAssociation).add_property(
-    "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation))
+    "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation,
+        overlaps="output_dataset_collection_instances, dataset_collection_instance"))
 
 
 # Helper methods.

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1971,7 +1971,6 @@ mapper(model.DefaultHistoryPermissions, model.DefaultHistoryPermissions.table, p
 ))
 
 mapper(model.Role, model.Role.table, properties=dict(
-    users=relation(model.UserRoleAssociation),
     groups=relation(model.GroupRoleAssociation)
 ))
 
@@ -1985,7 +1984,7 @@ mapper(model.UserRoleAssociation, model.UserRoleAssociation.table, properties=di
             & (model.UserRoleAssociation.table.c.role_id == model.Role.table.c.id)
             & not_(model.Role.table.c.name == model.User.table.c.email))
     ),
-    role=relation(model.Role)
+    role=relation(model.Role, backref="users")
 ))
 
 mapper(model.GroupRoleAssociation, model.GroupRoleAssociation.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1745,15 +1745,10 @@ simple_mapping(model.HistoryDatasetAssociation,
         remote_side=[model.HistoryDatasetAssociation.table.c.id],
         uselist=False,
         backref='copied_to_history_dataset_associations'),
-    copied_from_library_dataset_dataset_association=relation(
-        model.LibraryDatasetDatasetAssociation,
-        primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
-                     == model.LibraryDatasetDatasetAssociation.table.c.id),
-        uselist=False,
-        backref='copied_to_history_dataset_associations'),
     copied_to_library_dataset_dataset_associations=relation(model.LibraryDatasetDatasetAssociation,
-        primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id
-                     == model.LibraryDatasetDatasetAssociation.table.c.id)),
+        primaryjoin=(model.HistoryDatasetAssociation.table.c.id
+                     == model.LibraryDatasetDatasetAssociation.table.c.copied_from_history_dataset_association_id),
+        backref='copied_from_history_dataset_association'),
     implicitly_converted_datasets=relation(model.ImplicitlyConvertedDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.hda_parent_id
                      == model.HistoryDatasetAssociation.table.c.id)),
@@ -2137,10 +2132,10 @@ mapper(model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssoci
         remote_side=[model.LibraryDatasetDatasetAssociation.table.c.id],
         uselist=False,
         backref='copied_to_library_dataset_dataset_associations'),
-    copied_from_history_dataset_association=relation(model.HistoryDatasetAssociation,
-        primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.copied_from_history_dataset_association_id
-                     == model.HistoryDatasetAssociation.table.c.id),
-        uselist=False),
+    copied_to_history_dataset_associations=relation(model.HistoryDatasetAssociation,
+        primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.id
+                     == model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id),
+        backref='copied_from_library_dataset_dataset_association'),
     implicitly_converted_datasets=relation(model.ImplicitlyConvertedDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.ldda_parent_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2321,10 +2321,8 @@ simple_mapping(model.HistoryDatasetCollectionAssociation,
         primaryjoin=(model.HistoryDatasetCollectionAssociation.table.c.copied_from_history_dataset_collection_association_id
                      == model.HistoryDatasetCollectionAssociation.table.c.id),
         remote_side=[model.HistoryDatasetCollectionAssociation.table.c.id],
+        backref='copied_to_history_dataset_collection_associations',
         uselist=False),
-    copied_to_history_dataset_collection_associations=relation(model.HistoryDatasetCollectionAssociation,
-        primaryjoin=(model.HistoryDatasetCollectionAssociation.table.c.copied_from_history_dataset_collection_association_id
-                     == model.HistoryDatasetCollectionAssociation.table.c.id)),
     implicit_input_collections=relation(model.ImplicitlyCreatedDatasetCollectionInput,
         primaryjoin=(model.HistoryDatasetCollectionAssociation.table.c.id
                      == model.ImplicitlyCreatedDatasetCollectionInput.table.c.dataset_collection_id),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2214,7 +2214,6 @@ mapper(model.JobToInputLibraryDatasetAssociation, model.JobToInputLibraryDataset
 ))
 
 mapper(model.JobToOutputLibraryDatasetAssociation, model.JobToOutputLibraryDatasetAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset=relation(model.LibraryDatasetDatasetAssociation,
         lazy=False)
 ))
@@ -2775,7 +2774,8 @@ mapper(model.Job, model.Job.table, properties=dict(
         backref="job", lazy=True),
     post_job_actions=relation(model.PostJobActionAssociation, backref="job", lazy=False),
     input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation, backref="job"),
-    output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation, lazy=True),
+    output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation,
+        backref="job", lazy=True),
     external_output_metadata=relation(model.JobExternalOutputMetadata, lazy=True, backref='job'),
     tasks=relation(model.Task, backref='job')
 ))

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2320,9 +2320,7 @@ mapper(model.PostJobActionAssociation, model.PostJobActionAssociation.table, pro
     post_job_action=relation(model.PostJobAction)
 ))
 
-mapper(model.Task, model.Task.table, properties=dict(
-    job=relation(model.Job)
-))
+mapper(model.Task, model.Task.table)
 
 mapper(model.DeferredJob, model.DeferredJob.table, properties={})
 
@@ -2784,7 +2782,7 @@ mapper(model.Job, model.Job.table, properties=dict(
     input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation),
     output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation, lazy=True),
     external_output_metadata=relation(model.JobExternalOutputMetadata, lazy=True),
-    tasks=relation(model.Task)
+    tasks=relation(model.Task, backref='job')
 ))
 model.Job.any_output_dataset_deleted = column_property(  # type: ignore
     exists([model.HistoryDatasetAssociation],

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1749,9 +1749,6 @@ simple_mapping(model.HistoryDatasetAssociation,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.id
                      == model.LibraryDatasetDatasetAssociation.table.c.copied_from_history_dataset_association_id),
         backref='copied_from_history_dataset_association'),
-    implicitly_converted_datasets=relation(model.ImplicitlyConvertedDatasetAssociation,
-        primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.hda_parent_id
-                     == model.HistoryDatasetAssociation.table.c.id)),
     tags=relation(model.HistoryDatasetAssociationTagAssociation,
         order_by=model.HistoryDatasetAssociationTagAssociation.table.c.id,
         backref='history_tag_associations'),
@@ -1823,7 +1820,8 @@ mapper(model.HistoryDatasetAssociationSubset, model.HistoryDatasetAssociationSub
 mapper(model.ImplicitlyConvertedDatasetAssociation, model.ImplicitlyConvertedDatasetAssociation.table, properties=dict(
     parent_hda=relation(model.HistoryDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.hda_parent_id
-                     == model.HistoryDatasetAssociation.table.c.id)),
+                     == model.HistoryDatasetAssociation.table.c.id),
+        backref='implicitly_converted_datasets'),
     dataset_ldda=relation(model.LibraryDatasetDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.ldda_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2665,7 +2665,7 @@ mapper(model.Page, model.Page.table, properties=dict(
         backref="pages"),
     ratings=relation(model.PageRatingAssociation,
         order_by=model.PageRatingAssociation.table.c.id,
-        backref="pages"),
+        backref="page"),
     average_rating=column_property(
         select(func.avg(model.PageRatingAssociation.table.c.rating)).where(model.PageRatingAssociation.table.c.page_id == model.Page.table.c.id).scalar_subquery(),
         deferred=True
@@ -2768,13 +2768,12 @@ def rating_mapping(rating_class, **kwds):
 rating_mapping(model.HistoryRatingAssociation, history=model.History)
 rating_mapping(model.HistoryDatasetAssociationRatingAssociation, hda=model.HistoryDatasetAssociation)
 rating_mapping(model.StoredWorkflowRatingAssociation, stored_workflow=model.StoredWorkflow)
-rating_mapping(model.PageRatingAssociation, page=model.Page)
+rating_mapping(model.PageRatingAssociation)
 rating_mapping(model.VisualizationRatingAssociation, visualizaiton=model.Visualization)
 rating_mapping(model.HistoryDatasetCollectionRatingAssociation,
     history_dataset_collection=model.HistoryDatasetCollectionAssociation)
 rating_mapping(model.LibraryDatasetCollectionRatingAssociation,
     libary_dataset_collection=model.LibraryDatasetCollectionAssociation)
-
 
 mapper(model.Job, model.Job.table, properties=dict(
     # user=relation( model.User.mapper ),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2182,7 +2182,6 @@ mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.ta
 ))
 
 mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.table, properties=dict(
-    job=relation(model.Job),
     dataset=relation(model.HistoryDatasetAssociation,
         lazy=False)
 ))
@@ -2772,7 +2771,8 @@ mapper(model.Job, model.Job.table, properties=dict(
     input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, backref="job", lazy=True),
     input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation,
         backref="job", lazy=True),
-    output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
+    output_datasets=relation(model.JobToOutputDatasetAssociation,
+        backref="job", lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation, lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation, lazy=True),
     post_job_actions=relation(model.PostJobActionAssociation, lazy=False),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1761,7 +1761,7 @@ simple_mapping(model.HistoryDatasetAssociation,
         backref='history_tag_associations'),
     annotations=relation(model.HistoryDatasetAssociationAnnotationAssociation,
         order_by=model.HistoryDatasetAssociationAnnotationAssociation.table.c.id,
-        backref="hdas"),
+        backref="hda"),
     ratings=relation(model.HistoryDatasetAssociationRatingAssociation,
         order_by=model.HistoryDatasetAssociationRatingAssociation.table.c.id,
         backref="hda"),
@@ -2751,7 +2751,7 @@ def annotation_mapping(annotation_class, **kwds):
 
 
 annotation_mapping(model.HistoryAnnotationAssociation)
-annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation, hda=model.HistoryDatasetAssociation)
+annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation)
 annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=model.StoredWorkflow)
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
 annotation_mapping(model.PageAnnotationAssociation)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1976,15 +1976,16 @@ mapper(model.Role, model.Role.table, properties=dict(
 
 mapper(model.UserRoleAssociation, model.UserRoleAssociation.table, properties=dict(
     user=relation(model.User, backref="roles"),
+    role=relation(model.Role, backref="users"),
     non_private_roles=relation(
         model.User,
         backref="non_private_roles",
+        viewonly=True,
         primaryjoin=(
             (model.User.table.c.id == model.UserRoleAssociation.table.c.user_id)
             & (model.UserRoleAssociation.table.c.role_id == model.Role.table.c.id)
             & not_(model.Role.table.c.name == model.User.table.c.email))
-    ),
-    role=relation(model.Role, backref="users")
+    )
 ))
 
 mapper(model.GroupRoleAssociation, model.GroupRoleAssociation.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1828,9 +1828,6 @@ mapper(model.ImplicitlyConvertedDatasetAssociation, model.ImplicitlyConvertedDat
     parent_hda=relation(model.HistoryDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.hda_parent_id
                      == model.HistoryDatasetAssociation.table.c.id)),
-    parent_ldda=relation(model.LibraryDatasetDatasetAssociation,
-        primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.ldda_parent_id
-                     == model.LibraryDatasetDatasetAssociation.table.c.id)),
     dataset_ldda=relation(model.LibraryDatasetDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.ldda_id
                      == model.LibraryDatasetDatasetAssociation.table.c.id),
@@ -2150,7 +2147,8 @@ mapper(model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssoci
                      == model.LibraryDatasetDatasetAssociation.table.c.id)),
     implicitly_converted_datasets=relation(model.ImplicitlyConvertedDatasetAssociation,
         primaryjoin=(model.ImplicitlyConvertedDatasetAssociation.table.c.ldda_parent_id
-                     == model.LibraryDatasetDatasetAssociation.table.c.id)),
+                     == model.LibraryDatasetDatasetAssociation.table.c.id),
+        backref='parent_ldda'),
     tags=relation(model.LibraryDatasetDatasetAssociationTagAssociation,
                   order_by=model.LibraryDatasetDatasetAssociationTagAssociation.table.c.id,
                   backref='history_tag_associations'),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2565,10 +2565,10 @@ simple_mapping(model.WorkflowInvocationStep,
     job=relation(model.Job, backref=backref('workflow_invocation_step', uselist=False), uselist=False),
     implicit_collection_jobs=relation(model.ImplicitCollectionJobs, backref=backref('workflow_invocation_step', uselist=False), uselist=False),
     subworkflow_invocation_id=column_property(
-        select([(model.WorkflowInvocationToSubworkflowInvocationAssociation.table.c.subworkflow_invocation_id)]).where(and_(
+        select(model.WorkflowInvocationToSubworkflowInvocationAssociation.table.c.subworkflow_invocation_id).where(and_(
             model.WorkflowInvocationToSubworkflowInvocationAssociation.table.c.workflow_invocation_id == model.WorkflowInvocationStep.table.c.workflow_invocation_id,
             model.WorkflowInvocationToSubworkflowInvocationAssociation.table.c.workflow_step_id == model.WorkflowInvocationStep.table.c.workflow_step_id,
-        )),
+        )).scalar_subquery(),
     ),
 )
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2787,8 +2787,7 @@ mapper(model.DataManagerJobAssociation, model.DataManagerJobAssociation.table, p
 ))
 
 class_mapper(model.HistoryDatasetCollectionAssociation).add_property(
-    "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation,
-        overlaps="output_dataset_collection_instances, dataset_collection_instance"))
+    "creating_job_associations", relation(model.JobToOutputDatasetCollectionAssociation, viewonly=True))
 
 
 # Helper methods.

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2161,7 +2161,8 @@ mapper(model.JobToInputDatasetAssociation, model.JobToInputDatasetAssociation.ta
 ))
 
 mapper(model.JobToOutputDatasetAssociation, model.JobToOutputDatasetAssociation.table, properties=dict(
-    job=relation(model.Job),
+    job=relation(model.Job,
+        backref="output_datasets"),
     dataset=relation(model.HistoryDatasetAssociation,
         lazy=False,
         backref="creating_job_associations")
@@ -2745,7 +2746,6 @@ mapper(model.Job, model.Job.table, properties=dict(
     input_dataset_collections=relation(model.JobToInputDatasetCollectionAssociation, backref="job", lazy=True),
     input_dataset_collection_elements=relation(model.JobToInputDatasetCollectionElementAssociation,
         backref="job", lazy=True),
-    output_datasets=relation(model.JobToOutputDatasetAssociation, lazy=True),
     output_dataset_collection_instances=relation(model.JobToOutputDatasetCollectionAssociation,
         backref="job", lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2701,7 +2701,7 @@ mapper(model.Visualization, model.Visualization.table, properties=dict(
         backref="visualizations"),
     annotations=relation(model.VisualizationAnnotationAssociation,
         order_by=model.VisualizationAnnotationAssociation.table.c.id,
-        backref="visualizations"),
+        backref="visualization"),
     ratings=relation(model.VisualizationRatingAssociation,
         order_by=model.VisualizationRatingAssociation.table.c.id,
         backref="visualization"),
@@ -2755,7 +2755,7 @@ annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation, hda=mod
 annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=model.StoredWorkflow)
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
 annotation_mapping(model.PageAnnotationAssociation)
-annotation_mapping(model.VisualizationAnnotationAssociation, visualization=model.Visualization)
+annotation_mapping(model.VisualizationAnnotationAssociation)
 annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation,
     history_dataset_collection=model.HistoryDatasetCollectionAssociation)
 annotation_mapping(model.LibraryDatasetCollectionAnnotationAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2309,7 +2309,6 @@ mapper(model.PostJobAction, model.PostJobAction.table, properties=dict(
 ))
 
 mapper(model.PostJobActionAssociation, model.PostJobActionAssociation.table, properties=dict(
-    job=relation(model.Job),
     post_job_action=relation(model.PostJobAction)
 ))
 
@@ -2775,7 +2774,7 @@ mapper(model.Job, model.Job.table, properties=dict(
         backref="job", lazy=True),
     output_dataset_collections=relation(model.JobToImplicitOutputDatasetCollectionAssociation,
         backref="job", lazy=True),
-    post_job_actions=relation(model.PostJobActionAssociation, lazy=False),
+    post_job_actions=relation(model.PostJobActionAssociation, backref="job", lazy=False),
     input_library_datasets=relation(model.JobToInputLibraryDatasetAssociation),
     output_library_datasets=relation(model.JobToOutputLibraryDatasetAssociation, lazy=True),
     external_output_metadata=relation(model.JobExternalOutputMetadata, lazy=True, backref='job'),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1743,10 +1743,8 @@ simple_mapping(model.HistoryDatasetAssociation,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_history_dataset_association_id
                      == model.HistoryDatasetAssociation.table.c.id),
         remote_side=[model.HistoryDatasetAssociation.table.c.id],
-        uselist=False),
-    copied_to_history_dataset_associations=relation(model.HistoryDatasetAssociation,
-        primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_history_dataset_association_id
-                     == model.HistoryDatasetAssociation.table.c.id)),
+        uselist=False,
+        backref='copied_to_history_dataset_associations'),
     copied_from_library_dataset_dataset_association=relation(
         model.LibraryDatasetDatasetAssociation,
         primaryjoin=(model.HistoryDatasetAssociation.table.c.copied_from_library_dataset_dataset_association_id

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2410,12 +2410,11 @@ mapper(model.Event, model.Event.table, properties=dict(
 ))
 
 mapper(model.GalaxySession, model.GalaxySession.table, properties=dict(
-    histories=relation(model.GalaxySessionToHistoryAssociation),
     current_history=relation(model.History),
 ))
 
 mapper(model.GalaxySessionToHistoryAssociation, model.GalaxySessionToHistoryAssociation.table, properties=dict(
-    galaxy_session=relation(model.GalaxySession),
+    galaxy_session=relation(model.GalaxySession, backref='histories'),
     history=relation(model.History, backref='galaxy_sessions')
 ))
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1846,6 +1846,7 @@ mapper(model.History, model.History.table, properties=dict(
         backref="history",
         order_by=asc(model.HistoryDatasetAssociation.table.c.hid)),
     exports=relation(model.JobExportHistoryArchive,
+        backref="history",
         primaryjoin=(model.JobExportHistoryArchive.table.c.history_id == model.History.table.c.id),
         order_by=desc(model.JobExportHistoryArchive.table.c.id)),
     active_datasets=relation(model.HistoryDatasetAssociation,
@@ -2277,7 +2278,6 @@ mapper(model.JobExternalOutputMetadata, model.JobExternalOutputMetadata.table, p
 
 mapper(model.JobExportHistoryArchive, model.JobExportHistoryArchive.table, properties=dict(
     job=relation(model.Job),
-    history=relation(model.History),
     dataset=relation(model.Dataset, backref='job_export_history_archive')
 ))
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2588,7 +2588,8 @@ simple_mapping(
             model.WorkflowInvocationStep.table.c.workflow_invocation_id == model.WorkflowInvocationOutputValue.table.c.workflow_invocation_id,
             model.WorkflowInvocationStep.table.c.workflow_step_id == model.WorkflowInvocationOutputValue.table.c.workflow_step_id,
         ),
-        backref='output_value'
+        backref='output_value',
+        viewonly=True
     ),
     workflow_step=relation(model.WorkflowStep),
     workflow_output=relation(model.WorkflowOutput),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1681,10 +1681,7 @@ mapper(model.FormValues, model.FormValues.table, properties=dict(
         primaryjoin=(model.FormValues.table.c.form_definition_id == model.FormDefinition.table.c.id))
 ))
 
-mapper(model.FormDefinition, model.FormDefinition.table, properties=dict(
-    current=relation(model.FormDefinitionCurrent,
-        primaryjoin=(model.FormDefinition.table.c.form_definition_current_id == model.FormDefinitionCurrent.table.c.id))
-))
+mapper(model.FormDefinition, model.FormDefinition.table)
 
 mapper(model.FormDefinitionCurrent, model.FormDefinitionCurrent.table, properties=dict(
     forms=relation(model.FormDefinition,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1884,7 +1884,7 @@ mapper(model.History, model.History.table, properties=dict(
         backref="histories"),
     annotations=relation(model.HistoryAnnotationAssociation,
         order_by=model.HistoryAnnotationAssociation.table.c.id,
-        backref="histories"),
+        backref="history"),
     ratings=relation(model.HistoryRatingAssociation,
         order_by=model.HistoryRatingAssociation.table.c.id,
         backref="history"),
@@ -2750,7 +2750,7 @@ def annotation_mapping(annotation_class, **kwds):
     simple_mapping(annotation_class, **dict(user=relation(model.User), **kwds))
 
 
-annotation_mapping(model.HistoryAnnotationAssociation, history=model.History)
+annotation_mapping(model.HistoryAnnotationAssociation)
 annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation, hda=model.HistoryDatasetAssociation)
 annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=model.StoredWorkflow)
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1794,7 +1794,8 @@ simple_mapping(model.Dataset,
     active_library_associations=relation(model.LibraryDatasetDatasetAssociation,
         primaryjoin=(
             (model.Dataset.table.c.id == model.LibraryDatasetDatasetAssociation.table.c.dataset_id)
-            & (model.LibraryDatasetDatasetAssociation.table.c.deleted == false()))),
+            & (model.LibraryDatasetDatasetAssociation.table.c.deleted == false())),
+        viewonly=True),
 )
 
 mapper(model.DatasetHash, model.DatasetHash.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1945,8 +1945,6 @@ mapper(model.User, model.User.table, properties=dict(
     api_keys=relation(model.APIKeys,
         backref="user",
         order_by=desc(model.APIKeys.table.c.create_time)),
-    cloudauthzs=relation(model.CloudAuthz,
-                         primaryjoin=model.CloudAuthz.table.c.user_id == model.User.table.c.id),
 ))
 
 mapper(model.PasswordResetToken, model.PasswordResetToken.table,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2450,7 +2450,7 @@ mapper(model.WorkflowStep, model.WorkflowStep.table, properties=dict(
         backref="workflow_steps"),
     annotations=relation(model.WorkflowStepAnnotationAssociation,
         order_by=model.WorkflowStepAnnotationAssociation.table.c.id,
-        backref="workflow_steps")
+        backref="workflow_step")
 ))
 
 mapper(model.WorkflowStepInput, model.WorkflowStepInput.table, properties=dict(
@@ -2753,7 +2753,7 @@ def annotation_mapping(annotation_class, **kwds):
 annotation_mapping(model.HistoryAnnotationAssociation)
 annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation)
 annotation_mapping(model.StoredWorkflowAnnotationAssociation)
-annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
+annotation_mapping(model.WorkflowStepAnnotationAssociation)
 annotation_mapping(model.PageAnnotationAssociation)
 annotation_mapping(model.VisualizationAnnotationAssociation)
 annotation_mapping(model.HistoryDatasetCollectionAssociationAnnotationAssociation)

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1891,11 +1891,11 @@ mapper(model.History, model.History.table, properties=dict(
         order_by=model.HistoryRatingAssociation.table.c.id,
         backref="histories"),
     average_rating=column_property(
-        select([func.avg(model.HistoryRatingAssociation.table.c.rating)]).where(model.HistoryRatingAssociation.table.c.history_id == model.History.table.c.id),
+        select(func.avg(model.HistoryRatingAssociation.table.c.rating)).where(model.HistoryRatingAssociation.table.c.history_id == model.History.table.c.id).scalar_subquery(),
         deferred=True
     ),
     users_shared_with_count=column_property(
-        select([func.count(model.HistoryUserShareAssociation.table.c.id)]).where(model.History.table.c.id == model.HistoryUserShareAssociation.table.c.history_id),
+        select(func.count(model.HistoryUserShareAssociation.table.c.id)).where(model.History.table.c.id == model.HistoryUserShareAssociation.table.c.history_id).scalar_subquery(),
         deferred=True
     ),
     update_time=column_property(
@@ -2434,7 +2434,7 @@ mapper(model.Workflow, model.Workflow.table, properties=dict(
         cascade="all, delete-orphan",
         lazy=False),
     step_count=column_property(
-        select([func.count(model.WorkflowStep.table.c.id)]).where(model.Workflow.table.c.id == model.WorkflowStep.table.c.workflow_id),
+        select(func.count(model.WorkflowStep.table.c.id)).where(model.Workflow.table.c.id == model.WorkflowStep.table.c.workflow_id).scalar_subquery(),
         deferred=True
     )
 
@@ -2513,7 +2513,7 @@ mapper(model.StoredWorkflow, model.StoredWorkflow.table, properties=dict(
         order_by=model.StoredWorkflowRatingAssociation.table.c.id,
         backref="stored_workflows"),
     average_rating=column_property(
-        select([func.avg(model.StoredWorkflowRatingAssociation.table.c.rating)]).where(model.StoredWorkflowRatingAssociation.table.c.stored_workflow_id == model.StoredWorkflow.table.c.id),
+        select(func.avg(model.StoredWorkflowRatingAssociation.table.c.rating)).where(model.StoredWorkflowRatingAssociation.table.c.stored_workflow_id == model.StoredWorkflow.table.c.id).scalar_subquery(),
         deferred=True
     )
 ))
@@ -2672,7 +2672,7 @@ mapper(model.Page, model.Page.table, properties=dict(
         order_by=model.PageRatingAssociation.table.c.id,
         backref="pages"),
     average_rating=column_property(
-        select([func.avg(model.PageRatingAssociation.table.c.rating)]).where(model.PageRatingAssociation.table.c.page_id == model.Page.table.c.id),
+        select(func.avg(model.PageRatingAssociation.table.c.rating)).where(model.PageRatingAssociation.table.c.page_id == model.Page.table.c.id).scalar_subquery(),
         deferred=True
     )
 ))
@@ -2708,7 +2708,7 @@ mapper(model.Visualization, model.Visualization.table, properties=dict(
         order_by=model.VisualizationRatingAssociation.table.c.id,
         backref="visualizations"),
     average_rating=column_property(
-        select([func.avg(model.VisualizationRatingAssociation.table.c.rating)]).where(model.VisualizationRatingAssociation.table.c.visualization_id == model.Visualization.table.c.id),
+        select(func.avg(model.VisualizationRatingAssociation.table.c.rating)).where(model.VisualizationRatingAssociation.table.c.visualization_id == model.Visualization.table.c.id).scalar_subquery(),
         deferred=True
     )
 ))

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2533,7 +2533,7 @@ mapper(model.WorkflowInvocation, model.WorkflowInvocation.table, properties=dict
     history=relation(model.History, backref=backref('workflow_invocations', uselist=True)),
     input_parameters=relation(model.WorkflowRequestInputParameter, backref='workflow_invocation'),
     step_states=relation(model.WorkflowRequestStepState, backref='workflow_invocation'),
-    input_step_parameters=relation(model.WorkflowRequestInputStepParameter),
+    input_step_parameters=relation(model.WorkflowRequestInputStepParameter, backref='workflow_invocation'),
     input_datasets=relation(model.WorkflowRequestToInputDatasetAssociation),
     input_dataset_collections=relation(model.WorkflowRequestToInputDatasetCollectionAssociation),
     subworkflow_invocations=relation(model.WorkflowInvocationToSubworkflowInvocationAssociation,
@@ -2574,7 +2574,6 @@ simple_mapping(model.WorkflowRequestStepState,
     workflow_step=relation(model.WorkflowStep))
 
 simple_mapping(model.WorkflowRequestInputStepParameter,
-    workflow_invocation=relation(model.WorkflowInvocation),
     workflow_step=relation(model.WorkflowStep))
 
 simple_mapping(model.WorkflowRequestToInputDatasetAssociation,

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -1789,8 +1789,6 @@ simple_mapping(model.Dataset,
             (model.Dataset.table.c.id == model.HistoryDatasetAssociation.table.c.dataset_id)
             & (model.HistoryDatasetAssociation.table.c.purged == true())),
         viewonly=True),
-    library_associations=relation(model.LibraryDatasetDatasetAssociation,
-        primaryjoin=(model.Dataset.table.c.id == model.LibraryDatasetDatasetAssociation.table.c.dataset_id)),
     active_library_associations=relation(model.LibraryDatasetDatasetAssociation,
         primaryjoin=(
             (model.Dataset.table.c.id == model.LibraryDatasetDatasetAssociation.table.c.dataset_id)
@@ -2132,7 +2130,9 @@ mapper(model.LibraryDataset, model.LibraryDataset.table, properties=dict(
 ))
 
 mapper(model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssociation.table, properties=dict(
-    dataset=relation(model.Dataset),
+    dataset=relation(model.Dataset,
+        primaryjoin=(model.LibraryDatasetDatasetAssociation.table.c.dataset_id == model.Dataset.table.c.id),
+        backref='library_associations'),
     library_dataset=relation(model.LibraryDataset,
         foreign_keys=model.LibraryDatasetDatasetAssociation.table.c.library_dataset_id),
     # user=relation( model.User.mapper ),

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2506,7 +2506,7 @@ mapper(model.StoredWorkflow, model.StoredWorkflow.table, properties=dict(
         order_by=model.StoredWorkflowTagAssociation.table.c.id),
     annotations=relation(model.StoredWorkflowAnnotationAssociation,
         order_by=model.StoredWorkflowAnnotationAssociation.table.c.id,
-        backref="stored_workflows"),
+        backref="stored_workflow"),
     ratings=relation(model.StoredWorkflowRatingAssociation,
         order_by=model.StoredWorkflowRatingAssociation.table.c.id,
         backref="stored_workflow"),
@@ -2752,7 +2752,7 @@ def annotation_mapping(annotation_class, **kwds):
 
 annotation_mapping(model.HistoryAnnotationAssociation)
 annotation_mapping(model.HistoryDatasetAssociationAnnotationAssociation)
-annotation_mapping(model.StoredWorkflowAnnotationAssociation, stored_workflow=model.StoredWorkflow)
+annotation_mapping(model.StoredWorkflowAnnotationAssociation)
 annotation_mapping(model.WorkflowStepAnnotationAssociation, workflow_step=model.WorkflowStep)
 annotation_mapping(model.PageAnnotationAssociation)
 annotation_mapping(model.VisualizationAnnotationAssociation)

--- a/lib/galaxy/model/orm/engine_factory.py
+++ b/lib/galaxy/model/orm/engine_factory.py
@@ -47,14 +47,14 @@ def pretty_stack():
 def build_engine(url, engine_options, database_query_profiling_proxy=False, trace_logger=None, slow_query_log_threshold=0, thread_local_log=None, log_query_counts=False):
     if database_query_profiling_proxy or slow_query_log_threshold or thread_local_log or log_query_counts:
 
-        @event.listens_for(Engine, "before_execute")
-        def before_execute(conn, clauseelement, multiparams, params):
+        @event.listens_for(Engine, "before_cursor_execute")
+        def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
             conn.info.setdefault('query_start_time', []).append(time.time())
 
     if slow_query_log_threshold or thread_local_log or log_query_counts:
+
         @event.listens_for(Engine, "after_cursor_execute")
-        def after_cursor_execute(conn, cursor, statement,
-                                 parameters, context, executemany):
+        def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
             total = time.time() - conn.info['query_start_time'].pop(-1)
             fragment = 'Slow query: '
             if total > slow_query_log_threshold:

--- a/lib/galaxy/model/view/utils.py
+++ b/lib/galaxy/model/view/utils.py
@@ -29,7 +29,7 @@ class View:
                 c.type,
                 primary_key=(c.name in pkeys)
             )
-            for c in selectable.c
+            for c in selectable.subquery().columns
         ]
         # We do not use the metadata object from model.mapping.py that contains all the Table objects
         # because that would create a circular import (create_view is called from View objects

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -303,10 +303,7 @@ class ToolShedRepositoryCache:
         try:
             session = self.app.install_model._SessionLocal()
             self.repositories = session.query(ToolShedRepository).options(
-                defer(ToolShedRepository.metadata),
-                joinedload('tool_dependencies').subqueryload('tool_shed_repository').options(
-                    defer(ToolShedRepository.metadata)
-                ),
+                defer(ToolShedRepository.metadata), joinedload('tool_dependencies')
             ).all()
             repos_by_tuple = defaultdict(list)
             for repository in self.repositories + self.local_repositories:

--- a/lib/galaxy/webapps/galaxy/api/cloudauthz.py
+++ b/lib/galaxy/webapps/galaxy/api/cloudauthz.py
@@ -134,7 +134,7 @@ class CloudAuthzController(BaseGalaxyAPIController):
 
         # No two authorization configuration with
         # exact same key/value should exist.
-        for ca in trans.user.cloudauthzs:
+        for ca in trans.user.cloudauthz:
             if ca.equals(trans.user.id, provider, authn_id, config):
                 log.debug("Rejected user `{}`'s request to create cloud authorization because a similar config "
                           "already exists.".format(trans.user.id))

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -284,8 +284,8 @@ class GroupListGrid(grids.Grid):
 
     class UsersColumn(grids.GridColumn):
         def get_value(self, trans, grid, group):
-            if group.members:
-                return len(group.members)
+            if group.users:
+                return len(group.users)
             return 0
 
     # Grid definition

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,7 +13,7 @@ pycryptodome
 pydantic
 pysam
 social-auth-core[openidconnect]==3.3.0
-SQLAlchemy>=1.4.5
+SQLAlchemy
 sqlalchemy-migrate
 tifffile<=2021.2.26 # Last release compatible with python 3.6
 WebOb

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -15,6 +15,4 @@ pysam
 social-auth-core[openidconnect]==3.3.0
 SQLAlchemy>=1.4.5
 sqlalchemy-migrate
-sqlalchemy-utils
-tifffile<=2020.9.3  # Last version compatible with python 3.6
 WebOb

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,7 +13,7 @@ pycryptodome
 pydantic
 pysam
 social-auth-core[openidconnect]==3.3.0
-SQLAlchemy>=1.4.12,<2
+SQLAlchemy>=1.4.15,<2
 sqlalchemy-migrate
 tifffile<=2021.2.26 # Last release compatible with python 3.6
 WebOb

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,7 +13,7 @@ pycryptodome
 pydantic
 pysam
 social-auth-core[openidconnect]==3.3.0
-SQLAlchemy
+SQLAlchemy>=1.4.12,<2
 sqlalchemy-migrate
 tifffile<=2021.2.26 # Last release compatible with python 3.6
 WebOb

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,7 +13,7 @@ pycryptodome
 pydantic
 pysam
 social-auth-core[openidconnect]==3.3.0
-SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
+SQLAlchemy>=1.4.5
 sqlalchemy-migrate
 sqlalchemy-utils
 tifffile<=2020.9.3  # Last version compatible with python 3.6

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -15,4 +15,5 @@ pysam
 social-auth-core[openidconnect]==3.3.0
 SQLAlchemy>=1.4.5
 sqlalchemy-migrate
+tifffile<=2021.2.26 # Last release compatible with python 3.6
 WebOb

--- a/packages/test_driver/requirements.txt
+++ b/packages/test_driver/requirements.txt
@@ -8,5 +8,4 @@ galaxy-web-framework
 nose
 pytest
 pyyaml
-sqlalchemy-utils
 six

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -8,5 +8,5 @@ pydantic<1.8
 requests
 Routes
 six
-SQLAlchemy>=1.4.12,<2
+SQLAlchemy>=1.4.15,<2
 WebOb

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -8,5 +8,5 @@ pydantic<1.8
 requests
 Routes
 six
-SQLAlchemy>=1.4.5
+SQLAlchemy
 WebOb

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -8,5 +8,5 @@ pydantic<1.8
 requests
 Routes
 six
-SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
+SQLAlchemy>=1.4.5
 WebOb

--- a/packages/web_framework/requirements.txt
+++ b/packages/web_framework/requirements.txt
@@ -8,5 +8,5 @@ pydantic<1.8
 requests
 Routes
 six
-SQLAlchemy
+SQLAlchemy>=1.4.12,<2
 WebOb

--- a/packages/web_stack/requirements.txt
+++ b/packages/web_stack/requirements.txt
@@ -1,2 +1,2 @@
-SQLAlchemy
+SQLAlchemy>=1.4.12,<2
 galaxy-util

--- a/packages/web_stack/requirements.txt
+++ b/packages/web_stack/requirements.txt
@@ -1,2 +1,2 @@
-SQLAlchemy>=1.4.5
+SQLAlchemy
 galaxy-util

--- a/packages/web_stack/requirements.txt
+++ b/packages/web_stack/requirements.txt
@@ -1,2 +1,2 @@
-SQLAlchemy>=1.4.12,<2
+SQLAlchemy>=1.4.15,<2
 galaxy-util

--- a/packages/web_stack/requirements.txt
+++ b/packages/web_stack/requirements.txt
@@ -1,2 +1,2 @@
-SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
+SQLAlchemy>=1.4.5
 galaxy-util

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.2"
+SQLAlchemy = ">=1.4.3"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.12,<2"
+SQLAlchemy = ">=1.4.14,<2"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.6"
+SQLAlchemy = ">=1.4.7"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.3"
+SQLAlchemy = ">=1.4.5"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.12"
+SQLAlchemy = ">=1.4.12,<2"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.5"
+SQLAlchemy = ">=1.4.6"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.9"
+SQLAlchemy = ">=1.4.10"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.10"
+SQLAlchemy = ">=1.4.11"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.11"
+SQLAlchemy = ">=1.4.12"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.7"
+SQLAlchemy = ">=1.4.9"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.4.14,<2"
+SQLAlchemy = ">=1.4.15,<2"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ requests = "*"
 Routes = "*"
 social-auth-core = {version = "==3.3.0", extras = ["openidconnect"]}
 sortedcontainers = "*"
-SQLAlchemy = ">=1.3.22, <1.4.0"  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
+SQLAlchemy = ">=1.4.2"
 sqlalchemy-migrate = "*"
 sqlitedict = "*"
 sqlparse = "*"

--- a/scripts/check_model.py
+++ b/scripts/check_model.py
@@ -19,7 +19,7 @@ IndexTuple = namedtuple('IndexTuple', 'table column_names')
 
 
 def tuple_from_index(index):
-    columns = tuple([getattr(index.columns, c).name for c in dir(index.columns) if not c.startswith('__')])
+    columns = tuple([index.columns[key].name for key in index.columns.keys()])
     if len(columns) == 1:
         columns = columns[0]
     return IndexTuple(index.table.name, columns)

--- a/scripts/cleanup_datasets/pgcleanup.py
+++ b/scripts/cleanup_datasets/pgcleanup.py
@@ -991,7 +991,7 @@ class Cleanup:
     def conn(self):
         if self.__conn is None:
             url = make_url(galaxy.config.get_database_url(self.config))
-            log.info('Connecting to database with URL: %s' % url)
+            log.info(f'Connecting to database with URL: {url}')
             args = url.translate_connect_args(username='user')
             args.update(url.query)
             assert url.get_dialect().name == 'postgresql', 'This script can only be used with PostgreSQL.'

--- a/test/unit/tools/test_evaluation.py
+++ b/test/unit/tools/test_evaluation.py
@@ -9,7 +9,8 @@ from galaxy.model import (
     HistoryDatasetAssociation,
     Job,
     JobParameter,
-    JobToInputDatasetAssociation
+    JobToInputDatasetAssociation,
+    JobToOutputDatasetAssociation,
 )
 from galaxy.tool_util.parser.output_objects import ToolOutput
 from galaxy.tools.evaluation import ToolEvaluator
@@ -207,17 +208,19 @@ class ToolEvaluatorTestCase(TestCase, UsesApp):
         assert "exec_before_job" in self.tool.hooks_called
 
     def _setup_test_bwa_job(self):
-        self.job.input_datasets = [self._job_dataset('input1', '/galaxy/files/dataset_1.dat')]
-        self.job.output_datasets = [self._job_dataset('output1', '/galaxy/files/dataset_2.dat')]
 
-    def _job_dataset(self, name, path):
-        metadata = dict()
-        hda = HistoryDatasetAssociation(name=name, metadata=metadata)
-        hda.dataset = Dataset(id=123, external_filename=path)
-        hda.dataset.metadata = dict()
-        hda.children = []
-        jida = JobToInputDatasetAssociation(name=name, dataset=hda)
-        return jida
+        def hda(id, name, path):
+            hda = HistoryDatasetAssociation(name=name, metadata=dict())
+            hda.dataset = Dataset(id=id, external_filename=path)
+            hda.dataset.metadata = dict()
+            hda.children = []
+            return hda
+
+        id, name, path = 111, 'input1', '/galaxy/files/dataset_1.dat'
+        self.job.input_datasets = [JobToInputDatasetAssociation(name=name, dataset=hda(id, name, path))]
+
+        id, name, path = 112, 'output1', '/galaxy/files/dataset_2.dat'
+        self.job.output_datasets = [JobToOutputDatasetAssociation(name=name, dataset=hda(id, name, path))]
 
 
 class MockHistoryDatasetAssociation(HistoryDatasetAssociation):

--- a/test/unit/workflows/test_extract_summary.py
+++ b/test/unit/workflows/test_extract_summary.py
@@ -108,6 +108,13 @@ class TestWorkflowExtractSummary(unittest.TestCase):
         assert len(job_dict) == 0
 
 
+class MockJobToOutputDatasetAssociation:
+
+    def __init__(self, name, dataset):
+        self.name = name
+        self.dataset = dataset
+
+
 class MockHistory:
 
     def __init__(self):
@@ -140,7 +147,7 @@ class MockHda:
             if not job:
                 job = model.Job()
             self.job = job
-            assoc = model.JobToOutputDatasetAssociation(output_name, self)
+            assoc = MockJobToOutputDatasetAssociation(output_name, self)
             assoc.job = job
             self.creating_job_associations = [assoc]
         else:


### PR DESCRIPTION
The purpose of this branch is to migrate Galaxy to SQLAlchemy 1.4. This builds upon previous work (see #10892 for context).

