### PR TITLE
Added documentation for FASTQ datatypes and implemented quality check

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -124,16 +124,16 @@
     <datatype extension="fastq" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:Fastq" display_in_upload="true" description="FASTQ format is a text-based format for storing both a biological sequence (usually nucleotide sequence) and its corresponding quality scores." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fastq">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
-    <datatype extension="fastqsanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSanger" display_in_upload="true">
+    <datatype extension="fastqsanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSanger" display_in_upload="true" description="Sanger variant of the FASTQ format: phred+33">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
-    <datatype extension="fastqsolexa" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSolexa" display_in_upload="true" description="FastqSolexa is the Illumina (Solexa) variant of the Fastq format, which stores sequences and quality scores in a single file." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#FastqSolexa">
+    <datatype extension="fastqsolexa" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSolexa" display_in_upload="true" description="Solexa variant of the FASTQ format: solexa+64" description_url="https://wiki.galaxyproject.org/Learn/Datatypes#FastqSolexa">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
-    <datatype extension="fastqcssanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqCSSanger" display_in_upload="true">
+    <datatype extension="fastqcssanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqCSSanger" display_in_upload="true" description="sequence in in color space phred scored quality values 0:93 represented by ASCII 33:126">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
-    <datatype extension="fastqillumina" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true">
+    <datatype extension="fastqillumina" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true" description="Sanger variant of the FASTQ format: phred+33, sequence in color space">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
     <datatype extension="fqtoc" type="galaxy.datatypes.sequence:SequenceSplitLocations" display_in_upload="true"/>

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -133,7 +133,7 @@
     <datatype extension="fastqcssanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqCSSanger" display_in_upload="true" description="sequence in in color space phred scored quality values 0:93 represented by ASCII 33:126">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
-    <datatype extension="fastqillumina" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true" description="Sanger variant of the FASTQ format: phred+33, sequence in color space">
+    <datatype extension="fastqillumina" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true" description="Sanger variant of the FASTQ format: phred+64">
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
     <datatype extension="fqtoc" type="galaxy.datatypes.sequence:SequenceSplitLocations" display_in_upload="true"/>

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -829,7 +829,10 @@ class Fastq(BaseFastq):
 
 
 class FastqSanger(Fastq):
-    """Class representing a FASTQ sequence ( the Sanger variant )"""
+    """Class representing a FASTQ sequence (the Sanger variant)
+
+    phred scored quality values 0:93 represented by ASCII 33:126
+    """
     edam_format = "format_1932"
     file_ext = "fastqsanger"
     bases_regexp = re.compile("^[NGTAC]*$", re.IGNORECASE)
@@ -844,19 +847,29 @@ class FastqSanger(Fastq):
 
 
 class FastqSolexa(Fastq):
-    """Class representing a FASTQ sequence ( the Solexa variant )"""
+    """Class representing a FASTQ sequence ( the Solexa variant )
+    
+    solexa scored quality values -5:62 represented by ASCII 59:126
+    """
     edam_format = "format_1933"
     file_ext = "fastqsolexa"
 
 
 class FastqIllumina(Fastq):
-    """Class representing a FASTQ sequence ( the Illumina 1.3+ variant )"""
+    """Class representing a FASTQ sequence ( the Illumina 1.3+ variant )
+    
+    phred scored quality values 0:62 represented by ASCII 64:126
+    """
     edam_format = "format_1931"
     file_ext = "fastqillumina"
 
 
 class FastqCSSanger(Fastq):
-    """Class representing a Color Space FASTQ sequence ( e.g a SOLiD variant )"""
+    """Class representing a Color Space FASTQ sequence ( e.g a SOLiD variant )
+    
+    sequence in in color space
+    phred scored quality values 0:93 represented by ASCII 33:126
+    """
     file_ext = "fastqcssanger"
     bases_regexp = re.compile(r"^[NGTAC][0123\.]*$", re.IGNORECASE)
 

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -839,9 +839,12 @@ class FastqSanger(Fastq):
 
     @staticmethod
     def quality_check(lines):
-        """Presuming lines are lines from a fastq file, return True if the qualities are compatible with sanger encoding"""
+        """
+        Presuming lines are lines from a fastq file,
+        return True if the qualities are compatible with sanger encoding
+        """
         for line in islice(lines, 3, None, 4):
-            if not all(_ >= '!' and _ <= 'S' for _ in line[0]):
+            if not all(q >= '!' and q <= 'S' for q in line[0]):
                 return False
         return True
 
@@ -856,9 +859,12 @@ class FastqSolexa(Fastq):
 
     @staticmethod
     def quality_check(lines):
