### PR TITLE
Add exception handling for job submission when user is not logged in

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -605,6 +605,16 @@ class JobHandlerQueue(Monitors):
                 log.debug("Intentionally failing job with message (%s)" % failure_message)
             job_wrapper.fail(failure_message)
             return JOB_ERROR, job_destination
+
+        try:
+            failure_message= 'You do not seem to be logged in, and can therefore not submit jobs.'
+            assert job.user is not None, failure_message
+        except AssertionError as e:
+            log.debug("Intentionally failing job with message (%s)" % e)
+            job_wrapper.fail(e)
+            state = JOB_ERROR
+            return JOB_ERROR, job_destination
+        
         # job is ready to run, check limits
         # TODO: these checks should be refactored to minimize duplication and made more modular/pluggable
         state = self.__check_destination_jobs(job, job_wrapper)


### PR DESCRIPTION
## What did you do? 
Added an exception handling for job-submission if user is not logged in. This seems to not be allowed (in some cases, maybe not all?)


## Why did you make this change?
Fix issue #11917 

Our galaxy-setup shows the current error if a job is submitted if the user is not logged in:

![Screen Shot 2021-05-03 at 10 55 27](https://user-images.githubusercontent.com/22190352/116995872-ed5bda80-acda-11eb-8923-9a97d8fbfadd.png)

The job will not start, but the user gets no message what is happening. 

## How to test the changes? 
Applied the patch on our system, and now the job will fail for the user, with an error message explaining why the job failed. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
