### PR TITLE
Improve error handling when creating a new History with the master API key

### DIFF
--- a/lib/galaxy/exceptions/__init__.py
+++ b/lib/galaxy/exceptions/__init__.py
@@ -131,6 +131,11 @@ class ToolInputsNotReadyException(MessageException):
     error_code = error_codes_by_name['TOOL_INPUTS_NOT_READY']
 
 
+class RealUserRequiredException(MessageException):
+    status_code = 400
+    error_code = error_codes_by_name['REAL_USER_REQUIRED']
+
+
 class AuthenticationFailed(MessageException):
     status_code = 401
     err_code = error_codes_by_name['USER_AUTHENTICATION_FAILED']

--- a/lib/galaxy/exceptions/error_codes.json
+++ b/lib/galaxy/exceptions/error_codes.json
@@ -1,78 +1,78 @@
 [
    {
-    "name": "UNKNOWN",
-    "code": 0,
-    "message": "Unknown error occurred while processing request."
+      "name": "UNKNOWN",
+      "code": 0,
+      "message": "Unknown error occurred while processing request."
    },
    {
-    "name": "USER_CANNOT_RUN_AS",
-    "code": 400001,
-    "message": "User does not have permissions to run jobs as another user."
-    },
-   {
-    "name": "USER_INVALID_RUN_AS",
-    "code": 400002,
-    "message": "Invalid run_as request - run_as user does not exist."
-    },
-   {
-    "name": "USER_INVALID_JSON",
-    "code": 400003,
-    "message": "Your request did not appear to be valid JSON, please consult the API documentation."
-    },
-   {
-    "name": "USER_OBJECT_ATTRIBUTE_INVALID",
-    "code": 400004,
-    "message": "Attempted to create or update object with invalid attribute value."
-    },
-   {
-    "name": "USER_OBJECT_ATTRIBUTE_MISSING",
-    "code": 400005,
-    "message": "Attempted to create or update object without required attribute."
-    },
-   {
-    "name": "USER_SLUG_DUPLICATE",
-    "code": 400006,
-    "message": "Slug must be unique per user."
-    },
-   {
-    "name": "USER_REQUEST_MISSING_PARAMETER",
-    "code": 400007,
-    "message": "Request is missing parameter required to complete desired action."
+      "name": "USER_CANNOT_RUN_AS",
+      "code": 400001,
+      "message": "User does not have permissions to run jobs as another user."
    },
    {
-    "name": "USER_REQUEST_INVALID_PARAMETER",
-    "code": 400008,
-    "message": "Request contained invalid parameter, action could not be completed."
+      "name": "USER_INVALID_RUN_AS",
+      "code": 400002,
+      "message": "Invalid run_as request - run_as user does not exist."
    },
    {
-    "name": "MALFORMED_ID",
-    "code": 400009,
-    "message": "The id of the resource is malformed."
-    },
-   {
-    "name": "UNKNOWN_CONTENTS_TYPE",
-    "code": 400010,
-    "message": "The request contains unknown type of contents."
-    },
-   {
-    "name": "USER_IDENTIFIER_DUPLICATE",
-    "code": 400011,
-    "message": "Request contained a duplicated identifier that must be unique."
-    },
-   {
-    "name": "USER_TOOL_META_PARAMETER_PROBLEM",
-    "code": 400012,
-    "message": "Supplied incorrect or incompatible tool meta parameters."
+      "name": "USER_INVALID_JSON",
+      "code": 400003,
+      "message": "Your request did not appear to be valid JSON, please consult the API documentation."
    },
    {
-    "name": "MALFORMED_CONTENTS",
-    "code": 400013,
-    "message": "The contents of the request are malformed."
-    },
+      "name": "USER_OBJECT_ATTRIBUTE_INVALID",
+      "code": 400004,
+      "message": "Attempted to create or update object with invalid attribute value."
+   },
    {
-    "name": "USER_TOOL_MISSING_PROBLEM",
-    "code": 400014,
-    "message": "Tool could not be found."
+      "name": "USER_OBJECT_ATTRIBUTE_MISSING",
+      "code": 400005,
+      "message": "Attempted to create or update object without required attribute."
+   },
+   {
+      "name": "USER_SLUG_DUPLICATE",
+      "code": 400006,
+      "message": "Slug must be unique per user."
+   },
+   {
+      "name": "USER_REQUEST_MISSING_PARAMETER",
+      "code": 400007,
+      "message": "Request is missing parameter required to complete desired action."
+   },
+   {
+      "name": "USER_REQUEST_INVALID_PARAMETER",
+      "code": 400008,
+      "message": "Request contained invalid parameter, action could not be completed."
+   },
+   {
+      "name": "MALFORMED_ID",
+      "code": 400009,
+      "message": "The id of the resource is malformed."
+   },
+   {
+      "name": "UNKNOWN_CONTENTS_TYPE",
+      "code": 400010,
+      "message": "The request contains unknown type of contents."
+   },
+   {
+      "name": "USER_IDENTIFIER_DUPLICATE",
+      "code": 400011,
+      "message": "Request contained a duplicated identifier that must be unique."
+   },
+   {
+      "name": "USER_TOOL_META_PARAMETER_PROBLEM",
+      "code": 400012,
+      "message": "Supplied incorrect or incompatible tool meta parameters."
+   },
+   {
+      "name": "MALFORMED_CONTENTS",
+      "code": 400013,
+      "message": "The contents of the request are malformed."
+   },
+   {
+      "name": "USER_TOOL_MISSING_PROBLEM",
+      "code": 400014,
+      "message": "Tool could not be found."
    },
    {
       "name": "TOOL_INPUTS_NOT_READY",
@@ -80,93 +80,98 @@
       "message": "Tool inputs not yet ready, try again later."
    },
    {
-    "name": "USER_AUTHENTICATION_FAILED",
-    "code": 401001,
-    "message": "Authentication failed, invalid credentials supplied."
+      "name": "REAL_USER_REQUIRED",
+      "code": 400016,
+      "message": "Only real users can make this request."
    },
    {
-    "name": "USER_NO_API_KEY",
-    "code": 403001,
-    "message": "Authentication required for this request"
-    },
-   {
-    "name": "USER_CANNOT_ACCESS_ITEM",
-    "code": 403002,
-    "message": "User cannot access specified item."
-    },
-   {
-    "name": "USER_DOES_NOT_OWN_ITEM",
-    "code": 403003,
-    "message": "User does not own specified item."
+      "name": "USER_AUTHENTICATION_FAILED",
+      "code": 401001,
+      "message": "Authentication failed, invalid credentials supplied."
    },
    {
-    "name": "CONFIG_DOES_NOT_ALLOW",
-    "code": 403004,
-    "message": "The configuration of this Galaxy instance does not allow that operation"
+      "name": "USER_NO_API_KEY",
+      "code": 403001,
+      "message": "Authentication required for this request"
    },
    {
-    "name": "INSUFFICIENT_PERMISSIONS",
-    "code": 403005,
-    "message": "You don't have proper permissions to perform the requested operation"
+      "name": "USER_CANNOT_ACCESS_ITEM",
+      "code": 403002,
+      "message": "User cannot access specified item."
    },
    {
-    "name": "ADMIN_REQUIRED",
-    "code": 403006,
-    "message": "Action requires admin account."
+      "name": "USER_DOES_NOT_OWN_ITEM",
+      "code": 403003,
+      "message": "User does not own specified item."
    },
    {
-    "name": "USER_ACTIVATION_REQUIRED",
-    "code": 403007,
-    "message": "Action requires account activation."
+      "name": "CONFIG_DOES_NOT_ALLOW",
+      "code": 403004,
+      "message": "The configuration of this Galaxy instance does not allow that operation"
    },
    {
-    "name": "USER_OBJECT_NOT_FOUND",
-    "code": 404001,
-    "message": "No such object found."
+      "name": "INSUFFICIENT_PERMISSIONS",
+      "code": 403005,
+      "message": "You don't have proper permissions to perform the requested operation"
    },
    {
-    "name": "DEPRECATED_API_CALL",
-    "code": 404002,
-    "message": "This API method or call signature has been deprecated and is no longer available"
+      "name": "ADMIN_REQUIRED",
+      "code": 403006,
+      "message": "Action requires admin account."
    },
    {
-    "name": "CONFLICT",
-    "code": 409001,
-    "message": "Database conflict prevented fulfilling the request."
+      "name": "USER_ACTIVATION_REQUIRED",
+      "code": 403007,
+      "message": "Action requires account activation."
    },
    {
-    "name": "INTERNAL_SERVER_ERROR",
-    "code": 500001,
-    "message": "Internal server error."
+      "name": "USER_OBJECT_NOT_FOUND",
+      "code": 404001,
+      "message": "No such object found."
    },
    {
-    "name": "INCONSISTENT_DATABASE",
-    "code": 500002,
-    "message": "Inconsistent database prevented fulfilling the request."
+      "name": "DEPRECATED_API_CALL",
+      "code": 404002,
+      "message": "This API method or call signature has been deprecated and is no longer available"
    },
    {
-    "name": "CONFIG_ERROR",
-    "code": 500003,
-    "message": "Error in a configuration file."
+      "name": "CONFLICT",
+      "code": 409001,
+      "message": "Database conflict prevented fulfilling the request."
    },
    {
-    "name": "TOOL_EXECUTION_ERROR",
-    "code": 500004,
-    "message": "Tool execution failed due to an internal server error."
+      "name": "INTERNAL_SERVER_ERROR",
+      "code": 500001,
+      "message": "Internal server error."
    },
    {
-    "name": "INVALID_FILE_FORMAT",
-    "code": 500005,
-    "message": "File format not supported for this operation."
+      "name": "INCONSISTENT_DATABASE",
+      "code": 500002,
+      "message": "Inconsistent database prevented fulfilling the request."
    },
    {
-    "name": "REFERENCE_DATA_ERROR",
-    "code": 500006,
-    "message": "Reference data required for program execution failed to load."
+      "name": "CONFIG_ERROR",
+      "code": 500003,
+      "message": "Error in a configuration file."
    },
    {
-    "name": "NOT_IMPLEMENTED",
-    "code": 501001,
-    "message": "Method is not implemented."
+      "name": "TOOL_EXECUTION_ERROR",
+      "code": 500004,
+      "message": "Tool execution failed due to an internal server error."
+   },
+   {
+      "name": "INVALID_FILE_FORMAT",
+      "code": 500005,
+      "message": "File format not supported for this operation."
+   },
+   {
+      "name": "REFERENCE_DATA_ERROR",
+      "code": 500006,
+      "message": "Reference data required for program execution failed to load."
+   },
+   {
+      "name": "NOT_IMPLEMENTED",
+      "code": 501001,
+      "message": "Method is not implemented."
    }
 ]

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -334,6 +334,8 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsH
         :rtype:     dict
         :returns:   element view of new history
         """
+        if not trans.galaxy_session:
+            raise exceptions.MessageException("Only users with a session can create histories.")
         hist_name = None
         if payload.get('name', None):
             hist_name = restore_text(payload['name'])

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -334,7 +334,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsH
         :rtype:     dict
         :returns:   element view of new history
         """
