### PR TITLE
Migrate Libraries API (top level) to FastAPI

### DIFF
--- a/client/src/components/Libraries/LibraryPermissions/services.js
+++ b/client/src/components/Libraries/LibraryPermissions/services.js
@@ -79,18 +79,18 @@ export class Services {
     }
 
     async setPermissions(apiRootUrl, id, new_roles_ids, onSuccess, onError) {
-        var formData = new FormData();
+        const data = { action: "set_permissions" };
         new_roles_ids.forEach((permissionType) => {
-            Object.keys(permissionType).map(function (k) {
-                const ids = permissionType[k].map((a) => a.id);
-                formData.append(k, ids);
+            Object.keys(permissionType).map(function (type) {
+                const ids = permissionType[type].map((a) => a.id);
+                data[type] = ids;
             });
         });
 
         axios({
             method: "post",
-            url: `${apiRootUrl}/${id}/permissions?action=set_permissions`,
-            data: formData,
+            url: `${apiRootUrl}/${id}/permissions`,
+            data: data,
             headers: { "Content-Type": "multipart/form-data" },
         })
             .then(function (response) {

--- a/client/src/components/Libraries/LibraryPermissions/services.js
+++ b/client/src/components/Libraries/LibraryPermissions/services.js
@@ -87,12 +87,7 @@ export class Services {
             });
         });
 
-        axios({
-            method: "post",
-            url: `${apiRootUrl}/${id}/permissions`,
-            data: data,
-            headers: { "Content-Type": "multipart/form-data" },
-        })
+        axios.post(`${apiRootUrl}/${id}/permissions`, data)
             .then(function (response) {
                 onSuccess(response);
             })

--- a/client/src/components/Libraries/LibraryPermissions/services.js
+++ b/client/src/components/Libraries/LibraryPermissions/services.js
@@ -87,7 +87,8 @@ export class Services {
             });
         });
 
-        axios.post(`${apiRootUrl}/${id}/permissions`, data)
+        axios
+            .post(`${apiRootUrl}/${id}/permissions`, data)
             .then(function (response) {
                 onSuccess(response);
             })

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -546,7 +546,7 @@ class LibraryPermissionsPayload(BaseModel):
         use_enum_values = True  # When using .dict()
         allow_population_by_alias = True
 
