### PR TITLE
[21.01] Fix non-closing masthead dropdown 

### DIFF
--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -22,7 +22,6 @@
         </template>
     </b-nav-item>
     <b-nav-item-dropdown
-        @blur="hideDropdown"
         ref="dropdown"
         v-else
         :class="classes"
@@ -113,10 +112,10 @@ export default {
         },
     },
     mounted() {
-        window.addEventListener("blur", () => this.hideDropdown());
+        window.addEventListener("blur", this.hideDropdown);
     },
     destroyed() {
-        window.removeEventListener("blur", () => this.hideDropdown());
+        window.removeEventListener("blur", this.hideDropdown);
     },
     methods: {
         hideDropdown() {

--- a/client/src/components/Masthead/MastheadItem.vue
+++ b/client/src/components/Masthead/MastheadItem.vue
@@ -22,6 +22,7 @@
         </template>
     </b-nav-item>
     <b-nav-item-dropdown
+        @blur="hideDropdown"
         ref="dropdown"
         v-else
         :class="classes"
@@ -111,20 +112,13 @@ export default {
             return document.getElementById("galaxy_main");
         },
     },
-    updated() {
-        if (this.$refs.dropdown && this.galaxyIframe) {
-            this.galaxyIframe.addEventListener("load", this.iframeListener);
-        }
+    mounted() {
+        window.addEventListener("blur", () => this.hideDropdown());
     },
     destroyed() {
-        if (this.$refs.dropdown && this.galaxyIframe) {
-            this.galaxyIframe.removeEventListener("load", this.iframeListener);
-        }
+        window.removeEventListener("blur", () => this.hideDropdown());
     },
     methods: {
-        iframeListener() {
-            return this.galaxyIframe.contentDocument.addEventListener("click", this.hideDropdown);
-        },
         hideDropdown() {
             if (this.$refs.dropdown) this.$refs.dropdown.hide();
         },


### PR DESCRIPTION
## What did you do? 
So the problem with [current solution](https://github.com/galaxyproject/galaxy/blob/dev/client/src/components/Masthead/MastheadItem.vue#L116) that it doesn't close dropdown on nested iframes. 
This PR creates an event listener on `blur`

## Why did you make this change?
dropdown is not getting closed on https://usegalaxy.org.au, https://usegalaxy.eu, https://usegalaxy.fr


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] Instructions for manual testing are as follows:
  1. open `galaxy.yml`
  2. write `welcome_url: https://galaxyproject.eu/galaxy/`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
![dropdown](https://user-images.githubusercontent.com/15801412/117867834-2aa30800-b299-11eb-8144-966fbf5facbe.gif)
