### PR TITLE
do not chown pasted urls

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -56,6 +56,9 @@ def stream_url_to_file(path, file_sources=None):
         file_source_path.file_source.realize_to(file_source_path.path, temp_name)
         return temp_name
     else:
+        if 'file://' in path:
+            # This shouldn't happen, but seems like a reasonable safeguard to prevent exposing system secrets
+            raise Exception(f"stream_url_to_file received file:// URL '{path}', this is not allowed")
         page = urllib.request.urlopen(path)  # page will be .close()ed in stream_to_file
         temp_name = stream_to_file(page, prefix=prefix, source_encoding=util.get_charset_from_http_headers(page.headers))
         return temp_name

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -58,7 +58,7 @@ def stream_url_to_file(path, file_sources=None):
     else:
         if 'file://' in path:
             # This shouldn't happen, but seems like a reasonable safeguard to prevent exposing system secrets
-            raise Exception(f"stream_url_to_file received file:// URL '{path}', this is not allowed")
+            raise ValueError(f"stream_url_to_file received file:// URL '{path}', this is not allowed")
         page = urllib.request.urlopen(path)  # page will be .close()ed in stream_to_file
         temp_name = stream_to_file(page, prefix=prefix, source_encoding=util.get_charset_from_http_headers(page.headers))
         return temp_name

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -56,9 +56,6 @@ def stream_url_to_file(path, file_sources=None):
         file_source_path.file_source.realize_to(file_source_path.path, temp_name)
         return temp_name
     else:
-        if 'file://' in path:
-            # This shouldn't happen, but seems like a reasonable safeguard to prevent exposing system secrets
-            raise ValueError(f"stream_url_to_file received file:// URL '{path}', this is not allowed")
         page = urllib.request.urlopen(path)  # page will be .close()ed in stream_to_file
         temp_name = stream_to_file(page, prefix=prefix, source_encoding=util.get_charset_from_http_headers(page.headers))
         return temp_name

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -376,7 +376,7 @@ def create_paramfile(trans, uploaded_datasets):
             # TODO: This will have to change when we start bundling inputs.
             # Also, in_place above causes the file to be left behind since the
             # user cannot remove it unless the parent directory is writable.
-            if link_data_only == 'copy_files' and trans.user and trans.app.config.external_chown_script:
+            if link_data_only == 'copy_files' and trans.user and trans.app.config.external_chown_script and not (uploaded_dataset.path.startswith("http://") or uploaded_dataset.path.startswith("https://") or uploaded_dataset.path.startswith("ftp://")):
                 external_chown(uploaded_dataset.path,
                                trans.user.system_user_pwent(trans.app.config.real_system_username),
                                trans.app.config.external_chown_script, description="uploaded file")

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -16,7 +16,10 @@ from galaxy.exceptions import (
     RequestParameterInvalidException,
 )
 from galaxy.model import tags
-from galaxy.util import unicodify
+from galaxy.util import (
+    is_url,
+    unicodify
+)
 from galaxy.util.path import external_chown
 
 log = logging.getLogger(__name__)
@@ -376,7 +379,7 @@ def create_paramfile(trans, uploaded_datasets):
             # TODO: This will have to change when we start bundling inputs.
             # Also, in_place above causes the file to be left behind since the
             # user cannot remove it unless the parent directory is writable.
-            if link_data_only == 'copy_files' and trans.user and trans.app.config.external_chown_script and not (uploaded_dataset.path.startswith("http://") or uploaded_dataset.path.startswith("https://") or uploaded_dataset.path.startswith("ftp://")):
+            if link_data_only == 'copy_files' and trans.user and trans.app.config.external_chown_script and not is_url(uploaded_dataset.path):
                 external_chown(uploaded_dataset.path,
                                trans.user.system_user_pwent(trans.app.config.real_system_username),
                                trans.app.config.external_chown_script, description="uploaded file")

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1627,16 +1627,19 @@ def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, back
     return response.text
 
 
