### PR TITLE
Allow site-specific history default, leave fallback option to legacy

### DIFF
--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -11,6 +11,7 @@ on:
     - cron: '0 0 * * 2'
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
+  GALAXY_CONFIG_BETA_HISTORY_DEFAULT_ON: true
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -11,7 +11,7 @@ on:
     - cron: '0 0 * * 2'
 env:
   GALAXY_CONFIG_GALAXY_URL_PREFIX: '/galaxypf'
-  GALAXY_CONFIG_BETA_HISTORY_DEFAULT_ON: true
+  GALAXY_CONFIG_USE_LEGACY_HISTORY: false
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1

--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -12,7 +12,7 @@ import { buildCollectionModal } from "./buildCollectionModal";
 import { createDatasetCollection } from "components/History/model/queries";
 
 // extend existing current history panel
-export default class HistoryPanelProxy {
+export class HistoryPanelProxy {
     constructor() {
         const Galaxy = getGalaxyInstance();
         Galaxy.currHistoryPanel = this;

--- a/client/src/components/History/adapters/betaToggle.js
+++ b/client/src/components/History/adapters/betaToggle.js
@@ -17,5 +17,5 @@ export const switchToLegacyHistoryPanel = () => {
 
 export const switchToBetaHistoryPanel = () => {
     sessionStorage.setItem(USE_BETA_HISTORY_STORAGE_KEY, 1);
-    location.reload(false);
+    location.reload();
 };

--- a/client/src/components/History/adapters/betaToggle.js
+++ b/client/src/components/History/adapters/betaToggle.js
@@ -4,7 +4,7 @@ export const shouldUseBetaHistory = (instanceDefault) => {
     // If there's a value set, respect it.  Otherwise get instance default from config.
     const userPrefBetaHistory = sessionStorage.getItem(USE_BETA_HISTORY_STORAGE_KEY);
     if (userPrefBetaHistory != null) {
-        return userPrefBetaHistory === 1;
+        return userPrefBetaHistory === "1";
     } else {
         return instanceDefault;
     }

--- a/client/src/components/History/adapters/betaToggle.js
+++ b/client/src/components/History/adapters/betaToggle.js
@@ -1,21 +1,21 @@
-const USE_BETA_HISTORY_STORAGE_KEY = "useBetaHistory";
+const USE_LEGACY_HISTORY_STORAGE_KEY = "useLegacyHistory";
 
-export const shouldUseBetaHistory = (instanceDefault) => {
+export const shouldUseLegacyHistory = (instanceDefaultUseLegacyHistory) => {
     // If there's a value set, respect it.  Otherwise get instance default from config.
-    const userPrefBetaHistory = sessionStorage.getItem(USE_BETA_HISTORY_STORAGE_KEY);
-    if (userPrefBetaHistory != null) {
-        return userPrefBetaHistory === "1";
+    const userPrefLegacyHistory = sessionStorage.getItem(USE_LEGACY_HISTORY_STORAGE_KEY);
+    if (userPrefLegacyHistory != null) {
+        return userPrefLegacyHistory === "1";
     } else {
-        return instanceDefault;
+        return instanceDefaultUseLegacyHistory;
     }
 };
 
 export const switchToLegacyHistoryPanel = () => {
-    sessionStorage.setItem(USE_BETA_HISTORY_STORAGE_KEY, 0);
+    sessionStorage.setItem(USE_LEGACY_HISTORY_STORAGE_KEY, 1);
     location.reload();
 };
 
 export const switchToBetaHistoryPanel = () => {
-    sessionStorage.setItem(USE_BETA_HISTORY_STORAGE_KEY, 1);
+    sessionStorage.setItem(USE_LEGACY_HISTORY_STORAGE_KEY, 0);
     location.reload();
 };

--- a/client/src/components/History/adapters/betaToggle.js
+++ b/client/src/components/History/adapters/betaToggle.js
@@ -1,13 +1,21 @@
-export const isBetaHistoryOpen = () => {
-    return sessionStorage.getItem("useBetaHistory");
+const USE_BETA_HISTORY_STORAGE_KEY = "useBetaHistory";
+
+export const shouldUseBetaHistory = (instanceDefault) => {
+    // If there's a value set, respect it.  Otherwise get instance default from config.
+    const userPrefBetaHistory = sessionStorage.getItem(USE_BETA_HISTORY_STORAGE_KEY);
+    if (userPrefBetaHistory != null) {
+        return userPrefBetaHistory === 1;
+    } else {
+        return instanceDefault;
+    }
 };
 
 export const switchToLegacyHistoryPanel = () => {
-    sessionStorage.removeItem("useBetaHistory");
+    sessionStorage.setItem(USE_BETA_HISTORY_STORAGE_KEY, 0);
     location.reload();
 };
 
 export const switchToBetaHistoryPanel = () => {
-    sessionStorage.setItem("useBetaHistory", 1);
+    sessionStorage.setItem(USE_BETA_HISTORY_STORAGE_KEY, 1);
     location.reload(false);
 };

--- a/client/src/entry/analysis/index.js
+++ b/client/src/entry/analysis/index.js
@@ -6,7 +6,7 @@ import Page from "layout/page";
 
 // Vue adapter emulates current features of backbone history panel
 import { HistoryPanelProxy } from "components/History/adapters/HistoryPanelProxy";
-import { shouldUseBetaHistory } from "components/History/adapters/betaToggle";
+import { shouldUseLegacyHistory } from "components/History/adapters/betaToggle";
 
 addInitialization((Galaxy, { options = {} }) => {
     console.log("Analysis custom page setup");
@@ -14,9 +14,7 @@ addInitialization((Galaxy, { options = {} }) => {
     // Handle beta history panel
     // Need to mock Galaxy.currHistoryPanel
     // pass config through for defaults
-    const HistoryPanel = shouldUseBetaHistory(Galaxy.config.beta_history_default_on)
-        ? HistoryPanelProxy
-        : MvcHistoryPanel;
+    const HistoryPanel = shouldUseLegacyHistory(Galaxy.config.use_legacy_history) ? MvcHistoryPanel : HistoryPanelProxy;
 
     const pageOptions = Object.assign({}, options, {
         config: Object.assign({}, options.config, {

--- a/client/src/entry/analysis/index.js
+++ b/client/src/entry/analysis/index.js
@@ -5,12 +5,19 @@ import MvcHistoryPanel from "entry/panels/history-panel";
 import Page from "layout/page";
 
 // Vue adapter emulates current features of backbone history panel
-import HistoryPanelProxy from "components/History/adapters/HistoryPanelProxy";
-import { isBetaHistoryOpen } from "components/History/adapters/betaToggle";
+import { HistoryPanelProxy } from "components/History/adapters/HistoryPanelProxy";
+import { shouldUseBetaHistory } from "components/History/adapters/betaToggle";
 
 addInitialization((Galaxy, { options = {} }) => {
     console.log("Analysis custom page setup");
-    const HistoryPanel = isBetaHistoryOpen() ? HistoryPanelProxy : MvcHistoryPanel;
+
+    // Handle beta history panel
+    // Need to mock Galaxy.currHistoryPanel
+    // pass config through for defaults
+    const HistoryPanel = shouldUseBetaHistory(Galaxy.config.beta_history_default_on)
+        ? HistoryPanelProxy
+        : MvcHistoryPanel;
+
     const pageOptions = Object.assign({}, options, {
         config: Object.assign({}, options.config, {
             hide_panels: Galaxy.params.hide_panels,

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1879,12 +1879,12 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``beta_history_default_on``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
+``use_legacy_history``
+~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Server-wide default selection of the 'beta' history during the
+    Server-wide default selection to use the legacy history during the
     transition period, after which this option will disappear.  Users
     will remain able to swap back and forth per their preference.
 :Default: ``false``
@@ -3732,8 +3732,13 @@
 :Description:
     When the simplified workflow run form is rendered, should the
     invocation outputs be sent to the 'current' history or a 'new'
-    history.
-:Default: ``current``
+    history. If the user should be presented and option between these
+    - set this to 'prefer_current' or 'prefer_new' to display a
+    runtime setting with the corresponding default. The default is to
+    provide the user this option and default it to the current history
+    (the traditional behavior of Galaxy for years) - this corresponds
+    to the setting 'prefer_current'.
+:Default: ``prefer_current``
 :Type: str
 
 
@@ -4807,3 +4812,6 @@
     Display built-in converters in the tool panel.
 :Default: ``true``
 :Type: bool
+
+
+

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1879,6 +1879,18 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``beta_history_default_on``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Server-wide default selection of the 'beta' history during the
+    transition period, after which this option will disappear.  Users
+    will remain able to swap back and forth per their preference.
+:Default: ``false``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``user_preferences_extra_conf_path``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1014,6 +1014,11 @@ galaxy:
   # <config_dir>.
   #trs_servers_config_file: trs_servers_conf.yml
 
+  # Server-wide default selection of the 'beta' history during the
+  # transition period, after which this option will disappear.  Users
+  # will remain able to swap back and forth per their preference.
+  #beta_history_default_on: false
+
   # Location of the configuration file containing extra user
   # preferences.
   # The value of this option will be resolved with respect to

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1,21 +1,21 @@
 # Galaxy is configured by default to be usable in a single-user development
 # environment.  To tune the application for a multi-user production
 # environment, see the documentation at:
-#
+# 
 #  https://docs.galaxyproject.org/en/master/admin/production.html
-#
+# 
 # Throughout this sample configuration file, except where stated otherwise,
 # uncommented values override the default if left unset, whereas commented
 # values are set to the default value.  Relative paths are relative to the root
 # Galaxy directory.
-#
+# 
 # Examples of many of these options are explained in more detail in the Galaxy
 # Community Hub.
-#
+# 
 #   https://galaxyproject.org/admin/config
-#
+# 
 # Config hackers are encouraged to check there before asking for help.
-#
+# 
 # Configuration for Gravity process manager.
 # ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
 gravity:
@@ -1014,10 +1014,10 @@ galaxy:
   # <config_dir>.
   #trs_servers_config_file: trs_servers_conf.yml
 
-  # Server-wide default selection of the 'beta' history during the
+  # Server-wide default selection to use the legacy history during the
   # transition period, after which this option will disappear.  Users
   # will remain able to swap back and forth per their preference.
-  #beta_history_default_on: false
+  #use_legacy_history: false
 
   # Location of the configuration file containing extra user
   # preferences.
@@ -1850,8 +1850,13 @@ galaxy:
 
   # When the simplified workflow run form is rendered, should the
   # invocation outputs be sent to the 'current' history or a 'new'
-  # history.
-  #simplified_workflow_run_ui_target_history: current
+  # history. If the user should be presented and option between these -
+  # set this to 'prefer_current' or 'prefer_new' to display a runtime
+  # setting with the corresponding default. The default is to provide
+  # the user this option and default it to the current history (the
+  # traditional behavior of Galaxy for years) - this corresponds to the
+  # setting 'prefer_current'.
+  #simplified_workflow_run_ui_target_history: prefer_current
 
   # When the simplified workflow run form is rendered, should the
   # invocation use job caching. This isn't a boolean so an option for
@@ -2364,3 +2369,4 @@ galaxy:
 
   # Display built-in converters in the tool panel.
   #display_builtin_converters: true
+

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1357,7 +1357,7 @@ mapping:
 
       beta_history_default_on:
         type: bool
-        default: false
+        default: true
         required: false
         desc: |
           Server-wide default selection of the 'beta' history during the

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1355,12 +1355,12 @@ mapping:
           If this is null (the default), a simple configuration containing
           just Dockstore will be used.
 
-      beta_history_default_on:
+      use_legacy_history:
         type: bool
-        default: true
+        default: false
         required: false
         desc: |
-          Server-wide default selection of the 'beta' history during the
+          Server-wide default selection to use the legacy history during the
           transition period, after which this option will disappear.  Users will
           remain able to swap back and forth per their preference.
 

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1355,6 +1355,15 @@ mapping:
           If this is null (the default), a simple configuration containing
           just Dockstore will be used.
 
+      beta_history_default_on:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Server-wide default selection of the 'beta' history during the
+          transition period, after which this option will disappear.  Users will
+          remain able to swap back and forth per their preference.
+
       user_preferences_extra_conf_path:
         type: str
         default: 'user_preferences_extra_conf.yml'

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -168,7 +168,7 @@ class ConfigSerializer(base.ModelSerializer):
             "matomo_site_id": _use_config,
             "enable_unique_workflow_defaults": _use_config,
             "enable_beta_markdown_export": _use_config,
-            "beta_history_default_on": _use_config,
+            "use_legacy_history": _use_config,
             "simplified_workflow_run_ui": _use_config,
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -168,6 +168,7 @@ class ConfigSerializer(base.ModelSerializer):
             "matomo_site_id": _use_config,
             "enable_unique_workflow_defaults": _use_config,
             "enable_beta_markdown_export": _use_config,
+            "beta_history_default_on": _use_config,
             "simplified_workflow_run_ui": _use_config,
             "simplified_workflow_run_ui_target_history": _use_config,
             "simplified_workflow_run_ui_job_cache": _use_config,

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1409,6 +1409,12 @@ class NavigatesGalaxy(HasDriver):
             option_component = option_label_or_component
             option_component.wait_for_and_click()
 
+    def use_legacy_history(self):
+        if self.is_beta_history():
+            self.components.history_panel.histories_operation_menu.wait_for_and_click()
+            self.components.history_panel.options_use_legacy_history.wait_for_and_click()
+            self.components.history_panel.legacy.wait_for_present()
+
     def use_beta_history(self):
         if not self.is_beta_history():
             self.click_history_option(self.components.history_panel.options_use_beta_history)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1702,6 +1702,7 @@ class NavigatesGalaxy(HasDriver):
             tour_callback = NullTourCallback()
 
         self.home()
+        self.use_legacy_history()
 
         with open(path) as f:
             tour_dict = yaml.safe_load(f)

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -228,6 +228,7 @@ history_panel:
 
   selectors:
     beta: '.history-index'
+    legacy: '.list-panel'
     _: '#current-history-panel'
     search: '#current-history-panel input.search-query'
     refresh_button: '.history-refresh-button'
@@ -273,9 +274,7 @@ history_panel:
     options_use_beta_history:
       type: xpath
       selector: '//a[text()="Use Beta History Panel"]'
-    options_use_legacy_history:
-      type: xpath
-      selector: '//button[contains(span, "Return to legacy history panel")]'
+    options_use_legacy_history: 'a[data-description="switch to legacy history view"]'
     
     collection_menu_button: '.collection-menu'
     collection_menu_edit_attributes: 

--- a/lib/galaxy_test/selenium/test_anon_history.py
+++ b/lib/galaxy_test/selenium/test_anon_history.py
@@ -8,6 +8,7 @@ class AnonymousHistoriesTestCase(SeleniumTestCase):
     @selenium_test
     def test_anon_history_landing(self):
         self.home()
+        self.use_legacy_history()
         self.assert_initial_history_panel_state_correct()
 
         # Anonymous users can annotate or tag, these components should be absent.
@@ -41,6 +42,7 @@ class AnonymousHistoriesTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_clean_anon_history_after_logout(self):
+        self.use_legacy_history()
         self._upload_file_anonymous_then_register_user()
         self.logout_if_needed()
         # Give Galaxy the chance to load a new empty history for that now

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -18,7 +18,7 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
     @selenium_test
     def test_build_delete(self):
         self._login()
-
+        self.use_legacy_history()
         self.navigate_to_custom_builds_page()
 
         self.add_custom_build(self.build_name2, self.build_key2)

--- a/lib/galaxy_test/selenium/test_custom_builds.py
+++ b/lib/galaxy_test/selenium/test_custom_builds.py
@@ -9,7 +9,7 @@ class CustomBuildsTestcase(SharedStateSeleniumTestCase):
     @selenium_test
     def test_build_add(self):
         self._login()
-
+        self.use_legacy_history()
         self.navigate_to_custom_builds_page()
 
         self.add_custom_build(self.build_name1, self.build_key1)

--- a/lib/galaxy_test/selenium/test_history_options.py
+++ b/lib/galaxy_test/selenium/test_history_options.py
@@ -9,6 +9,7 @@ class HistoryOptionsTestCase(SeleniumTestCase):
     def test_options(self):
         self.register()
         self.perform_upload(self.get_filename("1.txt"))
+        self.use_legacy_history()
         self.click_history_options()
 
         menu_selector = self.navigation.history_panel.selectors.options_menu

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -17,6 +17,7 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_valid_by_id(self):
+        self.use_legacy_history()
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history(share_by_id=True)
         self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get(f"histories/{history_id}", raw=True)

--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -10,6 +10,7 @@ VALID_LOGIN_RETRIES = 3
 class HistorySharingTestCase(SeleniumTestCase):
     @selenium_test
     def test_sharing_valid(self):
+        self.use_legacy_history()
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
         self.submit_login(user2_email, retries=VALID_LOGIN_RETRIES)
         response = self.api_get(f"histories/{history_id}", raw=True)
@@ -25,6 +26,7 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_unsharing(self):
+        self.use_legacy_history()
         user1_email, user2_email, history_id = self.setup_two_users_with_one_shared_history()
         self.submit_login(user1_email, retries=VALID_LOGIN_RETRIES)
         self.navigate_to_history_share_page()
@@ -58,6 +60,7 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_with_invalid_user(self):
+        self.use_legacy_history()
         user1_email = self._get_random_email()
         self.register(user1_email)
         self.share_history_with_user(user_email="invalid_user@test.com")
@@ -65,6 +68,7 @@ class HistorySharingTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_sharing_with_self(self):
+        self.use_legacy_history()
         user1_email = self._get_random_email()
         self.register(user1_email)
         self.share_history_with_user(user_email=user1_email)

--- a/lib/galaxy_test/selenium/test_library_to_collections.py
+++ b/lib/galaxy_test/selenium/test_library_to_collections.py
@@ -55,7 +55,7 @@ class LibraryToCollectionsTestCase(SeleniumTestCase, UsesLibraryAssertions):
 
     def collection_export(self, is_new_history=False, collection_option=None):
         random_name = self._get_random_name()
-
+        self.use_legacy_history()
         self.prepare_library_for_data_export(["1.bam", "1.bed"], random_name if is_new_history else None)
         self.components.libraries.folder.export_to_history_options.wait_for_and_click()
 

--- a/lib/galaxy_test/selenium/test_library_to_collections.py
+++ b/lib/galaxy_test/selenium/test_library_to_collections.py
@@ -70,6 +70,7 @@ class LibraryToCollectionsTestCase(SeleniumTestCase, UsesLibraryAssertions):
             assert self.history_panel_name_element().text == random_name
 
     def list_of_pairs_export(self, is_new_history=False):
+        self.use_legacy_history()
         history_name = self._get_random_name()
         self.prepare_library_for_data_export(
             ["bam_from_sam.bam", "asian_chars_1.txt", "1.bam", "1.bed"], history_name if is_new_history else None

--- a/lib/galaxy_test/selenium/test_navigates_galaxy.py
+++ b/lib/galaxy_test/selenium/test_navigates_galaxy.py
@@ -15,6 +15,7 @@ class NavigatesGalaxySeleniumTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_click_error(self):
+        self.use_legacy_history()
         self.home()
         self.upload_start_click()
         # Open the details, verify they are open and do a refresh.

--- a/lib/galaxy_test/selenium/test_published_histories_grid.py
+++ b/lib/galaxy_test/selenium/test_published_histories_grid.py
@@ -159,6 +159,7 @@ class HistoryGridTestCase(SharedStateSeleniumTestCase):
         self.sleep_for(self.wait_types.UX_RENDER)
 
     def setup_shared_state(self):
+        self.use_legacy_history()
         tag1 = self._get_random_name(len=5)
         tag2 = self._get_random_name(len=5)
         tag3 = self._get_random_name(len=5)

--- a/lib/galaxy_test/selenium/test_tool_describing_tours.py
+++ b/lib/galaxy_test/selenium/test_tool_describing_tours.py
@@ -34,7 +34,7 @@ class ToolDescribingToursTestCase(SeleniumTestCase):
     def test_generate_tour_with_data(self):
         """Ensure a tour with data populates history."""
         self._ensure_tdt_available()
-
+        self.use_legacy_history()
         self.tool_open("md5sum")
 
         self.tool_form_generate_tour()

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -89,6 +89,7 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_rerun(self):
+        self.use_legacy_history()
         self._run_environment_test_tool()
         self.history_panel_wait_for_hid_ok(1)
         self.hda_click_primary_action_button(1, "rerun")

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -13,6 +13,7 @@ from .framework import (
 class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
     @selenium_test
     def test_upload_simplest(self):
+        self.use_legacy_history()
         self.perform_upload(self.get_filename("1.sam"))
 
         self.history_panel_wait_for_hid_ok(1)

--- a/lib/galaxy_test/selenium/test_uploads.py
+++ b/lib/galaxy_test/selenium/test_uploads.py
@@ -64,6 +64,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_list(self):
+        self.use_legacy_history()
         self.upload_list([self.get_filename("1.tabular")], name="Test List")
         self.history_panel_wait_for_hid_ok(2)
         # Make sure modals disappeared - both List creator (TODO: upload).
@@ -76,6 +77,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_pair(self):
+        self.use_legacy_history()
         self.upload_list([self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Pair")
         self.history_panel_wait_for_hid_ok(3)
         # Make sure modals disappeared - both collection creator (TODO: upload).
@@ -105,6 +107,7 @@ class UploadsTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
     @selenium_test
     def test_upload_paired_list(self):
+        self.use_legacy_history()
         self.upload_paired_list(
             [self.get_filename("1.tabular"), self.get_filename("2.tabular")], name="Test Paired List"
         )

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -22,6 +22,7 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
 
     @selenium_test
     def test_history_import_export(self):
+        self.use_legacy_history()
         email = self.get_logged_in_user()["email"]
         user_ftp_dir = os.path.join(self.ftp_dir(), email)
         os.makedirs(user_ftp_dir)


### PR DESCRIPTION
 With an eye to 22.05 for the new history being the default, I want to swap it early(enough) in the cycle to put us on track for that and get more eyes on it.  This will allow per-instance specification of the default.

Test failures when run with the default swapped, for easy reference:

- [x] FAILED lib/galaxy_test/selenium/test_collection_edit.py::CollectionEditTestCase::test_change_dbkey_simple_list
- [x] FAILED lib/galaxy_test/selenium/test_custom_builds.py::CustomBuildsTestcase::test_build_add
- [x] FAILED lib/galaxy_test/selenium/test_history_sharing.py::HistorySharingTestCase::test_sharing_valid_by_id
- [x] FAILED lib/galaxy_test/selenium/test_navigates_galaxy.py::NavigatesGalaxySeleniumTestCase::test_click_error
- [x] FAILED lib/galaxy_test/selenium/test_published_histories_grid.py::HistoryGridTestCase::test_history_grid_search_standard
- [x] FAILED lib/galaxy_test/selenium/test_uploads.py::UploadsTestCase::test_upload_list


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] Instructions for manual testing are as follows:
  1. Start galaxy
  2. Observe new history enabled by default
  3. Test swapping legacy/beta, still works.