### PR TITLE
[21.01] Fix running metadata tool on LDDAs

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1894,13 +1894,12 @@ class DataToolParameter(BaseDataToolParameter):
                         rval.append(trans.sa_session.query(trans.app.model.LibraryDatasetDatasetAssociation).get(decoded_id))
                     else:
                         raise ValueError("Unknown input source %s passed to job submission API." % single_value['src'])
-                elif isinstance(single_value, trans.app.model.HistoryDatasetCollectionAssociation):
-                    rval.append(single_value)
-                elif isinstance(single_value, trans.app.model.DatasetCollectionElement):
-                    rval.append(single_value)
-                elif isinstance(single_value, trans.app.model.HistoryDatasetAssociation):
-                    rval.append(single_value)
-                elif isinstance(single_value, trans.app.model.LibraryDatasetDatasetAssociation):
+                elif isinstance(single_value, (
+                        trans.app.model.HistoryDatasetCollectionAssociation,
+                        trans.app.model.DatasetCollectionElement,
+                        trans.app.model.HistoryDatasetAssociation,
+                        trans.app.model.LibraryDatasetDatasetAssociation
+                )):
                     rval.append(single_value)
                 else:
                     if len(str(single_value)) == 16:
@@ -1913,7 +1912,7 @@ class DataToolParameter(BaseDataToolParameter):
                 for val in rval:
                     if not isinstance(val, trans.app.model.HistoryDatasetCollectionAssociation):
                         raise ParameterValueError("if collections are supplied to multiple data input parameter, only collections may be used", self.name)
-        elif isinstance(value, trans.app.model.HistoryDatasetAssociation):
+        elif isinstance(value, (trans.app.model.HistoryDatasetAssociation, trans.app.model.LibraryDatasetDatasetAssociation)):
             rval = value
         elif isinstance(value, dict) and 'src' in value and 'id' in value:
             if value['src'] == 'hda':

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -1,5 +1,4 @@
 import json
