### PR TITLE
Update localisation options to include Español

### DIFF
--- a/client/src/nls/locale.js
+++ b/client/src/nls/locale.js
@@ -458,4 +458,5 @@ define({
     ja: true,
     fr: true,
     zh: true,
+    es: true,
 });

--- a/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
+++ b/lib/galaxy/config/sample/user_preferences_extra_conf.yml.sample
@@ -59,10 +59,11 @@ preferences:
               required: False
               options:
                   - [Navigator default, auto]
-                  - [Chinese, zh]
+                  - [中文, zh]
                   - [English, en]
-                  - [French, fr]
-                  - [Japanese, ja]
+                  - [Español, es]
+                  - [Français, fr]
+                  - [日本語, ja]
 
     # Used in file_sources_conf.yml
     dropbox:


### PR DESCRIPTION
## What did you do? 
- the l10n options in user preferences sample file were missing Spanish, despite it being in `./client/src/nls/`
- Updated the user preference selectors to use the localised versions of language names. (though I don't think anyone would be able to find this menu if they didn't speak enough english to get there.)

Open questions: can we remove the `locale` directory in the root, right? Not touched since 2011/references makos?

## Why did you make this change?

@nomadscientist was asking about support for Spanish in the GTN and on EU, I noticed the 'es' directory that wasn't included, and she relates that one of their departments regularly has a group that can work on small en→es translation tasks.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. copy the user-preferences sample to a non-sample version
  2. start galaxy
  3. select Español
  4. ¡Éxito!

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [x] I've included a screenshot of the changes

¿Donde está la biblioteca? Aqui:

![image](https://user-images.githubusercontent.com/458683/113699896-70871200-96d6-11eb-9570-c873f28395bf.png)

l10n:

![image](https://user-images.githubusercontent.com/458683/113700045-a3310a80-96d6-11eb-9660-23b22b873188.png)
