### PR TITLE
Cancel in progress CI on same branch, cache yarn cache

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -2,6 +2,9 @@ name: API tests
 on: [push, pull_request]
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
+concurrency:
+  group: api-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -3,6 +3,9 @@ on: [push, pull_request]
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_USE_UVICORN: false
+concurrency:
+  group: api-legacy-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -1,7 +1,9 @@
 name: Converter tests
 on: [push, pull_request]
+concurrency:
+  group: converter-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
-
   test:
     name: Test
     runs-on: ubuntu-18.04

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -1,5 +1,8 @@
 name: Database indexes
 on: [push, pull_request]
+concurrency:
+  group: database-${{ github.ref }}
+  cancel-in-progress: true
 defaults:
   run:
     working-directory: 'galaxy root'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,8 @@
 name: Build docs
 on: [push, pull_request]
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -30,6 +30,9 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+    - uses: mvdbeek/gha-yarn-cache@master
+      with:
+        yarn-lock-file: 'galaxy root/client/yarn.lock'
     - name: Install tox
       run: pip install tox
       # Use this job to test the latest migrations

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -1,5 +1,7 @@
 name: first startup
 on: [push, pull_request]
+env:
+  YARN_INSTALL_OPTS: --frozen-lockfile
 jobs:
 
   test:

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -1,5 +1,8 @@
 name: first startup
 on: [push, pull_request]
+concurrency:
+  group: first-startup-${{ github.ref }}
+  cancel-in-progress: true
 env:
   YARN_INSTALL_OPTS: --frozen-lockfile
 jobs:

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -1,5 +1,8 @@
 name: Framework tests
 on: [push, pull_request]
+concurrency:
+  group: framework-${{ github.ref }}
+  cancel-in-progress: true
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 jobs:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,5 +1,8 @@
 name: Integration
 on: [push, pull_request]
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -1,5 +1,8 @@
 name: Integration Selenium
 on: [push, pull_request]
+concurrency:
+  group: integration-selenium-${{ github.ref }}
+  cancel-in-progress: true
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_SELENIUM_REMOTE: '1'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -6,6 +6,7 @@ env:
   GALAXY_TEST_SELENIUM_REMOTE_PORT: "4444"
   GALAXY_SKIP_CLIENT_BUILD: '0'
   GALAXY_TEST_SELENIUM_RETRIES: 1
+  YARN_INSTALL_OPTS: --frozen-lockfile
 jobs:
   test:
     name: Test

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -41,6 +41,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - uses: mvdbeek/gha-yarn-cache@master
+        with:
+          yarn-lock-file: 'galaxy root/client/yarn.lock'
       - name: Run tests
         run: './run_tests.sh -integration test/integration_selenium'
         working-directory: 'galaxy root'

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -12,6 +12,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node}}
+    - uses: mvdbeek/gha-yarn-cache@master
+      with:
+        yarn-lock-file: 'client/yarn.lock'
     - run: yarn install
       working-directory: client
     - run: yarn jest

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -15,7 +15,7 @@ jobs:
     - uses: mvdbeek/gha-yarn-cache@master
       with:
         yarn-lock-file: 'client/yarn.lock'
-    - run: yarn install
+    - run: yarn install --frozen-lockfile
       working-directory: client
     - run: yarn jest
       working-directory: client

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -1,5 +1,8 @@
 name: Client Unit Testing
 on: [push, pull_request]
+concurrency:
+  group: client-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   jest:
     runs-on: ubuntu-latest

--- a/.github/workflows/labels-verifier.yaml
+++ b/.github/workflows/labels-verifier.yaml
@@ -2,7 +2,6 @@ name: Labels Verifier
 on:
   pull_request_target:
     types: [closed]
-
 jobs:
   onMerged:
     name: "Check Labels on merge"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,8 @@
 name: Python linting
 on: [push, pull_request]
+concurrency:
+  group: py-lint-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/.github/workflows/maintenance_bot.yaml
+++ b/.github/workflows/maintenance_bot.yaml
@@ -2,7 +2,6 @@ name: Maintenance Bot
 on:
   pull_request_target:
     types: [opened, reopened, edited, ready_for_review, unlabeled]
