### PR TITLE
[21.05] Fix autodetect message as seen in edit attributes

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -386,6 +386,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         elif operation == 'autodetect':
             # The user clicked the Auto-detect button on the 'Edit Attributes' form
             self.hda_manager.set_metadata(trans, data, overwrite=True)
+            message = "Auto-detect operation successfully submitted."
         elif operation == 'conversion':
             target_type = payload.get('target_type')
             if target_type:


### PR DESCRIPTION
Fixes the green success message just being `XXXX` when clicking autodetect metadata

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Edit attributes on a dataset, click 'autodetect'.  Observe message is no longer "XXXX"

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
