### PR TITLE
Update framework dependencies

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -1,13 +1,13 @@
 --extra-index-url https://wheels.galaxyproject.org/simple
 
-adal==1.2.6
+adal==1.2.7
 aiofiles==0.6.0
 alabaster==0.7.12; python_version >= "3.5"
 amqp==5.0.6; python_version >= "3.6"
 appdirs==1.4.4; python_version >= "3.6"
-argcomplete==1.12.2; python_version >= "3.6" and python_version < "4"
+argcomplete==1.12.3; python_version >= "3.6" and python_version < "4"
 async-exit-stack==1.0.1; python_version >= "3.6" and python_version < "3.7"
-async-generator==1.10; python_version >= "3.6" and python_version < "3.7"
+async-generator==1.10; python_version < "3.7" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
 attmap==0.13.0
 attrs==20.3.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
@@ -32,7 +32,7 @@ celery==5.0.5; python_version >= "3.6"
 certifi==2020.12.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 cffi==1.14.5; implementation_name == "pypy" and python_version >= "3.6" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 chardet==4.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-cheetah3==3.2.6.post1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+cheetah3==3.2.6.post2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 circus==0.17.1
 click-didyoumean==0.0.3; python_version >= "3.6"
 click-plugins==1.1.1; python_version >= "3.6"
@@ -51,13 +51,13 @@ cryptography==3.4.7; python_version >= "3.6"
 cwltool==3.0.20201109103151; python_version >= "3.6" and python_version < "4"
 dataclasses==0.8; python_version >= "3.6" and python_version < "3.7"
 debtcollector==2.2.0; python_version >= "3.6"
-decorator==5.0.3; python_version >= "3.6"
+decorator==5.0.7; python_version >= "3.6"
 defusedxml==0.7.1; python_version >= "3.0" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.0"
 deprecated==1.2.12; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 deprecation==2.1.0
 dictobj==0.4
 docopt==0.6.2
-docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 dogpile.cache==1.1.2; python_version >= "3.6"
 ecdsa==0.14.1; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 fabric3==1.14.post1
@@ -70,20 +70,20 @@ galaxy-sequence-utils==1.1.5
 google-api-core==1.26.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 google-api-python-client==1.12.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth-httplib2==0.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-google-auth==1.28.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+google-auth==1.30.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 googleapis-common-protos==1.53.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 gunicorn==20.1.0; python_version >= "3.5"
 gxformat2==0.15.0
 h11==0.12.0; python_version >= "3.6"
 h5py==3.1.0; python_version >= "3.6"
-httpcore==0.12.3; python_version >= "3.6"
+httpcore==0.13.0; python_version >= "3.6"
 httplib2==0.19.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-httpx==0.17.1; python_version >= "3.6"
+httpx==0.18.0; python_version >= "3.6"
 humanfriendly==9.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0"
 idna==2.10; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 imagesize==1.2.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5"
 immutables==0.15; python_version >= "3.6" and python_version < "3.7"
-importlib-metadata==3.10.0; python_version < "3.8" and python_version >= "3.6" and (python_version == "3.6" or python_version == "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8")
+importlib-metadata==4.0.1; python_version < "3.8" and python_version >= "3.6" and (python_version == "3.6" or python_version == "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.4.0" and python_version >= "3.6" and python_version < "3.8")
 importlib-resources==5.1.2; python_version < "3.7" and python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.6"
 isa-rwval==0.10.10
@@ -106,14 +106,14 @@ markupsafe==1.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") o
 mercurial==5.7.1
 mirakuru==2.3.0; python_version >= "3.6"
 mistune==0.8.4; python_version >= "3.6" and python_version < "4"
-mrcfile==1.2.0; python_version >= "3.6"
+mrcfile==1.3.0
 msgpack==1.0.2; python_version >= "3.6"
 munch==2.5.0; python_version >= "3.6"
 mypy-extensions==0.4.3; python_version >= "3.6" and python_version < "4"
 netaddr==0.8.0; python_version >= "3.6"
 netifaces==0.10.9; python_version >= "3.6"
 networkx==2.5; python_version >= "3.6" and python_version < "4"
-nodeenv==1.5.0
+nodeenv==1.6.0
 nose==1.3.7
 nosehtml==0.4.6
 numpy==1.19.5; python_version >= "3.6"
