### PR TITLE
[21.05] Wait for uploaded datasets in API tests

### DIFF
--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1573,6 +1573,7 @@ class BaseDatasetCollectionPopulator:
             if contents:
                 new_kwds["content"] = contents[i]
             datasets.append(self.dataset_populator.new_dataset(history_id, **new_kwds))
+        self.dataset_populator.wait_for_history(history_id, assert_ok=True)
         return datasets
 
     def wait_for_dataset_collection(self, create_payload, assert_ok=False, timeout=DEFAULT_TIMEOUT):


### PR DESCRIPTION
Most methods that stage datasets already do that anyway. Might be nice
in the future if we could just cancel running jobs at the end of a test
and not wait for uploads where not necessary, but this should increase
test stability in the short term.

Fixes https://github.com/galaxyproject/galaxy/pull/12136#issuecomment-861531075

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
