### PR TITLE
Add FastAPI routes for Library Folders

### DIFF
--- a/lib/galaxy/managers/folders.py
+++ b/lib/galaxy/managers/folders.py
@@ -138,7 +138,7 @@ class FolderManager:
         folder_dict['id'] = f"F{folder_dict['id']}"
         if folder_dict['parent_id'] is not None:
             folder_dict['parent_id'] = f"F{folder_dict['parent_id']}"
-        folder_dict['update_time'] = folder.update_time.strftime("%Y-%m-%d %I:%M %p")
+        folder_dict['update_time'] = folder.update_time
         return folder_dict
 
     def create(self, trans, parent_folder_id, new_folder_name, new_folder_description=''):

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -2,21 +2,13 @@
 Manager and Serializer for libraries.
 """
 import logging
-from datetime import datetime
-from enum import Enum
 from typing import (
     Any,
     Dict,
-    List,
     Optional,
-    Tuple,
     Union,
 )
 
-from pydantic import (
-    BaseModel,
-    Field,
-)
 from sqlalchemy import and_, false, not_, or_, true
 from sqlalchemy.orm.exc import MultipleResultsFound
 from sqlalchemy.orm.exc import NoResultFound
@@ -25,15 +17,20 @@ from galaxy import (
     exceptions,
     util,
 )
-from galaxy.managers import (
-    folders,
-)
 from galaxy.managers.context import ProvidesAppContext
-from galaxy.managers.roles import (
-    BasicRoleModel,
-    RoleManager,
-)
+from galaxy.managers.folders import FolderManager
+from galaxy.managers.roles import RoleManager
 from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import (
+    CreateLibraryPayload,
+    LibraryAvailablePermissions,
+    LibraryCurrentPermissions,
+    LibraryLegacySummary,
+    LibraryPermissionScope,
+    LibrarySummary,
+    LibrarySummaryList,
+    UpdateLibraryPayload,
+)
 from galaxy.util import (
     pretty_print_time_interval,
     unicodify,
@@ -98,7 +95,7 @@ class LibraryManager:
             library.name = name
             changed = True
             #  When library is renamed the root folder has to be renamed too.
-            folder_manager = folders.FolderManager()
+            folder_manager = FolderManager()
             folder_manager.update(trans, library.root_folder, name=name)
         if description is not None:
             library.description = description
@@ -334,252 +331,6 @@ def get_containing_library_from_library_dataset(trans, library_dataset):
     return None
 
 
-class LibraryLegacySummary(BaseModel):
-    model_class: str = Field(
-        "Library", const=True,
-        title="Model class",
-        description="The name of the database model class.",
-    )
-    id: EncodedDatabaseIdField = Field(
-        ...,
-        title="ID",
-        description="Encoded ID of the Library.",
-    )
-    name: str = Field(
-        ...,
-        title="Name",
-        description="The name of the Library.",
-    )
-    description: Optional[str] = Field(
-        "",
-        title="Description",
-        description="A detailed description of the Library.",
-    )
-    synopsis: Optional[str] = Field(
-        None,
-        title="Description",
-        description="A short text describing the contents of the Library.",
-    )
-    root_folder_id: EncodedDatabaseIdField = Field(
-        ...,
-        title="Root Folder ID",
-        description="Encoded ID of the Library's base folder.",
-    )
-    create_time: datetime = Field(
-        ...,
-        title="Create Time",
-        description="The time and date this item was created.",
-    )
-    deleted: bool = Field(
-        ...,
-        title="Deleted",
-        description="Whether this Library has been deleted.",
-    )
-
-
-class LibrarySummary(LibraryLegacySummary):
-    create_time_pretty: str = Field(  # This is somewhat redundant, maybe the client can do this with `create_time`?
-        ...,
-        title="Create Time Pretty",
-        description="Nice time representation of the creation date.",
-        example="2 months ago",
-    )
-    public: bool = Field(
-        ...,
-        title="Public",
-        description="Whether this Library has been deleted.",
-    )
-    can_user_add: bool = Field(
-        ...,
-        title="Can User Add",
-        description="Whether the current user can add contents to this Library.",
-    )
-    can_user_modify: bool = Field(
-        ...,
-        title="Can User Modify",
-        description="Whether the current user can modify this Library.",
-    )
-    can_user_manage: bool = Field(
-        ...,
-        title="Can User Manage",
-        description="Whether the current user can manage the Library and its contents.",
-    )
-
-
-class LibrarySummaryList(BaseModel):
-    __root__: List[LibrarySummary] = Field(
-        default=[],
-        title='List with summary information of Libraries.',
-    )
-
-
-class CreateLibraryPayload(BaseModel):
-    name: str = Field(
-        ...,
-        title="Name",
-        description="The name of the Library.",
-    )
-    description: Optional[str] = Field(
-        "",
-        title="Description",
-        description="A detailed description of the Library.",
-    )
-    synopsis: Optional[str] = Field(
-        "",
-        title="Synopsis",
-        description="A short text describing the contents of the Library.",
-    )
-
-
-class UpdateLibraryPayload(BaseModel):
-    name: Optional[str] = Field(
-        None,
-        title="Name",
-        description="The new name of the Library. Leave unset to keep the existing.",
-    )
-    description: Optional[str] = Field(
-        None,
-        title="Description",
-        description="A detailed description of the Library. Leave unset to keep the existing.",
-    )
-    synopsis: Optional[str] = Field(
-        None,
-        title="Synopsis",
-        description="A short text describing the contents of the Library. Leave unset to keep the existing.",
-    )
-
-
-class DeleteLibraryPayload(BaseModel):
-    undelete: bool = Field(
-        ...,
-        title="Undelete",
-        description="Whether to restore this previously deleted library.",
-    )
-
-
-class LibraryPermissionScope(str, Enum):
-    current = "current"
-    available = "available"
-
-
-# The tuple should probably be another proper model instead?
-# Keeping it as a Tuple for now for backward compatibility
-RoleNameIdTuple = Tuple[str, EncodedDatabaseIdField]
-
-
-class LibraryCurrentPermissions(BaseModel):
-    access_library_role_list: List[RoleNameIdTuple] = Field(
-        ...,
-        title="Access Role List",
-        description="A list containing pairs of role names and corresponding encoded IDs which have access to the Library.",
-    )
-    modify_library_role_list: List[RoleNameIdTuple] = Field(
-        ...,
-        title="Modify Role List",
-        description="A list containing pairs of role names and corresponding encoded IDs which can modify the Library.",
-    )
-    manage_library_role_list: List[RoleNameIdTuple] = Field(
-        ...,
-        title="Manage Role List",
-        description="A list containing pairs of role names and corresponding encoded IDs which can manage the Library.",
-    )
-    add_library_item_role_list: List[RoleNameIdTuple] = Field(
-        ...,
-        title="Add Role List",
-        description="A list containing pairs of role names and corresponding encoded IDs which can add items to the Library.",
-    )
-
-
-class LibraryAvailablePermissions(BaseModel):
-    roles: List[BasicRoleModel] = Field(
-        ...,
-        title="Roles",
-        description="A list available roles that can be assigned to a particular permission.",
-    )
-    page: int = Field(
-        ...,
-        title="Page",
-        description="Current page .",
-    )
-    page_limit: int = Field(
-        ...,
-        title="Page Limit",
-        description="Maximum number of items per page.",
-    )
-    total: int = Field(
-        ...,
-        title="Total",
-        description="Total number of items",
-    )
-
-
-RoleIdList = Union[List[EncodedDatabaseIdField], EncodedDatabaseIdField]  # Should we support just List[EncodedDatabaseIdField] in the future?
-
-
-class LegacyLibraryPermissionsPayload(BaseModel):
-    LIBRARY_ACCESS_in: Optional[RoleIdList] = Field(
-        [],
-        title="Access IDs",
-        description="A list of role encoded IDs defining roles that should have access permission on the library.",
-    )
-    LIBRARY_MODIFY_in: Optional[RoleIdList] = Field(
-        [],
-        title="Add IDs",
-        description="A list of role encoded IDs defining roles that should be able to add items to the library.",
-    )
-    LIBRARY_ADD_in: Optional[RoleIdList] = Field(
-        [],
-        title="Manage IDs",
-        description="A list of role encoded IDs defining roles that should have manage permission on the library.",
-    )
-    LIBRARY_MANAGE_in: Optional[RoleIdList] = Field(
-        [],
-        title="Modify IDs",
-        description="A list of role encoded IDs defining roles that should have modify permission on the library.",
-    )
-
-
-class LibraryPermissionAction(str, Enum):
-    set_permissions = "set_permissions"
-    remove_restrictions = "remove_restrictions"  # name inconsistency? should be `make_public`?
-
-
-class LibraryPermissionsPayload(BaseModel):
-    class Config:
-        use_enum_values = True  # When using .dict()
-        allow_population_by_alias = True
-
-    action: Optional[LibraryPermissionAction] = Field(
-        ...,
-        title="Action",
-        description="Indicates what action should be performed on the Library.",
-    )
-    access_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="access_ids[]",  # Added for backward compatibility but it looks really ugly...
-        title="Access IDs",
-        description="A list of role encoded IDs defining roles that should have access permission on the library.",
-    )
-    add_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="add_ids[]",
-        title="Add IDs",
-        description="A list of role encoded IDs defining roles that should be able to add items to the library.",
-    )
-    manage_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="manage_ids[]",
-        title="Manage IDs",
-        description="A list of role encoded IDs defining roles that should have manage permission on the library.",
-    )
-    modify_ids: Optional[RoleIdList] = Field(
-        [],
-        alias="modify_ids[]",
-        title="Modify IDs",
-        description="A list of role encoded IDs defining roles that should have modify permission on the library.",
-    )
-
-
 class LibrariesService:
     """
     Interface/service object for sharing logic between controllers.
