### PR TITLE
Limit max column in tabular dataset preview

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -868,7 +868,7 @@ class Eland(Tabular):
                 out.append('<th>{}.{}</th>'.format(str(i + 1), name))
             # This data type requires at least 11 columns in the data
             if dataset.metadata.columns - len(self.column_names) > 0:
-                for i in range(max(len(self.column_names), 50), dataset.metadata.columns):
+                for i in range(len(self.column_names), max(dataset.metadata.columns, self.max_peek_columns)):
                     out.append('<th>%s</th>' % str(i + 1))
                 out.append('</tr>')
             out.append(self.make_html_peek_rows(dataset, skipchars=skipchars, peek=peek))


### PR DESCRIPTION
## What did you do? 
- Limit max column in tabular dataset preview


## Why did you make this change?
https://github.com/galaxyproject/galaxy/issues/11885


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Load https://zenodo.org/record/4597857/files/GSE123818_Root_single_cell_wt_datamatrix.fixednames.transposed.csv.gz and make sure the time to open the daatset details in the history is acceptable.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
