### PR TITLE
Make conda_auto_init option overrridable

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -162,6 +162,7 @@ EXPOSE 8080
 USER $GALAXY_USER
 
 ENV PATH="$SERVER_DIR/.venv/bin:${PATH}"
+ENV GALAXY_CONFIG_CONDA_AUTO_INIT=False
 
 # [optional] to run:
 CMD uwsgi --yaml config/galaxy.yml


### PR DESCRIPTION
When using galaxy-k8s as a container for testing a single instance of galaxy, it is very useful if that galaxy can install tools. Having `conda_auto_init` on `False` is desirable when running kubernetes, but for other use cases it might be better to have it on `True`. Currently that requires mounting a new galaxy config file in the container (also overwriting the default configuration settings), but with this change the setting can be overridden with an environment variable. This is much more convenient.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
