### PR TITLE
Stabilize test_history_options selenium test

### DIFF
--- a/lib/galaxy_test/selenium/test_history_options.py
+++ b/lib/galaxy_test/selenium/test_history_options.py
@@ -10,7 +10,6 @@ class HistoryOptionsTestCase(SeleniumTestCase):
     def test_options(self):
         self.register()
         self.perform_upload(self.get_filename("1.txt"))
-        self.wait_for_history()
         self.click_history_options()
 
         menu_selector = self.navigation.history_panel.selectors.options_menu
@@ -22,6 +21,7 @@ class HistoryOptionsTestCase(SeleniumTestCase):
         self.wait_for_absent_or_hidden(menu_selector)
 
         hid = 1
+        self.history_panel_wait_for_hid_state(hid, 'ok')
         self.history_panel_click_item_title(hid=hid, wait=True)
         item_component = self.history_panel_item_body_component(hid=hid)
         item_component.wait_for_visible()


### PR DESCRIPTION
## What did you do? 
- Do no not wait on disappearing element when clicking on the dataset title. That is checked by the next line in the test (taking into account transition)


## Why did you make this change?
This is being checked on the next line anyway, and some of the test
screenshots show the transition currently happening.
![last](https://user-images.githubusercontent.com/6804901/116865595-36902980-ac0a-11eb-9d4c-d0ad78bc4cb5.png)


This is just a guess, but I suspect it might fix:
```
_____________________ HistoryOptionsTestCase.test_options ______________________

self = <galaxy_test.selenium.test_history_options.HistoryOptionsTestCase testMethod=test_options>

    @selenium_test
    def test_options(self):
        self.register()
        self.perform_upload(self.get_filename("1.txt"))
        self.wait_for_history()
        self.click_history_options()

        menu_selector = self.navigation.history_panel.selectors.options_menu
        self.wait_for_visible(menu_selector)

        # Click away closes history options
        self.click_center()

        self.wait_for_absent_or_hidden(menu_selector)

        hid = 1
        self.history_panel_click_item_title(hid=hid, wait=True)
        item_component = self.history_panel_item_body_component(hid=hid)
        item_component.wait_for_visible()
>       self.history_panel_click_item_title(hid=hid, wait=True)

lib/galaxy_test/selenium/test_history_options.py:28:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
lib/galaxy/selenium/navigates_galaxy.py:1350: in history_panel_click_item_title
    details_component.wait_for_absent_or_hidden()
lib/galaxy/selenium/smart_components.py:79: in wait_for_absent_or_hidden
    self._has_driver.wait_for_absent_or_hidden(self._target, **kwds)
lib/galaxy/selenium/has_driver.py:145: in wait_for_absent_or_hidden
    **kwds
lib/galaxy/selenium/has_driver.py:167: in _wait_on
    return wait.until(condition, self._timeout_message(on_str))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <selenium.webdriver.support.wait.WebDriverWait (session="f6478ee5ab12c8d35994bc35db8e0c7a")>
method = <selenium.webdriver.support.expected_conditions.invisibility_of_element_located object at 0x7fbb1f656450>
message = 'Timeout waiting on CSS selector [#dataset-0865882de2e81d71 .details] to become absent or hidden.'

    def until(self, method, message=''):
        """Calls the method provided with the driver as an argument until the \
        return value is not False."""
        screen = None
        stacktrace = None

        end_time = time.time() + self._timeout
        while True:
            try:
                value = method(self._driver)
                if value:
                    return value
            except self._ignored_exceptions as exc:
                screen = getattr(exc, 'screen', None)
                stacktrace = getattr(exc, 'stacktrace', None)
            time.sleep(self._poll)
            if time.time() > end_time:
                break
>       raise TimeoutException(message, screen, stacktrace)
E       selenium.common.exceptions.TimeoutException: Message: Timeout waiting on CSS selector [#dataset-0865882de2e81d71 .details] to become absent or hidden.
```


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