-import time
 import unittest
 
 from galaxy_test.base.populators import (
@@ -284,44 +283,43 @@ class LibrariesApiTestCase(ApiTestCase, TestsDatasets):
         container_update_time = container_fetch_response.json()['folder_contents'][0]['update_time']
         assert dataset_update_time == container_update_time, container_fetch_response
 
-    def test_update_dataset_in_folder(self):
-        ld = self._create_dataset_in_folder_in_library("ForUpdateDataset")
-        data = {'name': 'updated_name', 'file_ext': 'fastq', 'misc_info': 'updated_info', 'genome_build': 'updated_genome_build'}
-        create_response = self._patch("libraries/datasets/%s" % ld.json()["id"], data=data)
+    def _patch_library_dataset(self, library_dataset_id, data):
+        create_response = self._patch("libraries/datasets/{}".format(library_dataset_id), data=data)
         self._assert_status_code_is(create_response, 200)
-        self._assert_has_keys(create_response.json(), "name", "file_ext", "misc_info", "genome_build")
+        ld = create_response.json()
+        library_id = ld['parent_library_id']
+        return self.library_populator.wait_on_library_dataset(library={'id': library_id}, dataset=ld)
+
+    def test_update_dataset_in_folder(self):
+        ld = self._create_dataset_in_folder_in_library("ForUpdateDataset", content=">seq\nATGC", wait=True).json()
+        data = {'name': 'updated_name', 'file_ext': 'fasta', 'misc_info': 'updated_info', 'genome_build': 'updated_genome_build'}
+        ld_updated = self._patch_library_dataset(ld['id'], data)
+        self._assert_has_keys(ld_updated, "name", "file_ext", "misc_info", "genome_build")
 
     def test_update_dataset_tags(self):
-        ld = self._create_dataset_in_folder_in_library("ForTagtestDataset")
+        ld = self._create_dataset_in_folder_in_library("ForTagtestDataset", wait=True).json()
         data = {"tags": ["#Lancelot", "name:Holy Grail", "blue"]}
-        create_response = self._patch("libraries/datasets/%s" % ld.json()["id"], data=data)
-        self._assert_status_code_is(create_response, 200)
-        self._assert_has_keys(create_response.json(), "tags")
-        assert create_response.json()["tags"] == "name:Lancelot, name:HolyGrail, blue"
+        ld_updated = self._patch_library_dataset(ld['id'], data)
+        self._assert_has_keys(ld_updated, "tags")
+        assert ld_updated["tags"] == "name:Lancelot, name:HolyGrail, blue"
 
     def test_invalid_update_dataset_in_folder(self):
-        ld = self._create_dataset_in_folder_in_library("ForInvalidUpdateDataset")
+        ld = self._create_dataset_in_folder_in_library("ForInvalidUpdateDataset", wait=True).json()
         data = {'file_ext': 'nonexisting_type'}
-        create_response = self._patch("libraries/datasets/%s" % ld.json()["id"], data=data)
+        create_response = self._patch("libraries/datasets/{}".format(ld["id"]), data=data)
         self._assert_status_code_is(create_response, 400)
         assert 'This Galaxy does not recognize the datatype of:' in create_response.json()['err_msg']
 
     def test_detect_datatype_of_dataset_in_folder(self):
-        ld = self._create_dataset_in_folder_in_library("ForDetectDataset")
-        # Wait for metadata job to finish.
-        time.sleep(2)
+        ld = self._create_dataset_in_folder_in_library("ForDetectDataset", wait=True).json()
         data = {'file_ext': 'data'}
-        create_response = self._patch("libraries/datasets/%s" % ld.json()["id"], data=data)
-        self._assert_status_code_is(create_response, 200)
-        self._assert_has_keys(create_response.json(), "file_ext")
-        assert create_response.json()["file_ext"] == "data"
-        # Wait for metadata job to finish.
-        time.sleep(2)
+        ld_updated = self._patch_library_dataset(ld['id'], data)
+        self._assert_has_keys(ld_updated, "file_ext")
+        assert ld_updated["file_ext"] == "data"
         data = {'file_ext': 'auto'}
-        create_response = self._patch("libraries/datasets/%s" % ld.json()["id"], data=data)
-        self._assert_status_code_is(create_response, 200)
-        self._assert_has_keys(create_response.json(), "file_ext")
-        assert create_response.json()["file_ext"] == "txt"
+        ld_updated = self._patch_library_dataset(ld['id'], data)
+        self._assert_has_keys(ld_updated, "file_ext")
+        assert ld_updated["file_ext"] == "txt"
 
     def test_ldda_collection_import_to_history(self):
         self._import_to_history(visible=True)
@@ -426,13 +424,13 @@ class LibrariesApiTestCase(ApiTestCase, TestsDatasets):
         )
         return self._post("folders/%s" % containing_folder_id, data=create_data)
 
-    def _create_dataset_in_folder_in_library(self, library_name):
+    def _create_dataset_in_folder_in_library(self, library_name, content="1 2 3", wait=False):
         library = self.library_populator.new_private_library(library_name)
         folder_response = self._create_folder(library)
         self._assert_status_code_is(folder_response, 200)
         folder_id = folder_response.json()[0]['id']
         history_id = self.dataset_populator.new_history()
-        hda_id = self.dataset_populator.new_dataset(history_id, content="1 2 3")['id']
+        hda_id = self.dataset_populator.new_dataset(history_id, content=content, wait=wait)['id']
         payload = {'from_hda_id': hda_id, 'create_type': 'file', 'folder_id': folder_id}
         ld = self._post("libraries/%s/contents" % folder_id, payload)
         return ld

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1570,7 +1570,7 @@ def wait_on_state(state_func, desc="state", skip_states=None, ok_states=None, as
             return state
 
     if skip_states is None:
-        skip_states = ["running", "queued", "new", "ready", "stop", "stopped"]
+        skip_states = ["running", "queued", "new", "ready", "stop", "stopped", "setting_metadata"]
     if ok_states is None:
         ok_states = ["ok", "scheduled"]
     try:


### PR DESCRIPTION
The library tests were producing datasets with failed_metadata states,
but we never asserted the state, so we never noticed this.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
