### PR TITLE
Switch default handler assignment to skip locked or transaction isolation if possible

### DIFF
--- a/doc/source/admin/scaling.md
+++ b/doc/source/admin/scaling.md
@@ -83,7 +83,9 @@ Referred to in this documentation as the **uWSGI all-in-one** strategy.
 Under this strategy, jobs will be handled by uWSGI web workers. Having web processes handle jobs will negatively impact
 UI/API performance.
 
-This is the default out-of-the-box configuration as of Galaxy Release 18.01.
+This is the default out-of-the-box configuration as of Galaxy Release 18.01 and will be deprecated in Galaxy Release 21.09
+in favor of running separate processes for handling web requests (gunicorn serving a fastAPI instance), for handling jobs and
+workflows (using the current webless job handling code) and Celery workers for running long-running and/or CPU-intensive tasks.
 
 ### uWSGI for web serving with Mules as job handlers
 
@@ -98,7 +100,8 @@ Under this strategy, job handling is offloaded to dedicated non-web-serving proc
 directly by the master uWSGI process. As a benefit of using mule messaging, only job handlers that are alive will be
 selected to run jobs.
 
-This is the recommended deployment strategy.
+This was the recommended deployment strategy until Galaxy release 21.01. This deployment strategy will be supported
+until Galaxy release 21.05 and will be deprecated in Galaxy release 21.09.
 
 ```eval_rst
 .. important::
@@ -121,15 +124,15 @@ Referred to in this documentation as the **uWSGI + Webless** strategy.
 * Jobs are dispatched from web workers to job handlers via the Galaxy database
 * Jobs can be dispatched to job handlers running on any host
 * Additional job handlers can be added dynamically without reconfiguring/restarting Galaxy (19.01 or later)
-* The recommended deployment strategy for production Galaxy instances prior to 18.01
+* The recommended deployment strategy for production Galaxy instances
 
 Like mules, under this strategy, job handling is offloaded to dedicated non-web-serving processes, but those processes
 are [managed by the administrator](#starting-and-stopping).
 
-By default, a handler is randomly assigned by the web worker when the job is submitted via the UI/API, meaning that jobs
-may be assigned to dead handlers. However, beginning in Galaxy release 19.01, new job handler assignment methods are
-available that allow handlers to self-assign jobs (a handler is no longer required to be assigned when the job is
-created).
+By default, handler assignment will occur using the **Database Transaction Isolation** or **Database SKIP LOCKED**
+methods (see below). However, if the database used does not support this mechanism (in practice this should only apply
+to sqlite before version 3.25, which is not at all recommended for production Galaxy server) a handler is randomly
+assigned by the web worker when the job is submitted via the UI/API, meaning that jobs may be assigned to dead handlers.
 
 This is the recommended deployment strategy when **Zerg Mode** is used, for Galaxy servers that run web servers and
 job handlers **on different hosts**, and for deployments where dynamic handler addition is desired.
@@ -144,47 +147,50 @@ documentation, but these are deprecated and should no longer be used.
 
 ## Job Handler Assignment Methods
 
-Prior to Galaxy release 19.01, the method by which handlers were selected to be assigned to jobs was dependent on your
-job configuration and use of uWSGI Mules, and was not configurable by the administrator.  Beginning with Galaxy release
-19.01, two new handler assignment methods have been added and methods are now configurable with the `assign_with`
+Job handler assignment methods configurable with the `assign_with`
 attribute on the `<handlers>` tag in `job_conf.xml`.  The available methods are:
-
-- **Database Self Assignment** (`db-self`) - Like *In-memory Self Assignment* but assignment occurs by setting a new job's 'handler'
-  column in the database to the process that created the job at the time it is created. Additionally, if a tool is
-  configured to use a specific handler (ID or tag), that handler is assigned (tags by *Database Preassignment*). This is
-  the default if no handlers are defined and no `job-handlers` uWSGI Farm is present (the default for a completely
-  unconfigured Galaxy).
-
-- **In-memory Self Assignment** (`mem-self`) - Jobs are assigned to the web worker that received the tool execution request from the
-  user via an internal in-memory queue. If a tool is configured to use a specific handler, that configuration is
-  ignored; the process that creates the job *always* handles it. This can be slightly faster than **Database Self
-  Assignment** but only makes sense in single process environments without dedicated job handlers. This option
-  supercedes the former `track_jobs_in_database` option in `galaxy.yml` and corresponds to setting that option to
-  `false`.
-
-- **Database Preassignment** (`db-preassign`) - Jobs are assigned a handler by selecting one at random from the configured tag or default
-  handlers at the time the job is created. This occurs by the web worker that receives the tool execution request (via
-  the UI or API) setting a new job's 'handler' column in the database to the randomly chose handler ID (hence
-  "preassignment"). This is the default if handlers are defined and no `job-handlers` uWSGI Farm is present.
-
-- **uWSGI Mule Messaging** (`uwsgi-mule-message`) - Jobs are assigned a handler via uWSGI mule messaging.  A mule in the `job-handlers` (for
-  default/untagged tool-to-handler mappings) or `job-handlers.<tag>` farm will receive the message and assign itself.
-  This the default if a `job-handlers` uWSGI Farm is present and no handlers are configured.
 
 - **Database Transaction Isolation** (`db-transaction-isolation`, new in 19.01) - Jobs are assigned a handler by handlers selecting the unassigned
   job from the database using SQL transaction isolation, which uses database locks to guarantee that only one handler
   can select a given job. This occurs by the web worker that receives the tool execution request (via the UI or API)
   setting a new job's 'handler' column in the database to the configured tag/default (or `_default_` if no tag/default
   is configured). Handlers "listen" for jobs by selecting jobs from the database that match the handler tag(s) for which
-  they are configured.
+  they are configured. This is the default if no handlers are defined, or handlers are defined but no assign_with attribute is set
+  on the `handlers` tag and *Database SKIP LOCKED* is not available and no uwsgi-mule-messaging is set up.
 
 - **Database SKIP LOCKED** (`db-skip-locked`, new in 19.01) - Jobs are assigned a handler by handlers selecting the unassigned job from
   the database using `SELECT ... FOR UPDATE SKIP LOCKED` on databases that support this query (see the next section for
   details). This occurs via the same process as *Database Transaction Isolation*, the only difference is the way in
-  which handlers query the database.
+  which handlers query the database. This is the default if no handlers are defined, or handlers are defined but no assign_with attribute is set
+  on the `handlers` tag and *Database SKIP LOCKED* is available and no uwsgi-mule-messaging is set up.
+
+- **Database Self Assignment** (`db-self`) - Like *In-memory Self Assignment* but assignment occurs by setting a new job's 'handler'
+  column in the database to the process that created the job at the time it is created. Additionally, if a tool is
+  configured to use a specific handler (ID or tag), that handler is assigned (tags by *Database Preassignment*). This is
+  the default if no handlers are defined and no `job-handlers` uWSGI Farm is present and the database does not support
+  *Database SKIP LOCKED* or *Database Transaction Isolation*.
+
+- **In-memory Self Assignment** (`mem-self`) - Jobs are assigned to the web worker that received the tool execution request from the
+  user via an internal in-memory queue. If a tool is configured to use a specific handler, that configuration is
+  ignored; the process that creates the job *always* handles it. This can be slightly faster than **Database Self
+  Assignment** but only makes sense in single process environments without dedicated job handlers. This option
+  supercedes the former `track_jobs_in_database` option in `galaxy.yml` and corresponds to setting that option to
+  `false`. Will be removed from Galaxy in release 21.09.
+
+- **Database Preassignment** (`db-preassign`) - Jobs are assigned a handler by selecting one at random from the configured tag or default
+  handlers at the time the job is created. This occurs by the web worker that receives the tool execution request (via
+  the UI or API) setting a new job's 'handler' column in the database to the randomly chose handler ID (hence
+  "preassignment"). This is the default if handlers are defined and no `job-handlers` uWSGI Farm is present
+  and the database does not support *Database SKIP LOCKED* or *Database Transaction Isolation*.
+
+- **uWSGI Mule Messaging** (`uwsgi-mule-message`) - Jobs are assigned a handler via uWSGI mule messaging.  A mule in the `job-handlers` (for
+  default/untagged tool-to-handler mappings) or `job-handlers.<tag>` farm will receive the message and assign itself.
+  This the default if a `job-handlers` uWSGI Farm is present and no handlers are configured.
+  Will be removed in Galaxy release 21.09.
 
 In the event that both a `job-handlers` uWSGI Farm is present and handlers are configured, the default is *uWSGI Mule
-Messaging* followed by *Database Preassignment*. At present, only *uWSGI Mule Messaging* is capable of deferring handler
+Messaging* followed by *Database SKIP LOCKED* or *Database Transaction Isolation*  or *Database Preassignment*, depending on which method
+is supported by the database in use. At present, only *uWSGI Mule Messaging* is capable of deferring handler
 assignment to a later method (which would occur in the event that a tool is configured to use a tag for which there is
 not a matching farm).
 
@@ -213,7 +219,7 @@ PostgreSQL Blog][2ndquadrant-blog].
 
 The preferred method depends on your deployment strategy:
 
-- **uWSGI + Mules** - *uWSGI Mule Messaging* is preferred.
+- **uWSGI + Mules** -  Either *Database SKIP LOCKED* or *Database Transaction Isolation* is preferred.
 - **uWSGI + Webless** - Either *Database SKIP LOCKED* or *Database Transaction Isolation* is preferred.
 - **uWSGI + Hybrid** - Either *Database SKIP LOCKED* or *Database Transaction Isolation* is preferred. If your mule and
   webless handlers are in non-overlapping pools (i.e. tags, or untagged), you can alternatively use both *uWSGI Mule
@@ -404,7 +410,7 @@ You can run the startup-time setup steps as the galaxy user after upgrading Gala
 
 Ensure that no `<handlers>` section exists in your `job_conf.xml` (or no `job_conf.xml` exists at all) and start Galaxy
 normally. No additional configuration is required. To increase the number of web workers/job handlers, increase the
-value of `processes`. Jobs will be handled by the web worker that receives the job setup request (via the UI/API).
+value of `processes`. Jobs will be handled according to rules outlined above in [Job Handler Assignment Methods](#job-handler-assignment-methods).
 
 ```eval_rst
 .. note::

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -941,6 +941,13 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
                 'HOST_IP': socket.gethostbyname(socket.gethostname())
             })
