### PR TITLE
Incorporate changes from Pulsar's copy of galaxy.jobs.runners.util

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -18,6 +18,7 @@ import galaxy.jobs
 from galaxy import model
 from galaxy.job_execution.output_collect import default_exit_code_file, read_exit_code_from
 from galaxy.jobs.command_factory import build_command
+from galaxy.jobs.runners.util import runner_states
 from galaxy.jobs.runners.util.env import env_to_statement
 from galaxy.jobs.runners.util.job_script import (
     job_script,
@@ -36,7 +37,6 @@ from galaxy.util import (
     shrink_stream_by_size,
     unicodify,
 )
-from galaxy.util.bunch import Bunch
 from galaxy.util.custom_logging import get_logger
 from galaxy.util.monitors import Monitors
 from .state_handler_factory import build_state_handlers
@@ -548,15 +548,7 @@ class JobState:
     """
     Encapsulate state of jobs.
     """
-    runner_states = Bunch(
-        WALLTIME_REACHED='walltime_reached',
-        MEMORY_LIMIT_REACHED='memory_limit_reached',
-        JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER='Job output not returned from cluster',
-        UNKNOWN_ERROR='unknown_error',
-        GLOBAL_WALLTIME_REACHED='global_walltime_reached',
-        OUTPUT_SIZE_LIMIT='output_size_limit',
-        TOOL_DETECT_ERROR='tool_detected',  # job runner interaction worked fine but the tool indicated error
-    )
+    runner_states = runner_states
 
     def __init__(self, job_wrapper, job_destination):
         self.runner_state_handled = False

--- a/lib/galaxy/jobs/runners/util/__init__.py
+++ b/lib/galaxy/jobs/runners/util/__init__.py
@@ -3,8 +3,23 @@ This module and its submodules contains utilities for running external
 processes and interfacing with job managers. This module should contain
 functionality shared between Galaxy and the Pulsar.
 """
+from galaxy.util.bunch import Bunch
+
 from .kill import kill_pid
+
+
+runner_states = Bunch(
+    WALLTIME_REACHED='walltime_reached',
+    MEMORY_LIMIT_REACHED='memory_limit_reached',
+    JOB_OUTPUT_NOT_RETURNED_FROM_CLUSTER='Job output not returned from cluster',
+    UNKNOWN_ERROR='unknown_error',
+    GLOBAL_WALLTIME_REACHED='global_walltime_reached',
+    OUTPUT_SIZE_LIMIT='output_size_limit',
+    TOOL_DETECT_ERROR='tool_detected',  # job runner interaction worked fine but the tool indicated error
+)
+
 
 __all__ = (
     'kill_pid',
+    'runner_states',
 )

--- a/lib/galaxy/jobs/runners/util/__init__.py
+++ b/lib/galaxy/jobs/runners/util/__init__.py
@@ -4,7 +4,6 @@ processes and interfacing with job managers. This module should contain
 functionality shared between Galaxy and the Pulsar.
 """
 from galaxy.util.bunch import Bunch
-
 from .kill import kill_pid
 
 

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -3,7 +3,7 @@
 from logging import getLogger
 from os import path
 
-from galaxy.jobs import JobState
+from ... import runner_states
 from ..job import BaseJobExec, job_states
 
 log = getLogger(__name__)
@@ -99,7 +99,7 @@ class LSF(BaseJobExec):
         # Exited with exit code 143.
         for line in reason.splitlines():
             if "TERM_MEMLIMIT" in line:
-                return JobState.runner_states.MEMORY_LIMIT_REACHED
+                return runner_states.MEMORY_LIMIT_REACHED
         return None
 
     def _get_job_state(self, state):

--- a/lib/galaxy/jobs/runners/util/cli/job/lsf.py
+++ b/lib/galaxy/jobs/runners/util/cli/job/lsf.py
@@ -3,8 +3,8 @@
 from logging import getLogger
 from os import path
 
-from ... import runner_states
 from ..job import BaseJobExec, job_states
+from ... import runner_states
 
 log = getLogger(__name__)
 

--- a/lib/galaxy/jobs/runners/util/condor/__init__.py
+++ b/lib/galaxy/jobs/runners/util/condor/__init__.py
@@ -26,11 +26,12 @@ SUBMIT_PARAM_PREFIX = "submit_"
 
 def submission_params(prefix=SUBMIT_PARAM_PREFIX, **kwds):
     submission_params = {}
+    prefix_len = len(prefix)
     for key in kwds:
         value = kwds[key]
         key = key.lower()
         if key.startswith(prefix):
-            condor_key = key[len(prefix):]
+            condor_key = key[prefix_len:]
             submission_params[condor_key] = value
     return submission_params
 
@@ -73,16 +74,17 @@ def condor_submit(submit_file):
     the submission or return None and a reason for the failure.
     """
     external_id = None
+    failure_message = None
     try:
-        message = commands.execute(('condor_submit', submit_file))
+        condor_message = commands.execute(('condor_submit', submit_file))
     except commands.CommandLineException as e:
-        message = unicodify(e)
+        failure_message = unicodify(e)
     else:
         try:
-            external_id = parse_external_id(message, type='condor')
+            external_id = parse_external_id(condor_message, type='condor')
         except Exception:
-            message = PROBLEM_PARSING_EXTERNAL_ID
-    return external_id, message
+            failure_message = f"{PROBLEM_PARSING_EXTERNAL_ID}: {condor_message}"
+    return external_id, failure_message
 
 
 def condor_stop(external_id):


### PR DESCRIPTION
## What did you do? 
- A copy of galaxy.jobs.runners.util exists at pulsar.managers.util, this brings in changes that were made on the Pulsar side but not the Galaxy side


## Why did you make this change?
Step 1 in making a package containing `galaxy.jobs.runners.util` that Pulsar can require rather than needing to make this periodic copy and deal with manual reverse merges.

xref: galaxyproject/pulsar#177 galaxyproject/pulsar#213 galaxyproject/pulsar#229


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
