### PR TITLE
Normalize Vue mounts in analysis, admin endpoints

### DIFF
--- a/client/src/components/Form/FormCardTool.vue
+++ b/client/src/components/Form/FormCardTool.vue
@@ -198,7 +198,7 @@ export default {
         // add tool menu webhooks
         Webhooks.load({
             type: "tool-menu",
-            callback: function (webhooks) {
+            callback: (webhooks) => {
                 webhooks.each((model) => {
                     const webhook = model.toJSON();
                     if (webhook.activate && webhook.config.function) {

--- a/client/src/components/Libraries/index.js
+++ b/client/src/components/Libraries/index.js
@@ -1,0 +1,8 @@
+import router from "./LibraryFolderRouter";
+
+export const Libraries = {
+    router,
+    render: (h) => h("router-view"),
+};
+
+export default Libraries;

--- a/client/src/components/admin/DataManager/DataManagerJobs.vue
+++ b/client/src/components/admin/DataManager/DataManagerJobs.vue
@@ -117,7 +117,7 @@ export default {
             return [
                 {
                     text: "Data Managers",
-                    to: "/",
+                    to: { name: "DataManager" },
                 },
                 {
                     text: this.dataManager["name"] + " ( " + this.dataManager["description"] + " )",

--- a/client/src/components/admin/DataManager/DataManagerRouter.js
+++ b/client/src/components/admin/DataManager/DataManagerRouter.js
@@ -13,11 +13,6 @@ export default new VueRouter({
     base: `${getAppRoot()}admin/data_manager`,
     routes: [
         {
-            path: "/",
-            name: "DataManager",
-            component: DataManager,
-        },
-        {
             path: "/jobs/:id",
             name: "DataManagerJobs",
             component: DataManagerJobs,
@@ -36,8 +31,13 @@ export default new VueRouter({
             props: true,
         },
         {
+            path: "/",
+            name: "DataManager",
+            component: DataManager,
+        },
+        {
             path: "*",
-            redirect: "/",
+            redirect: { name: "DataManager" },
         },
     ],
 });

--- a/client/src/components/admin/DataManager/index.js
+++ b/client/src/components/admin/DataManager/index.js
@@ -1,0 +1,14 @@
+import router from "./DataManagerRouter";
+import DataManagerView from "./DataManagerView";
+
+export const DataManager = {
+    router,
+    render: (h) => h(DataManagerView),
+    created() {
+        if (router.currentRoute.name !== "DataManager") {
+            router.push({ name: "DataManager" });
+        }
+    },
+};
+
+export default DataManager;

--- a/client/src/entry/admin/AdminRouter.js
+++ b/client/src/entry/admin/AdminRouter.js
@@ -11,15 +11,13 @@ import Jobs from "components/admin/Jobs.vue";
 import ActiveInvocations from "components/admin/ActiveInvocations.vue";
 import Landing from "components/admin/Dependencies/Landing.vue";
 import AdminHome from "components/admin/Home.vue";
-import DataManagerView from "components/admin/DataManager/DataManagerView.vue";
-import DataManagerRouter from "components/admin/DataManager/DataManagerRouter";
+import DataManager from "components/admin/DataManager";
 import Register from "components/login/Register.vue";
 import ErrorStack from "components/admin/ErrorStack.vue";
 import DisplayApplications from "components/admin/DisplayApplications.vue";
 import ResetMetadata from "components/admin/ResetMetadata.vue";
 import Toolshed from "components/Toolshed/Index.vue";
-import Vue from "vue";
-import store from "store";
+import { mountVueComponent } from "utils/mountVueComponent";
 
 export const getAdminRouter = (Galaxy, options) => {
     const galaxyRoot = getAppRoot();
@@ -108,10 +106,10 @@ export const getAdminRouter = (Galaxy, options) => {
         },
 
         _display_vue_helper: function (component, propsData = {}) {
-            const instance = Vue.extend(component);
             const container = document.createElement("div");
             this.page.display(container);
-            new instance({ store, propsData }).$mount(container);
+            const mountFn = mountVueComponent(component);
+            return mountFn(propsData, container);
         },
 
         show_data_tables: function () {
@@ -146,16 +144,13 @@ export const getAdminRouter = (Galaxy, options) => {
             this._display_vue_helper(ResetMetadata);
         },
 
-        show_data_manager: function (path) {
-            const Galaxy = getGalaxyInstance();
-            console.log("show_data_manager");
-            const vueMount = document.createElement("div");
-            this.page.display(vueMount);
-            // always set the route back to the base, i.e.
-            // `${galaxyRoot}admin/data_manager`
-            Galaxy.debug("show_data_manager: path='" + path + "'");
-            DataManagerRouter.replace(path || "/");
-            new Vue({ router: DataManagerRouter, render: (h) => h(DataManagerView) }).$mount(vueMount);
+        // Because this has a router in it, we need to be careful about destroying it properly
+        dataManagerInstance: null,
+        show_data_manager: function () {
+            if (this.dataManagerInstance) {
+                this.dataManagerInstance.$destroy();
+            }
+            this.dataManagerInstance = this._display_vue_helper(DataManager);
         },
 
         show_forms: function () {

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -48,10 +48,8 @@ import DisplayStructure from "components/DisplayStructured.vue";
 import { CloudAuth } from "components/User/CloudAuth";
 import { ExternalIdentities } from "components/User/ExternalIdentities";
 import Confirmation from "components/login/Confirmation.vue";
-import LibraryFolderRouter from "components/Libraries/LibraryFolderRouter";
-import Vue from "vue";
-import store from "store";
-import VueRouterMain from "./VueRouterMain.vue";
+import Libraries from "components/Libraries";
+import { mountVueComponent } from "utils/mountVueComponent";
 
 /** Routes */
 export const getAnalysisRouter = (Galaxy) => {
@@ -110,24 +108,14 @@ export const getAnalysisRouter = (Galaxy) => {
         },
 
         _display_vue_helper: function (component, propsData = {}, active_tab = null, noPadding = false) {
-            const instance = Vue.extend(component);
             const container = document.createElement("div");
             if (active_tab) {
                 container.active_tab = active_tab;
             }
             this.page.display(container, noPadding);
-            new instance({ store, propsData }).$mount(container);
-        },
-        _display_vue_router: function (router, propsData = {}, active_tab = null, noPadding = false) {
-            const container = document.createElement("div");
-            if (active_tab) {
-                container.active_tab = active_tab;
-            }
-            this.page.display(container, noPadding);
-            new Vue({
-                router: router,
-                render: (h) => h(VueRouterMain),
-            }).$mount(container);
+
+            const mountFn = mountVueComponent(component);
+            return mountFn(propsData, container);
         },
 
         show_tours: function (tour_id) {
@@ -161,10 +149,10 @@ export const getAnalysisRouter = (Galaxy) => {
             this._display_vue_helper(InteractiveTools);
         },
 
-        show_library_folder: function (folder_id) {
+        show_library_folder: function () {
             this.page.toolPanel?.component.hide(0);
             this.page.panels.right.hide();
-            this._display_vue_router(LibraryFolderRouter, { folder_id: folder_id });
+            this._display_vue_helper(Libraries);
         },
 
         show_cloud_auth: function () {

--- a/client/src/entry/analysis/VueRouterMain.vue
+++ b/client/src/entry/analysis/VueRouterMain.vue
@@ -1,3 +1,0 @@
-<template>
-    <router-view />
-</template>


### PR DESCRIPTION
## What did you do? 

Normalized component mounts in analysis and admin backbone routers. This gives access to all our standard Vue plugins to every component whereas before it was hit or miss with individual contributors re-inventing their own mounting mechanisms, store access and bootstrap-vue import schemes.

In order to do this I had to push vue-router objects for Libraries and data managers down into the sub-modules they were routing, which is probably a better organization anyway.

Also corrected a routing bug that can occur when a vue-router container is removed, but not properly destroyed, as was the case with the backbone router which rebuilt the router module every time the link was clicked. The end result is invisible routing views that keep firing their lifetime hooks and resulting ajax calls even though there is no longer a way to access those view instances. Basically it's a fancy memory leak, and it's a pattern I don't want to see propagate.


## Why did you make this change?

Until we have a single mount location, Vue components are being mounted inside backbone views, and this is an attempt to guarantee that those components all start with the same set of features as would normally be the case in a single page app with a single mount location.

This also provides the standard environment that matches the  testing environment (getLocalVue) from the jest helpers.

I need the routing normalization for the replacement of the turducken Library module, so that I can continue removing global Galaxy references from as much of the code as possible so that we can one day switch over to the beta history.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
