### PR TITLE
Separate tests for "remote" and "remote + extended" metadata.

### DIFF
--- a/test/integration/test_pulsar_embedded_extended_metadata.py
+++ b/test/integration/test_pulsar_embedded_extended_metadata.py
@@ -8,7 +8,7 @@ SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
 EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_metadata_job_conf.yml")
 
 
-class EmbeddedMetadataPulsarIntegrationInstance(integration_util.IntegrationInstance):
+class EmbeddedAndExtendedMetadataPulsarIntegrationInstance(integration_util.IntegrationInstance):
     """Describe a Galaxy test instance with embedded pulsar configured."""
 
     framework_tool_and_types = True
@@ -21,7 +21,7 @@ class EmbeddedMetadataPulsarIntegrationInstance(integration_util.IntegrationInst
         config['retry_metadata_internally'] = False
 
 
-instance = integration_util.integration_module_instance(EmbeddedMetadataPulsarIntegrationInstance)
+instance = integration_util.integration_module_instance(EmbeddedAndExtendedMetadataPulsarIntegrationInstance)
 
 test_tools = integration_util.integration_tool_runner(
     [

--- a/test/integration/test_pulsar_embedded_remote_metadata.py
+++ b/test/integration/test_pulsar_embedded_remote_metadata.py
@@ -1,0 +1,31 @@
+"""Integration tests for the Pulsar embedded runner with remote metadata."""
+
+import os
+
+from galaxy_test.driver import integration_util
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_metadata_job_conf.yml")
+
+
+class EmbeddedMetadataPulsarIntegrationInstance(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with embedded pulsar configured."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
+        config['object_store_store_by'] = 'uuid'
+        config['retry_metadata_internally'] = False
+
+
+instance = integration_util.integration_module_instance(EmbeddedMetadataPulsarIntegrationInstance)
+
+test_tools = integration_util.integration_tool_runner(
+    [
+        "simple_constructs",
+        "metadata_bam",
+        # "job_properties",  # https://github.com/galaxyproject/galaxy/issues/11813
+    ]
+)


### PR DESCRIPTION
## What did you do? 

Duplicate and differentiate integration tests for pulsar embedded metadata so that we're testing both "remote" metadata and "remote extended" metadata scenarios. 

## Why did you make this change?

We should be testing both these scenarios and ensure they both continue to work.

## How to test the changes? 
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
