### PR TITLE
[21.05] Fix various TRS bugs and add tests

### DIFF
--- a/client/src/components/Workflow/TrsImport.vue
+++ b/client/src/components/Workflow/TrsImport.vue
@@ -18,7 +18,7 @@
             <div v-else>
                 <div>
                     <b>TRS ID:</b>
-                    <b-form-input v-model="toolId" />
+                    <b-form-input v-model="debouncedToolId" id="trs-id-input" />
                 </div>
                 <trs-tool :trs-tool="trsTool" v-if="trsTool" @onImport="importVersion(trsTool.id, $event)" />
             </div>
@@ -66,10 +66,11 @@ export default {
     data() {
         return {
             trsSelection: null,
-            toolId: null,
             trsTool: null,
             errorMessage: null,
             isAutoImport: this.queryTrsVersionId && this.queryTrsServer && this.queryTrsId,
+            timeout: null,
+            toolId: null,
         };
     },
     computed: {
@@ -78,6 +79,19 @@ export default {
         },
         isAnonymous() {
             return getGalaxyInstance().user.isAnonymous();
+        },
+        debouncedToolId: {
+            get() {
+                return this.toolId;
+            },
+            set(val) {
+                if (this.timeout) {
+                    clearTimeout(this.timeout);
+                }
+                this.timeout = setTimeout(() => {
+                    this.toolId = val.trim();
+                }, 300);
+            },
         },
     },
     watch: {

--- a/client/src/components/Workflow/TrsTool.vue
+++ b/client/src/components/Workflow/TrsTool.vue
@@ -16,8 +16,12 @@
             <b>Versions</b>
             <ul>
                 <li v-for="version in trsTool.versions" :key="version.id">
-                    <b-link>{{ version.name }}</b-link>
-                    <b-button id="workflow-import" class="m-1" @click="importVersion(version)">
+                    <b-button
+                        class="m-1 workflow-import"
+                        :data-version-name="version.name"
+                        @click="importVersion(version)"
+                    >
+                        {{ version.name }}
                         <font-awesome-icon icon="upload" />
                     </b-button>
                 </li>
@@ -48,7 +52,8 @@ export default {
     },
     methods: {
         importVersion(version) {
-            this.$emit("onImport", version);
+            const version_id = version.id.includes(`:${version.name}`) ? version.name : version.id;
+            this.$emit("onImport", version_id);
         },
     },
 };

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -163,6 +163,14 @@ class NavigatesGalaxy(HasDriver):
         self.wait_for_visible(self.navigation.masthead.selector)
         self.wait_for_visible(self.navigation.history_panel.selector)
 
+    def trs_search(self):
+        self.driver.get(self.build_url('workflows/trs_search'))
+        self.wait_for_visible(self.navigation.masthead.selector)
+
+    def trs_by_id(self):
+        self.driver.get(self.build_url('workflows/trs_import'))
+        self.wait_for_visible(self.navigation.masthead.selector)
+
     def switch_to_main_panel(self):
         self.driver.switch_to.frame("galaxy_main")
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -380,6 +380,31 @@ workflows:
     import_button: '#workflow-import'
     save_button: '#workflow-save-button'
     search_box: "#workflow-search"
+    workflow_table: "#workflow-table"
+
+trs_search:
+  selectors:
+    search: "#trs-search-query"
+    search_result:
+      type: xpath
+      selector: "//td[contains(text(), '${workflow_name}')]"
+    import_button: ".workflow-import"
+    select_server_button: "#dropdownTrsServer"
+    select_server:
+      type: xpath
+      selector: "//a[contains(@class, 'dropdown-item') and text() = '${server}']"
+
+trs_import:
+  selectors:
+    input: "#trs-id-input"
+    # *= means attribute value contains "${version}"
+    # needed because dockstore uses branch or git tag, while workflowhub
+    # concatenates name and version
+    import_version: '[data-version-name*="${version}"]'
+    select_server_button: "#dropdownTrsServer"
+    select_server:
+      type: xpath
+      selector: "//a[contains(@class, 'dropdown-item') and text() = '${server}']"
 
 workflow_run:
 

--- a/test/integration_selenium/test_trs_import.py
+++ b/test/integration_selenium/test_trs_import.py
@@ -1,0 +1,93 @@
+import os
+
+from .framework import SeleniumIntegrationTestCase
+
+TRS_CONFIG = """
+- api_url: https://dockstore.org/api
+  doc: 'Dockstore is an open platform used by the GA4GH for sharing Docker-based tools
+    and workflows.'
+  id: dockstore
+  label: dockstore
+  link_url: https://dockstore.org
+- api_url: https://workflowhub.eu
+  doc: 'WorkflowHub is a registry of scientific workflows.'
+  id: workflowhub
+  label: workflowhub
+  link_url: https://workflowhub.eu
+"""
+TRS_ID_DOCKSTORE = "workflow/github.com/iwc-workflows/sars-cov-2-pe-illumina-artic-variant-calling/COVID-19-PE-ARTIC-ILLUMINA"
+TRS_VERSION_DOCKSTORE = 'v0.4'
+TRS_ID_WORKFLOWHUB = "110"
+TRS_VERSION_WORKFLOWHUB = "4"
+WORKFLOW_NAME = 'COVID-19: variation analysis on ARTIC PE data'
+
+
+class TrsImportTestCase(SeleniumIntegrationTestCase):
+    ensure_registered = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        trs_config_dir = cls.trs_config_dir()
+        os.makedirs(trs_config_dir)
+        trs_config_file = os.path.join(trs_config_dir, "trs_config.yml")
+        with open(trs_config_file, 'w') as trs_config:
+            trs_config.write(TRS_CONFIG)
+        config["trs_servers_config_file"] = trs_config_file
+
+    @classmethod
+    def trs_config_dir(cls):
+        return cls.temp_config_dir("trs")
+
+    def assert_workflow_imported(self, name):
+        self.workflow_index_search_for(name)
+        assert len(self.workflow_index_table_elements()) == 1, "workflow ${name} not imported"
+
+    def test_import_workflow_by_url_dockstore(self):
+        import_url = f"workflows/trs_import?trs_server=dockstore.org&trs_version={TRS_VERSION_DOCKSTORE}&trs_id=%23{TRS_ID_DOCKSTORE}"
+        self._import_workflow_by_url(import_url)
+
+    def test_import_workflow_by_url_workflowhub(self):
+        import_url = f"workflows/trs_import?trs_server=workflowhub&trs_version={TRS_VERSION_WORKFLOWHUB}&trs_id={TRS_ID_WORKFLOWHUB}"
+        self._import_workflow_by_url(import_url)
+
+    def _import_workflow_by_url(self, import_url):
+        full_url = self.build_url(import_url)
+        self.driver.get(full_url)
+        self.components.workflows.workflow_table.wait_for_visible()
+        self.assert_workflow_imported(WORKFLOW_NAME)
+
+    def test_import_by_search_dockstore(self):
+        self.trs_search()
+        self.components.trs_search.search.wait_for_and_send_keys('This is the documentation for the workflow.')
+        self.components.trs_search.search_result(workflow_name='galaxy-workflow-dockstore-example-1').wait_for_and_click()
+        self.components.trs_search.import_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_index_open()
+        self.assert_workflow_imported("Test Workflow")
+
+    def test_import_by_search_workflowhub(self):
+        self.trs_search()
+        self.components.trs_search.select_server_button.wait_for_and_click()
+        self.components.trs_search.select_server(server='workflowhub').wait_for_and_click()
+        self.components.trs_search.search.wait_for_and_send_keys(WORKFLOW_NAME)
+        self.components.trs_search.search_result(workflow_name=WORKFLOW_NAME).wait_for_and_click()
+        self.components.trs_search.import_button.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_index_open()
+        self.assert_workflow_imported(WORKFLOW_NAME)
+
+    def test_import_by_id_dockstore(self):
+        self._import_by_id(f"#{TRS_ID_DOCKSTORE}", server='dockstore')
+
+    def test_import_by_id_workflowhub(self):
+        self._import_by_id(TRS_ID_WORKFLOWHUB, server='workflowhub')
+
+    def _import_by_id(self, trs_id, server):
+        self.trs_by_id()
+        self.components.trs_import.select_server_button.wait_for_and_click()
+        self.components.trs_import.select_server(server=server).wait_for_and_click()
+        self.components.trs_import.input.wait_for_and_send_keys(trs_id)
+        self.components.trs_import.import_version(version="v0.4").wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.workflow_index_open()
+        self.assert_workflow_imported(WORKFLOW_NAME)


### PR DESCRIPTION
The test should cover all of the existing functionality and runs against workflowhub and dockstore.

Fixes the actual workflow import via the search form that was broken at least on dockstore, pasting a TRS id with a trailing whitespace, and a selenium testing issue when rapidly typing the TRS id.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
