### PR TITLE
[21.05] Add indexes on update_time columns used in ORDER BY clauses

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -236,7 +236,7 @@ model.HistoryDatasetAssociation.table = Table(
     Column("history_id", Integer, ForeignKey("history.id"), index=True),
     Column("dataset_id", Integer, ForeignKey("dataset.id"), index=True),
     Column("create_time", DateTime, default=now),
-    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("update_time", DateTime, default=now, onupdate=now, index=True),
     Column("state", TrimmedString(64), index=True, key="_state"),
     Column("copied_from_history_dataset_association_id", Integer,
            ForeignKey("history_dataset_association.id"), nullable=True),
@@ -513,7 +513,7 @@ model.LibraryDatasetDatasetAssociation.table = Table(
     Column("library_dataset_id", Integer, ForeignKey("library_dataset.id"), index=True),
     Column("dataset_id", Integer, ForeignKey("dataset.id"), index=True),
     Column("create_time", DateTime, default=now),
-    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("update_time", DateTime, default=now, onupdate=now, index=True),
     Column("state", TrimmedString(64), index=True, key="_state"),
     Column("copied_from_history_dataset_association_id", Integer,
         ForeignKey("history_dataset_association.id", use_alter=True, name='history_dataset_association_dataset_id_fkey'),
@@ -610,7 +610,7 @@ model.Job.table = Table(
     "job", metadata,
     Column("id", Integer, primary_key=True),
     Column("create_time", DateTime, default=now),
-    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("update_time", DateTime, default=now, onupdate=now, index=True),
     Column("history_id", Integer, ForeignKey("history.id"), index=True),
     Column("library_folder_id", Integer, ForeignKey("library_folder.id"), index=True),
     Column("tool_id", String(255)),
@@ -928,7 +928,7 @@ model.HistoryDatasetCollectionAssociation.table = Table(
     Column("job_id", ForeignKey("job.id"), index=True, nullable=True),
     Column("implicit_collection_jobs_id", ForeignKey("implicit_collection_jobs.id"), index=True, nullable=True),
     Column("create_time", DateTime, default=now),
-    Column("update_time", DateTime, default=now, onupdate=now))
+    Column("update_time", DateTime, default=now, onupdate=now, index=True))
 
 model.LibraryDatasetCollectionAssociation.table = Table(
     "library_dataset_collection_association", metadata,
@@ -991,7 +991,7 @@ model.StoredWorkflow.table = Table(
     "stored_workflow", metadata,
     Column("id", Integer, primary_key=True),
     Column("create_time", DateTime, default=now),
-    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("update_time", DateTime, default=now, onupdate=now, index=True),
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True, nullable=False),
     Column("latest_workflow_id", Integer,
         ForeignKey("workflow.id", use_alter=True, name='stored_workflow_latest_workflow_id_fk'), index=True),
@@ -1121,7 +1121,7 @@ model.WorkflowInvocation.table = Table(
     "workflow_invocation", metadata,
     Column("id", Integer, primary_key=True),
     Column("create_time", DateTime, default=now),
-    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("update_time", DateTime, default=now, onupdate=now, index=True),
     Column("workflow_id", Integer, ForeignKey("workflow.id"), index=True, nullable=False),
     Column("state", TrimmedString(64), index=True),
     Column("scheduler", TrimmedString(255), index=True),

--- a/lib/galaxy/model/migrate/versions/0176_add_indexes_on_update_time.py
+++ b/lib/galaxy/model/migrate/versions/0176_add_indexes_on_update_time.py
@@ -1,0 +1,65 @@
+"""
+Migration script to add indexes on update_time columns that are frequently used in ORDER BY clauses.
+"""
+
+import logging
+
+from sqlalchemy import MetaData
+
+from galaxy.model.migrate.versions.util import (
+    add_index,
+    drop_index
+)
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+indexes = [
+    [
+        "ix_history_dataset_association_update_time",
+        "history_dataset_association",
+        "update_time"
+    ],
+    [
+        "ix_library_dataset_dataset_association_update_time",
+        "library_dataset_dataset_association",
+        "update_time"
+    ],
+    [
+        "ix_job_update_time",
+        "job",
+        "update_time"
+    ],
+    [
+        "ix_history_dataset_collection_association_update_time",
+        "history_dataset_collection_association",
+        "update_time"
+    ],
+    [
+        "ix_workflow_invocation_update_time",
+        "workflow_invocation",
+        "update_time"
+    ],
+    [
+        "ix_stored_workflow_update_time",
+        "stored_workflow",
+        "update_time"
+    ],
+]
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    for ix, table, col in indexes:
+        add_index(ix, table, col, metadata)
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    for ix, table, col in indexes:
+        drop_index(ix, table, col, metadata)


### PR DESCRIPTION
## What did you do? 
- Add update_time indexes on columns used in ORDER BY clauses.

## Why did you make this change?
Without an index here the database typically needs to do a seq scan.
Noticed this with a fast query to api/jobs with a user that has few datasets, and a timeout for a user that has many datasets.

Probably also fixes https://github.com/galaxyproject/galaxy/issues/9881

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
