### PR TITLE
[21.01] Temporary fix for keycloak OIDC

### DIFF
--- a/lib/galaxy/authnz/custos_authnz.py
+++ b/lib/galaxy/authnz/custos_authnz.py
@@ -87,6 +87,7 @@ class CustosAuthnz(IdentityProvider):
         else:
             userinfo = self._get_userinfo(oauth2_session)
         email = userinfo['email']
+        username = userinfo.get('preferred_username', self._generate_username(trans, email))
         user_id = userinfo['sub']
 
         # Create or update custos_authnz_token record
@@ -110,9 +111,13 @@ class CustosAuthnz(IdentityProvider):
                         message = "There already exists a user with email %s.  To associate this external login, you must first be logged in as that existing account." % email
                         log.exception(message)
                         raise exceptions.AuthenticationFailed(message)
-                else:
-                    login_redirect_url = login_redirect_url + 'root/login?confirm=true&custos_token=' + json.dumps(token)
+                elif self.config['provider'] == 'custos':
+                    login_redirect_url = f"{login_redirect_url}root/login?confirm=true&custos_token={json.dumps(token)}"
                     return login_redirect_url, None
+                else:
+                    user = trans.app.user_manager.create(email=email, username=username)
+                    if trans.app.config.user_activation_on:
+                        trans.app.user_manager.send_activation_email(trans, email, username)
 
             custos_authnz_token = CustosAuthnzToken(user=user,
                                    external_user_id=user_id,
@@ -130,7 +135,7 @@ class CustosAuthnz(IdentityProvider):
             custos_authnz_token.refresh_expiration_time = refresh_expiration_time
         trans.sa_session.add(custos_authnz_token)
         trans.sa_session.flush()
-        return login_redirect_url, custos_authnz_token.user
+        return "/", custos_authnz_token.user
 
     def create_user(self, token, trans, login_redirect_url):
         token_dict = json.loads(token)

--- a/test/unit/authnz/test_custos_authnz.py
+++ b/test/unit/authnz/test_custos_authnz.py
@@ -313,7 +313,7 @@ class CustosAuthnzTestCase(unittest.TestCase):
         self.assertTrue(self._create_oauth2_session_called)
         self.assertTrue(self._fetch_token_called)
         self.assertTrue(self._get_userinfo_called)
-        self.assertEqual(login_redirect_url, "http://localhost:8000/")
+        self.assertEqual(login_redirect_url, "/")
         self.assertIsNotNone(user)
 
     def test_callback_nonce_validation_with_bad_nonce(self):


### PR DESCRIPTION
When the confirmation page was added for Custos, it broke other OIDC providers. This makes the confirmation page conditional for only the custos provider, and essentially reverts the other providers to create a user without a confirmation page without removing the functionality from Custos.

The long term fix should include a confirmation page for non-custos providers as well, but this unblocks OIDC with Keycloak in the meantime.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
