### PR TITLE
[21.05] Create history_audit table to avoid write deadlocks during history.update_time updates

### DIFF
--- a/config/celery.ini
+++ b/config/celery.ini
@@ -1,0 +1,14 @@
+[env]
+PYTHONPATH = lib
+
+[watcher:celery]
+cmd = celery
+args = --app galaxy.celery worker --concurrency 2 -l debug
+copy_env = True
+numprocesses = 1
+
+[watcher:celery-beat]
+cmd = celery
+args = --app galaxy.celery beat -l debug
+copy_env = True
+numprocesses = 1

--- a/config/dev.ini
+++ b/config/dev.ini
@@ -1,5 +1,6 @@
 [circus]
 debug = True
+include = celery.ini
 
 [env]
 PYTHONPATH=lib
@@ -25,9 +26,3 @@ stop_children = True
 [socket:web]
 host = 0.0.0.0
 port = 8080
-
-[watcher:celery]
-cmd = celery
-args = --app galaxy.celery worker -l debug
-copy_env = True
-numprocesses = 1

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -246,6 +246,17 @@
 :Type: float
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``history_audit_table_prune_interval``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Time (in seconds) between attempts to remove old rows from the
+    history_audit database table. Set to 0 to disable pruning.
+:Default: ``3600``
+:Type: int
+
+
 ~~~~~~~~~~~~~
 ``file_path``
 ~~~~~~~~~~~~~
@@ -2705,6 +2716,17 @@
     sending them to InfluxDB, Galaxy can provide more nicely tagged
     metrics. Instead of sending prefix + dot-separated-path, Galaxy
     will send prefix with a tag path set to the page url
+:Default: ``false``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~
+``statsd_mock_calls``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Mock out statsd client calls - only used by testing infrastructure
+    really. Do not set this in production environments.
 :Default: ``false``
 :Type: bool
 

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -1,9 +1,4 @@
 from lagom import magic_bind_to_container
-from sqlalchemy import (
-    and_,
-    func,
-    tuple_
-)
 from sqlalchemy.orm.scoping import (
     scoped_session,
 )