-        if not trans.galaxy_session:
+        if trans.user.bootstrap_admin_user:
             raise exceptions.MessageException("Only users with a session can create histories.")
         hist_name = None
         if payload.get('name', None):

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -335,7 +335,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsH
         :returns:   element view of new history
         """
         if trans.user.bootstrap_admin_user:
-            raise exceptions.MessageException("Only users with a session can create histories.")
+            raise exceptions.RealUserRequiredException("Only real users can create histories.")
         hist_name = None
         if payload.get('name', None):
             hist_name = restore_text(payload['name'])

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -197,6 +197,12 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories, SharingApiTests):
         create_response = post(url=histories_url, data=post_data)
         self._assert_status_code_is(create_response, 403)
 
+    def test_create_without_session_fails(self):
+        post_data = dict(name="SessionNeeded")
+        # Using admin=True will boostrap an Admin user without session
+        create_response = self._post("histories", data=post_data, admin=True)
+        self._assert_status_code_is(create_response, 400)
+
     def test_create_tag(self):
         post_data = dict(name="TestHistoryForTag")
         history_id = self._post("histories", data=post_data).json()["id"]


### PR DESCRIPTION
## What did you do? 
- Check if the user has a proper session when creating a new history from the API. This will return a `BadRequest` instead of an `InternalServerError` if, for example, the master API key is used to create a new history, since it has no session.
- Included an API test.


## Why did you make this change?
Fixes #10178


## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
