### PR TITLE
[21.01] Create install database with create_db.sh

### DIFF
--- a/lib/galaxy/model/orm/scripts.py
+++ b/lib/galaxy/model/orm/scripts.py
@@ -136,8 +136,9 @@ def get_config(argv, use_argparse=True, cwd=None):
         db_url = properties["%sdatabase_connection" % config_prefix]
     else:
         db_url = "sqlite:///%s?isolation_level=IMMEDIATE" % os.path.join(get_data_dir(properties), default_sqlite_file)
+    install_database_connection = properties.get('install_database_connection')
 
-    return dict(db_url=db_url, repo=repo, config_file=config_file, database=database)
+    return dict(db_url=db_url, repo=repo, config_file=config_file, database=database, install_database_connection=install_database_connection)
 
 
 def manage_db():

--- a/scripts/create_db.py
+++ b/scripts/create_db.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 def invoke_create():
     config = get_config(sys.argv)
     if config['database'] == 'galaxy':
-        create_db(config['db_url'], config['config_file'])
+        create_db(config['db_url'], config['config_file'], map_install_models=not config['install_database_connection'])
     elif config['database'] == 'tool_shed':
         create_tool_shed_db(config['db_url'])
     elif config['database'] == 'install':


### PR DESCRIPTION
## What did you do? 
- Create install database with create_db.sh when the config does not specify a separate install_database_connection.


## Why did you make this change?
If you just run create_db.sh and you didn't set up a separate install_database_connection you'll be greeted with this exception.

```
Traceback (most recent call last):
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UndefinedTable: relation "tool_shed_repository" does not exist
LINE 2: FROM tool_shed_repository LEFT OUTER JOIN tool_dependency AS...
             ^
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/galaxy/server/lib/galaxy/webapps/galaxy/buildapp.py", line 60, in app_pair
    app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
  File "/galaxy/server/lib/galaxy/app.py", line 169, in __init__
    self.tool_shed_repository_cache = self._register_singleton(ToolShedRepositoryCache)
  File "/galaxy/server/lib/galaxy/di.py", line 22, in _register_singleton
    instance = self[dep_type]
  File "/galaxy/server/.venv/lib/python3.8/site-packages/lagom/container.py", line 358, in __getitem__
    return self.resolve(dep)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/lagom/container.py", line 243, in resolve
    return self._reflection_build_with_err_handling(dep_type, suppress_error)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/lagom/container.py", line 369, in _reflection_build_with_err_handling
    return self._reflection_build(dep_type)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/lagom/container.py", line 385, in _reflection_build
    return dep_type(**sub_deps)  # type: ignore
  File "/galaxy/server/lib/galaxy/tools/cache.py", line 296, in __init__
    self.rebuild()
  File "/galaxy/server/lib/galaxy/tools/cache.py", line 305, in rebuild
    self.repositories = session.query(ToolShedRepository).options(
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 3373, in all
    return list(self)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 3535, in __iter__
    return self._execute_and_instances(context)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 3560, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1011, in execute
    return meth(self, multiparams, params)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/sql/elements.py", line 298, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1124, in _execute_clauseelement
    ret = self._execute_context(
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1316, in _execute_context
    self._handle_dbapi_exception(
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1510, in _handle_dbapi_exception
    util.raise_(
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File "/galaxy/server/.venv/lib/python3.8/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedTable) relation "tool_shed_repository" does not exist
LINE 2: FROM tool_shed_repository LEFT OUTER JOIN tool_dependency AS...
             ^
[SQL: SELECT tool_shed_repository.id AS tool_shed_repository_id, tool_shed_repository.create_time AS tool_shed_repository_create_time, tool_shed_repository.update_time AS tool_shed_repository_update_time, tool_shed_repository.tool_shed AS tool_shed_repository_tool_shed, tool_shed_repository.name AS tool_shed_repository_name, tool_shed_repository.description AS tool_shed_repository_description, tool_shed_repository.owner AS tool_shed_repository_owner, tool_shed_repository.installed_changeset_revision AS tool_shed_repository_installed_changeset_revision, tool_shed_repository.changeset_revision AS tool_shed_repository_changeset_revision, tool_shed_repository.ctx_rev AS tool_shed_repository_ctx_rev, tool_shed_repository.includes_datatypes AS tool_shed_repository_includes_datatypes, tool_shed_repository.tool_shed_status AS tool_shed_repository_tool_shed_status, tool_shed_repository.deleted AS tool_shed_repository_deleted, tool_shed_repository.uninstalled AS tool_shed_repository_uninstalled, tool_shed_repository.dist_to_shed AS tool_shed_repository_dist_to_shed, tool_shed_repository.status AS tool_shed_repository_status, tool_shed_repository.error_message AS tool_shed_repository_error_message, tool_dependency_1.id AS tool_dependency_1_id, tool_dependency_1.create_time AS tool_dependency_1_create_time, tool_dependency_1.update_time AS tool_dependency_1_update_time, tool_dependency_1.tool_shed_repository_id AS tool_dependency_1_tool_shed_repository_id, tool_dependency_1.name AS tool_dependency_1_name, tool_dependency_1.version AS tool_dependency_1_version, tool_dependency_1.type AS tool_dependency_1_type, tool_dependency_1.status AS tool_dependency_1_status, tool_dependency_1.error_message AS tool_dependency_1_error_message
FROM tool_shed_repository LEFT OUTER JOIN tool_dependency AS tool_dependency_1 ON tool_shed_repository.id = tool_dependency_1.tool_shed_repository_id ORDER BY tool_dependency_1.name]
(Background on this error at: http://sqlalche.me/e/13/f405)
```


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
Make sure you don't have a install_database_connection set up in your galaxy.yml and point the database_connection to a new database, then run `./create_db.sh -c config/galaxy.yml`.
You should see:
```
Activating virtualenv at .venv
INFO:galaxy.model.migrate.check:Creating database for URI [sqlite:///./database/universe123.sqlite?isolation_level=IMMEDIATE]
INFO:galaxy.model.migrate.check:Creating new database from scratch, skipping migrations
``` 
Then verify the tool_shed_repository table exists.