### PR TITLE
[21.01] Fix auto-pair naming in list paired creator.

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -693,27 +693,22 @@ export default {
         /** try to find a good pair name for the given fwd and rev datasets */
         _guessNameForPair: function (fwd, rev, removeExtensions) {
             removeExtensions = removeExtensions ? removeExtensions : this.removeExtensions;
-            var fwdName = fwd.name;
-            var revName = rev.name;
-
-            var lcs = this._naiveStartingAndEndingLCS(
-                fwdName.replace(new RegExp(this.filters[0]), ""),
-                revName.replace(new RegExp(this.filters[1]), "")
-            );
-
+            let fwdName = fwd.name;
+            let revName = rev.name;
+            const fwdNameFilter = fwdName.replace(new RegExp(this.forwardFilter), "");
+            const revNameFilter = revName.replace(new RegExp(this.reverseFilter), "");
+            let lcs = this._naiveStartingAndEndingLCS(fwdNameFilter, revNameFilter);
             /** remove url prefix if files were uploaded by url */
-            var lastSlashIndex = lcs.lastIndexOf("/");
+            const lastSlashIndex = lcs.lastIndexOf("/");
             if (lastSlashIndex > 0) {
-                var urlprefix = lcs.slice(0, lastSlashIndex + 1);
+                const urlprefix = lcs.slice(0, lastSlashIndex + 1);
                 lcs = lcs.replace(urlprefix, "");
-                fwdName = fwdName.replace(extension, "");
-                revName = revName.replace(extension, "");
             }
 
             if (removeExtensions) {
-                var lastDotIndex = lcs.lastIndexOf(".");
+                const lastDotIndex = lcs.lastIndexOf(".");
                 if (lastDotIndex > 0) {
-                    var extension = lcs.slice(lastDotIndex, lcs.length);
+                    const extension = lcs.slice(lastDotIndex, lcs.length);
                     lcs = lcs.replace(extension, "");
                     fwdName = fwdName.replace(extension, "");
                     revName = revName.replace(extension, "");


### PR DESCRIPTION
Improve auto-pair naming in list paired creator.

## What did you do? 

Fixes (or at least improves) https://github.com/galaxyproject/galaxy/issues/11744.

## Why did you make this change?

xref #11744

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Create a list paired collection from two datasets with the names outlined in #11744
  2. Disable filters.
  3. Pair the two datasets - verify the prefix is longer now (it still has a period it shouldn't I think, but this is less broken at least).

## For UI Components
- [x] I've included a screenshot of the changes

<img width="941" alt="Screen Shot 2021-04-01 at 1 33 30 PM" src="https://user-images.githubusercontent.com/216771/113332222-e19d8280-92ee-11eb-8726-eef197886026.png">
