### PR TITLE
[21.05] fix library search filter 

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -271,7 +271,11 @@ export default {
         async getSelected() {
             if (this.isAllSelectedMode) {
                 this.$emit("setBusy", true);
-                const selected = await this.services.getFilteredFolderContents(this.folder_id, this.unselected, this.$parent.search_text);
+                const selected = await this.services.getFilteredFolderContents(
+                    this.folder_id,
+                    this.unselected,
+                    this.$parent.search_text
+                );
                 this.$emit("setBusy", false);
                 return selected;
             } else {

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -271,7 +271,7 @@ export default {
         async getSelected() {
             if (this.isAllSelectedMode) {
                 this.$emit("setBusy", true);
-                const selected = await this.services.getFilteredFolderContents(this.folder_id, this.unselected);
+                const selected = await this.services.getFilteredFolderContents(this.folder_id, this.unselected, this.$parent.search_text);
                 this.$emit("setBusy", false);
                 return selected;
             } else {

--- a/client/src/components/Libraries/LibraryFolder/services.js
+++ b/client/src/components/Libraries/LibraryFolder/services.js
@@ -8,8 +8,11 @@ export class Services {
     }
 
     async getFolderContents(id, include_deleted, limit, offset, search_text = false) {
-        search_text = search_text ? `&search_text=${encodeURI(search_text.trim())}` : "";
-        const url = `${this.root}api/folders/${id}/contents?include_deleted=${include_deleted}&limit=${limit}&offset=${offset}${search_text}`;
+        const url = `${
+            this.root
+        }api/folders/${id}/contents?include_deleted=${include_deleted}&limit=${limit}&offset=${offset}${this.getSearchQuery(
+            search_text
+        )}`;
         try {
             const response = await axios.get(url);
             return response.data;
@@ -18,11 +21,15 @@ export class Services {
         }
     }
 
-    async getFilteredFolderContents(id, excluded) {
-        const contents = await axios.get(`${this.root}api/folders/${id}/contents`);
+    async getFilteredFolderContents(id, excluded, search_text) {
+        const contents = await axios.get(`${this.root}api/folders/${id}/contents?${this.getSearchQuery(search_text)}`);
         return contents.data.folder_contents.filter((item) => {
             return !excluded.some((exc) => exc.id === item.id);
         });
+    }
+
+    getSearchQuery(search_text) {
+        return search_text ? `&search_text=${encodeURI(search_text.trim())}` : "";
     }
 
     updateFolder(item, onSucess, onError) {


### PR DESCRIPTION
Just a small typo, fetching function was missing the search value

fixes https://github.com/galaxyproject/galaxy/issues/11916

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Open data libs
  2. Search for dataset
  3. Press selectAll try to export the result

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
