### PR TITLE
[21.05] Use dateutil for python 3.6 compatibility

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -5,7 +5,8 @@ import json
 import logging
 import os
 import re
-from datetime import datetime
+
+import dateutil.parser
 
 from galaxy import (
     exceptions,
@@ -1082,8 +1083,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         # if it hasn't then we can short-circuit the poll request
         since = kwd.get('update_time-gt', None)
         if since:
-            since_str = self.history_contents_filters.parse_date(since)
-            since_date = datetime.fromisoformat(since_str)
+            since_date = dateutil.parser.isoparse(since)
             if history.update_time <= since_date:
                 trans.response.status = 204
                 return

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -1,6 +1,7 @@
 """
 API operations on the contents of a history.
 """
+import datetime
 import json
 import logging
 import os
@@ -1083,7 +1084,10 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         # if it hasn't then we can short-circuit the poll request
         since = kwd.get('update_time-gt', None)
         if since:
-            since_date = dateutil.parser.isoparse(since)
+            # sqlalchemy DateTime columns are not timezone aware, so parse `since` into timezone-aware
+            # datetime and then convert to naive datetime object representing UTC,
+            # assuming history.update_time represents UTC time.
+            since_date = dateutil.parser.isoparse(since).astimezone(datetime.timezone.utc).replace(tzinfo=None)
             if history.update_time <= since_date:
                 trans.response.status = 204
                 return


### PR DESCRIPTION

## What did you do? 
- Use dateutil for python 3.6 compatibility


## Why did you make this change?
datetime.fromisoformat was added in python 3.7 and we still support 3.6


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Start Galaxy under Python 3.6, go to new history panel and make sure you're not seeing:
```
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 312, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/history_contents.py", line 1086, in contents_near
    since_date = datetime.fromisoformat(since_str)
AttributeError: type object 'datetime.datetime' has no attribute 'fromisoformat'
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
