### PR TITLE
Fix CI docs build for feature branches

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -50,7 +50,6 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          pip install awscli
           case "$TARGET_BRANCH" in
               release_[[:digit:]][[:digit:]].[[:digit:]][[:digit:]]|master)
                   UPLOAD_DIR=$TARGET_BRANCH
@@ -63,4 +62,5 @@ jobs:
                   exit 0
                   ;;
           esac
+          pip install awscli
           aws s3 sync doc/build/html/ "s3://galaxy-docs/en/$UPLOAD_DIR" --region us-east-2 --size-only --delete

--- a/doc/source/conf.versioning.py
+++ b/doc/source/conf.versioning.py
@@ -2,6 +2,7 @@
 # Galaxy sphinxcontrib-simpleversioning documentation build configuration file
 # This file is appended to conf.py by the Build docs github workflow.
 #
+import re
 from distutils.version import LooseVersion
 from subprocess import check_output
 
@@ -34,12 +35,6 @@ simpleversioning_versions = [
 
 # Used for determining the latest stable release so the banner can be added to older releases.
 _stable = None
-
-_target_ver = None
-_pre_release = False
-if TARGET_GIT_BRANCH.startswith('release_'):
-    _target_ver = TARGET_GIT_BRANCH[len('release_'):]
-
 # Use tags to determine versions - a stable version will have a branch before it's released, but not a tag.
 tags = check_output(('git', 'tag')).decode().splitlines()
 for _tag in reversed(tags):
@@ -48,25 +43,27 @@ for _tag in reversed(tags):
         _ver = _tag[1:]
         if not _stable:
             _stable = _ver
-            if _target_ver and LooseVersion(_target_ver) > LooseVersion(_ver):
-                # Pre-release
-                simpleversioning_versions.append(
-                    {'id': TARGET_GIT_BRANCH, 'name': _target_ver}
-                )
-                _pre_release = True
         if LooseVersion(_ver) >= MIN_DOC_VERSION:
             simpleversioning_versions.append(
                 {'id': 'release_%s' % _ver, 'name': _ver}
             )
 
-if TARGET_GIT_BRANCH.startswith('release_'):
-    # The current stable release will go here but fail the next conditional, avoiding either banner.
-    if TARGET_GIT_BRANCH != 'release_%s' % _stable:
-        simpleversioning_show_banner = True
-        if _pre_release:
-            simpleversioning_banner_message = PRE_BANNER + BANNER_APPEND
-        else:
-            simpleversioning_banner_message = OLD_BANNER + BANNER_APPEND
+if re.fullmatch(r'release_\d{2}\.\d{2}', TARGET_GIT_BRANCH):
+    if _stable:
+        # The current stable release will go here but fail the next conditional, avoiding either banner.
+        if TARGET_GIT_BRANCH != 'release_%s' % _stable:
+            simpleversioning_show_banner = True
+            _target_ver = TARGET_GIT_BRANCH[len('release_'):]
+            if LooseVersion(_target_ver) > LooseVersion(_stable):
+                # Pre-release
+                # Insert it between master and _stable
+                simpleversioning_versions.insert(
+                    2,
+                    {'id': TARGET_GIT_BRANCH, 'name': _target_ver}
+                )
+                simpleversioning_banner_message = PRE_BANNER + BANNER_APPEND
+            else:
+                simpleversioning_banner_message = OLD_BANNER + BANNER_APPEND
 elif TARGET_GIT_BRANCH != 'master':
     if TARGET_GIT_BRANCH != 'dev':
         # Feature branch

--- a/doc/source/conf.versioning.py
+++ b/doc/source/conf.versioning.py
@@ -71,5 +71,10 @@ if TARGET_GIT_BRANCH.startswith('release_'):
         else:
             simpleversioning_banner_message = OLD_BANNER + BANNER_APPEND
 elif TARGET_GIT_BRANCH != 'master':
+    if TARGET_GIT_BRANCH != 'dev':
+        # Feature branch
+        simpleversioning_versions.append(
+            {'id': TARGET_GIT_BRANCH, 'name': TARGET_GIT_BRANCH}
+        )
     simpleversioning_show_banner = True
     simpleversioning_banner_message = DEV_BANNER + BANNER_APPEND

--- a/doc/source/conf.versioning.py
+++ b/doc/source/conf.versioning.py
@@ -27,6 +27,7 @@ simpleversioning_path_template = '/en/{version}/{pagename}'
 simpleversioning_stable_version = 'master'
 simpleversioning_current_version = TARGET_GIT_BRANCH
 simpleversioning_versions = [
+    {'id': 'latest', 'name': 'dev'},
     {'id': 'master', 'name': 'stable'},
     # Additional versions added below
 ]
@@ -57,10 +58,6 @@ for _tag in reversed(tags):
             simpleversioning_versions.append(
                 {'id': 'release_%s' % _ver, 'name': _ver}
             )
-
-simpleversioning_versions.append(
-    {'id': 'latest', 'name': 'dev'},
-)
 
 if TARGET_GIT_BRANCH.startswith('release_'):
     # The current stable release will go here but fail the next conditional, avoiding either banner.


### PR DESCRIPTION
## What did you do? 
- Allow feature branches in docs versioning
- Move the dev version on top as in https://docs.python.org
- Stricter check for release branch using a regular expression
- Don't crash if there are no tags in the repo.
- Refactor
- Install `awscli` only when needed

## Why did you make this change?
Fix https://github.com/galaxyproject/galaxy/issues/11733 .


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

CI docs build fine on my fork: https://github.com/nsoranzo/galaxy/actions/runs/690596979
