### PR TITLE
Html sniffer updates

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -780,9 +780,7 @@ def handle_uploaded_dataset_file_internal(
                 ext = guess_ext(converted_path, sniff_order=datatypes_registry.sniff_order, is_binary=is_binary)
         else:
             ext = guessed_ext
-
-        if not is_binary and check_content and check_html(converted_path):
-            raise InappropriateDatasetContentError('The uploaded file contains invalid HTML content')
+            
     except Exception:
         if filename != converted_path:
             os.unlink(converted_path)

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -18,7 +18,9 @@ from galaxy.util import (
     string_as_bool,
     unicodify,
 )
-
+from galaxy.util.checkers import (
+    check_html
+)
 log = logging.getLogger(__name__)
 
 
@@ -52,11 +54,7 @@ class Html(Text):
         >>> Html().sniff( fname )
         True
         """
-        headers = iter_headers(file_prefix, None)
-        for hdr in headers:
-            if hdr and hdr[0].lower().find('<html>') >= 0:
-                return True
-        return False
+        return check_html(file_prefix.filename)
 
 
 @build_sniff_from_prefix


### PR DESCRIPTION
## What did you do? 
- Updated HTML sniffer to use existing check_html code
- Removed InappropriateDataset exception check for html


## Why did you make this change?
- Unable to import HTML files into Galaxy
- Existing html sniffer wasn't finding the necessary html tag
- check_html(converted_path) returns true for html and always throws a InappropriateDatasetContentError

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. From the UI, click the Upload Data button
  2. Select "Choose Local Files", select a .txt, .json, and a .html file
  3. Click "Start" and verify the 3 files are imported successfully and the correct data type is selected

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