@@ -587,7 +338,7 @@ class LibrariesService:
 
     def __init__(
         self,
-        folder_manager: folders.FolderManager,
+        folder_manager: FolderManager,
         library_manager: LibraryManager,
         role_manager: RoleManager,
     ):

--- a/lib/galaxy/managers/roles.py
+++ b/lib/galaxy/managers/roles.py
@@ -2,12 +2,7 @@
 Manager and Serializer for Roles.
 """
 import logging
-from typing import List, Optional
 
-from pydantic import (
-    BaseModel,
-    Field,
-)
 from sqlalchemy import false
 from sqlalchemy.orm import exc as sqlalchemy_exceptions
 
@@ -17,33 +12,9 @@ from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.managers import base
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import Role
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.util import unicodify
 
 log = logging.getLogger(__name__)
-
-RoleIdField = Field(title="ID", description="Encoded ID of the role")
-RoleNameField = Field(title="Name", description="Name of the role")
-RoleDescriptionField = Field(title="Description", description="Description of the role")
-
-
-class BasicRoleModel(BaseModel):
-    id: EncodedDatabaseIdField = RoleIdField
-    name: str = RoleNameField
-    type: str = Field(title="Type", description="Type or category of the role")
-
-
-class RoleModel(BasicRoleModel):
-    description: str = RoleDescriptionField
-    url: str = Field(title="URL", description="URL for the role")
-    model_class: str = Field(title="Model class", description="Database model class (Role)")
-
-
-class RoleDefinitionModel(BaseModel):
-    name: str = RoleNameField
-    description: str = RoleDescriptionField
-    user_ids: Optional[List[EncodedDatabaseIdField]] = Field(title="User IDs", default=[])
-    group_ids: Optional[List[EncodedDatabaseIdField]] = Field(title="Group IDs", default=[])
 
 
 class RoleManager(base.ModelManager):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -1588,3 +1589,262 @@ class WorkflowToExport(BaseModel):
         title="Steps",
         description="A dictionary with information about all the steps of the workflow."
     )
+
+
+# Roles -----------------------------------------------------------------
+
+RoleIdField = Field(title="ID", description="Encoded ID of the role")
+RoleNameField = Field(title="Name", description="Name of the role")
+RoleDescriptionField = Field(title="Description", description="Description of the role")
+
+
+class BasicRoleModel(BaseModel):
+    id: EncodedDatabaseIdField = RoleIdField
+    name: str = RoleNameField
+    type: str = Field(title="Type", description="Type or category of the role")
+
+
+class RoleModel(BasicRoleModel):
+    description: str = RoleDescriptionField
+    url: str = Field(title="URL", description="URL for the role")
+    model_class: str = Field(title="Model class", description="Database model class (Role)")
+
+
+class RoleDefinitionModel(BaseModel):
+    name: str = RoleNameField
+    description: str = RoleDescriptionField
+    user_ids: Optional[List[EncodedDatabaseIdField]] = Field(title="User IDs", default=[])
+    group_ids: Optional[List[EncodedDatabaseIdField]] = Field(title="Group IDs", default=[])
+
+
+class RoleListModel(BaseModel):
+    __root__: List[RoleModel]
+
+
+# The tuple should probably be another proper model instead?
+# Keeping it as a Tuple for now for backward compatibility
+RoleNameIdTuple = Tuple[str, EncodedDatabaseIdField]
+
+
+# Libraries -----------------------------------------------------------------
+
+
+class LibraryPermissionScope(str, Enum):
+    current = "current"
+    available = "available"
+
+
+class LibraryLegacySummary(BaseModel):
+    model_class: str = ModelClassField("Library")
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="Encoded ID of the Library.",
+    )
+    name: str = Field(
+        ...,
+        title="Name",
+        description="The name of the Library.",
+    )
+    description: Optional[str] = Field(
+        "",
+        title="Description",
+        description="A detailed description of the Library.",
+    )
+    synopsis: Optional[str] = Field(
+        None,
+        title="Description",
+        description="A short text describing the contents of the Library.",
+    )
+    root_folder_id: EncodedDatabaseIdField = Field(
+        ...,
+        title="Root Folder ID",
+        description="Encoded ID of the Library's base folder.",
+    )
+    create_time: datetime = Field(
+        ...,
+        title="Create Time",
+        description="The time and date this item was created.",
+    )
+    deleted: bool = Field(
+        ...,
+        title="Deleted",
+        description="Whether this Library has been deleted.",
+    )
+
+
+class LibrarySummary(LibraryLegacySummary):
+    create_time_pretty: str = Field(  # This is somewhat redundant, maybe the client can do this with `create_time`?
+        ...,
+        title="Create Time Pretty",
+        description="Nice time representation of the creation date.",
+        example="2 months ago",
+    )
+    public: bool = Field(
+        ...,
+        title="Public",
+        description="Whether this Library has been deleted.",
+    )
+    can_user_add: bool = Field(
+        ...,
+        title="Can User Add",
+        description="Whether the current user can add contents to this Library.",
+    )
+    can_user_modify: bool = Field(
+        ...,
+        title="Can User Modify",
+        description="Whether the current user can modify this Library.",
+    )
+    can_user_manage: bool = Field(
+        ...,
+        title="Can User Manage",
+        description="Whether the current user can manage the Library and its contents.",
+    )
+
+
+class LibrarySummaryList(BaseModel):
+    __root__: List[LibrarySummary] = Field(
+        default=[],
+        title='List with summary information of Libraries.',
+    )
+
+
+class CreateLibraryPayload(BaseModel):
+    name: str = Field(
+        ...,
+        title="Name",
+        description="The name of the Library.",
+    )
+    description: Optional[str] = Field(
+        "",
+        title="Description",
+        description="A detailed description of the Library.",
+    )
+    synopsis: Optional[str] = Field(
+        "",
+        title="Synopsis",
+        description="A short text describing the contents of the Library.",
+    )
+
+
+class UpdateLibraryPayload(BaseModel):
+    name: Optional[str] = Field(
+        None,
+        title="Name",
+        description="The new name of the Library. Leave unset to keep the existing.",
+    )
+    description: Optional[str] = Field(
+        None,
+        title="Description",
+        description="A detailed description of the Library. Leave unset to keep the existing.",
+    )
+    synopsis: Optional[str] = Field(
+        None,
+        title="Synopsis",
+        description="A short text describing the contents of the Library. Leave unset to keep the existing.",
+    )
+
+
+class DeleteLibraryPayload(BaseModel):
+    undelete: bool = Field(
+        ...,
+        title="Undelete",
+        description="Whether to restore this previously deleted library.",
+    )
+
+
+class LibraryCurrentPermissions(BaseModel):
+    access_library_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Access Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which have access to the Library.",
+    )
+    modify_library_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Modify Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which can modify the Library.",
+    )
+    manage_library_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Manage Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which can manage the Library.",
+    )
+    add_library_item_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Add Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which can add items to the Library.",
+    )
+
+
+RoleIdList = Union[List[EncodedDatabaseIdField], EncodedDatabaseIdField]  # Should we support just List[EncodedDatabaseIdField] in the future?
+
+
+class LegacyLibraryPermissionsPayload(BaseModel):
+    LIBRARY_ACCESS_in: Optional[RoleIdList] = Field(
+        [],
+        title="Access IDs",
+        description="A list of role encoded IDs defining roles that should have access permission on the library.",
+    )
+    LIBRARY_MODIFY_in: Optional[RoleIdList] = Field(
+        [],
+        title="Add IDs",
+        description="A list of role encoded IDs defining roles that should be able to add items to the library.",
+    )
+    LIBRARY_ADD_in: Optional[RoleIdList] = Field(
+        [],
+        title="Manage IDs",
+        description="A list of role encoded IDs defining roles that should have manage permission on the library.",
+    )
+    LIBRARY_MANAGE_in: Optional[RoleIdList] = Field(
+        [],
+        title="Modify IDs",
+        description="A list of role encoded IDs defining roles that should have modify permission on the library.",
+    )
+
+
+class LibraryPermissionAction(str, Enum):
+    set_permissions = "set_permissions"
+    remove_restrictions = "remove_restrictions"  # name inconsistency? should be `make_public`?
+
+
+
+class LibraryPermissionsPayloadBase(BaseModel):
+    class Config:
+        use_enum_values = True  # When using .dict()
+        allow_population_by_alias = True
+
+    add_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="add_ids[]",
+        title="Add IDs",
+        description="A list of role encoded IDs defining roles that should be able to add items to the library.",
+    )
+    manage_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="manage_ids[]",
+        title="Manage IDs",
+        description="A list of role encoded IDs defining roles that should have manage permission on the library.",
+    )
+    modify_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="modify_ids[]",
+        title="Modify IDs",
+        description="A list of role encoded IDs defining roles that should have modify permission on the library.",
+    )
+
+
+
+class LibraryPermissionsPayload(LibraryPermissionsPayloadBase):
+    action: Optional[LibraryPermissionAction] = Field(
+        ...,
+        title="Action",
+        description="Indicates what action should be performed on the Library.",
+    )
+    access_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="access_ids[]",  # Added for backward compatibility but it looks really ugly...
+        title="Access IDs",
+        description="A list of role encoded IDs defining roles that should have access permission on the library.",
+    )
+
+

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1807,7 +1807,6 @@ class LibraryPermissionAction(str, Enum):
     remove_restrictions = "remove_restrictions"  # name inconsistency? should be `make_public`?
 
 
-
 class LibraryPermissionsPayloadBase(BaseModel):
     class Config:
         use_enum_values = True  # When using .dict()
@@ -1833,7 +1832,6 @@ class LibraryPermissionsPayloadBase(BaseModel):
     )
 
 
-
 class LibraryPermissionsPayload(LibraryPermissionsPayloadBase):
     action: Optional[LibraryPermissionAction] = Field(
         ...,
@@ -1848,3 +1846,124 @@ class LibraryPermissionsPayload(LibraryPermissionsPayloadBase):
     )
 
 
+# Library Folders -----------------------------------------------------------------
+
+class LibraryFolderPermissionAction(str, Enum):
+    set_permissions = "set_permissions"
+
+
+FolderNameField: str = Field(
+    ...,
+    title="Name",
+    description="The name of the library folder.",
+)
+FolderDescriptionField: Optional[str] = Field(
+    "",
+    title="Description",
+    description="A detailed description of the library folder.",
+)
+
+
+class LibraryFolderPermissionsPayload(LibraryPermissionsPayloadBase):
+    action: Optional[LibraryFolderPermissionAction] = Field(
+        None,
+        title="Action",
+        description="Indicates what action should be performed on the library folder.",
+    )
+
+
+class LibraryFolderDetails(BaseModel):
+    model_class: str = ModelClassField("LibraryFolder")
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="Encoded ID of the library folder.",
+    )
+    name: str = FolderNameField
+    description: Optional[str] = FolderDescriptionField
+    item_count: int = Field(
+        ...,
+        title="Item Count",
+        description="A detailed description of the library folder.",
+    )
+    parent_library_id: EncodedDatabaseIdField = Field(
+        ...,
+        title="Parent Library ID",
+        description="Encoded ID of the Library this folder belongs to.",
+    )
+    parent_id: Optional[EncodedDatabaseIdField] = Field(
+        None,
+        title="Parent Folder ID",
+        description="Encoded ID of the parent folder. Empty if it's the root folder.",
+    )
+    genome_build: str = GenomeBuildField
+    update_time: datetime = UpdateTimeField
+    deleted: bool = Field(
+        ...,
+        title="Deleted",
+        description="Whether this folder is marked as deleted.",
+    )
+    library_path: List[str] = Field(
+        [],
+        title="Path",
+        description="The list of folder names composing the path to this folder.",
+    )
+
+
+class CreateLibraryFolderPayload(BaseModel):
+    name: str = FolderNameField
+    description: Optional[str] = FolderDescriptionField
+
+
+class UpdateLibraryFolderPayload(BaseModel):
+    name: Optional[str] = Field(
+        default=None,
+        title="Name",
+        description="The new name of the library folder.",
+    )
+    description: Optional[str] = Field(
+        default=None,
+        title="Description",
+        description="The new description of the library folder.",
+    )
+
+
+class LibraryAvailablePermissions(BaseModel):
+    roles: List[BasicRoleModel] = Field(
+        ...,
+        title="Roles",
+        description="A list available roles that can be assigned to a particular permission.",
+    )
+    page: int = Field(
+        ...,
+        title="Page",
+        description="Current page .",
+    )
+    page_limit: int = Field(
+        ...,
+        title="Page Limit",
+        description="Maximum number of items per page.",
+    )
+    total: int = Field(
+        ...,
+        title="Total",
+        description="Total number of items",
+    )
+
+
+class LibraryFolderCurrentPermissions(BaseModel):
+    modify_folder_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Modify Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which can modify the Library folder.",
+    )
+    manage_folder_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Manage Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which can manage the Library folder.",
+    )
+    add_library_item_role_list: List[RoleNameIdTuple] = Field(
+        ...,
+        title="Add Role List",
+        description="A list containing pairs of role names and corresponding encoded IDs which can add items to the Library folder.",
+    )

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -2,19 +2,177 @@
 API operations on library folders.
 """
 import logging
