### PR TITLE
Fix value of 'unknown_error' resubmit condition variable

### DIFF
--- a/lib/galaxy/jobs/runners/state_handlers/resubmit.py
+++ b/lib/galaxy/jobs/runners/state_handlers/resubmit.py
@@ -187,7 +187,7 @@ class _ExpressionContext:
             self._lazy_context = {
                 "walltime_reached": runner_state == JobState.runner_states.WALLTIME_REACHED,
                 "memory_limit_reached": runner_state == JobState.runner_states.MEMORY_LIMIT_REACHED,
-                "unknown_error": JobState.runner_states.UNKNOWN_ERROR,
+                "unknown_error": runner_state == JobState.runner_states.UNKNOWN_ERROR,
                 "tool_detected_failure": runner_state == JobState.runner_states.TOOL_DETECT_ERROR,
                 "any_failure": True,
                 "any_potential_job_failure": True,  # Add a hook here - later on allow tools to describe things that are definitely input problems.


### PR DESCRIPTION
## What did you do? 
- Set `unknown_error` resubmit condition variable to True/False rather than "unknown_error" value


## Why did you make this change?
I spotted this while trying to determine why a job was not being resubmitted.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## For UI Components
- [ ] I've included a screenshot of the changes
