### PR TITLE
Support role and group permissions in file sources plugins

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -243,6 +243,20 @@ class ProvidesUserFileSourcesUserContext:
         user = self.trans.user
         return user and user.extra_preferences or defaultdict(lambda: None)
 
+    @property
+    def role_names(self):
+        user = self.trans.user
+        return user and set([ura.role.name for ura in user.roles])
+
+    @property
+    def group_names(self):
+        user = self.trans.user
+        return user and set([ugr.group.name for ugr in user.groups])
+
+    @property
+    def is_admin(self):
+        return self.trans.user_is_admin
+
 
 class DictFileSourcesUserContext:
 
@@ -264,3 +278,15 @@ class DictFileSourcesUserContext:
     @property
     def preferences(self):
         return self._kwd.get("preferences")
+
+    @property
+    def role_names(self):
+        return self._kwd.get("role_names")
+
+    @property
+    def group_names(self):
+        return self._kwd.get("group_names")
+
+    @property
+    def is_admin(self):
+        return self._kwd.get("is_admin")

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -245,16 +245,19 @@ class ProvidesUserFileSourcesUserContext:
 
     @property
     def role_names(self):
+        """The set of role names of this user."""
         user = self.trans.user
         return user and set([ura.role.name for ura in user.roles])
 
     @property
     def group_names(self):
+        """The set of group names to which this user belongs."""
         user = self.trans.user
         return user and set([ugr.group.name for ugr in user.groups])
 
     @property
     def is_admin(self):
+        """Whether this user is an administrator."""
         return self.trans.user_is_admin
 
 

--- a/lib/galaxy/files/_schema.py
+++ b/lib/galaxy/files/_schema.py
@@ -1,5 +1,8 @@
 from enum import Enum
-from typing import List
+from typing import (
+    List,
+    Optional,
+)
 
 from pydantic import (
     BaseModel,
@@ -61,6 +64,16 @@ class FilesSourcePlugin(BaseModel):
         title="Writeable",
         description="Whether this files source plugin allows write access.",
         example=False,
+    )
+    requires_roles: Optional[str] = Field(
+        None,
+        title="Requires roles",
+        description="Only users with the roles specified here can access this files source.",
+    )
+    requires_groups: Optional[str] = Field(
+        None,
+        title="Requires groups",
+        description="Only users belonging to the groups specified here can access this files source.",
     )
 
     class Config:

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -63,10 +63,13 @@ class BaseFilesSource(FilesSource):
         return self.writable
 
     def user_has_access(self, user_context) -> bool:
-        return user_context is None or (
-            user_context.is_admin
-            or self._user_has_required_roles(user_context)
-            or self._user_has_required_groups(user_context)
+        return (
+            user_context is None
+            or user_context.is_admin
+            or (
+                self._user_has_required_roles(user_context)
+                and self._user_has_required_groups(user_context)
+            )
         )
 
     def get_uri_root(self):

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -69,13 +69,15 @@ class BaseFilesSource(FilesSource):
         uri_root = self.get_uri_root()
         return uri_join(uri_root, path)
 
-    def _parse_common_config_opts(self, kwd):
+    def _parse_common_config_opts(self, kwd: dict):
         self._file_sources_config = kwd.pop("file_sources_config")
         self.id = kwd.pop("id")
         self.label = kwd.pop("label", None) or self.id
         self.doc = kwd.pop("doc", None)
         self.scheme = kwd.pop("scheme", DEFAULT_SCHEME)
         self.writable = kwd.pop("writable", DEFAULT_WRITABLE)
+        self.requires_roles = kwd.pop("requires_roles", None)
+        self.requires_groups = kwd.pop("requires_groups", None)
         # If coming from to_dict, strip API helper values
         kwd.pop("uri_root", None)
         kwd.pop("type", None)
@@ -89,6 +91,8 @@ class BaseFilesSource(FilesSource):
             "label": self.label,
             "doc": self.doc,
             "writable": self.writable,
+            "requires_roles": self.requires_roles,
+            "requires_groups": self.requires_groups,
         }
         if for_serialization:
             rval.update(self._serialization_props(user_context=user_context))

