### PR TITLE
[21.01] add GALAXY_MEMORY_MB* to passt hrough

### DIFF
--- a/lib/galaxy/tool_util/deps/dependencies.py
+++ b/lib/galaxy/tool_util/deps/dependencies.py
@@ -42,7 +42,7 @@ class ToolInfo:
 
     def __init__(self, container_descriptions=None, requirements=None, requires_galaxy_python_environment=False, env_pass_through=None, guest_ports=None, tool_id=None, tool_version=None, profile=-1):
         if env_pass_through is None:
-            env_pass_through = ["GALAXY_SLOTS"]
+            env_pass_through = ["GALAXY_SLOTS", "GALAXY_MEMORY_MB", "GALAXY_MEMORY_MB_PER_SLOT"]
         if container_descriptions is None:
             container_descriptions = []
         if requirements is None:

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -110,7 +110,8 @@ class ToolSource(metaclass=ABCMeta):
         return ["TMPDIR", "TMP", "TEMP"]
 
     def parse_docker_env_pass_through(self):
-        return ["GALAXY_SLOTS", "HOME", "_GALAXY_JOB_HOME_DIR", "_GALAXY_JOB_TMP_DIR"] + self.parse_tmp_directory_vars()
+        return ["GALAXY_SLOTS", "GALAXY_MEMORY_MB", "GALAXY_MEMORY_MB_PER_SLOT", "HOME",
+                "_GALAXY_JOB_HOME_DIR", "_GALAXY_JOB_TMP_DIR"] + self.parse_tmp_directory_vars()
 
     @abstractmethod
     def parse_interpreter(self):


### PR DESCRIPTION
## What did you do? 

Its passes "GALAXY_MEMORY_MB" and "GALAXY_MEMORY_MB_PER_SLOT" inside containers. Currently only GALAXY_SLOTS, HOME and a few TEMP dirs are passed through.

## Why did you make this change?

I found container tools that did not use the specified GALAXY_SLOTS.


## How to test the changes? 

Run a Docker enabled Tool and check if GALAXY_MEMORY_MB is set via the `-e` variables.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.


