### PR TITLE
Unquote globs in from_work_dir ouptuts

### DIFF
--- a/lib/galaxy/jobs/command_factory.py
+++ b/lib/galaxy/jobs/command_factory.py
@@ -244,6 +244,8 @@ def __handle_metadata(commands_builder, job_wrapper, runner, remote_command_para
 
 def __copy_if_exists_command(work_dir_output):
     source_file, destination = work_dir_output
+    if '?' in source_file or '*' in source_file:
+        source_file = source_file.replace('*', '"*"').replace('?', '"?"')
     return f'\nif [ -f "{source_file}" ] ; then cp "{source_file}" "{destination}" ; fi'
 
 

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -79,6 +79,12 @@ class TestCommandFactory(TestCase):
         self.workdir_outputs = [("foo", "bar")]
         self.__assert_command_is(_surround_command('%s; return_code=$?; \nif [ -f "foo" ] ; then cp "foo" "bar" ; fi' % MOCK_COMMAND_LINE))
 
+    def test_workdir_outputs_with_glob(self):
+        self.include_work_dir_outputs = True
+        self.workdir_outputs = [("foo*bar", "foo_x_bar")]
+        self.__assert_command_is(_surround_command(
+            '%s; return_code=$?; \nif [ -f "foo"*"bar" ] ; then cp "foo"*"bar" "foo_x_bar" ; fi' % MOCK_COMMAND_LINE))
+
     def test_set_metadata_skipped_if_unneeded(self):
         self.include_metadata = True
         self.include_work_dir_outputs = False


### PR DESCRIPTION
## What did you do? 
- Unquote glob/wildcard characters when generating commands for checking for the existence of `from_work_dir` outputs.


## Why did you make this change?
These paths were traditionally fully unquoted but should be quoted, so this change was made in #11960 with the intent that globbing still worked, but quoted glob characters do not work this way. Unfortunately, this change breaks many existing tools that rely on the glob to work. In a future tool profile we will disable the glob syntax but for now, this restores the old behavior while still quoting the rest of the path.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
