### PR TITLE
Priority menu css tweaks

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -15,15 +15,10 @@ either through the props, and make updates through the events -->
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
     >
         <!-- name, state buttons, menus -->
-        <nav
-            class="content-top-menu d-flex align-items-center justify-content-between"
-            @click.stop="$emit('update:expanded', !expanded)"
-        >
-            <div class="d-flex mr-1 align-items-center" @click.stop>
+        <nav class="content-top-menu" @click.stop="$emit('update:expanded', !expanded)">
+            <div class="content-status-indicators" @click.stop>
                 <b-check v-if="showSelection" :checked="selected" @change="$emit('update:selected', $event)" />
-
                 <StatusIcon v-if="!ok" class="status-icon px-1" :state="dataset.state" @click.stop="onStatusClick" />
-
                 <StateBtn
                     v-if="!dataset.visible"
                     class="px-1"
@@ -42,20 +37,18 @@ either through the props, and make updates through the events -->
                 />
             </div>
 
-            <h5 class="flex-grow-1 overflow-hidden mr-auto text-nowrap text-truncate">
-                <span class="hid">{{ dataset.hid }}</span>
-                <span v-if="collapsed || !dataset.canEditName" class="name">{{ dataset.title }}</span>
-            </h5>
+            <div class="content-title">
+                <h5 class="text-truncate">
+                    <span class="hid">{{ dataset.hid }}</span>
+                    <span v-if="collapsed || !dataset.canEditName" class="name">{{ dataset.title }}</span>
+                </h5>
+            </div>
 
-            <slot name="menu">
-                <DatasetMenu
-                    class="content-item-menu"
-                    :dataset="dataset"
-                    :expanded="expanded"
-                    v-on="$listeners"
-                    :show-tags.sync="showTags"
-                />
-            </slot>
+            <div class="content-item-menu">
+                <slot name="menu">
+                    <DatasetMenu :dataset="dataset" :expanded="expanded" v-on="$listeners" :show-tags.sync="showTags" />
+                </slot>
+            </div>
         </nav>
 
         <!--- read-only tags with name: prefix -->

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -10,8 +10,8 @@
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
         @click.stop="$emit('viewCollection')"
     >
-        <nav class="d-flex content-top-menu align-items-center justify-content-between">
-            <div class="d-flex mr-1 align-items-center" @click.stop>
+        <nav class="content-top-menu">
+            <div class="content-status-indicators mr-1" @click.stop>
                 <b-check v-if="showSelection" :checked="selected" @change="$emit('update:selected', $event)" />
 
                 <StatusIcon
@@ -31,6 +31,15 @@
                 />
 
                 <StateBtn
+                    v-if="dsc.deleted"
+                    class="px-1"
+                    state="deleted"
+                    title="Undelete"
+                    icon="fas fa-trash-restore"
+                    @click.stop="$emit('undelete')"
+                />
+
+                <StateBtn
                     class="px-1"
                     state="ok"
                     title="Collection"
@@ -39,26 +48,21 @@
                 />
             </div>
 
-            <h5 class="flex-grow-1 overflow-hidden mr-auto text-nowrap text-truncate">
-                <span class="hid">{{ dsc.hid }}</span>
-                <span class="name">{{ dsc.name }}</span>
-                <span class="description">
-                    ({{ dsc.collectionType | localize }} {{ dsc.collectionCountDescription | localize }})
-                </span>
-            </h5>
+            <div class="content-title mr-1">
+                <h5 class="text-truncate">
+                    <span class="hid">{{ dsc.hid }}</span>
+                    <span class="name">{{ dsc.name }}</span>
+                    <span class="description">
+                        ({{ dsc.collectionType | localize }} {{ dsc.collectionCountDescription | localize }})
+                    </span>
+                </h5>
+            </div>
 
-            <slot name="menu">
-                <DscMenu v-if="!dsc.deleted" class="content-item-menu" v-on="$listeners" />
-            </slot>
-
-            <StateBtn
-                v-if="dsc.deleted"
-                class="px-1"
-                state="deleted"
-                title="Undelete"
-                icon="fas fa-trash-restore"
-                @click.stop="$emit('undelete')"
-            />
+            <div class="content-item-menu">
+                <slot name="menu">
+                    <DscMenu v-if="!dsc.deleted" v-on="$listeners" />
+                </slot>
+            </div>
         </nav>
 
         <!--- read-only tags with name: prefix -->

--- a/client/src/components/History/ContentItem/styles.scss
+++ b/client/src/components/History/ContentItem/styles.scss
@@ -3,15 +3,43 @@
 
 .content-item {
     outline: none;
-    // margin-bottom: 1px;
     border-bottom: 1px solid white;
-
     &:focus-within {
         box-shadow: inset 0 0 1em 0.25em rgba(255, 255, 255, 0.25);
     }
+}
 
-    .content-top-menu {
-        cursor: pointer;
+// Nav across the top of the content item
+.content-item .content-top-menu {
+    /* a fixed-height is important for proper
+    functioning of the PriorityMenuItem dropdown since
+    it relies on flexbox and overflow */
+    min-height: 2em;
+
+    cursor: pointer;
+
+    // flex parent
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    // error, clock, etc.
+    .content-status-indicators {
+        // d-flex mr-1 align-items-center
+        display: flex;
+        align-items: center;
+    
+        &:blank {
+            display: none;
+        }
+    }
+
+    // name & labelling
+    .content-title {
+
+        // flex child
+        flex-grow: 1;
+        overflow: hidden;
 
         .hid {
             color: adjust-color($text-color, $alpha: -0.6);
@@ -24,29 +52,28 @@
                 content: ":";
             }
         }
-
         .name {
             font-weight: 700;
         }
-
-        /* a fixed-height is important for proper
-        functioning of the PriorityMenuItem dropdown since
-        it relies on flexbox and overflow */
-        min-height: 2em;
     }
 
-    .content-menu button:hover,
-    .content-menu .show > button.dropdown-toggle {
-        background-color: transparent;
-        border-color: transparent;
+    // priority menu on right side
+    .content-item-menu {
+        display: flex;
+        justify-content: flex-end;
     }
+
 }
 
-.collapsed .content-item-menu {
-    display: flex;
-    justify-content: flex-end;
-    .primary {
-        max-width: 0;
-    }
+// Setting a max-width here limits the number of icons that
+// will show. The priority menu is css awayre
+
+.content-item.collapsed .content-item-menu {
+    max-width: 90px;
 }
 
+// .content-menu button:hover,
+// .content-menu .show > button.dropdown-toggle {
+//     background-color: transparent;
+//     border-color: transparent;
+// }


### PR DESCRIPTION
## What did you do? 
Style adjustments to the priority menus.

Adjusted priority menus to show 3 buttons if available.

<img width="218" alt="galaxy-new-menu" src="https://user-images.githubusercontent.com/290292/116592756-370c8580-a8d5-11eb-87cc-d57cda2269c2.png">


## Why did you make this change?

Requests from testers from...
https://github.com/galaxyproject/galaxy/issues/10947

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [x] I've included a screenshot of the changes

