### PR TITLE
Show target datatype in datatype conversion

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -253,12 +253,12 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
                 message = 'Required metadata values are missing. Some of these values may not be editable by the user. Selecting "Auto-detect" will attempt to fix these values.'
                 status = 'warning'
             # datatype conversion
-            conversion_options = [(convert_name, convert_id) for convert_id, convert_name in converters_collection]
+            conversion_options = [(f"{convert_id} (using '{convert_name}')", convert_id) for convert_id, convert_name in converters_collection]
             conversion_disable = len(conversion_options) == 0
             conversion_inputs = [{
                 'type': 'select',
                 'name': 'target_type',
-                'label': 'Name',
+                'label': 'Target datatype',
                 'help': 'This will create a new dataset with the contents of this dataset converted to a new format.',
                 'options': conversion_options
             }]


### PR DESCRIPTION
in https://github.com/galaxyproject/galaxy/pull/12185 we introduced that a single converter can convert to multiple target datatypes.

the current conversion form shows only the converter names in the select form. this is confusing since all targets have the same name (see https://github.com/galaxyproject/galaxy/pull/12224#issuecomment-873220322 for a screenshot).

with the change the form shows the target datatype and in parenthesis the name of the converter.

Now it looks like:

![Screenshot from 2021-07-05 11-51-21](https://user-images.githubusercontent.com/25689525/124454027-46ea8f00-dd88-11eb-9e9a-a73655e40655.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows: So far only the converters for biom datasets have been unified, so:
  1. Upload a biom1 or biom2 dataset
  2. Check the conversion form

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
