### PR TITLE
Make markdown components for reports and pages full width 

### DIFF
--- a/client/src/components/Dataset/DatasetAsImage/DatasetAsImage.vue
+++ b/client/src/components/Dataset/DatasetAsImage/DatasetAsImage.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div v-if="imageUrl" class="w-50 p-2 float-left">
+        <div v-if="imageUrl" class="w-100 p-2">
             <b-card nobody body-class="p-1">
                 <b-img :src="imageUrl" fluid />
             </b-card>

--- a/client/src/components/Markdown/Elements/HistoryDatasetCollection/CollectionDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetCollection/CollectionDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card body-class="p-0">
             <b-card-header>
                 <span class="float-right">

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card body-class="p-0">
             <b-card-header v-if="!embedded">
                 <span class="float-right">

--- a/client/src/components/Markdown/Elements/JobMetrics.vue
+++ b/client/src/components/Markdown/Elements/JobMetrics.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card nobody>
             <JobMetrics class="job-metrics" :job-id="args.job_id" />
         </b-card>

--- a/client/src/components/Markdown/Elements/JobParameters.vue
+++ b/client/src/components/Markdown/Elements/JobParameters.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card nobody>
             <JobParameters class="job-parameters" :job-id="args.job_id" :param="args.param" :include-title="false" />
         </b-card>

--- a/client/src/components/Markdown/Elements/ToolStd.vue
+++ b/client/src/components/Markdown/Elements/ToolStd.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card nobody class="content-height">
             <div :class="name" :job_id="args.job_id">
                 <pre><code class="text-normalwrap">{{ jobContent }}</code></pre>

--- a/client/src/components/Markdown/Elements/Visualization.vue
+++ b/client/src/components/Markdown/Elements/Visualization.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card body-class="embed-responsive embed-responsive-4by3">
             <LoadingSpan v-if="loading" class="m-2" message="Loading Visualization" />
             <div v-else-if="error" class="m-2">{{ error }}</div>

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-50 p-2 float-left">
+    <div class="w-100 p-2">
         <b-card body-class="p-0">
             <b-card-header v-if="!embedded">
                 <span class="float-right">


### PR DESCRIPTION
This pull requests makes all components full width in the report interface. It fixes https://github.com/galaxyproject/galaxy/issues/11564 and the issues with content flowing weirdly because all of the boxes were `float: left`.

![image of report with full width boxes](https://user-images.githubusercontent.com/458683/120171949-db4e5880-c202-11eb-84ff-332f5d798881.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Make a workflow
  2. add a report
  3. run the workflow
  4. see that the report has full-width components


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