@@ -85,17 +80,6 @@ def export_history(
 @galaxy_task
 def prune_history_audit_table(sa_session: scoped_session):
     """Prune ever growing history_audit table."""
-    history_audit_table = model.HistoryAudit.table
-    latest_subq = sa_session.query(
-        history_audit_table.c.history_id,
-        func.max(history_audit_table.c.update_time).label('max_update_time')).group_by(history_audit_table.c.history_id).subquery()
-    not_latest_query = sa_session.query(
-        history_audit_table.c.history_id, history_audit_table.c.update_time
-    ).select_from(latest_subq).join(
-        history_audit_table, and_(
-            history_audit_table.c.update_time < latest_subq.columns.max_update_time,
-            history_audit_table.c.history_id == latest_subq.columns.history_id))
-    d = history_audit_table.delete()
     timer = ExecutionTimer()
-    sa_session.execute(d.where(tuple_(history_audit_table.c.history_id, history_audit_table.c.update_time).in_(not_latest_query)))
+    model.HistoryAudit.prune(sa_session)
     log.debug(f"Successfully pruned history_audit table {timer}")

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -222,6 +222,10 @@ galaxy:
   # seconds).
   #database_wait_sleep: 1.0
 
+  # Time (in seconds) between attempts to remove old rows from the
+  # history_audit database table. Set to 0 to disable pruning.
+  #history_audit_table_prune_interval: 3600
+
   # Where dataset files are stored. It must be accessible at the same
   # path on any cluster nodes that will run Galaxy jobs, unless using
   # Pulsar. The default value has been changed from 'files' to 'objects'
@@ -1364,6 +1368,10 @@ galaxy:
   # Instead of sending prefix + dot-separated-path, Galaxy will send
   # prefix with a tag path set to the page url
   #statsd_influxdb: false
+
+  # Mock out statsd client calls - only used by testing infrastructure
+  # really. Do not set this in production environments.
+  #statsd_mock_calls: false
 
   # Add an option to the library upload form which allows administrators
   # to upload a directory of files.

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -85,7 +85,7 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         """
         if self.user_manager.is_anonymous(user):
             return None if (not current_history or current_history.deleted) else current_history
-        desc_update_time = desc(self.model_class.table.c.update_time)
+        desc_update_time = desc(self.model_class.update_time)
         filters = self._munge_filters(filters, self.model_class.user_id == user.id)
         # TODO: normalize this return value
         return self.query(filters=filters, order_by=desc_update_time, limit=1, **kwargs).first()

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1845,6 +1845,12 @@ def is_hda(d):
     return isinstance(d, HistoryDatasetAssociation)
 
 
+class HistoryAudit(RepresentById):
+    def __init__(self, history, update_time):
+        self.history = history
+        self.update_time = update_time
+
+
 class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
 
     dict_collection_visible_keys = ['id', 'name', 'published', 'deleted']

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1866,6 +1866,7 @@ class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):
         self.importing = False
         self.genome_build = None
         self.published = False
+        self.update_time = None
         # Relationships
         self.user = user
         self.datasets = []

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
     select,
     text,
     true,
+    tuple_,
     type_coerce,
     types)
 from sqlalchemy.exc import OperationalError
@@ -1849,6 +1850,21 @@ class HistoryAudit(RepresentById):
     def __init__(self, history, update_time):
         self.history = history
         self.update_time = update_time
+
+    @classmethod
+    def prune(cls, sa_session):
+        history_audit_table = cls.table
+        latest_subq = sa_session.query(
+            history_audit_table.c.history_id,
+            func.max(history_audit_table.c.update_time).label('max_update_time')).group_by(history_audit_table.c.history_id).subquery()
+        not_latest_query = sa_session.query(
+            history_audit_table.c.history_id, history_audit_table.c.update_time
+        ).select_from(latest_subq).join(
+            history_audit_table, and_(
+                history_audit_table.c.update_time < latest_subq.columns.max_update_time,
+                history_audit_table.c.history_id == latest_subq.columns.history_id))
+        d = history_audit_table.delete()
+        sa_session.execute(d.where(tuple_(history_audit_table.c.history_id, history_audit_table.c.update_time).in_(not_latest_query)))
 
 
 class History(HasTags, Dictifiable, UsesAnnotations, HasName, RepresentById):

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     MetaData,
     not_,
     Numeric,
+    PrimaryKeyConstraint,
     select,
     String, Table,
     TEXT,
@@ -220,6 +221,7 @@ model.HistoryAudit.table = Table(
     "history_audit", metadata,
     Column("history_id", Integer, ForeignKey("history.id"), primary_key=True, nullable=False),
     Column("update_time", DateTime, default=now, primary_key=True, nullable=False),
+    PrimaryKeyConstraint(sqlite_on_conflict='IGNORE')
 )
 
 model.HistoryUserShareAssociation.table = Table(

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -218,12 +218,9 @@ model.History.table = Table(
 
 model.HistoryAudit.table = Table(
     "history_audit", metadata,
-    Column("id", Integer, primary_key=True),
-    Column("history_id", Integer, ForeignKey("history.id"), nullable=False),
-    Column("update_time", DateTime, default=now, nullable=False),
+    Column("history_id", Integer, ForeignKey("history.id"), primary_key=True, nullable=False),
+    Column("update_time", DateTime, default=now, primary_key=True, nullable=False),
 )
-
-Index('ix_history_audit_history_id_update_time_desc', model.HistoryAudit.table.c.history_id.desc(), model.HistoryAudit.table.c.update_time.desc())
 
 model.HistoryUserShareAssociation.table = Table(
     "history_user_share_association", metadata,

--- a/lib/galaxy/model/migrate/triggers/history_update_time_field.py
+++ b/lib/galaxy/model/migrate/triggers/history_update_time_field.py
@@ -2,7 +2,7 @@
 Database trigger installation and removal
 """
 
-from sqlalchemy import DDL
+from galaxy.model.migrate.versions.util import execute_statements
 
 
 def install_timestamp_triggers(engine):
@@ -19,12 +19,6 @@ def drop_timestamp_triggers(engine):
     """
     statements = get_timestamp_drop_sql(engine.name)
     execute_statements(engine, statements)
-
-
-def execute_statements(engine, statements):
-    for sql in statements:
-        cmd = DDL(sql)
-        cmd.execute(bind=engine)
 
 
 def get_timestamp_install_sql(variant):

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -123,8 +123,7 @@ def _sqlite_install():
                 BEGIN
                     INSERT INTO history_audit (history_id, update_time)
                     SELECT NEW.{id_field}, strftime('%%Y-%%m-%%d %%H:%%M:%%f', 'now')
-                    WHERE NEW.{id_field} IS NOT NULL
-                    ON CONFLICT IGNORE;
+                    WHERE NEW.{id_field} IS NOT NULL;
                 END;
         """
 

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -124,7 +124,7 @@ def _sqlite_install():
                 FOR EACH ROW
                 BEGIN
                     INSERT INTO history_audit (history_id, update_time)
-                    SELECT NEW.{id_field}, CURRENT_TIMESTAMP
+                    SELECT NEW.{id_field}, strftime('%%Y-%%m-%%d %%H:%%M:%%f', 'now')
                     WHERE NEW.{id_field} IS NOT NULL;
                 END;
         """

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -108,7 +108,8 @@ def _sqlite_remove():
 
 
 def _sqlite_install():
-    sql = []
+    # delete old stuff first
+    sql = _sqlite_remove()
 
     def trigger_def(source_table, id_field, operation, when="AFTER"):
 

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -58,7 +58,8 @@ def _postgres_install():
                 BEGIN
                     INSERT INTO history_audit (history_id, update_time)
                     SELECT {id_field}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
-                    FROM new_table;
+                    FROM new_table
+                    WHERE {id_field} IS NOT NULL;
                     RETURN NULL;
                 END;
             $BODY$
@@ -122,7 +123,8 @@ def _sqlite_install():
                 FOR EACH ROW
                 BEGIN
                     INSERT INTO history_audit (history_id, update_time)
-                    VALUES (NEW.{id_field}, CURRENT_TIMESTAMP);
+                    SELECT NEW.{id_field}, CURRENT_TIMESTAMP
+                    WHERE NEW.{id_field} IS NOT NULL;
                 END;
         """
 

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -93,9 +93,6 @@ def _postgres_install():
     return sql
 
 
-# Other DBs
-
-
 def _sqlite_remove():
     sql = []
 
@@ -134,9 +131,6 @@ def _sqlite_install():
             sql.append(trigger_def(source_table, id_field, operation))
 
     return sql
-
-
-# Utils
 
 
 def get_trigger_name(label, operation, when, statement=False):

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -1,0 +1,143 @@
+from galaxy.model.migrate.versions.util import execute_statements
+
+
+# function name prefix
+fn_prefix = "fn_audit_history_by"
+
+# map between source table and associated incoming id field
+trigger_config = {
+    'history_dataset_association': "history_id",
+    'history_dataset_collection_association': "history_id",
+    'history': "id",
+}
+
+
+def install(engine):
+    """Install history audit table triggers"""
+    sql = _postgres_install() if 'postgres' in engine.name else _sqlite_install()
+    execute_statements(engine, sql)
+
+
+def remove(engine):
+    """Uninstall history audit table triggers"""
+    sql = _postgres_remove() if 'postgres' in engine.name else _sqlite_remove()
+    execute_statements(engine, sql)
+
+
+# Postgres trigger installation
+
+
+def _postgres_remove():
+    """postgres trigger removal sql"""
+
+    sql = []
+    sql.append(f"DROP FUNCTION IF EXISTS {fn_prefix}_history_id() CASCADE;")
+    sql.append(f"DROP FUNCTION IF EXISTS {fn_prefix}_id() CASCADE;")
+
+    return sql
+
+
+def _postgres_install():
+    """postgres trigger installation sql"""
+
+    sql = []
+
+    # postgres trigger function template
+    # need to make separate functions purely because the incoming history_id field name will be
+    # different for different source tables. There may be a fancier way to dynamically choose
+    # between incoming fields, but having 2 triggers fns seems straightforward
+
+    def trigger_fn(id_field):
+        fn = f"{fn_prefix}_{id_field}"
+
+        return f"""
+            CREATE OR REPLACE FUNCTION {fn}()
+                RETURNS TRIGGER
+                LANGUAGE 'plpgsql'
+            AS $BODY$
+                BEGIN
+                    INSERT INTO history_audit (history_id, update_time)
+                    SELECT {id_field}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+                    FROM new_table;
+                    RETURN NULL;
+                END;
+            $BODY$
+        """
+
+    def trigger_def(source_table, id_field, operation, when="AFTER"):
+        fn = f"{fn_prefix}_{id_field}"
+
+        # Postgres supports many triggers per operation/table so the label can
+        # be indicative of what's happening
+        label = f"history_audit_by_{id_field}"
+        trigger_name = get_trigger_name(label, operation, when, statement=True)
+
+        return f"""
+            CREATE TRIGGER {trigger_name}
+            {when} {operation} ON {source_table}
+            REFERENCING NEW TABLE AS new_table
+            FOR EACH STATEMENT EXECUTE FUNCTION {fn}();
+        """
+
+    # trigger functions, each reads a different incoming id
+    for id_field in ["history_id", "id"]:
+        sql.append(trigger_fn(id_field))
+
+    # add triggers for each configured table (history, hda, hdca)
+    # picking the appropriate function via the config
+    for source_table, id_field in trigger_config.items():
+        for operation in ["UPDATE", "INSERT"]:
+            sql.append(trigger_def(source_table, id_field, operation))
+
+    return sql
+
+
+# Other DBs
+
+
+def _sqlite_remove():
+    sql = []
+
+    for source_table in trigger_config:
+        for operation in ["UPDATE", "INSERT"]:
+            trigger_name = get_trigger_name(source_table, operation, "AFTER")
+            sql.append(f"DROP TRIGGER IF EXISTS {trigger_name};")
+
+    return sql
+
+
+def _sqlite_install():
+    sql = []
+
+    def trigger_def(source_table, id_field, operation, when="AFTER"):
+
+        # only one trigger per operation/table in simple databases, so
+        # trigger name is less descriptive
+        trigger_name = get_trigger_name(source_table, operation, when)
+
+        return f"""
+            CREATE TRIGGER {trigger_name}
+                {when} {operation}
+                ON {source_table}
+                FOR EACH ROW
+                BEGIN
+                    INSERT INTO history_audit (history_id, update_time)
+                    VALUES (NEW.{id_field}, CURRENT_TIMESTAMP);
+                END;
+        """
+
+    for source_table, id_field in trigger_config.items():
+        for operation in ["UPDATE", "INSERT"]:
+            sql.append(trigger_def(source_table, id_field, operation))
+
+    return sql
+
+
+# Utils
+
+
+def get_trigger_name(label, operation, when, statement=False):
+    op_initial = operation.lower()[0]
+    when_initial = when.lower()[0]
+    rs = "s" if statement else "r"
+    return f"trigger_{label}_{when_initial}{op_initial}{rs}"

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -57,7 +57,7 @@ def _postgres_install():
             AS $BODY$
                 BEGIN
                     INSERT INTO history_audit (history_id, update_time)
-                    SELECT {id_field}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
+                    SELECT DISTINCT {id_field}, CURRENT_TIMESTAMP AT TIME ZONE 'UTC'
                     FROM new_table
                     WHERE {id_field} IS NOT NULL;
                     RETURN NULL;

--- a/lib/galaxy/model/migrate/versions/0165_add_content_update_time.py
+++ b/lib/galaxy/model/migrate/versions/0165_add_content_update_time.py
@@ -7,9 +7,9 @@ import logging
 
 from sqlalchemy import Column, DateTime, MetaData, Table
 
+from galaxy.model.migrate.triggers.history_update_time_field import drop_timestamp_triggers, install_timestamp_triggers
 from galaxy.model.migrate.versions.util import add_column, drop_column
 from galaxy.model.orm.now import now
-from galaxy.model.triggers import drop_timestamp_triggers, install_timestamp_triggers
 
 log = logging.getLogger(__name__)
 metadata = MetaData()

--- a/lib/galaxy/model/migrate/versions/0174_readd_update_time_triggers.py
+++ b/lib/galaxy/model/migrate/versions/0174_readd_update_time_triggers.py
@@ -6,7 +6,7 @@ import logging
 
 from sqlalchemy import MetaData
 
-from galaxy.model.triggers import (
+from galaxy.model.migrate.triggers.history_update_time_field import (
     drop_timestamp_triggers,
     install_timestamp_triggers,
 )

--- a/lib/galaxy/model/migrate/versions/0175_history_audit.py
+++ b/lib/galaxy/model/migrate/versions/0175_history_audit.py
@@ -1,0 +1,86 @@
+"""
+Add history audit table and associated triggers
+"""
+
+import datetime
+import logging
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, MetaData, Table
+
+from galaxy.model.migrate.triggers import (
+    history_update_time_field as old_triggers,  # rollback to old ones
+    update_audit_table as new_triggers,  # install me
+)
+from galaxy.model.migrate.versions.util import (
+    create_table,
+    drop_table
+)
+
+log = logging.getLogger(__name__)
+now = datetime.datetime.utcnow
+metadata = MetaData()
+
+# NOTE: A normal incrementing PK is not typically used in an audit table,
+# just foreign keys, but the ORM will probably choke without it
+AuditTable = Table(
+    "history_audit",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("history_id", Integer, ForeignKey("history.id"), nullable=False),
+    Column("update_time", DateTime, default=now, nullable=False),
+)
+
+Index('ix_history_audit_history_id_update_time_desc', AuditTable.c.history_id.desc(), AuditTable.c.update_time.desc())
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    # create table + index
+    create_table(AuditTable)
+
+    # populate with update_time from every history
+    copy_update_times = """
+        INSERT INTO history_audit (history_id, update_time)
+        SELECT id, update_time FROM history
+    """
+    migrate_engine.execute(copy_update_times)
+
+    # drop existing timestamp triggers
+    old_triggers.drop_timestamp_triggers(migrate_engine)
+
+    # install new timestamp triggers
+    new_triggers.install(migrate_engine)
+
+
+def downgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    # drop existing timestamp triggers
+    new_triggers.remove(migrate_engine)
+
+    try:
+        # update history.update_time with vals from audit table
+        put_em_back = """
+            UPDATE history h
+            SET update_time = a.max_update_time
+            FROM (
+                SELECT history_id, max(update_time) as max_update_time
+                FROM history_audit
+                GROUP BY history_id, update_time
+            ) a
+            WHERE h.id = a.history_id
+        """
+        migrate_engine.execute(put_em_back)
+    except Exception:
+        print("Unable to put update_times back")
+
+    # drop audit table
+    drop_table(AuditTable)
+
+    # install old timestamp triggers
+    old_triggers.install_timestamp_triggers(migrate_engine)

--- a/lib/galaxy/model/migrate/versions/0175_history_audit.py
+++ b/lib/galaxy/model/migrate/versions/0175_history_audit.py
@@ -35,6 +35,7 @@ def upgrade(migrate_engine):
     metadata.reflect()
 
     # create table + index
+    AuditTable.drop(migrate_engine, checkfirst=True)
     create_table(AuditTable)
 
     # populate with update_time from every history

--- a/lib/galaxy/model/migrate/versions/0175_history_audit.py
+++ b/lib/galaxy/model/migrate/versions/0175_history_audit.py
@@ -5,7 +5,7 @@ Add history audit table and associated triggers
 import datetime
 import logging
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, Table
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, MetaData, PrimaryKeyConstraint, Table
 
 from galaxy.model.migrate.triggers import (
     history_update_time_field as old_triggers,  # rollback to old ones
@@ -25,6 +25,7 @@ AuditTable = Table(
     metadata,
     Column("history_id", Integer, ForeignKey("history.id"), primary_key=True, nullable=False),
     Column("update_time", DateTime, default=now, primary_key=True, nullable=False),
+    PrimaryKeyConstraint(sqlite_on_conflict='IGNORE')
 )
 
 

--- a/lib/galaxy/model/migrate/versions/util.py
+++ b/lib/galaxy/model/migrate/versions/util.py
@@ -3,6 +3,7 @@ import logging
 
 from sqlalchemy import (
     BLOB,
+    DDL,
     Index,
     Table,
     Text
@@ -193,3 +194,10 @@ def drop_index(index, table, column_name=None, metadata=None):
         index.drop()
     except Exception:
         log.exception("Dropping index '%s' from table '%s' failed", index, table)
+
+
+def execute_statements(engine, raw_sql):
+    statements = raw_sql if isinstance(raw_sql, list) else [raw_sql]
+    for sql in statements:
+        cmd = DDL(sql)
+        cmd.execute(bind=engine)

--- a/lib/galaxy/util/task.py
+++ b/lib/galaxy/util/task.py
@@ -1,0 +1,51 @@
+import logging
+from threading import (
+    Event,
+    Thread,
+)
+
+from galaxy.util import ExecutionTimer
+
+log = logging.getLogger(__name__)
+
+
+class IntervalTask:
+
+    def __init__(self, func, name="Periodic task", interval=3600, immediate_start=False, time_execution=False):
+        """
+        Run an arbitrary function `func` every `interval` seconds.
+
+        Set `immediate_start` to True to run `func` when task is started.
+        """
+        self.func = func
+        self.name = name
+        self.interval = interval
+        self.time_execution = time_execution
+        self.immediate_start = immediate_start
+        self.event = Event()
+        self.thread = Thread(target=self.run, name=self.name, daemon=True)
+        self.running = False
+
+    def start(self):
+        self.running = True
+        self.thread.start()
+
+    def _exec(self):
+        if self.time_execution:
+            timer = ExecutionTimer()
+        self.func()
+        if self.time_execution:
+            log.debug(f"Executed periodic task {self.name} {timer}")
+
+    def run(self):
+        if self.immediate_start:
+            self._exec()
+        while not self.event.isSet():
+            self.event.wait(self.interval)
+            if self.running:
+                self._exec()
+
+    def shutdown(self):
+        self.running = False
+        self.event.set()
+        self.thread.join(5)

--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -76,10 +76,13 @@ class GridColumn:
         """Sort query using this column."""
         if column_name is None:
             column_name = self.key
+        column = self.model_class.table.c.get(column_name)
+        if column is None:
+            column = getattr(self.model_class, column_name)
         if ascending:
-            query = query.order_by(self.model_class.table.c.get(column_name).asc())
+            query = query.order_by(column.asc())
         else:
-            query = query.order_by(self.model_class.table.c.get(column_name).desc())
+            query = query.order_by(column.desc())
         return query
 
 

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -197,6 +197,14 @@ mapping:
         desc: |
           Time to sleep between attempts if database_wait is enabled (in seconds).
 
+      history_audit_table_prune_interval:
+        type: int
+        default: 3600
+        required: false
+        desc: |
+          Time (in seconds) between attempts to remove old rows from the history_audit database table.
+          Set to 0 to disable pruning.
+
       file_path:
         type: str
         default: objects

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -86,9 +86,9 @@ class HistoryListGrid(grids.Grid):
 
         def sort(self, trans, query, ascending, column_name=None):
             if ascending:
-                query = query.order_by(self.model_class.table.c.purged.asc(), self.model_class.table.c.update_time.desc())
+                query = query.order_by(self.model_class.table.c.purged.asc(), self.model_class.update_time.desc())
             else:
-                query = query.order_by(self.model_class.table.c.purged.desc(), self.model_class.table.c.update_time.desc())
+                query = query.order_by(self.model_class.table.c.purged.desc(), self.model_class.update_time.desc())
             return query
 
     def build_initial_query(self, trans, **kwargs):

--- a/lib/galaxy/webapps/reports/controllers/system.py
+++ b/lib/galaxy/webapps/reports/controllers/system.py
@@ -60,7 +60,7 @@ class System(BaseUIController):
             for history in trans.sa_session.query(model.History) \
                     .filter(and_(model.History.table.c.user_id == null(),
                     model.History.table.c.deleted == true(),
-                    model.History.table.c.update_time < cutoff_time)):
+                    model.History.update_time < cutoff_time)):
                 for dataset in history.datasets:
                     if not dataset.deleted:
                         dataset_count += 1
@@ -86,7 +86,7 @@ class System(BaseUIController):
             histories = trans.sa_session.query(model.History) \
                 .filter(and_(model.History.table.c.deleted == true(),
                     model.History.table.c.purged == false(),
-                    model.History.table.c.update_time < cutoff_time)) \
+                    model.History.update_time < cutoff_time)) \
                 .options(eagerload('datasets'))
 
             for history in histories:

