### PR TITLE
Add configuration option to hide user account management interfaces

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -33,7 +33,7 @@
             </div>
         </b-row>
         <ConfigProvider v-slot="{ config }">
-            <b-row v-if="config && !config.single_user && config.enable_account_management" class="ml-3 mb-1">
+            <b-row v-if="config && !config.single_user && config.enable_account_interface" class="ml-3 mb-1">
                 <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
                 <div class="pref-content pr-1">
                     <a id="delete-account" href="javascript:void(0)"

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -33,7 +33,7 @@
             </div>
         </b-row>
         <ConfigProvider v-slot="{ config }">
-            <b-row v-if="config && !config.single_user" class="ml-3 mb-1">
+            <b-row v-if="config && !config.single_user && config.enable_account_management" class="ml-3 mb-1">
                 <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
                 <div class="pref-content pr-1">
                     <a id="delete-account" href="javascript:void(0)"

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -12,7 +12,7 @@ export const getUserPreferencesModel = () => {
             url: `api/users/${Galaxy.user.id}/information/inputs`,
             icon: "fa-user",
             redirect: "user",
-            shouldRender: !config.use_remote_user,
+            shouldRender: !config.use_remote_user && config.enable_account_management,
         },
         password: {
             title: _l("Change Password"),
@@ -22,7 +22,7 @@ export const getUserPreferencesModel = () => {
             url: `api/users/${Galaxy.user.id}/password/inputs`,
             submit_title: "Save Password",
             redirect: "user",
-            shouldRender: !config.use_remote_user,
+            shouldRender: !config.use_remote_user && config.enable_account_management,
         },
         external_ids: {
             title: _l("Manage Third-Party Identities"),
@@ -67,6 +67,7 @@ export const getUserPreferencesModel = () => {
             icon: "fa-cloud",
             submit_title: "Create a new Key",
             submit_icon: "fa-check",
+            shouldRender: config.enable_account_management,
         },
         toolbox_filters: {
             title: _l("Manage Toolbox Filters"),

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -12,7 +12,7 @@ export const getUserPreferencesModel = () => {
             url: `api/users/${Galaxy.user.id}/information/inputs`,
             icon: "fa-user",
             redirect: "user",
-            shouldRender: !config.use_remote_user && config.enable_account_management,
+            shouldRender: !config.use_remote_user && config.enable_account_interface,
         },
         password: {
             title: _l("Change Password"),
@@ -22,7 +22,7 @@ export const getUserPreferencesModel = () => {
             url: `api/users/${Galaxy.user.id}/password/inputs`,
             submit_title: "Save Password",
             redirect: "user",
-            shouldRender: !config.use_remote_user && config.enable_account_management,
+            shouldRender: !config.use_remote_user && config.enable_account_interface,
         },
         external_ids: {
             title: _l("Manage Third-Party Identities"),
@@ -67,7 +67,7 @@ export const getUserPreferencesModel = () => {
             icon: "fa-cloud",
             submit_title: "Create a new Key",
             submit_icon: "fa-check",
-            shouldRender: config.enable_account_management,
+            shouldRender: config.enable_account_interface,
         },
         toolbox_filters: {
             title: _l("Manage Toolbox Filters"),

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1456,9 +1456,9 @@
 :Type: int
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_account_management``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_account_interface``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
     Allow users to manage their account data, change passwords or

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1456,6 +1456,17 @@
 :Type: int
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``enable_account_management``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Allow users to manage their account data, change passwords or
+    delete their accounts.
+:Default: ``true``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~~~~~~
 ``session_duration``
 ~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -812,6 +812,10 @@ galaxy:
   # 0 to disable password expiration.
   #password_expiration_period: 0
 
+  # Allow users to manage their account data, change passwords or delete
+  # their accounts.
+  #enable_account_management: true
+
   # Galaxy Session Timeout This provides a timeout (in minutes) after
   # which a user will have to log back in. A duration of 0 disables this
   # feature.

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -814,7 +814,7 @@ galaxy:
 
   # Allow users to manage their account data, change passwords or delete
   # their accounts.
-  #enable_account_management: true
+  #enable_account_interface: true
 
   # Galaxy Session Timeout This provides a timeout (in minutes) after
   # which a user will have to log back in. A duration of 0 disables this

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -147,6 +147,7 @@ class ConfigSerializer(base.ModelSerializer):
             'default_locale': _use_config,
             'enable_openid': _use_config,
             'enable_tool_recommendations': _use_config,
+            'enable_account_management': _use_config,
             'tool_recommendation_model_path': _use_config,
             'admin_tool_recommendations_path': _use_config,
             'overwrite_model_recommendations': _use_config,

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -147,7 +147,7 @@ class ConfigSerializer(base.ModelSerializer):
             'default_locale': _use_config,
             'enable_openid': _use_config,
             'enable_tool_recommendations': _use_config,
-            'enable_account_management': _use_config,
+            'enable_account_interface': _use_config,
             'tool_recommendation_model_path': _use_config,
             'admin_tool_recommendations_path': _use_config,
             'overwrite_model_recommendations': _use_config,

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1053,6 +1053,14 @@ mapping:
           screen when they log in after their password expires. Enter 0 to disable
           password expiration.
 
+      enable_account_management:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          Allow users to manage their account data, change passwords or delete their
+          accounts.
+
       session_duration:
         type: int
         default: 0

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1053,7 +1053,7 @@ mapping:
           screen when they log in after their password expires. Enter 0 to disable
           password expiration.
 
-      enable_account_management:
+      enable_account_interface:
         type: bool
         default: true
         required: false


### PR DESCRIPTION
Currently users are always allowed to change their passwords, delete their accounts, edit their usernames and other account associated details. This PR introduces a config option which restricts access to these features through the user interface. This is useful for administrator managed Galaxy instances.