### PR TITLE
Fix documentation for ``ftp_upload_dir`` and `ftp_upload_site ` setting

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -3652,28 +3652,29 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~
-``ftp_upload_dir``
-~~~~~~~~~~~~~~~~~~
-
-:Description:
-    Enable Galaxy's "Upload via FTP" interface.  You'll need to
-    install and configure an FTP server (we've used ProFTPd since it
-    can use Galaxy's database for authentication) and set the
-    following two options. This should point to a directory containing
-    subdirectories matching users' identifier (defaults to e-mail),
-    where Galaxy will look for files.
-:Default: ``None``
-:Type: str
-
-
 ~~~~~~~~~~~~~~~~~~~
 ``ftp_upload_site``
 ~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    This should be the hostname of your FTP server, which will be
-    provided to users in the help text.
+    Enable Galaxy's "Upload via FTP" interface.  You'll need to
+    install and configure an FTP server (we've used ProFTPd since it
+    can use Galaxy's database for authentication) and set the
+    following two options. This will be provided to users in the help
+    text as 'log in to the FTP server at '. Thus, it should be the
+    hostname of your FTP server.
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~
+``ftp_upload_dir``
+~~~~~~~~~~~~~~~~~~
+
+:Description:
+    This should point to a directory containing subdirectories
+    matching users' identifier (defaults to e-mail), where Galaxy will
+    look for files.
 :Default: ``None``
 :Type: str
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1809,14 +1809,15 @@ galaxy:
   # Enable Galaxy's "Upload via FTP" interface.  You'll need to install
   # and configure an FTP server (we've used ProFTPd since it can use
   # Galaxy's database for authentication) and set the following two
-  # options. This should point to a directory containing subdirectories
-  # matching users' identifier (defaults to e-mail), where Galaxy will
-  # look for files.
-  #ftp_upload_dir: null
-
-  # This should be the hostname of your FTP server, which will be
-  # provided to users in the help text.
+  # options. This will be provided to users in the help text as 'log in
+  # to the FTP server at '. Thus, it should be the hostname of your FTP
+  # server.
   #ftp_upload_site: null
+
+  # This should point to a directory containing subdirectories matching
+  # users' identifier (defaults to e-mail), where Galaxy will look for
+  # files.
+  #ftp_upload_dir: null
 
   # User attribute to use as subdirectory in calculating default
   # ftp_upload_dir pattern. By default this will be email so a user's

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2659,22 +2659,22 @@ mapping:
         desc: |
           The URL to the myExperiment instance being used (omit scheme but include port).
 
-      ftp_upload_dir:
+      ftp_upload_site:
         type: str
         required: false
         desc: |
           Enable Galaxy's "Upload via FTP" interface.  You'll need to install and
           configure an FTP server (we've used ProFTPd since it can use Galaxy's
           database for authentication) and set the following two options.
-          This should point to a directory containing subdirectories matching users'
-          identifier (defaults to e-mail), where Galaxy will look for files.
+          This will be provided to users in the help text as 'log in to the FTP
+          server at '. Thus, it should be the hostname of your FTP server.
 
-      ftp_upload_site:
+      ftp_upload_dir:
         type: str
         required: false
         desc: |
-          This should be the hostname of your FTP server, which will be provided to
-          users in the help text.
+          This should point to a directory containing subdirectories matching users'
+          identifier (defaults to e-mail), where Galaxy will look for files.
 
       ftp_upload_dir_identifier:
         type: str


### PR DESCRIPTION
What:
- I changed the documentation text for `ftp_upload_dir` and `ftp_upload_site` and changed the order.

Why:
- Because I realized that setting `ftp_upload_site` was necessary and sufficient to enable the Galaxy's "Upload via FTP" interface. While in the current doc it is said that it is `ftp_upload_dir` which enables it.

## How to test the changes?
I think this is not applicable as it is only changes in doc.
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
