### PR TITLE
[21.01] Catching exception opening wav files in sniffere

### DIFF
--- a/lib/galaxy/datatypes/media.py
+++ b/lib/galaxy/datatypes/media.py
@@ -152,8 +152,11 @@ class Wav(Audio):
         return 'audio/wav'
 
     def sniff(self, filename):
-        with wave.open(filename, 'rb'):
-            return True
+        try:
+            with wave.open(filename, 'rb'):
+                return True
+        except wave.Error:
+            return False
 
     def set_meta(self, dataset, overwrite=True, **kwd):
         """Set the metadata for this dataset from the file contents."""


### PR DESCRIPTION
## What did you do? 
- Catching wav.open exception in WAV data type sniffer 


## Why did you make this change?
Depending on the order of data types in the configuration, MP4 and other media types will be checked by the wav sniffer.  wav.open throws an exception when trying to open other media types, and importing the file is not successful.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Click Upload Data -> "Choose Local Files".  Select an .mp4 and a .wav file.  Click start.  Verify the correct data types are assigned to the files

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

