### PR TITLE
Fix `GET /api/datasets/` docs

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -100,21 +100,17 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         The list returned can be ordered using the optional parameter:
             order:  string containing one of the valid ordering attributes followed
-                    (optionally) by '-asc' or '-dsc' for ascending and descending
+                    (optionally) by '-asc' or '-dsc' (default) for ascending and descending
                     order respectively. Orders can be stacked as a comma-
                     separated list of values.
+                    Allowed ordering attributes are: 'create_time', 'extension',
+                    'hid', 'history_id', 'name', 'update_time'.
+                   'order' defaults to 'create_time'.
 
         ..example:
             To sort by name descending then create time descending:
                 '?order=name-dsc,create_time'
 
-        The ordering attributes and their default orders are:
-            hid defaults to 'hid-asc'
-            create_time defaults to 'create_time-dsc'
-            update_time defaults to 'update_time-dsc'
-            name    defaults to 'name-asc'
-
-        'order' defaults to 'create_time'
         """
         filter_params = self.parse_filter_params(kwd)
         filters = self.history_contents_filters.parse_filters(filter_params)

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -105,7 +105,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
                     separated list of values.
                     Allowed ordering attributes are: 'create_time', 'extension',
                     'hid', 'history_id', 'name', 'update_time'.
-                   'order' defaults to 'create_time'.
+                    'order' defaults to 'create_time'.
 
         ..example:
             To sort by name descending then create time descending:


### PR DESCRIPTION
## What did you do? 
- Fix `GET /api/datasets/` docs about the ordering of the query results.

## Why did you make this change?
The documentation was not in line with what the API actually does.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
