### PR TITLE
Allow rerunning uploads from link

### DIFF
--- a/lib/galaxy/tools/data_fetch.xml
+++ b/lib/galaxy/tools/data_fetch.xml
@@ -1,7 +1,6 @@
 <tool id="__DATA_FETCH__"
       name="Data Fetch"
       version="0.1.0"
-      workflow_compatible="false"
       profile="18.01">
   <action module="galaxy.tools.actions.upload" class="FetchUploadToolAction"/>
     <edam_operations>


### PR DESCRIPTION
## What did you do? 
- Set the `__DATA_FETCH__` tool as `workflow_compatible`.


## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/8420.

@wm75 and I are currently working on a bot for automatic analysis of SARS-CoV-2 data which uploads data via links into collections, before invoking a workflow, and we would like to be able to automatically rerun uploads that fail due to server issues.

I also thought of achieving the same effect by replacing https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/managers/datasets.py#L572 with `if tool and (tool.is_workflow_compatible or tool.id == "__DATA_FETCH__")`. If this is better, or there's another preferred alternative, please let me know. 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload a file by pasting a link in the UI. The dataset created should have a rerun icon; clicking on it allows rerunning the upload.

## For UI Components
- [ ] I've included a screenshot of the changes
