### PR TITLE
[21.05] restrict invalid input in library pagination

### DIFF
--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -158,7 +158,7 @@
                                     id="paginationPerPage"
                                     autocomplete="off"
                                     type="number"
-                                    onkeyup="if(this.value<0)this.value=1"
+                                    onkeyup="if(this.value<1)this.value=1"
                                     v-model="perPage"
                                 />
                             </td>

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -158,7 +158,7 @@
                                     id="paginationPerPage"
                                     autocomplete="off"
                                     type="number"
-                                    onkeyup="if(this.value<1)this.value=1"
+                                    onkeyup="this.value|=0;if(this.value<1)this.value=1"
                                     v-model="perPage"
                                 />
                             </td>

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -158,6 +158,7 @@
                                     id="paginationPerPage"
                                     autocomplete="off"
                                     type="number"
+                                    onkeyup="if(this.value<0)this.value=1"
                                     v-model="perPage"
                                 />
                             </td>


### PR DESCRIPTION
## What did you do? 
restricted negative input in pagination field


## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/11993


## How to test the changes? 
  1. open folder, try to enter a negative value

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
