### PR TITLE
Refactoring: Remove ExportsHistoryMixin and ImportsHistoryMixin

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -178,6 +178,45 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
         job, _ = history_imp_tool.execute(trans, incoming=incoming)
         return job
 
+    def serve_ready_history_export(self, trans, jeha):
+        assert jeha.ready
+        if jeha.compressed:
+            trans.response.set_content_type('application/x-gzip')
+        else:
+            trans.response.set_content_type('application/x-tar')
+        disposition = f'attachment; filename="{jeha.export_name}"'
+        trans.response.headers["Content-Disposition"] = disposition
+        archive = trans.app.object_store.get_filename(jeha.dataset)
+        return open(archive, mode='rb')
+
+    def queue_history_export(self, trans, history, gzip=True, include_hidden=False, include_deleted=False, directory_uri=None, file_name=None):
+        # Convert options to booleans.
+        if isinstance(gzip, str):
+            gzip = (gzip in ['True', 'true', 'T', 't'])
+        if isinstance(include_hidden, str):
+            include_hidden = (include_hidden in ['True', 'true', 'T', 't'])
+        if isinstance(include_deleted, str):
+            include_deleted = (include_deleted in ['True', 'true', 'T', 't'])
+
+        params = {
+            'history_to_export': history,
+            'compress': gzip,
+            'include_hidden': include_hidden,
+            'include_deleted': include_deleted
+        }
+
+        if directory_uri is None:
+            export_tool_id = '__EXPORT_HISTORY__'
+        else:
+            params['directory_uri'] = directory_uri
+            params['file_name'] = file_name or None
+            export_tool_id = '__EXPORT_HISTORY_TO_URI__'
+
+        # Run job to do export.
+        history_exp_tool = trans.app.toolbox.get_tool(export_tool_id)
+        job, _ = history_exp_tool.execute(trans, incoming=params, history=history, set_output_hid=True)
+        return job
+
 
 class HistoryExportView:
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -171,6 +171,13 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
             .filter(model.Job.state.in_(model.Job.non_ready_states)))
         return jobs
 
+    def queue_history_import(self, trans, archive_type, archive_source):
+        # Run job to do import.
+        history_imp_tool = trans.app.toolbox.get_tool('__IMPORT_HISTORY__')
+        incoming = {'__ARCHIVE_SOURCE__': archive_source, '__ARCHIVE_TYPE__': archive_type}
+        job, _ = history_imp_tool.execute(trans, incoming=incoming)
+        return job
+
 
 class HistoryExportView:
 

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -440,16 +440,6 @@ class ExportsHistoryMixin:
         return job
 
 
-class ImportsHistoryMixin:
-
-    def queue_history_import(self, trans, archive_type, archive_source):
-        # Run job to do import.
-        history_imp_tool = trans.app.toolbox.get_tool('__IMPORT_HISTORY__')
-        incoming = {'__ARCHIVE_SOURCE__': archive_source, '__ARCHIVE_TYPE__': archive_type}
-        job, _ = history_imp_tool.execute(trans, incoming=incoming)
-        return job
-
-
 class UsesLibraryMixinItems(SharableItemSecurityMixin):
 
     def get_library_folder(self, trans, id, check_ownership=False, check_accessible=True):

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -398,48 +398,6 @@ class SharableItemSecurityMixin:
         return managers_base.security_check(trans, item, check_ownership=check_ownership, check_accessible=check_accessible)
 
 
-class ExportsHistoryMixin:
-
-    def serve_ready_history_export(self, trans, jeha):
-        assert jeha.ready
-        if jeha.compressed:
-            trans.response.set_content_type('application/x-gzip')
-        else:
-            trans.response.set_content_type('application/x-tar')
-        disposition = f'attachment; filename="{jeha.export_name}"'
-        trans.response.headers["Content-Disposition"] = disposition
-        archive = trans.app.object_store.get_filename(jeha.dataset)
-        return open(archive, mode='rb')
-
-    def queue_history_export(self, trans, history, gzip=True, include_hidden=False, include_deleted=False, directory_uri=None, file_name=None):
-        # Convert options to booleans.
-        if isinstance(gzip, str):
-            gzip = (gzip in ['True', 'true', 'T', 't'])
-        if isinstance(include_hidden, str):
-            include_hidden = (include_hidden in ['True', 'true', 'T', 't'])
-        if isinstance(include_deleted, str):
-            include_deleted = (include_deleted in ['True', 'true', 'T', 't'])
-
-        params = {
-            'history_to_export': history,
-            'compress': gzip,
-            'include_hidden': include_hidden,
-            'include_deleted': include_deleted
-        }
-
-        if directory_uri is None:
-            export_tool_id = '__EXPORT_HISTORY__'
-        else:
-            params['directory_uri'] = directory_uri
-            params['file_name'] = file_name or None
-            export_tool_id = '__EXPORT_HISTORY_TO_URI__'
-
-        # Run job to do export.
-        history_exp_tool = trans.app.toolbox.get_tool(export_tool_id)
-        job, _ = history_exp_tool.execute(trans, incoming=params, history=history, set_output_hid=True)
-        return job
-
-
 class UsesLibraryMixinItems(SharableItemSecurityMixin):
 
     def get_library_folder(self, trans, id, check_ownership=False, check_accessible=True):

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -34,15 +34,12 @@ from galaxy.web import (
     expose_api_anonymous_and_sessionless,
     expose_api_raw,
 )
