### PR TITLE
[21.01] galaxy.webapps.tool_shed to webapp.tool_shed

### DIFF
--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -350,7 +350,7 @@ GALAXY_APP = App(
 SHED_APP = App(
     ["tool_shed_wsgi.ini", "config/tool_shed.ini"],
     "9009",
-    ["galaxy.webapps.tool_shed.buildapp:app_factory"],
+    ["tool_shed.webapp.buildapp:app_factory"],
     "config/tool_shed.yml",
     "lib/tool_shed/webapp/config_schema.yml",
     'tool_shed.webapp.buildapp:uwsgi_app()',

--- a/test/unit/config/config_manage/1607_root_filters/config/tool_shed.ini
+++ b/test/unit/config/config_manage/1607_root_filters/config/tool_shed.ini
@@ -29,7 +29,7 @@ prefix = /shed
 filter-with = proxy-prefix
 
 # Specifies the factory for the universe WSGI application
-paste.app_factory = galaxy.webapps.tool_shed.buildapp:app_factory
+paste.app_factory = tool_shed.webapp.buildapp:app_factory
 
 # Verbosity of console log messages.  Acceptable values can be found here:
 # https://docs.python.org/2/library/logging.html#logging-levels

--- a/test/unit/config/config_manage/1607_root_samples/config/tool_shed.ini
+++ b/test/unit/config/config_manage/1607_root_samples/config/tool_shed.ini
@@ -22,7 +22,7 @@ threadpool_kill_thread_limit = 10800
 [app:main]
 
 # Specifies the factory for the universe WSGI application
-paste.app_factory = galaxy.webapps.tool_shed.buildapp:app_factory
+paste.app_factory = tool_shed.webapp.buildapp:app_factory
 
 # Verbosity of console log messages.  Acceptable values can be found here:
 # https://docs.python.org/2/library/logging.html#logging-levels


### PR DESCRIPTION
This might not actually be a good change, but came across it randomly and thought I'd PR so someone who might know better can decide, just in case these three were omitted by mistake from the refactoring in  https://github.com/galaxyproject/galaxy/pull/8949
