### PR TITLE
Fix retry_job_output_collection never succeeding

### DIFF
--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -761,6 +761,7 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors):
                 with open(job_state.output_file, "rb") as stdout_file, open(job_state.error_file, 'rb') as stderr_file:
                     stdout = self._job_io_for_db(stdout_file)
                     stderr = self._job_io_for_db(stderr_file)
+                    collect_output_success = True
                 break
             except Exception as e:
                 if which_try == self.app.config.retry_job_output_collection:


### PR DESCRIPTION
## What did you do? 
Set success flag to true upon success


## Why did you make this change?
Resolves https://github.com/galaxyproject/galaxy/issues/10388


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
