### PR TITLE
Don't move the `update_time` goalpost

### DIFF
--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -594,12 +594,12 @@ class HistoryContentsApiTestCase(ApiTestCase):
                 history_id,
                 assert_ok=False,
             ).json()
+            update_time = datetime.utcnow().isoformat()
             collection_id = response['implicit_collections'][0]['id']
             for _ in range(20):
-                update_time = datetime.utcnow().isoformat()
                 time.sleep(1)
                 update = self._get_content(history_id, update_time=update_time)
-                if any((c for c in update if c['history_content_type'] == 'dataset_collection' and c['job_state_summary']['ok'] == 3)):
+                if any(c for c in update if c['history_content_type'] == 'dataset_collection' and c['job_state_summary']['ok'] == 3):
                     return
             raise Exception(f"History content update time query did not include final update for implicit collection {collection_id}")
 
@@ -613,11 +613,11 @@ class HistoryContentsApiTestCase(ApiTestCase):
                 history_id,
                 assert_ok=False,
             ).json()
+            update_time = datetime.utcnow().isoformat()
             collection_id = response['output_collections'][0]['id']
             for _ in range(20):
-                update_time = datetime.utcnow().isoformat()
                 time.sleep(1)
                 update = self._get_content(history_id, update_time=update_time)
-                if any((c for c in update if c['history_content_type'] == 'dataset_collection' and c['populated_state'] == 'ok')):
+                if any(c for c in update if c['history_content_type'] == 'dataset_collection' and c['populated_state'] == 'ok'):
                     return
             raise Exception(f"History content update time query did not include populated_state update for dynamic nested collection {collection_id}")


### PR DESCRIPTION
## What did you do?
- Define the `update_time` before the loop starts.


## Why did you make this change?
In the previous implementation, the tests will raise an Exception if the dataset collection were updated between `self._get_content()` and `datetime.utcnow()` .

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
