### PR TITLE
[21.05] Add failed-to-submit error handling for simplified workflow run form

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRun.test.js
+++ b/client/src/components/Workflow/Run/WorkflowRun.test.js
@@ -58,4 +58,23 @@ describe("WorkflowRun.vue", () => {
         expect(model.hasStepVersionChanges).toBe(false);
         expect(model.wpInputs.wf_param.label).toBe("wf_param");
     });
+
+    it("displays submission error", async () => {
+        // waits for vue to render wrapper
+        await localVue.nextTick();
+
+        expect(wrapper.vm.loading).toBe(true);
+        expect(wrapper.vm.error).toBeNull();
+        expect(wrapper.vm.model).toBeNull();
+
+        await watchForChange({ vm: wrapper.vm, propName: "loading" });
+
+        expect(wrapper.vm.error).toBeNull();
+        expect(wrapper.vm.loading).toBe(false);
+        expect(wrapper.find("b-alert-stub").exists()).toBe(false);
+        wrapper.vm.handleSubmissionError("Some exception here");
+        await localVue.nextTick();
+        expect(wrapper.vm.submissionError).toBe("Some exception here");
+        expect(wrapper.find("b-alert-stub").attributes("variant")).toEqual("danger");
+    });
 });

--- a/client/src/components/Workflow/Run/WorkflowRun.vue
+++ b/client/src/components/Workflow/Run/WorkflowRun.vue
@@ -25,6 +25,9 @@
                         instance. To upgrade your workflow and dismiss this message simply edit the workflow and re-save
                         it.
                     </b-alert>
+                    <b-alert v-if="submissionError" variant="danger" show>
+                        Workflow submission failed: {{ submissionError }}
+                    </b-alert>
                 </div>
                 <!-- h4 as a class here looks odd but it was in the Backbone -->
                 <div class="ui-form-composite-header h4">
@@ -56,6 +59,7 @@
                         :target-history="simpleFormTargetHistory"
                         :use-job-cache="simpleFormUseJobCache"
                         @submissionSuccess="handleInvocations"
+                        @submissionError="handleSubmissionError"
                     />
                     <!-- Options to default one way or the other, disable if admins want, etc.. -->
                     <a href="#" @click="showAdvanced">Expand to full workflow form.</a>
@@ -111,6 +115,7 @@ export default {
             runButtonPercentage: -1,
             invocations: null,
             simpleForm: null,
+            submissionError: null,
             model: null,
         };
     },
@@ -160,6 +165,7 @@ export default {
     methods: {
         execute() {
             this.$refs.runform.execute();
+            this.submissionError = null;
         },
         setRunButtonStatus(enabled, waitText, percentage) {
             this.runButtonEnabled = enabled;
@@ -168,6 +174,9 @@ export default {
         },
         handleInvocations(invocations) {
             this.invocations = invocations;
+        },
+        handleSubmissionError(error) {
+            this.submissionError = errorMessageAsString(error);
         },
         showAdvanced() {
             this.simpleForm = false;

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -105,6 +105,7 @@ export default {
                 })
                 .catch((error) => {
                     console.log(error);
+                    this.$emit("submissionError", error);
                 });
         },
     },


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/10268#issuecomment-716614591

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
