### PR TITLE
[21.01] Fix format="input" with implicit conversions

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -975,6 +975,13 @@ def determine_output_format(output, parameter_context, input_datasets, input_dat
     # the type should match the input
     ext = output.format
     if ext == "input":
+        if input_datasets and random_input_ext in {'data', 'auto'}:
+            # Probably dealing with an implicitly converted dataset
+            try:
+                first_input_dataset = next(iter(input_datasets.values()))
+                random_input_ext = get_ext_or_implicit_ext(first_input_dataset)
+            except Exception:
+                pass
         ext = random_input_ext
     format_source = output.format_source
     if format_source is not None and format_source in input_datasets:

--- a/test/functional/tools/implicit_conversion_format_input.xml
+++ b/test/functional/tools/implicit_conversion_format_input.xml
@@ -1,0 +1,22 @@
+<tool id="implicit_conversion_format_input" name="implicit_conversion with input format">
+  <command>
+    cut -f 1 '$input1' > '$output1'
+  </command>
+  <inputs>
+    <param type="data" format="fasta" name="input1" label="Input 1" />
+  </inputs>
+  <outputs>
+    <data name="output1" format="input" />
+  </outputs>
+  <tests>
+    <!-- Test implicit conversion. -->
+    <test>
+      <param name="input1" value="1.fasta.gz" ftype="fasta.gz" />
+      <output name="output1" ftype="fasta">
+        <assert_contents>
+          <has_line line=">hg17" />
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -133,6 +133,7 @@
   <tool file="empty_output.xml" />
   <tool file="validation_empty_dataset.xml" />
   <tool file="implicit_conversion.xml" />
+  <tool file="implicit_conversion_format_input.xml" />
   <tool file="implicit_collection_conversion.xml" />
   <tool file="implicit_nested_list_conversion.xml" />
   <tool file="explicit_conversion.xml" />


### PR DESCRIPTION
## What did you do? 
- Fix format="input" when the input is the result of a implicit conversion (and the implicit converter uses galaxy.json to set the extension).


## Why did you make this change?
Without this fix the dataset would always be created with the "data" extension.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## For UI Components
- [ ] I've included a screenshot of the changes
