### PR TITLE
Add an explicit statement of assent to licensing to the pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -15,5 +15,9 @@
 - [ ] Instructions for manual testing are as follows:
   1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
 
+## License
+- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
+- [x] I agree to allow the Galaxy committers to license these and all past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
+
 ## For UI Components
 - [ ] I've included a screenshot of the changes

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -17,7 +17,7 @@
 
 ## License
 - [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
-- [x] I agree to allow the Galaxy committers to license these and all past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
+- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
 
 ## For UI Components
 - [ ] I've included a screenshot of the changes


### PR DESCRIPTION
## What did you do? 

Add an explicit statement of consent to licensing to the pull request template.

Start collecting people's assent to re-license under MIT. We might never get to the point where enough people have agreed to this that we can do that, but we can start the process of trying this way.

## Why did you make this change?

Better to make this first part explicit I think.

Also for the second part - we can't be packaged properly with Debian, etc.. without changing our license to something more standard. MIT is very much in spirit of what people wanted with the Galaxy license and what we would have chosen if we started over. The APL has not seen the adoption one would have hoped and not been interpreted in a way we would have wanted (I think). I unfortunately am speaking for a lot of people here and I try to avoid that, so if anyone doesn't agree let me know and I will change the pull request description.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] Instructions for manual testing are as follows:
  1. Make this dev branch of a Gtihub fork and open a pull request.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.