### PR TITLE
Refactor History contents API

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -26,6 +26,7 @@ from galaxy.managers.histories import HistoryManager
 from galaxy.managers.interactivetool import InteractiveToolManager
 from galaxy.managers.jobs import JobSearch
 from galaxy.managers.libraries import LibraryManager
+from galaxy.managers.library_datasets import LibraryDatasetsManager
 from galaxy.managers.roles import RoleManager
 from galaxy.managers.session import GalaxySessionManager
 from galaxy.managers.tools import DynamicToolManager
@@ -149,6 +150,7 @@ class MinimalGalaxyApplication(BasicApp, config.ConfiguresGalaxyMixin, HaltableC
 
 class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
     """Extends the MinimalGalaxyApplication with most managers that are not tied to a web or job handling context."""
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._register_singleton(MinimalManagerApp, self)
@@ -173,6 +175,7 @@ class GalaxyManagerApplication(MinimalManagerApp, MinimalGalaxyApplication):
         self.workflow_contents_manager = self._register_singleton(WorkflowContentsManager)
         self.library_folder_manager = self._register_singleton(FolderManager)
         self.library_manager = self._register_singleton(LibraryManager)
+        self.library_datasets_manager = self._register_singleton(LibraryDatasetsManager)
         self.role_manager = self._register_singleton(RoleManager)
         from galaxy.jobs.manager import JobManager
         self.job_manager = self._register_singleton(JobManager)

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -47,6 +47,7 @@ from galaxy import exceptions
 from galaxy import model
 from galaxy.model import tool_shed_install
 from galaxy.schema import FilterQueryParams
+from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import BasicApp, MinimalManagerApp
 from galaxy.util import namedtuple
@@ -1211,15 +1212,21 @@ class ServiceBase:
     def __init__(self, security: IdEncodingHelper):
         self.security = security
 
-    def decode_id(self, id):
+    def decode_id(self, id: EncodedDatabaseIdField) -> int:
         """Decodes a previously encoded database ID."""
         return decode_with_security(self.security, id)
 
-    def encode_id(self, id):
-        """Decodes a previously encoded database ID."""
+    def encode_id(self, id: int) -> EncodedDatabaseIdField:
+        """Encodes a raw database ID."""
         return encode_with_security(self.security, id)
 
-    def encode_all_ids(self, rval, recursive=False):
+    def decode_ids(self, ids: List[EncodedDatabaseIdField]) -> List[int]:
+        """
+        Decodes all encoded IDs in the given list.
+        """
+        return [self.decode_id(id) for id in ids]
+
+    def encode_all_ids(self, rval, recursive: bool = False):
         """
         Encodes all integer values in the dict rval whose keys are 'id' or end with '_id'
 

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -114,6 +114,10 @@ def decode_with_security(security: IdEncodingHelper, id: Any):
     return security.decode_id(str(id))
 
 
+def encode_with_security(security: IdEncodingHelper, id: Any):
+    return security.encode_id(id)
+
+
 def get_object(trans, id, class_name, check_ownership=False, check_accessible=False, deleted=None):
     """
     Convenience method to get a model object with the specified checks. This is
@@ -1210,6 +1214,10 @@ class ServiceBase:
     def decode_id(self, id):
         """Decodes a previously encoded database ID."""
         return decode_with_security(self.security, id)
+
+    def encode_id(self, id):
+        """Decodes a previously encoded database ID."""
+        return encode_with_security(self.security, id)
 
     def build_order_by(self, manager: SortableManager, order_by_query: Optional[str] = None):
         """Returns an ORM compatible order_by clause using the order attribute and the given manager.

--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -1219,6 +1219,14 @@ class ServiceBase:
         """Decodes a previously encoded database ID."""
         return encode_with_security(self.security, id)
 
+    def encode_all_ids(self, rval, recursive=False):
+        """
+        Encodes all integer values in the dict rval whose keys are 'id' or end with '_id'
+
+        It might be useful to turn this in to a decorator
+        """
+        return self.security.encode_all_ids(rval, recursive=recursive)
+
     def build_order_by(self, manager: SortableManager, order_by_query: Optional[str] = None):
         """Returns an ORM compatible order_by clause using the order attribute and the given manager.
 

--- a/lib/galaxy/managers/history_contents.py
+++ b/lib/galaxy/managers/history_contents.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 
 # into its own class to have it's own filters, etc.
 # TODO: but can't inherit from model manager (which assumes only one model)
-class HistoryContentsManager(containers.ContainerManagerMixin):
+class HistoryContentsManager(containers.ContainerManagerMixin, base.SortableManager):
 
     root_container_class = model.History
 

--- a/lib/galaxy/managers/library_datasets.py
+++ b/lib/galaxy/managers/library_datasets.py
@@ -15,6 +15,7 @@ from galaxy.managers import (
     datasets,
 )
 from galaxy.model import tags
+from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import validation
 
 log = logging.getLogger(__name__)
@@ -24,7 +25,7 @@ class LibraryDatasetsManager(datasets.DatasetAssociationManager):
     """Interface/service object for interacting with library datasets."""
     model_class = model.LibraryDatasetDatasetAssociation
 
-    def __init__(self, app):
+    def __init__(self, app: MinimalManagerApp):
         self.app = app
         self.tag_handler = tags.GalaxyTagHandler(app.model.context)
 

--- a/lib/galaxy/schema/__init__.py
+++ b/lib/galaxy/schema/__init__.py
@@ -47,12 +47,12 @@ class FilterQueryParams(BaseModel):
         description="The maximum number of items to return.",
     )
     order: Optional[str] = Field(
-        default="create_time-dsc",
+        default=None,
         title="Order",
         description=(
             "String containing one of the valid ordering attributes followed (optionally) "
             "by '-asc' or '-dsc' for ascending and descending order respectively. "
-                "Orders can be stacked as a comma-separated list of values."
+            "Orders can be stacked as a comma-separated list of values."
         ),
         example="name-dsc,create_time",
     )

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 from pydantic import (
     Field,
@@ -61,4 +62,17 @@ def ModelClassField(class_name: str) -> str:
         title="Model class",
         description="The name of the database model class.",
         const=True,  # Make this field constant
+    )
+
+
+def OrderParamField(default_order: str) -> Optional[str]:
+    return Field(
+        default=default_order,
+        title="Order",
+        description=(
+            "String containing one of the valid ordering attributes followed (optionally) "
+            "by '-asc' or '-dsc' for ascending and descending order respectively. "
+            "Orders can be stacked as a comma-separated list of values."
+        ),
+        example="name-dsc,create_time",
     )

