### PR TITLE
avoid name clashes when storing input data sets

### DIFF
--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -119,22 +119,22 @@ class DefaultToolAction:
                         if i == 0:
                             # Allow copying metadata to output, first item will be source.
                             input_datasets[prefix + input.name] = processed_dataset
-                        input_datasets[prefix + input.name + str(i + 1)] = processed_dataset
+                        input_datasets[prefix + input.name + "." + str(i + 1)] = processed_dataset
                         conversions = []
                         for conversion_name, conversion_extensions, conversion_datatypes in input.conversions:
-                            new_data = process_dataset(input_datasets[prefix + input.name + str(i + 1)], conversion_datatypes)
+                            new_data = process_dataset(input_datasets[prefix + input.name + "." + str(i + 1)], conversion_datatypes)
                             if not new_data or new_data.datatype.matches_any(conversion_datatypes):
-                                input_datasets[prefix + conversion_name + str(i + 1)] = new_data
+                                input_datasets[prefix + conversion_name + "." + str(i + 1)] = new_data
                                 conversions.append((conversion_name, new_data))
                             else:
                                 raise Exception('A path for explicit datatype conversion has not been found: {} --/--> {}'.format(input_datasets[prefix + input.name + str(i + 1)].extension, conversion_extensions))
                         if parent:
-                            parent[input.name][i] = input_datasets[prefix + input.name + str(i + 1)]
+                            parent[input.name][i] = input_datasets[prefix + input.name + "." + str(i + 1)]
                             for conversion_name, conversion_data in conversions:
                                 # allow explicit conversion to be stored in job_parameter table
                                 parent[conversion_name][i] = conversion_data.id  # a more robust way to determine JSONable value is desired
                         else:
-                            param_values[input.name][i] = input_datasets[prefix + input.name + str(i + 1)]
+                            param_values[input.name][i] = input_datasets[prefix + input.name + "." + str(i + 1)]
                             for conversion_name, conversion_data in conversions:
                                 # allow explicit conversion to be stored in job_parameter table
                                 param_values[conversion_name][i] = conversion_data.id  # a more robust way to determine JSONable value is desired
@@ -190,7 +190,7 @@ class DefaultToolAction:
                         processed_dataset = process_dataset(v)
                         if processed_dataset is not v:
                             processed_dataset_dict[v] = processed_dataset
-                    input_datasets[prefix + input.name + str(i + 1)] = processed_dataset or v
+                    input_datasets[prefix + input.name + "." + str(i + 1)] = processed_dataset or v
                 if conversion_required:
                     collection_type_description = trans.app.dataset_collections_service.collection_type_descriptions.for_collection_type(collection.collection_type)
                     collection_builder = CollectionBuilder(collection_type_description)

--- a/test/functional/tools/name_clash.xml
+++ b/test/functional/tools/name_clash.xml
@@ -1,0 +1,37 @@
+<tool id="name_clash" name="name_clash" version="0.1.0">
+  <command><![CDATA[
+    cat '$input1' > '$output' &&
+    cat '$another_input1' > '$another_output'
+    ## this should fail, because there are no such inputs
+    ## but I do not undestand why in the above the output
+    ## is simple_line.txt and not the tabular / bed files
+    ## &&
+    cat '$input2' > /dev/null &&
+    cat '$another_input2' > /dev/null
+  ]]></command>
+  <inputs>
+    <param name="input1" type="data" label="Input" help="Input to be split." />
+    <param name="input" type="data_collection"/>
+    <param name="another_input1" type="data" label="Input" help="Input to be split." />
+    <param name="another_input" type="data" multiple="true"/>
+  </inputs>
+  <outputs>
+    <data name="output" format_source="input1"/>
+    <data name="another_output" format_source="another_input1"/>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input1" value="simple_line.txt" ftype="txt" />
+      <param name="input">
+        <collection type="list">
+          <element name="1" value="2.tabular" ftype="tabular" />
+          <element name="2" value="1.tabular" ftype="tabular" />
+        </collection>
+      </param>
+      <output name="output" value="simple_line.txt" ftype="tabular"/> <!-- this should be txt -->
+      <param name="another_input1" value="simple_line_alternative.txt" ftype="txt" />
+      <param name="another_input" value="2.bed,1.bed" ftype="bed" /> <!-- this should be txt -->
+      <output name="another_output" value="simple_line_alternative.txt" ftype="bed"/>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -193,6 +193,7 @@
   <tool file="cheetah_problem_syntax_error.xml" />
   <tool file="python_environment_problem.xml" />
   <tool file="config_vars.xml" />
+  <tool file="name_clash.xml" />
 
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v02.xml" />


### PR DESCRIPTION
## What did you do? 

So far only a test .. want to see what fails .. side project of https://github.com/galaxyproject/galaxy/pull/11754

by adding a `.` this can not be accessed via cheetah. 

- alternatively make it `'[i]'`

## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

https://gitter.im/galaxyproject/dev?at=60645b301049fe429b8f87a2)
https://gitter.im/galaxyproject/dev?at=606e0b95bc8e6f2e0d2f0cc0

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
