### PR TITLE
[21.01] update legacy_framework.grids.StateColumn (bug fix)

### DIFF
--- a/lib/galaxy/web/legacy_framework/grids.py
+++ b/lib/galaxy/web/legacy_framework/grids.py
@@ -399,7 +399,7 @@ class StateColumn(GridColumn):
         """Modify query to filter self.model_class by state."""
         if column_filter == "All":
             pass
-        elif column_filter in [state.value for state in self.model_class.states]:
+        elif column_filter in list(self.model_class.states):
             query = query.filter(self.model_class.state == column_filter)
         return query
 

--- a/lib/galaxy/web/legacy_framework/grids.py
+++ b/lib/galaxy/web/legacy_framework/grids.py
@@ -390,9 +390,6 @@ class DeletedColumn(GridColumn):
 class StateColumn(GridColumn):
     """
     Column that tracks and filters for items with state attribute.
-
-    IMPORTANT NOTE: self.model_class must have a states Bunch or dict if
-    this column type is used in the grid.
     """
 
     def get_value(self, trans, grid, item):
@@ -402,7 +399,7 @@ class StateColumn(GridColumn):
         """Modify query to filter self.model_class by state."""
         if column_filter == "All":
             pass
-        elif column_filter in [v for k, v in self.model_class.states.items()]:
+        elif column_filter in [state.value for state in self.model_class.states]:
             query = query.filter(self.model_class.state == column_filter)
         return query
 
@@ -410,9 +407,9 @@ class StateColumn(GridColumn):
         """Returns a list of accepted filters for this column."""
         all = GridColumnFilter('all', {self.key: 'All'})
         accepted_filters = [all]
-        for v in self.model_class.states.values():
-            args = {self.key: v}
-            accepted_filters.append(GridColumnFilter(v, args))
+        for state in self.model_class.states:
+            args = {self.key: state.value}
+            accepted_filters.append(GridColumnFilter(state.value, args))
         return accepted_filters
 
 


### PR DESCRIPTION
## What did you do? 

- updated StateColumn methods in legacy_framework.grids.py


## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)
We restarted the reports webapp and it was breaking because these methods were expecting model_class.states to be Bunch objects.  They have recently changed to Enum.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
 I have not written a test

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
