### PR TITLE
fixes upload link in beta history empty history message

### DIFF
--- a/client/src/components/History/HistoryEmpty.vue
+++ b/client/src/components/History/HistoryEmpty.vue
@@ -5,18 +5,18 @@
             <span v-localize>This history is empty.</span>
         </h4>
         <p>
-            <a href="#" @click.prevent="openUploader" v-localize>You can load your own data</a> or
+            <a href="#" @click.prevent="openGlobalUploadModal" v-localize>You can load your own data</a> or
             <a href="#" @click.prevent="clickDataLink" v-localize>get data from an external source</a>.
         </p>
     </b-alert>
 </template>
 
 <script>
+import { openGlobalUploadModal } from "components/Upload";
+
 export default {
     methods: {
-        openUploader() {
-            this.eventHub.$emit("upload:open");
-        },
+        openGlobalUploadModal,
         clickDataLink() {
             this.eventHub.$emit("openToolSection", "getext");
         },


### PR DESCRIPTION
## What did you do? 
- Fixed link on beta history empty history message. Similar to broken link fixed yesterday on legacy history message.


## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

Noticed a bug during testing.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Sign in
  2. Change to the beta history view with the gear menu in the history panel.
  2. Make a new history
  3. Click on the links in the empty history message. First link should open the uploader.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [x] I've included a screenshot of the changes

<img width="224" alt="empty_history_link" src="https://user-images.githubusercontent.com/290292/114904482-c477b200-9dcc-11eb-8bef-fa2491818aa4.png">
