### PR TITLE
[21.01] Patch to click the button which should be more stable

### DIFF
--- a/config/plugins/webhooks/gtn/script.js
+++ b/config/plugins/webhooks/gtn/script.js
@@ -129,7 +129,7 @@ function addIframe() {
                     tool_id = $(target).data("tool");
 
                     if (tool_id === "upload1" || tool_id === "upload") {
-                        Galaxy.upload.show();
+                        document.getElementById("tool-panel-upload-button").click();
                     } else {
                         Galaxy.router.push(`?tool_id=${tool_id}`);
                     }


### PR DESCRIPTION
## What did you do? 
- Replaced the now removed `Galaxy.upload.show` with clicking on the button


## Why did you make this change?
This seems to have broken in 21.01, making the 'upload' button in tutorials accessed through this webhook non-functional

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. activate the webhook
  2. setup proxying (there's a link at the bottom that appears with documentation on the nginx configuration needed) / setup nginx / etc.
  3. activate webhook
  4. browse to a tutorial that uses the feature (e.g. assembly → the MRSA tutorials)
  5. Click on the blue 'import' button during the first hands-on box
  6. It should open the upload dialogue

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
