### PR TITLE
[21.05] Disable import button during "Import to History"

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/import-to-history/import-dataset.js
@@ -79,13 +79,13 @@ var ImportDatasetModal = Backbone.View.extend({
                     Toast.error("An error occurred.");
                 })
                 .always(() => {
-                    this.modal.enableButton("Import");
+                    this.modal.disableButton("Import");
                 });
         } else {
             var history_id = $("select[name=import_to_history] option:selected").val();
             var history_name = $("select[name=import_to_history] option:selected").text();
             this.processImportToHistory(history_id, history_name);
-            this.modal.enableButton("Import");
+            this.modal.disableButton("Import");
         }
     },
 


### PR DESCRIPTION
## What did you do? 
Disabled import button during "Import to History"

## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/12013

## How to test the changes? 
  1. please follow https://github.com/galaxyproject/galaxy/issues/12013

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [x] I've included a screenshot of the changes

![image](https://user-images.githubusercontent.com/15801412/118841309-82a8c280-b8c8-11eb-8a4e-d9ddf7a6127a.png)

