### PR TITLE
Move default PR milestone to 21.09

### DIFF
--- a/.github/workflows/maintenance_bot.yaml
+++ b/.github/workflows/maintenance_bot.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository_owner == 'galaxyproject'
     runs-on: ubuntu-latest
     env:
-      MILESTONE_NUMBER: 19
+      MILESTONE_NUMBER: 20
     steps:
       - name: Get latest pull request labels
         id: get_pr_labels


### PR DESCRIPTION
## What did you do? 
- Move default PR milestone to 21.09


## Why did you make this change?
New PRs should not get the 21.05 milestone (by default).


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
