### PR TITLE
Open update deps PRs from galaxybot's fork

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -27,9 +27,11 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.GALAXYBOT_PAT }}
           commit-message: Update Python dependencies
-          title: Update Python dependencies
-          body: Run `make update-dependencies`.
           branch: dev_auto_update_dependencies
           delete-branch: true
+          push-to-fork: galaxybot/galaxy
+          title: Update Python dependencies
+          body: Run `make update-dependencies`.
           labels: area/dependencies


### PR DESCRIPTION
## What did you do? 
- Modified the "Update dependencies" GitHub workflow to open PRs using galaxybot's Personal Access Token (**which needs to be created and added as a secret by a repository admin**) from its own `galaxy` repository fork.


## Why did you make this change?

Pull requests created by an action (in this case `create-pull-request`) using the default `GITHUB_TOKEN` cannot trigger other workflows, see https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#triggering-further-workflow-runs

Using a machine account like galaxybot that creates pull requests from its own fork is the most secure workaround, see https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#push-pull-request-branches-to-a-fork


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Be a repository admin
  2. Create a Personal Access Token for the galaxybot user and add it to this repository as the `GALAXYBOT_PAT` secret
  3. Merge and wait for Saturday :)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
