### PR TITLE
[21.05] Fix crash when uwsgi + mules has unhandled jobs at startup

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -266,6 +266,9 @@ class UniverseApplication(StructuredApp, GalaxyManagerApplication):
         # Load history import/export tools.
         load_lib_tools(self.toolbox)
         self.toolbox.persist_cache(register_postfork=True)
+        # If app is not job handler but uses mule messaging.
+        # Can be removed when removing mule support.
+        self.job_manager._check_jobs_at_startup()
         # visualizations registry: associates resources with visualizations, controls how to render
         self.visualizations_registry = self._register_singleton(VisualizationsRegistry, VisualizationsRegistry(
             self,

--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -29,6 +29,9 @@ class JobManager:
             self.job_handler = handler.JobHandler(app)
         else:
             self.job_handler = NoopHandler()
+
+    def _check_jobs_at_startup(self):
+        if not self.app.is_job_handler:
             self.__check_jobs_at_startup()
 
     def __check_jobs_at_startup(self):


### PR DESCRIPTION
Should fix:
```
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]: galaxy.jobs.manager INFO 2021-07-01 13:24:31,659 [pN:main,p:6779,w:0,m:0,tN:MainThread] No handler assigned at startup for the following jobs, will dispatch via message: 263002, 263003, 263004, 263005, 263006, 263009
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]: Traceback (most recent call last):
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/server/lib/galaxy/webapps/galaxy/buildapp.py", line 60, in app_pair
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/server/lib/galaxy/app.py", line 206, in __init__
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     super().__init__(fsmon=True, **kwargs)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/server/lib/galaxy/app.py", line 178, in __init__
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     self.job_manager = self._register_singleton(JobManager)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/server/lib/galaxy/di.py", line 22, in _register_singleton
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     instance = self[dep_type]
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/venv/lib/python3.6/site-packages/lagom/container.py", line 358, in __getitem__
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     return self.resolve(dep)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/venv/lib/python3.6/site-packages/lagom/container.py", line 243, in resolve
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     return self._reflection_build_with_err_handling(dep_type, suppress_error)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/venv/lib/python3.6/site-packages/lagom/container.py", line 369, in _reflection_build_with_err_handling
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     return self._reflection_build(dep_type)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/venv/lib/python3.6/site-packages/lagom/container.py", line 385, in _reflection_build
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     return dep_type(**sub_deps)  # type: ignore
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/server/lib/galaxy/jobs/manager.py", line 32, in __init__
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     self.__check_jobs_at_startup()
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:   File "/gpfs/covid19.usegalaxy.es/galaxy/server/lib/galaxy/jobs/manager.py", line 43, in __check_jobs_at_startup
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]:     tool = self.app.toolbox.get_tool(job.tool_id, job.tool_version, exact=True)
Jul 01 13:24:31 covid19.usegalaxy.es uwsgi[6779]: AttributeError: 'UniverseApplication' object has no attribute 'toolbox'
```

This happened when we broke down the app into smaller pieces.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Put some new jobs in the database and start galaxy with a mule config

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