--- a/lib/galaxy/schema/fields.py
+++ b/lib/galaxy/schema/fields.py
@@ -1,7 +1,9 @@
+import inspect
 import re
 from typing import Optional
 
 from pydantic import (
+    BaseModel,
     Field,
 )
 
@@ -76,3 +78,22 @@ def OrderParamField(default_order: str) -> Optional[str]:
         ),
         example="name-dsc,create_time",
     )
+
+
+def optional(*fields):
+    """Decorator function used to modify a pydantic model's fields to all be optional.
+    Alternatively, you can  also pass the field names that should be made optional as arguments
+    to the decorator.
+    Taken from https://github.com/samuelcolvin/pydantic/issues/1223#issuecomment-775363074
+    """
+    def dec(_cls):
+        for field in fields:
+            _cls.__fields__[field].required = False
+        return _cls
+
+    if fields and inspect.isclass(fields[0]) and issubclass(fields[0], BaseModel):
+        cls = fields[0]
+        fields = cls.__fields__
+        return dec(cls)
+
+    return dec

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -54,7 +54,7 @@ RelativeUrlField: RelativeUrl = Field(
     deprecated=False  # TODO Should this field be deprecated in FastAPI?
 )
 
-DownloadUrlField: AnyUrl = Field(
+DownloadUrlField: RelativeUrl = Field(
     ...,
     title="Download URL",
     description="The URL to download this item from the server.",
@@ -227,7 +227,7 @@ class HistoryContentSource(str, Enum):
 class TagCollection(Model):
     """Represents the collection of tags associated with an item."""
     __root__: List[str] = Field(
-        [],
+        default=...,
         title="Tags",
         description="The collection of tags associated with an item.",
     )
@@ -240,7 +240,7 @@ class MetadataFile(Model):
         title="File Type",
         description="TODO",
     )
-    download_url: AnyUrl = DownloadUrlField
+    download_url: RelativeUrl = DownloadUrlField
 
 
 class DatasetPermissions(Model):
@@ -479,7 +479,7 @@ class HDADetailed(HDASummary):
         description="The message with details about the datatype validation result for this dataset.",
     )
     annotation: Optional[str] = AnnotationField
