### PR TITLE
[21.01] Fix pysam.view call

### DIFF
--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -184,12 +184,12 @@ def _bam_to_sam(local_name, temp_name):
     temp_local = tempfile.NamedTemporaryFile(suffix='.sam', prefix='local_bam_converted_to_sam_')
     with tempfile.NamedTemporaryFile(suffix='.sam', prefix='history_bam_converted_to_sam_', delete=False) as temp:
         try:
-            pysam.view('-h', '-o%s' % temp_local.name, local_name)
+            pysam.view('-h', '-o', temp_local.name, local_name, catch_stdout=False)
         except Exception as e:
             msg = "Converting local (test-data) BAM to SAM failed: %s" % unicodify(e)
             raise Exception(msg)
         try:
-            pysam.view('-h', '-o%s' % temp.name, temp_name)
+            pysam.view('-h', '-o', temp.name, temp_name, catch_stdout=False)
         except Exception as e:
             msg = "Converting history BAM to SAM failed: %s" % unicodify(e)
             raise Exception(msg)

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -184,12 +184,12 @@ def _bam_to_sam(local_name, temp_name):
     temp_local = tempfile.NamedTemporaryFile(suffix='.sam', prefix='local_bam_converted_to_sam_')
     with tempfile.NamedTemporaryFile(suffix='.sam', prefix='history_bam_converted_to_sam_', delete=False) as temp:
         try:
-            pysam.view('-h', '-o', temp_local.name, local_name, catch_stdout=False)
+            pysam.view('-h', '--no-PG', '-o', temp_local.name, local_name, catch_stdout=False)
         except Exception as e:
             msg = "Converting local (test-data) BAM to SAM failed: %s" % unicodify(e)
             raise Exception(msg)
         try:
-            pysam.view('-h', '-o', temp.name, temp_name, catch_stdout=False)
+            pysam.view('-h', '--no-PG', '-o', temp.name, temp_name, catch_stdout=False)
         except Exception as e:
             msg = "Converting history BAM to SAM failed: %s" % unicodify(e)
             raise Exception(msg)

--- a/test/functional/tools/sam_to_bam.xml
+++ b/test/functional/tools/sam_to_bam.xml
@@ -11,7 +11,7 @@ cat '$input1' > '$out_file1'
     <tests>
         <test>
             <param name="input1" value="sam_with_header.sam" ftype="sam"/>
-            <output name="out_file1" file="bam_from_sam.bam"/>
+            <output name="out_file1" file="bam_from_sam.bam" ftype="bam"/>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
## What did you do? 

Change the call of `pysam.view`.

## Why did you make this change?

Otherwise samtools output is the return value of `pysam.view` and the output file (given by `-o`) stays empty.

see also https://github.com/pysam-developers/pysam/issues/677

The consequence of the old call is that two empty files were compared in `planemo test` .. which is always successful.

## How to test the changes? 
(select the most appropriate option; if the latter, provide steps for testing below)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

Testing here https://github.com/galaxyproject/tools-iuc/issues/3699

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

## For UI Components
- [ ] I've included a screenshot of the changes
