### PR TITLE
[21.01] Fix ``Delete account`` visibility

### DIFF
--- a/client/src/components/providers/ConfigProvider.js
+++ b/client/src/components/providers/ConfigProvider.js
@@ -18,6 +18,6 @@ export default {
         this.loadConfigs();
     },
     render() {
-        return this.$scopedSlots.default(this.config);
+        return this.$scopedSlots.default({ config: this.config });
     },
 };


### PR DESCRIPTION
## What did you do? 
- Add the `config` slot to ConfigProvider

## Why did you make this change?
Fixes ``Delete account`` visibility


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
User -> Preferences -> Delete Account

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes