### PR TITLE
Allow to filter /api/invocations by job_id

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -248,7 +248,7 @@ class WorkflowsManager:
         trans.sa_session.flush()
         return workflow_invocation_step
 
-    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, dataset_id=None, user_id=None,
+    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, job_id=None, user_id=None,
                                 include_terminal=True, limit=None):
         """Get invocations owned by the current user."""
         sa_session = trans.sa_session
@@ -275,10 +275,10 @@ class WorkflowsManager:
                 model.WorkflowInvocation.table.c.history_id == history_id
             )
 
-        if dataset_id is not None:
+        if job_id is not None:
             invocations_query = invocations_query.join(
-                model.WorkflowInvocationOutputDatasetAssociation
-            ).filter(model.WorkflowInvocationOutputDatasetAssociation.table.c.dataset_id == dataset_id)
+                model.WorkflowInvocationStep
+            ).filter(model.WorkflowInvocationStep.table.c.job_id == job_id)
 
         if not include_terminal:
             invocations_query = invocations_query.filter(

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -248,7 +248,8 @@ class WorkflowsManager:
         trans.sa_session.flush()
         return workflow_invocation_step
 
-    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, user_id=None, include_terminal=True, limit=None):
+    def build_invocations_query(self, trans, stored_workflow_id=None, history_id=None, dataset_id=None, user_id=None,
+                                include_terminal=True, limit=None):
         """Get invocations owned by the current user."""
         sa_session = trans.sa_session
         invocations_query = sa_session.query(model.WorkflowInvocation).order_by(model.WorkflowInvocation.table.c.id.desc())
@@ -273,6 +274,11 @@ class WorkflowsManager:
             invocations_query = invocations_query.filter(
                 model.WorkflowInvocation.table.c.history_id == history_id
             )
+
+        if dataset_id is not None:
+            invocations_query = invocations_query.join(
+                model.WorkflowInvocationOutputDatasetAssociation
+            ).filter(model.WorkflowInvocationOutputDatasetAssociation.table.c.dataset_id == dataset_id)
 
         if not include_terminal:
             invocations_query = invocations_query.filter(

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -62,6 +62,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
     def __init__(self, app: StructuredApp):
         super().__init__(app)
         self.history_manager = app.history_manager
+        self.hda_manager = app.hda_manager
         self.workflow_manager = app.workflow_manager
         self.workflow_contents_manager = app.workflow_contents_manager
         self.tool_recommendations = recommendations.ToolRecommendations()
@@ -883,6 +884,9 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :param  history_id:       an encoded history id to restrict query to
         :type   history_id:       str
 
+        :param  dataset_id:       an encoded dataset id to restrict query to
+        :type   dataset_id:       str
+
         :param  user_id:          an encoded user id to restrict query to, must be own id if not admin user
         :type   user_id:          str
 
@@ -906,6 +910,14 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         else:
             history_id = None
 
+        encoded_dataset_id = kwd.get("dataset_id", None)
+        if encoded_dataset_id:
+            dataset = self.hda_manager.get_accessible(self.decode_id(encoded_dataset_id), trans.user,
+                                                      current_history=trans.history)
+            dataset_id = dataset.id
+        else:
+            dataset_id = None
+
         encoded_user_id = kwd.get("user_id", None)
         if encoded_user_id:
             target_user_id = self.decode_id(encoded_user_id)
@@ -926,7 +938,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         if limit is not None:
             limit = int(limit)
         invocations = self.workflow_manager.build_invocations_query(
-            trans, stored_workflow_id=stored_workflow_id, history_id=history_id, user_id=user_id, include_terminal=include_terminal, limit=limit
+            trans, stored_workflow_id=stored_workflow_id, history_id=history_id, dataset_id=dataset_id, user_id=user_id, include_terminal=include_terminal, limit=limit
         )
         return self.workflow_manager.serialize_workflow_invocations(invocations, **kwd)
 

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -62,7 +62,6 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
     def __init__(self, app: StructuredApp):
         super().__init__(app)
         self.history_manager = app.history_manager
-        self.hda_manager = app.hda_manager
         self.workflow_manager = app.workflow_manager
         self.workflow_contents_manager = app.workflow_contents_manager
         self.tool_recommendations = recommendations.ToolRecommendations()
@@ -884,8 +883,8 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         :param  history_id:       an encoded history id to restrict query to
         :type   history_id:       str
 
-        :param  dataset_id:       an encoded dataset id to restrict query to
-        :type   dataset_id:       str
+        :param  job_id:           an encoded job id to restrict query to
+        :type   job_id:           str
 
         :param  user_id:          an encoded user id to restrict query to, must be own id if not admin user
         :type   user_id:          str
@@ -910,13 +909,11 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         else:
             history_id = None
 
-        encoded_dataset_id = kwd.get("dataset_id", None)
-        if encoded_dataset_id:
-            dataset = self.hda_manager.get_accessible(self.decode_id(encoded_dataset_id), trans.user,
-                                                      current_history=trans.history)
-            dataset_id = dataset.id
+        encoded_job_id = kwd.get("job_id", None)
+        if encoded_job_id:
+            job_id = self.decode_id(encoded_job_id)
         else:
-            dataset_id = None
+            job_id = None
 
         encoded_user_id = kwd.get("user_id", None)
         if encoded_user_id:
@@ -938,7 +935,7 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
         if limit is not None:
             limit = int(limit)
         invocations = self.workflow_manager.build_invocations_query(
-            trans, stored_workflow_id=stored_workflow_id, history_id=history_id, dataset_id=dataset_id, user_id=user_id, include_terminal=include_terminal, limit=limit
+            trans, stored_workflow_id=stored_workflow_id, history_id=history_id, job_id=job_id, user_id=user_id, include_terminal=include_terminal, limit=limit
         )
         return self.workflow_manager.serialize_workflow_invocations(invocations, **kwd)
 


### PR DESCRIPTION
## What did you do? 

Add an additional filter to `/api/invocations` to filter this endpoint by a job id.

## Why did you make this change?

This will allow one to retrieve the workflow invocation and subsequently the workflow (through the workflow id) that produced the given dataset. 
Without this, I could only see to retrieve the responsible workflow through `/datasets/<id> -> creating_job -> /jobs/<id/ -> __workflow_invocation_uuid__ -> filter invocations/ -> (..)` 

Alternatively, I wanted to add the `workflow_id` to the dataset show endpoint, but due to the additional queries/joins this might be too heavy.
In addition, I'm happy for alternative solutions to the problem "dataset_id => workflow_id".

## How to test the changes? 

- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. run a workflow
  2. use the resulting dataset id to filter -> `/api/invocations?dataset_id=`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