-def is_url(uri):
+def is_url(uri, allow_list=None):
     """
-    check if uri is (most likely) an url
-
+    check if uri is (most likely) an url, more precisely the function checks
+    if the uri starts with a protocol from the allow list (defaults to
+    "http://", "https://", "ftp://")
     >>> is_url('https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
     True
     >>> is_url('/some/path')
     False
     """
-    return uri.find('://') != -1
+    if allow_list is None:
+        allow_list = ["http://", "https://", "ftp://"]
+    return any([uri.startswith(_) for _ in allow_list])
 
 
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1630,9 +1630,9 @@ def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, back
 def is_url(uri, allow_list=None):
     """
     check if uri is (most likely) an url, more precisely the function checks
-    if the uri contains a protocol from the allow list (defaults to "http://",
+    if the uri starts with a protocol from the allow list (defaults to "http://",
     "https://", "ftp://")
-    >>> is_url(' https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
+    >>> is_url('https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
     True
     >>> is_url('file:///some/path')
     False
@@ -1641,7 +1641,7 @@ def is_url(uri, allow_list=None):
     """
     if allow_list is None:
         allow_list = ["http://", "https://", "ftp://"]
-    return any([uri.find(_) != -1 for _ in allow_list])
+    return any([uri.startswith(_) for _ in allow_list])
 
 
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1629,8 +1629,8 @@ def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, back
 
 def is_url(uri, allow_list=None):
     """
-    check if uri is (most likely) an url, more precisely the function checks
-    if the uri starts with a protocol from the allow list (defaults to "http://",
+    Check if uri is (most likely) an URL, more precisely the function checks
+    if uri starts with a scheme from the allow list (defaults to "http://",
     "https://", "ftp://")
     >>> is_url('https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
     True
@@ -1640,8 +1640,8 @@ def is_url(uri, allow_list=None):
     False
     """
     if allow_list is None:
-        allow_list = ["http://", "https://", "ftp://"]
-    return any([uri.startswith(_) for _ in allow_list])
+        allow_list = ("http://", "https://", "ftp://")
+    return any(uri.startswith(scheme) for scheme in allow_list)
 
 
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1627,6 +1627,18 @@ def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, back
     return response.text
 
 
