### PR TITLE
Fixed uploader link on tool list and legacy empty history message

### DIFF
--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -50,7 +50,7 @@
 <script>
 import ToolSection from "./Common/ToolSection";
 import ToolSearch from "./Common/ToolSearch";
-import { UploadButton } from "components/Upload";
+import { UploadButton, openGlobalUploadModal } from "components/Upload";
 import FavoritesButton from "./Buttons/FavoritesButton";
 import { filterToolSections, filterTools } from "./utilities";
 import { getGalaxyInstance } from "app";
@@ -145,7 +145,7 @@ export default {
         onOpen(tool, evt) {
             if (tool.id === "upload1") {
                 evt.preventDefault();
-                this.eventHub.$emit("upload:open");
+                openGlobalUploadModal();
             } else if (tool.form_style === "regular") {
                 evt.preventDefault();
                 const Galaxy = getGalaxyInstance();

--- a/client/src/mvc/history/history-view-edit-current.js
+++ b/client/src/mvc/history/history-view-edit-current.js
@@ -5,7 +5,7 @@ import { getGalaxyInstance } from "app";
 import HISTORY_VIEW_EDIT from "mvc/history/history-view-edit";
 import BASE_MVC from "mvc/base-mvc";
 import _l from "utils/localization";
-import { eventHub } from "components/plugins/eventHub";
+import { openGlobalUploadModal } from "components/Upload";
 
 // ============================================================================
 /** session storage for history panel preferences (and to maintain state)
@@ -338,7 +338,7 @@ var CurrentHistoryView = _super.extend(
         events: _.extend(_.clone(_super.prototype.events), {
             // the two links in the empty message
             "click .uploader-link": function (ev) {
-                eventHub.$emit("upload:open");
+                openGlobalUploadModal();
             },
             "click .get-data-link": function (ev) {
                 var $toolMenu = $(".toolMenuContainer");


### PR DESCRIPTION
## What did you do? 
- Fixed broken links on tool listing and empty history message. Links were supplied to open the upload dialog that no longer worked in the wake of upload box changes a few weeks back.


## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

Bug I found.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Open the tool listing on the left, click "Get Data", try to click on the "Upload File from your computer" tool
  2. Make a new empty history, try to click on the "load your own data" link in the empty history message in the legacy history view.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes

<img width="148" alt="upload-link" src="https://user-images.githubusercontent.com/290292/114592549-e98aea00-9c3f-11eb-9707-64608b1baa6c.png">

<img width="141" alt="load-own" src="https://user-images.githubusercontent.com/290292/114592584-f3ace880-9c3f-11eb-8509-a2fb02aa6d5a.png">
