### PR TITLE
Add toml datatype

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -320,6 +320,7 @@
     <datatype extension="mrc" type="galaxy.datatypes.images:Mrc2014" mimetype="application/octet-stream" display_in_upload="true" />
     <datatype extension="star" type="galaxy.datatypes.images:Star" display_in_upload="true" />
     <datatype extension="peff" type="galaxy.datatypes.proteomics:PEFF" display_in_upload="true" />
+    <datatype extension="toml" type="galaxy.datatypes.data:Text" subclass="true" display_in_upload="true"/>
     <!-- End Proteomics Datatypes -->
     <!-- FlowCytometry -->
     <datatype extension="fcs" type="galaxy.datatypes.flow:FCS" mimetype="application/octet-stream" display_in_upload="true" description="A FCS binary sequence file with a '.fcs' file extension." />


### PR DESCRIPTION
Add toml datatype.   MetaMorpheus proteomics application uses toml format for parameter configuration.

## What did you do? 
- Added the "toml" format to datatypes_conf.xml.sample


## Why did you make this change?
The GalaxyP group plans to add Galaxy tools for the MetaMorpheus proteomics application from UW Madison. 
https://github.com/smith-chem-wisc/MetaMorpheus
MetaMorpheus proteomics application uses toml format for parameter configuration.  
I think it is sufficient to have this as just a subclass of Text.  
I put with "Proteomics" datatypes, however, toml is a configuration format that could be used in other contexts.  


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. toml should be an option when uploading a dataset.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
