### PR TITLE
Allow AWS s3 access for ec2 instances without hardcoding credentials

### DIFF
--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -207,7 +207,11 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
 
     def _configure_connection(self):
         log.debug("Configuring S3 Connection")
-        self.conn = S3Connection(self.access_key, self.secret_key)
+        # If access_key is empty use default credential chain
+        if self.access_key:
+            self.conn = S3Connection(self.access_key, self.secret_key)
+        else:
+            self.conn = S3Connection()
 
     @classmethod
     def parse_xml(clazz, config_xml):

--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -32,7 +32,10 @@ def mp_from_ids(s3server, mp_id, mp_keyname, mp_bucketname):
                                calling_format=boto.s3.connection.OrdinaryCallingFormat(),
                                path=s3server['conn_path'])
     else:
-        conn = S3Connection(s3server['access_key'], s3server['secret_key'])
+        if s3server['access_key']:
+            conn = S3Connection(s3server['access_key'], s3server['secret_key'])
+        else:
+            conn = S3Connection()
 
     bucket = conn.lookup(mp_bucketname)
     mp = boto.s3.multipart.MultiPartUpload(bucket)


### PR DESCRIPTION
If an access key is not set in the configuration it will now use the default credential chain and allow using the ec2 instance credentials to access the s3 bucket.

Signed-off-by: crashGoBoom <crashGoBoom@users.noreply.github.com>

## What did you do? 
- Added logic to check for an empty access_key in the config.


## Why did you make this change?
To allow s3 access to ec2 instances without hard coding credentials.

Issue #11713

