### PR TITLE
Allow multiple input datasets in jupyter interactive tool

### DIFF
--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -39,15 +39,15 @@
             cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
         #else:
             #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
-            cp '$mode.ipynb' ./${noteboook_name}.ipynb &&
-            jupyter trust ./${noteboook_name}.ipynb &&
+            cp '$mode.ipynb' './${noteboook_name}.ipynb' &&
+            jupyter trust './${noteboook_name}.ipynb' &&
             #if $mode.run_it:
                 jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
                 #set $noteboook_name = 'ipython_galaxy_notebook'
             #else:
                 jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             #end if
-            cp ./${noteboook_name}.ipynb '$jupyter_notebook'
+            cp './${noteboook_name}.ipynb' '$jupyter_notebook'
         #end if
     ]]>
     </command>

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -17,21 +17,13 @@
     </environment_variables>
     <command detect_errors="aggressive"><![CDATA[
         #import re
-        #import random
-        #import string
         export GALAXY_WORKING_DIR=`pwd` &&
         mkdir -p ./jupyter/outputs/ &&
         mkdir -p ./jupyter/data &&
 
-        #set $cleaned_names = []
-        #for $file in $input
-            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($file.element_identifier))
-            ## prevent overwriting data with a randomized suffix
-            #if $cleaned_name in $cleaned_names:
-                #set $cleaned_name = $cleaned_name + '_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(3))
-            #end if
-            #set $cleaned_names += [$cleaned_name]
-            ln -sf '$file' './jupyter/data/${cleaned_name}' &&
+        #for $count, $file in enumerate($input):
+            #set $cleaned_name = str($count + 1) + '_' + re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
+            ln -sf '$file' './jupyter/data/${cleaned_name}.${file.ext}' &&
         #end for
 
         ## change into the directory where the notebooks are located
@@ -46,7 +38,7 @@
             jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
         #else:
-            #set $noteboook_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
+            #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
             cp '$mode.ipynb' ./${noteboook_name}.ipynb &&
             jupyter trust ./${noteboook_name}.ipynb &&
             #if $mode.run_it:

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -16,38 +16,47 @@
         <environment_variable name="API_KEY" inject="api_key" />
     </environment_variables>
     <command detect_errors="aggressive"><![CDATA[
-        #import re
-        export GALAXY_WORKING_DIR=`pwd` &&
-        mkdir -p ./jupyter/outputs/ &&
-        mkdir -p ./jupyter/data &&
+#import re
+#import random
+#import string
+export GALAXY_WORKING_DIR=`pwd` &&
+mkdir -p ./jupyter/outputs/ &&
+mkdir -p ./jupyter/data &&
 
-        #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
-        ln -sf '$input' './jupyter/data/${cleaned_name}' &&
+#set $cleaned_names = []
+#for $file in $input
+    #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($file.element_identifier))
+    ## prevent overwriting data with a randomized suffix
+    #if $cleaned_name in $cleaned_names:
+        #set $cleaned_name = $cleaned_name + '_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(3))
+    #end if
+    #set $cleaned_names += [$cleaned_name]
+    ln -sf '$file' './jupyter/data/${cleaned_name}' &&
+#end for
 
-        ## change into the directory where the notebooks are located
-        cd ./jupyter/ &&
-        export HOME=/home/jovyan/ &&
-        export PATH=/home/jovyan/.local/bin:\$PATH &&
+## change into the directory where the notebooks are located
+cd ./jupyter/ &&
+export HOME=/home/jovyan/ &&
+export PATH=/home/jovyan/.local/bin:\$PATH &&
 
-        #if $mode.mode_select == 'scratch':
-            ## copy default notebook
-            cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
-            jupyter trust ./ipython_galaxy_notebook.ipynb &&
-            jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
-            cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
-
-        #else:
-            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($input.element_identifier))
-            cp '$mode.ipynb' ./${cleaned_name}.ipynb &&
-            jupyter trust ./${cleaned_name}.ipynb &&
-
-            #if $mode.run_it:
-                jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
-            #else:
-                jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
-            #end if
-            cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
-        #end if
+#if $mode.mode_select == 'scratch':
+    ## copy default notebook
+    cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
+    jupyter trust ./ipython_galaxy_notebook.ipynb &&
+    jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
+    cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
+#else:
+    #set $noteboook_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
+    cp '$mode.ipynb' ./${noteboook_name}.ipynb &&
+    jupyter trust ./${noteboook_name}.ipynb &&
+    #if $mode.run_it:
+        jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
+        #set $noteboook_name = 'ipython_galaxy_notebook'
+    #else:
+        jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
+    #end if
+    cp ./${noteboook_name}.ipynb '$jupyter_notebook'
+#end if
     ]]>
     </command>
     <inputs>
@@ -64,7 +73,7 @@
                     help="This option is useful in workflows when you just want to execute a notebook and not dive into the webfrontend."/>
             </when>
         </conditional>
