### PR TITLE
[21.01] Backport 11773 which was originally intended for this branch.

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -693,27 +693,22 @@ export default {
         /** try to find a good pair name for the given fwd and rev datasets */
         _guessNameForPair: function (fwd, rev, removeExtensions) {
             removeExtensions = removeExtensions ? removeExtensions : this.removeExtensions;
-            var fwdName = fwd.name;
-            var revName = rev.name;
-
-            var lcs = this._naiveStartingAndEndingLCS(
-                fwdName.replace(new RegExp(this.filters[0]), ""),
-                revName.replace(new RegExp(this.filters[1]), "")
-            );
-
+            let fwdName = fwd.name;
+            let revName = rev.name;
+            const fwdNameFilter = fwdName.replace(new RegExp(this.forwardFilter), "");
+            const revNameFilter = revName.replace(new RegExp(this.reverseFilter), "");
+            let lcs = this._naiveStartingAndEndingLCS(fwdNameFilter, revNameFilter);
             /** remove url prefix if files were uploaded by url */
-            var lastSlashIndex = lcs.lastIndexOf("/");
+            const lastSlashIndex = lcs.lastIndexOf("/");
             if (lastSlashIndex > 0) {
-                var urlprefix = lcs.slice(0, lastSlashIndex + 1);
+                const urlprefix = lcs.slice(0, lastSlashIndex + 1);
                 lcs = lcs.replace(urlprefix, "");
-                fwdName = fwdName.replace(extension, "");
-                revName = revName.replace(extension, "");
             }
 
             if (removeExtensions) {
-                var lastDotIndex = lcs.lastIndexOf(".");
+                const lastDotIndex = lcs.lastIndexOf(".");
                 if (lastDotIndex > 0) {
-                    var extension = lcs.slice(lastDotIndex, lcs.length);
+                    const extension = lcs.slice(lastDotIndex, lcs.length);
                     lcs = lcs.replace(extension, "");
                     fwdName = fwdName.replace(extension, "");
                     revName = revName.replace(extension, "");


### PR DESCRIPTION
Fix auto-pair naming in list paired creator.

Improves the situation in https://github.com/galaxyproject/galaxy/issues/11744 a bit.

## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. Follow instructions on attached issue. Though this is a back port so it won't need to be manually retested, just making sure CI still passes.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
