### PR TITLE
Attempt to reduce frequency of transiently failing editor parameter value test.

### DIFF
--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -101,6 +101,9 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         node.title.wait_for_and_click()
         self.components.tool_form.parameter_checkbox(parameter='select_single').wait_for_and_click()
         self.components.tool_form.parameter_input(parameter='select_single').wait_for_and_send_keys('parameter value')
+        # some sort of value change listener requires a sleep here or the downloaded workflow sometimes has
+        # the value 'parameter val' or 'parameter valu'.
+        self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_has_changes_and_save()
         self.sleep_for(self.wait_types.UX_RENDER)
         workflow = self.workflow_populator.download_workflow(workflow_id)


### PR DESCRIPTION
Test is transiently failing at least in dev currently.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
