### PR TITLE
[21.01] Don't assert output_metadata state

### DIFF
--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -444,7 +444,6 @@ def output_to_cwl_json(
         return galaxy_output.history_content_id
     elif output_metadata["history_content_type"] == "dataset":
         ext = output_metadata["file_ext"]
-        assert output_metadata["state"] == "ok"
         if ext == "expression.json":
             dataset_dict = get_dataset(output_metadata)
             return dataset_dict_to_json_content(dataset_dict)


### PR DESCRIPTION
`output_to_cwl_json` is used for converting dataset collections into
cwl_json when checking workflow outputs.
xref https://github.com/galaxyproject/planemo/pull/1174


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Test a workflow using `planemo test` that produces a dataset collection in a step that fails. For instance https://github.com/galaxyproject/planemo/blob/0a5e627020c715fafd58c9813bd90b7071a3d2f7/tests/data/wf_failed_step.ga.
You'll see that without this PR the test output just says that the test failed. With this PR you'll see the step job, which includes the exit code and the stderr.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
