### PR TITLE
[WIP] Support collections as 'single item' in Libraries

### DIFF
--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -85,13 +85,7 @@ class HDCAManager(
                 returned.append(processed)
         return returned
 
-    def is_owner(
-        self,
-        hdca: model.HistoryDatasetCollectionAssociation,
-        user,
-        current_history=None,
-        **kwargs,
-    ):
+    def is_owner(self, hdca, user, current_history=None, **kwargs):
         """
         Use history to see if current user owns HDCA.
         """

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3651,6 +3651,7 @@ class LibraryFolder(Dictifiable, HasName, RepresentById):
         self.genome_build = genome_build
         self.folders = []
         self.datasets = []
+        self.collections = []
 
     def add_library_dataset(self, library_dataset, genome_build=None):
         library_dataset.folder_id = self.id
@@ -3662,6 +3663,11 @@ class LibraryFolder(Dictifiable, HasName, RepresentById):
     def add_folder(self, folder):
         folder.parent_id = self.id
         folder.order_id = self.item_count
+        self.item_count += 1
+
+    def add_library_collection(self, library_collection):
+        library_collection.folder_id = self.id
+        library_collection.order_id = self.item_count
         self.item_count += 1
 
     @property
@@ -3684,6 +3690,10 @@ class LibraryFolder(Dictifiable, HasName, RepresentById):
         for folder in self.folders:
             folders.append(folder.serialize(id_encoder, serialization_options))
         rval["folders"] = folders
+        collections = []
+        for collection in self.collections:
+            collections.append(collection.serialize(id_encoder, serialization_options))
+        rval["collections"] = collections
         datasets = []
         for dataset in self.datasets:
             datasets.append(dataset.serialize(id_encoder, serialization_options))
@@ -3712,6 +3722,55 @@ class LibraryFolder(Dictifiable, HasName, RepresentById):
         while f.parent:
             f = f.parent
         return f.library_root[0]
+
+
+class LibraryDatasetCollection(RepresentById):
+    # This class acts as a proxy to the currently selected LDCA
+
+    def __init__(self, folder=None, order_id=None, name=None, library_dataset_collection_association=None):
+        self.folder = folder
+        self.order_id = order_id
+        self.name = name
+        self.library_dataset_collection_association = library_dataset_collection_association
+
+    def get_name(self):
+        if self.library_dataset_collection_association:
+            return self.library_dataset_collection_association.name
+        elif self._name:
+            return self._name
+        else:
+            return 'Unnamed collection'
+
+    def set_name(self, name):
+        self._name = name
+    name = property(get_name, set_name)
+
+    def display_name(self):
+        self.library_dataset_collection_association.display_name()
+
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            name=self.name,
+            order_id=self.order_id,
+            ldca=self.library_dataset_collection_association.serialize(id_encoder, serialization_options, for_link=True),
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
+
+    def to_dict(self, view='collection'):
+        ldca = self.library_dataset_collection_association
+        rval = dict(id=self.id,
+                    ldca_id=ldca.id,
+                    name=ldca.name,
+                    update_time=ldca.collection.update_time.isoformat(),
+                    collection_type=ldca.collection.collection_type,
+                    element_count=ldca.collection.element_count,
+                    parent_library_id=self.folder.parent_library.id,
+                    folder_id=self.folder_id,
+                    model_class=self.__class__.__name__,
+                    )
+        return rval
 
 
 class LibraryDataset(RepresentById):
@@ -4616,6 +4675,27 @@ class HistoryDatasetCollectionAssociation(DatasetCollectionInstance,
 
         results = qry.with_session(sa_session).all()
         return len(results) > 0
+
+    def to_library_dataset_collection_association(self, trans, target_folder: LibraryFolder, roles=None):
+        """
+        Copy this HDCA to a library.
+        """
+        # TODO: allow replace?
+        library_collection = LibraryDatasetCollection(folder=target_folder, name=self.name)
+        ldca = LibraryDatasetCollectionAssociation(name=self.name, collection=self.collection, deleted=self.deleted, folder=target_folder)
+        library_collection.library_dataset_collection_association = ldca
+        # TODO: If roles were selected on the upload form, restrict access to the collection to those roles
+        # roles = roles or []
+        # for role in roles:
+        #     dp = trans.model.DatasetPermissions(trans.app.security_agent.permitted_actions.DATASET_ACCESS.action,
+        #                                         ldca.collection, role)
+        #     trans.sa_session.add(dp)
+        # TODO: copy #tags from history
+        target_folder.add_library_collection(library_collection)
+        object_session(self).add(target_folder)
+        object_session(self).add(library_collection)
+        object_session(self).flush()
+        return ldca
 
 
 class LibraryDatasetCollectionAssociation(DatasetCollectionInstance, RepresentById):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -922,6 +922,23 @@ model.HistoryDatasetCollectionAssociation.table = Table(
     Column("create_time", DateTime, default=now),
     Column("update_time", DateTime, default=now, onupdate=now))
 
+model.LibraryDatasetCollection.table = Table(
+    "library_dataset_collection", metadata,
+    Column("id", Integer, primary_key=True),
+    # current version of dataset, if null, there is not a current version selected
+    Column("library_dataset_collection_association_id", Integer,
+        ForeignKey("library_dataset_collection_association.id", use_alter=True, name="library_dataset_collection_association_id_fk"),
+        nullable=True, index=True),
+    Column("folder_id", Integer, ForeignKey("library_folder.id"), index=True),
+    # not currently being used, but for possible future use
+    Column("order_id", Integer),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, default=now, onupdate=now),
+    # when not None/null this will supercede display in library (but not when imported into user's history?)
+    Column("name", TrimmedString(255), key="_name", index=True),
+    Column("deleted", Boolean, index=True, default=False),
+    Column("purged", Boolean, index=True, default=False))
+
 model.LibraryDatasetCollectionAssociation.table = Table(
     "library_dataset_collection_association", metadata,
     Column("id", Integer, primary_key=True),
@@ -2085,6 +2102,11 @@ mapper(model.LibraryFolder, model.LibraryFolder.table, properties=dict(
         order_by=asc(model.LibraryDataset.table.c._name),
         lazy=True,
         viewonly=True),
+    collections=relation(model.LibraryDatasetCollection,
+        primaryjoin=(model.LibraryDatasetCollection.table.c.folder_id == model.LibraryFolder.table.c.id),
+        order_by=asc(model.LibraryDatasetCollection.table.c._name),
+        lazy=True,
+        viewonly=True),
     active_datasets=relation(model.LibraryDataset,
         primaryjoin=(
             (model.LibraryDataset.table.c.folder_id == model.LibraryFolder.table.c.id)
@@ -2122,6 +2144,13 @@ mapper(model.LibraryDataset, model.LibraryDataset.table, properties=dict(
         ),
         viewonly=True,
         uselist=True)
+))
+
+mapper(model.LibraryDatasetCollection, model.LibraryDatasetCollection.table, properties=dict(
+    folder=relation(model.LibraryFolder),
+    library_dataset_collection_association=relation(model.LibraryDatasetCollectionAssociation,
+        foreign_keys=model.LibraryDatasetCollection.table.c.library_dataset_collection_association_id,
+        post_update=True),
 ))
 
 mapper(model.LibraryDatasetDatasetAssociation, model.LibraryDatasetDatasetAssociation.table, properties=dict(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -2097,14 +2097,22 @@ mapper(model.LibraryFolder, model.LibraryFolder.table, properties=dict(
         # Cant use eager loading on a self referential relationship."""
         lazy=True,
         viewonly=True),
-    datasets=relation(model.LibraryDataset,
-        primaryjoin=(model.LibraryDataset.table.c.folder_id == model.LibraryFolder.table.c.id),
-        order_by=asc(model.LibraryDataset.table.c._name),
-        lazy=True,
-        viewonly=True),
     collections=relation(model.LibraryDatasetCollection,
         primaryjoin=(model.LibraryDatasetCollection.table.c.folder_id == model.LibraryFolder.table.c.id),
         order_by=asc(model.LibraryDatasetCollection.table.c._name),
+        lazy=True,
+        viewonly=True),
+    active_collections=relation(model.LibraryDatasetCollection,
+        primaryjoin=(
+            (model.LibraryDatasetCollection.table.c.folder_id == model.LibraryFolder.table.c.id)
+            & (not_(model.LibraryDatasetCollection.table.c.deleted))
+        ),
+        order_by=asc(model.LibraryDatasetCollection.table.c._name),
+        lazy=True,
+        viewonly=True),
+    datasets=relation(model.LibraryDataset,
+        primaryjoin=(model.LibraryDataset.table.c.folder_id == model.LibraryFolder.table.c.id),
+        order_by=asc(model.LibraryDataset.table.c._name),
         lazy=True,
         viewonly=True),
     active_datasets=relation(model.LibraryDataset,

--- a/lib/galaxy/model/migrate/versions/0174_add_library_dataset_collection_table.py
+++ b/lib/galaxy/model/migrate/versions/0174_add_library_dataset_collection_table.py
@@ -1,0 +1,61 @@
+"""
+Migration script to add the library_dataset_collection table.
+"""
+
+import datetime
+import logging
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    Table
+)
+
+from galaxy.model.custom_types import (
+    TrimmedString
+)
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
+
+log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
+metadata = MetaData()
+
+LibraryDatasetCollection_table = Table(
+    "library_dataset_collection", metadata,
+    Column("id", Integer, primary_key=True),
+    Column("library_dataset_collection_association_id", Integer,
+        ForeignKey(
+            "library_dataset_collection_association.id",
+            use_alter=True,
+            name="library_dataset_collection_association_id_fk",
+        ),
+        nullable=True, index=True),
+    Column("folder_id", Integer, ForeignKey("library_folder.id"), index=True),
+    Column("order_id", Integer),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("name", TrimmedString(255), key="_name", index=True),
+    Column("deleted", Boolean, index=True, default=False),
+    Column("purged", Boolean, index=True, default=False))
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    create_table(LibraryDatasetCollection_table)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    drop_table(LibraryDatasetCollection_table)

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -216,9 +216,10 @@ class FolderContentsService(UsesLibraryMixinItems):
     and pydantic models to declare its parameters and return types.
     """
 
-    def __init__(self, app: StructuredApp, hda_manager: HDAManager, folder_manager: FolderManager):
+    def __init__(self, app: StructuredApp, hda_manager: HDAManager, hdca_manager: HDCAManager, folder_manager: FolderManager):
         self.app = app
         self.hda_manager = hda_manager
+        self.hdca_manager = hdca_manager
         self.folder_manager = folder_manager
 
     def get_object(self, trans, id, class_name, check_ownership=False, check_accessible=False, deleted=None):

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -26,9 +26,12 @@ FOLDER_TYPE_NAME = "folder"
 FILE_TYPE_NAME = "file"
 
 
-class FolderContentsAPIView(UsesLibraryMixinItems):
-    """
-    Interface/service object for interacting with folders contents providing a shared view for API controllers.
+# TODO: refactor and remove UsesLibraryMixinItems then move this class to lib/galaxy/managers/folder_contents.py
+class FolderContentsService(UsesLibraryMixinItems):
+    """Common interface/service logic for interactions with library folder contents in the context of the API.
+
+    Provides the logic of the actions invoked by API controllers and uses type definitions
+    and pydantic models to declare its parameters and return types.
     """
 
     def __init__(self, app: StructuredApp, hda_manager: HDAManager, folder_manager: FolderManager):
@@ -354,7 +357,7 @@ class FolderContentsController(BaseGalaxyAPIController):
     """
     Class controls retrieval, creation and updating of folder contents.
     """
-    view: FolderContentsAPIView = depends(FolderContentsAPIView)
+    service: FolderContentsService = depends(FolderContentsService)
 
     @expose_api_anonymous
     def index(self, trans, folder_id, limit=None, offset=None, search_text=None, **kwd):
@@ -393,7 +396,7 @@ class FolderContentsController(BaseGalaxyAPIController):
              InternalServerError
         """
         include_deleted = util.asbool(kwd.get('include_deleted', False))
-        return self.view.index(trans, folder_id, limit, offset, search_text, include_deleted)
+        return self.service.index(trans, folder_id, limit, offset, search_text, include_deleted)
 
     @expose_api
     def create(self, trans, encoded_folder_id, payload, **kwd):
@@ -423,4 +426,4 @@ class FolderContentsController(BaseGalaxyAPIController):
             InsufficientPermissionsException, ItemAccessibilityException,
             InternalServerError
         """
-        return self.view.create(trans, encoded_folder_id, payload)
+        return self.service.create(trans, encoded_folder_id, payload)

--- a/lib/galaxy/webapps/galaxy/api/folder_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/folder_contents.py
@@ -250,6 +250,13 @@ class CreateLibraryItemPayload(BaseModel):
         title="HDCA Encoded ID",
         description="The encoded identifier of the History Dataset Collection Association instance to add to the library.",
     )
+    collection_as_single_item: Optional[bool] = Field(
+        None,
+        title="Collection as single item",
+        description=(
+            "This will create the collection as a single item in the library instead of unpacking all the datasets."
+        ),
+    )
 
 
 # TODO: refactor and remove UsesLibraryMixinItems then move this class to lib/galaxy/managers/folder_contents.py
@@ -450,7 +457,9 @@ class FolderContentsService(UsesLibraryMixinItems):
                 return self._copy_hda_to_library_folder(trans, self.hda_manager, decoded_hda_id, encoded_folder_id_16, ldda_message)
             if from_hdca_id:
                 decoded_hdca_id = self._decode_id(from_hdca_id)
-                return self._copy_hdca_to_library_folder_single(trans, self.hdca_manager, decoded_hdca_id, encoded_folder_id_16)
+                if payload.collection_as_single_item:
+                    return self._copy_hdca_to_library_folder_single(trans, self.hdca_manager, decoded_hdca_id, encoded_folder_id_16)
+                return self._copy_hdca_to_library_folder(trans, self.hda_manager, decoded_hdca_id, encoded_folder_id_16, ldda_message)
         except Exception as exc:
             # TODO handle exceptions better within the mixins
             exc_message = util.unicodify(exc)

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -37,8 +37,20 @@ class FolderContentsApiTestCase(ApiTestCase):
     def test_create_hdca(self):
         contents = ["dataset01", "dataset02"]
         hdca_id = self._create_hdca_with_contents(name="Test Dataset Collection", contents=contents)
+        ldda_message = "Test message"
         data = {
             "from_hdca_id": hdca_id,
+            "ldda_message": ldda_message,
+        }
+        lddas = self._create_content_in_folder_with_payload(self.root_folder_id, data)
+        assert len(contents) == len(lddas)
+
+    def test_create_hdca_single_item(self):
+        contents = ["dataset01", "dataset02"]
+        hdca_id = self._create_hdca_with_contents(name="Test Dataset Collection Single", contents=contents)
+        data = {
+            "from_hdca_id": hdca_id,
+            "collection_as_single_item": True
         }
         ldca = self._create_content_in_folder_with_payload(self.root_folder_id, data)
         self._assert_has_keys(ldca, "name", "id", "element_count")
@@ -49,7 +61,7 @@ class FolderContentsApiTestCase(ApiTestCase):
 
         self._create_subfolder_in(folder_id)
         self._create_dataset_in_folder(folder_id)
-        self._create_dataset_collection_in_folder(folder_id)
+        self._create_dataset_collection_in_folder(folder_id, single_item=True)
 
         response = self._get(f"folders/{folder_id}/contents")
         self._assert_status_code_is(response, 200)
@@ -85,7 +97,7 @@ class FolderContentsApiTestCase(ApiTestCase):
 
         num_collections = 2
         for _ in range(num_collections):
-            self._create_dataset_collection_in_folder(folder_id)
+            self._create_dataset_collection_in_folder(folder_id, single_item=True)
 
         num_datasets = 5
         for _ in range(num_datasets):
@@ -234,11 +246,12 @@ class FolderContentsApiTestCase(ApiTestCase):
         ldda = self._create_content_in_folder_with_payload(folder_id, data)
         return ldda["id"]
 
-    def _create_dataset_collection_in_folder(self, folder_id: str, name: Optional[str] = None, num_items: int = 3) -> str:
+    def _create_dataset_collection_in_folder(self, folder_id: str, name: Optional[str] = None, num_items: int = 3, single_item: bool = False) -> str:
         contents = [f"dataset{index}" for index in range(num_items)]
         hdca_id = self._create_hdca_with_contents(name or "Test Dataset Collection", contents)
         data = {
             "from_hdca_id": hdca_id,
+            "collection_as_single_item": single_item
         }
         ldca = self._create_content_in_folder_with_payload(folder_id, data)
         return ldca["id"]


### PR DESCRIPTION
This is a very WIP, but I wanted to get some feedback to see if this is going in the right direction or I'm completely off-road here.

## What did you do? 

I basically tried to simulate what the Library API is doing right now with simple datasets, so I:
- Created a new `LibraryDatasetCollection` model to act as a proxy of an existing LDCA.
- Modified the HDCAManager and HDCASerializer to implement some required methods that were missing.
- Created a new `_copy_hdca_to_library_folder_single` method in the controller that will add a new `LibraryDatasetCollection` to the database and return the basic information:
  ````JSON
  {
      "id": "f2db41e1fa331b3e",
      "name": "ABCD Collection",
      "deleted": false,
      "can_manage": true,
      "create_time": "2021-04-08 11:52 AM",
      "update_time": "2021-04-08 11:52 AM",
      "type": "collection",
      "element_count": 4,
      "collection_type": "list"
  }
  ````
- The index action for the folder_contents API now returns in the `folder_contents` list three types of items, [folders, datasets, and collections](https://github.com/galaxyproject/galaxy/commit/9affdc4737b6f11f26eac88babf64aa5779b9785#diff-4d8a61dd287e53dffb1e6cc4fd5f8986674b61782a45b95ff85d43c4c08c5d68R176).
- I couldn't help to add pydantic models for the `FolderContentsService` inputs and outputs, this probably should have been part of the API modernization in a different PR but they usually help me better understand what is being returned by the API. Anyway, now it will be really easy to just add the FastAPI endpoints :)
- Updated and added some more cases to the API tests for collection items.

## Why did you make this change?

This is related to https://github.com/galaxyproject/galaxy/issues/11250 and somewhat a follow-up on https://github.com/galaxyproject/galaxy/pull/3559 but trying to add the collection as a single library item that will act as a special kind of folder, instead of importing all the contained datasets as individual items.

## Open questions / Feedback required

- I am not dealing with the permissions for collections right now [see this](https://github.com/galaxyproject/galaxy/commit/c48c0d95cd04095627ec07dd193b0b9c2adf20fb#diff-ba2f1698ef177fe3b44d3c46eaccd9dd343fae96d7d29d81bd6cbec90c253dc2R606-R607). What will be the best way to deal with them? Do I need to create something similar to `LibraryDatasetPermissions` and also for associations?
- <del>I have replaced the previous call in the API to add a new HDCA by unpacking the datasets with [the one that returns the LDCA](https://github.com/galaxyproject/galaxy/commit/9affdc4737b6f11f26eac88babf64aa5779b9785#diff-4d8a61dd287e53dffb1e6cc4fd5f8986674b61782a45b95ff85d43c4c08c5d68R433) but I didn't remove the previous implementation. Maybe is a good idea to add an optional bool parameter to [CreateLibraryItemPayload](https://github.com/galaxyproject/galaxy/commit/eb7a7e220f665a5295944076c1e53e4c0c848a23#diff-4d8a61dd287e53dffb1e6cc4fd5f8986674b61782a45b95ff85d43c4c08c5d68R234) that will call the old way of importing collections by default so there is no change for existing calls to the API that expect a list of datasets as return value.</del> Easier to do than to explain :) see https://github.com/galaxyproject/galaxy/pull/11806/commits/109264b8f47c3328e9c45132219140b109006fbf
- Any other information worth including in [CollectionItem](https://github.com/galaxyproject/galaxy/commit/9affdc4737b6f11f26eac88babf64aa5779b9785#diff-4d8a61dd287e53dffb1e6cc4fd5f8986674b61782a45b95ff85d43c4c08c5d68R155)?
- How to deal with the actual contents of the collection? Treat the library collection item like a read-only folder? What about the different types of collections?

## How to test the changes? 

- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Go to Data Libraries
  2. From inside a folder, choose `Datasets -> Import form History`
  3. Select a collection from your history
  4. The library folder will contain a new collection item instead of all the unpacked datasets.

## License

- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
Here is a preview of what is showing now without any changes in the client:
![image](https://user-images.githubusercontent.com/46503462/114033079-3a37c700-987d-11eb-895a-7af21694f2a5.png)
