### PR TITLE
Abstraction for fetching qualified app URL across webapp types

### DIFF
--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -37,7 +37,7 @@ A method that requires a user but not a history should declare its
 import abc
 import string
 from json import dumps
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from sqlalchemy.orm.scoping import scoped_session
 
@@ -65,6 +65,10 @@ class ProvidesAppContext:
     def app(self) -> MinimalManagerApp:
         """Provide access to the Galaxy ``app`` object.
         """
+
+    @abc.abstractproperty
+    def qualified_url_builder(self) -> Optional[Callable[[str], str]]:
+        """Provide access to fully qualified Galaxy URLs (if available)."""
 
     @property
     def security(self) -> IdEncodingHelper:

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1593,7 +1593,7 @@ class Tool(Dictifiable):
         to the form or execute the tool (only if 'execute' was clicked and
         there were no errors).
         """
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history or trans.history)
+        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history or trans.history, qualified_url_builder=trans.qualified_url_builder)
         all_params, all_errors, rerun_remap_job_id, collection_info = self.expand_incoming(trans=trans, incoming=incoming, request_context=request_context, input_format=input_format)
         # If there were errors, we stay on the same page and display them
         if any(all_errors):
@@ -1767,7 +1767,7 @@ class Tool(Dictifiable):
         from a database in case new parameters have been added.
         """
         messages = {}
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=trans.history, workflow_building_mode=workflow_building_mode)
+        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=trans.history, workflow_building_mode=workflow_building_mode, qualified_url_builder=trans.qualified_url_builder)
 
         def validate_inputs(input, value, error, parent, context, prefixed_name, prefixed_label, **kwargs):
             if not error:
@@ -2130,7 +2130,7 @@ class Tool(Dictifiable):
                 raise exceptions.MessageException('History unavailable. Please specify a valid history id')
 
         # build request context
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode)
+        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode, qualified_url_builder=trans.qualified_url_builder)
 
         # load job parameters into incoming
         tool_message = ''

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -107,7 +107,7 @@ from galaxy.util.tool_shed.common_util import (
     get_tool_shed_url_from_tool_shed_registry,
 )
 from galaxy.version import VERSION_MAJOR
-from galaxy.work.context import WorkRequestContext
+from galaxy.work.context import proxy_work_context_for_history
 from .execute import (
     execute as execute_job,
     MappingParameters,
@@ -1593,7 +1593,7 @@ class Tool(Dictifiable):
         to the form or execute the tool (only if 'execute' was clicked and
         there were no errors).
         """
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history or trans.history, qualified_url_builder=trans.qualified_url_builder)
+        request_context = proxy_work_context_for_history(trans, history=history)
         all_params, all_errors, rerun_remap_job_id, collection_info = self.expand_incoming(trans=trans, incoming=incoming, request_context=request_context, input_format=input_format)
         # If there were errors, we stay on the same page and display them
         if any(all_errors):
@@ -1767,7 +1767,7 @@ class Tool(Dictifiable):
         from a database in case new parameters have been added.
         """
         messages = {}
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=trans.history, workflow_building_mode=workflow_building_mode, qualified_url_builder=trans.qualified_url_builder)
+        request_context = proxy_work_context_for_history(trans, workflow_building_mode=workflow_building_mode)
 
         def validate_inputs(input, value, error, parent, context, prefixed_name, prefixed_label, **kwargs):
             if not error:
@@ -2130,7 +2130,7 @@ class Tool(Dictifiable):
                 raise exceptions.MessageException('History unavailable. Please specify a valid history id')
 
         # build request context
-        request_context = WorkRequestContext(app=trans.app, user=trans.user, history=history, workflow_building_mode=workflow_building_mode, qualified_url_builder=trans.qualified_url_builder)
+        request_context = proxy_work_context_for_history(trans, history, workflow_building_mode=workflow_building_mode)
 
         # load job parameters into incoming
         tool_message = ''

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -800,7 +800,7 @@ class BaseURLToolParameter(HiddenToolParameter):
         try:
             if not self.value.startswith("/"):
                 raise Exception("baseurl value must start with a /")
