### PR TITLE
Expose StoredWorkflowId in invocation API

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5559,6 +5559,7 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
 
     def to_dict(self, view='collection', value_mapper=None, step_details=False, legacy_job_state=False):
         rval = super().to_dict(view=view, value_mapper=value_mapper)
+        rval['stored_workflow_id'] = self.workflow.stored_workflow.id
         if view == 'element':
             steps = []
             for step in self.steps:

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -827,7 +827,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :raises: exceptions.MessageException, exceptions.RequestParameterInvalidException
         """
         # Get workflow + accessibility check.
-        stored_workflow = self.__get_stored_accessible_workflow(trans, workflow_id)
+        stored_workflow = self.__get_stored_accessible_workflow(trans, workflow_id, instance=kwd.get('instance', False))
         workflow = stored_workflow.latest_workflow
         run_configs = build_workflow_run_configs(trans, workflow, payload)
         is_batch = payload.get('batch')
@@ -876,6 +876,10 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :param  workflow_id:      an encoded stored workflow id to restrict query to
         :type   workflow_id:      str
 
+        :param  instance:         true if fetch by Workflow ID instead of StoredWorkflow id, false
+                                  by default.
+        :type   instance:         boolean
+
         :param  history_id:       an encoded history id to restrict query to
         :type   history_id:       str
 
@@ -891,7 +895,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :raises: exceptions.MessageException, exceptions.ObjectNotFound
         """
         if workflow_id is not None:
-            stored_workflow_id = self.__get_stored_workflow(trans, workflow_id).id
+            stored_workflow_id = self.__get_stored_workflow(trans, workflow_id, instance=kwd.get('instance', False)).id
         else:
             stored_workflow_id = None
 


### PR DESCRIPTION
## What did you do? 
- Expose `StoredWorkflowId` in the invocation API in addition to `WorkflowId`
- Allow use of the `instance` param for the `index_invocations` and `invoke` methods (for the others it was already supported). This allows the user to select whether they want to invoke / index workflows using the `StoredWorkflowId` or `WorkflowId`.


## Why did you make this change?
Almost all interactions with the Galaxy API require the `StoredWorkflowId`, it's quite confusing (and not that useful) that accessing an invocation provides the `WorkflowId`. E.g. accessing an invocation, getting the workflow id and attempting to use it to re-invoke the workflow will fail (unless the two IDs are coincidentally the same).

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
