### PR TITLE
Reposition history scroller during new updates

### DIFF
--- a/client/src/components/History/providers/ContentProvider/ContentProvider.js
+++ b/client/src/components/History/providers/ContentProvider/ContentProvider.js
@@ -67,10 +67,11 @@ export const ContentProvider = {
     created() {
         this.params$ = this.watch$("params");
         this.scrollPos$ = this.watch$("scrollPos");
-        const { payload$, loading$, scrolling$ } = this.initStreams();
+        const { payload$, loading$, scrolling$, resetPos$ = NEVER } = this.initStreams();
 
         this.listenTo(scrolling$, (val) => (this.scrolling = val));
         this.listenTo(loading$, (val) => (this.loading = val));
+        this.listenTo(resetPos$, (val) => this.resetScrollPos(val));
 
         // render output
         this.listenTo(payload$, {
@@ -81,13 +82,13 @@ export const ContentProvider = {
     },
 
     methods: {
-        resetScrollPos() {
-            this.scrollPos = ScrollPos.create();
+        resetScrollPos(pos = ScrollPos.create()) {
+            this.scrollPos = pos;
         },
 
         initStreams() {
             console.warn("Override initStreams in ContentProvider");
-            return { payload$: NEVER, loading$: NEVER, scrolling$: NEVER };
+            return { payload$: NEVER, loading$: NEVER, scrolling$: NEVER, resetPos$: NEVER };
         },
 
         /**

--- a/client/src/components/History/providers/ContentProvider/processContentStreams.js
+++ b/client/src/components/History/providers/ContentProvider/processContentStreams.js
@@ -8,7 +8,7 @@ import { activity, whenAny, show } from "utils/observable";
 import { propMatch } from "./helpers";
 import { SearchParams, ScrollPos } from "../../model";
 import { defaultPayload } from "../ContentProvider";
-import { BehaviorSubject } from "rxjs";
+import { BehaviorSubject, Subject } from "rxjs";
 
 /**
  * Takes incoming history, filters and scroll position and generates loading, scrolling and payload
@@ -44,6 +44,7 @@ export function processContentStreams(payloadOperator, sources = {}, settings = 
     );
 
     const loading$ = new BehaviorSubject(false);
+    const resetPos$ = new Subject();
 
     // The actual loader, when history or params change we poll against the api and
     // set up a cachewatcher, both of which are controlled by the scroll position
@@ -54,11 +55,11 @@ export function processContentStreams(payloadOperator, sources = {}, settings = 
                 console.clear();
                 console.log("processContentStreams: pos", JSON.stringify(pos));
             }),
-            payloadOperator({ parent, filters, loading$, ...settings }),
+            payloadOperator({ parent, filters, loading$, resetPos$, ...settings }),
             startWith({ ...defaultPayload, placeholder: true }),
         )),
         share()
     );
 
-    return { payload$, scrolling$, loading$ };
+    return { payload$, scrolling$, loading$, resetPos$ };
 }

--- a/client/src/components/History/providers/HistoryContentProvider/contentPayload.js
+++ b/client/src/components/History/providers/HistoryContentProvider/contentPayload.js
@@ -134,7 +134,6 @@ export const contentPayload = (cfg = {}) => {
                 return aboveTop && scrollAtTop;
             }),
             map(([hid]) => ScrollPos.create({ key: hid })),
-            tap((hid) => console.log("trigger", hid)),
             debounceTime(debouncePeriod),
         );
 

--- a/client/src/components/History/providers/HistoryContentProvider/contentPayload.js
+++ b/client/src/components/History/providers/HistoryContentProvider/contentPayload.js
@@ -1,4 +1,4 @@
-import { merge, partition, Observable, BehaviorSubject } from "rxjs";
+import { merge, partition, Observable, BehaviorSubject, Subject } from "rxjs";
 import {
     tap,
     distinctUntilChanged,
@@ -36,8 +36,8 @@ export const contentPayload = (cfg = {}) => {
         disablePoll = false,
         debug = false,
         // status outputs
-        loading$,
-        resetPos$,
+        loading$ = new BehaviorSubject(),
+        resetPos$ = new Subject(),
     } = cfg;
 
     // stats for this history + filters, accumulates and improves over successive polls

--- a/client/src/components/History/providers/UserHistories/UserHistories.test.js
+++ b/client/src/components/History/providers/UserHistories/UserHistories.test.js
@@ -18,6 +18,8 @@ const resetTestData = () => {
     fullHistories = historySummaries.map((h) => ({ ...h, detailView: true }));
 };
 
+const fakeUser = { id: 123234, name: "Bob" };
+
 // #endregion
 
 // #region Mock server responses
@@ -108,6 +110,9 @@ describe("UserHistories", () => {
         wrapper = shallowMount(UserHistories, {
             localVue,
             store: historiesStore,
+            propsData: {
+                user: fakeUser,
+            },
             scopedSlots: {
                 default(props) {
                     slotProps = props;


### PR DESCRIPTION
NOTE: This is a duplicate of another PR that was accidentally merged before I could push the first commit. The previous merged PR had no changes yet so it didn't actually do anything. These are the actual updates.


## What did you do? 
- Monitored incoming history polling updates to shift the scroller view-window in response to fresh updates, when the user is near the top of the list.


## Why did you make this change?

The new scroller is fixed to a region of interest in what could potentially be a very long list, because of this, fresh updates sometimes do not appear in the scroller because they would logically be "above" the region of interest. If we had the complete list at all times, then the new data would simply appear at the top of the list, but we do not (in general) have the complete list of data.

Nonetheless, it is natural to expect the scroller to constantly be showing the most recent data if you are roughly at the top, so we're going to have to adjust the region of interest in response to incoming updates.

https://user-images.githubusercontent.com/290292/115618783-ffd02000-a2a7-11eb-991a-8c4fef8e4b5f.mp4

The problem was discovered while syncing the current history between the beta history code and the legacy history code.

https://github.com/galaxyproject/galaxy/pull/11850


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
- 1. Upload or otherwise add some stuff to a history. Does the scroller shift naturally to show you your recent changes?

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
