### PR TITLE
Add ``delete account`` selenium test

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -36,7 +36,7 @@
             <b-row v-if="config && !config.single_user" class="ml-3 mb-1">
                 <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
                 <div class="pref-content pr-1">
-                    <a href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
+                    <a id="delete-account" href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
                     <div class="form-text text-muted">Delete your account on this Galaxy server.</div>
                     <b-modal
                         id="modal-prevent-closing"

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -36,7 +36,9 @@
             <b-row v-if="config && !config.single_user" class="ml-3 mb-1">
                 <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
                 <div class="pref-content pr-1">
-                    <a id="delete-account" href="javascript:void(0)"><b v-b-modal.modal-prevent-closing>Delete Account</b></a>
+                    <a id="delete-account" href="javascript:void(0)"
+                        ><b v-b-modal.modal-prevent-closing>Delete Account</b></a
+                    >
                     <div class="form-text text-muted">Delete your account on this Galaxy server.</div>
                     <b-modal
                         id="modal-prevent-closing"

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -76,6 +76,9 @@ preferences:
     manage_api_key: '#edit-preferences-api-key'
     current_email: "#user-preferences-current-email"
     get_new_key: '#submit'
+    delete_account: '#delete-account'
+    delete_account_input: '#name-input'
+    delete_account_ok_btn: '.modal-footer .btn-primary'
 
 toolbox_filters:
   selectors:

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -138,12 +138,10 @@ class DeleteCurrentAccountTestCase(SeleniumTestCase):
         self.register(email)
         self.navigate_to_user_preferences()
         self.sleep_for(self.wait_types.UX_RENDER)
-
         self.components.preferences.delete_account.wait_for_and_click()
         delete_confirmation_field = self.components.preferences.delete_account_input.wait_for_visible()
         delete_confirmation_field.send_keys(email)
         self.components.preferences.delete_account_ok_btn.wait_for_and_click()
         self.submit_login(email=email, assert_valid=False)
-        self.assert_error_message(contains='This account has been marked deleted, contact your local Galaxy administrator to restore the account.')
-
-
+        self.assert_error_message(contains='This account has been marked deleted, contact your local Galaxy'
+                                           ' administrator to restore the account.')

--- a/lib/galaxy_test/selenium/test_personal_information.py
+++ b/lib/galaxy_test/selenium/test_personal_information.py
@@ -128,3 +128,22 @@ class ManageInformationTestCase(SeleniumTestCase):
 
     def get_address_input_field(self, address_form, input_field_label):
         return address_form.find_element_by_css_selector("[data-label='" + input_field_label + "'] > input")
+
+
+class DeleteCurrentAccountTestCase(SeleniumTestCase):
+
+    @selenium_test
+    def test_delete_account(self):
+        email = self._get_random_email()
+        self.register(email)
+        self.navigate_to_user_preferences()
+        self.sleep_for(self.wait_types.UX_RENDER)
+
+        self.components.preferences.delete_account.wait_for_and_click()
+        delete_confirmation_field = self.components.preferences.delete_account_input.wait_for_visible()
+        delete_confirmation_field.send_keys(email)
+        self.components.preferences.delete_account_ok_btn.wait_for_and_click()
+        self.submit_login(email=email, assert_valid=False)
+        self.assert_error_message(contains='This account has been marked deleted, contact your local Galaxy administrator to restore the account.')
+
+


### PR DESCRIPTION
## What did you do? 
implemented selenium test for testing user self-delete 

## Why did you make this change?
so we don't have to fix such a problem https://github.com/galaxyproject/galaxy/pull/11897 in the future


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. ```./run_tests.sh -selenium lib/galaxy_test/selenium/test_personal_information.py::DeleteCurrentAccountTestCase::test_delete_account```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

