### PR TITLE
[20.09] Fix user total walltime calculation when jobs are missing states in job state history

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -614,8 +614,8 @@ class JobHandlerQueue(Monitors):
                 if started is not None and finished is not None:
                     time_spent += finished - started
                 else:
-                    log.warning(
-                        f"Unable to calculate time spent for job {job.id}; started: {started}, finished: {finished}")
+                    log.warning("Unable to calculate time spent for job %s; started: %s, finished: %s",
+                                job.id, started, finished)
 
             if time_spent > self.app.job_config.limits.total_walltime["delta"]:
                 return JOB_USER_OVER_TOTAL_WALLTIME, job_destination

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -611,7 +611,11 @@ class JobHandlerQueue(Monitors):
                     elif history.state == "ok":
                         finished = history.create_time
 
-                time_spent += finished - started
+                if started is not None and finished is not None:
+                    time_spent += finished - started
+                else:
+                    log.warning(
+                        f"Unable to calculate time spent for job {job.id}; started: {started}, finished: {finished}")
 
             if time_spent > self.app.job_config.limits.total_walltime["delta"]:
                 return JOB_USER_OVER_TOTAL_WALLTIME, job_destination


### PR DESCRIPTION
## What did you do? 
- Handle the case where `running` or `ok` states are missing from the job state history when calculating total run times for the total_walltime limit.


## Why did you make this change?
```pytb
galaxy.jobs.handler ERROR 2021-04-21 15:40:54,322 [p:335016,w:0,m:2] [JobHandlerQueue.monitor_thread] failure running job 4
Traceback (most recent call last):
  File "/srv/galaxy/server/lib/galaxy/jobs/handler.py", line 400, in __handle_waiting_jobs
    job_state = self.__check_job_state(job)
  File "/srv/galaxy/server/lib/galaxy/jobs/handler.py", line 538, in __check_job_state
    state, job_destination = self.__verify_job_ready(job, job_wrapper)
  File "/srv/galaxy/server/lib/galaxy/jobs/handler.py", line 614, in __verify_job_ready
    time_spent += finished - started
TypeError: unsupported operand type(s) for -: 'datetime.datetime' and 'NoneType'

```
Reported by @vazovn on the admins channel.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Enable total walltime limit in `job_conf.xml`
  2. Enable an asynchronous job runner
  3. Configure DRM to accept but not start jobs
  4. Submit Galaxy job
  5. Stop handler
  6. Signal DRM to start job and wait for it to complete
  7. Start handler
  8. Submit another job

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