+        if "GALAXY_WEB_PORT" in self.galaxy_infrastructure_url:
+            port = os.environ.get('GALAXY_WEB_PORT')
+            if not port:
+                raise Exception('$GALAXY_WEB_PORT set in galaxy_infrastructure_url, but environment variable not set')
+            self.galaxy_infrastructure_url = string.Template(self.galaxy_infrastructure_url).safe_substitute({
+                'GALAXY_WEB_PORT': port
+            })
         if "UWSGI_PORT" in self.galaxy_infrastructure_url:
             import uwsgi
             http = unicodify(uwsgi.opt['http'])

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -736,6 +736,8 @@ class PulsarJobRunner(AsynchronousJobRunner):
     def shutdown(self):
         super().shutdown()
         self.client_manager.shutdown()
+        if self.pulsar_app:
+            self.pulsar_app.shutdown()
 
     def _job_state(self, job, job_wrapper):
         job_state = AsynchronousJobState()

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -78,9 +78,12 @@ class ConfiguresHandlers:
     def get_preferred_handler_assignment_method(self):
         if not self.supports_returning(self.app.model.session):
             log.debug("Database does not support RETURNING statement, cannot use DB-SKIP-LOCKED or DB-TRANSACTION-ISOLATION handler assignment")
+            self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED)
+            self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION)
             return None
         if self.supports_skip_locked(self.app.model.session):
             log.debug("Database does not support WITH FOR UPDATE statement, cannot use DB-SKIP-LOCKED handler assignment")
