### PR TITLE
[21.05] Fix copying text in workflow editor

### DIFF
--- a/client/src/components/Workflow/Editor/modules/canvas.js
+++ b/client/src/components/Workflow/Editor/modules/canvas.js
@@ -220,12 +220,17 @@ class CanvasManager {
     }
     init_copy_paste() {
         /*
-            Both of these copy/paste event bindings check the active element
+            The copy/paste event bindings check the active element
             and, if it's one of the text inputs, skip the workflow copy/paste
             logic so we don't interfere with standard copy/paste functionality.
+            The copy binding also skips the node copy if text is currently highlighted.
         */
         document.addEventListener("copy", (e) => {
-            if (document.activeElement && !inputElementTypes.includes(document.activeElement.type)) {
+            if (
+                document.activeElement &&
+                !inputElementTypes.includes(document.activeElement.type) &&
+                !document.getSelection().toString()
+            ) {
                 if (this.app.activeNode && this.app.activeNode.type !== "subworkflow") {
                     e.clipboardData.setData(
                         "application/json",
@@ -233,8 +238,8 @@ class CanvasManager {
                             nodeId: this.app.activeNode.id,
                         })
                     );
+                    e.preventDefault();
                 }
-                e.preventDefault();
             }
         });
         document.addEventListener("paste", (e) => {


### PR DESCRIPTION
The only text we could copy had to be within input boxes, but we may
want to also copy text from the error / upgrade message modal or from
the help text or other links.
So if there's currently any highlighted text we skip the workflow copy
logic.
Copying nodes continues to work correctly, one only needs to make sure we're not currently highlighting text or that we're within a input element.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Open a workflow and highlight any tool help text or tool label, and paste it into another window.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
