### PR TITLE
[21.01] Open input file in read mode in liftover wrapper

### DIFF
--- a/tools/extract/liftOver_wrapper.py
+++ b/tools/extract/liftOver_wrapper.py
@@ -25,7 +25,7 @@ def safe_bed_file(infile):
     https://lists.soe.ucsc.edu/pipermail/genome/2007-May/013561.html
     """
     fix_pat = re.compile("^(track|browser)")
-    with tempfile.NamedTemporaryFile(mode='w', delete=False) as out_handle, open(infile, 'w') as in_handle:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as out_handle, open(infile, 'r') as in_handle:
         for line in in_handle:
             if fix_pat.match(line):
                 line = "#" + line


### PR DESCRIPTION
## What did you do? 
- Open input file in read mode


## Why did you make this change?
The liftover tool crashes when trying to read the input BED file, because that file was being opened in write-only mode.
Broken in https://github.com/galaxyproject/galaxy/pull/10862/commits/ccdb6c3f1025a4b57484e266503ee955f816280a

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
