### PR TITLE
Activate virtualenv in `updateucsc.sh.sample`

### DIFF
--- a/cron/updateucsc.sh.sample
+++ b/cron/updateucsc.sh.sample
@@ -6,6 +6,13 @@
 
 ## Change the Galaxy path on the next line if needed:
 GALAXY=$(dirname "$0")/..
+
+GALAXY_VIRTUAL_ENV="${GALAXY_VIRTUAL_ENV:-$GALAXY/.venv}"
+if [ -d "$GALAXY_VIRTUAL_ENV" ]; then
+    echo "Activating virtualenv at $GALAXY_VIRTUAL_ENV"
+    . "$GALAXY_VIRTUAL_ENV/bin/activate"
+fi
+
 PYTHONPATH=${GALAXY}/lib
 export PYTHONPATH
 
@@ -61,7 +68,7 @@ echo "Building chromInfo tables."
 python "${GALAXY}/cron/build_chrom_db.py" "${GALAXY}/tool-data/shared/ucsc/chrom/new/" "${GALAXY}/tool-data/shared/ucsc/builds.txt"
 if [ $? -eq 0 ]
 then
-    for src in ${GALAXY}/tool-data/shared/ucsc/chrom/new/*.len
+    for src in "${GALAXY}"/tool-data/shared/ucsc/chrom/new/*.len
     do
         dst=${GALAXY}/tool-data/shared/ucsc/chrom/$(basename "$src")
         diff "$src" "$dst" > /dev/null 2>&1


### PR DESCRIPTION
## What did you do? 
- Activate virtualenv in the `cron/updateucsc.sh.sample` script


## Why did you make this change?
If the virtualenv is not activated, Python 2 is used or `requests` may be missing, resulting in errors:

```
$ bash cron/updateucsc.sh.sample
Creating required directories.
cron/../tool-data/shared/ucsc/new already exists, continuing.
cron/../tool-data/shared/ucsc/chrom already exists, continuing.
cron/../tool-data/shared/ucsc/chrom/new already exists, continuing.
Wed  7 Apr 18:12:25 BST 2021
Updating UCSC shared data tables.
Updating builds.txt
Traceback (most recent call last):
  File "cron/../cron/parse_builds.py", line 11, in <module>
    import requests
ImportError: No module named requests
Failed to update builds.txt
Updating ucsc_build_sites.txt
Traceback (most recent call last):
  File "cron/../cron/parse_builds_3_sites.py", line 8, in <module>
    import requests
ImportError: No module named requests
Failed to update builds.txt
Building chromInfo tables.
  File "cron/../cron/build_chrom_db.py", line 78
    print("\t".join(chrominfo), file=outfile)
                                    ^
SyntaxError: invalid syntax
Failed to update chromInfo tables.
Update complete.
Adding Manual Builds.
  File "cron/../cron/add_manual_builds.py", line 36
    print(build + "\t" + name + " (" + build + ")", file=build_file_out)
                                                        ^
SyntaxError: invalid syntax
Manual addition failed
```

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. `bash cron/updateucsc.sh.sample`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
