### PR TITLE
fixed distracting error output in jest unit test

### DIFF
--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -1,7 +1,8 @@
 import Vuex from "vuex";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { mount, createLocalVue } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
 import JobInformation from "./JobInformation";
 import datasetResponse from "components/DatasetInformation/testData/datasetResponse";
 import jobResponse from "./testData/jobInformationResponse.json";
@@ -13,8 +14,7 @@ jest.mock("app");
 
 const JOB_ID = "test_id";
 
-const localVue = createLocalVue();
-localVue.use(Vuex);
+const localVue = getLocalVue();
 
 const jobStore = new Vuex.Store({
     plugins: [createCache()],


### PR DESCRIPTION
## What did you do? 
- Fixed an existing unit test that was merged into dev


## Why did you make this change?
Existing test was not using the proper localVue creation helper, resulted in a bunch of warnings in the test log that were apparently ignored. The warnings themselves aren't a big deal, but the fact that they're showing means the test wasn't running in the standard Vue plugin setup.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
