### PR TITLE
[21.05] Fix history import for anonymous users

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -334,7 +334,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsH
         :rtype:     dict
         :returns:   element view of new history
         """
-        if trans.user.bootstrap_admin_user:
+        if trans.user and trans.user.bootstrap_admin_user:
             raise exceptions.RealUserRequiredException("Only real users can create histories.")
         hist_name = None
         if payload.get('name', None):


### PR DESCRIPTION
## What did you do? 
- Fix history import for anonymous users

The `user` attribute in `trans` is `None` for anonymous users.

## Why did you make this change?
Fixes https://github.com/galaxyproject/galaxy/issues/12019


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Import a history as anonymous user and see that it works now.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
