### PR TITLE
[21.05] add path to the SSH plugin

### DIFF
--- a/lib/galaxy/files/sources/ssh.py
+++ b/lib/galaxy/files/sources/ssh.py
@@ -13,7 +13,10 @@ class SshFilesSource(PyFilesystem2FilesSource):
 
     def _open_fs(self, user_context):
         props = self._serialization_props(user_context)
+        path = props.pop('path')
         handle = SSHFS(**props)
+        if path:
+            handle = handle.opendir(path)
         return handle
 
 


### PR DESCRIPTION
Fix from @bgruening for:

```pytb
galaxy.managers.remote_files WARNING 2021-06-23 15:01:14,903 [pN:main.web.6,p:29675,w:6,m:0,tN:uWSGIWorker6Core0] Problem listing file source path FileSourcePath(file_source=<galaxy.files.sources.ssh.SshFilesSource object at 0x7f763493c978>, path='/')
Traceback (most recent call last):
  File "lib/galaxy/managers/remote_files.py", line 85, in index
    index = file_source.list(file_source_path.path, recursive=recursive, user_context=user_file_source_context)
  File "lib/galaxy/files/sources/__init__.py", line 142, in list
    return self._list(path, recursive, user_context)
  File "lib/galaxy/files/sources/_pyfilesystem2.py", line 28, in _list
    with self._open_fs(user_context=user_context) as h:
  File "lib/galaxy/files/sources/ssh.py", line 16, in _open_fs
    handle = SSHFS(**props)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.6/site-packages/fs/sshfs/sshfs.py", line 143, in __init__
    **argdict
TypeError: connect() got an unexpected keyword argument 'path'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Add a file source plugin of `type: ssh`
  2. Browse to that file source in the UI

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