+            self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED)
             return HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
         return HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
 

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -147,7 +147,7 @@ class ConfiguresHandlers:
                 self.handler_assignment_methods = [HANDLER_ASSIGNMENT_METHODS.MEM_SELF]
             elif not self.handlers:
                 # No handlers defined, default is for processes to handle the jobs they create
-                self.handler_assignment_methods = [HANDLER_ASSIGNMENT_METHODS.DB_SELF]
+                self.handler_assignment_methods = [HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED]
             else:
                 # Handlers are defined, default is the value if the default attribute, or any untagged handler if
                 # default attribute is unset
@@ -256,6 +256,10 @@ class ConfiguresHandlers:
         for collection in self.handlers.values():
             if self.app.config.server_name in collection:
                 return True
+        if not self.handlers:
+            # Assume that if no handlers are set up this is an all-in-one setup ...
+            # Probably breaks some assumptions with a pool setup ??
+            return True
         return False
 
     def _set_is_handler(self, value):
@@ -284,7 +288,7 @@ class ConfiguresHandlers:
     def self_handler_tags(self):
         """Get an iterable of the current process's configured handler tags.
         """
-        return filter(lambda k: self.app.config.server_name in self.handlers[k], self.handler_tags)
+        return [k for k in self.handler_tags if self.app.config.server_name in self.handlers[k]] or [self.DEFAULT_HANDLER_TAG]
 
     # If these get to be any more complex we should probably modularize them, or at least move to a separate class
 

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -152,14 +152,8 @@ class ConfiguresHandlers:
                             " handler assignment method in the job handler configuration",
                             HANDLER_ASSIGNMENT_METHODS.MEM_SELF)
                 self.handler_assignment_methods = [HANDLER_ASSIGNMENT_METHODS.MEM_SELF]
