### PR TITLE
[21.05] Don't start workflow scheduler for handler in job pool

### DIFF
--- a/lib/galaxy/workflow/scheduling_manager.py
+++ b/lib/galaxy/workflow/scheduling_manager.py
@@ -187,6 +187,7 @@ class WorkflowSchedulingManager(ConfiguresHandlers):
         if use_default_scheduler:
             self.__init_default_scheduler()
         else:
+            self.DEFAULT_BASE_HANDLER_POOLS = ('workflow-schedulers',)
             plugins_element = parse_xml(config_file).getroot()
             self.__init_schedulers_for_element(plugins_element)
 

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -302,3 +302,16 @@ class ExplicitWorkflowHandlersOffTestCase(BaseWorkflowHandlerConfigurationTestCa
 
     def test_app_is_not_workflow_scheduler(self):
         assert not self.is_app_workflow_scheduler
+
+
+class ExplicitWorkflowHandlersOffPoolTestCase(BaseWorkflowHandlerConfigurationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        super().handle_galaxy_config_kwds(config)
+        config["workflow_schedulers_config_file"] = config_file(WORKFLOW_SCHEDULERS_CONFIG_TEMPLATE, assign_with=cls.assign_with)
+        config["server_name"] = "handler0"  # Configured as a job handler but not a workflow handler.
+        config["attach_to_pools"] = ["job-handlers"]
+
+    def test_app_is_not_workflow_scheduler(self):
+        assert not self.is_app_workflow_scheduler


### PR DESCRIPTION
Backport of #12075 which was supposed to go to 21.05 ...

Broken in https://github.com/galaxyproject/galaxy/pull/11792,
fixes https://github.com/galaxyproject/galaxy/issues/11986.

This only happens when the job handler is configured to attach to a job
pool. Includes a test that reproduces the issue.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
