### PR TITLE
[21.05] Fix select all in import from history backbone modal

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/add-datasets.js
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/add-datasets.js
@@ -710,6 +710,26 @@ var AddDatasets = Backbone.View.extend({
         }
     },
 
+    /**
+     * User clicked the checkbox in the table heading
+     * @param  {context} event
+     */
+    selectAll: function (event) {
+        var selected = event.target.checked;
+        var self = this;
+        // Iterate each checkbox
+        $(":checkbox", "#dataset_list tbody").each(function () {
+            this.checked = selected;
+            var $row = $(this).closest("tr");
+            // Change color of selected/unselected
+            if (selected) {
+                self.makeDarkRow($row);
+            } else {
+                self.makeWhiteRow($row);
+            }
+        });
+    },
+
     makeDarkRow: function ($row) {
         $row.addClass("table-primary");
     },


### PR DESCRIPTION
Select button in backbone modal wasn't working. Somehow `selectAll` function was lost during transition.
Fixes https://github.com/galaxyproject/galaxy/issues/12006

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. try to import all your datasets  from history to the library folder
 
![image](https://user-images.githubusercontent.com/15801412/120223849-88949100-c242-11eb-9d6d-c858173f3af3.png)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
