### PR TITLE
Set cache_ok flag for SQLAlchemy custom types

### DIFF
--- a/lib/galaxy/model/custom_types.py
+++ b/lib/galaxy/model/custom_types.py
@@ -78,7 +78,7 @@ class GalaxyLargeBinary(LargeBinary):
         return process
 
 
-class JSONType(sqlalchemy.types.TypeDecorator):
+class JSONType(TypeDecorator):
     """
     Represents an immutable structure as a json-encoded string.
 
@@ -90,6 +90,7 @@ class JSONType(sqlalchemy.types.TypeDecorator):
     # something like sqlalchemy.String, or even better, when applicable, native
     # sqlalchemy.dialects.postgresql.JSON
     impl = GalaxyLargeBinary
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if value is not None:
@@ -367,6 +368,7 @@ class UUIDType(TypeDecorator):
     CHAR(32), storing as stringified hex values.
     """
     impl = CHAR
+    cache_ok = True
 
     def load_dialect_impl(self, dialect):
         return dialect.type_descriptor(CHAR(32))
@@ -388,6 +390,7 @@ class UUIDType(TypeDecorator):
 
 class TrimmedString(TypeDecorator):
     impl = String
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         """Automatically truncate string values"""


### PR DESCRIPTION
## What did you do? 
Set cache_ok=True for custom types

## Why did you make this change?
Removes SAWarning.
Cause of warning: `cache_ok` added in SQLAlchemy 1.4.14. Default is None, which generates a warning and does NOT allow caching of a statement that includes this type. If it is safe to be used as part of a cache key, set `cache_ok = True`. 

All 3 types are safe.

(Also see this conversation https://github.com/galaxyproject/galaxy/pull/11737#issuecomment-845401779)

Ref: 
[SQLAlchemy docs](https://docs.sqlalchemy.org/en/14/core/custom_types.html?highlight=cache_ok#sqlalchemy.types.TypeDecorator.cache_ok) (also explains criteria for safe)
[Example of not safe for cache](https://github.com/sqlalchemy/sqlalchemy/issues/6436)


## How to test the changes? 
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