--- a/lib/galaxy/files/sources/_pyfilesystem2.py
+++ b/lib/galaxy/files/sources/_pyfilesystem2.py
@@ -22,7 +22,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
     def _open_fs(self, user_context=None):
         """Subclasses must instantiate a PyFilesystem2 handle for this file system."""
 
-    def list(self, path="/", recursive=False, user_context=None):
+    def _list(self, path="/", recursive=False, user_context=None):
         """Return dictionary of 'Directory's and 'File's."""
 
         with self._open_fs(user_context=user_context) as h:
@@ -38,7 +38,7 @@ class PyFilesystem2FilesSource(BaseFilesSource):
                 to_dict = functools.partial(self._resource_info_to_dict, path)
                 return list(map(to_dict, res))
 
-    def realize_to(self, source_path, native_path, user_context=None):
+    def _realize_to(self, source_path, native_path, user_context=None):
         with open(native_path, 'wb') as write_file:
             self._open_fs(user_context=user_context).download(source_path, write_file)
 

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -30,7 +30,7 @@ class PosixFilesSource(BaseFilesSource):
         self.enforce_symlink_security = props.get("enforce_symlink_security", DEFAULT_ENFORCE_SYMLINK_SECURITY)
         self.delete_on_realize = props.get("delete_on_realize", DEFAULT_DELETE_ON_REALIZE)
 
-    def list(self, path="/", recursive=True, user_context=None):
+    def _list(self, path="/", recursive=True, user_context=None):
         dir_path = self._to_native_path(path, user_context=user_context)
         if not self._safe_directory(dir_path):
             raise exceptions.ObjectNotFound('The specified directory does not exist [%s].' % dir_path)
@@ -47,7 +47,7 @@ class PosixFilesSource(BaseFilesSource):
             to_dict = functools.partial(self._resource_info_to_dict, path, user_context=user_context)
             return list(map(to_dict, res))
 
-    def realize_to(self, source_path, native_path, user_context=None):
+    def _realize_to(self, source_path, native_path, user_context=None):
         effective_root = self._effective_root(user_context)
         source_native_path = self._to_native_path(source_path, user_context=user_context)
         if self.enforce_symlink_security:

--- a/lib/galaxy/files/sources/s3fs.py
+++ b/lib/galaxy/files/sources/s3fs.py
@@ -27,7 +27,7 @@ class S3FsFilesSource(BaseFilesSource):
         assert self._endpoint_url or self._bucket
         self._props = props
 
-    def list(self, path="/", recursive=True, user_context=None):
+    def _list(self, path="/", recursive=True, user_context=None):
         fs = self._open_fs(user_context=user_context)
         if recursive:
             res = []
@@ -43,7 +43,7 @@ class S3FsFilesSource(BaseFilesSource):
             to_dict = functools.partial(self._resource_info_to_dict, path)
             return list(map(to_dict, res))
 
-    def realize_to(self, source_path, native_path, user_context=None):
+    def _realize_to(self, source_path, native_path, user_context=None):
         bucket_path = self._bucket_path(source_path)
         self._open_fs(user_context=user_context).download(bucket_path, native_path)
 

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -29,7 +29,7 @@ ParserElement.enablePackrat()
 
 # Defines the allowed characters that form a valid token.
 # Tokens that don't match this format will raise an exception when found.
-DEFAULT_TOKEN_FORMAT = alphanums + "_"
+DEFAULT_TOKEN_FORMAT = alphanums + "_-@."
 
 TRUE = Keyword("True")
 FALSE = Keyword("False")
@@ -125,7 +125,7 @@ class BooleanExpressionEvaluator:
         :param evaluator: The custom TokenEvaluator used to transform any token into a boolean.
         :type evaluator:  TokenEvaluator
         :param token_format: A string of all allowed characters used to form a valid token, defaults to None.
