### PR TITLE
[21.05] Fix history audit table row trigger

### DIFF
--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
-        image: postgres:13
+        image: postgres:9.6
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -12,6 +12,7 @@ jobs:
         python-version: ['3.7']
     services:
       postgres:
+        # Run tests on the oldest Galaxy-supported version
         image: postgres:9.6
         env:
           POSTGRES_USER: postgres

--- a/lib/galaxy/model/migrate/triggers/update_audit_table.py
+++ b/lib/galaxy/model/migrate/triggers/update_audit_table.py
@@ -107,7 +107,9 @@ def _postgres_install(engine):
         return f"""
             CREATE TRIGGER {trigger_name}
             {when} {operation} ON {source_table}
-            FOR EACH ROW EXECUTE {function_keyword} {fn}();
+            FOR EACH ROW
+            WHEN (NEW.{id_field} IS NOT NULL)
+            EXECUTE {function_keyword} {fn}();
         """
 
     # pick row or statement triggers depending on postgres version


### PR DESCRIPTION
The row trigger definition in postgres doesn't check for non-null values, failing on usegalaxy.eu.
I've changed the legacy paste API tests to run against postgresql 9.6, so that that branch is tested as well.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
