### PR TITLE
[21.05] Add switch for optional select in workflow editor

### DIFF
--- a/client/src/mvc/form/form-parameters.js
+++ b/client/src/mvc/form/form-parameters.js
@@ -140,6 +140,7 @@ export default Backbone.Model.extend({
     /** Text input field */
     _fieldText: function (input_def) {
         // field replaces e.g. a select field
+        const inputClass = input_def.optional && input_def.type === "select" ? Ui.NullableText : Ui.Input;
         if (
             ["SelectTagParameter", "ColumnListParameter"].includes(input_def.model_class) ||
             (input_def.options && input_def.data)
@@ -162,7 +163,7 @@ export default Backbone.Model.extend({
             }
         }
         // create input element
-        return new Ui.Input({
+        return new inputClass({
             id: `field-${input_def.id}`,
             type: input_def.type,
             area: input_def.area,
@@ -170,6 +171,7 @@ export default Backbone.Model.extend({
             placeholder: input_def.placeholder,
             datalist: input_def.datalist,
             onchange: input_def.onchange,
+            value: input_def.value,
         });
     },
 

--- a/client/src/mvc/ui/ui-misc.js
+++ b/client/src/mvc/ui/ui-misc.js
@@ -152,6 +152,64 @@ export var Hidden = Backbone.View.extend({
     },
 });
 
+export var NullableText = Input.extend({
+    initialize: function (options) {
+        this.model =
+            (options && options.model) ||
+            new Backbone.Model({
+                type: "text",
+                placeholder: "",
+                disabled: false,
+                readonly: false,
+                visible: true,
+                cls: "",
+                area: false,
+                color: null,
+                style: null,
+                value: null,
+            }).set(options);
+        // Add button that determines whether an optional value should be defined
+        this.optional_button = new Switch({
+            id: `optional-switch-${this.model.id}`,
+        });
+        // Determine true/false value of button based on initial value
+        this.optional_button.model.set("value", this.model.get("value") === null ? "false" : "true");
+        this.toggleButton();
+        this.optional_button.setElement(
+            $(`<div>Set value for this optional select field ?</div>`).append(this.optional_button.$el)
+        );
+        this.tagName = this.model.get("area") ? "textarea" : "input";
+        this.setElement($(`<${this.tagName}/>`));
+        this.listenTo(this.model, "change", this.render, this);
+        this.listenTo(this.optional_button.model, "change", this.toggleButton, this);
+        this.render();
+    },
+    render: function () {
+        Input.prototype.render.call(this);
+        this.optional_button.$el.insertBefore(this.$el);
+    },
+    toggleButton: function () {
+        const setOptional = this.optional_button.model.get("value");
+        if (setOptional === "true") {
+            // Enable text field, set value to `""` if the value is falsy and trigger _onchange
+            this.model.set("disabled", false);
+            !this.model.get("value") && this.model.set("value", "") && this._onchange();
+        } else {
+            // Set text field to disabled, set model value to null and trigger _onchange
+            this.model.set("disabled", true);
+            this.model.set("value", null);
+            this._onchange();
+        }
+    },
+    value: function (new_val) {
+        const setOptional = this.optional_button.model.get("value");
+        if (setOptional === "true") {
+            new_val != undefined && this.model.set("value", typeof new_val === "string" ? new_val : "");
+        }
+        return this.model.get("value");
+    },
+});
+
 /** Creates an input element which switches between select and text field */
 export var TextSelect = Backbone.View.extend({
     initialize: function (options) {
@@ -267,6 +325,7 @@ export default {
     Radio: Options.Radio,
     Switch: Switch,
     Select: Select,
+    NullableText: NullableText,
     TextSelect: TextSelect,
     Hidden: Hidden,
     Slider: Slider,

--- a/client/src/mvc/ui/ui-misc.js
+++ b/client/src/mvc/ui/ui-misc.js
@@ -215,7 +215,8 @@ export var TextSelect = Backbone.View.extend({
     initialize: function (options) {
         this.select = new options.SelectClass.View(options);
         this.model = this.select.model;
-        this.text = new Input({
+        const textInputClass = options.optional ? NullableText : Input;
+        this.text = new textInputClass({
             onchange: this.model.get("onchange"),
         });
         this.on("change", () => {

--- a/client/tests/qunit/tests/ui_tests.js
+++ b/client/tests/qunit/tests/ui_tests.js
@@ -673,6 +673,30 @@ QUnit.test("textarea", function (assert) {
     assert.ok(input.$el.hasClass("_cls"), "Has custom class.");
 });
 
+QUnit.test("nullableText", function (assert) {
+    // Start with null value, optional button should be off
+    var input = new Ui.NullableText({ area: false, value: null });
+    $("body").prepend(input.$el);
+    assert.ok(input.tagName === "input", "input tag");
+    assert.ok(input.value() === null, "null value");
+    assert.ok(input.optional_button.model.get("value") === "false");
+    // toggle button, will set value to `""`
+    input.optional_button.model.set("value", "true");
+    assert.ok(input.value() === "", "Correct new value.");
+    // set value
+    input.model.set("value", "_value");
+    assert.ok(input.value() === "_value", "Correct new value.");
+    assert.ok(input.optional_button.model.get("value") === "true");
+    // toggle button to false, will reset value to null
+    input.optional_button.model.set("value", "false");
+    assert.ok(input.value() === null, "Correct new value.");
+    assert.ok(input.optional_button.model.get("value") === "false");
+    // New input, start with value, optional button should be on
+    var definedInput = new Ui.NullableText({ area: false, value: "123" });
+    assert.ok(definedInput.value() === "123");
+    assert.ok(definedInput.optional_button.model.get("value") === "true");
+});
+
 QUnit.test("message", function (assert) {
     var message = new Ui.Message({
         persistent: true,

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -364,6 +364,8 @@ tool_form:
     options: '#options [data-toggle="dropdown"]'
     execute: 'button#execute'
     parameter_div: 'div.ui-form-element[tour_id="${parameter}"]'
+    parameter_checkbox: 'div.ui-form-element[tour_id="${parameter}"] .ui-switch div'
+    parameter_input: 'div.ui-form-element[tour_id="${parameter}"] .ui-input'
     parameter_textarea: 'div.ui-form-element[tour_id="${parameter}"] textarea'
     reference: '.formatted-reference'
     about: '.tool-footer'

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -930,6 +930,7 @@ class SelectToolParameter(ToolParameter):
             if self.optional and self.tool.profile < 18.09:
                 # Covers optional parameters with default values that reference other optional parameters.
                 # These will have a value but no legal_values.
+                # See https://github.com/galaxyproject/tools-iuc/pull/1842#issuecomment-394083768 for context.
                 return None
             raise ParameterValueError("requires a value, but no legal values defined", self.name, is_dynamic=self.is_dynamic)
         if isinstance(value, list):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -470,7 +470,8 @@ class SubWorkflowModule(WorkflowModule):
 
     def check_and_update_state(self):
         states = (m.check_and_update_state() for m in self.get_modules())
-        return [upgrade_message for upgrade_message in states if upgrade_message] or None
+        # TODO: key ("Step N:") is not currently consumed in UI
+        return {f"Step {i + 1}": upgrade_message for i, upgrade_message in enumerate(states) if upgrade_message} or None
 
     def get_errors(self, **kwargs):
         errors = (module.get_errors(include_tool_id=True) for module in self.get_modules())

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -57,6 +57,16 @@ steps:
 """
 
 
+WORKFLOW_SELECT_FROM_OPTIONAL_DATASET = """
+class: GalaxyWorkflow
+steps:
+  select_from_dataset_optional:
+    tool_id: select_from_dataset_optional
+    state:
+      select_single: null
+"""
+
+
 # Throwing a bunch of broken steps in to get a really long modal and sure it
 # is scrollable.
 WORKFLOW_WITH_INVALID_STATE = """

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -447,6 +447,8 @@ steps:
     def test_editor_subworkflow_tool_upgrade_message(self):
         workflow_populator = self.workflow_populator
         embedded_workflow = yaml.safe_load(WORKFLOW_WITH_OLD_TOOL_VERSION)
+        # Create invalid tool state
+        embedded_workflow['steps']['mul_versions']['state']['inttest'] = 'Invalid'
         outer_workflow = yaml.safe_load("""
 class: GalaxyWorkflow
 inputs:
@@ -463,6 +465,7 @@ steps:
         self.workflow_index_click_option("Edit")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_modal_has_text("Using version '0.2' instead of version '0.0.1'")
+        self.assert_modal_has_text("parameter 'inttest': an integer or workflow parameter is required")
         self.screenshot("workflow_editor_subworkflow_tool_upgrade")
         self.components.workflow_editor.modal_button_continue.wait_for_and_click()
         self.assert_has_changes_and_save()

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.keys import Keys
 from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_NESTED_SIMPLE,
     WORKFLOW_OPTIONAL_TRUE_INPUT_COLLECTION,
+    WORKFLOW_SELECT_FROM_OPTIONAL_DATASET,
     WORKFLOW_SIMPLE_CAT_TWICE,
     WORKFLOW_SIMPLE_MAPPING,
     WORKFLOW_WITH_INVALID_STATE,
@@ -92,14 +93,7 @@ class WorkflowEditorTestCase(SeleniumTestCase):
     @selenium_test
     def test_optional_select_data_field(self):
         editor = self.components.workflow_editor
-        workflow_id = self.workflow_populator.upload_yaml_workflow("""
-class: GalaxyWorkflow
-steps:
-  select_from_dataset_optional:
-    tool_id: select_from_dataset_optional
-    state:
-      select_single: null
-      """)
+        workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SELECT_FROM_OPTIONAL_DATASET)
         self.workflow_index_open()
         self.workflow_index_click_option("Edit")
         editor = self.components.workflow_editor

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -8,6 +8,7 @@ from galaxy_test.base.workflow_fixtures import (
     WORKFLOW_NESTED_SIMPLE,
     WORKFLOW_RENAME_ON_REPLACEMENT_PARAM,
     WORKFLOW_RUNTIME_PARAMETER_SIMPLE,
+    WORKFLOW_SELECT_FROM_OPTIONAL_DATASET,
     WORKFLOW_SIMPLE_CAT_TWICE,
     WORKFLOW_WITH_CUSTOM_REPORT_1,
     WORKFLOW_WITH_CUSTOM_REPORT_1_TEST_DATA,
@@ -198,6 +199,14 @@ steps:
         self.get("workflows/invocations/report?id=%s" % invocation_0["id"])
         self.wait_for_selector_visible(".embedded-dataset")
         self.screenshot("workflow_report_custom_1")
+
+    @selenium_test
+    @managed_history
+    def test_execution_with_null_optional_select_from_data(self):
+        self.open_in_workflow_run(WORKFLOW_SELECT_FROM_OPTIONAL_DATASET)
+        self.workflow_run_submit()
+        history_id = self.current_history_id()
+        self.workflow_populator.wait_for_history_workflows(history_id, expected_invocation_count=1)
 
     def open_in_workflow_run(self, yaml_content):
         name = self.workflow_upload_yaml_with_random_name(yaml_content)

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -46,6 +46,7 @@
   <tool file="filter_multiple_splitter.xml" />
   <tool file="filter_static_regexp.xml" />
   <tool file="select_from_dataset.xml" />
+  <tool file="select_from_dataset_optional.xml" />
   <tool file="dbkey_filter_input.xml" />
   <tool file="dbkey_filter_multi_input.xml" />
   <tool file="dbkey_filter_collection.xml" />

--- a/test/functional/tools/select_from_dataset_optional.xml
+++ b/test/functional/tools/select_from_dataset_optional.xml
@@ -1,0 +1,21 @@
+<tool id="select_from_dataset_optional" name="select_from_dataset_optional" version="0.1.0" profile="21.05">
+    <description>Create dynamic options from data sets</description>
+    <command><![CDATA[
+echo select_single '$select_single' > '$output'
+    ]]></command>
+    <inputs>
+        <param name="single" type="data" optional="true" format="tabular" label="single"/>
+        <param name="select_single" type="select" optional="true" label="select_single">
+            <options from_dataset="single">
+                <column name="name" index="1"/>
+                <column name="value" index="0"/>
+                <validator type="no_options" message="No data is available in single" />
+            </options>
+        </param>
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
If the `Set value for this optional select field ? `switch is set to no, we serialize the value as `null` instead of `""`, which is especially important in optional select fields, where `""` may correspond to an option that is distinct from not setting a value.

I have only enabled this for select parameters that are cast to text parameters, but I think this discrimination between set and unset would also be great for optional text parameters.
There might be a better way to do it in the UI (maybe some icon that indicates that the value is set, that can be toggled with an backspace when the field is empty?), but I think this will do for the relatively rare case of optional select parameters that are cast to text fields.

Fixes https://github.com/galaxyproject/galaxy/issues/12081
Note that this does not not fix any changes to the tool state on a second run, that is a separate bug. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
