### PR TITLE
Use `assertRaisesRegex()` to fix new B017 linting errors

### DIFF
--- a/test/unit/authnz/test_custos_authnz.py
+++ b/test/unit/authnz/test_custos_authnz.py
@@ -334,10 +334,13 @@ class CustosAuthnzTestCase(unittest.TestCase):
         self.test_nonce_hash = self.test_nonce_hash + "Z"
 
         # self.custos_authnz._fetch_token = fetch_token
-        with self.assertRaises(Exception):
-            self.custos_authnz.callback(state_token="xxx",
-                                      authz_code=self.test_code, trans=self.trans,
-                                      login_redirect_url="http://localhost:8000/")
+        with self.assertRaisesRegex(Exception, "^Nonce mismatch!$"):
+            self.custos_authnz.callback(
+                state_token="xxx",
+                authz_code=self.test_code,
+                trans=self.trans,
+                login_redirect_url="http://localhost:8000/"
+            )
         self.assertTrue(self._fetch_token_called)
         self.assertFalse(self._get_userinfo_called)
 

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -393,7 +393,7 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
         assert '@' not in command
 
     def test_recursive_token(self):
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegex(Exception, "^Token '@NESTED_TOKEN@' cannot contain itself$"):
             self._get_tool_source(source_contents=TOOL_WITH_RECURSIVE_TOKEN)
 
     def test_creator(self):

--- a/test/unit/util/test_compression_util.py
+++ b/test/unit/util/test_compression_util.py
@@ -39,7 +39,7 @@ class CompressionUtilTestCase(unittest.TestCase):
             if expected_to_be_safe:
                 CompressedFile(path).extract(temp_dir)
             else:
-                with self.assertRaises(Exception):
+                with self.assertRaisesRegex(Exception, "is blocked"):
                     CompressedFile(path).extract(temp_dir)
         finally:
             shutil.rmtree(temp_dir, ignore_errors=True)


### PR DESCRIPTION
## What did you do? 
- Fix the following errors reported by flake8-bugbear 21.4.3

## Why did you make this change?
`B017 assertRaises(Exception): should be considered evil. It can lead to your test passing even if the code being tested is never executed due to a typo. Either assert for a more specific exception (builtin or custom), use assertRaisesRegex, or use the context manager form of assertRaises.`

See https://github.com/galaxyproject/galaxy/runs/2260679647?check_suite_focus=true

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