@@ -123,7 +123,7 @@ openstacksdk==0.52.0; python_version >= "3.6"
 os-client-config==2.1.0; python_version >= "3.6"
 os-service-types==1.7.0; python_version >= "3.6"
 osc-lib==2.3.1; python_version >= "3.6"
-oslo.config==8.5.0; python_version >= "3.6"
+oslo.config==8.6.0; python_version >= "3.6"
 oslo.context==3.2.0; python_version >= "3.6"
 oslo.i18n==5.0.1; python_version >= "3.6"
 oslo.log==4.4.0; python_version >= "3.6"
@@ -135,12 +135,12 @@ paramiko==2.7.2
 parsley==1.3
 paste==3.5.0
 pastedeploy==2.1.1
-pbr==5.5.1; python_version >= "3.6"
+pbr==5.6.0; python_version >= "3.6"
 pluggy==0.13.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 port-for==0.4; python_version >= "3.6"
 prettytable==0.7.2; python_version >= "3.6"
 prompt-toolkit==3.0.3; python_version >= "3.6"
-protobuf==3.15.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+protobuf==3.15.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 prov==1.5.1; python_version >= "3.6" and python_version < "4"
 psutil==5.8.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 pulsar-galaxy-lib==0.14.5
@@ -153,28 +153,28 @@ pydantic==1.7.3; python_version >= "3.6" and python_version < "4.0"
 pydot==1.4.2; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.4.0"
 pyeventsystem==0.1.0
 pyfaidx==0.5.9.5
-pygithub==1.54.1; python_version >= "3.6"
+pygithub==1.55; python_version >= "3.6"
 pygments==2.8.1; python_version >= "3.5"
 pyinotify==0.9.6; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "sunos5" and python_version >= "3.6"
-pyjwt==1.7.1; python_version >= "3.6"
+pyjwt==2.0.1; python_version >= "3.6"
 pykwalify==1.8.0
-pynacl==1.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+pynacl==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyparsing==2.4.7; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
 pyperclip==1.8.2; python_version >= "3.6"
 pyreadline3==3.3; sys_platform == "win32" and python_version >= "3.8"
 pyreadline==2.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "3.8" and sys_platform == "win32" or python_version >= "3.6" and python_version < "3.8" and python_full_version >= "3.5.0" and sys_platform == "win32"
 pyrsistent==0.17.3; python_version >= "3.5"
 pysam==0.16.0.1
-pytest-asyncio==0.14.0; python_version >= "3.5"
+pytest-asyncio==0.15.1; python_version >= "3.6"
 pytest-cov==2.11.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pytest-html==3.1.1; python_version >= "3.6"
 pytest-json-report==1.2.4
 pytest-metadata==1.11.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytest-mock==3.5.1; python_version >= "3.5"
+pytest-mock==3.6.0; python_version >= "3.6"
 pytest-postgresql==2.6.1; python_version >= "3.6"
 pytest-pythonpath==0.7.3
 pytest-shard==0.1.2; python_version >= "3.6"
-pytest==6.2.2; python_version >= "3.6"
+pytest==6.2.3; python_version >= "3.6"
 python-dateutil==2.8.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.3.0"
 python-irodsclient==0.8.6
 python-jose==3.2.0
@@ -202,7 +202,7 @@ routes==2.5.1
 rsa==4.7.2; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.8" and python_version >= "3.6"
 ruamel.yaml==0.16.5; python_version >= "3.6" and python_version < "4"
-s3transfer==0.3.6
+s3transfer==0.3.7
 schema-salad==7.1.20210316164414; python_version >= "3.6" and python_version < "4"
 selenium==3.141.0
 setuptools-scm==5.0.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
@@ -226,7 +226,7 @@ sqlalchemy-migrate==0.13.0
 sqlalchemy==1.3.24; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
-starlette-context==0.3.1; python_version >= "3.7"
+starlette-context==0.3.2; python_version >= "3.7"
 starlette==0.13.6; python_version >= "3.6"
 statsd==3.3.0
 stevedore==3.3.0; python_version >= "3.6"
@@ -234,10 +234,10 @@ svgwrite==1.4.1; python_version >= "3.6"
 tempita==0.5.2
 tenacity==7.0.0
 testfixtures==6.17.1
-tifffile==2020.9.3
+tifffile==2020.9.3; python_version >= "3.6"
 toml==0.10.2; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6"
 tornado==6.1; python_version >= "3.5"
