### PR TITLE
[21.01]Join QueueWorker thread

### DIFF
--- a/lib/galaxy/queue_worker.py
+++ b/lib/galaxy/queue_worker.py
@@ -410,3 +410,4 @@ class GalaxyQueueWorker(ConsumerProducerMixin, threading.Thread):
 
     def shutdown(self):
         self.should_stop = True
+        self.join()


### PR DESCRIPTION
## What did you do? 
- Stop kombu `ConsumerProducerMixin` thread on Application shutdown


## Why did you make this change?
Prevents a ugly traceback when a test database is deleted while the thread still runs,
and we're supposed to do that based on https://docs.celeryproject.org/projects/kombu/en/stable/reference/kombu.mixins.html,
under should_stop:
"When this is set to true the consumer should stop consuming and return, so that it can be joined if it is the implementation of a thread."

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Run any test and verify there's no kombu related traceback.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
