### PR TITLE
Handle deprecated postgresql db urls; update postgres version in ci

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -1,7 +1,7 @@
 name: API tests
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 jobs:
   test:
     name: Test

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -1,7 +1,7 @@
 name: API (legacy paste) tests
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_USE_UVICORN: false
 jobs:
   test:

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Check indexes on postgresql
       if: matrix.db == 'postgresql'
       env:
-        GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+        GALAXY_CONFIG_OVERRIDE_DATABASE_CONNECTION: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
       run: tox -e check_indexes
     - name: Check indexes on sqlite
       if: matrix.db == 'sqlite'

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -13,7 +13,7 @@ jobs:
         db: ['postgresql', 'sqlite']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -1,7 +1,7 @@
 name: Framework tests
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 jobs:
   test:
     name: Test

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,7 +1,7 @@
 name: Integration
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
 jobs:
   test:

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -1,7 +1,7 @@
 name: Integration Selenium
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_SELENIUM_REMOTE: '1'
   GALAXY_TEST_SELENIUM_REMOTE_PORT: "4444"
   GALAXY_SKIP_CLIENT_BUILD: '0'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,7 +1,7 @@
 name: Performance tests
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 jobs:
   test:
     name: Test

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -1,7 +1,7 @@
 name: Selenium tests
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 'true'
   GALAXY_TEST_SELENIUM_RETRIES: 1
 jobs:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -15,7 +15,7 @@ jobs:
         chunk: [0, 1, 2]
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -1,8 +1,8 @@
 name: Toolshed tests
 on: [push, pull_request]
 env:
-  GALAXY_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
-  TOOL_SHED_TEST_DBURI: 'postgres://postgres:postgres@localhost:5432/toolshed?client_encoding=utf8'
+  GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+  TOOL_SHED_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/toolshed?client_encoding=utf8'
 jobs:
   test:
     name: Test

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -168,7 +168,7 @@ class BaseAppConfiguration:
                     if value.startswith(prefix):
                         value = f'{new_dialect}{value[offset:]}'
                         kwargs[key] = value
-                        log.warning('Postgresql database URLs of the form "postgres://" have been '
+                        log.warning('PostgreSQL database URLs of the form "postgres://" have been '
                             'deprecated. Please use "postgresql://".')
 
     def is_set(self, key):

--- a/test/unit/config/config_manage/1607_root_samples/config/reports.ini
+++ b/test/unit/config/config_manage/1607_root_samples/config/reports.ini
@@ -44,7 +44,7 @@ log_level = DEBUG
 # Database connection
 # Galaxy reports are intended for production Galaxy instances, so sqlite is not supported.
 # You may use a SQLAlchemy connection string to specify an external database.
-#database_connection = postgres:///galaxy_test?user=postgres&password=postgres
+#database_connection = postgresql:///galaxy_test?user=postgres&password=postgres
 
 # Where dataset files are saved
 #file_path = database/files


### PR DESCRIPTION
## What did you do? 
1. Updated db urls to use `postgresql` instead of `postgres` (deprecated in SQLAlchemy 1.3, removed in 1.4)
2. Added automated fixing of deprecated values set by the user (a descriptive warning is logged)
3. Updated pinned version in github workflows to postgres:13 (was 11 in all but one workflow)

## Why did you make this change?
With the move to SQLAlchemy 1.4, `database_connection` values of the old `postgres://` form will fail.
Ref: https://docs.sqlalchemy.org/en/14/changelog/changelog_14.html#change-3687655465c25a39b968b4f5f6e9170b
Updating the pin in github workflows from 11 to 13 is related cleanup.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] unit test added