-from galaxy.webapps.base.controller import (
-    ExportsHistoryMixin,
-)
 from . import BaseGalaxyAPIController, depends
 
 log = logging.getLogger(__name__)
 
 
-class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin):
+class HistoriesController(BaseGalaxyAPIController):
     citations_manager: citations.CitationsManager = depends(citations.CitationsManager)
     user_manager: users.UserManager = depends(users.UserManager)
     workflow_manager: workflows.WorkflowsManager = depends(workflows.WorkflowsManager)
@@ -513,7 +510,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin):
             include_deleted = kwds.get("include_deleted", False)
             directory_uri = kwds.get("directory_uri", None)
             file_name = kwds.get("file_name", None)
-            job = self.queue_history_export(
+            job = self.manager.queue_history_export(
                 trans,
                 history,
                 gzip=gzip,
@@ -556,7 +553,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin):
         ``download_url``.
         """
         jeha = self.history_export_view.get_ready_jeha(trans, id, jeha_id)
-        return self.serve_ready_history_export(trans, jeha)
+        return self.manager.serve_ready_history_export(trans, jeha)
 
     @expose_api
     def get_custom_builds_metadata(self, trans, id, payload=None, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -36,14 +36,13 @@ from galaxy.web import (
 )
 from galaxy.webapps.base.controller import (
     ExportsHistoryMixin,
-    ImportsHistoryMixin,
 )
 from . import BaseGalaxyAPIController, depends
 
 log = logging.getLogger(__name__)
 
 
-class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsHistoryMixin):
+class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin):
     citations_manager: citations.CitationsManager = depends(citations.CitationsManager)
     user_manager: users.UserManager = depends(users.UserManager)
     workflow_manager: workflows.WorkflowsManager = depends(workflows.WorkflowsManager)
@@ -353,7 +352,7 @@ class HistoriesController(BaseGalaxyAPIController, ExportsHistoryMixin, ImportsH
                 archive_type = "file"
             else:
                 raise exceptions.MessageException("Please provide a url or file.")
-            job = self.queue_history_import(trans, archive_type=archive_type, archive_source=archive_source)
+            job = self.manager.queue_history_import(trans, archive_type=archive_type, archive_source=archive_source)
             job_dict = job.to_dict()
             job_dict["message"] = f"Importing history from source '{archive_source}'. This history will be visible when the import is complete."
             return trans.security.encode_all_ids(job_dict)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -42,7 +42,6 @@ from galaxy.webapps.base.controller import (
     BaseUIController,
     ERROR,
     ExportsHistoryMixin,
-    ImportsHistoryMixin,
     INFO,
     SharableMixin,
     SUCCESS,
@@ -237,7 +236,7 @@ class HistoryAllPublishedGrid(grids.Grid):
 
 
 class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesItemRatings,
-                        ExportsHistoryMixin, ImportsHistoryMixin):
+                        ExportsHistoryMixin):
     history_manager: histories.HistoryManager = depends(histories.HistoryManager)
     history_export_view: histories.HistoryExportView = depends(histories.HistoryExportView)
     history_serializer: histories.HistorySerializer = depends(histories.HistorySerializer)

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -1104,7 +1104,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         # Get history to export.
         #
         jeha = self.history_export_view.get_ready_jeha(trans, id, jeha_id)
-        return self.manager.serve_ready_history_export(trans, jeha)
+        return self.history_manager.serve_ready_history_export(trans, jeha)
 
     @web.expose
     @web.json

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -41,7 +41,6 @@ from galaxy.web.framework.helpers import (
 from galaxy.webapps.base.controller import (
     BaseUIController,
     ERROR,
-    ExportsHistoryMixin,
     INFO,
     SharableMixin,
     SUCCESS,
@@ -235,8 +234,7 @@ class HistoryAllPublishedGrid(grids.Grid):
         return query.filter(self.model_class.published == true()).filter(self.model_class.slug != null()).filter(self.model_class.deleted == false())
 
 
-class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesItemRatings,
-                        ExportsHistoryMixin):
+class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesItemRatings):
     history_manager: histories.HistoryManager = depends(histories.HistoryManager)
     history_export_view: histories.HistoryExportView = depends(histories.HistoryExportView)
     history_serializer: histories.HistorySerializer = depends(histories.HistorySerializer)
@@ -1106,7 +1104,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         # Get history to export.
         #
         jeha = self.history_export_view.get_ready_jeha(trans, id, jeha_id)
-        return self.serve_ready_history_export(trans, jeha)
+        return self.manager.serve_ready_history_export(trans, jeha)
 
     @web.expose
     @web.json


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/11231

The logic has been moved to the HistoryManager.

@jmchilton => +2 :beers: :laughing:  

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