+from typing import (
+    Optional,
+    Union,
+)
+
+from fastapi import (
+    Body,
+    Path,
+    Query,
+)
 
 from galaxy import (
     exceptions,
     util
 )
+from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.folders import FoldersService
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import (
+    CreateLibraryFolderPayload,
+    LibraryAvailablePermissions,
+    LibraryFolderCurrentPermissions,
+    LibraryFolderDetails,
+    LibraryFolderPermissionAction,
+    LibraryFolderPermissionsPayload,
+    LibraryPermissionScope,
+    UpdateLibraryFolderPayload,
+)
 from galaxy.web import expose_api
 from . import (
     BaseGalaxyAPIController,
     depends,
+    DependsOnTrans,
+    Router,
 )
 
 log = logging.getLogger(__name__)
+
+router = Router(tags=['folders'])
+
+FolderIdPathParam: EncodedDatabaseIdField = Path(
+    ...,
+    title="Folder ID",
+    description="The encoded identifier of the library folder."
+)
+
+UndeleteQueryParam: Optional[bool] = Query(
+    default=None,
+    title="Undelete",
+    description="Whether to restore a deleted library folder."
+)
+
+
+@router.cbv
+class FastAPIFolders:
+    service: FoldersService = depends(FoldersService)
+
+    @router.get(
+        '/api/folders/{id}',
+        summary="Displays information about a particular library folder.",
+    )
+    def show(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = FolderIdPathParam,
+    ) -> LibraryFolderDetails:
+        """Returns detailed information about the library folder with the given ID."""
+        return self.service.show(trans, id)
+
+    @router.post(
+        '/api/folders/{id}',
+        summary="Create a new library folder underneath the one specified by the ID.",
+    )
+    def create(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = FolderIdPathParam,
+        payload: CreateLibraryFolderPayload = Body(...)
+
+    ) -> LibraryFolderDetails:
+        """Returns detailed information about the newly created library folder."""
+        return self.service.create(trans, id, payload)
+
+    @router.put(
+        '/api/folders/{id}',
+        summary="Updates the information of an existing library folder.",
+    )
+    @router.patch('/api/folders/{id}')
+    def update(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = FolderIdPathParam,
+        payload: UpdateLibraryFolderPayload = Body(...),
+    ) -> LibraryFolderDetails:
+        """Updates the information of an existing library folder."""
+        return self.service.update(trans, id, payload)
+
+    @router.delete(
+        '/api/folders/{id}',
+        summary="Marks the specified library folder as deleted (or undeleted).",
+    )
+    def delete(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = FolderIdPathParam,
+        undelete: Optional[bool] = UndeleteQueryParam,
+    ) -> LibraryFolderDetails:
+        """Marks the specified library folder as deleted (or undeleted)."""
+        return self.service.delete(trans, id, undelete)
+
+    @router.get(
+        '/api/folders/{id}/permissions',
+        summary="Gets the current or available permissions of a particular library folder.",
+    )
+    def get_permissions(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = FolderIdPathParam,
+        scope: Optional[LibraryPermissionScope] = Query(
+            None, title="Scope",
+            description="The scope of the permissions to retrieve. Either the `current` permissions or the `available`."
+        ),
+        page: Optional[int] = Query(
+            default=1,
+            title="Page",
+            description="The page number to retrieve when paginating the available roles."
+        ),
+        page_limit: Optional[int] = Query(
+            default=10,
+            title="Page Limit",
+            description="The maximum number of permissions per page when paginating."
+        ),
+        q: Optional[str] = Query(
+            None, title="Query",
+            description="Optional search text to retrieve only the roles matching this query."
+        ),
+    ) -> Union[LibraryFolderCurrentPermissions, LibraryAvailablePermissions]:
+        """Gets the current or available permissions of a particular library.
+        The results can be paginated and additionally filtered by a query."""
+        return self.service.get_permissions(
+            trans,
+            id,
+            scope,
+            page,
+            page_limit,
+            q,
+        )
+
+    @router.post(
+        '/api/folders/{id}/permissions',
+        summary="Sets the permissions to manage a library folder.",
+    )
+    def set_permissions(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = FolderIdPathParam,
+        action: Optional[LibraryFolderPermissionAction] = Query(
+            default=None,
+            title="Action",
+            description=(
+                "Indicates what action should be performed on the Library. "
+                f"Currently only `{LibraryFolderPermissionAction.set_permissions}` is supported."
+            ),
+        ),
+        payload: LibraryFolderPermissionsPayload = Body(...),
+    ) -> LibraryFolderCurrentPermissions:
+        """Sets the permissions to manage a library folder."""
+        payload_dict = payload.dict(by_alias=True)
+        if isinstance(payload, LibraryFolderPermissionsPayload) and action is not None:
+            payload_dict["action"] = action
+        return self.service.set_permissions(trans, id, payload_dict)
 
 
 class FoldersController(BaseGalaxyAPIController):

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -253,7 +253,7 @@ class FoldersController(BaseGalaxyAPIController):
         return self.service.get_permissions(trans, encoded_folder_id, scope, page, page_limit, query)
 
     @expose_api
