### PR TITLE
Fix up package structure for recent filter linting changes.

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -1,8 +1,21 @@
+
 """This module contains a linting functions for tool inputs."""
-from galaxy.tools.parameters.dynamic_options import filter_types
 from galaxy.util import string_as_bool
 from ._util import is_datasource, is_valid_cheetah_placeholder
 from ..parser.util import _parse_name
+
+FILTER_TYPES = [
+    'data_meta',
+    'param_value',
+    'static_value',
+    'regexp',
+    'unique_value',
+    'multiple_splitter',
+    'attribute_value_splitter',
+    'add_value',
+    'remove_value',
+    'sort_by',
+]
 
 
 def lint_inputs(tool_xml, lint_ctx):
@@ -53,7 +66,7 @@ def lint_inputs(tool_xml, lint_ctx):
                     if ftype is None:
                         lint_ctx.error(f"Select parameter [{param_name}] contains filter without type.")
                         continue
-                    if ftype not in filter_types:
+                    if ftype not in FILTER_TYPES:
                         lint_ctx.error(f"Select parameter [{param_name}] contains filter with unknown type '{ftype}'.")
                         continue
                     if ftype in ['add_value', 'data_meta']:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -6067,6 +6067,7 @@ and ``bibtex`` are the only supported options.</xs:documentation>
       <xs:enumeration value="regexp"/>
       <xs:enumeration value="unique_value"/>
       <xs:enumeration value="multiple_splitter"/>
+      <xs:enumeration value="attribute_value_splitter" />
       <xs:enumeration value="add_value"/>
       <xs:enumeration value="remove_value"/>
       <xs:enumeration value="sort_by"/>


### PR DESCRIPTION
## What did you do? 
- tool_util cannot import tool, so adjust the imports around filter type linting introduced in https://github.com/galaxyproject/galaxy/pull/11832.


## Why did you make this change?

- It is breaking CI and would break Planemo.

## How to test the changes? 
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