-            elif not self.handlers:
-                # No handlers defined, default is for processes to handle the jobs they create
-                # Ideally this is DB_SKIP_LOCKED or TRANSACTION_ISOLATION, falls back to DB_SELF
-                self.handler_assignment_methods = [self.get_preferred_handler_assignment_method() or HANDLER_ASSIGNMENT_METHODS.DB_SELF]
             else:
-                # Handlers are defined, default is the value of the default attribute, or any untagged handler if
-                # default attribute is unset
-                self.handler_assignment_methods = [self.get_preferred_handler_assignment_method() or HANDLER_ASSIGNMENT_METHODS.DB_PREASSIGN]
+                self.handler_assignment_methods = [self.get_preferred_handler_assignment_method()]
             # If the stack has handler pools it can override these defaults
             self.app.application_stack.init_job_handling(self)
             log.info("%s: No job handler assignment method is set, defaulting to '%s', set the `assign_with` attribute"

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -291,7 +291,7 @@ class ConfiguresHandlers:
         for collection in self.handlers.values():
             if self.app.config.server_name in collection:
                 return True
-        if (not self.handler_assignment_methods_configured
+        if not self.handlers and (not self.handler_assignment_methods_configured
                 and HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION in self.handler_assignment_methods
                 or HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED in self.handler_assignment_methods):
             return True

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -53,13 +53,6 @@ class ConfiguresHandlers:
             else:
                 self.handlers[tag] = [handler_id]
 
-    def get_preferred_handler_assignment_method(self):
-        if self.app.application_stack.supports_skip_locked():
-            return HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
-        log.debug("Database does not support WITH FOR UPDATE statement, cannot use DB-SKIP-LOCKED handler assignment")
-        self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED)
-        return HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
-
     @staticmethod
     def xml_to_dict(config, config_element):
         handling_config_dict = {}
@@ -153,7 +146,7 @@ class ConfiguresHandlers:
                             HANDLER_ASSIGNMENT_METHODS.MEM_SELF)
                 self.handler_assignment_methods = [HANDLER_ASSIGNMENT_METHODS.MEM_SELF]
             else:
