### PR TITLE
WIP Make history selection dropdown scrollable

### DIFF
--- a/client/src/components/History/CurrentHistoryPanel.vue
+++ b/client/src/components/History/CurrentHistoryPanel.vue
@@ -8,6 +8,7 @@
                             :histories="histories"
                             :current-history="currentHistory"
                             @update:currentHistory="handlers.setCurrentHistory"
+                            class="select-history"
                         />
                         <HistoriesMenu v-on="handlers" />
                     </div>
@@ -38,3 +39,9 @@ export default {
     },
 };
 </script>
+<style>
+.select-history .dropdown-menu {
+    max-width: 90%;
+    overflow-x: auto;
+}
+</style>

--- a/client/src/components/History/HistorySelector.vue
+++ b/client/src/components/History/HistorySelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-dropdown text="Select history..." size="sm" boundary="viewport" class="select-history">
+    <b-dropdown text="Select history..." size="sm" boundary="viewport">
         <b-dropdown-item
             v-for="h in histories"
             :key="h.id"
@@ -19,9 +19,3 @@ export default {
     },
 };
 </script>
-<style>
-.select-history .dropdown-menu {
-    max-width: 90%;
-    overflow-x: auto;
-}
-</style>

--- a/client/src/components/History/HistorySelector.vue
+++ b/client/src/components/History/HistorySelector.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-dropdown text="Select history..." size="sm">
+    <b-dropdown text="Select history..." size="sm" boundary="viewport" class="select-history">
         <b-dropdown-item
             v-for="h in histories"
             :key="h.id"
@@ -19,3 +19,9 @@ export default {
     },
 };
 </script>
+<style>
+.select-history .dropdown-menu {
+    max-width: 90%;
+    overflow-x: auto;
+}
+</style>


### PR DESCRIPTION
## What did you do? 
- Make history selection dropdown scrollable


## Why did you make this change?
Without this a long history name in the dropdown items will lead to all
other history names being invisible. I guess in the intermediate future this should look different (sortable, filterable, tag display etc), so I didn't want to spend a lot of time on this.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Create a long history name and make sure the dropdown remains usable.



## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [x] I've included a screenshot of the changes

<img width="245" alt="Screenshot 2021-04-23 at 17 14 31" src="https://user-images.githubusercontent.com/6804901/115892405-67789d80-a457-11eb-8236-2ba16286b844.png">