### PR TITLE
Hide masthead help resources if resource urls are unavailable

### DIFF
--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -238,6 +238,7 @@ export function fetchMenu(options = {}) {
             },
         ],
     };
+    menu.push(helpTab);
 
     //
     // User tab.

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -181,29 +181,40 @@ export function fetchMenu(options = {}) {
         tooltip: _l("Support, contact, and community"),
         menu: [
             {
+                title: _l("Galaxy Help"),
+                url: options.helpsite_url,
+                target: "_blank",
+                hidden: !options.helpsite_url,
+            },
+            {
                 title: _l("Support"),
                 url: options.support_url,
                 target: "_blank",
+                hidden: !options.support_url,
             },
             {
                 title: _l("Search"),
                 url: options.search_url,
                 target: "_blank",
+                hidden: !options.search_url,
             },
             {
                 title: _l("Mailing Lists"),
                 url: options.mailing_lists,
                 target: "_blank",
+                hidden: !options.mailing_lists,
             },
             {
                 title: _l("Videos"),
                 url: options.screencasts_url,
                 target: "_blank",
+                hidden: !options.screencasts_url,
             },
             {
                 title: _l("Wiki"),
                 url: options.wiki_url,
                 target: "_blank",
+                hidden: !options.wiki_url,
             },
             {
                 title: _l("How to Cite Galaxy"),
@@ -219,23 +230,14 @@ export function fetchMenu(options = {}) {
                 url: versionUserDocumentationUrl,
                 target: "_blank",
             },
+            {
+                title: _l("Terms and Conditions"),
+                url: options.terms_url,
+                target: "_blank",
+                hidden: !options.terms_url,
+            },
         ],
     };
-    if (options.terms_url) {
-        helpTab.menu.push({
-            title: _l("Terms and Conditions"),
-            url: options.terms_url,
-            target: "_blank",
-        });
-    }
-    if (options.helpsite_url) {
-        helpTab.menu.unshift({
-            title: _l("Galaxy Help"),
-            url: options.helpsite_url,
-            target: "_blank",
-        });
-    }
-    menu.push(helpTab);
 
     //
     // User tab.


### PR DESCRIPTION
The masthead navigation bar contains the Help dropdown section which contains links to helpful resources e.g. Support, Wiki and others. Currently these links will always appear, although admins of some instances might not want to display all of them. The current change allows admins to set the corresponding resource url to `null` in the main configuration and hide individual resources in the masthead. This option is already available for some urls. This PR expands the list of urls which can be disabled.