### PR TITLE
[21.05]Fix deleted libs for user

### DIFF
--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -9,7 +9,7 @@
                 Library
             </b-button>
             <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
-            <b-form-checkbox class="mr-1" @input="toggle_include_deleted($event)"> include deleted </b-form-checkbox>
+            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)"> include deleted </b-form-checkbox>
             <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)">
                 exclude restricted
             </b-form-checkbox>

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -9,7 +9,9 @@
                 Library
             </b-button>
             <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
-            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)"> include deleted </b-form-checkbox>
+            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)">
+                include deleted
+            </b-form-checkbox>
             <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)">
                 exclude restricted
             </b-form-checkbox>

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -148,7 +148,7 @@ class LibraryManager:
         else:
             #  Nonadmins can't see deleted libraries
             if deleted:
-                query = []
+                raise exceptions.AdminRequiredException()
             else:
                 query = query.filter(trans.app.model.Library.table.c.deleted == false())
                 current_user_role_ids = [role.id for role in trans.get_current_user_roles()]

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -147,32 +147,35 @@ class LibraryManager:
                 query = query.filter(trans.app.model.Library.table.c.deleted == false())
         else:
             #  Nonadmins can't see deleted libraries
-            query = query.filter(trans.app.model.Library.table.c.deleted == false())
-            current_user_role_ids = [role.id for role in trans.get_current_user_roles()]
-            all_actions = trans.sa_session.query(trans.model.LibraryPermissions).filter(trans.model.LibraryPermissions.table.c.role_id.in_(current_user_role_ids))
-            library_add_action = trans.app.security_agent.permitted_actions.LIBRARY_ADD.action
-            library_modify_action = trans.app.security_agent.permitted_actions.LIBRARY_MODIFY.action
-            library_manage_action = trans.app.security_agent.permitted_actions.LIBRARY_MANAGE.action
-            accessible_restricted_library_ids = set()
-            allowed_library_add_ids = set()
-            allowed_library_modify_ids = set()
-            allowed_library_manage_ids = set()
-            for action in all_actions:
-                if action.action == library_access_action:
-                    accessible_restricted_library_ids.add(action.library_id)
-                if action.action == library_add_action:
-                    allowed_library_add_ids.add(action.library_id)
-                if action.action == library_modify_action:
-                    allowed_library_modify_ids.add(action.library_id)
-                if action.action == library_manage_action:
-                    allowed_library_manage_ids.add(action.library_id)
-            query = query.filter(or_(
-                not_(trans.model.Library.table.c.id.in_(restricted_library_ids)),
-                trans.model.Library.table.c.id.in_(accessible_restricted_library_ids)
-            ))
-            prefetched_ids['allowed_library_add_ids'] = allowed_library_add_ids
-            prefetched_ids['allowed_library_modify_ids'] = allowed_library_modify_ids
-            prefetched_ids['allowed_library_manage_ids'] = allowed_library_manage_ids
+            if deleted:
+                query = []
+            else:
+                query = query.filter(trans.app.model.Library.table.c.deleted == false())
+                current_user_role_ids = [role.id for role in trans.get_current_user_roles()]
+                all_actions = trans.sa_session.query(trans.model.LibraryPermissions).filter(trans.model.LibraryPermissions.table.c.role_id.in_(current_user_role_ids))
+                library_add_action = trans.app.security_agent.permitted_actions.LIBRARY_ADD.action
+                library_modify_action = trans.app.security_agent.permitted_actions.LIBRARY_MODIFY.action
+                library_manage_action = trans.app.security_agent.permitted_actions.LIBRARY_MANAGE.action
+                accessible_restricted_library_ids = set()
+                allowed_library_add_ids = set()
+                allowed_library_modify_ids = set()
+                allowed_library_manage_ids = set()
+                for action in all_actions:
+                    if action.action == library_access_action:
+                        accessible_restricted_library_ids.add(action.library_id)
+                    if action.action == library_add_action:
+                        allowed_library_add_ids.add(action.library_id)
+                    if action.action == library_modify_action:
+                        allowed_library_modify_ids.add(action.library_id)
+                    if action.action == library_manage_action:
+                        allowed_library_manage_ids.add(action.library_id)
+                query = query.filter(or_(
+                    not_(trans.model.Library.table.c.id.in_(restricted_library_ids)),
+                    trans.model.Library.table.c.id.in_(accessible_restricted_library_ids)
+                ))
+                prefetched_ids['allowed_library_add_ids'] = allowed_library_add_ids
+                prefetched_ids['allowed_library_modify_ids'] = allowed_library_modify_ids
+                prefetched_ids['allowed_library_manage_ids'] = allowed_library_manage_ids
         return query, prefetched_ids
 
     def secure(self, trans, library, check_accessible=True):


### PR DESCRIPTION
## What did you do? 
Normally, if Admin presses "include deleted" on libraries, it returns him only the list of deleted libraries. Meanwhile, users are [not allowed to see deleted libraries](https://github.com/galaxyproject/galaxy/blob/b61ee98f795c20b40884588ba3ace89c7c983b0e/lib/galaxy/managers/libraries.py#L149)
So what was happening in https://github.com/galaxyproject/galaxy/issues/11995, is that if a user is not an Admin, it returns you the whole library instead of only "deleted". This PR makes sure, that user get an empty array if a regular user wants to see "deleted" libs. Additionally we hide "include deleted" button for the user

## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/11995

## How to test the changes? 
  1. please replicate https://github.com/galaxyproject/galaxy/issues/11995


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.