### PR TITLE
[21.01] Fix typo in `upstream_mod_zip` admin docs

### DIFF
--- a/doc/source/admin/nginx.md
+++ b/doc/source/admin/nginx.md
@@ -364,7 +364,7 @@ nginx should serve files and edit `galaxy.yml` and make the following changes be
 ```yaml
 galaxy:
     #...
-    upstream_zip: true
+    upstream_mod_zip: true
 ```
 
 Instead of creating archives Galaxy will send a special header containing the list of files to be archived.


### PR DESCRIPTION
## What did you do? 
- Fix typo in `upstream_mod_zip` admin docs

## Why did you make this change?
There was a typo introduced in https://github.com/galaxyproject/galaxy/pull/10919 .

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
