### PR TITLE
add minerva display app for covid

### DIFF
--- a/lib/galaxy/datatypes/display_applications/configs/minerva/tabular.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/minerva/tabular.xml
@@ -1,7 +1,7 @@
 <display id="minerva_tabular" version="1.0.0" name="display at Minerva">
 	<link id="covid19" name="SARS-CoV-2 Minerva Map">
 		<url>https://covid19map.elixir-luxembourg.org/minerva/?plugins=3ca603e96a3412d52201ab76d5377ae3&amp;datasource=${data.url}</url>
-		<filter>${ $dataset.dbkey == "covid19" }</filter>
+		<filter>${ $dataset.dbkey == "wuhCor1" or $dataset.dbkey == "NC_045512" }</filter>
 		<param type="data" name="data" url="galaxy_${DATASET_HASH}.tsv" />
 	</link>
 </display>

--- a/lib/galaxy/datatypes/display_applications/configs/minerva/tabular.xml
+++ b/lib/galaxy/datatypes/display_applications/configs/minerva/tabular.xml
@@ -1,0 +1,7 @@
+<display id="minerva_tabular" version="1.0.0" name="display at Minerva">
+	<link id="covid19" name="SARS-CoV-2 Minerva Map">
+		<url>https://covid19map.elixir-luxembourg.org/minerva/?plugins=3ca603e96a3412d52201ab76d5377ae3&amp;datasource=${data.url}</url>
+		<filter>${ $dataset.dbkey == "covid19" }</filter>
+		<param type="data" name="data" url="galaxy_${DATASET_HASH}.tsv" />
+	</link>
+</display>


### PR DESCRIPTION
## What did you do? 
- Added covid19 pathway map display application


## Why did you make this change?
This is a followup to BioHackathon2020 where we worked on the integration of pathway analysis in Galaxy.


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. load a tabular dataset (mine was on test.usegalaxy.eu which is currently down or I'd share)
  2. correct dbkey
  3. click viz and be taken to a nice pathway diagram showing enrichment.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes

@bgruening what's the dbkey for covid? This feels wrong but can't tell.