-    download_url: AnyUrl = DownloadUrlField
+    download_url: RelativeUrl = DownloadUrlField
     type: str = Field(
         "file",
         const=True,
@@ -888,7 +888,7 @@ class JobExportHistoryArchive(Model):
         title="Up to Date",
         description="False, if a new export archive should be generated for the corresponding history.",
     )
-    download_url: str = Field(
+    download_url: RelativeUrl = Field(
         ...,
         title="Download URL",
         description="Relative API URL to download the exported history archive.",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1028,6 +1028,27 @@ class JobImportHistoryResponse(JobBaseModel):
     )
 
 
+class JobStateSummary(Model):
+    id: EncodedDatabaseIdField = EncodedEntityIdField
+    model: str = ModelClassField("Job")
+    populated_state: DatasetCollection.populated_states = PopulatedStateField
+    states: Dict[Job.states, int] = Field(
+        {},
+        title="States",
+        description=(
+            "A dictionary of job states and the number of jobs in that state."
+        )
+    )
+
+
+class ImplicitCollectionJobsStateSummary(JobStateSummary):
+    model: str = ModelClassField("ImplicitCollectionJobs")
+
+
+class WorkflowInvocationStateSummary(JobStateSummary):
+    model: str = ModelClassField("WorkflowInvocation")
+
+
 class JobSummary(JobBaseModel):
     """Basic information about a job."""
     external_id: Optional[str] = Field(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2309,3 +2309,16 @@ class UpdateDatasetPermissionsPayload(BaseModel):
         title="Modify IDs",
         description="A list of role encoded IDs defining roles that should have modify permission on the dataset.",
     )
+
+
+class DeleteHDCAResult(Model):
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="The encoded ID of the collection.",
+    )
+    deleted: bool = Field(
+        ...,
+        title="Deleted",
+        description="True if the collection was successfully deleted.",
+    )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -31,6 +31,7 @@ from galaxy.model import (
 from galaxy.schema.fields import (
     EncodedDatabaseIdField,
     ModelClassField,
+    optional,
 )
 from galaxy.schema.types import RelativeUrl
 
@@ -524,6 +525,12 @@ class HDABeta(HDADetailed):  # TODO: change HDABeta name to a more appropriate o
     pass
 
 
+@optional
+class UpdateHDAPayload(HDABeta):
+    """Used for updating a particular HDA. All fields are optional."""
+    pass
+
+
 class DCSummary(Model):
     """Dataset Collection summary information."""
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
@@ -602,6 +609,28 @@ class HDCADetailed(HDCASummary):
     """History Dataset Collection Association detailed information."""
     populated: bool = PopulatedField
     elements: List[DCESummary] = ElementsField
+
+
+@optional
+class UpdateHDCAPayload(HDCADetailed):
+    """Used for updating a particular HDCA. All fields are optional."""
+    pass
+
+
+class UpdateHistoryContentsBatchPayload(Model):
+    items: List[Union[UpdateHDAPayload, UpdateHDCAPayload]] = Field(
+        ...,
+        title="Items",
+        description="A list of content items to update with the changes.",
+    )
+    deleted: Optional[bool] = Field(
+        default=False,
+        title="Deleted",
+        description=(
+            "This will check the uploading state if not deleting (i.e: deleted=False), "
+            "otherwise cannot delete uploading files, so it will raise an error."
+        ),
+    )
 
 
 class HistoryBase(BaseModel):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -208,6 +208,21 @@ class DatasetSourceType(str, Enum):
     ldda = "ldda"
 
 
+class ColletionSourceType(str, Enum):
+    hda = "hda"
+    ldda = "ldda"
+    hdca = "hdca"
+    new_collection = "new_collection"
+
+
+class HistoryContentSource(str, Enum):
+    hda = "hda"
+    hdca = "hdca"
+    library = "library"
+    library_folder = "library_folder"
+    new_collection = "new_collection"
+
+
 class TagCollection(Model):
     """Represents the collection of tags associated with an item."""
     __root__: List[str] = Field(

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2054,6 +2054,12 @@ class LibraryPermissionAction(str, Enum):
     remove_restrictions = "remove_restrictions"  # name inconsistency? should be `make_public`?
 
 
+class DatasetPermissionAction(str, Enum):
+    set_permissions = "set_permissions"
+    make_private = "make_private"
+    remove_restrictions = "remove_restrictions"
+
+
 class LibraryPermissionsPayloadBase(BaseModel):
     class Config:
         use_enum_values = True  # When using .dict()
@@ -2213,4 +2219,64 @@ class LibraryFolderCurrentPermissions(BaseModel):
         ...,
         title="Add Role List",
         description="A list containing pairs of role names and corresponding encoded IDs which can add items to the Library folder.",
+    )
+
+
+class DatasetAssociationRoles(Model):
+    access_dataset_roles: List[RoleNameIdTuple] = Field(
+        default=[],
+        title="Access Roles",
+        description=(
+            "A list of roles that can access the dataset. "
+            "The user has to **have all these roles** in order to access this dataset. "
+            "Users without access permission **cannot** have other permissions on this dataset. "
+            "If there are no access roles set on the dataset it is considered **unrestricted**."
+        ),
+    )
+    manage_dataset_roles: List[RoleNameIdTuple] = Field(
+        default=[],
+        title="Manage Roles",
+        description=(
+            "A list of roles that can manage permissions on the dataset. "
+            "Users with **any** of these roles can manage permissions of this dataset. "
+            "If you remove yourself you will lose the ability to manage this dataset unless you are an admin."
+        ),
+    )
+    modify_item_roles: List[RoleNameIdTuple] = Field(
+        default=[],
+        title="Modify Roles",
+        description=(
+            "A list of roles that can modify the library item. This is a library related permission. "
+            "User with **any** of these roles can modify name, metadata, and other information about this library item."
+        ),
+    )
+
+
+class UpdateDatasetPermissionsPayload(BaseModel):
+    class Config:
+        use_enum_values = True  # When using .dict()
+        allow_population_by_alias = True
+
+    action: Optional[DatasetPermissionAction] = Field(
+        ...,
+        title="Action",
+        description="Indicates what action should be performed on the dataset.",
+    )
+    access_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="access_ids[]",  # Added for backward compatibility but it looks really ugly...
+        title="Access IDs",
+        description="A list of role encoded IDs defining roles that should have access permission on the dataset.",
+    )
+    manage_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="manage_ids[]",
+        title="Manage IDs",
+        description="A list of role encoded IDs defining roles that should have manage permission on the dataset.",
+    )
+    modify_ids: Optional[RoleIdList] = Field(
+        [],
+        alias="modify_ids[]",
+        title="Modify IDs",
+        description="A list of role encoded IDs defining roles that should have modify permission on the dataset.",
     )