-        <param name="input" type="data" optional="true" label="Include data into the environment"/>
+        <param name="input" multiple="true" type="data" optional="true" label="Include data into the environment"/>
 
     </inputs>
     <outputs>

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -16,47 +16,47 @@
         <environment_variable name="API_KEY" inject="api_key" />
     </environment_variables>
     <command detect_errors="aggressive"><![CDATA[
-#import re
-#import random
-#import string
-export GALAXY_WORKING_DIR=`pwd` &&
-mkdir -p ./jupyter/outputs/ &&
-mkdir -p ./jupyter/data &&
+        #import re
+        #import random
+        #import string
+        export GALAXY_WORKING_DIR=`pwd` &&
+        mkdir -p ./jupyter/outputs/ &&
+        mkdir -p ./jupyter/data &&
 
-#set $cleaned_names = []
-#for $file in $input
-    #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($file.element_identifier))
-    ## prevent overwriting data with a randomized suffix
-    #if $cleaned_name in $cleaned_names:
-        #set $cleaned_name = $cleaned_name + '_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(3))
-    #end if
-    #set $cleaned_names += [$cleaned_name]
-    ln -sf '$file' './jupyter/data/${cleaned_name}' &&
-#end for
+        #set $cleaned_names = []
+        #for $file in $input
+            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($file.element_identifier))
+            ## prevent overwriting data with a randomized suffix
+            #if $cleaned_name in $cleaned_names:
+                #set $cleaned_name = $cleaned_name + '_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(3))
+            #end if
+            #set $cleaned_names += [$cleaned_name]
+            ln -sf '$file' './jupyter/data/${cleaned_name}' &&
+        #end for
 
-## change into the directory where the notebooks are located
-cd ./jupyter/ &&
-export HOME=/home/jovyan/ &&
-export PATH=/home/jovyan/.local/bin:\$PATH &&
+        ## change into the directory where the notebooks are located
+        cd ./jupyter/ &&
+        export HOME=/home/jovyan/ &&
+        export PATH=/home/jovyan/.local/bin:\$PATH &&
 
-#if $mode.mode_select == 'scratch':
-    ## copy default notebook
-    cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
-    jupyter trust ./ipython_galaxy_notebook.ipynb &&
-    jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
-    cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
-#else:
-    #set $noteboook_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
-    cp '$mode.ipynb' ./${noteboook_name}.ipynb &&
-    jupyter trust ./${noteboook_name}.ipynb &&
-    #if $mode.run_it:
-        jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
-        #set $noteboook_name = 'ipython_galaxy_notebook'
-    #else:
-        jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
-    #end if
-    cp ./${noteboook_name}.ipynb '$jupyter_notebook'
-#end if
+        #if $mode.mode_select == 'scratch':
+            ## copy default notebook
+            cp '$__tool_directory__/default_notebook.ipynb' ./ipython_galaxy_notebook.ipynb &&
+            jupyter trust ./ipython_galaxy_notebook.ipynb &&
+            jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
+            cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
+        #else:
+            #set $noteboook_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
+            cp '$mode.ipynb' ./${noteboook_name}.ipynb &&
+            jupyter trust ./${noteboook_name}.ipynb &&
+            #if $mode.run_it:
+                jupyter nbconvert --to notebook --execute --output ./ipython_galaxy_notebook.ipynb --allow-errors  ./*.ipynb &&
+                #set $noteboook_name = 'ipython_galaxy_notebook'
+            #else:
+                jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
+            #end if
+            cp ./${noteboook_name}.ipynb '$jupyter_notebook'
+        #end if
     ]]>
     </command>
     <inputs>

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -25,13 +25,13 @@
 
         #set $cleaned_names = []
         #for $file in $input
-            #set $cleaned_name = re.sub('[^\w\-\.]', '_', str($file.element_identifier))
+            #set $cleaned_name = re.sub('[^\w\-\.\s]', '_', str($file.element_identifier))
             ## prevent overwriting data with a randomized suffix
             #if $cleaned_name in $cleaned_names:
                 #set $cleaned_name = $cleaned_name + '_' + ''.join(random.choice(string.ascii_lowercase) for _ in range(3))
             #end if
             #set $cleaned_names += [$cleaned_name]
-            ln -sf '$file' './jupyter/data/${cleaned_name}' &&
+            ln -sf '$file' './jupyter/data/${cleaned_name}.${file.ext}' && 
         #end for
 
         ## change into the directory where the notebooks are located
@@ -46,7 +46,7 @@
             jupyter lab --allow-root --no-browser --NotebookApp.shutdown_button=True &&
             cp ./ipython_galaxy_notebook.ipynb '$jupyter_notebook'
         #else:
-            #set $noteboook_name = re.sub('[^\w\-\.]', '_', str($mode.ipynb.element_identifier))
+            #set $noteboook_name = re.sub('[^\w\-\.\s]', '_', str($mode.ipynb.element_identifier))
             cp '$mode.ipynb' ./${noteboook_name}.ipynb &&
             jupyter trust ./${noteboook_name}.ipynb &&
             #if $mode.run_it:

--- a/tools/interactive/interactivetool_jupyter_notebook.xml
+++ b/tools/interactive/interactivetool_jupyter_notebook.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive Jupyter Notebook" version="0.1">
+<tool id="interactive_tool_jupyter_notebook" tool_type="interactive" name="Interactive Jupyter Notebook" version="0.2">
     <requirements>
         <container type="docker">quay.io/bgruening/docker-jupyter-notebook:ie2</container>
     </requirements>


### PR DESCRIPTION
Also works with a collection of type "list". 

+ fix a bug with saving notebooks on exit that had non-default name
+ remove the confusion with naming notebooks after inputs
+ bump version

tested on release_21.01

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
