### PR TITLE
[21.01] Backport #11900

### DIFF
--- a/lib/galaxy/config/script.py
+++ b/lib/galaxy/config/script.py
@@ -8,7 +8,7 @@ from argparse import ArgumentParser
 try:
     import pip
 except ImportError:
-    pip = None
+    pip = None  # type: ignore
 
 
 CONFIGURE_URL = "https://docs.galaxyproject.org/en/master/admin/"


### PR DESCRIPTION
## What did you do? 
- Ignore type to make mypy happy


## Why did you make this change?
Not sure why it started happening in the release_21.01 and master branches as well after I merged forward, see https://github.com/galaxyproject/galaxy/runs/2517416444?check_suite_focus=true

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