-                             The default value (None) will use DEFAULT_TOKEN_FORMAT which means the allowed characters are [A-Za-z0-9_].
+                             The default value (None) will use DEFAULT_TOKEN_FORMAT which means the allowed characters are [A-Za-z0-9_-@.].
         :type token_format:  Optional[str]
         """
         action = BoolOperand

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -1,0 +1,167 @@
+"""Simple boolean expression parser and evaluator using pyparsing.
+
+Based on the example: https://github.com/pyparsing/pyparsing/blob/master/examples/simpleBool.py
+"""
+
+import logging
+from typing import (
+    Callable,
+    Iterable,
+    Optional,
+    Set,
+)
+
+from pyparsing import (
+    alphanums,
+    CaselessKeyword,
+    Forward,
+    infixNotation,
+    Keyword,
+    opAssoc,
+    ParseException,
+    ParserElement,
+    Word,
+)
+
+log = logging.getLogger(__name__)
+
+ParserElement.enablePackrat()
+
+# Defines the allowed characters that form a valid token.
+# Tokens that don't match this format will raise an exception when found.
+DEFAULT_TOKEN_FORMAT = alphanums + "_"
+
+TRUE = Keyword("True")
+FALSE = Keyword("False")
+NOT_OP = CaselessKeyword("not")
+AND_OP = CaselessKeyword("and")
+OR_OP = CaselessKeyword("or")
+
+
+class TokenEvaluator:
+    """Interface to evaluate a token and determine its boolean value."""
+
+    def evaluate(self, token: str) -> bool:
+        """Returns the boolean representation of the given token according to some custom logic."""
+        raise NotImplementedError
+
+
+class BoolOperand:
+    """Represents a boolean operand that has a label and a value.
+
+    The value is determined by a custom TokenEvaluator."""
+    evaluator: TokenEvaluator
+
+    def __init__(self, token):
+        self.label = token[0]
+        self.value = self.evaluator.evaluate(token[0])
+
+    def __bool__(self):
+        return self.value
+
+    def __str__(self):
+        return self.label
+
+    __repr__ = __str__
+
+
+class BoolBinaryOperation:
+    """Base representation of a boolean binary operation."""
+    reprsymbol: str
+    evalop: Callable[[Iterable[object]], bool]
+
+    def __init__(self, token):
+        self.args = token[0][0::2]
+
+    def __str__(self):
+        sep = f" {self.reprsymbol} "
+        return f"({sep.join(map(str, self.args))})"
+
+    def __bool__(self):
+        return self.evalop(bool(a) for a in self.args)
+
+    __nonzero__ = __bool__
+
+
+class BoolAnd(BoolBinaryOperation):
+    """Represents the `AND` boolean operation."""
+    reprsymbol = "&"
+    evalop = all
+
+
+class BoolOr(BoolBinaryOperation):
+    """Represents the `OR` boolean operation."""
+    reprsymbol = "|"
+    evalop = any
+
+
+class BoolNot:
+    """Represents the `NOT` boolean operation."""
+
+    def __init__(self, token):
+        self.arg = token[0][1]
+
+    def __bool__(self):
+        v = bool(self.arg)
+        return not v
+
+    def __str__(self):
+        return f"~{self.arg}"
+
+    __repr__ = __str__
+
+
+class BooleanExpressionEvaluator:
+    """Boolean logic parser that can evaluate an expression using a particular TokenEvaluator.
+
+    Supports AND, OR and NOT operator including parentheses to override operator precedences.
+
+    You can pass in different TokenEvaluator implementations to customize how the tokens (or variables) are
+    converted to a boolean value when evaluating the expression."""
+
+    def __init__(self, evaluator: TokenEvaluator, token_format: Optional[str] = None) -> None:
+        """Initializes the expression evaluator.
+
+        :param evaluator: The custom TokenEvaluator used to transform any token into a boolean.
+        :type evaluator:  TokenEvaluator
+        :param token_format: A string of all allowed characters used to form a valid token, defaults to None.
+                             The default value (None) will use DEFAULT_TOKEN_FORMAT which means the allowed characters are [A-Za-z0-9_].
+        :type token_format:  Optional[str]
+        """
+        action = BoolOperand
+        action.evaluator = evaluator
+        boolOperand = TRUE | FALSE | Word(token_format or DEFAULT_TOKEN_FORMAT)
+        boolOperand.setParseAction(action)
+        self.boolExpr: Forward = infixNotation(
+            boolOperand,
+            [
+                (NOT_OP, 1, opAssoc.RIGHT, BoolNot),
+                (AND_OP, 2, opAssoc.LEFT, BoolAnd),
+                (OR_OP, 2, opAssoc.LEFT, BoolOr),
+            ],
+        )
+
+    def evaluate_expression(self, expr: str) -> bool:
+        """Given an expression it gets evaluated to True or False using boolean logic."""
+        try:
+            res = self.boolExpr.parseString(expr, parseAll=True)[0]
+            return bool(res)
+        except ParseException as e:
+            log.error(f'BooleanExpressionEvaluator unable to evaluate expression => {expr}', exc_info=e)
+            raise e
+
+
+class TokenContainedEvaluator(TokenEvaluator):
+    """Implements the TokenEvaluator interface to determine if a token is contained
+    in a particular list of tokens."""
+
+    def __init__(self, tokens: Set[str]) -> None:
+        """Initializes the token evaluator with the set of tokens that will evaluate to `True`.
+
+        :param tokens: The list of tokens that should be evaluated to True.
+        :type tokens: List[str]
+        """
+        self.tokens = tokens
+
+    def evaluate(self, token: str) -> bool:
+        return token in self.tokens

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -150,6 +150,17 @@ class BooleanExpressionEvaluator:
             log.error(f'BooleanExpressionEvaluator unable to evaluate expression => {expr}', exc_info=e)
             raise e
 
+    @classmethod
+    def is_valid_expression(cls, expr: str) -> bool:
+        """Tries to evaluate the given boolean expression and returns True if it is valid or
+        False if it has syntax or gramatical errors."""
+        try:
+            evaluator = BooleanExpressionEvaluator(ValidationOnlyTokenEvaluator())
+            evaluator.evaluate_expression(expr)
+            return True
+        except ParseException:
+            return False
+
 
 class TokenContainedEvaluator(TokenEvaluator):
     """Implements the TokenEvaluator interface to determine if a token is contained
