### PR TITLE
SGE DRMAA example for queue, RAM and CPUs request

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -956,6 +956,10 @@
             <!-- The destination that you resubmit jobs to can be any runner type -->
             <param id="nativeSpecification">-l h_rt=96:00:00</param>
         </destination>
+        <destination id="4cpu_8gb_ram_queueA" runner="sge">
+            <!-- SGE DRMAA to send to a specific queue A, request 8 GB of RAM (2 per CPU) and 4 CPUs -->
+            <param id="nativeSpecification">-q A -l h_vmem=2G -pe smp 4</param>
+        </destination>
         <destination id="smallmem" runner="slurm">
             <param id="nativeSpecification">--mem-per-cpu=512</param>
             <resubmit condition="memory_limit_reached" destination="bigmem" />


### PR DESCRIPTION
## What did you do? 

- Adds an example on job conf of how to request CPU, RAM and a specific queue on SGE through DRMAA

## Why did you make this change?

Finding SGE docs to find out how to do this took time, and since requesting those resources is common, I thought an example might help someone in the future.


## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)

This is just a documentation change.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