-
 jobs:
   labeler:
     name: Assign labels and milestone

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -1,5 +1,8 @@
 name: Mulled Unit Tests
 on: [push, pull_request]
+concurrency:
+  group: mulled-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -1,7 +1,9 @@
 name: macOS startup
 on: [push, pull_request]
+concurrency:
+  group: osx-first-startup-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
-
   test:
     name: Startup test
     runs-on: macos-latest

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,5 +1,8 @@
 name: Performance tests
 on: [push, pull_request]
+concurrency:
+  group: performance-${{ github.ref }}
+  cancel-in-progress: true
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 jobs:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -4,6 +4,7 @@ env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 'true'
   GALAXY_TEST_SELENIUM_RETRIES: 1
+  YARN_INSTALL_OPTS: --frozen-lockfile
 jobs:
   test:
     name: Test

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -34,6 +34,9 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+      - uses: mvdbeek/gha-yarn-cache@master
+        with:
+          yarn-lock-file: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@master
       - name: Run tests
         run: ./run_tests.sh -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -1,5 +1,8 @@
 name: Selenium tests
 on: [push, pull_request]
+concurrency:
+  group: selenium-${{ github.ref }}
+  cancel-in-progress: true
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 'true'

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -1,5 +1,8 @@
 name: Toolshed tests
 on: [push, pull_request]
+concurrency:
+  group: toolshed-${{ github.ref }}
+  cancel-in-progress: true
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   TOOL_SHED_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/toolshed?client_encoding=utf8'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,5 +1,8 @@
 name: Unit tests
 on: [push, pull_request]
+concurrency:
+  group: py-unit-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SLIDESHOW_DIR=$(DOC_SOURCE_DIR)/slideshow
 OPEN_RESOURCE=bash -c 'open $$0 || xdg-open $$0'
 SLIDESHOW_TO_PDF?=bash -c 'docker run --rm -v `pwd`:/cwd astefanutti/decktape /cwd/$$0 /cwd/`dirname $$0`/`basename -s .html $$0`.pdf'
 YARN := $(shell command -v yarn 2> /dev/null)
+YARN_INSTALL_OPTS=--network-timeout 300000 --check-files
 
 all: help
 	@echo "This makefile is used for building Galaxy's JS client, documentation, and drive the release process. A sensible all target is not implemented."
@@ -134,7 +135,7 @@ ifndef YARN
 	@echo "Could not find yarn, which is required to build the Galaxy client.\nTo install yarn, please visit \033[0;34mhttps://yarnpkg.com/en/docs/install\033[0m for instructions, and package information for all platforms.\n"
 	false;
 else
-	cd client && yarn install --network-timeout 300000 --check-files
+	cd client && yarn install $(YARN_INSTALL_OPTS)
 endif
 	
 

--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -19,6 +19,7 @@ REPLACE_PIP=$SET_VENV
 COPY_SAMPLE_FILES=1
 SKIP_CLIENT_BUILD=${GALAXY_SKIP_CLIENT_BUILD:-0}
 NODE_VERSION=${GALAXY_NODE_VERSION:-"$(cat client/.node_version)"}
+YARN_INSTALL_OPTS=${YARN_INSTALL_OPTS:-"--network-timeout 300000 --check-files"}
 
 for arg in "$@"; do
     [ "$arg" = "--skip-eggs" ] && FETCH_WHEELS=0
@@ -258,7 +259,7 @@ if [ $SKIP_CLIENT_BUILD -eq 0 ]; then
     fi
     # Build client
     cd client
-    if yarn install --network-timeout 300000 --check-files; then
+    if yarn install $YARN_INSTALL_OPTS; then
         if ! yarn run build-production-maps; then
             echo "ERROR: Galaxy client build failed. See ./client/README.md for more information, including how to get help."
             exit 1


### PR DESCRIPTION
and use `--frozen-lockfile`.

This will cancel ongoing github workflow runs if you push again on the same branch. We discussed this in the testing and hardening WG meeting. This should keep our testing queue free even if someone pushes commits sequentially.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
