### PR TITLE
Add support for the Relion STAR data format

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -317,6 +317,7 @@
     <datatype extension="tck" type="galaxy.datatypes.images:Tck" mimetype="application/octet-stream" display_in_upload="true" />
     <datatype extension="trk" type="galaxy.datatypes.images:Trk" mimetype="application/octet-stream" display_in_upload="true" />
     <datatype extension="mrc" type="galaxy.datatypes.images:Mrc2014" mimetype="application/octet-stream" display_in_upload="true" />
+    <datatype extension="star" type="galaxy.datatypes.images:Star" display_in_upload="true" />
     <datatype extension="peff" type="galaxy.datatypes.proteomics:PEFF" display_in_upload="true" />
     <!-- End Proteomics Datatypes -->
     <!-- FlowCytometry -->
@@ -1079,6 +1080,7 @@
     <sniffer type="galaxy.datatypes.images:Trk" />
     <sniffer type="galaxy.datatypes.images:Nifti1" />
     <sniffer type="galaxy.datatypes.images:Nifti2" />
+    <sniffer type="galaxy.datatypes.images:Star" />
     <sniffer type="galaxy.datatypes.media:Wav"/>
     <sniffer type="galaxy.datatypes.media:Mkv"/>
     <sniffer type="galaxy.datatypes.media:Mp3"/>

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -528,6 +528,47 @@ class Gifti(GenericXml):
         return False
 
 
+class Star(data.Text):
+    """Base format class for Relion STAR (Self-defining
+    Text Archiving and Retrieval) image files.
+    https://relion.readthedocs.io/en/latest/Reference/Conventions.html"""
+    file_ext = "star"
+
+    def set_peek(self, dataset, is_multi_byte=False):
+        """Set the peek and blurb text"""
+        if not dataset.dataset.purged:
+            dataset.peek = data.get_file_peek(dataset.file_name)
+            dataset.blurb = 'Relion STAR data'
+        else:
+            dataset.peek = 'file does not exist'
+            dataset.blurb = 'file purged from disk'
+
+    def sniff(self, filename):
+        """Each file must have one or more data blocks.
+        The start of a data block is defined by the keyword
+        "data_" followed by an optional string for
+        identification (e.g., "data_images").  All text
+        before the first "data_" keyword are comments
+
+        >>> from galaxy.datatypes.sniff import get_test_fname
+        >>> fname = get_test_fname('1.star')
+        >>> Star().sniff(fname)
+        True
+        >>> fname = get_test_fname('interval.interval')
+        >>> Star().sniff(fname)
+        False
+        """
+        with open(filename) as fh:
+            for i, line in enumerate(fh):
+                if line.startswith("data_"):
+                    return True
+                if i == 1000:
+                    # Assume less than 1000 lines
+                    # before the first data_ block.
+                    return False
+        return False
+
+
 class Html(HtmlFromText):
     """Deprecated class. This class should not be used anymore, but the galaxy.datatypes.text:Html one.
     This is for backwards compatibilities only."""

--- a/lib/galaxy/datatypes/test/1.star
+++ b/lib/galaxy/datatypes/test/1.star
@@ -1,0 +1,15 @@
+
+# version 30001
+
+data_optics
+
+loop_
+_rlnOpticsGroupName #1 
+_rlnOpticsGroup #2 
+_rlnMicrographPixelSize #3 
+_rlnMicrographOriginalPixelSize #4 
+_rlnVoltage #5 
+_rlnSphericalAberration #6 
+_rlnAmplitudeContrast #7 
+opticsGroup1            1     0.890000     0.890000   300.000000     0.010000     0.100000
+


### PR DESCRIPTION
## What did you do? 
- Added support for the Relion STAR image format - https://relion.readthedocs.io/en/latest/Reference/Conventions.html
- 


## Why did you make this change?
Enable Galaxy analyses to work with Relion STAR data files.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
