### PR TITLE
[21.05] Don't let reports auto-create database tables

### DIFF
--- a/lib/galaxy/webapps/reports/app.py
+++ b/lib/galaxy/webapps/reports/app.py
@@ -34,8 +34,7 @@ class UniverseApplication(BasicApp):
         # Setup the database engine and ORM
         self.model = galaxy.model.mapping.init(self.config.file_path,
                                                db_url,
-                                               self.config.database_engine_options,
-                                               create_tables=True)
+                                               self.config.database_engine_options)
         if not self.config.database_connection:
             self.targets_mysql = False
         else:


### PR DESCRIPTION
That fails when the database (and the triggers) already exists:
```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/webapps/reports/buildapp.py", line 136, in uwsgi_app
    return galaxy.webapps.base.webapp.build_native_uwsgi_app(app_factory, "reports")
  File "/Users/mvandenb/src/galaxy/lib/galaxy/webapps/base/webapp.py", line 993, in build_native_uwsgi_app
    uwsgi_app = paste_factory({}, load_app_kwds=app_kwds)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/webapps/reports/buildapp.py", line 59, in app_factory
    app = UniverseApplication(global_conf=global_conf, **kwargs)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/webapps/reports/app.py", line 35, in __init__
    self.model = galaxy.model.mapping.init(self.config.file_path,
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/mapping.py", line 2926, in init
    install_timestamp_triggers(engine)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/migrate/triggers/update_audit_table.py", line 18, in install
    execute_statements(engine, sql)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/migrate/versions/util.py", line 203, in execute_statements
    cmd.execute(bind=engine)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/ddl.py", line 100, in execute
    return bind.execute(self.against(target))
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 2235, in execute
    return connection.execute(statement, *multiparams, **params)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1011, in execute
    return meth(self, multiparams, params)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/sql/ddl.py", line 72, in _execute_on_connection
    return connection._execute_ddl(self, multiparams, params)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1068, in _execute_ddl
    ret = self._execute_context(
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1316, in _execute_context
    self._handle_dbapi_exception(
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1510, in _handle_dbapi_exception
    util.raise_(
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1276, in _execute_context
    self.dialect.do_execute(
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 608, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.ProgrammingError: (psycopg2.errors.DuplicateObject) trigger "trigger_history_audit_by_history_id_aus" for relation "history_dataset_association" already exists
[SQL:
            CREATE TRIGGER trigger_history_audit_by_history_id_aus
            AFTER UPDATE ON history_dataset_association
            REFERENCING NEW TABLE AS new_table
            FOR EACH STATEMENT EXECUTE FUNCTION fn_audit_history_by_history_id();
        ]
(Background on this error at: http://sqlalche.me/e/13/f405)
unable to load app 0 (mountpoint='') (callable not found or import error)
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
