### PR TITLE
Attempt to parse env config values as yaml to allow passing complex types

### DIFF
--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -11,7 +11,7 @@ from itertools import product, starmap
 
 import yaml
 
-from galaxy.exceptions import InvalidFileFormatError
+from galaxy.exceptions import InvalidFileFormatError, ConfigurationError
 from galaxy.util.path import extensions, has_ext, joinext
 
 
@@ -99,8 +99,8 @@ def load_app_properties(
             # Attempt to parse value as yaml to allow passing complex options via env
             if config_key:
                 properties[config_key] = yaml.safe_load(properties[config_key])
-        except yaml.YAMLError:
-            pass
+        except yaml.YAMLError as e:
+            raise ConfigurationError(f"Failed to parse {key} as YAML: {e}")
 
     return properties
 

--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -87,6 +87,7 @@ def load_app_properties(
     # update from env
     override_prefix = "%sOVERRIDE_" % config_prefix
     for key in os.environ:
+        config_key = None
         if key.startswith(override_prefix):
             config_key = key[len(override_prefix):].lower()
             properties[config_key] = os.environ[key]
@@ -94,6 +95,12 @@ def load_app_properties(
             config_key = key[len(config_prefix):].lower()
             if config_key not in properties:
                 properties[config_key] = os.environ[key]
+        try:
+            # Attempt to parse value as yaml to allow passing complex options via env
+            if config_key:
+                properties[config_key] = yaml.safe_load(properties[config_key])
+        except yaml.YAMLError:
+            pass
 
     return properties
 


### PR DESCRIPTION
## What did you do? 
Pass env config values to yaml parser. This works with primitives because yaml documents allow the root node to be of any type.

I tried to locate existing tests for the env override functionality but couldn't find any. I am not prepared to write an entire test suite to get tests for this off the ground.

## Why did you make this change?
Resolves https://github.com/galaxyproject/galaxy/issues/10379


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## For UI Components
- [ ] I've included a screenshot of the changes
