### PR TITLE
Increase API tests coverage for Data Library GET permissions

### DIFF
--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -92,6 +92,47 @@ class LibrariesApiTestCase(ApiTestCase):
             create_response = self._create_folder(library)
             self._assert_status_code_is(create_response, 403)
 
+    def test_get_library_current_permissions(self):
+        library = self.library_populator.new_library("GetCurrentPermissionTestLibrary")
+        library_id = library["id"]
+        current = self.library_populator.get_permissions(library_id, scope="current")
+        self._assert_has_keys(current, "access_library_role_list", "modify_library_role_list", "manage_library_role_list", "add_library_item_role_list")
+
+        role_id = self.library_populator.user_private_role_id()
+        self.library_populator.set_permissions_with_action(library_id, role_id, action="set_permissions")
+        current = self.library_populator.get_permissions(library_id, scope="current")
+        assert role_id in current["access_library_role_list"][0]
+        assert role_id in current["modify_library_role_list"][0]
+        assert role_id in current["manage_library_role_list"][0]
+        assert role_id in current["add_library_item_role_list"][0]
+
+    def test_get_library_available_permissions(self):
+        library = self.library_populator.new_library("GetAvailablePermissionTestLibrary")
+        library_id = library["id"]
+        role_id = self.library_populator.user_private_role_id()
+        # As we can manage this library our role will be available
+        current = self.library_populator.get_permissions(library_id, scope="available")
+        available_role_ids = [role["id"] for role in current["roles"]]
+        assert role_id in available_role_ids
+
+    def test_get_library_available_permissions_with_query(self):
+        library = self.library_populator.new_library("GetAvailablePermissionWithQueryTestLibrary")
+        library_id = library["id"]
+
+        with self._different_user():
+            email = self.library_populator.user_email()
+
+        # test at least 2 user roles should be available now
+        current = self.library_populator.get_permissions(library_id, scope="available")
+        available_role_ids = [role["id"] for role in current["roles"]]
+        assert len(available_role_ids) > 1
+
+        # test query for specific role/email
+        current = self.library_populator.get_permissions(library_id, scope="available", q=email)
+        available_role_emails = [role["name"] for role in current["roles"]]
+        assert current["total"] == 1
+        assert available_role_emails[0] == email
+
     def test_create_dataset_denied(self):
         library = self.library_populator.new_private_library("ForCreateDatasets")
         folder_response = self._create_folder(library)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1223,6 +1223,24 @@ class LibraryPopulator:
         create_response = self.galaxy_interactor.post("libraries", data=data, admin=True, json=True)
         return create_response.json()
 
+    def get_permissions(
+        self,
+        library_id,
+        scope: Optional[str] = "current",
+        is_library_access: Optional[bool] = False,
+        page: Optional[int] = 1,
+        page_limit: Optional[int] = 10,
+        q: Optional[str] = None,
+        admin: Optional[bool] = True
+    ):
+        query = f"&q={q}" if q else ""
+        response = self.galaxy_interactor.get(
+            f"libraries/{library_id}/permissions?scope={scope}&is_library_access={is_library_access}&page={page}&page_limit={page_limit}{query}",
+            admin=admin,
+        )
+        api_asserts.assert_status_code_is(response, 200)
+        return response.json()
+
     def set_permissions(self, library_id, role_id=None):
         """Old legacy way of setting permissions."""
         perm_list = role_id or []


### PR DESCRIPTION
## What did you do? 
Add some API tests for the `GET /api/libraries/{id}/permissions` endpoint that were missing.


## Why did you make this change?
Follow up on https://github.com/galaxyproject/galaxy/pull/12047


## How to test the changes? 
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.