### PR TITLE
Make k8s container 39 MB smaller by using vim-tiny

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -136,7 +136,8 @@ RUN set -xe; \
         locales \
         libpython3.6 \
         python3-virtualenv \
-        vim \
+        vim-tiny \
+        nano \
         curl \
     && locale-gen $LANG && update-locale LANG=$LANG \
     && apt-get autoremove -y && apt-get clean \

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -137,7 +137,7 @@ RUN set -xe; \
         libpython3.6 \
         python3-virtualenv \
         vim-tiny \
-        nano \
+        nano-tiny \
         curl \
     && locale-gen $LANG && update-locale LANG=$LANG \
     && apt-get autoremove -y && apt-get clean \


### PR DESCRIPTION
## What did you do? 
- Replace vim with vim-tiny
- Add ~nano~ nano-tiny

## Why did you make this change?
A text editor is useful for on the fly changes and debugging. Full-fledged vim is not necessary in the container. Nano is a useful alternative for people who use a US international keyboard instead of an [ADM-3A terminal, which comes with an intuitive vim keyboard](https://en.wikipedia.org/wiki/ADM-3A#Legacy). 

This makes the image 39 MB smaller. So in docker image terms, that is pretty great. 

```
galaxy/galaxy-k8s     before              23337ecfcf23        32 minutes ago      889MB
galaxy/galaxy-k8s     after               0a5bce934752        20 minutes ago      850MB
```

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Since vim is not called by the Galaxy process, there should be no bugs whatsoever. Unless Galaxy has some vimscript dependencies that I do not know about. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
