### PR TITLE
Fix redirecting after login w/ keycloak when served at a proxy prefix

### DIFF
--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -37,7 +37,7 @@ from .psa_authnz import (
 
 log = logging.getLogger(__name__)
 
-# Note: This if for backward compatibility. Icons can be specified in oidc_backends_config.xml.
+# Note: This is for backward compatibility. Icons can be specified in oidc_backends_config.xml.
 DEFAULT_OIDC_IDP_ICONS = {
     'google': 'https://developers.google.com/identity/images/btn_google_signin_light_normal_web.png',
     'elixir': 'https://elixir-europe.org/sites/default/files/images/login-button-orange.png',

--- a/lib/galaxy/authnz/managers.py
+++ b/lib/galaxy/authnz/managers.py
@@ -22,10 +22,8 @@ from galaxy.util import (
     string_as_bool,
     unicodify,
 )
-from .custos_authnz import (
-    CustosAuthnz,
-    KEYCLOAK_BACKENDS,
-)
+from .custos_authnz import KEYCLOAK_BACKENDS
+
 from .psa_authnz import (
     BACKENDS_NAME,
     on_the_fly_config,
@@ -120,7 +118,7 @@ class AuthnzManager:
                     self.app.config.oidc[idp] = {'icon': self._get_idp_icon(idp)}
                 elif idp in KEYCLOAK_BACKENDS:
                     self.oidc_backends_config[idp] = self._parse_custos_config(child)
-                    self.oidc_backends_implementation[idp] = 'custos'
+                    self.oidc_backends_implementation[idp] = idp
                     self.app.config.oidc[idp] = {'icon': self._get_idp_icon(idp)}
                 else:
                     raise etree.ParseError("Unknown provider specified")
@@ -203,10 +201,8 @@ class AuthnzManager:
     def _get_identity_provider_class(implementation):
         if implementation == 'psa':
             return PSAAuthnz
-        elif implementation == 'custos':
-            return CustosAuthnz
         else:
-            return None
+            return KEYCLOAK_BACKENDS.get(implementation)
 
     def _extend_cloudauthz_config(self, cloudauthz, request, sa_session, user_id):
         config = copy.deepcopy(cloudauthz.config)

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -115,7 +115,7 @@ class OIDC(JSAppLauncher):
         trans.handle_user_login(user)
         # Record which idp provider was logged into, so we can logout of it later
         trans.set_cookie(value=provider, name=PROVIDER_COOKIE_NAME)
-        return trans.response.send_redirect(url_for(redirect_url))
+        return trans.response.send_redirect(url_for('/'))
 
     @web.expose
     def create_user(self, trans, provider, **kwargs):

--- a/lib/galaxy/webapps/galaxy/controllers/authnz.py
+++ b/lib/galaxy/webapps/galaxy/controllers/authnz.py
@@ -103,7 +103,7 @@ class OIDC(JSAppLauncher):
         if success is False:
             return trans.show_error_message(message)
         if "?confirm" in redirect_url:
-            return trans.response.send_redirect(url_for(redirect_url))
+            return trans.response.send_redirect(redirect_url)
         elif redirect_url is None:
             redirect_url = url_for('/')
 
@@ -139,7 +139,7 @@ class OIDC(JSAppLauncher):
         trans.set_cookie(value=provider, name=PROVIDER_COOKIE_NAME)
         if redirect_url is None:
             redirect_url = url_for('/')
-        return trans.response.send_redirect(url_for(redirect_url))
+        return trans.response.send_redirect(redirect_url)
 
     @web.expose
     @web.require_login("authenticate against the selected identity provider")

--- a/test/unit/authnz/test_custos_authnz.py
+++ b/test/unit/authnz/test_custos_authnz.py
@@ -261,7 +261,7 @@ class CustosAuthnzTestCase(unittest.TestCase):
 
     def test_authenticate_sets_env_var_when_localhost_redirect(self):
         """Verify that OAUTHLIB_INSECURE_TRANSPORT var is set with localhost redirect."""
-        self.custos_authnz = custos_authnz.CustosAuthnz('Custos', {
+        self.custos_authnz = custos_authnz.KeycloakAuthnz('Custos', {
             'VERIFY_SSL': True
         }, {
             'url': self._get_idp_url(),


### PR DESCRIPTION
## What did you do? 
- WIP, looking to rework some of this, but this broke keycloak-based login w/ proxy-prefix.
- Changed default post-login URL to root.

## Why did you make this change?

The previous change broke login w/ keycloak when galaxy was served at prefix (like via cloudman in GVL, etc)

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
