### PR TITLE
[21.05] Fix export select_all in collections

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -249,10 +249,7 @@ export default {
             const Galaxy = getGalaxyInstance();
             // logic from legacy code
             return !!(this.contains_file_or_folder && Galaxy.user);
-        },
-        allDatasets: function () {
-            return this.folderContents.filter((element) => element.type === "file");
-        },
+        }
     },
     methods: {
         updateSearch: function (value) {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -319,7 +319,6 @@ export default {
                 if (isCollection) {
                     new mod_import_collection.ImportCollectionModal({
                         selected: checkedItems,
-                        allDatasets: this.allDatasets,
                     });
                 } else {
                     new mod_import_dataset.ImportDatasetModal({

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -249,7 +249,7 @@ export default {
             const Galaxy = getGalaxyInstance();
             // logic from legacy code
             return !!(this.contains_file_or_folder && Galaxy.user);
-        }
+        },
     },
     methods: {
         updateSearch: function (value) {


### PR DESCRIPTION
Since we already have `select all` mechanism in folder itself, there is no need to the duplicate functionality in export modal. Since, the library is paginated now, `select_all` is a tricky thing and it would be logical to have the same behavior as regular export "as datasets". This PR basically unifies `as Datasets` and `as Collection` behavior with "select all"

fixes https://github.com/galaxyproject/galaxy/issues/12014

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Select ALL in a lib folder -> export as a collection
![image](https://user-images.githubusercontent.com/15801412/120324882-69037400-c2e7-11eb-8bd5-6d012be4c022.png)
![image](https://user-images.githubusercontent.com/15801412/120324929-76b8f980-c2e7-11eb-88a2-21080f18f242.png)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
