### PR TITLE
Restore triggers dropped in #10821

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -49,7 +49,7 @@ from galaxy.model.custom_types import (
 from galaxy.model.orm.engine_factory import build_engine
 from galaxy.model.orm.now import now
 from galaxy.model.security import GalaxyRBACAgent
-from galaxy.model.triggers import drop_timestamp_triggers
+from galaxy.model.triggers import install_timestamp_triggers
 from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
 from galaxy.model.view.utils import install_views
 
@@ -2912,11 +2912,8 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     # Create tables if needed
     if create_tables:
         metadata.create_all()
+        install_timestamp_triggers(engine)
         install_views(engine)
-        # metadata.engine.commit()
-    else:
-        # TODO: replace this in 21.01 with a migration.
-        drop_timestamp_triggers(engine)
 
     result.create_tables = create_tables
     # load local galaxy security policy

--- a/lib/galaxy/model/migrate/versions/0174_readd_update_time_triggers.py
+++ b/lib/galaxy/model/migrate/versions/0174_readd_update_time_triggers.py
@@ -1,0 +1,28 @@
+"""
+Re-add triggers to update history.update_time when contents are changed.
+"""
+
+import logging
+
+from sqlalchemy import MetaData
+
+from galaxy.model.triggers import (
+    drop_timestamp_triggers,
+    install_timestamp_triggers,
+)
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+    install_timestamp_triggers(migrate_engine)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+    drop_timestamp_triggers(migrate_engine)

--- a/lib/galaxy/model/triggers.py
+++ b/lib/galaxy/model/triggers.py
@@ -71,7 +71,9 @@ def get_timestamp_install_sql(variant):
 
 
 def get_timestamp_drop_sql(variant):
-    """generate a list of statements to drop the timestammp update triggers"""
+    """
+    Generate a list of statements to drop the timestamp update triggers
+    """
 
     sql = []
 
@@ -79,8 +81,9 @@ def get_timestamp_drop_sql(variant):
         sql.append("DROP FUNCTION IF EXISTS update_history_update_time() CASCADE;")
     else:
         for operation in ['INSERT', 'UPDATE', 'DELETE']:
-            sql.append(build_drop_trigger(operation, 'history_dataset_association'))
-            sql.append(build_drop_trigger(operation, 'history_dataset_collection_association'))
+            for when in ['BEFORE', 'AFTER']:
+                sql.append(build_drop_trigger(operation, 'history_dataset_association', when))
+                sql.append(build_drop_trigger(operation, 'history_dataset_collection_association', when))
 
     return sql
 

--- a/lib/galaxy/model/triggers.py
+++ b/lib/galaxy/model/triggers.py
@@ -6,13 +6,17 @@ from sqlalchemy import DDL
 
 
 def install_timestamp_triggers(engine):
-    """Install update_time propagation triggers for history data tables"""
+    """
+    Install update_time propagation triggers for history table
+    """
     statements = get_timestamp_install_sql(engine.name)
     execute_statements(engine, statements)
 
 
 def drop_timestamp_triggers(engine):
-    """Remove update_time propagation triggers for historydata tables"""
+    """
+    Remove update_time propagation triggers for history table
+    """
     statements = get_timestamp_drop_sql(engine.name)
     execute_statements(engine, statements)
 
@@ -24,12 +28,14 @@ def execute_statements(engine, statements):
 
 
 def get_timestamp_install_sql(variant):
-    """Generate a list of sql statements for insalllation of timetamp triggers"""
+    """
+    Generate a list of SQL statements for installation of timestamp triggers
+    """
 
     sql = get_timestamp_drop_sql(variant)
 
     if 'postgres' in variant:
-        # Postgres has a separate function definition and a trigger
+        # PostgreSQL has a separate function definition and a trigger
         # assignment. The first two statements the functions, and
         # the later assign those functions to triggers on tables
 
@@ -47,13 +53,19 @@ def get_timestamp_install_sql(variant):
 
             # change hda -> update history
             sql.append(build_timestamp_trigger(
-                operation, 'history_dataset_association', 'history',
-                source_key='history_id'))
+                operation,
+                'history_dataset_association',
+                'history',
+                source_key='history_id'
+            ))
 
             # change hdca -> update history
             sql.append(build_timestamp_trigger(
-                operation, 'history_dataset_collection_association', 'history',
-                source_key='history_id'))
+                operation,
+                'history_dataset_collection_association',
+                'history',
+                source_key='history_id'
+            ))
 
     return sql
 
@@ -73,89 +85,84 @@ def get_timestamp_drop_sql(variant):
     return sql
 
 
-def build_pg_timestamp_fn(fn_name, table_name, local_key='id', source_key='id', stamp_column='update_time'):
-    """Generates a postgres history update timestamp function"""
+def build_pg_timestamp_fn(fn_name, target_table, source_key, target_key='id'):
+    """Generates a PostgreSQL history update timestamp function"""
 
-    sql = """
+    return f"""
         CREATE OR REPLACE FUNCTION {fn_name}()
             RETURNS trigger
             LANGUAGE 'plpgsql'
         AS $BODY$
             BEGIN
                 IF (TG_OP = 'DELETE') THEN
