### PR TITLE
[21.01] Shared visualization display fix

### DIFF
--- a/templates/webapps/galaxy/visualization/display_in_frame.mako
+++ b/templates/webapps/galaxy/visualization/display_in_frame.mako
@@ -49,7 +49,7 @@
 <%def name="render_item( visualization, config )">
     <div id="${trans.security.encode_id( visualization.id )}" class="unified-panel-body" style="overflow:none;top:0px;">
         <iframe frameborder="0" width="100%" height="100%" sandbox="allow-forms allow-same-origin allow-scripts"
-                src="/visualization/saved?id=${encoded_visualization_id}&embedded=True">
+                src="/visualization/saved?id=${encoded_visualization_id}">
         </iframe>
     </div>
 </%def>


### PR DESCRIPTION
## What did you do? 
- Use full page context (not just the short embed chunk) when injecting a viz in an iframe

## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/11888

## How to test the changes? 
- [x] Instructions for manual testing are as follows:
  1. See https://github.com/galaxyproject/galaxy/issues/11888, create and view a visualization (basic chart like nvd3 will work fine) like that.
 
## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.