### PR TITLE
[21.01] Access collection elements more efficiently by index

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4286,9 +4286,16 @@ class DatasetCollection(Dictifiable, UsesAnnotations, RepresentById):
 
     def __getitem__(self, key):
         get_by_attribute = "element_index" if isinstance(key, int) else "element_identifier"
-        for element in self.elements:
-            if getattr(element, get_by_attribute) == key:
-                return element
+        if isinstance(key, int):
+            try:
+                return self.elements[key]
+            except IndexError:
+                pass
+        else:
+            # This might be a peformance issue for large collection, but we don't use this a lot
+            for element in self.elements:
+                if element.element_identifier == key:
+                    return element
         error_message = f"Dataset collection has no {get_by_attribute} with key {key}."
         raise KeyError(error_message)
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4285,7 +4285,6 @@ class DatasetCollection(Dictifiable, UsesAnnotations, RepresentById):
             raise Exception("Each dataset collection must define a collection type.")
 
     def __getitem__(self, key):
-        get_by_attribute = "element_index" if isinstance(key, int) else "element_identifier"
         if isinstance(key, int):
             try:
                 return self.elements[key]
@@ -4296,6 +4295,7 @@ class DatasetCollection(Dictifiable, UsesAnnotations, RepresentById):
             for element in self.elements:
                 if element.element_identifier == key:
                     return element
+        get_by_attribute = "element_index" if isinstance(key, int) else "element_identifier"
         error_message = f"Dataset collection has no {get_by_attribute} with key {key}."
         raise KeyError(error_message)
 

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -275,6 +275,18 @@ class MappingTests(BaseModelTestCase):
         library_dataset_collection = model.LibraryDatasetCollectionAssociation(collection=dataset_collection)
         tag_and_test(library_dataset_collection, model.LibraryDatasetCollectionTagAssociation, "tagged_library_dataset_collections")
 
+    def test_collection_get_interface(self):
+        model = self.model
+        u = model.User(email="mary@example.com", password="password")
+        h1 = model.History(name="History 1", user=u)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
+        c1 = model.DatasetCollection(collection_type="list")
+        dces = [model.DatasetCollectionElement(collection=c1, element=d1, element_identifier=f"{i}", element_index=i) for i in range(100)]
+        self.persist(u, h1, d1, c1, *dces, flush=False, expunge=False)
+        model.session.flush()
+        for i in range(100):
+            assert c1[i] == dces[i]
+
     def test_collections_in_histories(self):
         model = self.model
 

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -281,10 +281,11 @@ class MappingTests(BaseModelTestCase):
         h1 = model.History(name="History 1", user=u)
         d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
         c1 = model.DatasetCollection(collection_type="list")
-        dces = [model.DatasetCollectionElement(collection=c1, element=d1, element_identifier=f"{i}", element_index=i) for i in range(100)]
+        elements = 100
+        dces = [model.DatasetCollectionElement(collection=c1, element=d1, element_identifier=f"{i}", element_index=i) for i in range(elements)]
         self.persist(u, h1, d1, c1, *dces, flush=False, expunge=False)
         model.session.flush()
-        for i in range(100):
+        for i in range(elements):
             assert c1[i] == dces[i]
 
     def test_collections_in_histories(self):


### PR DESCRIPTION
This fixes slow mapping over for very large collections.

@nsoranzo reported extremely slow preparation of jobs for collections with 100000 elements.
This was the `py-spy dump` output for the workflow scheduler process:

```
Process 10370: /tgac/services/galaxy/prod/galaxy/.venv/bin/python ./scripts/galaxy-main -c config/galaxy.yml --server-name=handler0 --log-file=handler0.log
Python v3.6.8 (/tgac/services/galaxy/prod/galaxy/.venv/bin/python3)

Thread 10370 (idle): "MainThread"
    wait (threading.py:299)
    wait (threading.py:551)
    app_loop (scripts/galaxy-main:148)
    main (scripts/galaxy-main:294)
    <module> (scripts/galaxy-main:298)
Thread 10411 (active+gil): "WorkflowRequestMonitor.monitor_thread"
    __get__ (sqlalchemy/orm/attributes.py:283)
    __getitem__ (galaxy/model/__init__.py:4290)
    element (galaxy/model/dataset_collections/structure.py:91)
    <dictcomp> (galaxy/model/dataset_collections/structure.py:176)
    dict_map (galaxy/model/dataset_collections/structure.py:176)
    _walk_collections (galaxy/model/dataset_collections/structure.py:94)
    execute (galaxy/workflow/modules.py:1668)
    _invoke_step (galaxy/workflow/run.py:271)
    invoke (galaxy/workflow/run.py:195)
    __invoke (galaxy/workflow/run.py:82)
    schedule (galaxy/workflow/run.py:27)
    schedule (galaxy/workflow/schedulers/core.py:41)
    __attempt_schedule (galaxy/workflow/scheduling_manager.py:327)
    __schedule (galaxy/workflow/scheduling_manager.py:308)
    __monitor (galaxy/workflow/scheduling_manager.py:298)
    run (threading.py:864)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
Thread 10412 (idle): "database_heartbeart_handler0.thread"
    wait (threading.py:299)
    wait (threading.py:551)
    send_database_heartbeat (galaxy/model/database_heartbeat.py:101)
    run (threading.py:864)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
Thread 10413 (idle): "Thread-1"
    drain_events (kombu/transport/virtual/base.py:965)
    drain_events (kombu/connection.py:318)
    consume (kombu/mixins.py:194)
    run (kombu/mixins.py:172)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
```
This pointed to https://github.com/mvdbeek/galaxy/blob/e82cdcbd90fa708edf974c20776f73849b2950f3/lib/galaxy/model/__init__.py#L4289, which is a very inefficient way to get an item from a list at a specific index, especially since `_walk_collections` does that for every element in a collection.

Here's a quick table for the unit test without the fix:

| elements | time in ms |
| --------- | -----------|
| 1000 | 1233 |
| 5000 | 20798 |
| 10000 | 93719 |

If I plug that into polynomial regression that comes out to 10614599 ms or 176 minutes for 100 000 elements,
which is close to the 4 hours that @nsoranzo saw:
> So the "Attempting to schedule workflow invocation" takes about 4 hours, with memory use increasing till around 4 GB, then it starts sending jobs till maximum_workflow_jobs_per_scheduling_iteration is reached, then checks for other workflows to schedule, then goes back to finish scheduling the collection

With the fix:

| elements | time in ms |
| --------- | -----------|
| 1000 | 32 |
| 5000 | 172 |
| 10000 | 323 |

So that's pretty much linear and should come out at 3 seconds (but pytest inside vscode dies on me, I'm gonna blame that on in memory sqlite 😆).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
