### PR TITLE
Fix "Choose remote files" uploads

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -30,7 +30,7 @@
             <b-btn
                 v-if="multiple"
                 size="sm"
-                class="float-right ml-1"
+                class="float-right ml-1 file-dialog-modal-ok"
                 variant="primary"
                 @click="finalize"
                 :disabled="!hasValue"

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -11,6 +11,7 @@ import LazyLimited from "mvc/lazy/lazy-limited";
 import { findExtension } from "./utils";
 import { filesDialog } from "utils/data";
 import { getAppRoot } from "onload";
+import axios from "axios";
 
 const localize = _l;
 
@@ -85,20 +86,19 @@ export default {
                 }
             });
             if (list.length > 0) {
-                $.uploadpost({
-                    data: this.app.toData(list),
-                    url: this.app.uploadPath,
-                    success: (message) => {
+                const data = this.app.toFetchData(list, this.history_id);
+                axios
+                    .post("api/tools/fetch", data)
+                    .then((message) => {
                         list.forEach((model) => {
                             this._eventSuccess(model.id, message);
                         });
-                    },
-                    error: (message) => {
+                    })
+                    .catch((message) => {
                         list.forEach((model) => {
-                            self._eventError(model.id, message);
+                            this._eventError(model.id, message);
                         });
-                    },
-                });
+                    });
             }
         },
         renderNewModel: function (model) {

--- a/client/src/components/Upload/UploadModalContent.vue
+++ b/client/src/components/Upload/UploadModalContent.vue
@@ -294,19 +294,23 @@ export default {
 
             // Composite does not use the fetch API, so we can just
             // index into the first element of items
-            const urls = items[0].get("url_paste").split("\n");
-            for (var index in urls) {
-                var url = urls[index].trim();
-                if (url != "") {
-                    var element = {
-                        url: urls[index].trim(),
-                        src: "url",
-                        dbkey: items[0].get("genome", "?"),
-                        ext: items[0].get("extension", "auto"),
-                    };
-                    data.targets[0].elements.push(element);
-                }
+            const item = items[0];
+            let urls;
+            if (item.get("file_mode") == "ftp") {
+                urls = [item.get("file_path")];
+            } else {
+                urls = item.get("url_paste").split("\n");
             }
+            urls.forEach((url) => {
+                if (url != "") {
+                    data.targets[0].elements.push({
+                        url: url.trim(),
+                        src: "url",
+                        dbkey: item.get("genome", "?"),
+                        ext: item.get("extension", "auto"),
+                    });
+                }
+            });
             return data;
         },
     },

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -679,6 +679,10 @@ upload:
     rule_dataset_selector_row:
       selector: '.selection-dialog-modal [aria-rowindex="${rowindex}"]'
     build_btn: '#rule-based #btn-build'
+    file_source_selector:
+      type: xpath
+      selector: '//span[contains(@title, "${path}")]'
+    file_dialog_ok: '.file-dialog-modal-ok'
 
 rule_builder:
   selectors:

--- a/lib/galaxy_test/driver/integration_setup.py
+++ b/lib/galaxy_test/driver/integration_setup.py
@@ -1,0 +1,68 @@
+"""
+Test classes that should be shared between test scenarios.
+"""
+import os
+import shutil
+from tempfile import mkdtemp
+
+REQUIRED_ROLE = "user@bx.psu.edu"
+REQUIRED_GROUP = "fs_test_group"
+
+
+def get_posix_file_source_config(root_dir: str, roles: str, groups: str) -> str:
+    return f"""
+- type: posix
+  id: posix_test
+  label: Posix
+  doc: Files from local path
+  root: {root_dir}
+  writable: true
+  requires_roles: {roles}
+  requires_groups: {groups}
+
+"""
+
+
+def create_file_source_config_file_on(temp_dir, root_dir):
+    file_contents = get_posix_file_source_config(root_dir, REQUIRED_ROLE, REQUIRED_GROUP)
+    file_path = os.path.join(temp_dir, "file_sources_conf_posix.yml")
+    with open(file_path, "w") as f:
+        f.write(file_contents)
+    return file_path
+
+
+class PosixFileSourceSetup:
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        temp_dir = os.path.realpath(mkdtemp())
+        cls._test_driver.temp_directories.append(temp_dir)
+        cls.root_dir = os.path.join(temp_dir, "root")
+
+        file_sources_config_file = create_file_source_config_file_on(temp_dir, cls.root_dir)
+        config["file_sources_config_file"] = file_sources_config_file
+
+        # Disable all stock plugins
+        config["ftp_upload_dir"] = None
+        config["library_import_dir"] = None
+        config["user_library_import_dir"] = None
+
+    def _write_file_fixtures(self):
+        root = self.root_dir
+        if os.path.exists(root):
+            shutil.rmtree(root)
+        os.mkdir(root)
+
+        with open(os.path.join(root, "a"), "w") as f:
+            f.write("a\n")
+
+        subdir1 = os.path.join(root, "subdir1")
+        os.mkdir(subdir1)
+        with open(os.path.join(subdir1, "b"), "w") as f:
+            f.write("b\n")
+
+        return root
+
+    def setUp(self):
+        super().setUp()
+        self._write_file_fixtures()

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -3,75 +3,13 @@
 # Apache Docker host (shown next) doesn't work because displayname not set in response.
 # docker run -v `pwd`/test/integration/webdav:/var/lib/dav  -e AUTH_TYPE=Basic -e USERNAME=alice -e PASSWORD=secret1234  -e LOCATION=/ -p 7083:80 bytemark/webdav
 
-import os
-import shutil
-from tempfile import mkdtemp
-
 from galaxy_test.base import api_asserts
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
+from galaxy_test.driver.integration_setup import PosixFileSourceSetup
 
 REQUIRED_ROLE = "user@bx.psu.edu"
 REQUIRED_GROUP = "fs_test_group"
-
-
-def get_posix_file_source_config(root_dir: str, roles: str, groups: str) -> str:
-    return f"""
-- type: posix
-  id: posix_test
-  label: Posix
-  doc: Files from local path
-  root: {root_dir}
-  writable: true
-  requires_roles: {roles}
-  requires_groups: {groups}
-
-"""
-
-
-def create_file_source_config_file_on(temp_dir, root_dir):
-    file_contents = get_posix_file_source_config(root_dir, REQUIRED_ROLE, REQUIRED_GROUP)
-    file_path = os.path.join(temp_dir, "file_sources_conf_posix.yml")
-    with open(file_path, "w") as f:
-        f.write(file_contents)
-    return file_path
-
-
-class PosixFileSourceSetup:
-
-    @classmethod
-    def handle_galaxy_config_kwds(cls, config):
-        temp_dir = os.path.realpath(mkdtemp())
-        cls._test_driver.temp_directories.append(temp_dir)
-        cls.root_dir = os.path.join(temp_dir, "root")
-
-        file_sources_config_file = create_file_source_config_file_on(temp_dir, cls.root_dir)
-        config["file_sources_config_file"] = file_sources_config_file
-
-        # Disable all stock plugins
-        config["ftp_upload_dir"] = None
-        config["library_import_dir"] = None
-        config["user_library_import_dir"] = None
-
-    def _write_file_fixtures(self):
-        root = self.root_dir
-        if os.path.exists(root):
-            shutil.rmtree(root)
-        os.mkdir(root)
-
-        with open(os.path.join(root, "a"), "w") as f:
-            f.write("a\n")
-
-        subdir1 = os.path.join(root, "subdir1")
-        os.mkdir(subdir1)
-        with open(os.path.join(subdir1, "b"), "w") as f:
-            f.write("b\n")
-
-        return root
-
-    def setUp(self):
-        super().setUp()
-        self._write_file_fixtures()
 
 
 class PosixFileSourceIntegrationTestCase(PosixFileSourceSetup, integration_util.IntegrationTestCase):

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -37,7 +37,7 @@ def create_file_source_config_file_on(temp_dir, root_dir):
     return file_path
 
 
-class PosixFileSourceIntegrationTestCase(integration_util.IntegrationTestCase):
+class PosixFileSourceSetup:
 
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
@@ -53,10 +53,32 @@ class PosixFileSourceIntegrationTestCase(integration_util.IntegrationTestCase):
         config["library_import_dir"] = None
         config["user_library_import_dir"] = None
 
+    def _write_file_fixtures(self):
+        root = self.root_dir
+        if os.path.exists(root):
+            shutil.rmtree(root)
+        os.mkdir(root)
+
+        with open(os.path.join(root, "a"), "w") as f:
+            f.write("a\n")
+
+        subdir1 = os.path.join(root, "subdir1")
+        os.mkdir(subdir1)
+        with open(os.path.join(subdir1, "b"), "w") as f:
+            f.write("b\n")
+
+        return root
+
+    def setUp(self):
+        super().setUp()
+        self._write_file_fixtures()
+
+
+class PosixFileSourceIntegrationTestCase(PosixFileSourceSetup, integration_util.IntegrationTestCase):
+
     def setUp(self):
         super().setUp()
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
-        self._write_file_fixtures()
 
     def test_plugin_config(self):
         plugin_config_response = self.galaxy_interactor.get("remote_files/plugins")
@@ -117,19 +139,3 @@ class PosixFileSourceIntegrationTestCase(integration_util.IntegrationTestCase):
 
     def _assert_access_forbidden_response(self, response):
         api_asserts.assert_status_code_is(response, 403)
-
-    def _write_file_fixtures(self):
-        root = PosixFileSourceIntegrationTestCase.root_dir
-        if os.path.exists(root):
-            shutil.rmtree(root)
-        os.mkdir(root)
-
-        with open(os.path.join(root, "a"), "w") as f:
-            f.write("a\n")
-
-        subdir1 = os.path.join(root, "subdir1")
-        os.mkdir(subdir1)
-        with open(os.path.join(subdir1, "b"), "w") as f:
-            f.write("b\n")
-
-        return root

--- a/test/integration_selenium/test_upload_file_sources.py
+++ b/test/integration_selenium/test_upload_file_sources.py
@@ -1,0 +1,24 @@
+from .framework import (
+    selenium_test,
+    SeleniumIntegrationTestCase,
+)
+from ..integration.test_remote_files_posix import (
+    PosixFileSourceSetup,
+)
+
+
+class PosixFileSourceSeleniumIntegrationTestCase(PosixFileSourceSetup, SeleniumIntegrationTestCase):
+    # For simplicity, otherwise need to setup a different file_sources_config_file
+    requires_admin = True
+
+    @selenium_test
+    def test_upload_from_posix(self):
+        self.admin_login()
+        self.components.upload.start.wait_for_and_click()
+        self.components.upload.ftp_add.wait_for_and_click()
+        self.components.upload.file_source_selector(path='gxfiles://posix_test').wait_for_and_click()
+        self.components.upload.file_source_selector(path='gxfiles://posix_test/a').wait_for_and_click()
+        self.components.upload.file_dialog_ok.wait_for_and_click()
+        self.upload_start()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.wait_for_history()

--- a/test/integration_selenium/test_upload_file_sources.py
+++ b/test/integration_selenium/test_upload_file_sources.py
@@ -1,9 +1,9 @@
+from galaxy_test.driver.integration_setup import (
+    PosixFileSourceSetup,
+)
 from .framework import (
     selenium_test,
     SeleniumIntegrationTestCase,
-)
-from ..integration.test_remote_files_posix import (
-    PosixFileSourceSetup,
 )
 
 


### PR DESCRIPTION
This broke in https://github.com/galaxyproject/galaxy/pull/11276,
which moved all URL style uploads to fetch_data, but didn't build the
right payload for ftp / file_source uploads.

## What did you do? 
- [describe the proposed changes]
- 


## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