@@ -165,3 +176,12 @@ class TokenContainedEvaluator(TokenEvaluator):
 
     def evaluate(self, token: str) -> bool:
         return token in self.tokens
+
+
+class ValidationOnlyTokenEvaluator(TokenEvaluator):
+    """Simple TokenEvaluator that always evaluates to True for valid tokens.
+
+    This is only useful for validation purposes, do NOT use it for real expression evaluations."""
+
+    def evaluate(self, token: str) -> bool:
+        return True

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -36,11 +36,12 @@ TargetQueryParam: str = Query(
 )
 
 FormatQueryParam: Optional[RemoteFilesFormat] = Query(
-    default=RemoteFilesFormat.flat,
+    default=RemoteFilesFormat.uri,
     title="Response format",
     description=(
         "The requested format of returned data. Either `flat` to simply list all the files"
-        " or `jstree` to get a tree representation of the files."
+        ", `jstree` to get a tree representation of the files, or the default `uri` to list "
+        "files and directories by their URI."
     ),
 )
 

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -106,8 +106,14 @@ class PosixFileSourceIntegrationTestCase(integration_util.IntegrationTestCase):
         api_asserts.assert_status_code_is_ok(list_response)
         remote_files = list_response.json()
         assert len(remote_files) == 2
-        assert remote_files[0]["name"] == "a"
-        assert remote_files[1]["name"] == "subdir1"
+        if remote_files[0]["class"] == "Directory":
+            dir = remote_files[0]
+            file = remote_files[1]
+        else:
+            dir = remote_files[1]
+            file = remote_files[0]
+        assert file["name"] == "a"
+        assert dir["name"] == "subdir1"
 
     def _assert_access_forbidden_response(self, response):
         api_asserts.assert_status_code_is(response, 403)

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -1,0 +1,120 @@
+# Before running this test, start nginx+webdav in Docker using following command:
+# docker run -v `pwd`/test/integration/webdav/data:/media  -e WEBDAV_USERNAME=alice -e WEBDAV_PASSWORD=secret1234 -p 7083:7083 jmchilton/webdavdev
+# Apache Docker host (shown next) doesn't work because displayname not set in response.
+# docker run -v `pwd`/test/integration/webdav:/var/lib/dav  -e AUTH_TYPE=Basic -e USERNAME=alice -e PASSWORD=secret1234  -e LOCATION=/ -p 7083:80 bytemark/webdav
+
+import os
+import shutil
+from tempfile import mkdtemp
+
+from galaxy_test.base import api_asserts
+from galaxy_test.driver import integration_util
+
+REQUIRED_ROLES = "user@bx.psu.edu"
+REQUIRED_GROUPS = "fs_test_group"
+
+
+def get_posix_file_source_config(root_dir: str, roles: str, groups: str) -> str:
+    return f"""
+- type: posix
+  id: posix_test
+  label: Posix
+  doc: Files from local path
+  root: {root_dir}
+  writable: true
+  requires_roles: {roles}
+  requires_groups: {groups}
+
+"""
+
+
+def create_file_source_config_file_on(temp_dir, root_dir):
+    file_contents = get_posix_file_source_config(root_dir, REQUIRED_ROLES, REQUIRED_GROUPS)
+    file_path = os.path.join(temp_dir, "file_sources_conf_posix.yml")
+    with open(file_path, "w") as f:
+        f.write(file_contents)
+    return file_path
+
+
+class PosixFileSourceIntegrationTestCase(integration_util.IntegrationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        temp_dir = os.path.realpath(mkdtemp())
+        cls._test_driver.temp_directories.append(temp_dir)
+        cls.root_dir = os.path.join(temp_dir, "root")
+
+        file_sources_config_file = create_file_source_config_file_on(temp_dir, cls.root_dir)
+        config["file_sources_config_file"] = file_sources_config_file
+
+        # Disable all stock plugins
+        config["ftp_upload_dir"] = None
+        config["library_import_dir"] = None
+        config["user_library_import_dir"] = None
+
+    def setUp(self):
+        super().setUp()
+        self._write_file_fixtures()
+
+    def test_plugin_config(self):
+        plugin_config_response = self.galaxy_interactor.get("remote_files/plugins")
+        api_asserts.assert_status_code_is_ok(plugin_config_response)
+        plugins = plugin_config_response.json()
+        assert len(plugins) == 1
+        assert plugins[0]["type"] == "posix"
+        assert plugins[0]["uri_root"] == "gxfiles://posix_test"
+        assert plugins[0]["writable"] is True
+        assert plugins[0]["requires_roles"] == REQUIRED_ROLES
+        assert plugins[0]["requires_groups"] == REQUIRED_GROUPS
+
+    def test_admin_access(self):
+        data = {"target": "gxfiles://posix_test"}
+        list_response = self.galaxy_interactor.get("remote_files", data, admin=True)
+        api_asserts.assert_status_code_is_ok(list_response)
+        remote_files = list_response.json()
+        print(remote_files)
+        assert len(remote_files) == 2
+        assert remote_files[0]["name"] == "a"
+        assert remote_files[1]["name"] == "subdir1"
+
+    def test_user_require_role(self):
+        data = {"target": "gxfiles://posix_test"}
+
+        list_response = self.galaxy_interactor.get("remote_files", data)
+        api_asserts.assert_status_code_is_ok(list_response)
+        remote_files = list_response.json()
+        assert len(remote_files) > 0
+
+        with self._different_user():
+            list_response = self.galaxy_interactor.get("remote_files", data)
+            api_asserts.assert_status_code_is(list_response, 403)
+
+            list_response = self.galaxy_interactor.get("remote_files", data, admin=True)
+            api_asserts.assert_status_code_is_ok(list_response)
+            remote_files = list_response.json()
+            assert len(remote_files) > 0
+
+    def test_user_require_group(self):
+        data = {"target": "gxfiles://posix_test"}
+        list_response = self.galaxy_interactor.get("remote_files", data)
+        api_asserts.assert_status_code_is(list_response, 403)
+
+        with self._different_user():
+            list_response = self.galaxy_interactor.get("remote_files", data)
+            api_asserts.assert_status_code_is(list_response, 403)
+
+    def _write_file_fixtures(self):
+        root = PosixFileSourceIntegrationTestCase.root_dir
+        if os.path.exists(root):
+            shutil.rmtree(root)
+        os.mkdir(root)
+
+        with open(os.path.join(root, "a"), "w") as f:
+            f.write("a\n")
+
+        subdir1 = os.path.join(root, "subdir1")
+        os.mkdir(subdir1)
+        with open(os.path.join(subdir1, "b"), "w") as f:
+            f.write("b\n")
+
+        return root

--- a/test/unit/files/_util.py
+++ b/test/unit/files/_util.py
@@ -47,7 +47,7 @@ def list_dir(file_sources, uri, recursive, user_context=None):
     return res
 
 
-def user_context_fixture(user_ftp_dir=None):
+def user_context_fixture(user_ftp_dir=None, role_names=None, group_names=None, is_admin=False):
     user_context = DictFileSourcesUserContext(
         username=TEST_USERNAME,
         email=TEST_EMAIL,
@@ -55,7 +55,10 @@ def user_context_fixture(user_ftp_dir=None):
         preferences={
             'webdav|password': 'secret1234',
             'dropbox|access_token': os.environ.get('GALAXY_TEST_DROPBOX_ACCESS_TOKEN'),
-        }
+        },
+        role_names=role_names or set(),
+        group_names=group_names or set(),
+        is_admin=is_admin,
     )
     return user_context
 