-                    UPDATE {table_name}
-                    SET {stamp_column} = (now() at time zone 'utc')
-                    WHERE {local_key} = OLD.{source_key};
+                    UPDATE {target_table}
+                    SET update_time = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                    WHERE {target_key} = OLD.{source_key};
                     RETURN OLD;
                 ELSEIF (TG_OP = 'UPDATE') THEN
-                    UPDATE {table_name}
-                    SET {stamp_column} = (now() at time zone 'utc')
-                    WHERE {local_key} = NEW.{source_key} OR {local_key} = OLD.{source_key};
+                    UPDATE {target_table}
+                    SET update_time = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                    WHERE {target_key} = NEW.{source_key} OR {target_key} = OLD.{source_key};
                     RETURN NEW;
                 ELSIF (TG_OP = 'INSERT') THEN
-                    UPDATE {table_name}
-                    SET {stamp_column} = (now() at time zone 'utc')
-                    WHERE {local_key} = NEW.{source_key};
+                    UPDATE {target_table}
+                    SET update_time = (CURRENT_TIMESTAMP AT TIME ZONE 'UTC')
+                    WHERE {target_key} = NEW.{source_key};
                     RETURN NEW;
                 END IF;
             END;
         $BODY$;
     """
-    return sql.format(**locals())
 
 
-def build_pg_trigger(table_name, fn_name):
-    """assigns a postgres trigger to indicated table, calling user-defined function"""
-
-    trigger_name = "trigger_{table_name}_biudr".format(**locals())
-    tmpl = """
+def build_pg_trigger(source_table, fn_name, when='AFTER'):
+    """Assigns a PostgreSQL trigger to indicated table, calling user-defined function"""
+    when_initial = when.lower()[0]
+    trigger_name = f"trigger_{source_table}_{when_initial}iudr"
+    return f"""
         CREATE TRIGGER {trigger_name}
-            BEFORE INSERT OR DELETE OR UPDATE
-            ON {table_name}
+            {when} INSERT OR DELETE OR UPDATE
+            ON {source_table}
             FOR EACH ROW
             EXECUTE PROCEDURE {fn_name}();
     """
-    return tmpl.format(**locals())
 
 
-def build_timestamp_trigger(operation, source_table, target_table, source_key='id', target_key='id', when='BEFORE'):
-    """creates a non-postgres update_time trigger"""
+def build_timestamp_trigger(operation, source_table, target_table, source_key, target_key='id', when='AFTER'):
+    """Creates a non-PostgreSQL update_time trigger"""
 
     trigger_name = get_trigger_name(operation, source_table, when)
 
     # three different update clauses depending on update/insert/delete
     clause = ""
     if operation == "DELETE":
-        clause = "{target_key} = OLD.{source_key}"
+        clause = f"{target_key} = OLD.{source_key}"
     elif operation == "UPDATE":
-        clause = "{target_key} = NEW.{source_key} OR {target_key} = OLD.{source_key}"
+        clause = f"{target_key} = NEW.{source_key} OR {target_key} = OLD.{source_key}"
     else:
-        clause = "{target_key} = NEW.{source_key}"
-    clause = clause.format(**locals())
+        clause = f"{target_key} = NEW.{source_key}"
 
-    tmpl = """
+    return f"""
         CREATE TRIGGER {trigger_name}
             {when} {operation}
             ON {source_table}
             FOR EACH ROW
             BEGIN
                 UPDATE {target_table}
-                SET update_time = current_timestamp
+                SET update_time = CURRENT_TIMESTAMP
                 WHERE {clause};
             END;
     """
-    return tmpl.format(**locals())
 
 
-def build_drop_trigger(operation, source_table, when='BEFORE'):
-    """drops a non-postgres trigger by name"""
+def build_drop_trigger(operation, source_table, when='AFTER'):
+    """Drops a non-PostgreSQL trigger by name"""
     trigger_name = get_trigger_name(operation, source_table, when)
-    return "DROP TRIGGER IF EXISTS {trigger_name}".format(**locals())
+    return f"DROP TRIGGER IF EXISTS {trigger_name}"
 
 
-def get_trigger_name(operation, source_table, when='BEFORE'):
-    """non-postgres trigger name"""
+def get_trigger_name(operation, source_table, when):
+    """Non-PostgreSQL trigger name"""
     op_initial = operation.lower()[0]
     when_initial = when.lower()[0]
-    trigger_name = "trigger_{source_table}_{when_initial}{op_initial}r".format(**locals())
-    return trigger_name
+    return f"trigger_{source_table}_{when_initial}{op_initial}r"


### PR DESCRIPTION
## What did you do? 
- Partially revert commit 33883fe5eb972f638982dbb4e96604a618c498ea .
- Update `update_time` on target (i.e. `history`) table **AFTER** HDA/HDCA insert/update/delete
- Use f-strings instead of templates
- Use `CURRENT_TIMESTAMP` also in PostgreSQL (it's equivalent but standard SQL)
- Code cleanups

## Why did you make this change?
This is needed by the new history panel.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