-                self.handler_assignment_methods = [self.get_preferred_handler_assignment_method()]
+                self.handler_assignment_methods = [self.app.application_stack.get_preferred_handler_assignment_method()]
             # If the stack has handler pools it can override these defaults
             self.app.application_stack.init_job_handling(self)
             log.info("%s: No job handler assignment method is set, defaulting to '%s', set the `assign_with` attribute"

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -77,8 +77,10 @@ class ConfiguresHandlers:
 
     def get_preferred_handler_assignment_method(self):
         if not self.supports_returning(self.app.model.session):
+            log.debug("Database does not support RETURNING statement, cannot use DB-SKIP-LOCKED or DB-TRANSACTION-ISOLATION handler assignment")
             return None
         if self.supports_skip_locked(self.app.model.session):
+            log.debug("Database does not support WITH FOR UPDATE statement, cannot use DB-SKIP-LOCKED handler assignment")
             return HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
         return HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
 

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -82,9 +82,9 @@ class ConfiguresHandlers:
             self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION)
             return None
         if self.supports_skip_locked(self.app.model.session):
-            log.debug("Database does not support WITH FOR UPDATE statement, cannot use DB-SKIP-LOCKED handler assignment")
             self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED)
             return HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
+        log.debug("Database does not support WITH FOR UPDATE statement, cannot use DB-SKIP-LOCKED handler assignment")
         return HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
 
     @staticmethod

--- a/lib/galaxy/web_stack/handlers.py
+++ b/lib/galaxy/web_stack/handlers.py
@@ -251,8 +251,8 @@ class ConfiguresHandlers:
         for collection in self.handlers.values():
             if self.app.config.server_name in collection:
                 return True
