### PR TITLE
[21.05] Fix failure to serialize invocation / drop stored_workflow_id from invocation API

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5593,7 +5593,6 @@ class WorkflowInvocation(UsesCreateAndUpdateTime, Dictifiable, RepresentById):
 
     def to_dict(self, view='collection', value_mapper=None, step_details=False, legacy_job_state=False):
         rval = super().to_dict(view=view, value_mapper=value_mapper)
-        rval['stored_workflow_id'] = self.workflow.stored_workflow.id
         if view == 'element':
             steps = []
             for step in self.steps:


### PR DESCRIPTION
Old imported subworkflows may not have a StoredWorkflow instance, so
this was causing AttributeError if you're listing invocations for such
an invocation. But we also agreed to remove this in
https://github.com/galaxyproject/galaxy/pull/11881#discussion_r618314707
so I'm doing that now. With the release being just a few days old I hope
we can still make that change.

The alternative to removing this is to use `rval['stored_workflow_id'] = self.workflow.stored_workflow_id`, but I would prefer that this is not going to be used in the community.
`rerun_invocation` as implemented in https://github.com/galaxyproject/bioblend/pull/389 (which was later changed to use the workflow id) is a good example of why I think we shouldn't expose the StoredWorkflow at this level. If you edit the workflow you're going to run the latest version of the workflow, not the one used for the invocation.

ping @simonbray @nsoranzo

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
