### PR TITLE
Don't overwrite $GALAXY_MEMORY_MB if it's already set

### DIFF
--- a/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT.sh
+++ b/lib/galaxy/jobs/runners/util/job_script/MEMORY_STATEMENT.sh
@@ -1,8 +1,10 @@
-if [ -n "$SLURM_JOB_ID" ]; then
-    GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>memory_statement.log
-fi
-if [ -n "$SGE_HGR_h_vmem" ]; then
-    GALAXY_MEMORY_MB=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>memory_statement.log
+if [ -z "$GALAXY_MEMORY_MB" ]; then
+    if [ -n "$SLURM_JOB_ID" ]; then
+        GALAXY_MEMORY_MB=`scontrol -do show job "$SLURM_JOB_ID" | sed 's/.*\( \|^\)Mem=\([0-9][0-9]*\)\( \|$\).*/\2/p;d'` 2>memory_statement.log
+    fi
+    if [ -n "$SGE_HGR_h_vmem" ]; then
+        GALAXY_MEMORY_MB=`echo "$SGE_HGR_h_vmem" | sed 's/G$/ * 1024/' | bc | cut -d"." -f1` 2>memory_statement.log
+    fi
 fi
 
 if [ -z "$GALAXY_MEMORY_MB_PER_SLOT" -a -n "$GALAXY_MEMORY_MB" ]; then


### PR DESCRIPTION
## What did you do? 
- Don't overwrite $GALAXY_MEMORY_MB if it's already set


## Why did you make this change?
In #5880 and #5925 the memory statement was moved later in the job script so that 1. it would occur after `_galaxy_setup_environment` which might add the path to e.g. `scontrol` to `$PATH` and 2. it would occur after a `cd` to the working dir, since it writes a log file. Unfortunately this makes it impossible to override the detected `$GALAXY_MEMORY_MB` using the `env` feature in the job config, since those variables are set in `_galaxy_setup_environment`.

It is not super common but sometimes it's necessary to override this (and `$GALAXY_SLOTS`). In this case it's because the amount of memory available to the tool is actually slightly less than the total for the job assigned by the scheduler.

#6697 is also related but this does not solve that problem.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. set `env: [{name: GALAXY_MEMORY_MB, value: "123456"}]` in a Slurm or SGE environment in `job_conf.yml`
  2. Enable `env` job metrics plugin.
  3. Run a job through that environment.
  4. Verify value of `$GALAXY_MEMORY_MB`

I couldn't add a test for this since `$GALAXY_MEMORY_MB` is not set if you're not running jobs via Slurm or SGE. We could hack some test-specific logic into `MEMORY_STATEMENT.sh` though I suppose.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