--- a/lib/galaxy/webapps/galaxy/api/histories.py
+++ b/lib/galaxy/webapps/galaxy/api/histories.py
@@ -4,6 +4,7 @@ API operations on a history.
 .. seealso:: :class:`galaxy.model.History`
 """
 import logging
+from typing import Optional
 
 from galaxy import (
     util
@@ -13,6 +14,7 @@ from galaxy.managers import (
     sharable,
 )
 from galaxy.schema import FilterQueryParams
+from galaxy.schema.fields import OrderParamField
 from galaxy.schema.schema import (
     CreateHistoryPayload,
     ExportHistoryArchivePayload,
@@ -30,6 +32,10 @@ from galaxy.webapps.galaxy.api.configuration import parse_serialization_params
 from . import BaseGalaxyAPIController, depends
 
 log = logging.getLogger(__name__)
+
+
+class HistoryFilterQueryParams(FilterQueryParams):
+    order: Optional[str] = OrderParamField(default_order="create_time-dsc")
 
 
 class HistoriesController(BaseGalaxyAPIController):
@@ -130,7 +136,7 @@ class HistoriesController(BaseGalaxyAPIController):
         deleted_only = util.string_as_bool(deleted)
         all_histories = util.string_as_bool(kwd.get('all', False))
         serialization_params = parse_serialization_params(**kwd)
-        filter_parameters = FilterQueryParams(**kwd)
+        filter_parameters = HistoryFilterQueryParams(**kwd)
         return self.service.index(trans, serialization_params, filter_parameters, deleted_only, all_histories)
 
     @expose_api_anonymous
@@ -183,7 +189,7 @@ class HistoriesController(BaseGalaxyAPIController):
         Follows the same filtering logic as the index() method above.
         """
         serialization_params = parse_serialization_params(**kwd)
