### PR TITLE
Quote extract_dataset_parts.sh call for parallelism mechanism

### DIFF
--- a/lib/galaxy/jobs/splitters/multi.py
+++ b/lib/galaxy/jobs/splitters/multi.py
@@ -101,7 +101,7 @@ def do_split(job_wrapper):
                 for file in names:
                     os.symlink(file, os.path.join(dir, os.path.basename(file)))
     tasks = []
-    prepare_files = f"{os.path.join(util.galaxy_directory(), 'extract_dataset_parts.sh')} %s"
+    prepare_files = f"'{os.path.join(util.galaxy_directory(), 'extract_dataset_parts.sh')}' %s"
     for dir in task_dirs:
         task = model.Task(parent_job, dir, prepare_files % dir)
         tasks.append(task)


### PR DESCRIPTION
In https://github.com/galaxyproject/galaxy/pull/12104 I realized that `<pararalellism>` does not work if the galaxy root dir contains a space. Related: https://github.com/galaxyproject/galaxy/pull/9848

This would fix it, but maybe (probably) there is a better way do do it (galaxy root should always be quoted).
 
~No idea how this was not realized earlier since the converter tests use a space in galaxy root for a long time...~ Was not realized before because the converters using parallelism have no tests. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

I guess it would be sufficient to show in a revert of the commit that the converter tests fail.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
