### PR TITLE
[21.05] Hide edit libraries for users

### DIFF
--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -87,7 +87,7 @@
                     <font-awesome-icon icon="unlock" />
                     Undelete
                 </b-button>
-                <div v-else>
+                <div v-else-if="isAdmin">
                     <b-button
                         v-if="row.item.can_user_modify && row.item.editMode"
                         size="sm"


### PR DESCRIPTION
## What did you do? 
Non-admin users can neither edit nor delete data-libraries, so we hide the whole button, unless it's an admin 

## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/12004
 

## How to test the changes? 
  1. please follow https://github.com/galaxyproject/galaxy/issues/12004

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.


P.S.
Thanks a lot @davelopez for your extended testing, this was quite helpful, we managed to detect quite some bugs lately 
