### PR TITLE
[21.05] Small fixes for beta history panel.

### DIFF
--- a/client/src/components/History/HistoryDetails.vue
+++ b/client/src/components/History/HistoryDetails.vue
@@ -84,7 +84,7 @@
                     key="export-history-to-file"
                     title="Export History to File"
                     icon="fas fa-file-archive"
-                    @click="iframeRedirect('/history/export_archive?preview=True')"
+                    @click="backboneRoute(exportLink)"
                 />
             </PriorityMenu>
         </div>
@@ -183,6 +183,9 @@ export default {
                     this.updateFields({ name });
                 }
             },
+        },
+        exportLink() {
+            return `histories/${this.history.id}/export`;
         },
     },
     methods: {

--- a/client/src/components/History/adapters/buildCollectionModal.js
+++ b/client/src/components/History/adapters/buildCollectionModal.js
@@ -15,7 +15,7 @@ import LIST_OF_PAIRS_COLLECTION_CREATOR from "../../Collections/PairedListCollec
 import RULE_BASED_COLLECTION_CREATOR from "../../Collections/RuleBasedCollectionCreatorModal";
 
 // stand-in for buildCollection from history-view-edit.js
-export async function buildCollectionModal(collectionType, history_id, selectedContent, hideSourceItems = false) {
+export async function buildCollectionModal(collectionType, history_id, selectedContent, hideSourceItems = true) {
     // select legacy function
     let createFunc;
     if (collectionType == "list") {


### PR DESCRIPTION
Issues discovered from Selenium tests. Exporting histories link does not work and the collection creation operations don't hide their items by default.

## How to test the changes?
- [x] Instructions for manual testing are as follows:

Run selenium tests against beta history panel using work from #10965 -or-
  1. Enable the beta history panel and a history with some datasets.
  2. Click history export link and notice no page is resolved.

and 

  1. Enable the beta history panel and a history with some datasets.
  2. Click the button that allow operations on multiple datasets.
  3. Select a couple datasets and choose to build a list.
  4. The "hide items" checkbox will be off by default - this doesn't match the behavior of the existing history panel.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