-    action: LibraryPermissionAction = Field(
+    action: Optional[LibraryPermissionAction] = Field(
         ...,
         title="Action",
         description="Indicates what action should be performed on the Library.",

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -320,7 +320,7 @@ def get_containing_library_from_library_dataset(trans, library_dataset):
     return None
 
 
-class LibrariesManager:
+class LibrariesService:
     """
     Interface/service object for sharing logic between controllers.
     """

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -22,16 +22,19 @@ from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
 
-RoleIdField = Field("ID", description="Encoded ID of the role")
+RoleIdField = Field(title="ID", description="Encoded ID of the role")
 RoleNameField = Field(title="Name", description="Name of the role")
 RoleDescriptionField = Field(title="Description", description="Description of the role")
 
 
-class RoleModel(BaseModel):
+class BasicRoleModel(BaseModel):
     id: EncodedDatabaseIdField = RoleIdField
     name: str = RoleNameField
-    description: str = RoleDescriptionField
     type: str = Field(title="Type", description="Type or category of the role")
+
+
+class RoleModel(BasicRoleModel):
+    description: str = RoleDescriptionField
     url: str = Field(title="URL", description="URL for the role")
     model_class: str = Field(title="Model class", description="Database model class (Role)")
 

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -25,6 +25,7 @@ from galaxy.managers.libraries import (
     LibraryAvailablePermissions,
     LibraryCurrentPermissions,
     LibraryLegacySummary,
+    LibraryPermissionAction,
     LibraryPermissionScope,
     LibraryPermissionsPayload,
     LibrarySummary,
@@ -202,6 +203,11 @@ class FastAPILibraries:
         self,
         trans: ProvidesUserContext = DependsOnTrans,
         id: EncodedDatabaseIdField = LibraryIdPathParam,
+        action: Optional[LibraryPermissionAction] = Query(
+            default=None,
+            title="Action",
+            description="Indicates what action should be performed on the Library.",
+        ),
         payload: Union[
             LibraryPermissionsPayload,
             LegacyLibraryPermissionsPayload,
@@ -211,7 +217,10 @@ class FastAPILibraries:
         LibraryCurrentPermissions,
     ]:
         """Sets the permissions to access and manipulate a library."""
-        return self.service.set_permissions(trans, id, payload.dict(by_alias=True))
+        payload_dict = payload.dict(by_alias=True)
+        if isinstance(payload, LibraryPermissionsPayload) and action is not None:
+            payload_dict["action"] = action
+        return self.service.set_permissions(trans, id, payload_dict)
 
 
 class LibrariesController(BaseGalaxyAPIController):

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -47,7 +47,7 @@ class LibrariesController(BaseGalaxyAPIController):
         return self.service.index(trans, deleted)
 
     @expose_api_anonymous
-    def show(self, trans: ProvidesUserContext, id: EncodedDatabaseIdField, deleted='False', **kwd):
+    def show(self, trans: ProvidesUserContext, id: EncodedDatabaseIdField, **kwd):
         """
         show( self, trans, id, deleted='False', **kwd )
         * GET /api/libraries/{encoded_id}:
@@ -57,8 +57,6 @@ class LibrariesController(BaseGalaxyAPIController):
 
         :param  id:      the encoded id of the library
         :type   id:      an encoded id string
-        :param  deleted: if True, allow information on a ``deleted`` library
-        :type   deleted: boolean
 
         :returns:   detailed library information
         :rtype:     dictionary

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class LibrariesController(BaseGalaxyAPIController):
-    manager = depends(libraries.LibrariesManager)
+    service = depends(libraries.LibrariesService)
 
     @expose_api_anonymous
     def index(self, trans, **kwd):
@@ -38,7 +38,7 @@ class LibrariesController(BaseGalaxyAPIController):
 
         """
         deleted = util.string_as_bool_or_none(kwd.get('deleted', None))
-        return self.manager.index(trans, deleted)
+        return self.service.index(trans, deleted)
 
     @expose_api_anonymous
     def show(self, trans, id, deleted='False', **kwd):
@@ -61,7 +61,7 @@ class LibrariesController(BaseGalaxyAPIController):
 
         :raises: MalformedId, ObjectNotFound
         """
-        return self.manager.show(trans, id)
+        return self.service.show(trans, id)
 
     @expose_api
     def create(self, trans, payload: Dict[str, str], **kwd):
@@ -83,7 +83,7 @@ class LibrariesController(BaseGalaxyAPIController):
         :rtype:     dict
         :raises: RequestParameterMissingException
         """
-        return self.manager.create(trans, payload)
+        return self.service.create(trans, payload)
 
     @expose_api
     def update(self, trans, id, payload: Dict[str, str], **kwd):
@@ -107,7 +107,7 @@ class LibrariesController(BaseGalaxyAPIController):
         :rtype:     dict
         :raises: RequestParameterMissingException
         """
-        return self.manager.update(trans, id, payload)
+        return self.service.update(trans, id, payload)
 
     @expose_api
     def delete(self, trans, id, payload: Dict[str, Any] = None, **kwd):
@@ -132,7 +132,7 @@ class LibrariesController(BaseGalaxyAPIController):
         if payload:
             kwd.update(payload)
         undelete = util.string_as_bool(kwd.get('undelete', False))
-        return self.manager.delete(trans, id, undelete)
+        return self.service.delete(trans, id, undelete)
 
     @expose_api
     def get_permissions(self, trans, encoded_library_id, **kwd):
@@ -171,7 +171,7 @@ class LibrariesController(BaseGalaxyAPIController):
 
         query = kwd.get('q', None)
 
-        return self.manager.get_permissions(trans, encoded_library_id, scope, is_library_access, page, page_limit, query)
+        return self.service.get_permissions(trans, encoded_library_id, scope, is_library_access, page, page_limit, query)
 
     @expose_api
     def set_permissions(self, trans, encoded_library_id, payload: Dict[str, Any], **kwd):
@@ -202,4 +202,4 @@ class LibrariesController(BaseGalaxyAPIController):
         :raises: RequestParameterInvalidException, InsufficientPermissionsException, InternalServerError
                     RequestParameterMissingException
         """
-        return self.manager.set_permissions(trans, encoded_library_id, payload)
+        return self.service.set_permissions(trans, encoded_library_id, payload)

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -8,7 +8,13 @@ from typing import (
 )
 
 from galaxy import util
-from galaxy.managers import libraries
+from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.libraries import (
+    CreateLibraryPayload,
+    LibrariesService,
+    UpdateLibraryPayload,
+)
+from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.web import (
     expose_api,
     expose_api_anonymous,
@@ -19,10 +25,10 @@ log = logging.getLogger(__name__)
 
 
 class LibrariesController(BaseGalaxyAPIController):
-    service = depends(libraries.LibrariesService)
+    service: LibrariesService = depends(LibrariesService)
 
     @expose_api_anonymous
-    def index(self, trans, **kwd):
+    def index(self, trans: ProvidesUserContext, **kwd):
         """
         index( self, trans, **kwd )
         * GET /api/libraries:
@@ -41,7 +47,7 @@ class LibrariesController(BaseGalaxyAPIController):
         return self.service.index(trans, deleted)
 
     @expose_api_anonymous
-    def show(self, trans, id, deleted='False', **kwd):
+    def show(self, trans: ProvidesUserContext, id: EncodedDatabaseIdField, deleted='False', **kwd):
         """
         show( self, trans, id, deleted='False', **kwd )
         * GET /api/libraries/{encoded_id}:
@@ -64,7 +70,7 @@ class LibrariesController(BaseGalaxyAPIController):
         return self.service.show(trans, id)
 
     @expose_api
-    def create(self, trans, payload: Dict[str, str], **kwd):
+    def create(self, trans: ProvidesUserContext, payload: Dict[str, str], **kwd):
         """
         * POST /api/libraries:
             Creates a new library.
@@ -83,10 +89,11 @@ class LibrariesController(BaseGalaxyAPIController):
         :rtype:     dict
         :raises: RequestParameterMissingException
         """
-        return self.service.create(trans, payload)
+        create_payload = CreateLibraryPayload(**payload)
+        return self.service.create(trans, create_payload)
 
     @expose_api
-    def update(self, trans, id, payload: Dict[str, str], **kwd):
+    def update(self, trans: ProvidesUserContext, id: EncodedDatabaseIdField, payload: Dict[str, str], **kwd):
         """
         * PATCH /api/libraries/{encoded_id}
            Updates the library defined by an ``encoded_id`` with the data in the payload.
@@ -107,10 +114,11 @@ class LibrariesController(BaseGalaxyAPIController):
         :rtype:     dict
         :raises: RequestParameterMissingException
         """
-        return self.service.update(trans, id, payload)
+        update_payload = UpdateLibraryPayload(**payload)
+        return self.service.update(trans, id, update_payload)
 
     @expose_api
-    def delete(self, trans, id, payload: Dict[str, Any] = None, **kwd):
+    def delete(self, trans: ProvidesUserContext, id: EncodedDatabaseIdField, payload: Dict[str, Any] = None, **kwd):
         """
         * DELETE /api/libraries/{id}
             marks the library with the given ``id`` as `deleted` (or removes the `deleted` mark if the `undelete` param is true)
@@ -135,7 +143,7 @@ class LibrariesController(BaseGalaxyAPIController):
         return self.service.delete(trans, id, undelete)
 
     @expose_api
-    def get_permissions(self, trans, encoded_library_id, **kwd):
+    def get_permissions(self, trans: ProvidesUserContext, encoded_library_id: EncodedDatabaseIdField, **kwd):
         """
         * GET /api/libraries/{encoded_library_id}/permissions
 
@@ -174,7 +182,7 @@ class LibrariesController(BaseGalaxyAPIController):
         return self.service.get_permissions(trans, encoded_library_id, scope, is_library_access, page, page_limit, query)
 
     @expose_api
-    def set_permissions(self, trans, encoded_library_id, payload: Dict[str, Any], **kwd):
+    def set_permissions(self, trans: ProvidesUserContext, encoded_library_id: EncodedDatabaseIdField, payload: Dict[str, Any], **kwd):
         """
         POST /api/libraries/{encoded_library_id}/permissions
 

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -252,5 +252,5 @@ class FolderContentsApiTestCase(ApiTestCase):
         data = {
             "access_ids[]": role_id,
         }
-        response = self._post(f"libraries/{library_id}/permissions?action={action}", data=data, admin=True)
+        response = self._post(f"libraries/{library_id}/permissions?action={action}", data=data, admin=True, json=True)
         self._assert_status_code_is(response, 200)

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -23,7 +23,7 @@ class LibrariesApiTestCase(ApiTestCase):
 
     def test_create(self):
         data = dict(name="CreateTestLibrary")
-        create_response = self._post("libraries", data=data, admin=True)
+        create_response = self._post("libraries", data=data, admin=True, json=True)
         self._assert_status_code_is(create_response, 200)
         library = create_response.json()
         self._assert_has_keys(library, "name")
@@ -46,7 +46,7 @@ class LibrariesApiTestCase(ApiTestCase):
     def test_nonadmin(self):
         # Anons can't create libs
         data = dict(name="CreateTestLibrary")
-        create_response = self._post("libraries", data=data, admin=False, anon=True)
+        create_response = self._post("libraries", data=data, admin=False, anon=True, json=True)
         self._assert_status_code_is(create_response, 403)
         # Anons can't delete libs
         library = self.library_populator.new_library("AnonDeleteTestLibrary")

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -68,13 +68,29 @@ class LibrariesApiTestCase(ApiTestCase):
         assert library['description'] == 'ChangedDescription'
         assert library['synopsis'] == 'ChangedSynopsis'
 
-    def test_create_private_library_permissions(self):
-        library = self.library_populator.new_library("PermissionTestLibrary")
+    def test_create_private_library_legacy_permissions(self):
+        library = self.library_populator.new_library("LegacyPermissionTestLibrary")
         library_id = library["id"]
         role_id = self.library_populator.user_private_role_id()
         self.library_populator.set_permissions(library_id, role_id)
         create_response = self._create_folder(library)
         self._assert_status_code_is(create_response, 200)
+
+        with self._different_user():
+            create_response = self._create_folder(library)
+            self._assert_status_code_is(create_response, 403)
+
+    def test_create_private_library_permissions(self):
+        library = self.library_populator.new_library("PermissionTestLibrary")
+        library_id = library["id"]
+        role_id = self.library_populator.user_private_role_id()
+        self.library_populator.set_permissions_with_action(library_id, role_id, action="set_permissions")
+        create_response = self._create_folder(library)
+        self._assert_status_code_is(create_response, 200)
+
+        with self._different_user():
+            create_response = self._create_folder(library)
+            self._assert_status_code_is(create_response, 403)
 
     def test_create_dataset_denied(self):
         library = self.library_populator.new_private_library("ForCreateDatasets")

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1224,6 +1224,7 @@ class LibraryPopulator:
         return create_response.json()
 
     def set_permissions(self, library_id, role_id=None):
+        """Old legacy way of setting permissions."""
         if role_id:
             perm_list = json.dumps(role_id)
         else:
@@ -1236,6 +1237,24 @@ class LibraryPopulator:
             LIBRARY_MANAGE_in=perm_list,
         )
         response = self.galaxy_interactor.post(f"libraries/{library_id}/permissions", data=permissions, admin=True)
+        api_asserts.assert_status_code_is(response, 200)
+
+    def set_permissions_with_action(self, library_id, role_id=None, action=None):
+        if role_id:
+            perm_list = json.dumps(role_id)
+        else:
+            perm_list = json.dumps([])
+
+        action = action or "set_permissions"
+
+        permissions = {
+            action: action,
+            "access_ids[]": perm_list,
+            "add_ids[]": perm_list,
+            "manage_ids[]": perm_list,
+            "modify_ids[]": perm_list,
+        }
+        response = self.galaxy_interactor.post("libraries/%s/permissions" % library_id, data=permissions, admin=True)
         api_asserts.assert_status_code_is(response, 200)
 
     def user_email(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1248,7 +1248,7 @@ class LibraryPopulator:
         action = action or "set_permissions"
 
         permissions = {
-            action: action,
+            "action": action,
             "access_ids[]": perm_list,
             "add_ids[]": perm_list,
             "manage_ids[]": perm_list,

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1220,33 +1220,24 @@ class LibraryPopulator:
 
     def new_library(self, name):
         data = dict(name=name)
-        create_response = self.galaxy_interactor.post("libraries", data=data, admin=True)
+        create_response = self.galaxy_interactor.post("libraries", data=data, admin=True, json=True)
         return create_response.json()
 
     def set_permissions(self, library_id, role_id=None):
         """Old legacy way of setting permissions."""
-        if role_id:
-            perm_list = json.dumps(role_id)
-        else:
-            perm_list = json.dumps([])
-
-        permissions = dict(
-            LIBRARY_ACCESS_in=perm_list,
-            LIBRARY_MODIFY_in=perm_list,
-            LIBRARY_ADD_in=perm_list,
-            LIBRARY_MANAGE_in=perm_list,
-        )
-        response = self.galaxy_interactor.post(f"libraries/{library_id}/permissions", data=permissions, admin=True)
+        perm_list = role_id or []
+        permissions = {
+            "LIBRARY_ACCESS_in": perm_list,
+            "LIBRARY_MODIFY_in": perm_list,
+            "LIBRARY_ADD_in": perm_list,
+            "LIBRARY_MANAGE_in": perm_list,
+        }
+        response = self.galaxy_interactor.post(f"libraries/{library_id}/permissions", data=permissions, admin=True, json=True)
         api_asserts.assert_status_code_is(response, 200)
 
     def set_permissions_with_action(self, library_id, role_id=None, action=None):
-        if role_id:
-            perm_list = json.dumps(role_id)
-        else:
-            perm_list = json.dumps([])
-
+        perm_list = role_id or []
         action = action or "set_permissions"
-
         permissions = {
             "action": action,
             "access_ids[]": perm_list,
@@ -1254,7 +1245,7 @@ class LibraryPopulator:
             "manage_ids[]": perm_list,
             "modify_ids[]": perm_list,
         }
-        response = self.galaxy_interactor.post("libraries/%s/permissions" % library_id, data=permissions, admin=True)
+        response = self.galaxy_interactor.post(f"libraries/{library_id}/permissions", data=permissions, admin=True, json=True)
         api_asserts.assert_status_code_is(response, 200)
 
     def user_email(self):


### PR DESCRIPTION
## What did you do? 
- Create pydantic models for all parameters and responses.
- Include legacy pydantic models for backward compatibility.
- Annotate types in the service class for parameters and return values.
- Add FastAPI router with all the relevant endpoints.
- Fixed a permission check that allowed unauthorized users to create folders in a library https://github.com/galaxyproject/galaxy/commit/80a8e4d0dd3f3c0cb1b2e8f42ed38c998f7fdabf.


## Why did you make this change?
This is part of the FastAPI migration process, see xref #10889


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Launch Galaxy using uvicorn: `uvicorn --app-dir lib --factory galaxy.webapps.galaxy.fast_factory:factory`
  2. Go to `http://localhost:8080/api/docs#/libraries`
  3. Use the interactive documentation to manually test the API calls

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
![image](https://user-images.githubusercontent.com/46503462/118470915-732e4b80-b707-11eb-9c08-4091cf676341.png)

