### PR TITLE
Speed up get history list

### DIFF
--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -81,7 +81,7 @@ const stdHistoryParams = {
  * Return list of available histories
  */
 export async function getHistoryList() {
-    const response = await api.get("/histories", { params: stdHistoryParams });
+    const response = await api.get("/histories", { params: { view: "summary" } });
     return doResponse(response);
 }
 


### PR DESCRIPTION
## What did you do? 
- Use the summary view when getting a list of histories for the current user

I have no idea what fields are required, but a quick test didn't seem to break anything.

## Why did you make this change?
`getHistoryList` is called by the beta history client. The `betawebclient` view includes a lot of things and can take a very long time to return. This reduced the query from 47 seconds to ~ 500ms. It is probably a bug that this blocks rendering, but this is a good change to keep server load low(er) in any case.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Have a lot of histories (in my case ~ 400). Go to incognito mode and switch to the beta history panel, make sure the request returns faster than without the PR.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