--- a/test/unit/util/test_bool_expressions.py
+++ b/test/unit/util/test_bool_expressions.py
@@ -14,6 +14,27 @@ TOKEN_FORMAT = DEFAULT_TOKEN_FORMAT
 # of the *valid tokens* (those that match the TOKEN_FORMAT) will be evaluated to False.
 TOKENS_THAT_ARE_TRUE = {"T1", "token_2"}
 
+VALID_EXPRESSIONS_TESTS = [
+    ("T1", True),
+    ("token_2", True),
+    ("T3", False),
+    ("valid_token", False),
+    ("not T3", True),
+    ("NOT token_2", False),
+    ("T1 and not T3", True),
+    ("NOT T1 AND token_2", False),
+    ("not T3 or (T3 AND token_2)", True),
+    ("T1 and (T3 OR token_2)", True),
+    ("(T3 OR T1) and not (T3 OR valid_token)", True),
+]
+
+INVALID_EXPRESSIONS_TESTS = [
+    "",
+    "23 45",
+    "'some quoted str' and not T1",
+    "invalid expression",
+]
+
 
 @pytest.fixture(scope='module')
 def contained_evaluator() -> BooleanExpressionEvaluator:
@@ -26,30 +47,25 @@ def contained_evaluator() -> BooleanExpressionEvaluator:
     return evaluator
 
 
