### PR TITLE
[21.01] Fix mulled singularity building

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -101,11 +101,11 @@ inv.task('build')
 if VAR.SINGULARITY ~= '' then
     inv.task('singularity')
         .using(singularity_image)
-        .withHostConfig({binds = {"build:/data", "'" .. singularity_image_dir .. "':/import"}, privileged = true})
+        .withHostConfig({binds = {"build:/data", singularity_image_dir .. ":/import"}, privileged = true})
         .withConfig({entrypoint = {'/bin/sh', '-c'}})
-        .run('mkdir', '-p', '/usr/local/var/singularity/mnt/container')
-        .run('singularity', 'build', '/import/' .. VAR.SINGULARITY_IMAGE_NAME, '/import/Singularity.def')
-        .run('chown', VAR.USER_ID, '/import/' .. VAR.SINGULARITY_IMAGE_NAME)
+        .run('mkdir -p /usr/local/var/singularity/mnt/container && '
+            .. 'singularity build /import/' .. VAR.SINGULARITY_IMAGE_NAME .. ' /import/Singularity.def && '
+            .. 'chown ' .. VAR.USER_ID .. ' /import/' .. VAR.SINGULARITY_IMAGE_NAME)
 end
 
 inv.task('cleanup')

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -5,6 +5,7 @@ from galaxy.tool_util.deps.mulled.mulled_build import (
     build_target,
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
+    mull_targets,
 )
 from ..util import external_dependency_management
 
@@ -18,3 +19,11 @@ from ..util import external_dependency_management
 def test_base_image_for_targets(target, version, base_image):
     target = build_target(target, version=version)
     assert base_image_for_targets([target]) == base_image
+
+
+@external_dependency_management
+def test_mulled_build_files_cli(tmpdir):
+    singularity_image_dir = tmpdir.mkdir('singularity_image_dir')
+    target = build_target('zlib')
+    mull_targets([target], command='build-and-test', singularity=True, singularity_image_dir=singularity_image_dir)
+    assert singularity_image_dir.join('zlib').exists()

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -23,7 +23,7 @@ def test_base_image_for_targets(target, version, base_image):
 
 @external_dependency_management
 def test_mulled_build_files_cli(tmpdir):
-    singularity_image_dir = tmpdir.mkdir('singularity_image_dir')
+    singularity_image_dir = tmpdir.mkdir('singularity image dir')
     target = build_target('zlib')
     mull_targets([target], command='build-and-test', singularity=True, singularity_image_dir=singularity_image_dir)
     assert singularity_image_dir.join('zlib').exists()


### PR DESCRIPTION
## What did you do? 
- Fix mulled singularity building


## Why did you make this change?

This used to fail with
```
[May 13 12:53:06] DEBU Container [8a432293fb2f step-adb59c6b2d] started, waiting for completion
[May 13 12:53:06] SERR mkdir: missing operand
[May 13 12:53:06] SERR Try 'mkdir --help' for more information.
[May 13 12:53:06] ERRO Task processing failed: Unexpected exit code [1] of container [8a432293fb2f step-adb59c6b2d], container preserved
```
When using the `sh -c` entrypoint we need to concatenate arguments in `.run` as individual
commands. You can see the full error in https://github.com/BioContainers/multi-package-containers/pull/1713/checks?check_run_id=2575472382

Broke in https://github.com/mvdbeek/galaxy/commit/71a70ea1f12cca48c33ee5569bd74035f96376f7

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
