### PR TITLE
Attempt to parse env config values as yaml to allow passing complex types

### DIFF
--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -88,14 +88,9 @@ def load_app_properties(
     override_prefix = "override_"
     yaml_prefix = "yaml_"
     for key, val in os.environ.items():
-        override = False
         if key.startswith(config_prefix):
             # munch config_prefix
             config_key = key[len(config_prefix):].lower()
-            if config_key.startswith(override_prefix):
-                # munch override_prefix
-                config_key = config_key[len(override_prefix):]
-                override = True
 
             if config_key.startswith(yaml_prefix):
                 # munch yaml_prefix
@@ -106,8 +101,13 @@ def load_app_properties(
                 except yaml.YAMLError as e:
                     raise ConfigurationError(f"Failed to parse {key} as YAML: {e}")
 
-            if override or config_key not in properties:
-                properties[key] = val
+            if config_key.startswith(override_prefix):
+                # munch override_prefix
+                config_key = config_key[len(override_prefix):]
+                properties[config_key] = val
+
+            elif config_key not in properties:
+                properties[config_key] = val
 
     return properties
 

--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -11,7 +11,7 @@ from itertools import product, starmap
 
 import yaml
 
-from galaxy.exceptions import InvalidFileFormatError
+from galaxy.exceptions import InvalidFileFormatError, ConfigurationError
 from galaxy.util.path import extensions, has_ext, joinext
 
 
@@ -91,22 +91,22 @@ def load_app_properties(
         override = False
         if key.startswith(config_prefix):
             # munch config_prefix
-            key = key[len(config_prefix):].lower()
-            if key.startswith(override_prefix):
+            config_key = key[len(config_prefix):].lower()
+            if config_key.startswith(override_prefix):
                 # munch override_prefix
-                key = key[len(override_prefix):]
+                config_key = config_key[len(override_prefix):]
                 override = True
 
-            if key.startswith(yaml_prefix):
+            if config_key.startswith(yaml_prefix):
                 # munch yaml_prefix
-                key = key[len(yaml_prefix):]
+                config_key = config_key[len(yaml_prefix):]
                 try:
                     # Attempt to parse value as yaml to allow passing complex options via env
                     val = yaml.safe_load(val)
-                except yaml.YAMLError:
-                    pass
+                except yaml.YAMLError as e:
+                    raise ConfigurationError(f"Failed to parse {key} as YAML: {e}")
 
-            if override or key not in properties:
+            if override or config_key not in properties:
                 properties[key] = val
 
     return properties

--- a/lib/galaxy/util/properties.py
+++ b/lib/galaxy/util/properties.py
@@ -85,15 +85,29 @@ def load_app_properties(
         properties.update(kwds)
 
     # update from env
-    override_prefix = "%sOVERRIDE_" % config_prefix
-    for key in os.environ:
-        if key.startswith(override_prefix):
-            config_key = key[len(override_prefix):].lower()
-            properties[config_key] = os.environ[key]
-        elif key.startswith(config_prefix):
-            config_key = key[len(config_prefix):].lower()
-            if config_key not in properties:
-                properties[config_key] = os.environ[key]
+    override_prefix = "override_"
+    yaml_prefix = "yaml_"
+    for key, val in os.environ.items():
+        override = False
+        if key.startswith(config_prefix):
+            # munch config_prefix
+            key = key[len(config_prefix):].lower()
+            if key.startswith(override_prefix):
+                # munch override_prefix
+                key = key[len(override_prefix):]
+                override = True
+
+            if key.startswith(yaml_prefix):
+                # munch yaml_prefix
+                key = key[len(yaml_prefix):]
+                try:
+                    # Attempt to parse value as yaml to allow passing complex options via env
+                    val = yaml.safe_load(val)
+                except yaml.YAMLError:
+                    pass
+
+            if override or key not in properties:
+                properties[key] = val
 
     return properties
 


### PR DESCRIPTION
This PR competes with https://github.com/galaxyproject/galaxy/pull/11760
See that PR for more info and discussion.

Should it be `GALAXY_CONFIG_OVERRIDE_YAML_` or `GALAXY_CONFIG_YAML_OVERRIDE_`?