### PR TITLE
fix data stickiness on folder change

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -295,6 +295,18 @@ initFolderTableIcons();
 
 Vue.use(BootstrapVue);
 
+function initialFolderState() {
+    return {
+        selected: [],
+        unselected: [],
+        expandedMessage: [],
+        folderContents: [],
+        include_deleted: false,
+        search_text: "",
+        isAllSelectedMode: false,
+        currentPage: 1,
+    };
+}
 export default {
     props: {
         folder_id: {
@@ -309,27 +321,19 @@ export default {
     },
     data() {
         return {
-            current_folder_id: null,
-            error: null,
-            isBusy: false,
-            folder_metadata: {},
-            currentPage: 1,
-            fields: fields,
-            selectMode: "multi",
-            selected: [],
-            unselected: [],
-            expandedMessage: [],
-            folderContents: [],
-            perPage: DEFAULT_PER_PAGE,
-            maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
-            filter: null,
-            include_deleted: false,
-            filterOn: [],
-            search_text: "",
-            isAllSelectedMode: false,
-            total_rows: 0,
-            deselectedDatasets: [],
-            root: getAppRoot(),
+            ...initialFolderState(),
+            ...{
+                current_folder_id: null,
+                error: null,
+                isBusy: false,
+                folder_metadata: {},
+                fields: fields,
+                selectMode: "multi",
+                perPage: DEFAULT_PER_PAGE,
+                maxDescriptionLength: MAX_DESCRIPTION_LENGTH,
+                total_rows: 0,
+                root: getAppRoot(),
+            },
         };
     },
     created() {
@@ -339,8 +343,12 @@ export default {
     methods: {
         initFolder(folder_id) {
             this.current_folder_id = folder_id;
-            this.folderContents = [];
+            this.resetData();
             this.fetchFolderContents(this.include_deleted);
+        },
+        resetData() {
+            const data = initialFolderState();
+            Object.keys(data).forEach((k) => (this[k] = data[k]));
         },
         fetchFolderContents(include_deleted = false) {
             this.include_deleted = include_deleted;


### PR DESCRIPTION
## What did you do? 
created a set of default values. From now on, those values are being reset to default on folder change. 


## Why did you make this change?
resolves https://github.com/galaxyproject/galaxy/issues/11837
Thanks @martenson, that was a good catch 


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. open a library
  2. click on select all
  3. go to subfolder
  4. _select all_ should be reset

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
