### PR TITLE
[21.05] Fix downloading (sub)folders from data-libraries

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -287,7 +287,7 @@ export default {
                     Toast.info("You must select at least one dataset to download");
                     return;
                 }
-
+                console.log(folders);
                 download(format, datasets, folders);
             });
         },
@@ -303,12 +303,12 @@ export default {
         // helper function to make legacy code compatible
         findCheckedItems: async function (idOnly = true) {
             const datasets = [];
-            const folder = [];
+            const folders = [];
             const selected = await this.getSelected();
             selected.forEach((item) => {
-                item.type === "file" ? datasets.push(idOnly ? item.id : item) : idOnly ? item.id : item;
+                item.type === "file" ? datasets.push(idOnly ? item.id : item) : folders.push(idOnly ? item.id : item);
             });
-            return { datasets: datasets, folders: folder };
+            return { datasets: datasets, folders: folders };
         },
         importToHistoryModal: function (isCollection) {
             this.findCheckedItems(!isCollection).then(({ datasets, folders }) => {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -287,6 +287,7 @@ export default {
                     Toast.info("You must select at least one dataset to download");
                     return;
                 }
+
                 download(format, datasets, folders);
             });
         },
@@ -305,7 +306,8 @@ export default {
             const folders = [];
             const selected = await this.getSelected();
             selected.forEach((item) => {
-                item.type === "file" ? datasets.push(idOnly ? item.id : item) : folders.push(idOnly ? item.id : item);
+                const selected_item = idOnly ? item.id : item;
+                item.type === "file" ? datasets.push(selected_item) : folders.push(selected_item);
             });
             return { datasets: datasets, folders: folders };
         },

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -287,7 +287,6 @@ export default {
                     Toast.info("You must select at least one dataset to download");
                     return;
                 }
-                console.log(folders);
                 download(format, datasets, folders);
             });
         },

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/download.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/download.js
@@ -32,5 +32,7 @@ export default function download(format, dataset_ids, folder_ids) {
     // function download(format) {
     var url = `${getAppRoot()}api/libraries/datasets/download/${format}`;
     var data = { ld_ids: dataset_ids, folder_ids: folder_ids };
+    console.log("data", data);
+    console.log("data", data);
     processDownload(url, data, "get");
 }

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/download.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/download.js
@@ -32,7 +32,5 @@ export default function download(format, dataset_ids, folder_ids) {
     // function download(format) {
     var url = `${getAppRoot()}api/libraries/datasets/download/${format}`;
     var data = { ld_ids: dataset_ids, folder_ids: folder_ids };
-    console.log("data", data);
-    console.log("data", data);
     processDownload(url, data, "get");
 }


### PR DESCRIPTION
## What did you do? 
Fixed downloading folders in data-libraries

## Why did you make this change?
fixes https://github.com/galaxyproject/galaxy/issues/12007, fixes https://github.com/galaxyproject/galaxy/issues/12009

## How to test the changes? 
  1. enter libraries
  2. try to download non-empty subfolder

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