-            return trans.qualified_url_for_path(self.value)
+            return trans.qualified_url_builder(self.value)
         except Exception as e:
             log.debug('Url creation failed for "%s": %s', self.name, unicodify(e))
             return self.value

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -25,7 +25,6 @@ from galaxy.util import (
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.expressions import ExpressionContext
 from galaxy.util.rules_dsl import RuleSet
-from galaxy.web import url_for
 from . import (
     dynamic_options,
     history_query,
@@ -792,14 +791,16 @@ class BaseURLToolParameter(HiddenToolParameter):
         self.value = input_source.get('value', '')
 
     def get_initial_value(self, trans, other_values):
-        return self._get_value()
+        return self._get_value(trans)
 
     def from_json(self, value=None, trans=None, other_values=None):
-        return self._get_value()
+        return self._get_value(trans)
 
-    def _get_value(self):
+    def _get_value(self, trans):
         try:
-            return url_for(self.value, qualified=True)
+            if not self.value.startswith("/"):
+                raise Exception("baseurl value must start with a /")
+            return trans.qualified_url_for_path(self.value)
         except Exception as e:
             log.debug('Url creation failed for "%s": %s', self.name, unicodify(e))
             return self.value

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -968,6 +968,9 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
             return []
         return render
 
+    def qualified_url_for_path(self, path):
+        return url_for(path, qualified=True)
+
 
 def default_url_path(path):
     return os.path.abspath(os.path.join(os.path.dirname(__file__), path))

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -188,6 +188,10 @@ def config_allows_origin(origin_raw, config):
     return False
 
 
+def qualified_url_builder(path):
+    return url_for(path, qualified=True)
+
+
 class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryContext):
     """
     Encapsulates web transaction specific state for the Galaxy application
@@ -276,6 +280,10 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
     @property
     def app(self):
         return self._app
+
+    @property
+    def qualified_url_builder(self):
+        return qualified_url_builder
 
     def setup_i18n(self):
         locales = []

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -124,13 +124,12 @@ def get_user(galaxy_session: Optional[model.GalaxySession] = Depends(get_session
     return api_user
 
 
-class HttpSessionRequestContext(SessionRequestContext):
+class QualifiedUrlBuilder:
 
-    def __init__(self, **kwd):
-        self.request = kwd.pop('request', None)
-        super().__init__(**kwd)
+    def __init__(self, request: Request):
+        self.request = request
 
-    def qualified_url_for_path(self, path):
+    def __call__(self, path):
         return self.request.url_for(path)
 
 
@@ -139,8 +138,9 @@ DependsOnUser = Depends(get_user)
 
 def get_trans(request: Request, app: StructuredApp = DependsOnApp, user: Optional[User] = Depends(get_user),
               galaxy_session: Optional[model.GalaxySession] = Depends(get_session),
-              ) -> HttpSessionRequestContext:
-    return HttpSessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, request=request)
+              ) -> SessionRequestContext:
+    qualified_url_builder = QualifiedUrlBuilder(request)
+    return SessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, qualified_url_builder=qualified_url_builder)
 
 
 DependsOnTrans = Depends(get_trans)

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -124,13 +124,23 @@ def get_user(galaxy_session: Optional[model.GalaxySession] = Depends(get_session
     return api_user
 
 
+class HttpSessionRequestContext(SessionRequestContext):
+
+    def __init__(self, **kwd):
+        self.request = kwd.pop('request', None)
+        super().__init__(**kwd)
+
+    def qualified_url_for_path(self, path):
+        return self.request.url_for(path)
+
+
 DependsOnUser = Depends(get_user)
 
 
-def get_trans(app: StructuredApp = DependsOnApp, user: Optional[User] = Depends(get_user),
+def get_trans(request: Request, app: StructuredApp = DependsOnApp, user: Optional[User] = Depends(get_user),
               galaxy_session: Optional[model.GalaxySession] = Depends(get_session),
-              ) -> SessionRequestContext:
-    return SessionRequestContext(app=app, user=user, galaxy_session=galaxy_session)
+              ) -> HttpSessionRequestContext:
+    return HttpSessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, request=request)
 
 
 DependsOnTrans = Depends(get_trans)

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 from galaxy.managers.context import (
     ProvidesHistoryContext,
 )
+from galaxy.model import History
 
 
 class WorkRequestContext(ProvidesHistoryContext):
@@ -63,3 +66,13 @@ class SessionRequestContext(WorkRequestContext):
 
     def get_galaxy_session(self):
         return self.galaxy_session
+
+
+def proxy_work_context_for_history(trans: ProvidesHistoryContext, history: Optional[History] = None, workflow_building_mode=False):
+    """Create a WorkContext for supplied context with potentially different history.
+
+    This provides semi-structured access to a transaction/work context with a supplied target
+    history that is different from the user's current history (which also might change during
+    the request).
+    """
+    return WorkRequestContext(app=trans.app, user=trans.user, history=history or trans.history, qualified_url_builder=trans.qualified_url_builder, workflow_building_mode=workflow_building_mode)

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -16,16 +16,21 @@ class WorkRequestContext(ProvidesHistoryContext):
     objects.
     """
 
