### PR TITLE
[21.05] Revert default GxIT domain to interactivetool for existing deployments

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1620,7 +1620,7 @@
 :Description:
     Prefix to use in the formation of the subdomain or path for
     interactive tools
-:Default: ``interactivetools``
+:Default: ``interactivetool``
 :Type: str
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -884,7 +884,7 @@ galaxy:
 
   # Prefix to use in the formation of the subdomain or path for
   # interactive tools
-  #interactivetools_prefix: interactivetools
+  #interactivetools_prefix: interactivetool
 
   # Shorten the uuid portion of the subdomain or path for interactive
   # tools. Especially useful for avoiding the need for wildcard

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1165,7 +1165,7 @@ mapping:
 
       interactivetools_prefix:
         type: str
-        default: "interactivetools"
+        default: "interactivetool"
         required: false
         desc: |
           Prefix to use in the formation of the subdomain or path for interactive tools


### PR DESCRIPTION
## What did you do? 
- Change the default subdomain for interactive tool (GxIT) entry points to `interactivetool` rather than `interactivetools`.


## Why did you make this change?
This was the previous default, changing it breaks existing deployments' DNS setups and SSL certs. Changed in #11947.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run a GxIT
  2. Verify that linked URL is `<random>.interactivetoolentrypoint.interactivetool.galaxy.example.org`.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
