### PR TITLE
Cleanup use of refresh/undo/redo/sync icons

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -102,7 +102,7 @@
                     job_id: dataset.creating_job,
                 })
             "
-            icon="fa fa-refresh"
+            icon="fa fa-redo"
         />
 
         <PriorityMenuItem

--- a/client/src/components/History/HistoriesMenu.vue
+++ b/client/src/components/History/HistoriesMenu.vue
@@ -24,7 +24,12 @@
             icon="fas fa-save"
             @click="backboneRoute('/histories/list')"
         />
-        <PriorityMenuItem key="clear-history-cache" title="Clear Cache" icon="fa fa-refresh" @click.stop="clearCache" />
+        <PriorityMenuItem
+            key="clear-history-cache"
+            title="Refresh History"
+            icon="fa fa-sync"
+            @click.stop="clearCache"
+        />
         <PriorityMenuItem
             key="use-legacy-history"
             title="Return to legacy history panel"

--- a/client/src/components/admin/DataManager/DataManagerJob.vue
+++ b/client/src/components/admin/DataManager/DataManagerJob.vue
@@ -20,7 +20,7 @@
                                 <b-row align-v="center">
                                     <b-col cols="auto">
                                         <b-button v-b-tooltip.hover title="Rerun" :href="runUrl">
-                                            <span class="fa fa-refresh" />
+                                            <span class="fa fa-redo" />
                                         </b-button>
                                     </b-col>
                                     <b-col>

--- a/client/src/components/admin/DataManager/DataManagerJobs.vue
+++ b/client/src/components/admin/DataManager/DataManagerJobs.vue
@@ -43,7 +43,7 @@
                 <template v-slot:cell(actions)="row">
                     <b-button-group>
                         <b-button v-b-tooltip.hover title="Rerun" target="_top" :href="jobs[row.index]['runUrl']">
-                            <span class="fa fa-refresh" />
+                            <span class="fa fa-redo" />
                         </b-button>
                         <b-button
                             v-b-tooltip.hover

--- a/client/src/components/admin/DataManager/DataManagerTable.vue
+++ b/client/src/components/admin/DataManager/DataManagerTable.vue
@@ -18,7 +18,7 @@
                                 <b-row align-v="center">
                                     <b-col cols="auto">
                                         <b-button @click="reload()" v-b-tooltip.hover :title="buttonLabel">
-                                            <span class="fa fa-refresh" />
+                                            <span class="fa fa-sync" />
                                         </b-button>
                                     </b-col>
                                     <b-col>

--- a/client/src/components/admin/DataManagerGrid.vue
+++ b/client/src/components/admin/DataManagerGrid.vue
@@ -9,7 +9,7 @@
                         href="javascript:void(0)"
                         @click="handleReloadButtonClick"
                         :title="`Reload ${dataManagerTableName} tool data table`"
-                        ><span class="fa fa-refresh"></span
+                        ><span class="fa fa-sync"></span
                     ></a>
                 </th>
             </tr>

--- a/client/src/components/admin/DisplayApplications.vue
+++ b/client/src/components/admin/DisplayApplications.vue
@@ -1,7 +1,7 @@
 <template>
     <BaseList
         :fields="fields"
-        icon="fa fa-refresh"
+        icon="fa fa-sync"
         tooltip="Refresh"
         plural="display applications"
         success="reloaded"

--- a/client/src/entry/panels/history-panel.js
+++ b/client/src/entry/panels/history-panel.js
@@ -31,7 +31,7 @@ const HistoryPanel = Backbone.View.extend({
             id: "history-refresh-button",
             title: _l("Refresh history"),
             cls: "panel-header-button",
-            icon: "fa fa-refresh",
+            icon: "fa fa-sync",
             onclick: () => {
                 this.historyView.loadCurrentHistory();
             },

--- a/client/src/mvc/dataset/dataset-edit-attributes.js
+++ b/client/src/mvc/dataset/dataset-edit-attributes.js
@@ -136,7 +136,7 @@ var View = Backbone.View.extend({
                 submit_autodetect: new Ui.Button({
                     tooltip:
                         "This will inspect the dataset and attempt to correct the values of fields if they are not accurate.",
-                    icon: "fa-undo",
+                    icon: "fa-redo",
                     title: "Auto-detect",
                     onclick: function () {
                         self._submit("autodetect", form);
@@ -183,7 +183,7 @@ var View = Backbone.View.extend({
                 submit_datatype_detect: new Ui.Button({
                     tooltip: _l("Detect the datatype and change it."),
                     title: _l("Detect datatype"),
-                    icon: "fa-undo",
+                    icon: "fa-redo",
                     onclick: function () {
                         self._submit("datatype_detect", form);
                     },

--- a/client/src/mvc/dataset/dataset-li-edit.js
+++ b/client/src/mvc/dataset/dataset-li-edit.js
@@ -249,7 +249,7 @@ var DatasetListItemEdit = _super.extend(
                     href: this.model.urls.rerun,
                     classes: "rerun-btn",
                     target: this.linkTarget,
-                    faIcon: "fa-refresh",
+                    faIcon: "fa-redo",
                     onclick: function (ev) {
                         const Galaxy = getGalaxyInstance();
                         if (Galaxy.router) {

--- a/client/src/mvc/library/library-dataset-view.js
+++ b/client/src/mvc/library/library-dataset-view.js
@@ -473,7 +473,7 @@ var LibraryDatasetView = Backbone.View.extend({
                         <button data-toggle="tooltip" data-placement="top"
                             title="Attempt to detect the format of dataset"
                             class="btn btn-secondary toolbtn_detect_datatype toolbar-item mr-1" type="button">
-                            <span class="fa fa-undo"></span>
+                            <span class="fa fa-redo"></span>
                             &nbsp;Auto-detect datatype
                         </button>
                     <% } %>

--- a/config/plugins/tours/core.galaxy_ui.yaml
+++ b/config/plugins/tours/core.galaxy_ui.yaml
@@ -154,7 +154,7 @@ steps:
         - "div.title-bar.clear:eq(0)"
 
     - title: "Re-run tool"
-      element: "#current-history-panel .fa-refresh:first"
+      element: "#current-history-panel .fa-redo:first"
       intro: "By clicking the reload button, you can re-run your tool again (e.g. with different parameters or on another dataset)."
       position: "left"
 


### PR DESCRIPTION
- Replace `fa-refresh` icon with `fa-redo` for job re-run buttons to distinguish it from the sync button we use e.g. to refresh the history.
- Replace `fa-refresh` with `fa-sync` (the name was changed between FontAwesome 4 and 5).
- Replace "Clear Cache" tooltip with the less technical "Refresh History", as it has always been in the old history panel.
- Use `fa-redo` icon instead of `fa-undo` for datatype auto-detect buttons.

![Screenshot from 2021-06-15 15-15-48](https://user-images.githubusercontent.com/4924623/122072315-5d3ba580-cdef-11eb-87c6-a0f7f0b4b3c1.png)

![Screenshot from 2021-06-15 15-16-02](https://user-images.githubusercontent.com/4924623/122072339-63318680-cdef-11eb-93c1-98471a89103f.png)

![Screenshot from 2021-06-15 15-16-31](https://user-images.githubusercontent.com/4924623/122072517-8e1bda80-cdef-11eb-9265-1f504da30a95.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Start Galaxy
  2. Look at the history panel, edit dataset attributes and notice the changed icons as in the screenshots.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
to distinguish it from the sync button we use e.g. to refresh the history.