-    def __init__(self, app, user=None, history=None, workflow_building_mode=False):
+    def __init__(self, app, user=None, history=None, workflow_building_mode=False, qualified_url_builder=None):
         self._app = app
         self.__user = user
         self.__user_current_roles = None
         self.__history = history
+        self._qualified_url_builder = qualified_url_builder
         self.workflow_building_mode = workflow_building_mode
 
     @property
     def app(self):
         return self._app
+
+    @property
+    def qualified_url_builder(self):
+        return self._qualified_url_builder
 
     def get_history(self, create=False):
         return self.__history

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -207,6 +207,16 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         assert output["inherit_format"] is True
 
     @skip_without_tool("test_data_source")
+    def test_data_source_build_request(self):
+        with self.dataset_populator.test_history() as history_id:
+            build = self.dataset_populator.build_tool_state("test_data_source", history_id)
+            galaxy_url_param = build["inputs"][0]
+            assert galaxy_url_param["name"] == "GALAXY_URL"
+            galaxy_url = galaxy_url_param["value"]
+            assert galaxy_url.startswith("http")
+            assert galaxy_url.endswith("tool_runner?tool_id=ratmine")
+
+    @skip_without_tool("test_data_source")
     def test_data_source_ok_request(self):
         with self.dataset_populator.test_history() as history_id:
             payload = self.dataset_populator.run_tool_payload(
@@ -1574,7 +1584,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
     @uses_test_history(require_new=False)
     def test_list_selectable_in_multidata_input(self, history_id):
         self.dataset_collection_populator.create_list_in_history(history_id, contents=["123", "456"])
-        build = self._post("tools/identifier_multiple/build?history_id=%s" % history_id).json()
+        build = self.dataset_populator.build_tool_state("identifier_multiple", history_id)
         assert len(build['inputs'][0]['options']['hdca']) == 1
 
     @skip_without_tool("identifier_multiple")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -463,6 +463,11 @@ class BaseDatasetPopulator(BasePopulator):
             **kwds
         )
 
+    def build_tool_state(self, tool_id: str, history_id: str):
+        response = self._post(f"tools/{tool_id}/build?history_id={history_id}")
+        response.raise_for_status()
+        return response.json()
+
     def run_tool(self, tool_id: str, inputs: dict, history_id: str, assert_ok: bool = True, **kwds):
         payload = self.run_tool_payload(tool_id, inputs, history_id, **kwds)
         tool_response = self.tools_post(payload)

--- a/test/unit/test_routes.py
+++ b/test/unit/test_routes.py
@@ -31,6 +31,7 @@ def test_galaxy_routes():
     config.host = "usegalaxy.org"
     config.protocol = "https"
     assert_url_is(url_for("api_key_retrieval", qualified=True), "https://usegalaxy.org/api/authenticate/baseauth")
+    assert_url_is(url_for("/tool_runner/biomart", qualified=True), "https://usegalaxy.org/tool_runner/biomart")
 
     # Test previously problematic tool ids with slashes.
     test_webapp.assert_maps(

--- a/test/unit/test_routes.py
+++ b/test/unit/test_routes.py
@@ -1,3 +1,5 @@
+from routes import request_config
+
 from galaxy.util.bunch import Bunch
 from galaxy.web import url_for
 from galaxy.webapps.base.webapp import WebApplication
@@ -25,8 +27,10 @@ def test_galaxy_routes():
     test_webapp = TestWebapp(app)
 
     galaxy_buildapp.populate_api_routes(test_webapp, app)
-
-    assert_url_is(url_for("api_key_retrieval"), "/api/authenticate/baseauth")
+    config = request_config()
+    config.host = "usegalaxy.org"
+    config.protocol = "https"
+    assert_url_is(url_for("api_key_retrieval", qualified=True), "https://usegalaxy.org/api/authenticate/baseauth")
 
     # Test previously problematic tool ids with slashes.
     test_webapp.assert_maps(

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -204,6 +204,7 @@ class MockTrans:
         self.workflow_building_mode = False
         self.webapp = Bunch(name="galaxy")
         self.sa_session = self.app.model.context
+        self.qualified_url_builder = None
 
     def get_history(self, **kwargs):
         return self.history

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -236,6 +236,7 @@ class MockTrans:
         self.anonymous = False
         self.debug = True
         self.user_is_admin = True
+        self.qualified_url_builder = None
 
         self.galaxy_session = None
         self.__user = user


### PR DESCRIPTION
## What did you do? 
- Add abstraction for recovering URL.

## Why did you make this change?

- https://github.com/galaxyproject/galaxy/pull/11608/files#r601625363

## How to test the changes? 
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

