### PR TITLE
[21.01] Update default base images, make DEFAULT_CHANNELS configurable via env var

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -60,7 +60,7 @@ end
 
 local destination_base_image = VAR.DEST_BASE_IMAGE
 if destination_base_image == '' then
-    destination_base_image = 'bgruening/busybox-bash:0.1'
+    destination_base_image = 'quay.io/bioconda/base-glibc-busybox-bash:latest'
 end
 
 local verbose = VAR.VERBOSE

--- a/lib/galaxy/tool_util/deps/mulled/mulled_build.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_build.py
@@ -46,9 +46,12 @@ from ..conda_compat import MetaData
 log = logging.getLogger(__name__)
 
 DIRNAME = os.path.dirname(__file__)
-DEFAULT_BASE_IMAGE = "bgruening/busybox-bash:0.1"
-DEFAULT_EXTENDED_BASE_IMAGE = "bioconda/extended-base-image:latest"
-DEFAULT_CHANNELS = ["conda-forge", "bioconda"]
+DEFAULT_BASE_IMAGE = os.environ.get("DEFAULT_BASE_IMAGE", "quay.io/bioconda/base-glibc-busybox-bash:latest")
+DEFAULT_EXTENDED_BASE_IMAGE = os.environ.get("DEFAULT_EXTENDED_BASE_IMAGE", "quay.io/bioconda/base-glibc-debian-bash:latest")
+if 'DEFAULT_MULLED_CONDA_CHANNELS' in os.environ:
+    DEFAULT_CHANNELS = os.environ['DEFAULT_MULLED_CONDA_CHANNELS'].split(',')
+else:
+    DEFAULT_CHANNELS = ["conda-forge", "bioconda"]
 DEFAULT_REPOSITORY_TEMPLATE = "quay.io/${namespace}/${image}"
 DEFAULT_BINDS = ["build/dist:/usr/local/"]
 DEFAULT_WORKING_DIR = '/source/'


### PR DESCRIPTION
## What did you do? 
- Update default base images, make DEFAULT_CHANNELS configurable via env var


## Why did you make this change?
Bioconda updated the base image for containerized builds (https://github.com/bioconda/bioconda-recipes/issues/11583#issuecomment-830099492). Notably that fixes dns issues when using singularity and the default base image when you don't mount in /etc/resolv.conf. 


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
