### PR TITLE
[21.05] Fix expanding collections in invocation view

### DIFF
--- a/client/src/components/WorkflowInvocationState/DatasetCollectionContents.vue
+++ b/client/src/components/WorkflowInvocationState/DatasetCollectionContents.vue
@@ -24,13 +24,12 @@
 <script>
 import { DatasetProvider } from "./providers";
 import DatasetUIWrapper from "./DatasetUIWrapper";
-import DatasetCollectionUIWrapper from "./DatasetCollectionUIWrapper";
 import LoadingSpan from "components/LoadingSpan";
 
 export default {
     components: {
         DatasetProvider,
-        DatasetCollectionUIWrapper,
+        DatasetCollectionUIWrapper: () => import("components/WorkflowInvocationState/DatasetCollectionUIWrapper"),
         DatasetUIWrapper,
         LoadingSpan,
     },

--- a/client/src/components/WorkflowInvocationState/DatasetCollectionUIWrapper.test.js
+++ b/client/src/components/WorkflowInvocationState/DatasetCollectionUIWrapper.test.js
@@ -51,7 +51,7 @@ describe("DatasetUIWrapper.vue with Dataset", () => {
     });
     it("manages collection expansion", async () => {
         expect(wrapper.vm.expand).toBeFalsy();
-        wrapper.findComponent(DscUI).vm.$emit("update:expanded", wrapper.vm.datasetCollection);
+        wrapper.findComponent(DscUI).vm.$emit("viewCollection", wrapper.vm.datasetCollection);
         expect(wrapper.vm.expand).toBeTruthy();
     });
     it("build dsc from collection content", async () => {

--- a/client/src/components/WorkflowInvocationState/DatasetCollectionUIWrapper.vue
+++ b/client/src/components/WorkflowInvocationState/DatasetCollectionUIWrapper.vue
@@ -6,7 +6,7 @@
             v-on="$listeners"
             :dsc="datasetCollection"
             :show-tags="true"
-            @update:expanded="toggleExpand"
+            @viewCollection="toggleExpand"
             @hide="onHide(datasetCollection)"
             @unhide="onUnhide(datasetCollection)"
             @delete="onDelete(datasetCollection, $event)"

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -509,6 +509,12 @@ invocations:
     steps_details: '.workflow-invocation-state-component .invocation-steps-details'
     step_title: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .step-title'
     step_details: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .portlet-operations'
+    step_output_collection: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details'
+    step_output_collection_toggle: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details .name'
+    step_output_collection_element_identifier:
+      type: xpath
+      selector: '//span[@class="name"][text()="${element_identifier}"]'
+    step_output_collection_element_datatype: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-output-collection-details .datatype .value'
     step_job_details: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details'
     step_job_table: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table'
     step_job_table_rows: '.workflow-invocation-state-component .invocation-steps-details [data-step="${order_index}"] .invocation-step-job-details table tbody tr'

--- a/lib/galaxy_test/selenium/test_workflow_invocation_details.py
+++ b/lib/galaxy_test/selenium/test_workflow_invocation_details.py
@@ -66,3 +66,9 @@ class WorkflowInvocationDetailsTestCase(SeleniumTestCase):
 
         invocations.step_job_information(order_index="1").wait_for_visible()
         assert "collection_creates_pair" in invocations.step_job_information_tool_id(order_index="1").wait_for_visible().text
+
+        invocations.step_output_collection(order_index="1").wait_for_and_click()
+        invocations.step_output_collection_toggle(order_index="1").wait_for_and_click()
+        invocations.step_output_collection_element_identifier(element_identifier="forward").wait_for_and_click()
+        datatype = invocations.step_output_collection_element_datatype(order_index="1").wait_for_text()
+        assert datatype == 'txt'


### PR DESCRIPTION
Broke in https://github.com/galaxyproject/galaxy/commit/60efa8e094b4b2e70f59b8edda7c87998e6ecd99.

This is how it should look like
![image](https://user-images.githubusercontent.com/6804901/124148429-edd0e180-da8f-11eb-9399-4e56ba97102a.png)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
