### PR TITLE
[21.05] Fix subworkflow tool state upgrade parsing

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -470,7 +470,8 @@ class SubWorkflowModule(WorkflowModule):
 
     def check_and_update_state(self):
         states = (m.check_and_update_state() for m in self.get_modules())
-        return [upgrade_message for upgrade_message in states if upgrade_message] or None
+        # TODO: key ("Step N:") is not currently consumed in UI
+        return {f"Step {i + 1}": upgrade_message for i, upgrade_message in enumerate(states) if upgrade_message} or None
 
     def get_errors(self, **kwargs):
         errors = (module.get_errors(include_tool_id=True) for module in self.get_modules())

--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -409,6 +409,8 @@ steps:
     def test_editor_subworkflow_tool_upgrade_message(self):
         workflow_populator = self.workflow_populator
         embedded_workflow = yaml.safe_load(WORKFLOW_WITH_OLD_TOOL_VERSION)
+        # Create invalid tool state
+        embedded_workflow['steps']['mul_versions']['state']['inttest'] = 'Invalid'
         outer_workflow = yaml.safe_load("""
 class: GalaxyWorkflow
 inputs:
@@ -425,6 +427,7 @@ steps:
         self.workflow_index_click_option("Edit")
         self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_modal_has_text("Using version '0.2' instead of version '0.0.1'")
+        self.assert_modal_has_text("parameter 'inttest': an integer or workflow parameter is required")
         self.screenshot("workflow_editor_subworkflow_tool_upgrade")
         self.components.workflow_editor.modal_button_continue.wait_for_and_click()
         self.assert_has_changes_and_save()


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12137,
broken in https://github.com/galaxyproject/galaxy/pull/12120/

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
