### PR TITLE
Assorted fixes to debugging documentation

### DIFF
--- a/doc/source/dev/debugging_galaxy.md
+++ b/doc/source/dev/debugging_galaxy.md
@@ -6,10 +6,10 @@
 The following instructions assume that you have cloned your Galaxy fork into the
 `~/galaxy` directory and have created a VS Code workspace per instructions
 [here](./debugging_tests.md).  Additionally, we assume you have configured
-Galaxy and are using ${workspaceFolder}/config/galaxy.yml as your galaxy
-configuration file (so, not the default .sample). If you are still using the
-default configuration, simply `cp config/galaxy.yml.sample config/galaxy.yml`
-and it should work fine.
+Galaxy and are using `~/galaxy/config/galaxy.yml` as your galaxy configuration
+file (so, not the default .sample). If you are still using the default
+configuration, simply `cp config/galaxy.yml.sample config/galaxy.yml` and it
+should work fine.
 
 
 1. Add the following code snippet to `~/galaxy/.vscode/launch.json` (create the file if it does not already exist)

--- a/doc/source/dev/debugging_galaxy.md
+++ b/doc/source/dev/debugging_galaxy.md
@@ -3,7 +3,14 @@
 
 ## Debugging Galaxy in VS Code 
 
-The following instructions assume that you have cloned your Galaxy fork into the `~/galaxy` directory and have created a VS Code workspace per instructions [here](./debugging_tests.md)
+The following instructions assume that you have cloned your Galaxy fork into the
+`~/galaxy` directory and have created a VS Code workspace per instructions
+[here](./debugging_tests.md).  Additionally, we assume you have configured
+Galaxy and are using ${workspaceFolder}/config/galaxy.yml as your galaxy
+configuration file (so, not the default .sample). If you are still using the
+default configuration, simply `cp config/galaxy.yml.sample config/galaxy.yml`
+and it should work fine.
+
 
 1. Add the following code snippet to `~/galaxy/.vscode/launch.json` (create the file if it does not already exist)
     ``` 

--- a/doc/source/dev/debugging_galaxy.md
+++ b/doc/source/dev/debugging_galaxy.md
@@ -33,6 +33,6 @@ The following instructions assume that you have cloned your Galaxy fork into the
     ```
 2. Re-start VS Code
 3. Add a breakpoint somewhere in your code
-4. Select Run and Debug on Activity Bar, on the far left hand side. In the RUN AND DEBUG drop down, select Galaxy debug (galaxy), and click the Start Debugging button (green arrow)
+4. Select Run and Debug on Activity Bar, on the far left hand side. In the RUN AND DEBUG drop down, select `GalaxyFastAPI uvicorn`, and click the Start Debugging button (green arrow)
 5. Galaxy should stop right on the break point you added.
 6. Enjoy your debugging session :-)


### PR DESCRIPTION
Update debug target name in example .vscode launchconfig
Note that the debugging launch config assumes an explicit galaxy.yml configuration.
Noticed in dev-debugging-galaxy.


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
