### PR TITLE
Fixes for extended metadata working with Pulsar.

### DIFF
--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -751,11 +751,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
     def __client_outputs(self, client, job_wrapper):
         work_dir_outputs = self.get_work_dir_outputs(job_wrapper)
         output_files = self.get_output_files(job_wrapper)
-        if self.app.config.metadata_strategy == "legacy":
-            # Drop this branch in 19.09.
-            metadata_directory = job_wrapper.working_directory
-        else:
-            metadata_directory = os.path.join(job_wrapper.working_directory, "metadata")
+        metadata_directory = os.path.join(job_wrapper.working_directory, "metadata")
         client_outputs = ClientOutputs(
             working_directory=job_wrapper.tool_working_directory,
             metadata_directory=metadata_directory,

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -162,13 +162,26 @@ def set_metadata_portable():
 
             with open(os.path.join(outputs_directory, "tool_stderr"), "rb") as f:
                 tool_stderr = f.read()
+        elif os.path.exists(os.path.join(tool_job_working_directory, "stdout")):
+            with open(os.path.join(tool_job_working_directory, "stdout"), "rb") as f:
+                tool_stdout = f.read()
+
+            with open(os.path.join(tool_job_working_directory, "stderr"), "rb") as f:
+                tool_stderr = f.read()
         elif os.path.exists(os.path.join(outputs_directory, "stdout")):
-            # Puslar style working directory.
+            # Puslar style output directory? Was this ever used - did this ever work?
             with open(os.path.join(outputs_directory, "stdout"), "rb") as f:
                 tool_stdout = f.read()
 
             with open(os.path.join(outputs_directory, "stderr"), "rb") as f:
                 tool_stderr = f.read()
+        else:
+            wdc = os.listdir(tool_job_working_directory)
+            odc = os.listdir(outputs_directory)
+            error_desc = "Failed to find tool_stdout or tool_stderr for this job, cannot collect metadata"
+            error_extra = f"Working dir contents [{wdc}], output directory contents [{odc}]"
+            log.warn(f"{error_desc}. {error_extra}")
+            raise Exception(error_desc)
 
         job_id_tag = metadata_params["job_id_tag"]
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -772,7 +772,8 @@ class ObjectImportTracker:
 
 
 def get_import_model_store_for_directory(archive_dir, **kwd):
-    assert os.path.isdir(archive_dir)
+    if not os.path.isdir(archive_dir):
+        raise Exception(f"Could not find import model store for directory [{archive_dir}] (full path [{os.path.abspath(archive_dir)}])")
     if os.path.exists(os.path.join(archive_dir, ATTRS_FILENAME_EXPORT)):
         return DirectoryImportModelStoreLatest(archive_dir, **kwd)
     else:

--- a/lib/galaxy/tool_util/verify/asserts/text.py
+++ b/lib/galaxy/tool_util/verify/asserts/text.py
@@ -5,6 +5,7 @@ def assert_has_text(output, text, n=None):
     """ Asserts specified output contains the substring specified by
     the argument text. The exact number of occurrences can be
     optionally specified by the argument n."""
+    assert output is not None, "Checking has_text assertion on empty output (None)"
     if n is None:
         assert output.find(text) >= 0, f"Output file did not contain expected text '{text}' (output '{output}')"
     else:
@@ -15,6 +16,7 @@ def assert_has_text(output, text, n=None):
 def assert_not_has_text(output, text):
     """ Asserts specified output does not contain the substring
     specified by the argument text."""
+    assert output is not None, "Checking not_has_text assertion on empty output (None)"
     assert output.find(text) < 0, "Output file contains unexpected text '%s'" % text
 
 
@@ -22,6 +24,7 @@ def assert_has_line(output, line, n=None):
     """ Asserts the specified output contains the line specified by the
     argument line. The exact number of occurrences can be optionally
     specified by the argument n."""
+    assert output is not None, "Checking has_line assertion on empty output (None)"
     if n is None:
         match = re.search("^%s$" % re.escape(line), output, flags=re.MULTILINE)
         assert match is not None, f"No line of output file was '{line}' (output was '{output}') "
@@ -32,6 +35,7 @@ def assert_has_line(output, line, n=None):
 
 def assert_has_n_lines(output, n):
     """Asserts the specified output contains ``n`` lines."""
+    assert output is not None, "Checking has_n_lines assertion on empty output (None)"
     n_lines_found = len(output.splitlines())
     assert n_lines_found == int(n), f"Expected {n} lines in output, found {n_lines_found} lines"
 

--- a/test/integration/embedded_pulsar_metadata_job_conf.yml
+++ b/test/integration/embedded_pulsar_metadata_job_conf.yml
@@ -13,7 +13,6 @@ execution:
       runner: pulsar_embed
       remote_metadata: true
       default_file_action: copy
-      metadata_strategy: directory
 
 tools:
 - id: upload1

--- a/test/integration/test_pulsar_embedded_metadata.py
+++ b/test/integration/test_pulsar_embedded_metadata.py
@@ -17,12 +17,12 @@ class EmbeddedMetadataPulsarIntegrationInstance(integration_util.IntegrationInst
     def handle_galaxy_config_kwds(cls, config):
         config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
         config['object_store_store_by'] = 'uuid'
-        # We set the global metadata_strategy to `extended, but`metadata_strategy is
-        # being overridden in embedded_pulsar_metadata_job_conf.yml, since extended_metadata does not yet work on pulsar
         config['metadata_strategy'] = 'extended'
         config['retry_metadata_internally'] = False
 
 
 instance = integration_util.integration_module_instance(EmbeddedMetadataPulsarIntegrationInstance)
 
-test_tools = integration_util.integration_tool_runner(["simple_constructs", "metadata_bam"])
+test_tools = integration_util.integration_tool_runner(
+    ["simple_constructs", "metadata_bam", "job_properties"]
+)

--- a/test/integration/test_pulsar_embedded_metadata.py
+++ b/test/integration/test_pulsar_embedded_metadata.py
@@ -24,5 +24,9 @@ class EmbeddedMetadataPulsarIntegrationInstance(integration_util.IntegrationInst
 instance = integration_util.integration_module_instance(EmbeddedMetadataPulsarIntegrationInstance)
 
 test_tools = integration_util.integration_tool_runner(
-    ["simple_constructs", "metadata_bam", "job_properties"]
+    [
+        "simple_constructs",
+        "metadata_bam",
+        # "job_properties",  # https://github.com/galaxyproject/galaxy/issues/11813
+    ]
 )


### PR DESCRIPTION
Work started in https://github.com/galaxyproject/pulsar/pull/192.

## What did you do? 
- Get extended metadata working with Pulsar jobs.

## Why did you make this change?

Extended metadata collection prevents the need for Galaxy to have the data on-hand during job finishing. So this is a much stronger form of distributed data and compute available then when these two pieces aren't working in unison. Also extended metadata mode working would allow admins to bypass a bunch of little Pulsar correctness bugs where the right output files aren't being passed back and forth from Pulsar to Galaxy. Things like https://github.com/galaxyproject/pulsar/issues/212, https://github.com/galaxyproject/pulsar/issues/211, https://github.com/galaxyproject/pulsar/issues/93, and maybe https://github.com/galaxyproject/pulsar/issues/239. The model store would really be the only thing that would need to be passed from Pulsar back to Galaxy and that would have the whole context of the job's final models inside of it.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

