### PR TITLE
Add/drop index together with `job_id` column

### DIFF
--- a/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
+++ b/lib/galaxy/model/migrate/versions/0123_add_workflow_request_tables.py
@@ -95,7 +95,7 @@ def upgrade(migrate_engine):
     WorkflowUUID_column = Column("uuid", UUIDType, nullable=True)
     add_column(History_column, "workflow_invocation", metadata)
     add_column(State_column, "workflow_invocation", metadata)
-    add_column(SchedulerId_column, "workflow_invocation", metadata, index_nane="id_workflow_invocation_scheduler")
+    add_column(SchedulerId_column, "workflow_invocation", metadata, index_name="id_workflow_invocation_scheduler")
     add_column(HandlerId_column, "workflow_invocation", metadata, index_name="id_workflow_invocation_handler")
     add_column(WorkflowUUID_column, "workflow_invocation", metadata)
 

--- a/lib/galaxy/model/migrate/versions/0173_add_job_id_to_dataset.py
+++ b/lib/galaxy/model/migrate/versions/0173_add_job_id_to_dataset.py
@@ -14,9 +14,7 @@ from sqlalchemy import (
 
 from galaxy.model.migrate.versions.util import (
     add_column,
-    add_index,
     drop_column,
-    drop_index,
 )
 
 log = logging.getLogger(__name__)
@@ -28,9 +26,8 @@ def upgrade(migrate_engine):
     metadata.bind = migrate_engine
     metadata.reflect()
 
-    job_id_column = Column('job_id', Integer, ForeignKey('job.id'))
-    add_column(job_id_column, 'dataset', metadata)
-    add_index('ix_dataset_job_id', 'dataset', 'job_id', metadata)
+    job_id_column = Column('job_id', Integer, ForeignKey('job.id'), index=True)
+    add_column(job_id_column, 'dataset', metadata, index_name='ix_dataset_job_id')
 
 
 def downgrade(migrate_engine):
@@ -38,4 +35,3 @@ def downgrade(migrate_engine):
     metadata.reflect()
 
     drop_column('job_id', 'dataset', metadata)
-    drop_index('ix_dataset_job_id', 'dataset', 'job_id', metadata)


### PR DESCRIPTION
## What did you do? 
- Add/drop index together with `job_id` column
- Fix typo in old migration.


## Why did you make this change?
(Cite Issue number OR provide rationalization of changes if no issue exists)
(If fixing a bug, please add any relevant error or traceback)
The `add_column` function has built-in checks for adding a column which is a foreign key and/or it's indexed, so better to use a single command.
`drop_index` is unnecessary when dropping the indexed column.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