-        filter_parameters = FilterQueryParams(**kwd)
+        filter_parameters = HistoryFilterQueryParams(**kwd)
         return self.service.published(trans, serialization_params, filter_parameters)
 
     @expose_api
@@ -199,7 +205,7 @@ class HistoriesController(BaseGalaxyAPIController):
         Follows the same filtering logic as the index() method above.
         """
         serialization_params = parse_serialization_params(**kwd)
-        filter_parameters = FilterQueryParams(**kwd)
+        filter_parameters = HistoryFilterQueryParams(**kwd)
         return self.service.shared_with_me(trans, serialization_params, filter_parameters)
 
     @expose_api_anonymous

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -643,6 +643,118 @@ class HistoriesContentsService(ServiceBase):
         else:
             raise exceptions.UnknownContentsType(f'Unknown contents type: {contents_type}')
 
+    def archive(
+        self, trans,
+        history_id: EncodedDatabaseIdField,
+        filter_query_params: HistoryContentsFilterQueryParams,
+        filename: str = '',
+        dry_run: bool = True,
+    ):
+        """
+        Build and return a compressed archive of the selected history contents
+
+        :type   filename:  string
+        :param  filename:  (optional) archive name (defaults to history name)
+        :type   dry_run:   boolean
+        :param  dry_run:   (optional) if True, return the archive and file paths only
+                           as json and not an archive file
+
+        :returns:   archive file for download or json in `dry run` mode
+        """
+        # roughly from: http://stackoverflow.com/a/31976060 (windows, linux)
+        invalid_filename_char_regex = re.compile(r'[:<>|\\\/\?\* "]')
+        # path format string - dot separator between id and name
+        id_name_format = '{}.{}'
+
+        def name_to_filename(name, max_length=150, replace_with='_'):
+            # TODO: seems like shortening unicode with [:] would cause unpredictable display strings
+            return invalid_filename_char_regex.sub(replace_with, name)[0:max_length]
+
+        # given a set of parents for a dataset (HDCAs, DC, DCEs, etc.) - build a directory structure that
+        # (roughly) recreates the nesting in the contents using the parent names and ids
+        def build_path_from_parents(parents):
+            parent_names = []
+            for parent in parents:
+                # an HDCA
+                if hasattr(parent, 'hid'):
+                    name = name_to_filename(parent.name)
+                    parent_names.append(id_name_format.format(parent.hid, name))
+                # a DCE
+                elif hasattr(parent, 'element_index'):
+                    name = name_to_filename(parent.element_identifier)
+                    parent_names.append(id_name_format.format(parent.element_index, name))
+            # NOTE: DCs are skipped and use the wrapping DCE info instead
+            return parent_names
+
+        # get the history used for the contents query and check for accessibility
+        history = self.history_manager.get_accessible(trans.security.decode_id(history_id), trans.user)
+        archive_base_name = filename or name_to_filename(history.name)
+
+        # this is the fn applied to each dataset contained in the query
+        paths_and_files = []
+
+        def build_archive_files_and_paths(content, *parents):
+            archive_path = archive_base_name
+            if not self.hda_manager.is_accessible(content, trans.user):
+                # if the underlying dataset is not accessible, skip it silently
+                return
+
+            content_container_id = content.hid
+            content_name = name_to_filename(content.name)
+            if parents:
+                if hasattr(parents[0], 'element_index'):
+                    # if content is directly wrapped in a DCE, strip it from parents (and the resulting path)
+                    # and instead replace the content id and name with the DCE index and identifier
+                    parent_dce, parents = parents[0], parents[1:]
+                    content_container_id = parent_dce.element_index
+                    content_name = name_to_filename(parent_dce.element_identifier)
+                # reverse for path from parents: oldest parent first
+                archive_path = os.path.join(archive_path, *build_path_from_parents(parents)[::-1])
+                # TODO: this is brute force - building the path each time instead of re-using it
+                # possibly cache
+
+            # add the name as the last element in the archive path
+            content_id_and_name = id_name_format.format(content_container_id, content_name)
+            archive_path = os.path.join(archive_path, content_id_and_name)
+
+            # ---- for composite files, we use id and name for a directory and, inside that, ...
+            if self.hda_manager.is_composite(content):
+                # ...save the 'main' composite file (gen. html)
+                paths_and_files.append((content.file_name, os.path.join(archive_path, f"{content.name}.html")))
+                for extra_file in self.hda_manager.extra_files(content):
+                    extra_file_basename = os.path.basename(extra_file)
+                    archive_extra_file_path = os.path.join(archive_path, extra_file_basename)
+                    # ...and one for each file in the composite
+                    paths_and_files.append((extra_file, archive_extra_file_path))
+
+            # ---- for single files, we add the true extension to id and name and store that single filename
+            else:
+                # some dataset names can contain their original file extensions, don't repeat
+                if not archive_path.endswith(f".{content.extension}"):
+                    archive_path += f".{content.extension}"
+                paths_and_files.append((content.file_name, archive_path))
+
+        # filter the contents that contain datasets using any filters possible from index above and map the datasets
+        filters = self.history_contents_filters.parse_query_filters(filter_query_params)
+        self.history_contents_manager.map_datasets(history, build_archive_files_and_paths, filters=filters)
+
+        # if dry_run, return the structure as json for debugging
+        if dry_run:
+            trans.response.headers['Content-Type'] = 'application/json'
+            return safe_dumps(paths_and_files)
+
+        # create the archive, add the dataset files, then stream the archive as a download
+        archive = ZipstreamWrapper(
+            archive_name=archive_base_name,
+            upstream_mod_zip=trans.app.config.upstream_mod_zip,
+            upstream_gzip=trans.app.config.upstream_gzip,
+        )
+        for file_path, archive_path in paths_and_files:
+            archive.write(file_path, archive_path)
+
+        trans.response.headers.update(archive.get_headers())
+        return archive.response()
+
     def __delete_dataset(
         self, trans,
         id: EncodedDatabaseIdField,
@@ -1493,100 +1605,9 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
 
         .. note:: this is a volatile endpoint and settings and behavior may change.
         """
