### PR TITLE
Open partfile in rb-mode in multipart uploading

### DIFF
--- a/lib/galaxy/objectstore/s3_multipart_upload.py
+++ b/lib/galaxy/objectstore/s3_multipart_upload.py
@@ -48,7 +48,7 @@ def transfer_part(s3server, mp_id, mp_keyname, mp_bucketname, i, part):
     """Transfer a part of a multipart upload. Designed to be run in parallel.
     """
     mp = mp_from_ids(s3server, mp_id, mp_keyname, mp_bucketname)
-    with open(part) as t_handle:
+    with open(part, 'rb') as t_handle:
         mp.upload_part_from_file(t_handle, i + 1)
     os.remove(part)
 


### PR DESCRIPTION
Uploading binary files to S3ObjectStore results in empty files.
Fixes #12083

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure objectstore like this
 ```
 <object_store type="s3" order="0">
        <auth access_key="...." secret_key="...."/>
            <bucket name="..." use_reduced_redundancy="False" />
            <cache path="database/object_store_cache/" size="1000" />
            <extra_dir type="temp" path="database/tmp2"/>
            <extra_dir type="job_work" path="database/job_working_directory2"/>
        </object_store>
```
  2. Add fastq.gz file to data library from path.
  3. Download the uploaded file from s3 buckets. 
  4. Make sure that the original file and the downloaded file is identical.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