-    def set_permissions(self, trans, encoded_folder_id, payload, **kwd):
+    def set_permissions(self, trans, encoded_folder_id, payload: dict, **kwd):
         """
         POST /api/folders/{encoded_folder_id}/permissions
 
@@ -277,6 +277,8 @@ class FoldersController(BaseGalaxyAPIController):
         :rtype:     dictionary
         :raises: RequestParameterInvalidException, InsufficientPermissionsException, RequestParameterMissingException
         """
+        if payload:
+            payload.update(kwd)
         return self.service.set_permissions(trans, encoded_folder_id, payload)
 
     @expose_api

--- a/lib/galaxy/webapps/galaxy/api/folders.py
+++ b/lib/galaxy/webapps/galaxy/api/folders.py
@@ -67,7 +67,8 @@ class FoldersController(BaseGalaxyAPIController):
         :rtype:     dictionary
         :raises: RequestParameterMissingException
         """
-        return self.service.create(trans, encoded_parent_folder_id, payload)
+        create_payload = CreateLibraryFolderPayload(**payload)
+        return self.service.create(trans, encoded_parent_folder_id, create_payload)
 
     @expose_api
     def get_permissions(self, trans, encoded_folder_id, **kwd):
@@ -166,4 +167,5 @@ class FoldersController(BaseGalaxyAPIController):
 
         :raises: RequestParameterMissingException
         """