-        # roughly from: http://stackoverflow.com/a/31976060 (windows, linux)
-        invalid_filename_char_regex = re.compile(r'[:<>|\\\/\?\* "]')
-        # path format string - dot separator between id and name
-        id_name_format = '{}.{}'
-
-        def name_to_filename(name, max_length=150, replace_with='_'):
-            # TODO: seems like shortening unicode with [:] would cause unpredictable display strings
-            return invalid_filename_char_regex.sub(replace_with, name)[0:max_length]
-
-        # given a set of parents for a dataset (HDCAs, DC, DCEs, etc.) - build a directory structure that
-        # (roughly) recreates the nesting in the contents using the parent names and ids
-        def build_path_from_parents(parents):
-            parent_names = []
-            for parent in parents:
-                # an HDCA
-                if hasattr(parent, 'hid'):
-                    name = name_to_filename(parent.name)
-                    parent_names.append(id_name_format.format(parent.hid, name))
-                # a DCE
-                elif hasattr(parent, 'element_index'):
-                    name = name_to_filename(parent.element_identifier)
-                    parent_names.append(id_name_format.format(parent.element_index, name))
-            # NOTE: DCs are skipped and use the wrapping DCE info instead
-            return parent_names
-
-        # get the history used for the contents query and check for accessibility
-        history = self.history_manager.get_accessible(trans.security.decode_id(history_id), trans.user)
-        archive_base_name = filename or name_to_filename(history.name)
-
-        # this is the fn applied to each dataset contained in the query
-        paths_and_files = []
-
-        def build_archive_files_and_paths(content, *parents):
-            archive_path = archive_base_name
-            if not self.hda_manager.is_accessible(content, trans.user):
-                # if the underlying dataset is not accessible, skip it silently
-                return
-
-            content_container_id = content.hid
-            content_name = name_to_filename(content.name)
-            if parents:
-                if hasattr(parents[0], 'element_index'):
-                    # if content is directly wrapped in a DCE, strip it from parents (and the resulting path)
-                    # and instead replace the content id and name with the DCE index and identifier
-                    parent_dce, parents = parents[0], parents[1:]
-                    content_container_id = parent_dce.element_index
-                    content_name = name_to_filename(parent_dce.element_identifier)
-                # reverse for path from parents: oldest parent first
-                archive_path = os.path.join(archive_path, *build_path_from_parents(parents)[::-1])
-                # TODO: this is brute force - building the path each time instead of re-using it
-                # possibly cache
-
-            # add the name as the last element in the archive path
-            content_id_and_name = id_name_format.format(content_container_id, content_name)
-            archive_path = os.path.join(archive_path, content_id_and_name)
-
-            # ---- for composite files, we use id and name for a directory and, inside that, ...
-            if self.hda_manager.is_composite(content):
-                # ...save the 'main' composite file (gen. html)
-                paths_and_files.append((content.file_name, os.path.join(archive_path, f"{content.name}.html")))
-                for extra_file in self.hda_manager.extra_files(content):
-                    extra_file_basename = os.path.basename(extra_file)
-                    archive_extra_file_path = os.path.join(archive_path, extra_file_basename)
-                    # ...and one for each file in the composite
-                    paths_and_files.append((extra_file, archive_extra_file_path))
-
-            # ---- for single files, we add the true extension to id and name and store that single filename
-            else:
-                # some dataset names can contain their original file extensions, don't repeat
-                if not archive_path.endswith(f".{content.extension}"):
-                    archive_path += f".{content.extension}"
-                paths_and_files.append((content.file_name, archive_path))
-
-        # filter the contents that contain datasets using any filters possible from index above and map the datasets
-        filter_params = self.parse_filter_params(kwd)
-        filters = self.history_contents_filters.parse_filters(filter_params)
-        self.history_contents_manager.map_datasets(history, build_archive_files_and_paths, filters=filters)
-
-        # if dry_run, return the structure as json for debugging
-        if dry_run == 'True':
-            trans.response.headers['Content-Type'] = 'application/json'
-            return safe_dumps(paths_and_files)
-
-        # create the archive, add the dataset files, then stream the archive as a download
-        archive = ZipstreamWrapper(
-            archive_name=archive_base_name,
-            upstream_mod_zip=self.app.config.upstream_mod_zip,
-            upstream_gzip=self.app.config.upstream_gzip,
-        )
-        for file_path, archive_path in paths_and_files:
-            archive.write(file_path, archive_path)
-
-        trans.response.headers.update(archive.get_headers())
-        return archive.response()
+        dry_run = util.string_as_bool(dry_run)
+        filter_parameters = HistoryContentsFilterQueryParams(**kwd)
+        return self.service.archive(trans, history_id, filter_parameters, filename, dry_run)
 
     @expose_api_raw_anonymous
     def contents_near(self, trans, history_id, hid, limit, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -72,7 +72,6 @@ from galaxy.schema.schema import (
     JobStateSummary,
     Model,
     UpdateDatasetPermissionsPayload,
-    UpdateHDAPayload,
     UpdateHistoryContentsBatchPayload,
     WorkflowInvocationStateSummary,
 )
@@ -780,7 +779,7 @@ class HistoriesContentsService(ServiceBase):
         self, trans,
         history_id: EncodedDatabaseIdField,
         id: EncodedDatabaseIdField,
-        payload: UpdateHDAPayload,
+        payload: Dict[str, Any],
         serialization_params: SerializationParams
     ):
         # anon user: ensure that history ids match up and the history is the current,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -447,7 +447,7 @@ class HistoriesContentsService(ServiceBase):
         details: Any = params.dataset_details
         ids = None
         if params.ids:
