### PR TITLE
Backport to 20.09: watchdog dependency check bugfix.

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -220,7 +220,7 @@ class ConditionalDependencies:
         return 'webdav' in self.file_sources
 
     def check_watchdog(self):
-        install_set = {'auto', 'True', 'true', 'polling'}
+        install_set = {'auto', 'True', 'true', 'polling', True}
         return (self.config['watch_tools'] in install_set or
                 self.config['watch_tool_data_dir'] in install_set)
 


### PR DESCRIPTION
When people know how actual yaml works they might have

    galaxy:
        watch_tools: true

as their config. Which signifies an actual Boolean value. This should be considered by the script as well.

See #11861 
