### PR TITLE
[21.05] Allow trs_version to refer to name or id field

### DIFF
--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -105,9 +105,20 @@ export default {
                     this.trsTool = tool;
                     this.errorMessage = null;
                     if (this.isAutoImport) {
-                        const version = this.trsTool.versions.find((version) => version.id === this.queryTrsVersionId);
+                        /* Resolve discrepancy between workflowhub, which sends an id as query parameter,
+                           and dockstore, which uses the version name as the query parameter.
+                           Should just be one of them eventually. */
+                        let versionField = "name";
+                        const version = this.trsTool.versions.find((version) => {
+                            if (version.name === this.queryTrsVersionId) {
+                                return true;
+                            } else if (version.id === this.queryTrsVersionId) {
+                                versionField = "id";
+                                return true;
+                            }
+                        });
                         if (version) {
-                            this.importVersion(this.trsTool.id, version, this.isRun);
+                            this.importVersion(this.trsTool.id, version[versionField], this.isRun);
                         } else {
                             Toast.warning(`Specified version: ${this.queryTrsVersionId} doesn't exist`);
                             this.isAutoImport = false;

--- a/client/src/components/Workflow/trsMixin.js
+++ b/client/src/components/Workflow/trsMixin.js
@@ -11,7 +11,7 @@ export default {
     methods: {
         importVersion(toolId, version, isRunFormRedirect = false) {
             this.services
-                .importTrsTool(this.trsSelection.id, toolId, version.name)
+                .importTrsTool(this.trsSelection.id, toolId, version)
                 .then((response_data) => {
                     redirectOnImport(getAppRoot(), response_data, isRunFormRedirect);
                 })


### PR DESCRIPTION
This has diverged between workflowhub.eu and dockstore implementations.

## What did you do? 
- Allow trs_version to refer to name or id field


## Why did you make this change?
Works around https://github.com/galaxyproject/galaxy/issues/12017#issuecomment-844422502


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
- Import workflows from workflowhub and dockstore.
for dockstore:
<galaxy_url>/workflows/trs_import?trs_server=dockstore.org&run_form=true&trs_id=%23workflow/github.com/jmchilton/galaxy-workflow-dockstore-example-1/mycoolworkflow&trs_version=master
for workflowhub:
<galaxy_url>/workflows/trs_import?trs_server=workflowhub.eu&run_form=true&trs_id=111&trs_version=2

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
