### PR TITLE
[21.05] Don't let webless handlers join job-handlers pool automatically

### DIFF
--- a/scripts/galaxy_main.py
+++ b/scripts/galaxy_main.py
@@ -194,7 +194,7 @@ class GalaxyConfigBuilder:
         arg_parser.add_argument("--log-file", default=None, help="Galaxy log file (overrides log configuration in config_file if set)")
         arg_parser.add_argument("--pid-file", default=DEFAULT_PID, help="pid file (default is %s)" % DEFAULT_PID)
         arg_parser.add_argument("--server-name", default=None, help="set a galaxy server name")
-        arg_parser.add_argument("--attach-to-pool", action="append", default=['job-handlers'], help="attach to asynchronous worker pool (specify multiple times for multiple pools)")
+        arg_parser.add_argument("--attach-to-pool", action="append", default=None, help="attach to asynchronous worker pool (specify multiple times for multiple pools)")
 
     @property
     def config_is_ini(self):


### PR DESCRIPTION
## What did you do? 
- Partially revert https://github.com/galaxyproject/galaxy/pull/11792/commits/de8ef7609294d62fd5e1383cba7462bbc8a771c8

## Why did you make this change?
The workflow handler on test.galaxyproject.org joined (well, created) the job-handlers pool and started processing jobs.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Set up a default job config with a one or more job handlers (this is a common setup that I was worried about when I added https://github.com/galaxyproject/galaxy/pull/11792/commits/de8ef7609294d62fd5e1383cba7462bbc8a771c) and setup a workflow handler.
For the job_conf.xml:
```xml
    <handlers>
        <handler id="job0"/>
    </handlers>
```
This used to be assigned via db-preassign by default, but since 21.05 this is either db-transaction-isolation or db-skip-locked.
Set up a simple workflow_schedulers_conf.xml file (or put the equivalent into job_conf.xml):
```xml
<workflow_schedulers default="core">
    <core id="core" />
    <handlers default="schedulers">
        <handler id="test_workflow_scheduler0" tags="schedulers"/>
    </handlers>
</workflow_schedulers>
```
Start the web handler and the workflow scheduler (`run.sh` + `python scripts/galaxy_main.py -c config/galaxy.yml --server-name test_workflow_scheduler0`). Run a workflow and see that all jobs created by the workflow are assigned to handler `_default_` (check that in the database or in the admin panel -> jobs). The jobs will not run in the web or workflow handler. Now start the job handler (`python scripts/galaxy_main.py -c config/galaxy.yml --server-name job0`) and see that the assigned handler changes to job0 and the jobs start running.
Without this PR the workflow handler would start handling the jobs.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