-tqdm==4.59.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+tqdm==4.60.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 twill==3.0
 typing-extensions==3.7.4.3; python_version >= "3.6" and python_version < "3.8"
 tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
@@ -247,7 +247,7 @@ uritemplate==3.0.1; python_version >= "2.7" and python_full_version < "3.0.0" or
 urllib3==1.26.4; python_version >= "2.7" and python_full_version < "3.0.0" and python_version != "3.4" or python_full_version >= "3.5.0" and python_version < "4" and python_version != "3.4"
 uvicorn==0.13.4
 vine==5.0.0; python_version >= "3.6"
-watchdog==2.0.2; python_version >= "3.6"
+watchdog==2.0.3; python_version >= "3.6"
 wcwidth==0.2.5; python_version >= "3.6"
 webencodings==0.5.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 webob==1.8.7; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")

--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -27,7 +27,7 @@ botocore==1.19.63
 bx-python==0.8.11; python_version >= "3.6"
 cachecontrol==0.11.7; python_version >= "3.6" and python_version < "4"
 cached-property==1.5.2; python_version < "3.8" and python_version >= "3.6"
-cachetools==4.2.1; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+cachetools==4.2.2; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 celery==5.0.5; python_version >= "3.6"
 certifi==2020.12.5; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 cffi==1.14.5; implementation_name == "pypy" and python_version >= "3.6" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
@@ -57,7 +57,7 @@ deprecated==1.2.12; python_version >= "3.6" and python_full_version < "3.0.0" or
 deprecation==2.1.0
 dictobj==0.4
 docopt==0.6.2
-docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 dogpile.cache==1.1.2; python_version >= "3.6"
 ecdsa==0.14.1; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 fabric3==1.14.post1
@@ -156,7 +156,7 @@ pyfaidx==0.5.9.5
 pygithub==1.55; python_version >= "3.6"
 pygments==2.8.1; python_version >= "3.5"
 pyinotify==0.9.6; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "sunos5" and python_version >= "3.6"
-pyjwt==2.0.1; python_version >= "3.6"
+pyjwt==2.1.0; python_version >= "3.6"
 pykwalify==1.8.0
 pynacl==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyparsing==2.4.7; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
@@ -196,7 +196,7 @@ requests-oauthlib==1.3.0; python_version >= "2.7" and python_full_version < "3.0
 requests-toolbelt==0.9.1; python_version >= "3.6"
 requests==2.25.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 requestsexceptions==1.4.0; python_version >= "3.6"
-responses==0.13.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+responses==0.13.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 rfc3986==1.4.0; python_version >= "3.6"
 routes==2.5.1
 rsa==4.7.2; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
@@ -214,8 +214,8 @@ snowballstemmer==2.1.0; python_version >= "3.5"
 social-auth-core==3.3.0
 sortedcontainers==2.3.0
 sphinx-markdown-tables==0.0.15
-sphinx-rtd-theme==0.5.1
-sphinx==3.5.3; python_version >= "3.5"
+sphinx-rtd-theme==0.5.2
+sphinx==3.5.4; python_version >= "3.5"
 sphinxcontrib-applehelp==1.0.2; python_version >= "3.5"
 sphinxcontrib-devhelp==1.0.2; python_version >= "3.5"
 sphinxcontrib-htmlhelp==1.0.3; python_version >= "3.5"

--- a/lib/galaxy/dependencies/pinned-lint-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-lint-requirements.txt
@@ -1,13 +1,13 @@
 attrs==20.3.0
-flake8==3.9.0
+flake8==3.9.1
 flake8-bugbear==21.4.3
 flake8-import-order==0.18.1
-importlib-metadata==3.10.0
+importlib-metadata==4.0.1
 mccabe==0.6.1
 mypy==0.790
 mypy-extensions==0.4.3
 pycodestyle==2.7.0
 pyflakes==2.3.1
-typed-ast==1.4.2
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 zipp==3.4.1

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -25,7 +25,7 @@ botocore==1.19.63
 bx-python==0.8.11; python_version >= "3.6"
 cachecontrol==0.11.7; python_version >= "3.6" and python_version < "4"
 cached-property==1.5.2; python_version < "3.8" and python_version >= "3.6"
-cachetools==4.2.1; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+cachetools==4.2.2; python_version >= "3.5" and python_version < "4.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 celery==5.0.5; python_version >= "3.6"
 certifi==2020.12.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 cffi==1.14.5; implementation_name == "pypy" and python_version >= "3.6" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
