### PR TITLE
[21.05] invocation_time report fix

### DIFF
--- a/lib/galaxy/managers/markdown_parse.py
+++ b/lib/galaxy/managers/markdown_parse.py
@@ -33,9 +33,9 @@ VALID_ARGUMENTS = {
     "tool_stdout": ["step", "job_id"],
     "generate_galaxy_version": [],
     "generate_time": [],
-    "invocation_time": ["invocation_id"],
     "visualization": DYNAMIC_ARGUMENTS,
     # Invocation Flavored Markdown
+    "invocation_time": ["invocation_id"],
     "invocation_outputs": [],
     "invocation_inputs": [],
 }

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -685,7 +685,7 @@ history_dataset_collection_display(input={})
             return ("workflow_display(workflow_id=%s)\n" % invocation.workflow.stored_workflow.id, False)
         if container == "history_link":
             return ("history_link(history_id=%s)\n" % invocation.history.id, False)
-        if container == "invocation_date" or container == "invocation_time":
+        if container == "invocation_time":
             return ("invocation_time(invocation_id=%s)\n" % invocation.id, False)
         ref_object_type = None
         output_match = re.search(OUTPUT_LABEL_PATTERN, line)

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -685,8 +685,8 @@ history_dataset_collection_display(input={})
             return ("workflow_display(workflow_id=%s)\n" % invocation.workflow.stored_workflow.id, False)
         if container == "history_link":
             return ("history_link(history_id=%s)\n" % invocation.history.id, False)
-        if container == "invocation_date":
-            return ("invocation_date(invocation_id=%s)\n" % invocation.id, False)
+        if container == "invocation_date" or container == "invocation_time":
+            return ("invocation_time(invocation_id=%s)\n" % invocation.id, False)
         ref_object_type = None
         output_match = re.search(OUTPUT_LABEL_PATTERN, line)
         input_match = re.search(INPUT_LABEL_PATTERN, line)

--- a/test/unit/workflows/test_workflow_markdown.py
+++ b/test/unit/workflows/test_workflow_markdown.py
@@ -53,6 +53,18 @@ history_dataset_peek(input=input1)
     assert "```galaxy\nhistory_dataset_peek(history_dataset_id=567)\n```" in galaxy_markdown
 
 
+def test_invocation_time():
+    workflow_markdown = """
+And outputs...
+
+```galaxy
+invocation_time()
+```
+"""
+    galaxy_markdown = resolved_markdown(workflow_markdown)
+    assert "```galaxy\ninvocation_time(invocation_id=44)\n```" in galaxy_markdown
+
+
 def test_output_reference_mapping():
     workflow_markdown = """
 And outputs...
@@ -78,6 +90,7 @@ def example_invocation(trans):
     invocation = model.WorkflowInvocation()
     workflow = yaml_to_model(TEST_WORKFLOW_YAML)
     workflow.id = 342
+    invocation.id = 44
     invocation.workflow = workflow
 
     # TODO: fix this to use workflow id and eliminate hack.


### PR DESCRIPTION
Fixes invocation_time construct in workflow invocation reports, adds a test.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