-            ids = [self.decode_id(id) for id in params.ids.split(',')]
+            ids = [self.decode_id(EncodedDatabaseIdField(id)) for id in params.ids.split(',')]
             # If explicit ids given, always used detailed result.
             details = 'all'
         else:

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -1088,8 +1088,9 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
 
         :raises: InsufficientPermissionsException
         """
-        hda = self.hda_manager.get_owned(self.decode_id(encoded_dataset_id), trans.user, current_history=trans.history, trans=trans)
-        return self.hda_manager.serialize_dataset_association_roles(trans, hda)
+        raise NotImplementedError() # TODO: This endpoint doesn't seem to be in use, remove?
+        # hda = self.hda_manager.get_owned(self.decode_id(encoded_dataset_id), trans.user, current_history=trans.history, trans=trans)
+        # return self.hda_manager.serialize_dataset_association_roles(trans, hda)
 
     @expose_api
     def update_permissions(self, trans, history_id, history_content_id, payload=None, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -9,13 +9,13 @@ import re
 from typing import (
     Any,
     List,
-    Literal,
     Optional,
     Set,
     Union,
 )
 
 import dateutil.parser
+from typing_extensions import Literal
 
 from galaxy import (
     exceptions,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -278,7 +278,15 @@ class HistoriesContentsService(ServiceBase):
 
         :returns:   an array of job summary object dictionaries.
         """
-        return [self.encode_all_ids(trans, job_state) for job_state in fetch_job_states(trans.sa_session, ids, types)]
+        if len(ids) != len(types):
+            raise exceptions.RequestParameterInvalidException(
+                f"The number of ids ({len(ids)}) and types ({len(types)}) must match."
+            )
+        decoded_ids = self.decode_ids(ids)
+        return [
+            self.encode_all_ids(job_state)
+            for job_state in fetch_job_states(trans.sa_session, decoded_ids, types)
+        ]
 
     def show_jobs_summary(
         self, trans,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -502,7 +502,9 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         """
         serialization_params = parse_serialization_params(**kwd)
         contents_type = self.__get_contents_type(trans, kwd)
-        fuzzy_count = kwd.get("fuzzy_count")
+        fuzzy_count = kwd.get("fuzzy_count", None)
+        if fuzzy_count:
+            fuzzy_count = int(fuzzy_count)
         return self.service.show(trans, id, serialization_params, contents_type, fuzzy_count)
 
     @expose_api_anonymous


### PR DESCRIPTION
Preliminary refactorings in preparation for FastAPI migration of the Histories `contents` API, follow up to #12195.

For detailed information about the changes, please see each commit message.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
