### PR TITLE
[21.05] Fix version command when using extended metadata

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -646,3 +646,11 @@ def collect_extra_files(object_store, dataset, job_working_directory):
                 dataset.set_size()
         except Exception as e:
             log.warning('Unable to generate primary composite file automatically for %s: %s', dataset.dataset.id, unicodify(e))
+
+
+def collect_shrinked_content_from_path(path):
+    try:
+        with open(path, 'rb') as fh:
+            return galaxy.util.shrink_and_unicodify(fh.read().strip())
+    except FileNotFoundError:
+        return None

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -24,7 +24,6 @@ import packaging.version
 import yaml
 from pulsar.client.staging import COMMAND_VERSION_FILENAME
 
-import galaxy
 from galaxy import (
     model,
     util,
@@ -40,7 +39,10 @@ from galaxy.job_execution.datasets import (
     OutputsToWorkingDirectoryPathRewriter,
     TaskPathRewriter
 )
-from galaxy.job_execution.output_collect import collect_extra_files
+from galaxy.job_execution.output_collect import (
+    collect_extra_files,
+    collect_shrinked_content_from_path,
+)
 from galaxy.job_execution.setup import (  # noqa: F401
     create_working_directory_for_job,
     ensure_configs_directory,
@@ -1648,16 +1650,6 @@ class JobWrapper(HasResourceParameters):
         else:
             final_job_state = job.states.ERROR
 
-        if self.tool.version_string_cmd:
-            version_filename = self.get_version_string_path()
-            # TODO: Remove in Galaxy 20.XX, for running jobs at GX upgrade
-            if not os.path.exists(version_filename):
-                version_filename = self.get_version_string_path_legacy()
-            if os.path.exists(version_filename):
-                with open(version_filename, 'rb') as fh:
-                    self.version_string = galaxy.util.shrink_and_unicodify(fh.read())
-                os.unlink(version_filename)
-
         outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
         if not extended_metadata and outputs_to_working_directory and not self.__link_file_check():
             # output will be moved by job if metadata_strategy is extended_metadata, so skip moving here
@@ -1686,6 +1678,11 @@ class JobWrapper(HasResourceParameters):
             except Exception:
                 log.exception(f"problem importing job outputs. stdout [{job.stdout}] stderr [{job.stderr}]")
                 raise
+        else:
+            if self.tool.version_string_cmd:
+                version_filename = self.get_version_string_path()
+                self.version_string = collect_shrinked_content_from_path(version_filename)
+
         output_dataset_associations = job.output_datasets + job.output_library_datasets
         for dataset_assoc in output_dataset_associations:
             context = self.get_dataset_finish_context(job_context, dataset_assoc)

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -758,7 +758,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
         metadata_strategy = job_wrapper.get_destination_configuration('metadata_strategy', None)
         dynamic_outputs = None  # use default
         if metadata_strategy == "extended" and PulsarJobRunner.__remote_metadata(client):
-            # if Pulsar is doing remote metdata and the remote metadata is extended,
+            # if Pulsar is doing remote metadata and the remote metadata is extended,
             # we only need to recover the final model store.
             dynamic_outputs = EXTENDED_METADATA_DYNAMIC_COLLECTION_PATTERN
         client_outputs = ClientOutputs(

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -136,7 +136,7 @@ def set_metadata_portable():
 
     object_store = None
     job_context = None
-    version_string = ""
+    version_string = None
 
     export_store = None
     final_job_state = Job.states.OK
@@ -195,9 +195,9 @@ def set_metadata_portable():
         else:
             final_job_state = Job.states.ERROR
 
-        version_string = ""
-        if os.path.exists(COMMAND_VERSION_FILENAME):
-            version_string = open(COMMAND_VERSION_FILENAME).read()
+        version_string_path = os.path.join('outputs', COMMAND_VERSION_FILENAME)
+        if os.path.exists(version_string_path):
+            version_string = open(version_string_path).read().strip()
 
         expression_context = ExpressionContext(dict(stdout=tool_stdout, stderr=tool_stderr))
 

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -30,6 +30,7 @@ from galaxy.job_execution.output_collect import (
     collect_dynamic_outputs,
     collect_extra_files,
     collect_primary_datasets,
+    collect_shrinked_content_from_path,
     default_exit_code_file,
     read_exit_code_from,
     SessionlessJobContext,
@@ -196,8 +197,7 @@ def set_metadata_portable():
             final_job_state = Job.states.ERROR
 
         version_string_path = os.path.join('outputs', COMMAND_VERSION_FILENAME)
-        if os.path.exists(version_string_path):
-            version_string = open(version_string_path).read().strip()
+        version_string = collect_shrinked_content_from_path(version_string_path)
 
         expression_context = ExpressionContext(dict(stdout=tool_stdout, stderr=tool_stderr))
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3509,6 +3509,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         rval["hid"] = self.hid
         rval["annotation"] = unicodify(getattr(self, 'annotation', ''))
         rval["tags"] = self.make_tag_string_list()
+        rval['tool_version'] = self.tool_version
         if self.history:
             rval["history_encoded_id"] = serialization_options.get_identifier(id_encoder, self.history)
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -203,7 +203,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         "object_store_id",
                         "total_size",
                         "created_from_basename",
-                        "uuid"
+                        "uuid",
                     ]
 
                     for attribute in dataset_attributes:
@@ -231,10 +231,11 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     "designation",
                     "visible",
                     "metadata",
+                    "tool_version",
                 ]
                 for attribute in attributes:
                     if attribute in dataset_attrs:
-                        value = dataset_attrs[attribute]
+                        value = dataset_attrs.get(attribute)
                         if attribute == "metadata":
                             def remap_objects(p, k, obj):
                                 if isinstance(obj, dict) and "model_class" in obj and obj["model_class"] == "MetadataFile":
@@ -262,6 +263,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                                                                        visible=dataset_attrs['visible'],
                                                                        deleted=dataset_attrs.get('deleted', False),
                                                                        dbkey=metadata['dbkey'],
+                                                                       tool_version=metadata.get('tool_version'),
                                                                        metadata=metadata,
                                                                        history=history,
                                                                        create_dataset=True,
@@ -278,6 +280,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                                                                               visible=dataset_attrs['visible'],
                                                                               deleted=dataset_attrs.get('deleted', False),
                                                                               dbkey=metadata['dbkey'],
+                                                                              tool_version=metadata.get('tool_version'),
                                                                               metadata=metadata,
                                                                               create_dataset=True,
                                                                               sa_session=self.sa_session)

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -3,6 +3,7 @@
 from galaxy_test.driver import integration_util
 
 TEST_TOOL_IDS = [
+    "job_properties",
     "multi_output",
     "multi_output_configured",
     "multi_output_assign_primary",


### PR DESCRIPTION
I don't think it worked before (`job_properties` in test/integration/test_extended_metadata.py failed), and now it works. Also removes the legacy path handling.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