-        return self.service.update(trans, encoded_folder_id, payload)
+        update_payload = UpdateLibraryFolderPayload(**payload)
+        return self.service.update(trans, encoded_folder_id, update_payload)

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -17,11 +17,12 @@ from fastapi import (
 
 from galaxy import util
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.managers.libraries import (
+from galaxy.managers.libraries import LibrariesService
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import (
     CreateLibraryPayload,
     DeleteLibraryPayload,
     LegacyLibraryPermissionsPayload,
-    LibrariesService,
     LibraryAvailablePermissions,
     LibraryCurrentPermissions,
     LibraryLegacySummary,
@@ -32,7 +33,6 @@ from galaxy.managers.libraries import (
     LibrarySummaryList,
     UpdateLibraryPayload,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.web import (
     expose_api,
     expose_api_anonymous,

--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -3,24 +3,21 @@ API operations on Role objects.
 """
 import json
 import logging
-from typing import List
 
 from fastapi import (
     Body,
-)
-from pydantic import (
-    BaseModel,
 )
 
 from galaxy import web
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesUserContext
-from galaxy.managers.roles import (
+from galaxy.managers.roles import RoleManager
+from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import (
     RoleDefinitionModel,
-    RoleManager,
+    RoleListModel,
     RoleModel,
 )
-from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.webapps.base.controller import url_for
 from . import (
     BaseGalaxyAPIController,
@@ -35,10 +32,6 @@ log = logging.getLogger(__name__)
 # Empty paths (e.g. /api/roles) only work if a prefix is defined right here.
 # https://github.com/tiangolo/fastapi/pull/415/files
 router = Router(tags=["roles"])
-
-
-class RoleListModel(BaseModel):
-    __root__: List[RoleModel]
 
 
 def role_to_model(trans, role):

--- a/lib/galaxy_test/api/test_folder_contents.py
+++ b/lib/galaxy_test/api/test_folder_contents.py
@@ -210,7 +210,7 @@ class FolderContentsApiTestCase(ApiTestCase):
             "name": name,
             "description": f"The description of {name}",
         }
-        create_response = self._post(f"folders/{folder_id}", data=data)
+        create_response = self._post(f"folders/{folder_id}", data=data, json=True)
         self._assert_status_code_is(create_response, 200)
         folder = create_response.json()
         return folder["id"]
@@ -224,7 +224,7 @@ class FolderContentsApiTestCase(ApiTestCase):
         return ldda["id"]
 
     def _create_content_in_folder_with_payload(self, folder_id: str, payload) -> Any:
-        create_response = self._post(f"folders/{folder_id}/contents", data=payload)
+        create_response = self._post(f"folders/{folder_id}/contents", data=payload, json=True)
         self._assert_status_code_is(create_response, 200)
         return create_response.json()
 

--- a/lib/galaxy_test/api/test_folders.py
+++ b/lib/galaxy_test/api/test_folders.py
@@ -1,3 +1,5 @@
+import json
+
 from galaxy_test.base.populators import LibraryPopulator
 from ._framework import ApiTestCase
 
@@ -35,7 +37,7 @@ class FoldersApiTestCase(ApiTestCase):
             "manage_ids[]": role_id,  # string-lists also supported
             "modify_ids[]": [role_id]
         }
-        response = self._post(f"folders/{folder_id}/permissions?action={action}", data=data, admin=True)
+        response = self._post(f"folders/{folder_id}/permissions?action={action}", data=data, admin=True, json=True)
         self._assert_status_code_is(response, 200)
         new_permissions = response.json()
 
@@ -52,9 +54,9 @@ class FoldersApiTestCase(ApiTestCase):
             "name": updated_name,
             "description": updated_desc,
         }
-        patch_response = self._patch(f"folders/{folder_id}", data=data, admin=True)
-        self._assert_status_code_is(patch_response, 200)
-        updated_folder = patch_response.json()
+        put_response = self._put(f"folders/{folder_id}", data=json.dumps(data), admin=True)
+        self._assert_status_code_is(put_response, 200)
+        updated_folder = put_response.json()
         self._assert_valid_folder(updated_folder)
         assert updated_folder["name"] == updated_name
         assert updated_folder["description"] == updated_desc
@@ -89,8 +91,8 @@ class FoldersApiTestCase(ApiTestCase):
         data = {
             "name": "test",
         }
-        patch_response = self._patch(f"folders/{folder_id}", data=data, admin=True)
-        self._assert_status_code_is(patch_response, 403)
+        put_response = self._put(f"folders/{folder_id}", data=json.dumps(data), admin=True)
+        self._assert_status_code_is(put_response, 403)
 
     def _create_folder(self, name: str):
         root_folder_id = self.library["root_folder_id"]
@@ -98,7 +100,7 @@ class FoldersApiTestCase(ApiTestCase):
             "name": name,
             "description": f"The description of {name}",
         }
-        create_response = self._post(f"folders/{root_folder_id}", data=data, admin=True)
+        create_response = self._post(f"folders/{root_folder_id}", data=data, admin=True, json=True)
         self._assert_status_code_is(create_response, 200)
         folder = create_response.json()
         return folder

--- a/lib/galaxy_test/api/test_folders.py
+++ b/lib/galaxy_test/api/test_folders.py
@@ -1,5 +1,3 @@
-import json
-
 from galaxy_test.base.populators import LibraryPopulator
 from ._framework import ApiTestCase
 
@@ -54,7 +52,7 @@ class FoldersApiTestCase(ApiTestCase):
             "name": updated_name,
             "description": updated_desc,
         }
-        put_response = self._put(f"folders/{folder_id}", data=json.dumps(data), admin=True)
+        put_response = self._put(f"folders/{folder_id}", data=data, admin=True, json=True)
         self._assert_status_code_is(put_response, 200)
         updated_folder = put_response.json()
         self._assert_valid_folder(updated_folder)
@@ -91,7 +89,7 @@ class FoldersApiTestCase(ApiTestCase):
         data = {
             "name": "test",
         }
-        put_response = self._put(f"folders/{folder_id}", data=json.dumps(data), admin=True)
+        put_response = self._put(f"folders/{folder_id}", data=data, admin=True, json=True)
         self._assert_status_code_is(put_response, 403)
 
     def _create_folder(self, name: str):

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -480,7 +480,7 @@ class LibrariesApiTestCase(ApiTestCase):
             description="new subfolder desc",
             name="New Subfolder",
         )
-        return self._post(f"folders/{containing_folder_id}", data=create_data)
+        return self._post(f"folders/{containing_folder_id}", data=create_data, json=True)
 
     def _create_dataset_in_folder_in_library(self, library_name, wait=False):
         library = self.library_populator.new_private_library(library_name)


### PR DESCRIPTION
This is part of the efforts to migrate the full Galaxy API to FastAPI see #10889.

This PR also moves some existing pydantic models to the `lib/galaxy/schema/schema.py` module as discussed in the [Gitter channel](https://gitter.im/galaxyproject/wg-backend) for better reusability.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - It can be also manually tested using the API interactive documentation available at `http://localhost:8080/api/docs/`

![Screenshot from 2021-06-11 20-03-06](https://user-images.githubusercontent.com/46503462/121730534-19475880-caf0-11eb-92bf-1a4ef9686f15.png)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
