### PR TITLE
[21.01] Pulsar: mark cancelled jobs as finished

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -305,7 +305,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
 
     def _update_job_state_for_status(self, job_state, pulsar_status, full_status=None):
         log.debug('(%s) Received status update: %s %s', job_state.job_id, type(pulsar_status), pulsar_status)
-        if pulsar_status == "complete" or job_state.job_wrapper.get_state() == model.Job.states.STOPPED:
+        if pulsar_status in ["complete", "cancelled"] or job_state.job_wrapper.get_state() == model.Job.states.STOPPED:
             self.mark_as_finished(job_state)
             return None
         if pulsar_status in ["failed", "lost"]:


### PR DESCRIPTION
## What did you do? 

Fixes #11579 = avoid to constantly check status of cancelled pulsar jobs

## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

The "cancelled" state of pulsar jobs was not handled, resulting in galaxy continuing to check job states each second and flooding the logs (see #11579).
I wonder if calling `mark_as_finished` is better than `fail_job`?

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Launch an interactive tool with pulsar embedded, stop it form the ui (or delete it from the history) => with this patch there is no more lines like this flooding the logs:
 
```
[PulsarJobRunner.monitor_thread] (19077) Received status update: <class 'str'> cancelled
```

I think that's the last bug on my list for running gxits with embedded pulsar