### PR TITLE
[21.05] Fix breadcrumb in dataset details in libraries 

### DIFF
--- a/client/src/mvc/library/library-dataset-view.js
+++ b/client/src/mvc/library/library-dataset-view.js
@@ -492,12 +492,12 @@ var LibraryDatasetView = Backbone.View.extend({
                 <!-- BREADCRUMBS -->
                 <ol class="breadcrumb">
                     <li class="breadcrumb-item">
-                        <a title="Return to the list of libraries" href="<% rootPath %>libraries">Libraries</a>
+                        <a title="Return to the list of libraries" href="<% rootPath %>/libraries">Libraries</a>
                     </li>
                     <% _.each(item.get("full_path"), function(path_item) { %>
                         <% if (path_item[0] != item.id) { %>
                             <li class="breadcrumb-item">
-                                <a title="Return to this folder" href="<% rootPath %>folders/<%- path_item[0] %>">
+                                <a title="Return to this folder" href="<% rootPath %>/libraries/folders/<%- path_item[0] %>">
                                     <%- path_item[1] %>
                                 </a>
                             </li>


### PR DESCRIPTION
## What did you do? 
fixed breadcrumb navigation in dateset view in library folder 


## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/11997
Thanks @davelopez for reporting!


## How to test the changes? 
  1. go to dataset in libraries
  2. use breadcrumb

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

