### PR TITLE
BUGFIX: Also check for boolean True, not just string 'True' when evaluating conditional dependencies.

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -232,7 +232,7 @@ class ConditionalDependencies:
         return 's3fs' in self.file_sources
 
     def check_watchdog(self):
-        install_set = {'auto', 'True', 'true', 'polling'}
+        install_set = {'auto', 'True', 'true', 'polling', True}
         return (self.config['watch_tools'] in install_set
                 or self.config['watch_tool_data_dir'] in install_set)
 


### PR DESCRIPTION
## What did you do? 
- Accept `True` as a boolean true in the conditional dependencies script. Strangely enough it only checked for `'true'` and `'True'` not actual `True`. EDIT: I think this might be because the old INI config does not support literal booleans.


## Why did you make this change?

When people know how actual yaml works they might have

    galaxy:
        watch_tools: true

as their config. Which signifies an actual Boolean value. This should be considered by the script as well.

Can this be backported to all supported releases? On a production setup with ansible-galaxy and nginx this leads to quite annoying errors: "502 Bad gateway" in NGINX. Which prompts debugging, checking the logs and then finding out watchdogs is not installed while it should be.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.


## For UI Components
- [ ] I've included a screenshot of the changes
