### PR TITLE
[21.05] Drain invocations from job handler that is not (anymore) a workflow handler

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -104,8 +104,8 @@ class ItemGrabber:
         if self.handler_assignment_method == HANDLER_ASSIGNMENT_METHODS.DB_TRANSACTION_ISOLATION:
             self._grab_conn_opts['isolation_level'] = 'SERIALIZABLE'
         log.info(
-            "Handler job grabber initialized with '%s' assignment method for handler '%s', tag(s): %s", self.handler_assignment_method,
-            self.app.config.server_name, ', '.join(str(x) for x in self.handler_tags)
+            f"{self.grab_type} grabber initialized with '{self.handler_assignment_method}'"
+            f" assignment method for handler '{self.app.config.server_name}', tag(s): {', '.join(str(x) for x in self.handler_tags)}"
         )
 
     @staticmethod

--- a/test/integration/test_workflow_handler_configuration.py
+++ b/test/integration/test_workflow_handler_configuration.py
@@ -130,7 +130,7 @@ class BaseWorkflowHandlerConfigurationTestCase(integration_util.IntegrationTestC
 
     @property
     def is_app_workflow_scheduler(self):
-        return self._app.workflow_scheduling_manager.request_monitor is not None
+        return self._app.workflow_scheduling_manager._is_workflow_handler()
 
 
 class HistoryRestrictionConfigurationTestCase(BaseWorkflowHandlerConfigurationTestCase):


### PR DESCRIPTION
This is a followup to https://github.com/galaxyproject/galaxy/pull/12147,
which may leave some invocations assigned to job handlers that won't run
them. This will only happen for setups that separate workflow handlers
from job handlers.
It is an alternative to having admins manually run the appropriate
SQL statement on their servers (this is for main, where we have 2 workflow scheduler processes):
```
update workflow_invocation set handler = 'main_w3_workflow_scheduler0' where state = 'ready' and handler not in ('main_w3_workflow_scheduler0', 'main_w4_workflow_scheduler0');
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Start a job handler that is not supposed to be a workflow handler. Set the state column for an arbitrary terminal invocation to `ready` and set the `handler` column to the job handler. Notice that the job handler will continue processing the invocation.
Now do the same but set the handler column to `_default_` and see that the job handler will not pick up the new invocation.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