-@pytest.mark.parametrize('expr, expected', [
-    ("T1", True),
-    ("token_2", True),
-    ("T3", False),
-    ("valid_token", False),
-    ("not T3", True),
-    ("NOT token_2", False),
-    ("T1 and not T3", True),
-    ("NOT T1 AND token_2", False),
-    ("not T3 or (T3 AND token_2)", True),
-    ("T1 and (T3 OR token_2)", True),
-    ("(T3 OR T1) and not (T3 OR valid_token)", True),
-])
+@pytest.mark.parametrize('expr, expected', VALID_EXPRESSIONS_TESTS)
 def test_expression_evaluates_as_expected(expr: str, expected: bool, contained_evaluator: BooleanExpressionEvaluator):
     actual = contained_evaluator.evaluate_expression(expr)
     assert actual == expected
 
 
-@pytest.mark.parametrize('expr', [
-    "",
-    "23 45",
-    "'some quoted str' and not T1",
-    "invalid expression",
-])
+@pytest.mark.parametrize('expr', INVALID_EXPRESSIONS_TESTS)
 def test_invalid_expression_raises_exception(expr: str, contained_evaluator: BooleanExpressionEvaluator):
     with pytest.raises(Exception):
         contained_evaluator.evaluate_expression(expr)
+
+
+@pytest.mark.parametrize('expr, _', VALID_EXPRESSIONS_TESTS)
+def test_is_valid_expression_return_true_when_valid(expr: str, _: bool):
+    result = BooleanExpressionEvaluator.is_valid_expression(expr)
+    assert result is True
+
+
+@pytest.mark.parametrize('expr', INVALID_EXPRESSIONS_TESTS)
+def test_is_valid_expression_return_false_when_invalid(expr: str):
+    result = BooleanExpressionEvaluator.is_valid_expression(expr)
+    assert result is False

