### PR TITLE
[21.05] Allow ``decompress="true"`` in test comparison methods 

### DIFF
--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -465,7 +465,7 @@ class TestCollectionOutputDef:
     def from_dict(as_dict):
         return TestCollectionOutputDef(
             name=as_dict["name"],
-            attrib=as_dict["attributes"],
+            attrib=as_dict.get("attributes", {}),
             element_tests=as_dict["element_tests"],
         )
 

--- a/lib/galaxy/tool_util/verify/__init__.py
+++ b/lib/galaxy/tool_util/verify/__init__.py
@@ -224,8 +224,17 @@ def files_delta(file1, file2, attributes=None):
         raise AssertionError('Files %s=%db but %s=%db - compare by size (delta_frac=%s) failed' % (file1, s1, file2, s2, delta_frac))
 
 
+def get_compressed_formats(attributes):
+    attributes = attributes or {}
+    decompress = attributes.get("decompress")
+    # None means all compressed formats are allowed
+    return None if decompress else []
+
+
 def files_diff(file1, file2, attributes=None):
     """Check the contents of 2 files for differences."""
+    attributes = attributes or {}
+
     def get_lines_diff(diff):
         count = 0
         for line in diff:
@@ -234,14 +243,7 @@ def files_diff(file1, file2, attributes=None):
         return count
 
     if not filecmp.cmp(file1, file2, shallow=False):
-        if attributes is None:
-            attributes = {}
-        decompress = attributes.get("decompress", None)
-        if decompress:
-            # None means all compressed formats are allowed
-            compressed_formats = None
-        else:
-            compressed_formats = []
+        compressed_formats = get_compressed_formats(attributes)
         is_pdf = False
         try:
             with get_fileobj(file2, compressed_formats=compressed_formats) as fh:
@@ -309,12 +311,14 @@ def files_diff(file1, file2, attributes=None):
 
 def files_re_match(file1, file2, attributes=None):
     """Check the contents of 2 files for differences using re.match."""
+    attributes = attributes or {}
     join_char = ''
     to_strip = os.linesep
+    compressed_formats = get_compressed_formats(attributes)
     try:
-        with open(file2, encoding='utf-8') as fh:
+        with get_fileobj(file2, compressed_formats=compressed_formats) as fh:
             history_data = fh.readlines()
-        with open(file1, encoding='utf-8') as fh:
+        with get_fileobj(file1, compressed_formats=compressed_formats) as fh:
             local_file = fh.readlines()
     except UnicodeDecodeError:
         join_char = b''
@@ -324,8 +328,6 @@ def files_re_match(file1, file2, attributes=None):
         with open(file1, 'rb') as fh:
             local_file = fh.readlines()
     assert len(local_file) == len(history_data), 'Data File and Regular Expression File contain a different number of lines (%d != %d)\nHistory Data (first 40 lines):\n%s' % (len(local_file), len(history_data), join_char.join(history_data[:40]))
-    if attributes is None:
-        attributes = {}
     if attributes.get('sort', False):
         history_data.sort()
     lines_diff = int(attributes.get('lines_diff', 0))
@@ -343,11 +345,13 @@ def files_re_match(file1, file2, attributes=None):
 
 def files_re_match_multiline(file1, file2, attributes=None):
     """Check the contents of 2 files for differences using re.match in multiline mode."""
+    attributes = attributes or {}
     join_char = ''
+    compressed_formats = get_compressed_formats(attributes)
     try:
-        with open(file2, encoding='utf-8') as fh:
+        with get_fileobj(file2, compressed_formats=compressed_formats) as fh:
             history_data = fh.readlines()
-        with open(file1, encoding='utf-8') as fh:
+        with get_fileobj(file1, compressed_formats=compressed_formats) as fh:
             local_file = fh.read()
     except UnicodeDecodeError:
         join_char = b''
@@ -355,8 +359,6 @@ def files_re_match_multiline(file1, file2, attributes=None):
             history_data = fh.readlines()
         with open(file1, 'rb') as fh:
             local_file = fh.read()
-    if attributes is None:
-        attributes = {}
     if attributes.get('sort', False):
         history_data.sort()
     history_data = join_char.join(history_data)
@@ -367,11 +369,13 @@ def files_re_match_multiline(file1, file2, attributes=None):
 def files_contains(file1, file2, attributes=None):
     """Check the contents of file2 for substrings found in file1, on a per-line basis."""
     # TODO: allow forcing ordering of contains
+    attributes = attributes or {}
     to_strip = os.linesep
+    compressed_formats = get_compressed_formats(attributes)
     try:
-        with open(file2, encoding='utf-8') as fh:
+        with get_fileobj(file2, compressed_formats=compressed_formats) as fh:
             history_data = fh.read()
-        with open(file1, encoding='utf-8') as fh:
+        with get_fileobj(file1, compressed_formats=compressed_formats) as fh:
             local_file = fh.readlines()
     except UnicodeDecodeError:
         to_strip = os.linesep.encode('utf-8')
@@ -379,8 +383,6 @@ def files_contains(file1, file2, attributes=None):
             history_data = fh.read()
         with open(file1, 'rb') as fh:
             local_file = fh.readlines()
-    if attributes is None:
-        attributes = {}
     lines_diff = int(attributes.get('lines_diff', 0))
     line_diff_count = 0
     for contains in local_file:
@@ -388,4 +390,4 @@ def files_contains(file1, file2, attributes=None):
         if contains not in history_data:
             line_diff_count += 1
         if line_diff_count > lines_diff:
-            raise AssertionError("Failed to find '%s' in history data. (lines_diff=%i)" % (contains, lines_diff))
+            raise AssertionError(f"Failed to find '{contains}' in history data. (lines_diff={lines_diff}).")


### PR DESCRIPTION
- Allow ``decompress="true"`` in test comparison methods. We had not documented that this does not work for `re_match` and `contains`, so I'm calling it a bug.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
