### PR TITLE
fix GalaxyInteractorApi get_tool_tests

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -132,9 +132,8 @@ class GalaxyInteractorApi:
 
     def get_tool_tests(self, tool_id, tool_version=None):
         url = "tools/%s/test_data" % tool_id
-        if tool_version is not None:
-            url += "?tool_version=%s" % tool_version
-        response = self._get(url)
+        params = {'tool_version': tool_version} if tool_version else None
+        response = self._get(url, data=params)
         assert response.status_code == 200, "Non 200 response from tool test API. [%s]" % response.content
         return response.json()
 

--- a/lib/galaxy_test/api/test_galaxy_interactor.py
+++ b/lib/galaxy_test/api/test_galaxy_interactor.py
@@ -2,8 +2,8 @@
 
 from packaging.version import Version
 
-from ._framework import ApiTestCase
 from galaxy_test.base.populators import skip_without_tool
+from ._framework import ApiTestCase
 
 
 class GalaxyInteractorBackwardCompatTestCase(ApiTestCase):
@@ -35,8 +35,7 @@ class GalaxyInteractorTestCase(ApiTestCase):
         assert isinstance(test_data[0], dict)
         assert test_data[0].get('tool_version') == "0.1+galaxy6"
 
-        test_data = self.galaxy_interactor.get_tool_tests(tool_id="multiple_versions") # test that tool_version=None does not break it
+        test_data = self.galaxy_interactor.get_tool_tests(tool_id="multiple_versions")  # test that tool_version=None does not break it
         assert isinstance(test_data, list)
         assert len(test_data) > 0
         assert isinstance(test_data[0], dict)
-

--- a/lib/galaxy_test/api/test_galaxy_interactor.py
+++ b/lib/galaxy_test/api/test_galaxy_interactor.py
@@ -3,6 +3,7 @@
 from packaging.version import Version
 
 from ._framework import ApiTestCase
+from galaxy_test.base.populators import skip_without_tool
 
 
 class GalaxyInteractorBackwardCompatTestCase(ApiTestCase):
@@ -11,3 +12,31 @@ class GalaxyInteractorBackwardCompatTestCase(ApiTestCase):
         self.galaxy_interactor._target_galaxy_version = Version("18.09")
         assert self.galaxy_interactor.supports_test_data_download is False
         assert self.galaxy_interactor.test_data_download(tool_id='cat1', filename='1.bed').startswith(b'chr1\t147962192\t147962580')
+
+
+class GalaxyInteractorTestCase(ApiTestCase):
+
+    @skip_without_tool("multiple_versions")
+    def test_new_version_has_loaded(self):
+        # this test is redundant, it is just testing that new tool is loaded and the next test will break for the right reasons.  I'll remove this
+        tool_id = "multiple_versions"
+        tool_version = "0.1+galaxy6"
+        tool_show_response = self._get("tools/%s" % tool_id, data={'tool_version': tool_version})
+        self._assert_status_code_is(tool_show_response, 200)
+        self.assertEqual(tool_show_response.json().get('version'), tool_version, msg="The new version has not loaded")
+
+    @skip_without_tool("multiple_versions")
+    def test_get_tool_tests(self):
+        # test that get_tool_tests will return the right tests when the tool_version has a '+' in it
+        test_data = self.galaxy_interactor.get_tool_tests(tool_id="multiple_versions", tool_version="0.1+galaxy6")
+        print(test_data)
+        assert isinstance(test_data, list)
+        assert len(test_data) > 0
+        assert isinstance(test_data[0], dict)
+        assert test_data[0].get('tool_version') == "0.1+galaxy6"
+
+        test_data = self.galaxy_interactor.get_tool_tests(tool_id="multiple_versions") # test that tool_version=None does not break it
+        assert isinstance(test_data, list)
+        assert len(test_data) > 0
+        assert isinstance(test_data[0], dict)
+

--- a/lib/galaxy_test/api/test_galaxy_interactor.py
+++ b/lib/galaxy_test/api/test_galaxy_interactor.py
@@ -17,15 +17,6 @@ class GalaxyInteractorBackwardCompatTestCase(ApiTestCase):
 class GalaxyInteractorTestCase(ApiTestCase):
 
     @skip_without_tool("multiple_versions")
-    def test_new_version_has_loaded(self):
-        # this test is redundant, it is just testing that new tool is loaded and the next test will break for the right reasons.  I'll remove this
-        tool_id = "multiple_versions"
-        tool_version = "0.1+galaxy6"
-        tool_show_response = self._get("tools/%s" % tool_id, data={'tool_version': tool_version})
-        self._assert_status_code_is(tool_show_response, 200)
-        self.assertEqual(tool_show_response.json().get('version'), tool_version, msg="The new version has not loaded")
-
-    @skip_without_tool("multiple_versions")
     def test_get_tool_tests(self):
         # test that get_tool_tests will return the right tests when the tool_version has a '+' in it
         test_data = self.galaxy_interactor.get_tool_tests(tool_id="multiple_versions", tool_version="0.1+galaxy6")

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -724,7 +724,7 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         test_data_response = self._get("tools/%s/test_data?tool_version=*" % "multiple_versions")
         test_data_response.raise_for_status()
         test_data_dicts = test_data_response.json()
-        assert len(test_data_dicts) == 2
+        assert len(test_data_dicts) == 3
 
     @skip_without_tool("multiple_versions")
     @uses_test_history(require_new=False)

--- a/test/functional/tools/multiple_versions_v01galaxy6.xml
+++ b/test/functional/tools/multiple_versions_v01galaxy6.xml
@@ -1,0 +1,21 @@
+<tool id="multiple_versions" name="multiple_versions" version="0.1+galaxy6">
+    <command>
+        echo "Version 0.1+galaxy6" > $out_file1
+    </command>
+    <inputs>
+        <param name="inttest" value="1" type="integer" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="intest" value="1" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Version 0.1+galaxy6" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -195,6 +195,7 @@
   <tool file="config_vars.xml" />
 
   <tool file="multiple_versions_v01.xml" />
+  <tool file="multiple_versions_v01galaxy6.xml" />
   <tool file="multiple_versions_v02.xml" />
   <tool file="multiple_versions_changes_v01.xml" />
   <tool file="multiple_versions_changes_v02.xml" />


### PR DESCRIPTION
## What did you do? 
- updated the get_tool_tests function so that the tool version is encoded in the request

## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)
GalaxyInteractorApi get_tool_tests does not return the right test data when the tool version is not the newest and has a '+' in it

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
