### PR TITLE
Fix attribute error in converter tests

### DIFF
--- a/lib/galaxy/web_stack/__init__.py
+++ b/lib/galaxy/web_stack/__init__.py
@@ -105,7 +105,6 @@ class ApplicationStack:
                 self._preferred_handler_assignment_method = HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED
             else:
                 log.debug("Database does not support WITH FOR UPDATE statement, cannot use DB-SKIP-LOCKED handler assignment")
-                self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED)
                 self._preferred_handler_assignment_method = HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION
         return self._preferred_handler_assignment_method
 


### PR DESCRIPTION
## What did you do? 
Fix
```
2021-04-14 15:38:37,004 ERROR [galaxy.jobs] Problem parsing the XML in file /tmp/tmpniixo8f1/job_conf.xml, please correct the indicated portion of the file and restart Galaxy. 'WeblessApplicationStack' object has no attribute 'UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS'
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/__init__.py", line 361, in __init__
    self._configure_from_dict(job_config_dict)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/jobs/__init__.py", line 400, in _configure_from_dict
    self._set_default_handler_assignment_methods()
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/web_stack/handlers.py", line 149, in _set_default_handler_assignment_methods
    self.handler_assignment_methods = [self.app.application_stack.get_preferred_handler_assignment_method()]
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/web_stack/__init__.py", line 108, in get_preferred_handler_assignment_method
    self.UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS.add(HANDLER_ASSIGNMENT_METHODS.DB_SKIP_LOCKED)
AttributeError: 'WeblessApplicationStack' object has no attribute 'UNSUPPORTED_HANDLER_ASSIGNMENT_METHODS'
```
Adding DB-SKIP-LOCKED to the unsupported handler methods is not necessary since the workflow scheduler will call the same method if not assign-with is configured.

## Why did you make this change?
Fixes converter tests. Introduced in https://github.com/galaxyproject/galaxy/pull/11792

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
