### PR TITLE
Fix workflow refactor schema parsing for pydantic 1.8.

### DIFF
--- a/lib/galaxy/workflow/refactor/schema.py
+++ b/lib/galaxy/workflow/refactor/schema.py
@@ -241,7 +241,14 @@ union_action_classes = Union[
 
 ACTION_CLASSES_BY_TYPE = {}
 for action_class in union_action_classes.__args__:  # type: ignore
-    action_type = action_class.schema()["properties"]["action_type"]["const"]
+    action_type_def = action_class.schema()["properties"]["action_type"]
+    try:
+        # pydantic 1.8
+        action_type = action_type_def["enum"][0]
+    except KeyError:
+        # pydantic 1.7
+        action_type = action_type_def["const"]
+
     ACTION_CLASSES_BY_TYPE[action_type] = action_class
 
 


### PR DESCRIPTION
## What did you do? 
- Fix refactor schema parsing for pydantic 1.8 so we don't need to pin the packages.

## Why did you make this change?

@natefoo complained that it wasn't working.

## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. Run ``pytest -s test/unit/workflows/test_refactor_models.py`` after upgrading to latest pydantic in Galaxy's virtual env.