-        if not self.handlers and (not self.handler_assignment_methods_configured
-                and HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION in self.handler_assignment_methods
+        if not self.handlers and not self.handler_assignment_methods_configured \
+                and (HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION in self.handler_assignment_methods
                 or HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED in self.handler_assignment_methods):
             return True
         return False

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -186,15 +186,16 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
 
         if use_default_scheduler:
             self.__init_default_scheduler()
-            self._set_default_handler_assignment_methods()
         else:
             plugins_element = parse_xml(config_file).getroot()
             self.__init_schedulers_for_element(plugins_element)
 
-        if not self.__handlers_configured and self.__stack_has_pool:
+        if self.__stack_has_pool:
             # Stack has a pool for us so override inherited config and use the pool
             self.__init_handlers()
             self.__handlers_configured = True
+        elif use_default_scheduler:
+            self._set_default_handler_assignment_methods()
 
     def __init_default_scheduler(self):
         self.default_scheduler_id = DEFAULT_SCHEDULER_ID

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -186,6 +186,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
 
         if use_default_scheduler:
             self.__init_default_scheduler()
+            self._set_default_handler_assignment_methods()
         else:
             plugins_element = parse_xml(config_file).getroot()
             self.__init_schedulers_for_element(plugins_element)

--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -190,7 +190,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
             plugins_element = parse_xml(config_file).getroot()
             self.__init_schedulers_for_element(plugins_element)
 
-        if self.__stack_has_pool:
+        if not self.__handlers_configured and self.__stack_has_pool:
             # Stack has a pool for us so override inherited config and use the pool
             self.__init_handlers()
             self.__handlers_configured = True

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import shutil
 import signal
+import socket
 import string
 import subprocess
 import sys
@@ -512,16 +513,29 @@ def wait_for_http_server(host, port, sleep_amount=0.1, sleep_tries=150):
         raise Exception(message)
 
 
+def attempt_port(port):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(('', port))
+        sock.close()
+        return port
+    except OSError:
+        return None
+
+
 def attempt_ports(port):
     if port is not None:
-        yield port
+        return port
 
         raise Exception("An existing process seems bound to specified test server port [%s]" % port)
     else:
         random.seed()
         for _ in range(0, 9):
-            port = str(random.randint(8000, 10000))
-            yield port
+            port = attempt_port(random.randint(8000, 10000))
+            if port:
+                port = str(port)
+                os.environ['GALAXY_WEB_PORT'] = port
+                return port
 
         raise Exception("Unable to open a port between {} and {} to start Galaxy server".format(8000, 10000))
 
@@ -532,39 +546,24 @@ def serve_webapp(webapp, port=None, host=None):
     Return the port the webapp is running on.
     """
     server = None
-    for port in attempt_ports(port):
-        try:
-            server = httpserver.serve(webapp, host=host, port=port, start_loop=False)
-            break
-        except OSError as e:
-            if e.errno == 98:
-                continue
-            raise
-
+    port = attempt_ports(port)
+    server = httpserver.serve(webapp, host=host, port=port, start_loop=False)
     t = threading.Thread(target=server.serve_forever)
     t.start()
 
     return server, port
 
 
-def uvicorn_serve(app, port=None, host=None):
+def uvicorn_serve(app, port, host=None):
     """Serve the webapp on a recommend port or a free one.
 
     Return the port the webapp is running on.
     """
     import asyncio
-    server = None
-    for port in attempt_ports(port):
-        try:
-            from uvicorn.server import Server
-            from uvicorn.config import Config
-            config = Config(app, host=host, port=int(port))
-            server = Server(config=config)
-            break
-        except OSError as e:
-            if e.errno == 98:
-                continue
-            raise
+    from uvicorn.server import Server
+    from uvicorn.config import Config
+    config = Config(app, host=host, port=int(port))
+    server = Server(config=config)
 
     def run_in_loop(loop):
         asyncio.set_event_loop(loop)
@@ -682,6 +681,8 @@ def explicitly_configured_host_and_port(prefix, config_object):
     # for new tests.
     if port is None:
         os.environ["GALAXY_TEST_PORT_RANDOM"] = "1"
+    else:
+        os.environ['GALAXY_WEB_PORT'] = port
 
     return host, port
 
@@ -833,23 +834,25 @@ def launch_uwsgi(kwargs, tempdir, prefix=DEFAULT_CONFIG_PREFIX, config_object=No
             p, name, host, port
         )
 
-    for port in attempt_ports(port):
-        server_wrapper = attempt_port_bind(port)
-        try:
-            set_and_wait_for_http_target(prefix, host, port, sleep_tries=50)
-            log.info(f"Test-managed uwsgi web server for {name} started at {host}:{port}")
-            return server_wrapper
-        except Exception:
-            server_wrapper.stop()
+    port = attempt_ports(port)
+    server_wrapper = attempt_port_bind(port)
+    try:
+        set_and_wait_for_http_target(prefix, host, port, sleep_tries=50)
+        log.info(f"Test-managed uwsgi web server for {name} started at {host}:{port}")
+        return server_wrapper
+    except Exception:
+        server_wrapper.stop()
 
 
-def launch_uvicorn(gx_app, webapp_factory, kwargs, prefix=DEFAULT_CONFIG_PREFIX, config_object=None):
+def launch_uvicorn(webapp_factory, prefix=DEFAULT_CONFIG_PREFIX, galaxy_config=None, config_object=None):
     name = prefix.lower()
 
     host, port = explicitly_configured_host_and_port(prefix, config_object)
+    port = attempt_ports(port)
+    gx_app = build_galaxy_app(galaxy_config)
 
     gx_webapp = webapp_factory(
-        kwargs['global_conf'],
+        galaxy_config['global_conf'],
         app=gx_app,
         use_translogger=False,
         static_enabled=True,
@@ -1065,13 +1068,12 @@ class GalaxyTestDriver(TestDriver):
                     config_object=config_object,
                 )
             elif self.else_use_uvicorn:
-                self.app = build_galaxy_app(galaxy_config)
                 server_wrapper = launch_uvicorn(
-                    self.app,
                     lambda *args, **kwd: buildapp.app_factory(*args, wsgi_preflight=False, **kwd),
-                    galaxy_config,
+                    galaxy_config=galaxy_config,
                     config_object=config_object,
                 )
+                self.app = server_wrapper.app
             else:
                 # ---- Build Application --------------------------------------------------
                 self.app = build_galaxy_app(galaxy_config)

--- a/scripts/galaxy_main.py
+++ b/scripts/galaxy_main.py
@@ -194,7 +194,7 @@ class GalaxyConfigBuilder:
         arg_parser.add_argument("--log-file", default=None, help="Galaxy log file (overrides log configuration in config_file if set)")
         arg_parser.add_argument("--pid-file", default=DEFAULT_PID, help="pid file (default is %s)" % DEFAULT_PID)
         arg_parser.add_argument("--server-name", default=None, help="set a galaxy server name")
-        arg_parser.add_argument("--attach-to-pool", action="append", default=None, help="attach to asynchronous worker pool (specify multiple times for multiple pools)")
+        arg_parser.add_argument("--attach-to-pool", action="append", default=['job-handlers'], help="attach to asynchronous worker pool (specify multiple times for multiple pools)")
 
     @property
     def config_is_ini(self):

--- a/test/integration/test_kubernetes_staging.py
+++ b/test/integration/test_kubernetes_staging.py
@@ -119,8 +119,6 @@ def job_config(template_str, jobs_directory):
 @integration_util.skip_unless_amqp()
 @integration_util.skip_if_github_workflow()
 class BaseKubernetesStagingTest(BaseJobEnvironmentIntegrationTestCase, MulledJobTestCases):
-    # Test leverages $UWSGI_PORT in job code, need to set this up.
-    require_uwsgi = True
 
     def setUp(self):
         super().setUp()
@@ -208,7 +206,7 @@ class KubernetesDependencyResolutionIntegrationTestCase(BaseKubernetesStagingTes
 
 
 def set_infrastucture_url(config):
-    infrastructure_url = "http://%s:$UWSGI_PORT" % GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST
+    infrastructure_url = "http://%s:$GALAXY_WEB_PORT" % GALAXY_TEST_KUBERNETES_INFRASTRUCTURE_HOST
     config["galaxy_infrastructure_url"] = infrastructure_url
 
 

--- a/test/integration/test_pulsar_embedded_mq.py
+++ b/test/integration/test_pulsar_embedded_mq.py
@@ -52,8 +52,6 @@ class EmbeddedMessageQueuePulsarIntegrationInstance(integration_util.Integration
     """
 
     framework_tool_and_types = True
-    # Test leverages $UWSGI_PORT in job code, need to set this up.
-    require_uwsgi = True
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -71,7 +69,7 @@ class EmbeddedMessageQueuePulsarIntegrationInstance(integration_util.Integration
         with tempfile.NamedTemporaryFile(suffix="_mq_job_conf.yml", mode="w", delete=False) as job_conf:
             job_conf.write(job_conf_str)
         config["job_config_file"] = job_conf.name
-        infrastructure_url = "http://localhost:$UWSGI_PORT"
+        infrastructure_url = "http://localhost:$GALAXY_WEB_PORT"
         config["galaxy_infrastructure_url"] = infrastructure_url
 
 

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -135,6 +135,9 @@ class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestC
 
 class HistoryRestrictionConfigurationTestCase(BaseWorkflowHandlerConfigurationTestCase):
 
+    # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
+    assign_with = 'db-preassign'
+
     def test_history_to_handler_restriction(self):
         self._invoke_n_workflows(10)
         workflow_invocations = self._get_workflow_invocations()
@@ -149,9 +152,12 @@ class HistoryRestrictionConfigurationTestCase(BaseWorkflowHandlerConfigurationTe
 
 class HistoryParallelConfigurationTestCase(BaseWorkflowHandlerConfigurationTestCase):
 
+    # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
+    assign_with = 'db-preassign'
+
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["parallelize_workflow_scheduling_within_histories"] = True
 
     def test_workflows_spread_across_multiple_handlers(self):
@@ -170,9 +176,12 @@ class HistoryParallelConfigurationTestCase(BaseWorkflowHandlerConfigurationTestC
 # Setup an explicit workflow handler and make sure this is assigned to that.
 class WorkflowSchedulerHandlerAssignment(BaseWorkflowHandlerConfigurationTestCase):
 
+    # Assign with db-preassign. Would also work with grabbing assignment, but we don't start grabber.
+    assign_with = 'db-preassign'
+
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["workflow_schedulers_config_file"] = config_file(WORKFLOW_SCHEDULERS_CONFIG_TEMPLATE, assign_with=cls.assign_with)
 
     def test_handler_assignment(self):
@@ -205,7 +214,7 @@ class DefaultWorkflowHandlerIfJobHandlerOnTestCase(BaseWorkflowHandlerConfigurat
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["server_name"] = "handler0"
 
     def test_default_job_handler_is_workflow_handler(self):
@@ -218,7 +227,7 @@ class JobHandlerAsWorkflowHandlerWithDbSkipLocked(BaseWorkflowHandlerConfigurati
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["server_name"] = "handler0"
 
     def test_handler_assignment(self):
@@ -244,7 +253,7 @@ class DefaultWorkflowHandlerIfJobHandlerOffTestCase(BaseWorkflowHandlerConfigura
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["server_name"] = "web0"
 
     def test_default_job_handler_is_not_workflow_handler(self):
@@ -257,7 +266,7 @@ class ExplicitWorkflowHandlersOnTestCase(BaseWorkflowHandlerConfigurationTestCas
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["workflow_schedulers_config_file"] = config_file(WORKFLOW_SCHEDULERS_CONFIG_TEMPLATE, assign_with=cls.assign_with)
         config["server_name"] = "work1"
 
@@ -287,7 +296,7 @@ class ExplicitWorkflowHandlersOffTestCase(BaseWorkflowHandlerConfigurationTestCa
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        BaseWorkflowHandlerConfigurationTestCase.handle_galaxy_config_kwds(config)
+        super().handle_galaxy_config_kwds(config)
         config["workflow_schedulers_config_file"] = config_file(WORKFLOW_SCHEDULERS_CONFIG_TEMPLATE, assign_with=cls.assign_with)
         config["server_name"] = "handler0"  # Configured as a job handler but not a workflow handler.
 

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -61,13 +61,13 @@ class BaseJobConfXmlParserTestCase(unittest.TestCase):
     @property
     def application_stack(self):
         if not self._application_stack:
+            ApplicationStack.get_preferred_handler_assignment_method = lambda x: HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
             self._application_stack = ApplicationStack()
         return self._application_stack
 
     @property
     def job_config(self):
         if not self._job_configuration:
-            JobConfiguration.get_preferred_handler_assignment_method = lambda x: HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
             base_handler_pools = self._job_configuration_base_pools or JobConfiguration.DEFAULT_BASE_HANDLER_POOLS
             mock_uwsgi = mock.Mock()
             mock_uwsgi.mule_id = lambda: 1


### PR DESCRIPTION
## What did you do? 
- Switch default handler assignment mechanism to db skip locked or transaction isolation, depending on what the database connection supports
- Add the option to use DB-TRANSACTION-ISOLATION if the database doesn't support RETURNING (sqlite before 3.35.0)

## Why did you make this change?
Our recommended production database (postgres) has been supporting the necessary features (the RETURNING statement plus isolation level SERIALIZABLE ) since at least version 8. sqlite has recently added the RETURNING statement (and we don't necessarily need the returning statement ...).

This will help with deprecating uwsgi mules and should be the most robust mechanism and should also be the easiest way for re-assigning running jobs when handlers go away (which is to set jobs / invocations to the default tag) or when adding additional handlers.
This is also the easiest way to have celery tasks submit jobs (which can't use the default DB-SELF / MEM-SELF mechanism).

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
