### PR TITLE
[21.01] fix `Delete account` visibility

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -86,7 +86,6 @@ import _l from "utils/localization";
 import axios from "axios";
 import QueryStringParsing from "utils/query-string-parsing";
 import { getUserPreferencesModel } from "components/User/UserPreferencesModel";
-import ConfigProvider from "components/providers/ConfigProvider";
 import { userLogoutAll, userLogoutClient } from "layout/menu";
 import "@fortawesome/fontawesome-svg-core";
 
@@ -102,9 +101,6 @@ export default {
             type: Boolean,
             required: true,
         },
-    },
-    components: {
-        ConfigProvider,
     },
     data() {
         return {

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -32,43 +32,41 @@
                 </div>
             </div>
         </b-row>
-        <ConfigProvider v-slot="{ config }">
-            <b-row v-if="config && !config.single_user" class="ml-3 mb-1">
-                <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
-                <div class="pref-content pr-1">
-                    <a href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
-                    <div class="form-text text-muted">Delete your account on this Galaxy server.</div>
-                    <b-modal
-                        id="modal-prevent-closing"
-                        centered
-                        ref="modal"
-                        title="Account Deletion"
-                        title-tag="h2"
-                        @show="resetModal"
-                        @hidden="resetModal"
-                        @ok="handleOk"
-                    >
-                        <p>
-                            <b-alert variant="danger" :show="showDeleteError">{{ deleteError }}</b-alert>
-                            <b>
-                                This action cannot be undone. Your account will be permanently deleted, along with the
-                                data contained in it.
-                            </b>
-                        </p>
-                        <b-form ref="form" @submit.prevent="handleSubmit">
-                            <b-form-group
-                                :state="nameState"
-                                label="Enter your user email for this account as confirmation."
-                                label-for="Email"
-                                invalid-feedback="Incorrect email"
-                            >
-                                <b-form-input id="name-input" v-model="name" :state="nameState" required></b-form-input>
-                            </b-form-group>
-                        </b-form>
-                    </b-modal>
-                </div>
-            </b-row>
-        </ConfigProvider>
+        <b-row v-if="!isSingleUser" class="ml-3 mb-1">
+            <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
+            <div class="pref-content pr-1">
+                <a href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
+                <div class="form-text text-muted">Delete your account on this Galaxy server.</div>
+                <b-modal
+                    id="modal-prevent-closing"
+                    centered
+                    ref="modal"
+                    title="Account Deletion"
+                    title-tag="h2"
+                    @show="resetModal"
+                    @hidden="resetModal"
+                    @ok="handleOk"
+                >
+                    <p>
+                        <b-alert variant="danger" :show="showDeleteError">{{ deleteError }}</b-alert>
+                        <b>
+                            This action cannot be undone. Your account will be permanently deleted, along with the data
+                            contained in it.
+                        </b>
+                    </p>
+                    <b-form ref="form" @submit.prevent="handleSubmit">
+                        <b-form-group
+                            :state="nameState"
+                            label="Enter your user email for this account as confirmation."
+                            label-for="Email"
+                            invalid-feedback="Incorrect email"
+                        >
+                            <b-form-input id="name-input" v-model="name" :state="nameState" required></b-form-input>
+                        </b-form-group>
+                    </b-form>
+                </b-modal>
+            </div>
+        </b-row>
         <p class="mt-2">
             You are using <strong>{{ diskUsage }}</strong> of disk space in this Galaxy instance.
             <span v-html="quotaUsageString"></span>
@@ -114,6 +112,7 @@ export default {
             diskUsage: "",
             quotaUsageString: "",
             baseUrl: `${getAppRoot()}user`,
+            isSingleUser: getGalaxyInstance().config.single_user,
             messageVariant: null,
             message: null,
             name: "",


### PR DESCRIPTION
## What did you do? 
fix `Delete account`

## Why did you make this change?
Looks like scopedSlot in ConfigProvider is not that reactive. This v-if https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/User/UserPreferences.vue#L36 is not getting updated. As a result `Delete Account` option is always hidden. This is a temporary fix, just  to make things in 21.01 work again


## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. User -> Preferences -> Delete Account

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [x] I've included a screenshot of the changes
![image](https://user-images.githubusercontent.com/15801412/115994206-4db19480-a5d6-11eb-9c68-402de68a8c09.png)
