### PR TITLE
[21.01] Fix library scrolling

### DIFF
--- a/client/src/style/scss/library.scss
+++ b/client/src/style/scss/library.scss
@@ -1,10 +1,10 @@
 @import "theme/blue.scss";
 
 .library_style_container {
-    width: 95%;
-    margin: auto;
-    margin-top: 1em;
-    overflow: auto !important;
+    width: 100%;
+    height: 100%;
+    padding: 1em;
+    overflow: auto;
 
     .fa-globe,
     .fa-shield,


### PR DESCRIPTION
For good this time, I hope.  As implemented, we always want that container to take 100% height and scroll internal contents.  This way we don't need an !important rule, too.

## What did you do? 
- Adjusted layout of libraries container.

## Why did you make this change?

Fixes #11771 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)

- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open <galaxy>/libraries/list.  Make lots of data libraries.  Shrink screen down and scroll.