@@ -52,7 +52,7 @@ defusedxml==0.7.1; python_version >= "3.0" and python_full_version < "3.0.0" or 
 deprecation==2.1.0
 dictobj==0.4
 docopt==0.6.2
-docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 dogpile.cache==1.1.2; python_version >= "3.6"
 ecdsa==0.14.1; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 fabric3==1.14.post1
@@ -137,7 +137,7 @@ pydot==1.4.2; python_version >= "3.6" and python_full_version < "3.0.0" and pyth
 pyeventsystem==0.1.0
 pyfaidx==0.5.9.5
 pyinotify==0.9.6; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "sunos5" and python_version >= "3.6"
-pyjwt==2.0.1; python_version >= "3.6"
+pyjwt==2.1.0; python_version >= "3.6"
 pykwalify==1.8.0
 pynacl==1.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 pyparsing==2.4.7; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -1,10 +1,10 @@
 --extra-index-url https://wheels.galaxyproject.org/simple
 
-adal==1.2.6
+adal==1.2.7
 aiofiles==0.6.0
 amqp==5.0.6; python_version >= "3.6"
 appdirs==1.4.4; python_version >= "3.6"
-argcomplete==1.12.2; python_version >= "3.6" and python_version < "4"
+argcomplete==1.12.3; python_version >= "3.6" and python_version < "4"
 async-exit-stack==1.0.1; python_version >= "3.6" and python_version < "3.7"
 async-generator==1.10; python_version >= "3.6" and python_version < "3.7"
 attmap==0.13.0
@@ -30,7 +30,7 @@ celery==5.0.5; python_version >= "3.6"
 certifi==2020.12.5; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 cffi==1.14.5; implementation_name == "pypy" and python_version >= "3.6" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0")
 chardet==4.0.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
-cheetah3==3.2.6.post1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
+cheetah3==3.2.6.post2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 circus==0.17.1
 click-didyoumean==0.0.3; python_version >= "3.6"
 click-plugins==1.1.1; python_version >= "3.6"
@@ -47,12 +47,12 @@ cryptography==3.4.7; python_version >= "3.6"
 cwltool==3.0.20201109103151; python_version >= "3.6" and python_version < "4"
 dataclasses==0.8; python_version >= "3.6" and python_version < "3.7"
 debtcollector==2.2.0; python_version >= "3.6"
-decorator==5.0.3; python_version >= "3.6"
+decorator==5.0.7; python_version >= "3.6"
 defusedxml==0.7.1; python_version >= "3.0" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.0"
 deprecation==2.1.0
 dictobj==0.4
 docopt==0.6.2
-docutils==0.16; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+docutils==0.17.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 dogpile.cache==1.1.2; python_version >= "3.6"
 ecdsa==0.14.1; python_version >= "2.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0"
 fabric3==1.14.post1
@@ -64,7 +64,7 @@ galaxy-sequence-utils==1.1.5
 google-api-core==1.26.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 google-api-python-client==1.12.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 google-auth-httplib2==0.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
-google-auth==1.28.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+google-auth==1.30.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 googleapis-common-protos==1.53.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 gxformat2==0.15.0
 h11==0.12.0; python_version >= "3.6"
@@ -73,7 +73,7 @@ httplib2==0.19.1; python_version >= "2.7" and python_full_version < "3.0.0" or p
 humanfriendly==9.1; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" or python_version >= "3.6" and python_version < "4" and python_full_version >= "3.5.0"
 idna==2.10; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4" and python_version >= "3.6"
 immutables==0.15; python_version >= "3.6" and python_version < "3.7"
-importlib-metadata==3.10.0; python_version < "3.8" and python_version >= "3.6" and (python_version == "3.6" or python_version == "3.7")
+importlib-metadata==4.0.1; python_version < "3.8" and python_version >= "3.6" and (python_version == "3.6" or python_version == "3.7")
 importlib-resources==5.1.2; python_version < "3.7" and python_version >= "3.6"
 isa-rwval==0.10.10
 iso8601==0.1.14; python_version >= "3.6"
@@ -92,14 +92,14 @@ markdown==3.3.4; python_version >= "3.6"
 markupsafe==1.1.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 mercurial==5.7.1
 mistune==0.8.4; python_version >= "3.6" and python_version < "4"