-        """Presuming lines are lines from a fastq file, return True if the qualities are compatible with sanger encoding"""
+        """
+        Presuming lines are lines from a fastq file,
+        return True if the qualities are compatible with sanger encoding
+        """
         for line in islice(lines, 3, None, 4):
-            if not all(_ >= ';' and _ <= 'h' for _ in line[0]):
+            if not all(q >= ';' and q <= 'h' for q in line[0]):
                 return False
         return True
 
@@ -873,9 +879,12 @@ class FastqIllumina(Fastq):
 
     @staticmethod
     def quality_check(lines):
-        """Presuming lines are lines from a fastq file, return True if the qualities are compatible with sanger encoding"""
+        """
+        Presuming lines are lines from a fastq file,
+        return True if the qualities are compatible with sanger encoding
+        """
         for line in islice(lines, 3, None, 4):
-            if not all(_ >= '@' and _ <= 'h' for _ in line[0]):
+            if not all(q >= '@' and q <= 'h' for q in line[0]):
                 return False
         return True
 

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -848,7 +848,7 @@ class FastqSanger(Fastq):
 
 class FastqSolexa(Fastq):
     """Class representing a FASTQ sequence ( the Solexa variant )
-    
+
     solexa scored quality values -5:40 represented by ASCII 59:104
     """
     edam_format = "format_1933"
@@ -862,9 +862,10 @@ class FastqSolexa(Fastq):
                 return False
         return True
 
+
 class FastqIllumina(Fastq):
     """Class representing a FASTQ sequence ( the Illumina 1.3+ variant )
-    
+
     phred scored quality values 0:40 represented by ASCII 64:104
     """
     edam_format = "format_1931"
@@ -878,9 +879,10 @@ class FastqIllumina(Fastq):
                 return False
         return True
 
+
 class FastqCSSanger(Fastq):
     """Class representing a Color Space FASTQ sequence ( e.g a SOLiD variant )
-    
+
     sequence in in color space
     phred scored quality values 0:93 represented by ASCII 33:126
     """

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -831,7 +831,7 @@ class Fastq(BaseFastq):
 class FastqSanger(Fastq):
     """Class representing a FASTQ sequence (the Sanger variant)
 
-    phred scored quality values 0:93 represented by ASCII 33:126
+    phred scored quality values 0:50 represented by ASCII 33:83
     """
     edam_format = "format_1932"
     file_ext = "fastqsanger"
@@ -849,20 +849,34 @@ class FastqSanger(Fastq):
 class FastqSolexa(Fastq):
     """Class representing a FASTQ sequence ( the Solexa variant )
     
-    solexa scored quality values -5:62 represented by ASCII 59:126
+    solexa scored quality values -5:40 represented by ASCII 59:104
     """
     edam_format = "format_1933"
     file_ext = "fastqsolexa"
 
+    @staticmethod
+    def quality_check(lines):
+        """Presuming lines are lines from a fastq file, return True if the qualities are compatible with sanger encoding"""
+        for line in islice(lines, 3, None, 4):
+            if not all(_ >= ';' and _ <= 'h' for _ in line[0]):
+                return False
+        return True
 
 class FastqIllumina(Fastq):
     """Class representing a FASTQ sequence ( the Illumina 1.3+ variant )
     
-    phred scored quality values 0:62 represented by ASCII 64:126
+    phred scored quality values 0:40 represented by ASCII 64:104
     """
     edam_format = "format_1931"
     file_ext = "fastqillumina"
 
+    @staticmethod
+    def quality_check(lines):
+        """Presuming lines are lines from a fastq file, return True if the qualities are compatible with sanger encoding"""
+        for line in islice(lines, 3, None, 4):
+            if not all(_ >= '@' and _ <= 'h' for _ in line[0]):
+                return False
+        return True
 
 class FastqCSSanger(Fastq):
     """Class representing a Color Space FASTQ sequence ( e.g a SOLiD variant )


### PR DESCRIPTION
## What did you do? 

- Added documentation on the definition of the FASTQ data types
- Implemented quality check for the (sequence space) FASTQ data types

Definitions are based on 

- https://github.com/galaxyproject/sequence_utils/blob/master/galaxy_utils/sequence/fastq.py (ignoring the maxima)
- https://en.wikipedia.org/wiki/FASTQ_format#Encoding (keeping the current maximum quality of 50 for fastqsanger)

- [ ] Still confused by https://galaxyproject.org/learn/datatypes/#Fastq that uses integers for the qualities in the solexa example. 
- [ ] Maybe we should update the link and use it always as `description_url`

## Why did you make this change?

- Definition may be helpful for tool developers. 
- Stricter check for the format may forbid some wrong assignments by users. 

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
