### PR TITLE
Naive attempt at storing upload URL in metadata

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -115,6 +115,7 @@ class Data(metaclass=DataMeta):
 
     # Add metadata elements
     MetadataElement(name="dbkey", desc="Database/Build", default="?", param=metadata.DBKeyParameter, multiple=False, no_value="?")
+    MetadataElement(name="source_url", desc="Source URL", default=None, readonly=True, optional=True, no_value=None)
     # Stores the set of display applications, and viewing methods, supported by this datatype
     supported_display_apps: Dict[str, Any] = {}
     # If False, the peek is regenerated whenever a dataset of this type is copied

--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -170,12 +170,21 @@ def handle_library_params(trans, params, folder_id, replace_dataset=None):
     return library_bunch
 
 
+def __uploaded_dataset_metadata(uploaded_dataset):
+    metadata = {}
+    if uploaded_dataset.type == 'url':
+        metadata['source_url'] = uploaded_dataset.path
+    return metadata or None
+
+
 def __new_history_upload(trans, uploaded_dataset, history=None, state=None):
     if not history:
         history = trans.history
+    metadata = __uploaded_dataset_metadata(uploaded_dataset)
     hda = trans.app.model.HistoryDatasetAssociation(name=uploaded_dataset.name,
                                                     extension=uploaded_dataset.file_type,
                                                     dbkey=uploaded_dataset.dbkey,
+                                                    metadata=metadata,
                                                     history=history,
                                                     create_dataset=True,
                                                     sa_session=trans.sa_session)
@@ -220,9 +229,11 @@ def __new_library_upload(trans, cntrller, uploaded_dataset, library_bunch, tag_h
         trans.sa_session.add(ld)
         trans.sa_session.flush()
         trans.app.security_agent.copy_library_permissions(trans, folder, ld)
+    metadata = __uploaded_dataset_metadata(uploaded_dataset)
     ldda = trans.app.model.LibraryDatasetDatasetAssociation(name=uploaded_dataset.name,
                                                             extension=uploaded_dataset.file_type,
                                                             dbkey=uploaded_dataset.dbkey,
+                                                            metadata=metadata,
                                                             library_dataset=ld,
                                                             user=trans.user,
                                                             create_dataset=True,


### PR DESCRIPTION
## What did you do? 
- Added a MetadataElement to the base class of all datatypes that stores a read-only copy of the source URL for URL paste uploads


## Why did you make this change?
Requested in #11371, the URL is lost when you rename the dataset. It's in the API response as `metadata_source_url` when viewing a dataset info page but I haven't messed with the client to get it to display.

This may be the wrong approach, feedback would be appreciated.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Upload dataset via URL
  2. Verify metadata on HDA row in database
  3. Verify `metadata_source_url` in API response when viewing dataset info page

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
