### PR TITLE
Optimized beta history polling by leveraging history.update_time + loading behavior bug fixes

### DIFF
--- a/client/src/components/History/History.vue
+++ b/client/src/components/History/History.vue
@@ -40,7 +40,6 @@
 
                     <template v-slot:listcontrols>
                         <ContentOperations
-                            v-if="!history.empty"
                             :history="history"
                             :total-matches="payload.totalMatches"
                             :loading="loading"
@@ -56,9 +55,10 @@
                     </template>
 
                     <template v-slot:listing>
-                        <HistoryEmpty v-if="history.empty && payload.contents.length == 0" class="m-2" />
+                        <HistoryEmpty v-if="history.empty" class="m-2" />
+                        <HistoryEmpty v-else-if="payload && payload.noResults" message="No Results." class="m-2" />
                         <Scroller
-                            v-else
+                            v-else-if="payload"
                             :class="{ loadingBackground: loading }"
                             key-field="hid"
                             v-bind="payload"

--- a/client/src/components/History/HistoryEmpty.vue
+++ b/client/src/components/History/HistoryEmpty.vue
@@ -1,8 +1,8 @@
 <template>
     <b-alert show>
-        <h4>
+        <h4 class="mb-1">
             <i class="fa fa-info-circle"></i>
-            <span v-localize>This history is empty.</span>
+            <span>{{ message | l }}</span>
         </h4>
         <p>
             <a href="#" @click.prevent="openGlobalUploadModal" v-localize>You can load your own data</a> or
