### PR TITLE
Remove legacy current history reference from Workflow components, use standard component mounts

### DIFF
--- a/client/src/components/PluginList/PluginList.vue
+++ b/client/src/components/PluginList/PluginList.vue
@@ -62,12 +62,15 @@
     </div>
 </template>
 <script>
-import $ from "jquery";
-import { getAppRoot } from "onload/loadConfig";
-import { getGalaxyInstance } from "app";
 import axios from "axios";
+import { legacyNavigationMixin } from "components/plugins/legacyNavigation";
 
 export default {
+    mixins: [legacyNavigationMixin],
+    props: {
+        datasetId: { type: String, required: true },
+        currentHistoryId: { type: String, required: true },
+    },
     data() {
         return {
             plugins: [],
@@ -80,13 +83,11 @@ export default {
         };
     },
     created() {
-        const Galaxy = getGalaxyInstance();
-        let url = `${getAppRoot()}api/plugins`;
-        const dataset_id = Galaxy.params.dataset_id;
-        if (dataset_id) {
+        let url = this.prependUrl("api/plugins");
+        if (this.datasetId) {
             this.fixed = true;
-            this.selected = dataset_id;
-            url += `?dataset_id=${dataset_id}`;
+            this.selected = this.datasetId;
+            url += `?dataset_id=${this.datasetId}`;
         }
         axios
             .get(url)
@@ -102,11 +103,11 @@ export default {
             if (this.fixed) {
                 this.create(plugin);
             } else {
-                const Galaxy = getGalaxyInstance();
-                const history_id = Galaxy.currHistoryPanel && Galaxy.currHistoryPanel.model.id;
+                const history_id = this.currentHistoryId;
                 if (history_id) {
+                    const url = this.prependPath(`api/plugins/${plugin.name}?history_id=${history_id}`);
                     axios
-                        .get(`${getAppRoot()}api/plugins/${plugin.name}?history_id=${history_id}`)
+                        .get(url)
                         .then((response) => {
                             this.name = plugin.name;
                             this.hdas = response.data && response.data.hdas;
@@ -127,7 +128,7 @@ export default {
             if (plugin.target == "_top") {
                 window.location.href = href;
             } else {
-                $("#galaxy_main").attr("src", href);
+                document.getElementById("galaxy_main").setAttribute("src", href);
             }
         },
         match: function (plugin) {

--- a/client/src/components/PluginList/index.vue
+++ b/client/src/components/PluginList/index.vue
@@ -1,0 +1,24 @@
+<template>
+    <CurrentUser v-slot="{ user }">
+        <UserHistories v-if="user" :user="user" v-slot="{ currentHistory }">
+            <PluginList v-if="currentHistory.id" :dataset-id="datasetId" :current-history-id="currentHistory.id" />
+        </UserHistories>
+    </CurrentUser>
+</template>
+
+<script>
+import CurrentUser from "components/providers/CurrentUser";
+import { UserHistories } from "components/History/providers";
+import PluginList from "./PluginList";
+
+export default {
+    components: {
+        CurrentUser,
+        UserHistories,
+        PluginList,
+    },
+    props: {
+        datasetId: { type: String, required: true },
+    },
+};
+</script>

--- a/client/src/components/User/CustomBuilds.vue
+++ b/client/src/components/User/CustomBuilds.vue
@@ -154,22 +154,17 @@ chr5    152537259</pre
 </template>
 
 <script>
-import Vue from "vue";
-import BootstrapVue from "bootstrap-vue";
 import axios from "axios";
-import { getGalaxyInstance } from "app";
 import Multiselect from "vue-multiselect";
 import "vue-multiselect/dist/vue-multiselect.min.css";
-Vue.use(BootstrapVue);
+import { mapGetters } from "vuex";
 
 export default {
     components: {
         Multiselect,
     },
     data() {
-        const Galaxy = getGalaxyInstance();
         return {
-            customBuildsUrl: `${Galaxy.root}api/users/${Galaxy.user.id}/custom_builds`,
             selectedInstalledBuilds: [],
             installedBuilds: [],
             maxFileSize: 100,
@@ -204,6 +199,14 @@ export default {
         };
     },
     computed: {
+        ...mapGetters("user", ["currentUser"]),
+        ...mapGetters("betaHistory", ["currentHistoryId"]),
+
+        customBuildsUrl() {
+            const userId = this.currentUser.id;
+            return this.prependPath(`api/users/${userId}/custom_builds`);
+        },
+
         lengthType: function () {
             return this.selectedDataSource || "";
         },
@@ -220,11 +223,9 @@ export default {
         },
     },
     created() {
-        const Galaxy = getGalaxyInstance();
-        const historyId = Galaxy.currHistoryPanel && Galaxy.currHistoryPanel.model.id;
         this.loadCustomBuilds();
-        if (historyId) {
-            this.loadCustomBuildsMetadata(historyId);
+        if (this.currentHistoryId) {
+            this.loadCustomBuildsMetadata(this.currentHistoryId);
         } else {
             this.fastaFilesLoading = false;
         }
@@ -241,9 +242,9 @@ export default {
                 });
         },
         loadCustomBuildsMetadata(historyId) {
-            const Galaxy = getGalaxyInstance();
+            const url = this.prependPath("api/histories/${historyId}/custom_builds_metadata");
             axios
-                .get(`${Galaxy.root}api/histories/${historyId}/custom_builds_metadata`)
+                .get(url)
                 .then((response) => {
                     const fastaHdas = response.data.fasta_hdas;
                     for (let i = 0; i < fastaHdas.length; i++) {

--- a/client/src/components/User/CustomBuilds/index.vue
+++ b/client/src/components/User/CustomBuilds/index.vue
@@ -1,0 +1,25 @@
+<template>
+    <CurrentUser v-slot="{ user }">
+        <UserHistories v-if="user" :user="user" v-slot="{ currentHistory }">
+            <CustomBuildsView
+                v-if="currentHistory"
+                :current-user-id="user.id"
+                :current-history-id="currentHistory.id"
+            />
+        </UserHistories>
+    </CurrentUser>
+</template>
+
+<script>
+import CurrentUser from "components/providers/CurrentUser";
+import { UserHistories } from "components/History/providers";
+import CustomBuildsView from "./CustomBuildsView";
+
+export default {
+    components: {
+        CurrentUser,
+        UserHistories,
+        CustomBuildsView,
+    },
+};
+</script>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -77,12 +77,11 @@
 
 <script>
 import { getAppRoot } from "onload/loadConfig";
-import { getGalaxyInstance } from "app";
 import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import UtcDate from "components/UtcDate";
 import LoadingSpan from "components/LoadingSpan";
 import { mapCacheActions } from "vuex-cache";
-import { mapGetters } from "vuex";
+import { mapActions, mapGetters } from "vuex";
 
 export default {
     components: {
@@ -120,6 +119,7 @@ export default {
     },
     methods: {
         ...mapCacheActions(["fetchWorkflowForInstanceId", "fetchHistoryForId"]),
+        ...mapActions("betaHistory", ["setCurrentHistoryId"]),
         computeItems(items) {
             return items.map((invocation) => {
                 if (this.ownerGrid) {
@@ -144,8 +144,7 @@ export default {
             window.location = `${getAppRoot()}workflows/run?id=${workflowId}`;
         },
         switchHistory(historyId) {
-            const Galaxy = getGalaxyInstance();
-            Galaxy.currHistoryPanel.switchToHistory(historyId);
+            this.setCurrentHistoryId(historyId);
         },
     },
 };

--- a/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunSuccess.vue
@@ -33,6 +33,7 @@ import { WorkflowInvocationState } from "components/WorkflowInvocationState";
 import Webhooks from "mvc/webhooks";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
+import { mapGetters } from "vuex";
 
 export default {
     components: {
@@ -54,6 +55,7 @@ export default {
         };
     },
     computed: {
+        ...mapGetters("betaHistory", ["currentHistoryId"]),
         timesExecuted() {
             return this.invocations.length;
         },
@@ -71,13 +73,8 @@ export default {
             if (this.invocations.length < 1) {
                 return false;
             }
-            const Galaxy = getGalaxyInstance();
-            return (
-                (this.invocations[0].history_id &&
-                    Galaxy.currHistoryPanel &&
-                    Galaxy.currHistoryPanel.model.id != this.invocations[0].history_id) ||
-                false
-            );
+            const id = this.invocations[0].history_id;
+            return (id && this.currentHistoryId != id) || false;
         },
     },
     methods: {

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -49,9 +49,8 @@ import { CloudAuth } from "components/User/CloudAuth";
 import { ExternalIdentities } from "components/User/ExternalIdentities";
 import Confirmation from "components/login/Confirmation.vue";
 import LibraryFolderRouter from "components/Libraries/LibraryFolderRouter";
-import Vue from "vue";
-import store from "store";
 import VueRouterMain from "./VueRouterMain.vue";
+import { mountVueComponent } from "utils/mountVueComponent";
 
 /** Routes */
 export const getAnalysisRouter = (Galaxy) => {
@@ -109,25 +108,17 @@ export const getAnalysisRouter = (Galaxy) => {
             return (Galaxy.user && Galaxy.user.id) || this.require_login.indexOf(name) == -1;
         },
 
-        _display_vue_helper: function (component, propsData = {}, active_tab = null, noPadding = false) {
-            const instance = Vue.extend(component);
+        _display_vue_helper: function (component, propsData = {}, active_tab = null, noPadding = false, ...moreConfig) {
             const container = document.createElement("div");
             if (active_tab) {
                 container.active_tab = active_tab;
             }
             this.page.display(container, noPadding);
-            new instance({ store, propsData }).$mount(container);
+            const mountFn = mountVueComponent(component);
+            mountFn(propsData, container, ...moreConfig);
         },
         _display_vue_router: function (router, propsData = {}, active_tab = null, noPadding = false) {
-            const container = document.createElement("div");
-            if (active_tab) {
-                container.active_tab = active_tab;
-            }
-            this.page.display(container, noPadding);
-            new Vue({
-                router: router,
-                render: (h) => h(VueRouterMain),
-            }).$mount(container);
+            this._display_vue_helper(VueRouterMain, propsData, active_tab, noPadding, router);
         },
 
         show_tours: function (tour_id) {
@@ -387,13 +378,6 @@ export const getAnalysisRouter = (Galaxy) => {
         },
 
         show_custom_builds: function () {
-            const historyPanel = this.page.historyPanel.historyView;
-            if (!historyPanel || !historyPanel.model || !historyPanel.model.id) {
-                window.setTimeout(() => {
-                    this.show_custom_builds();
-                }, 500);
-                return;
-            }
             this._display_vue_helper(CustomBuilds);
         },
 

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -39,7 +39,7 @@ import RecentInvocations from "components/User/RecentInvocations.vue";
 import ToolsView from "components/ToolsView/ToolsView.vue";
 import ToolsJson from "components/ToolsView/ToolsSchemaJson/ToolsJson.vue";
 import HistoryList from "mvc/history/history-list";
-import PluginList from "components/PluginList.vue";
+import PluginList from "components/PluginList";
 import QueryStringParsing from "utils/query-string-parsing";
 import DatasetError from "mvc/dataset/dataset-error";
 import DatasetEditAttributes from "mvc/dataset/dataset-edit-attributes";
@@ -331,7 +331,9 @@ export const getAnalysisRouter = (Galaxy) => {
         },
 
         show_plugins: function () {
-            this._display_vue_helper(PluginList);
+            this._display_vue_helper(PluginList, {
+                datasetId: Galaxy.params.dataset_id,
+            });
         },
 
         show_workflows: function () {

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -21,7 +21,7 @@ import Sharing from "components/Sharing.vue";
 import UserPreferences from "components/User/UserPreferences.vue";
 import DatasetList from "components/Dataset/DatasetList.vue";
 import { getUserPreferencesModel } from "components/User/UserPreferencesModel";
-import CustomBuilds from "components/User/CustomBuilds.vue";
+import CustomBuilds from "components/User/CustomBuilds";
 import Tours from "mvc/tours";
 import GridView from "mvc/grid/grid-view";
 import GridShared from "mvc/grid/grid-shared";

--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -26,5 +26,5 @@ Vue.use(vueRxShortcutPlugin);
 
 export const mountVueComponent = (ComponentDefinition) => {
     const component = Vue.extend(ComponentDefinition);
-    return (propsData, el) => new component({ store, propsData, el });
+    return (propsData, el, ...moreConfig) => new component({ store, propsData, el, ...moreConfig });
 };


### PR DESCRIPTION
## What did you do? 
Removing references to the legacy current history panel functionality from the new Vue components. To do this, I changed all the custom mounts to use the standardized mount utility so they have access to both the store and the standard set of Vue plugins.


## Why did you make this change?
Needs to happen as a step to ultimately removing the old history panel.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
