### PR TITLE
Do not invoke workflow if not all tools are available

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -539,7 +539,6 @@ class WorkflowContentsManager(UsesAnnotations):
         option describes the workflow in a context more tied to the current Galaxy instance and includes
         fields like 'url' and 'url' and actual unencoded step ids instead of 'order_index'.
         """
-
         def to_format_2(wf_dict, **kwds):
             return from_galaxy_native(wf_dict, None, **kwds)
 
@@ -1485,6 +1484,16 @@ class WorkflowContentsManager(UsesAnnotations):
             workflow=self.workflow_to_dict(trans, refactored_workflow.stored_workflow, style=refactor_request.style),
             dry_run=refactor_request.dry_run,
         )
+
+    def get_all_tool_ids(self, workflow):
+        tool_ids = set()
+        for step in workflow.steps:
+            if step.type == 'tool':
+                if step.tool_id:
+                    tool_ids.add(step.tool_id)
+            elif step.type == 'subworkflow':
+                tool_ids.update(self.get_all_tool_ids(step.subworkflow))
+        return tool_ids
 
 
 class RefactorRequest(RefactorActions):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -928,6 +928,19 @@ steps:
         self._assert_status_code_is(run_workflow_response, 200)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
 
+    def test_run_workflow_with_missing_tool(self):
+        with self.dataset_populator.test_history() as history_id:
+            workflow_id = self._upload_yaml_workflow("""
+class: GalaxyWorkflow
+steps:
+  step1:
+    tool_id: nonexistent_tool
+    tool_version: "0.1"
+""")
+            invocation_response = self.__invoke_workflow(history_id, workflow_id, assert_ok=False)
+            self._assert_status_code_is(invocation_response, 400)
+            self.assertEqual(invocation_response.json().get('err_msg'), "Workflow was not invoked; some required tools are not installed.")
+
     @skip_without_tool("collection_creates_pair")
     def test_workflow_run_output_collections(self):
         with self.dataset_populator.test_history() as history_id:


### PR DESCRIPTION
## What did you do? 
- Check all required tools are available before invoking a workflow and raise an error if not.


## Why did you make this change?
Fixes #11311 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
