### PR TITLE
improve three debug messages

### DIFF
--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -413,7 +413,7 @@ class DRMAAJobRunner(AsynchronousJobRunner):
         """
         cmd = shlex.split(external_runjob_script)
         cmd.extend([str(username), jobtemplate_filename])
-        log.info("Running command %s" % cmd)
+        log.info(f"Running command: {' '.join(cmd)}")
         try:
             stdoutdata = commands.execute(cmd).strip()
         except commands.CommandLineException:

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -1099,8 +1099,7 @@ def _verify_outputs(testdef, history, jobs, tool_id, data_list, data_collection_
         expected = testdef.num_outputs
         actual = len(data_list) + len(data_collection_list)
         if expected != actual:
-            message_template = "Incorrect number of outputs - expected %d, found %s."
-            message = message_template % (expected, actual)
+            message = f"Incorrect number of outputs - expected {expected}, found {actual}: datasets {data_list} collections {data_collection_list}"
             raise Exception(message)
     found_exceptions = []
 

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -944,13 +944,12 @@ def on_text_for_names(input_names):
 
 
 def filter_output(tool, output, incoming):
-
     for filter in output.filters:
         try:
             if not eval(filter.text.strip(), globals(), incoming):
                 return True  # do not create this dataset
         except Exception as e:
-            log.info(f'Tool {tool.id} output {output.name}: dataset output filter ({filter.text}) failed: {e}')
+            log.debug('Tool %s output %s: dataset output filter (%s) failed: %s' % (tool.id, output.name, filter.text, e))
     return False
 
 

--- a/lib/galaxy/tools/actions/__init__.py
+++ b/lib/galaxy/tools/actions/__init__.py
@@ -944,12 +944,13 @@ def on_text_for_names(input_names):
 
 
 def filter_output(tool, output, incoming):
+
     for filter in output.filters:
         try:
             if not eval(filter.text.strip(), globals(), incoming):
                 return True  # do not create this dataset
         except Exception as e:
-            log.debug('Tool %s output %s: dataset output filter (%s) failed: %s' % (tool.id, output.name, filter.text, e))
+            log.info(f'Tool {tool.id} output {output.name}: dataset output filter ({filter.text}) failed: {e}')
     return False
 
 

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -563,7 +563,7 @@ def uvicorn_serve(app, port, host=None):
     import asyncio
     from uvicorn.server import Server
     from uvicorn.config import Config
-    config = Config(app, host=host, port=int(port))
+    config = Config(app, host=host, port=int(port), access_log=False)
     server = Server(config=config)
 
     def run_in_loop(loop):

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -564,13 +564,8 @@ def uvicorn_serve(app, port, host=None):
     from uvicorn.server import Server
     from uvicorn.config import Config
 
-    access_log = os.environ.get('GALAXY_TEST_UVICORN_ACCESS_LOG', None)
-    if access_log:
-        eal = asbool(access_log)
-    else:
-        eal = True
-
-    config = Config(app, host=host, port=int(port), access_log=eal)
+    access_log = False if 'GALAXY_TEST_DISABLE_ACCESS_LOG' in os.environ else True
+    config = Config(app, host=host, port=int(port), access_log=access_log)
     server = Server(config=config)
 
     def run_in_loop(loop):

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -564,7 +564,7 @@ def uvicorn_serve(app, port, host=None):
     from uvicorn.server import Server
     from uvicorn.config import Config
 
-    access_log = os.environ.get('GALAXY_UVICORN_ACCESS_LOG', None)
+    access_log = os.environ.get('GALAXY_TEST_UVICORN_ACCESS_LOG', None)
     if access_log:
         eal = asbool(access_log)
     else:

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -563,7 +563,14 @@ def uvicorn_serve(app, port, host=None):
     import asyncio
     from uvicorn.server import Server
     from uvicorn.config import Config
-    config = Config(app, host=host, port=int(port), access_log=False)
+
+    access_log = os.environ.get('GALAXY_UVICORN_ACCESS_LOG', None)
+    if access_log:
+        eal = asbool(access_log)
+    else:
+        eal = True
+
+    config = Config(app, host=host, port=int(port), access_log=eal)
     server = Server(config=config)
 
     def run_in_loop(loop):

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -246,7 +246,7 @@ TOOL_SHED_TEST_TMP_DIR          Defaults to random /tmp directory - place for
                                 tool shed test server files to be placed.
 TOOL_SHED_TEST_OMIT_GALAXY      Do not launch a Galaxy server for tool shed
                                 testing.
-GALAXY_TEST_UVICORN_ACCESS_LOG  Do not output uvicorn access messages to log if non-enmpty
+GALAXY_TEST_DISABLE_ACCESS_LOG  Do not log access messages
 
 Unit Test Environment Variables
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -246,6 +246,7 @@ TOOL_SHED_TEST_TMP_DIR          Defaults to random /tmp directory - place for
                                 tool shed test server files to be placed.
 TOOL_SHED_TEST_OMIT_GALAXY      Do not launch a Galaxy server for tool shed
                                 testing.
+GALAXY_TEST_UVICORN_ACCESS_LOG  Do not output uvicorn access messages to log if non-enmpty
 
 Unit Test Environment Variables
 


### PR DESCRIPTION
## What did you do? 

Small change to ~two~ three (debug) messages

## Why did you make this change?

tool evaluation: for tools with many outputs its helpful to know which datasets and collections have been created.

drmaa: for debugging its more convenient to see the command that could be copy pasted

filter errors: debug is not shown in planemo output where it would be really helpful. 
- [ ] actually I would like to reraise here .. the try except block is there from the beginning https://github.com/galaxyproject/galaxy/commit/89ff0efe84c99fcaa3fb8d7eab38be26088b8c04 ... maybe this is now a feature .. 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