-mrcfile==1.2.0; python_version >= "3.6"
+mrcfile==1.3.0
 msgpack==1.0.2; python_version >= "3.6"
 munch==2.5.0; python_version >= "3.6"
 mypy-extensions==0.4.3; python_version >= "3.6" and python_version < "4"
 netaddr==0.8.0; python_version >= "3.6"
 netifaces==0.10.9; python_version >= "3.6"
 networkx==2.5; python_version >= "3.6" and python_version < "4"
-nodeenv==1.5.0
+nodeenv==1.6.0
 nose==1.3.7
 numpy==1.19.5; python_version >= "3.6"
 oauth2client==4.1.3
@@ -108,7 +108,7 @@ openstacksdk==0.52.0; python_version >= "3.6"
 os-client-config==2.1.0; python_version >= "3.6"
 os-service-types==1.7.0; python_version >= "3.6"
 osc-lib==2.3.1; python_version >= "3.6"
-oslo.config==8.5.0; python_version >= "3.6"
+oslo.config==8.6.0; python_version >= "3.6"
 oslo.context==3.2.0; python_version >= "3.6"
 oslo.i18n==5.0.1; python_version >= "3.6"
 oslo.log==4.4.0; python_version >= "3.6"
@@ -120,10 +120,10 @@ paramiko==2.7.2
 parsley==1.3
 paste==3.5.0
 pastedeploy==2.1.1
-pbr==5.5.1; python_version >= "3.6"
+pbr==5.6.0; python_version >= "3.6"
 prettytable==0.7.2; python_version >= "3.6"
 prompt-toolkit==3.0.3; python_version >= "3.6"
-protobuf==3.15.7; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+protobuf==3.15.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 prov==1.5.1; python_version >= "3.6" and python_version < "4"
 psutil==5.8.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 pulsar-galaxy-lib==0.14.5
@@ -137,7 +137,7 @@ pydot==1.4.2; python_version >= "3.6" and python_full_version < "3.0.0" and pyth
 pyeventsystem==0.1.0
 pyfaidx==0.5.9.5
 pyinotify==0.9.6; sys_platform != "win32" and sys_platform != "darwin" and sys_platform != "sunos5" and python_version >= "3.6"
-pyjwt==1.7.1
+pyjwt==2.0.1; python_version >= "3.6"
 pykwalify==1.8.0
 pynacl==1.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 pyparsing==2.4.7; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
@@ -170,7 +170,7 @@ routes==2.5.1
 rsa==4.7.2; python_version >= "3.5" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 ruamel.yaml.clib==0.2.2; platform_python_implementation == "CPython" and python_version < "3.8" and python_version >= "3.6"
 ruamel.yaml==0.16.5; python_version >= "3.6" and python_version < "4"
-s3transfer==0.3.6
+s3transfer==0.3.7
 schema-salad==7.1.20210316164414; python_version >= "3.6" and python_version < "4"
 setuptools-scm==5.0.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 shellescape==3.4.1; python_version >= "3.6" and python_version < "4"
@@ -182,15 +182,15 @@ sqlalchemy-migrate==0.13.0
 sqlalchemy==1.3.24; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 sqlitedict==1.7.0
 sqlparse==0.4.1; python_version >= "3.5"
-starlette-context==0.3.1; python_version >= "3.7"
+starlette-context==0.3.2; python_version >= "3.7"
 starlette==0.13.6; python_version >= "3.6"
 stevedore==3.3.0; python_version >= "3.6"
 svgwrite==1.4.1; python_version >= "3.6"
 tempita==0.5.2
 tenacity==7.0.0
-tifffile==2020.9.3
+tifffile==2020.9.3; python_version >= "3.6"
 tornado==6.1; python_version >= "3.5"
-tqdm==4.59.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
+tqdm==4.60.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 typing-extensions==3.7.4.3; python_version >= "3.6" and python_version < "3.8"
 tzlocal==2.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4"
 ubiquerg==0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ contextvars = {version = "*", python = "~3.6"}
 circus = "*"
 cwltool = "==3.0.20201109103151"
 dictobj = "*"
-docutils = "*"
+docutils = "!=0.17, !=0.17.1"
 Fabric3 = "*"
 fastapi = ">=0.63.0"
 fastapi-utils = "*"


### PR DESCRIPTION
## What did you do? 
- Update framework dependencies


## Why did you make this change?
The `decorator` package needed to be updated due to a bug in 5.0.3.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
