### PR TITLE
[21.05] Make failure to save workflow dismissible

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -328,7 +328,11 @@ export default {
                         this.refactorActions = actions;
                     })
                     .catch((response) => {
-                        this.onWorkflowError("Saving workflow failed, cannot apply requested changes...");
+                        this.onWorkflowError("Saving workflow failed, cannot apply requested changes...", response, {
+                            Ok: () => {
+                                this.hideModal();
+                            },
+                        });
                     });
             } else {
                 this.refactorActions = actions;

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -1279,12 +1279,12 @@ class WorkflowContentsManager(UsesAnnotations):
             uuid = step_dict.get("uuid", None)
             if uuid and uuid != "None":
                 if uuid in discovered_uuids:
-                    raise exceptions.DuplicatedIdentifierException("Duplicate step UUID in request.")
+                    raise exceptions.DuplicatedIdentifierException(f"Duplicate step UUID '{uuid}' in request.")
                 discovered_uuids.add(uuid)
             label = step_dict.get("label", None)
             if label:
                 if label in discovered_labels:
-                    raise exceptions.DuplicatedIdentifierException("Duplicated step label in request.")
+                    raise exceptions.DuplicatedIdentifierException(f"Duplicated step label '{label}' in request.")
                 discovered_labels.add(label)
 
             if 'workflow_outputs' in step_dict:
@@ -1297,13 +1297,13 @@ class WorkflowContentsManager(UsesAnnotations):
                         output_label = output_dict.get("label", None)
                         if output_label:
                             if label in discovered_output_labels:
-                                raise exceptions.DuplicatedIdentifierException("Duplicated workflow output label in request.")
+                                raise exceptions.DuplicatedIdentifierException(f"Duplicated workflow output label '{label}' in request.")
                             discovered_output_labels.add(label)
 
                         output_uuid = step_dict.get("output_uuid", None)
                         if output_uuid:
                             if output_uuid in discovered_output_uuids:
-                                raise exceptions.DuplicatedIdentifierException("Duplicate workflow output UUID in request.")
+                                raise exceptions.DuplicatedIdentifierException(f"Duplicate workflow output UUID '{output_uuid}' in request.")
                             discovered_output_uuids.add(uuid)
 
             yield step_dict


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12034.
We might also want to highlight the nodes in question or make them
activatable from the modal, and also prevent saving in the first place.
But even if we should do that we should catch errors like this.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
https://github.com/galaxyproject/galaxy/issues/12034 has instructions.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.

<img width="794" alt="Screenshot 2021-06-10 at 10 52 28" src="https://user-images.githubusercontent.com/6804901/121496425-bdd77680-c9da-11eb-82d7-70e9a9437943.png">
