### PR TITLE
[20.09] Force galaxy_id to string in galactic_job_json

### DIFF
--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -172,7 +172,7 @@ def galactic_job_json(
 
     def replacement_file(value):
         if value.get('galaxy_id'):
-            return {"src": "hda", "id": value['galaxy_id']}
+            return {"src": "hda", "id": str(value['galaxy_id'])}
         file_path = value.get("location", None) or value.get("path", None)
         # format to match output definitions in tool, where did filetype come from?
         filetype = value.get("filetype", None) or value.get("format", None)
@@ -281,7 +281,7 @@ def galactic_job_json(
 
     def replacement_collection(value):
         if value.get('galaxy_id'):
-            return {"src": "hdca", "id": value['galaxy_id']}
+            return {"src": "hdca", "id": str(value['galaxy_id'])}
         assert "collection_type" in value
         collection_type = value["collection_type"]
         elements = to_elements(value, collection_type)


### PR DESCRIPTION
## What did you do? 
- Bugfix for https://github.com/galaxyproject/galaxy/pull/10334


## Why did you make this change?
It can randomly occur that Galaxy encoded IDs by default contain only numeric digits. In this case when the galaxy StagingInterface loads workflow inputs the ID is interpreted as an int and not a string. This then leads to `TypeError: decoding with 'hex' codec failed (TypeError: argument should be bytes, buffer or ASCII string, not 'int')` when the workflow is executed.

Obviously this should happen quite rarely, but we just encountered it scheduling workflows on usegalaxy.es with @HugoJH.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
