### PR TITLE
Update tensorflow to 2.5.0.  

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -38,4 +38,4 @@ pygithub
 influxdb
 
 # Deep learning packages for tool recommendation
-tensorflow==2.4.0
+tensorflow==2.5.0


### PR DESCRIPTION
## What did you do? 
- Tensorflow update
- This allows running under python 3.9.
- No breaking changes that affect us (https://github.com/tensorflow/tensorflow/releases/tag/v2.5.0)


## Why did you make this change?
Starting Galaxy under python 3.9 with tool suggestions fails due to tensorflow2.4 incompatibility.


## How to test the changes? 
- [ x ] Instructions for manual testing are as follows:
  1. Enable tool prediction
  2. Start galaxy w/ python 3.9

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
