### PR TITLE
[21.05] Fix isolated job home dir on pulsar

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -143,7 +143,7 @@ prompt-toolkit==3.0.3; python_version >= "3.6"
 protobuf==3.15.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 prov==1.5.1; python_version >= "3.6" and python_version < "4"
 psutil==5.8.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-pulsar-galaxy-lib==0.14.5
+pulsar-galaxy-lib==0.14.6
 py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.4.0" and python_version >= "3.6" and implementation_name == "pypy"
 pyasn1-modules==0.2.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyasn1==0.4.8; python_version >= "3.5" and python_version < "4"

--- a/lib/galaxy/dependencies/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-requirements.txt
@@ -126,7 +126,7 @@ prompt-toolkit==3.0.3; python_version >= "3.6"
 protobuf==3.15.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 prov==1.5.1; python_version >= "3.6" and python_version < "4"
 psutil==5.8.0; (python_version >= "2.6" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
-pulsar-galaxy-lib==0.14.5
+pulsar-galaxy-lib==0.14.6
 py==1.10.0; python_version >= "3.6" and python_full_version < "3.0.0" and implementation_name == "pypy" or implementation_name == "pypy" and python_version >= "3.6" and python_full_version >= "3.4.0"
 pyasn1-modules==0.2.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyasn1==0.4.8; python_version >= "3.5" and python_version < "4"

--- a/test/integration/test_job_environments.py
+++ b/test/integration/test_job_environments.py
@@ -15,6 +15,7 @@ SIMPLE_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "simple_job_conf.xml")
 IO_INJECTION_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "io_injection_job_conf.yml")
 SETS_TMP_DIR_TO_TRUE_JOB_CONFIG = os.path.join(SCRIPT_DIRECTORY, "sets_tmp_dir_to_true_job_conf.xml")
 SETS_TMP_DIR_AS_EXPRESSION_JOB_CONFIG = os.path.join(SCRIPT_DIRECTORY, "sets_tmp_dir_expression_job_conf.xml")
+EMBEDDED_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "embedded_pulsar_job_conf.xml")
 
 JobEnvironmentProperties = collections.namedtuple("JobEnvironmentProperties", [
     "user_id",
@@ -113,6 +114,35 @@ class DefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTest
         assert job_env.pwd.endswith("/working")
         job_directory = os.path.dirname(job_env.pwd)
         assert job_env.home == os.path.join(job_directory, "home"), job_env.home
+
+
+class EmbeddedPulsarDefaultJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls.jobs_directory = tempfile.mkdtemp()
+        config["jobs_directory"] = cls.jobs_directory
+        config["job_config_file"] = EMBEDDED_PULSAR_JOB_CONFIG_FILE
+
+    @skip_without_tool("job_environment_default")
+    def test_default_environment_1801(self):
+        job_env = self._run_and_get_environment_properties()
+
+        euid = os.geteuid()
+        egid = os.getgid()
+
+        assert job_env.user_id == str(euid), job_env.user_id
+        assert job_env.group_id == str(egid), job_env.group_id
+        assert 'pulsar_staging' in job_env.pwd
+        assert job_env.pwd.endswith("/working")
+        # job ran in embedded pulsar, not local job dir
+        assert self.jobs_directory not in job_env.pwd
+
+        # Newer tools get isolated home directories in job_directory/home
+        job_directory = os.path.dirname(job_env.pwd)
+        assert os.path.abspath(job_env.home) == os.path.join(job_directory, "home"), job_env.home
+
+        # Since job_conf doesn't set tmp_dir parameter - temp isn't in job_directory
+        assert not job_env.tmp.startswith(job_directory)
 
 
 class TmpDirToTrueJobEnvironmentIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase):


### PR DESCRIPTION
## What did you do? 
- Pass `$_GALAXY_JOB_HOME_DIR` and `_GALAXY_JOB_TMP_DIR` to pulsar if tool is configured that way


## Why did you make this change?
Some sratools tools that run on jetstream via pulsar are failing because they don't set up an isolated job home dir:
```
mkdir: cannot create directory '/home/g2main': Permission denied
```

For the tests to pass we also need a change in pulsar for locating `_GALAXY_JOB_HOME_DIR` outside of the job working directory (https://github.com/galaxyproject/pulsar/pull/255).

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
