### PR TITLE
[21.05] Fix FTP upload if remote file sources are not set up

### DIFF
--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -242,6 +242,7 @@ export default {
                 file_mode: file.mode || "local",
                 file_path: file.path,
                 file_data: file,
+                file_uri: file.uri,
                 extension: this.extension,
                 genome: this.genome,
             };

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -249,6 +249,7 @@ export default {
                 file_size: file.size,
                 file_mode: file.mode || "local",
                 file_path: file.path,
+                file_uri: file.uri,
                 file_data: file,
             };
         },

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -242,6 +242,7 @@ export default {
                                     name: ftp_file.path,
                                     size: ftp_file.size,
                                     path: ftp_file.path,
+                                    uri: ftp_file.uri,
                                 },
                             ]);
                         },

--- a/client/src/components/Upload/UploadModalContent.vue
+++ b/client/src/components/Upload/UploadModalContent.vue
@@ -297,7 +297,7 @@ export default {
             const item = items[0];
             let urls;
             if (item.get("file_mode") == "ftp") {
-                urls = [item.get("file_path")];
+                urls = [item.get("file_uri") || item.get("file_path")];
             } else {
                 urls = item.get("url_paste").split("\n");
             }

--- a/client/src/mvc/upload/upload-model.js
+++ b/client/src/mvc/upload/upload-model.js
@@ -12,6 +12,7 @@ var Model = Backbone.Model.extend({
         file_size: 0,
         file_type: null,
         file_path: "",
+        file_uri: null,
         file_data: null,
         percentage: 0,
         space_to_tab: false,

--- a/test/integration_selenium/test_upload_ftp.py
+++ b/test/integration_selenium/test_upload_ftp.py
@@ -37,3 +37,5 @@ class UploadFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestCase):
         self.components.upload.ftp_close.wait_for_and_click()
         self.components.upload.row(n=0).wait_for_visible()
         self.upload_start()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.wait_for_history()


### PR DESCRIPTION
## What did you do? 
- Fixes the upload from the "Choose FTP files" button
- Change test case to wait for upload


## Why did you make this change?
This broke in https://github.com/galaxyproject/galaxy/pull/11276.



## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
