### PR TITLE
[21.01] Fix a bug when unzipping collections with nametags.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3314,6 +3314,8 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
 
     def copy_tags_to(self, copy_tags=None):
         if copy_tags is not None:
+            if isinstance(copy_tags, dict):
+                copy_tags = copy_tags.values()
             for tag in copy_tags:
                 copied_tag = tag.copy(cls=HistoryDatasetAssociationTagAssociation)
                 self.tags.append(copied_tag)

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -402,11 +402,21 @@ class ToolsTestCase(ApiTestCase, TestsTools):
 
     def test_unzip_nested(self):
         with self.dataset_populator.test_history() as history_id:
-            hdca_list_id = self.__build_nested_list(history_id)
+            response = self.dataset_collection_populator.upload_collection(history_id, "list:paired", elements=[
+                {
+                    "name": "test0",
+                    "elements": [
+                        {"src": "pasted", "paste_content": "123\n", "name": "forward", "ext": "txt", "tags": ["#foo"]},
+                        {"src": "pasted", "paste_content": "456\n", "name": "reverse", "ext": "txt", "tags": ["#bar"]},
+                    ]
+                }
+            ])
+            self._assert_status_code_is(response, 200)
+            hdca_id = response.json()["outputs"][0]["id"]
             inputs = {
                 "input": {
                     'batch': True,
-                    'values': [{'src': 'hdca', 'map_over_type': 'paired', 'id': hdca_list_id}],
+                    'values': [{'src': 'hdca', 'map_over_type': 'paired', 'id': hdca_id}],
                 }
             }
             self.dataset_populator.wait_for_history(history_id, assert_ok=True)


### PR DESCRIPTION
## What did you do? 
- Fix a bug when unzipping collections with nametags.

## Why did you make this change?

It is broken and fails with:
```
Traceback (most recent call last):
  File "/Users/john/workspace/galaxy/lib/galaxy/tools/__init__.py", line 1659, in handle_single_execution
    flush_job=flush_job,
  File "/Users/john/workspace/galaxy/lib/galaxy/tools/__init__.py", line 1747, in execute
    return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs)
  File "/Users/john/workspace/galaxy/lib/galaxy/tools/actions/model_operations.py", line 60, in execute
    self._produce_outputs(trans, tool, out_data, output_collections, incoming=incoming, history=history, tags=preserved_tags)
  File "/Users/john/workspace/galaxy/lib/galaxy/tools/actions/model_operations.py", line 76, in _produce_outputs
    tool.produce_outputs(trans, out_data, output_collections, incoming, history=history, tags=tags, tag_handler=tag_handler)
  File "/Users/john/workspace/galaxy/lib/galaxy/tools/__init__.py", line 2825, in produce_outputs
    forward, reverse = forward_o.copy(copy_tags=tags), reverse_o.copy(copy_tags=tags)
  File "/Users/john/workspace/galaxy/lib/galaxy/model/__init__.py", line 3304, in copy
    hda.copy_tags_to(copy_tags)
  File "/Users/john/workspace/galaxy/lib/galaxy/model/__init__.py", line 3318, in copy_tags_to
    copied_tag = tag.copy(cls=HistoryDatasetAssociationTagAssociation)
AttributeError: 'str' object has no attribute 'copy'
```

## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