@@ -15,6 +15,9 @@
 import { openGlobalUploadModal } from "components/Upload";
 
 export default {
+    props: {
+        message: { type: String, default: "This history is empty." },
+    },
     methods: {
         openGlobalUploadModal,
         clickDataLink() {

--- a/client/src/components/History/Scroller.vue
+++ b/client/src/components/History/Scroller.vue
@@ -29,6 +29,7 @@
 <script>
 import { debounce } from "lodash";
 import { SearchParams } from "./model";
+import { clamp } from "utils/math";
 
 const clean = (o) => JSON.parse(JSON.stringify(o));
 
@@ -108,7 +109,7 @@ export default {
 
         // need to dynamically calculate width
         scrollSliderContainerStyles() {
-            const w = this.sbWidth;
+            const w = this.sbWidth + 1;
             return { width: `${w}px` };
         },
 
@@ -182,17 +183,9 @@ export default {
             // no wheel if list too short to warrant a scroll bar
             // let the browser figure that out
             if (this.showScroller) {
-                if (deltaY > 0) this.wheelDown();
-                if (deltaY < 0) this.wheelUp();
+                const n = deltaY == 0 ? 0 : Math.abs(deltaY) / deltaY;
+                this.manualStartIndex = clamp(this.itemStartIndex + n, 0, this.totalMatches - 1);
             }
-        },
-
-        wheelDown(n = 1) {
-            this.manualStartIndex = Math.min(this.itemStartIndex + n, this.totalMatches - 1);
-        },
-
-        wheelUp(n = 1) {
-            this.manualStartIndex = Math.max(0, this.itemStartIndex - n);
         },
 
         // move to whole new regions with the scrollbar, takes the percentage

--- a/client/src/components/History/adapters/HistoryPanelProxy.js
+++ b/client/src/components/History/adapters/HistoryPanelProxy.js
@@ -63,11 +63,16 @@ export const HistoryPanelProxy = Backbone.View.extend({
         });
 
         // Watch the store, change the fake history model when it changs
-        store.subscribe(({ type, payload: newId }) => {
-            if (type == "betaHistory/setCurrentHistoryId") {
-                Galaxy.currHistoryPanel.setModel(new History({ id: newId }));
+        store.watch(
+            (st, gets) => gets["betaHistory/currentHistory"],
+            (history) => {
+                const panel = Galaxy.currHistoryPanel;
+                const existingId = panel?.model?.id || undefined;
+                if (existingId != history.id) {
+                    panel.setModel(new History({ id: history.id }));
+                }
             }
-        });
+        );
     },
     render() {
         // Hack: For now, remove unused "unified-panel" elements until we can

--- a/client/src/components/History/model/History.js
+++ b/client/src/components/History/model/History.js
@@ -1,5 +1,4 @@
 import { dateMixin, ModelBase } from "./ModelBase";
-import { bytesToString } from "utils/utils";
 
 export class History extends dateMixin(ModelBase) {
     // not deleted
@@ -18,14 +17,6 @@ export class History extends dateMixin(ModelBase) {
         }, 0);
     }
 
-    get niceSize() {
-        return this.size ? bytesToString(this.size, true, 2) : "(empty)";
-    }
-
-    get empty() {
-        return this.size == 0;
-    }
-
     get statusDescription() {
         const status = [];
         if (this.shared) status.push("Shared");
@@ -34,12 +25,6 @@ export class History extends dateMixin(ModelBase) {
         if (this.isDeleted) status.push("Deleted");
         if (this.purged) status.push("Purged");
         return status.join(", ");
-    }
-
-    loadProps(raw = {}) {
-        // eslint-disable-next-line no-unused-vars
-        const { empty, ...theRest } = raw;
-        Object.assign(this, theRest);
     }
 }
 

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -81,7 +81,8 @@ const stdHistoryParams = {
  * Return list of available histories
  */
 export async function getHistoryList() {
-    const response = await api.get("/histories", { params: { view: "summary" } });
+    const params = { view: "summary" };
+    const response = await api.get("/histories", { params });
     return doResponse(response);
 }
 
@@ -116,8 +117,6 @@ export async function createNewHistory(props = {}) {
     }
     return doResponse(createResponse);
 }
-
-//localhost:8081/history/create_new_current
 
 /**
  * Generates copy of history on server

--- a/client/src/components/History/providers/ContentProvider/ContentProvider.js
+++ b/client/src/components/History/providers/ContentProvider/ContentProvider.js
@@ -1,6 +1,6 @@
 import { NEVER } from "rxjs";
 import { SearchParams, ScrollPos } from "../../model";
-import { isValidNumber } from "./helpers";
+import { isValidNumber } from "utils/validation";
 // import { reportPayload } from "../../test/providerTestHelpers";
 
 // first emission, emitted when parent (history) or filters changes to reset the view
@@ -71,7 +71,7 @@ export const ContentProvider = {
 
         this.listenTo(scrolling$, (val) => (this.scrolling = val));
         this.listenTo(loading$, (val) => (this.loading = val));
-        this.listenTo(resetPos$, (val) => this.resetScrollPos(val));
+        this.listenTo(resetPos$, (pos) => this.setScrollPos(pos));
 
         // render output
         this.listenTo(payload$, {
@@ -82,8 +82,8 @@ export const ContentProvider = {
     },
 
     methods: {
-        resetScrollPos(pos = ScrollPos.create()) {
-            this.scrollPos = pos;
+        resetScrollPos() {
+            this.setScrollPos(ScrollPos.create());
         },
 
         initStreams() {

--- a/client/src/components/History/providers/ContentProvider/helpers.js
+++ b/client/src/components/History/providers/ContentProvider/helpers.js
@@ -15,21 +15,6 @@ export const loadInputsSame = ([inputsA, cursorA], [inputsB, cursorB]) => {
     return cursorA == cursorB && inputsSame(inputsA, inputsB);
 };
 
-// dumb math util
-export const clamp = (val, [bottom, top]) => {
-    return Math.max(bottom, Math.min(top, val));
-};
-
-// simple comparators
-export const isDefined = (val) => {
-    return val !== null && val !== undefined;
-};
-
-// defined, number and finite
-export const isValidNumber = (val) => {
-    return isDefined(val) && !isNaN(val) && isFinite(val);
-};
-
 export const paginationEqual = (a, b) => {
     return a.offset == b.offset && a.limit == b.limit;
 };

--- a/client/src/components/History/providers/ContentProvider/index.js
+++ b/client/src/components/History/providers/ContentProvider/index.js
@@ -15,4 +15,4 @@ export { aggregateCacheUpdates } from "./aggregateCacheUpdates";
 export { processContentStreams } from "./processContentStreams";
 
 // utils
-export { isValidNumber, paginationEqual } from "./helpers";
+export { paginationEqual } from "./helpers";

--- a/client/src/components/History/providers/UserHistories/UserHistories.test.js
+++ b/client/src/components/History/providers/UserHistories/UserHistories.test.js
@@ -1,6 +1,6 @@
 import Vuex from "vuex";
 import { shallowMount } from "@vue/test-utils";
-import { getLocalVue, wait, waitForLifecyleEvent } from "jest/helpers";
+import { getLocalVue, wait, waitForLifecyleEvent, watchForChange } from "jest/helpers";
 import { historyStore } from "../../model/historyStore";
 import { History } from "../../model";
 import UserHistories from "./UserHistories";
@@ -152,7 +152,12 @@ describe("UserHistories", () => {
             // set another history as current
             const nextHistory = historySummaries[1];
             setCurrentHistory(nextHistory);
-            await waitForLifecyleEvent(wrapper.vm, "updated");
+
+            await watchForChange({
+                vm: wrapper.vm,
+                propName: "currentHistory",
+                label: "currenntHistoryChange",
+            });
 
             // wait for it to register
             const { currentHistory: changedHistory, histories: newHistories } = slotProps;
@@ -167,7 +172,11 @@ describe("UserHistories", () => {
 
             // create new history
             await createNewHistory();
-            await waitForLifecyleEvent(wrapper.vm, "updated");
+
+            await watchForChange({
+                vm: wrapper.vm,
+                propName: "currentHistory",
+            });
 
             // wait for it to come out of the slot
             expect(slotProps.currentHistory.id).toEqual(createdHistory.id);
@@ -184,8 +193,8 @@ describe("UserHistories", () => {
 
             expect(modifiedHistory.id).toBeDefined();
             await updateHistory(modifiedHistory);
-
             await waitForLifecyleEvent(wrapper.vm, "updated");
+
             expect(slotProps.histories.find((h) => h.foo == "bar")).toBeTruthy();
         });
 

--- a/client/src/utils/math.js
+++ b/client/src/utils/math.js
@@ -1,0 +1,3 @@
+export const clamp = (val, bottom, top) => {
+    return Math.max(bottom, Math.min(top, val));
+};

--- a/client/src/utils/observable/decay.js
+++ b/client/src/utils/observable/decay.js
@@ -1,20 +1,21 @@
 // Stateful delay gets longer with each repeated call
 import { of } from "rxjs";
-import { mergeMap, delay } from "rxjs/operators";
+import { concatMap, delay } from "rxjs/operators";
+import { show } from "utils/observable";
 
 export const decay = (cfg = {}) => {
-    const { initialInterval, maxInterval = 60 * 1000, lambda = 0.25 } = cfg;
-
-    if (undefined === initialInterval) {
-        throw new Error("provide an initialInterval to decay");
-    }
+    const { initialInterval = 1000, maxInterval = 60 * 1000, lambda = 0.25, debug = false } = cfg;
 
     let counter = 0;
 
-    return mergeMap((val) => {
+    return concatMap((val) => {
         let waitTime = Math.floor(initialInterval * Math.exp(lambda * counter++));
         waitTime = Math.max(waitTime, initialInterval);
         waitTime = Math.min(waitTime, maxInterval);
-        return of(val).pipe(delay(waitTime));
+
+        return of(val).pipe(
+            show(debug, (val) => console.log("decay", val, counter, waitTime)),
+            delay(waitTime)
+        );
     });
 };

--- a/client/src/utils/validation.js
+++ b/client/src/utils/validation.js
@@ -1,0 +1,10 @@
+// type utils
+
+// all args not null and not undefined
+export const areDefined = (...vals) => vals.every(isDefined);
+
+// not null and not undefined
+export const isDefined = (val) => val !== undefined && val !== null;
+
+// defined, number and finite
+export const isValidNumber = (val) => isDefined(val) && !isNaN(val) && isFinite(val);


### PR DESCRIPTION
## What did you do? 

Periodic history content polls for updates now use the history.update_time to determine whether to perform the subsequent 4 expensive SQL queries to determine if the history has updated in the region of interest.

This functionality had to be removed when row-locking problems with the trigger which keeps history.update_time current arose, but now that the trigger is back, we can take advantage of the date field to significantly reduce the number of queries required to keep the history updated.

When a query is not performed because the history.update_time indicates nothing has changed, the contents/near endpoint now returns a 204 status (no content), and no processing occurs on the client.

Some minor changes to the client-side polling processing had to be made because previously we were always receiving a result on a poll, but now it's possible to poll and not emit a response (if a 204 occurs).

Several bug fixes got squeezed into the PR as well:
1. A bug where the scroll handle of the history scroller would fail to appear was addressed. The issue was the calculation of the width of the container that holds that scroll handle, the calculated width was too narrow resulting in the scrollbar not being displayed.
2. Loading flag behavior has been solidified. Previously the loading flag would flip only when a result returned, resulting in infinite loading when there was nothing to load. Now a timeout is used to track input and output activity from the loader, and when it settles down enough we call it "done loading". 
3. Similarly, a timeout was introduced to indicate that a given set of query params have no result sets resulting in a "No Results" message. In reality, there is no difference between an empty query result and a response that is still loading, because updating the cache is a constant process. For purposes of user feedback, an arbitrary timeout period had to be implemented after which we decide that a given search query has no results. This may not always be perfect if a query legitimately goes over the 2 second timeout, but the worst case scenario is a flash of a "No results" message, followed by the results as they come in.
4. Updated the poll response to include the overall history size. This value is used to determine whether or not a history is "empty" and was required to improve the behavior of the "History is empty" message. Previously polling returned no data about the history object itself, only about the contents of that history.

## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

We recently put the trigger back in, so I wanted to take advantage of the improved performance.
The rest of the bug fixes probably should have gone in a more focused bug-fix PR but were noticed by the reviewers during the course of reviewing the initial polling changes.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

Open up the javascript console while viewing the beta history. The first query for a given set of filters should return a 200 and presumably some results. Subsequent queries may return a 204 indicating no change and no content. Other than that, the behavior of the polling should be the same as before.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

