### PR TITLE
[21.05] Work around null hid

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2102,8 +2102,8 @@ class DataToolParameter(BaseDataToolParameter):
                 continue
 
         # sort both lists
-        d['options']['hda'] = sorted(d['options']['hda'], key=lambda k: k['hid'], reverse=True)
-        d['options']['hdca'] = sorted(d['options']['hdca'], key=lambda k: k['hid'], reverse=True)
+        d['options']['hda'] = sorted(d['options']['hda'], key=lambda k: k.get('hid', -1), reverse=True)
+        d['options']['hdca'] = sorted(d['options']['hdca'], key=lambda k: k.get('hid', -1), reverse=True)
 
         # return final dictionary
         return d
@@ -2269,7 +2269,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
             })
 
         # sort both lists
-        d['options']['hdca'] = sorted(d['options']['hdca'], key=lambda k: k['hid'], reverse=True)
+        d['options']['hdca'] = sorted(d['options']['hdca'], key=lambda k: k.get('hid', -1), reverse=True)
 
         # return final dictionary
         return d


### PR DESCRIPTION
Avoids crash with
```
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]: galaxy.web.framework.decorators ERROR 2021-07-01 16:01:27,337 [pN:main.web.4,p:3852348,w:4,m:0,tN:uWSGIWorker4Core0] Uncaught exception in exposed API method:
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]: Traceback (most recent call last):
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/web/framework/decorators.py", line 312, in decorator
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     rval = func(self, trans, *args, **kwargs)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/webapps/galaxy/api/tools.py", line 129, in build
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     return tool.to_json(trans, kwd.get('inputs', kwd), history=history)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/__init__.py", line 2178, in to_json
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     self.populate_model(request_context, self.inputs, state_inputs, tool_model['inputs'])
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/__init__.py", line 2232, in populate_model
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     tool_dict = input.to_dict(request_context)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/grouping.py", line 716, in to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     cond_dict["cases"] = list(map(nested_to_dict, self.cases))
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/grouping.py", line 714, in nested_to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     return input.to_dict(trans)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/grouping.py", line 734, in to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     when_dict["inputs"] = list(map(input_to_dict, self.inputs.values()))
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/grouping.py", line 732, in input_to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     return input.to_dict(trans)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/grouping.py", line 144, in to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     repeat_dict["inputs"] = list(map(input_to_dict, self.inputs.values()))
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/grouping.py", line 142, in input_to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     return input.to_dict(trans)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:   File "lib/galaxy/tools/parameters/basic.py", line 2273, in to_dict
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]:     d['options']['hdca'] = sorted(d['options']['hdca'], key=lambda k: k['hid'], reverse=True)
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]: TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
Jul 01 16:01:27 sn06.galaxyproject.eu uwsgi[1940451]: 109.192.195.200 - - [01/Jul/2021:16:01:27 +0200] "GET /api/tools/toolshed.g2.bx.psu.edu/repos/iuc/qualimap_multi_bamqc/qualimap_multi_bamqc/2.2.2c/build?version=2.2.2c&__identifer=vbxf0z6wog8&tool_version=2.2.2c HTTP/1.1" 500 - "https://usegalaxy.eu/?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fiuc%2Fqualimap_multi_bamqc%2Fqualimap_multi_bamqc%2F2.2.2c&version=2.2.2c&__identifer=vbxf0z6wog8" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0"
```

xref https://github.com/galaxyproject/galaxy/issues/12068

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
