### PR TITLE
[20.05] Backport watchdog dependency check bugfix

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -180,7 +180,7 @@ class ConditionalDependencies(object):
         return 'irods' in self.object_stores
 
     def check_watchdog(self):
-        install_set = {'auto', 'True', 'true', 'polling'}
+        install_set = {'auto', 'True', 'true', 'polling', True}
         return (self.config['watch_tools'] in install_set or
                 self.config['watch_tool_data_dir'] in install_set)
 


### PR DESCRIPTION
When people know how actual yaml works they might have

    galaxy:
        watch_tools: true

as their config. Which signifies an actual Boolean value. This should be considered by the script as well.

See #11861 
