### PR TITLE
[21.01] Assorted tool shed fixes

### DIFF
--- a/lib/tool_shed/grids/repository_grids.py
+++ b/lib/tool_shed/grids/repository_grids.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from markupsafe import escape as escape_html
@@ -180,7 +181,7 @@ class RepositoryGrid(grids.Grid):
     class EmailAlertsColumn(grids.TextColumn):
 
         def get_value(self, trans, grid, repository):
-            if trans.user and trans.user.email in repository.email_alerts:
+            if trans.user and repository.email_alerts and trans.user.email in json.loads(repository.email_alerts):
                 return 'yes'
             return ''
 

--- a/lib/tool_shed/util/commit_util.py
+++ b/lib/tool_shed/util/commit_util.py
@@ -1,5 +1,6 @@
 import bz2
 import gzip
+import json
 import logging
 import os
 import shutil
@@ -71,7 +72,8 @@ def check_file_contents_for_email_alerts(app):
     admin_users = app.config.get("admin_users", "").split(",")
     for repository in sa_session.query(app.model.Repository) \
                                 .filter(app.model.Repository.table.c.email_alerts != null()):
-        for user_email in repository.email_alerts:
+        email_alerts = json.loads(repository.email_alerts)
+        for user_email in email_alerts:
             if user_email in admin_users:
                 return True
     return False

