### PR TITLE
Add celerybeat-schedule to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ database/tool_recommendation_model.hdf5
 *.lock
 *.log
 *.pid
+celerybeat-schedule
 
 # Tool Shed Runtime Files
 tool_shed_webapp.lock


### PR DESCRIPTION
With celery enabled configuration this file is automatically created and used to store the last run times of tasks locally, and should be .gitignored.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
