### PR TITLE
[21.05] Fix trigger statements on postgresql less than 11

### DIFF
--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -11,9 +11,13 @@ jobs:
       matrix:
         python-version: ['3.7']
         db: ['postgresql', 'sqlite']
+        postgresql-version: ['13']
+        include:
+          - db: postgresql
+            postgresql-version: '9.6'
     services:
       postgres:
-        image: postgres:13
+        image: postgres:${{ matrix.postgresql-version }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Fixes #12078.
The PROCEDURE and FUNCTION keyword statements are aliases, where PROCEDURE is deprecated, but postgresql < 11 does not support the modern FUNCTION keyword.
You can see the added index test failing in https://github.com/mvdbeek/galaxy/runs/2711521463?check_suite_focus=true#step:7:1677

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