--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -140,12 +140,12 @@ def delete_userless_histories(app, cutoff_time, info_only=False, force_retry=Fal
     if force_retry:
         histories = app.sa_session.query(app.model.History) \
                                   .filter(and_(app.model.History.table.c.user_id == null(),
-                                               app.model.History.table.c.update_time < cutoff_time))
+                                               app.model.History.update_time < cutoff_time))
     else:
         histories = app.sa_session.query(app.model.History) \
                                   .filter(and_(app.model.History.table.c.user_id == null(),
                                                app.model.History.table.c.deleted == false(),
-                                               app.model.History.table.c.update_time < cutoff_time))
+                                               app.model.History.update_time < cutoff_time))
     for history in histories:
         if not info_only:
             log.info("Deleting history id %d", history.id)
@@ -170,13 +170,13 @@ def purge_histories(app, cutoff_time, remove_from_disk, info_only=False, force_r
     if force_retry:
         histories = app.sa_session.query(app.model.History) \
                                   .filter(and_(app.model.History.table.c.deleted == true(),
-                                               app.model.History.table.c.update_time < cutoff_time)) \
+                                               app.model.History.update_time < cutoff_time)) \
                                   .options(eagerload('datasets'))
     else:
         histories = app.sa_session.query(app.model.History) \
                                   .filter(and_(app.model.History.table.c.deleted == true(),
                                                app.model.History.table.c.purged == false(),
-                                               app.model.History.table.c.update_time < cutoff_time)) \
+                                               app.model.History.update_time < cutoff_time)) \
                                   .options(eagerload('datasets'))
     for history in histories:
         log.info("### Processing history id %d (%s)", history.id, unicodify(history.name))

--- a/test/unit/util/test_task.py
+++ b/test/unit/util/test_task.py
@@ -1,0 +1,28 @@
+import time
+
+from galaxy.util.task import IntervalTask
+
+
+def test_interval_task_immediate_start():
+    results = []
+    task = IntervalTask(lambda: results.append(1), name="test_task", interval=0.2, immediate_start=True)
+    task.start()
+    task.shutdown()
+    assert len(results) == 1
+
+
+def test_interval_task_delayed_start():
+    results = []
+    task = IntervalTask(lambda: results.append(1), name="test_task", interval=0.2, immediate_start=False)
+    task.start()
+    task.shutdown()
+    assert len(results) == 0
+
+
+def test_interval_task_delayed_start_run_once():
+    results = []
+    task = IntervalTask(lambda: results.append(1), name="test_task", interval=0.2, immediate_start=False)
+    task.start()
+    time.sleep(0.25)
+    task.shutdown()
+    assert len(results) == 1


### PR DESCRIPTION
## What did you do? 

Created a separate audit trail table for the history table so that we can use triggers to insert audit rows as a means of tracking history.update_time without deadlocking the history table with a lot of write locks.

## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)

Previous trigger solution results in deadlocking the history table if a lot of job state updates or other changes happen in quick succession.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
