### PR TITLE
Fix typo in `interactivetool_jupyter_notebook.xml` help section

### DIFF
--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -86,7 +86,7 @@
     Galaxy offers you to use Jupyter Notebooks directly in Galaxy accessing and interacting with Galaxy datasets as you like. A very common use-case is to
     do the heavy lifting and data reduction steps in Galaxy and the plotting and more `interactive` part on smaller datasets in Jupyter.
 
-    You can start with a new Jupyter notebook from scratch or load an already existing one, e.g. from your collegue and execute it on your dataset.
+    You can start with a new Jupyter notebook from scratch or load an already existing one, e.g. from your colleague and execute it on your dataset.
     If you have a defined input dataset you can even execute a Jupyter notebook in a workflow, given that the notebook is writing the output back to the history.
 
     You can import data into the notebook via a predefined `get()` function and write results back to Galaxy with a `put()` function.


### PR DESCRIPTION
This PR fixes a typo in a help section of Interactive Jupyter Notebook tool ([galaxy tool link](https://usegalaxy.org/root?tool_id=interactive_tool_jupyter_notebook))

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