+def is_url(uri):
+    """
+    check if uri is (most likely) an url
+
+    >>> is_url('https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
+    True
+    >>> is_url('/some/path')
+    False
+    """
+    return uri.find('://') != -1
+
+
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):
     """Download a URL to a file in chunks."""
     with requests.get(url, timeout=timeout, stream=True) as r, open(dest_file_path, 'wb') as f:

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1630,16 +1630,18 @@ def url_get(base_url, auth=None, pathspec=None, params=None, max_retries=5, back
 def is_url(uri, allow_list=None):
     """
     check if uri is (most likely) an url, more precisely the function checks
-    if the uri starts with a protocol from the allow list (defaults to
-    "http://", "https://", "ftp://")
-    >>> is_url('https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
+    if the uri contains a protocol from the allow list (defaults to "http://",
+    "https://", "ftp://")
+    >>> is_url(' https://zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed')
     True
+    >>> is_url('file:///some/path')
+    False
     >>> is_url('/some/path')
     False
     """
     if allow_list is None:
         allow_list = ["http://", "https://", "ftp://"]
-    return any([uri.startswith(_) for _ in allow_list])
+    return any([uri.find(_) != -1 for _ in allow_list])
 
 
 def download_to_file(url, dest_file_path, timeout=30, chunk_size=2 ** 20):

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -777,6 +777,11 @@ class ToolsUploadTestCase(ApiTestCase):
         history_id, new_dataset = self._upload('https://usegalaxy.org/api/version')
         self.dataset_populator.get_history_dataset_details(history_id, dataset_id=new_dataset["id"], assert_ok=True)
 
+    @skip_if_site_down("https://usegalaxy.org")
+    def test_upload_from_valid_url_spaces(self):
+        history_id, new_dataset = self._upload('  https://usegalaxy.org/api/version  ')
+        self.dataset_populator.get_history_dataset_details(history_id, dataset_id=new_dataset["id"], assert_ok=True)
+
     def test_upload_and_validate_invalid(self):
         path = TestDataResolver().get_filename("1.fastqsanger")
         with open(path, "rb") as fh:

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -16,6 +16,7 @@ from galaxy.datatypes.registry import Registry
 from galaxy.datatypes.upload_util import handle_upload, UploadProblemException
 from galaxy.util import (
     bunch,
+    is_url,
     safe_makedirs,
     unicodify
 )
@@ -196,24 +197,24 @@ def add_composite_file(dataset, registry, output_path, files_path):
         datatype = registry.get_datatype_by_extension(dataset.file_type)
 
     def to_path(path_or_url):
-        is_url = path_or_url.find('://') != -1  # todo fixme
-        if is_url:
+        isa_url = is_url(path_or_url)
+        if isa_url:
             try:
                 temp_name = sniff.stream_url_to_file(path_or_url, file_sources=get_file_sources())
             except Exception as e:
                 raise UploadProblemException('Unable to fetch %s\n%s' % (path_or_url, unicodify(e)))
 
-            return temp_name, is_url
+            return temp_name, isa_url
 
-        return path_or_url, is_url
+        return path_or_url, isa_url
 
     def make_files_path():
         safe_makedirs(files_path)
 
     def stage_file(name, composite_file_path, is_binary=False):
         dp = composite_file_path['path']
-        path, is_url = to_path(dp)
-        if is_url:
+        path, isa_url = to_path(dp)
+        if isa_url:
             dataset.path = path
             dp = path
 

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -198,9 +198,10 @@ def add_composite_file(dataset, registry, output_path, files_path):
 
     def to_path(path_or_url):
         isa_url = is_url(path_or_url)
-        if isa_url:
+        file_sources = get_file_sources()
+        if isa_url or file_sources and file_sources.looks_like_uri(path_or_url):
             try:
-                temp_name = sniff.stream_url_to_file(path_or_url, file_sources=get_file_sources())
+                temp_name = sniff.stream_url_to_file(path_or_url, file_sources=file_sources)
             except Exception as e:
                 raise UploadProblemException('Unable to fetch %s\n%s' % (path_or_url, unicodify(e)))
 


### PR DESCRIPTION
## What did you do? 

Do not chown pasted URLs. Affects only real user setups.

## Why did you make this change?

```
Traceback (most recent call last):
  File "lib/galaxy/tools/__init__.py", line 1657, in handle_single_execution
    flush_job=flush_job,
  File "lib/galaxy/tools/__init__.py", line 1745, in execute
    return self.tool_action.execute(self, trans, incoming=incoming, set_output_hid=set_output_hid, history=history, **kwargs)
  File "lib/galaxy/tools/actions/upload.py", line 29, in execute
    rval = self._setup_job(tool, trans, incoming, dataset_upload_inputs, history)
  File "lib/galaxy/tools/actions/upload.py", line 52, in _setup_job
    json_file_path = upload_common.create_paramfile(trans, uploaded_datasets)
  File "lib/galaxy/tools/actions/upload_common.py", line 384, in create_paramfile
    trans.app.config.external_chown_script, description="uploaded file")
  File "lib/galaxy/util/path/__init__.py", line 362, in external_chown
    if Path(path).owner() == pwent[0]:
  File "/software/easybuild-broadwell/software/MPI/GCC/7.3.0-2.30/OpenMPI/3.1.1/Python/3.6.6/lib/python3.6/pathlib.py", line 1163, in owner
    return pwd.getpwuid(self.stat().st_uid).pw_name
  File "/software/easybuild-broadwell/software/MPI/GCC/7.3.0-2.30/OpenMPI/3.1.1/Python/3.6.6/lib/python3.6/pathlib.py", line 1156, in stat
    return self._accessor.stat(self)
  File "/software/easybuild-broadwell/software/MPI/GCC/7.3.0-2.30/OpenMPI/3.1.1/Python/3.6.6/lib/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
FileNotFoundError: [Errno 2] No such file or directory: 'https:/zenodo.org/record/4104428/files/UCSC-hg38-chr22-Coding-Exons.bed'
```


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. have a real user setup
  2. paste an URL in the upload form

I tested this on my 20.09 and 21.01 instance.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
