### PR TITLE
[21.05] Fix fugue pencil on old sharing not showing up correctly.

### DIFF
--- a/templates/webapps/galaxy/workflow/sharing.mako
+++ b/templates/webapps/galaxy/workflow/sharing.mako
@@ -145,7 +145,9 @@
                             ${"/".join( url_parts[:-1] )}/<span id='item-identifier'>${url_parts[-1]}</span>
                         </span>
 
-                        <a href="javascript:void(0)" role="button" id="edit-identifier"><img src="${h.url_for('/static/images/fugue/pencil.png')}"/></a>
+                        <a href="javascript:void(0)" role="button" id="edit-identifier">
+                            <span class="fa fa-pencil" style=""></span>
+                        </a>
                     </blockquote>
 
                     %if item.published:


### PR DESCRIPTION
Instead of tracking down and fixing the static I just
swapped to the fontawesome pencil already used elsewhere.

Before:  (except broken in some instances)
<img width="484" alt="image" src="https://user-images.githubusercontent.com/155398/124937224-2f541600-dfd5-11eb-85a2-b1c1617bd2bb.png">
After:
<img width="543" alt="image" src="https://user-images.githubusercontent.com/155398/124937361-50b50200-dfd5-11eb-98e5-6738ca77662b.png">


## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Look at old share interface (for workflows, for example)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
