### PR TITLE
Unify how the `GalaxyInteractorApi` handles JSON requests

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -753,7 +753,7 @@ class GalaxyInteractorApi:
         if headers:
             kwd['headers'] = headers
         if as_json:
-            kwd['json'] = data
+            kwd['json'] = data or None
             kwd['params'] = params
         else:
             data.update(params)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -678,32 +678,88 @@ class GalaxyInteractorApi:
         return header
 
     def _post(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
-        # If json=True, use post payload using request's json parameter instead of the data
-        # parameter (i.e. assume the contents is a jsonified blob instead of form parameters
-        # with individual parameters jsonified if needed).
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
-        url = f"{self.api_url}/{path}"
-        return galaxy_requests_post(url, data=data, files=files, as_json=json, headers=headers)
+        url = self.get_api_url(path)
+        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        return requests.post(url, **kwd)
 
-    def _delete(self, path, data=None, key=None, headers=None, admin=False, anon=False):
+    def _delete(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
-        return requests.delete(f"{self.api_url}/{path}", params=data, headers=headers)
+        url = self.get_api_url(path)
+        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        return requests.delete(url, **kwd)
 
-    def _patch(self, path, data=None, key=None, headers=None, admin=False, anon=False):
+    def _patch(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
-        return requests.patch(f"{self.api_url}/{path}", data=data, headers=headers)
+        url = self.get_api_url(path)
+        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        return requests.patch(url, **kwd)
 
-    def _put(self, path, data=None, key=None, headers=None, admin=False, anon=False):
+    def _put(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
-        return requests.put(f"{self.api_url}/{path}", data=data, headers=headers)
+        url = self.get_api_url(path)
+        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        return requests.put(url, **kwd)
 
     def _get(self, path, data=None, key=None, headers=None, admin=False, anon=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
-        if path.startswith("/api"):
-            path = path[len("/api"):]
-        url = f"{self.api_url}/{path}"
+        url = self.get_api_url(path)
         # no data for GET
         return requests.get(url, params=data, headers=headers)
+
+    def get_api_url(self, path: str) -> str:
+        if path.startswith("http"):
+            return path
+        elif path.startswith("/api"):
+            path = path[len("/api"):]
+        return f"{self.api_url}/{path}"
+
+    def _prepare_request_params(self, data=None, files=None, as_json: bool = False, params: dict = None, headers: dict = None):
+        """Handle some Galaxy conventions and work around requests issues.
+
+        This is admittedly kind of hacky, so the interface may change frequently - be
+        careful on reuse.
+
+        If ``as_json`` is True, use post payload using request's json parameter instead
+        of the data parameter (i.e. assume the contents is a json-ified blob instead of
+        form parameters with individual parameters json-ified if needed). requests doesn't
+        allow files to be specified with the json parameter - so rewrite the parameters
+        to handle that if as_json is True with specified files.
+        """
+        params = params or {}
+        data = data or {}
+
+        # handle encoded files
+        if files is None:
+            # if not explicitly passed, check __files... convention used in tool testing
+            # and API testing code
+            files = data.get("__files", None)
+            if files is not None:
+                del data["__files"]
+
+        # files doesn't really work with json, so dump the parameters
+        # and do a normal POST with request's data parameter.
+        if bool(files) and as_json:
+            as_json = False
+            new_items = {}
+            for key, val in data.items():
+                if isinstance(val, dict) or isinstance(val, list):
+                    new_items[key] = dumps(val)
+            data.update(new_items)
+
+        kwd = {
+            'files': files,
+        }
+        if headers:
+            kwd['headers'] = headers
+        if as_json:
+            kwd['json'] = data
+            kwd['params'] = params
+        else:
+            data.update(params)
+            kwd['data'] = data
+
+        return kwd
 
 
 def ensure_tool_run_response_okay(submit_response_object, request_desc, inputs=None):
@@ -1349,51 +1405,3 @@ def test_data_iter(required_files):
                 raise Exception(f"edit_attributes type ({edit_att.get('type', None)}) is unimplemented")
 
         yield data_dict
-
-
-def galaxy_requests_post(url, data=None, files=None, as_json=False, params=None, headers=None):
-    """Handle some Galaxy conventions and work around requests issues.
-
-    This is admittedly kind of hacky, so the interface may change frequently - be
-    careful on reuse.
-
-    If ``as_json`` is True, use post payload using request's json parameter instead
-    of the data parameter (i.e. assume the contents is a json-ified blob instead of
-    form parameters with individual parameters json-ified if needed). requests doesn't
-    allow files to be specified with the json parameter - so rewrite the parameters
-    to handle that if as_json is True with specified files.
-    """
-    params = params or {}
-    data = data or {}
-
-    # handle encoded files
-    if files is None:
-        # if not explicitly passed, check __files... convention used in tool testing
-        # and API testing code
-        files = data.get("__files", None)
-        if files is not None:
-            del data["__files"]
-
-    # files doesn't really work with json, so dump the parameters
-    # and do a normal POST with request's data parameter.
-    if bool(files) and as_json:
-        as_json = False
-        new_items = {}
-        for key, val in data.items():
-            if isinstance(val, dict) or isinstance(val, list):
-                new_items[key] = dumps(val)
-        data.update(new_items)
-
-    kwd = {
-        'files': files,
-    }
-    if headers:
-        kwd['headers'] = headers
-    if as_json:
-        kwd['json'] = data
-        kwd['params'] = params
-    else:
-        data.update(params)
-        kwd['data'] = data
-
-    return requests.post(url, **kwd)

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -683,22 +683,22 @@ class GalaxyInteractorApi:
         kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
         return requests.post(url, **kwd)
 
-    def _delete(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
+    def _delete(self, path, data=None, key=None, headers=None, admin=False, anon=False, json=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
         url = self.get_api_url(path)
-        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        kwd = self._prepare_request_params(data=data, as_json=json, headers=headers)
         return requests.delete(url, **kwd)
 
-    def _patch(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
+    def _patch(self, path, data=None, key=None, headers=None, admin=False, anon=False, json=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
         url = self.get_api_url(path)
-        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        kwd = self._prepare_request_params(data=data, as_json=json, headers=headers)
         return requests.patch(url, **kwd)
 
-    def _put(self, path, data=None, files=None, key=None, headers=None, admin=False, anon=False, json=False):
+    def _put(self, path, data=None, key=None, headers=None, admin=False, anon=False, json=False):
         headers = self.api_key_header(key=key, admin=admin, anon=anon, headers=headers)
         url = self.get_api_url(path)
-        kwd = self._prepare_request_params(data=data, files=files, as_json=json, headers=headers)
+        kwd = self._prepare_request_params(data=data, as_json=json, headers=headers)
         return requests.put(url, **kwd)
 
     def _get(self, path, data=None, key=None, headers=None, admin=False, anon=False):

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -1,4 +1,3 @@
-import json
 import textwrap
 
 from galaxy_test.base.populators import (
@@ -123,15 +122,13 @@ class DatasetsApiTestCase(ApiTestCase):
 
     def test_tag_change(self):
         hda_id = self.dataset_populator.new_dataset(self.history_id)['id']
-        payload = json.dumps({
+        payload = {
             'item_id': hda_id,
             'item_class': 'HistoryDatasetAssociation',
             'item_tags': ['cool:tag_a', 'cool:tag_b', 'tag_c', 'name:tag_d', '#tag_e'],
-        })
+        }
 
-        # TODO remove the headers here and add json parameter to _put method
-        put_response = self._put("tags", data=payload, headers={'Content-Type': 'application/json'})
-
+        put_response = self._put("tags", data=payload, json=True)
         self._assert_status_code_is_ok(put_response)
         updated_hda = self._get(
             f"histories/{self.history_id}/contents/{hda_id}").json()

--- a/lib/galaxy_test/api/test_groups.py
+++ b/lib/galaxy_test/api/test_groups.py
@@ -1,5 +1,3 @@
-import json
-
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -75,10 +73,10 @@ class GroupsApiTestCase(ApiTestCase):
 
         group_id = group["id"]
         updated_name = "group-test-updated"
-        update_payload = json.dumps({
+        update_payload = {
             "name": updated_name,
-        })
-        update_response = self._put(f"groups/{group_id}", data=update_payload, admin=True)
+        }
+        update_response = self._put(f"groups/{group_id}", data=update_payload, admin=True, json=True)
         self._assert_status_code_is_ok(update_response)
 
     def test_update_only_admin(self):
@@ -94,10 +92,10 @@ class GroupsApiTestCase(ApiTestCase):
         # Update group_b with the same name as group_a
         group_b_id = group_b["id"]
         updated_name = group_a["name"]
-        update_payload = json.dumps({
+        update_payload = {
             "name": updated_name,
-        })
-        update_response = self._put(f"groups/{group_b_id}", data=update_payload, admin=True)
+        }
+        update_response = self._put(f"groups/{group_b_id}", data=update_payload, admin=True, json=True)
         self._assert_status_code_is(update_response, 409)
 
     def _assert_valid_group(self, group, assert_id=None):

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -523,7 +523,7 @@ steps:
         assert dataset_details['state'] == 'paused'
         # Undelete input dataset
         undelete_response = self._put(f"histories/{history_id}/contents/{hda1['id']}",
-                                      data=json.dumps({'deleted': False}))
+                                      data={'deleted': False}, json=True)
         self._assert_status_code_is(undelete_response, 200)
         resume_response = self._put(f"jobs/{job_id}/resume")
         self._assert_status_code_is(resume_response, 200)
@@ -574,7 +574,7 @@ steps:
         self._job_search(tool_id='identifier_single', history_id=history_id, inputs=inputs)
         dataset_details = self._get(f"histories/{history_id}/contents/{dataset_id}").json()
         dataset_details['name'] = 'Renamed Test Dataset'
-        dataset_update_response = self._put(f"histories/{history_id}/contents/{dataset_id}", data=dict(name='Renamed Test Dataset'))
+        dataset_update_response = self._put(f"histories/{history_id}/contents/{dataset_id}", data=dict(name='Renamed Test Dataset'), json=True)
         self._assert_status_code_is(dataset_update_response, 200)
         assert dataset_update_response.json()['name'] == 'Renamed Test Dataset'
         search_payload = self._search_payload(history_id=history_id, tool_id='identifier_single', inputs=inputs)

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -38,7 +38,7 @@ class LibrariesApiTestCase(ApiTestCase):
         assert library["deleted"] is True
         # Test undeleting
         data = dict(undelete=True)
-        create_response = self._delete(f"libraries/{library['id']}", data=data, admin=True)
+        create_response = self._delete(f"libraries/{library['id']}", data=data, admin=True, json=True)
         library = create_response.json()
         self._assert_status_code_is(create_response, 200)
         assert library["deleted"] is False

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -4328,9 +4328,9 @@ input_c:
         workflow_id = self.workflow_populator.simple_workflow("dummy")
         response = self._show_workflow(workflow_id)
         assert not response['published']
-        published_worklow = self._put(f'workflows/{workflow_id}', data=json.dumps({'published': True})).json()
+        published_worklow = self._put(f'workflows/{workflow_id}', data={'published': True}, json=True).json()
         assert published_worklow['published']
-        unpublished_worklow = self._put(f'workflows/{workflow_id}', data=json.dumps({'published': False})).json()
+        unpublished_worklow = self._put(f'workflows/{workflow_id}', data={'published': False}, json=True).json()
         assert not unpublished_worklow['published']
 
     def _invoke_paused_workflow(self, history_id):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -628,8 +628,8 @@ class BaseDatasetPopulator(BasePopulator):
         role_id = self.user_private_role_id()
         # Give manage permission to the user.
         payload = {
-            "access": json.dumps([role_id]),
-            "manage": json.dumps([role_id]),
+            "access": [role_id],
+            "manage": [role_id],
         }
         url = f"histories/{history_id}/contents/{dataset_id}/permissions"
         update_response = self._put(url, payload, admin=True, json=True)

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1779,7 +1779,7 @@ class GiHttpMixin:
         data['key'] = self._gi.key
         return requests.put(self._url(route), data=data, headers=headers)
 
-    def _delete(self, route, data=None, headers=None, json: bool = False):
+    def _delete(self, route, data=None, headers=None, admin=False, json: bool = False):
         if data is None:
             data = {}
         data = data.copy()

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -572,7 +572,7 @@ class SeleniumSessionGetPostMixin:
         response = requests.post(full_url, data=data, cookies=cookies, files=files, headers=headers)
         return response
 
-    def _delete(self, route, data=None, headers=None, admin=False) -> Response:
+    def _delete(self, route, data=None, headers=None, admin=False, json: bool = False) -> Response:
         data = data or {}
         full_url = self.selenium_context.build_url(f"api/{route}", for_selenium=False)
         cookies = None
@@ -583,7 +583,7 @@ class SeleniumSessionGetPostMixin:
         response = requests.delete(full_url, data=data, cookies=cookies, headers=headers)
         return response
 
-    def _put(self, route, data=None, headers=None, admin=False) -> Response:
+    def _put(self, route, data=None, headers=None, admin=False, json: bool = False) -> Response:
         data = data or {}
         full_url = self.selenium_context.build_url(f"api/{route}", for_selenium=False)
         cookies = None

--- a/test/integration/test_tool_data_delete.py
+++ b/test/integration/test_tool_data_delete.py
@@ -6,13 +6,9 @@ To avoid altering the '.loc' files in test/functional/tool-data, these files are
 copied to a temp directory and then used by the integration test.
 """
 
-import json
 import os
 import shutil
 import time
-
-from requests import delete
-
 
 from galaxy_test.base.populators import DatasetPopulator
 from galaxy_test.driver import integration_util
@@ -62,9 +58,8 @@ class AdminToolDataIntegrationTestCase(integration_util.IntegrationTestCase):
         new_field = updated_fields[-1]
         url = self._api_url(f"tool_data/testbeta?key={self.galaxy_interactor.api_key}")
 
-        # TODO remove the headers here, use the interactor _delete method and add json parameter to it
-        delete_response = delete(url, data=json.dumps({"values": "\t".join(new_field)}), headers={'Content-Type': 'application/json'})
-
+        delete_payload = {"values": "\t".join(new_field)}
+        delete_response = self._delete(url, data=delete_payload, json=True)
         delete_response.raise_for_status()
         time.sleep(2)
         show_response = self._get("tool_data/testbeta")


### PR DESCRIPTION
This is a follow up to https://github.com/galaxyproject/galaxy/pull/12136#issuecomment-861315396

It basically allows the rest of the HTTP request methods in the `GalaxyInteractorApi` (that can contain a payload) to specify the `json=True` parameter. This will add the proper `Content-Type: application/json` to the header that is now explicitly required by FastAPI.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