--- a/lib/tool_shed/util/shed_util_common.py
+++ b/lib/tool_shed/util/shed_util_common.py
@@ -385,7 +385,7 @@ def handle_email_alerts(app, host, repository, content_alert_str='', new_repo_al
                     email_alerts.append(user.email)
         else:
             subject = "Galaxy tool shed update alert for repository named %s" % str(repository.name)
-            email_alerts = repository.email_alerts
+            email_alerts = json.loads(repository.email_alerts)
         for email in email_alerts:
             to = email.strip()
             # Send it

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -1658,6 +1658,10 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         alerts = kwd.get('alerts', '')
         alerts_checked = CheckboxField.is_checked(alerts)
         category_ids = util.listify(kwd.get('category_id', ''))
+        if repository.email_alerts:
+            email_alerts = json.loads(repository.email_alerts)
+        else:
+            email_alerts = []
         allow_push = kwd.get('allow_push', '')
         error = False
         user = trans.user
@@ -1710,12 +1714,14 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         elif kwd.get('receive_email_alerts_button', False):
             flush_needed = False
             if alerts_checked:
-                if user.email not in repository.email_alerts:
-                    repository.email_alerts.append(user.email)
+                if user.email not in email_alerts:
+                    email_alerts.append(user.email)
+                    repository.email_alerts = json.dumps(email_alerts)
                     flush_needed = True
             else:
-                if user.email in repository.email_alerts:
-                    repository.email_alerts.remove(user.email)
+                if user.email in email_alerts:
+                    email_alerts.remove(user.email)
+                    repository.email_alerts = json.dumps(email_alerts)
                     flush_needed = True
             if flush_needed:
                 trans.sa_session.add(repository)
@@ -1737,7 +1743,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         for obj in options:
             label = obj.username
             allow_push_select_field.add_option(label, trans.security.encode_id(obj.id))
-        checked = alerts_checked or user.email in repository.email_alerts
+        checked = alerts_checked or user.email in email_alerts
         alerts_check_box = CheckboxField('alerts', value=checked)
         changeset_revision_select_field = grids_util.build_changeset_revision_select_field(trans,
                                                                                            repository,
@@ -2267,14 +2273,19 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             flush_needed = False
             for repository_id in repository_ids:
                 repository = repository_util.get_repository_in_tool_shed(trans.app, repository_id)
-                email_alerts = repository.email_alerts
+                if repository.email_alerts:
+                    email_alerts = json.loads(repository.email_alerts)
+                else:
+                    email_alerts = []
                 if user.email in email_alerts:
                     email_alerts.remove(user.email)
+                    repository.email_alerts = json.dumps(email_alerts)
                     trans.sa_session.add(repository)
                     flush_needed = True
                     total_alerts_removed += 1
                 else:
                     email_alerts.append(user.email)
+                    repository.email_alerts = json.dumps(email_alerts)
                     trans.sa_session.add(repository)
                     flush_needed = True
                     total_alerts_added += 1
@@ -2557,7 +2568,10 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         display_reviews = kwd.get('display_reviews', False)
         alerts = kwd.get('alerts', '')
         alerts_checked = CheckboxField.is_checked(alerts)
-        email_alerts = repository.email_alerts
+        if repository.email_alerts:
+            email_alerts = json.loads(repository.email_alerts)
+        else:
+            email_alerts = []
         repository_dependencies = None
         user = trans.user
         if user and kwd.get('receive_email_alerts_button', False):
@@ -2565,10 +2579,12 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
             if alerts_checked:
                 if user.email not in email_alerts:
                     email_alerts.append(user.email)
+                    repository.email_alerts = json.dumps(email_alerts)
                     flush_needed = True
             else:
                 if user.email in email_alerts:
                     email_alerts.remove(user.email)
+                    repository.email_alerts = json.dumps(email_alerts)
                     flush_needed = True
             if flush_needed:
                 trans.sa_session.add(repository)

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -183,7 +183,7 @@ class Repository(Dictifiable, _HasTable):
     dict_collection_visible_keys = ['id', 'name', 'type', 'remote_repository_url', 'homepage_url', 'description', 'user_id', 'private', 'deleted',
                                     'times_downloaded', 'deprecated', 'create_time']
     dict_element_visible_keys = ['id', 'name', 'type', 'remote_repository_url', 'homepage_url', 'description', 'long_description', 'user_id', 'private',
-                                 'deleted', 'times_downloaded', 'deprecated', 'create_time', 'ratings', 'reviews', 'reviewers']
+                                 'deleted', 'times_downloaded', 'deprecated', 'create_time']
     file_states = Bunch(NORMAL='n',
                         NEEDS_MERGING='m',
                         MARKED_FOR_REMOVAL='r',

--- a/lib/tool_shed/webapp/model/mapping.py
+++ b/lib/tool_shed/webapp/model/mapping.py
@@ -118,7 +118,7 @@ Repository.table = Table("repository", metadata,
                          Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
                          Column("private", Boolean, default=False),
                          Column("deleted", Boolean, index=True, default=False),
-                         Column("email_alerts", JSONType, nullable=True, default=list),
+                         Column("email_alerts", JSONType, nullable=True),
                          Column("times_downloaded", Integer),
                          Column("deprecated", Boolean, default=False))
 

--- a/lib/tool_shed/webapp/search/tool_search.py
+++ b/lib/tool_shed/webapp/search/tool_search.py
@@ -13,6 +13,7 @@ from whoosh.qparser import MultifieldParser
 
 from galaxy import exceptions
 from galaxy.exceptions import ObjectNotFound
+from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
 
@@ -82,7 +83,8 @@ class ToolSearch:
                     hit_dict['repo_name'] = hit.get('repo_name')
                     hit_dict['name'] = hit.get('name')
                     hit_dict['description'] = hit.get('description')
-                    results['hits'].append({'tool': hit_dict, 'matched_terms': hit.matched_terms(), 'score': hit.score})
+                    matched_terms = {k: unicodify(v) for k, v in hit.matched_terms()}
+                    results['hits'].append({'tool': hit_dict, 'matched_terms': matched_terms, 'score': hit.score})
                 return results
             finally:
                 searcher.close()


### PR DESCRIPTION
## What did you do? 
- Fix email column handling: The default argument has no effect in our custom JSONType
implementation. This only worked with the sqlalchemy-mutable,
which we've removed again in the meantime.
- Don't serialize RepositoryRatingAssociation and other unused stuff. 
These would need need custom to_dict functions, else they fail with
```
TypeError: Object of type RepositoryRatingAssociation is not JSON serializable
  File "galaxy/web/framework/decorators.py", line 171, in decorator
    rval = format_return_as_json(rval, jsonp_callback, pretty=trans.debug)
  File "galaxy/web/framework/decorators.py", line 329, in format_return_as_json
    json = safe_dumps(rval, **dumps_kwargs)
  File "galaxy/util/json.py", line 67, in safe_dumps
    dumped = json.dumps(*args, allow_nan=False, **kwargs)
  File "json/__init__.py", line 234, in dumps
    return cls(
  File "json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
```
I think this has never worked since its addition in
#8661.
- Fix tool shed search returning matched terms as bytestrings, reported by @ksuderman 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] Instructions for manual testing are as follows:
Spin up a tool shed, create a repository, add a rating and 
- verify you can serialize the repository via the API (/api/repositories/<repo_id>)
- search for the repo (api/tools?q=sometool)
