### PR TITLE
Fix query parameter in `/api/libraries/{id}/permissions`

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -171,16 +171,16 @@ class FastAPILibraries:
         page: Optional[int] = Query(
             default=1,
             title="Page",
-            description="The page number to retrieve when paginating the permissions."
+            description="The page number to retrieve when paginating the available roles."
         ),
         page_limit: Optional[int] = Query(
             default=10,
             title="Page Limit",
             description="The maximum number of permissions per page when paginating."
         ),
-        query: Optional[str] = Query(
+        q: Optional[str] = Query(
             None, title="Query",
-            description="Optional search query to retrieve the permissions."
+            description="Optional search text to retrieve only the roles matching this query."
         ),
     ) -> Union[LibraryCurrentPermissions, LibraryAvailablePermissions]:
         """Gets the current or available permissions of a particular library.
@@ -192,7 +192,7 @@ class FastAPILibraries:
             is_library_access,
             page,
             page_limit,
-            query,
+            q,
         )
 
     @router.post(


### PR DESCRIPTION
## What did you do? 
- Rename the `query` parameter to `q` in `GET /api/libraries/{id}/permissions`


## Why did you make this change?
The `q` parameter sent by the UI was being ignored as the API was expecting `query` when filtering roles during libraries permission management.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Log in as Admin
  2. Go to Data Libraries
  2. Click on Manage in any folder or dataset
  3. Try to type the name of a role in any of the boxes
  4. The list should be filtering the roles as you type

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
