### PR TITLE
add a bit of docs to the add tags tool

### DIFF
--- a/lib/galaxy/tools/tag_collection_from_file.xml
+++ b/lib/galaxy/tools/tag_collection_from_file.xml
@@ -37,13 +37,13 @@
                     <assert_contents>
                         <has_text_matching expression="^This is a line of text.\n$" />
                     </assert_contents>
-                    <metadata name="tags" value="alias:f,alias:r1,name:forward,orientation:forward,zoo" />
+                    <metadata name="tags" value="alias:f,alias:r1,group:sample1,name:forward,orientation:forward,zoo" />
                 </element>
                 <element name="reverse">
                     <assert_contents>
                         <has_text_matching expression="^This is a different line of text.\n$" />
                     </assert_contents>
-                    <metadata name="tags" value="alias:r,alias:r2,name:reverse,orientation:reverse" />
+                    <metadata name="tags" value="alias:r,alias:r2,group:sample2,name:reverse,orientation:reverse" />
                 </element>
             </output_collection>
         </test>
@@ -66,13 +66,13 @@
                         <assert_contents>
                             <has_text_matching expression="^This is a line of text.\n$" />
                         </assert_contents>
-                        <metadata name="tags" value="alias:f,alias:r1,name:forward,orientation:forward" />
+                        <metadata name="tags" value="alias:f,alias:r1,group:sample1,name:forward,orientation:forward" />
                     </element>
                     <element name="reverse">
                         <assert_contents>
                             <has_text_matching expression="^This is a different line of text.\n$" />
                         </assert_contents>
-                        <metadata name="tags" value="alias:r,alias:r2,name:reverse,orientation:reverse" />
+                        <metadata name="tags" value="alias:r,alias:r2,group:sample2,name:reverse,orientation:reverse" />
                     </element>
                 </element>
             </output_collection>
@@ -90,5 +90,12 @@
 
         This tool will create new history datasets from your collection
         but your quota usage will not increase.
+
+        In order to create
+        
+        - name tags prefix the tag name with "#" or "name:"
+        - group tags prefix the tag name with "group:"
+
+
     ]]></help>
 </tool>

--- a/test-data/new_tags_1.txt
+++ b/test-data/new_tags_1.txt
@@ -1,2 +1,2 @@
-forward	orientation:forward	alias:r1	alias:f	#forward
-reverse	orientation:reverse	alias:r2	alias:r	#reverse
+forward	orientation:forward	alias:r1	alias:f	#forward	group:sample1
+reverse	orientation:reverse	alias:r2	alias:r	#reverse	group:sample2


### PR DESCRIPTION
## What did you do? 

Just add a bit of documentation to the tool and extend test for group tags

- [ ] wondering if we want to extend a GTN tutorial on the different tag types and their properties (see https://github.com/galaxyproject/galaxy/issues/8554#issuecomment-545471580) I just touched one anyway https://github.com/galaxyproject/training-material/pull/2512

## Why did you make this change?

I added a test because I made a mistake while trying this out and thought that adding group tags does not work. So I wanted to see if this works. It does :) .. guess it does not hurt to keep the test anyway.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
