### PR TITLE
Change icon for "Share or Publish" in new history panel

### DIFF
--- a/client/src/components/History/HistoryDetails.vue
+++ b/client/src/components/History/HistoryDetails.vue
@@ -29,7 +29,7 @@
                 <PriorityMenuItem
                     key="share"
                     title="Share or Publish"
-                    icon="fas fa-handshake"
+                    icon="fas fa-share-alt"
                     @click="backboneRoute('/histories/sharing', { id: history.id })"
                 />
                 <PriorityMenuItem


### PR DESCRIPTION
to use the ubiquitous 3-dots icon we already use for workflows (e.g. in client/src/components/History/HistoryDetails.vue ).

![Screenshot from 2021-06-15 12-21-33](https://user-images.githubusercontent.com/4924623/122044473-771bbf00-cdd4-11eb-83ec-b9ddeaea2baf.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy
  2. Check on the top right corner that you see the 3-dots icon for the "Share or Publish" button as in the screenshot

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
