### PR TITLE
Add double quotes to cp for from_work_dir

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -244,7 +244,7 @@ def __handle_metadata(commands_builder, job_wrapper, runner, remote_command_para
 
 def __copy_if_exists_command(work_dir_output):
     source_file, destination = work_dir_output
-    return f"if [ -f {source_file} ] ; then cp {source_file} {destination} ; fi"
+    return f'\nif [ -f "{source_file}" ] ; then cp "{source_file}" "{destination}" ; fi'
 
 
 class CommandsBuilder:

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -77,7 +77,7 @@ class TestCommandFactory(TestCase):
     def test_workdir_outputs(self):
         self.include_work_dir_outputs = True
         self.workdir_outputs = [("foo", "bar")]
-        self.__assert_command_is(_surround_command('%s; return_code=$?; if [ -f foo ] ; then cp foo bar ; fi' % MOCK_COMMAND_LINE))
+        self.__assert_command_is(_surround_command('%s; return_code=$?; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi' % MOCK_COMMAND_LINE))
 
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True


### PR DESCRIPTION
## What did you do? 

Added double quotes to file names used in `cp` that is executed for `from_work_dir` files.
Note that single quotes would break for glob style patterns that are used quite often.

## Why did you make this change?

Adds a bit of security against spaces in paths

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