--- a/test/unit/util/test_bool_expressions.py
+++ b/test/unit/util/test_bool_expressions.py
@@ -1,0 +1,55 @@
+import pytest
+
+from galaxy.util.bool_expressions import (
+    BooleanExpressionEvaluator,
+    DEFAULT_TOKEN_FORMAT,
+    TokenContainedEvaluator,
+)
+
+# Defines the allowed characters that form a valid token.
+# Tokens that don't match this format will raise a ParseException
+TOKEN_FORMAT = DEFAULT_TOKEN_FORMAT
+
+# The set of tokens that will be evaluated to True using the TokenContainedEvaluator the rest
+# of the *valid tokens* (those that match the TOKEN_FORMAT) will be evaluated to False.
+TOKENS_THAT_ARE_TRUE = {"T1", "token_2"}
+
+
+@pytest.fixture(scope='module')
+def contained_evaluator() -> BooleanExpressionEvaluator:
+    """Boolean expression evaluator using the TokenContainedEvaluator.
+
+    All the tokens in TOKENS_THAT_ARE_TRUE will be evaluated to True and
+    any other token to False."""
+    token_evaluator = TokenContainedEvaluator(TOKENS_THAT_ARE_TRUE)
+    evaluator = BooleanExpressionEvaluator(token_evaluator, TOKEN_FORMAT)
+    return evaluator
+
+
+@pytest.mark.parametrize('expr, expected', [
+    ("T1", True),
+    ("token_2", True),
+    ("T3", False),
+    ("valid_token", False),
+    ("not T3", True),
+    ("NOT token_2", False),
+    ("T1 and not T3", True),
+    ("NOT T1 AND token_2", False),
+    ("not T3 or (T3 AND token_2)", True),
+    ("T1 and (T3 OR token_2)", True),
+    ("(T3 OR T1) and not (T3 OR valid_token)", True),
+])
+def test_expression_evaluates_as_expected(expr: str, expected: bool, contained_evaluator: BooleanExpressionEvaluator):
+    actual = contained_evaluator.evaluate_expression(expr)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('expr', [
+    "",
+    "23 45",
+    "'some quoted str' and not T1",
+    "invalid expression",
+])
+def test_invalid_expression_raises_exception(expr: str, contained_evaluator: BooleanExpressionEvaluator):
+    with pytest.raises(Exception):
+        contained_evaluator.evaluate_expression(expr)

--- a/test/unit/util/test_bool_expressions.py
+++ b/test/unit/util/test_bool_expressions.py
@@ -33,6 +33,11 @@ INVALID_EXPRESSIONS_TESTS = [
     "23 45",
     "'some quoted str' and not T1",
     "invalid expression",
+    "T1 and and T2",
+    "T1 not and T3",
+    "(T1 and T3",
+    "T1 or T3)",
+    "T1 and or T2",
 ]
 
 


### PR DESCRIPTION
## What did you do? 
- Added new security options to file sources plugins:
  ````YAML
    requires_roles: some_role
    requires_groups: some_group
  ````
- Included unit tests to check the security rules defined in the options are enforced.
- Included some integration tests to check user access using the `posix` file source plugin.
- Fixed a small inconsistency between the legacy and the new FastAPI `remote_files` API default responses. This was detected while writing the tests. See this commit https://github.com/galaxyproject/galaxy/commit/4235e6e675cec92fc783096a3949bc9369d107e0

#### TODO
- [x] Use basic boolean logic to define the rules to match groups and roles.
- [x] Create unit tests for the boolean logic parser.

## Why did you make this change?
The details are in #11768


## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
