### PR TITLE
[21.05] Restore Grep1 version 1.0.1

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -78,6 +78,7 @@
     <tool file="stats/filtering.xml" />
     <tool file="filters/sorter.xml" />
     <tool file="filters/grep.xml" />
+    <tool file="filters/grep_1.0.1.xml"/>
     <label id="gff" text="GFF" />
     <tool file="filters/gff/extract_GFF_Features.xml" />
     <tool file="filters/gff/gff_filter_by_attribute.xml" />

--- a/lib/galaxy/tools/search/__init__.py
+++ b/lib/galaxy/tools/search/__init__.py
@@ -101,7 +101,7 @@ class ToolBoxSearch:
             for tool_id in tool_ids_to_remove:
                 writer.delete_by_term('id', tool_id)
             for tool_id in tool_cache._new_tool_ids - indexed_tool_ids:
-                tool = tool_cache.get_tool_by_id(tool_id)
+                tool = self.toolbox.get_tool(tool_id)
                 if tool and tool.is_latest_version:
                     if tool.hidden:
                         # we check if there is an older tool we can return

--- a/tools/filters/grep.py
+++ b/tools/filters/grep.py
@@ -1,0 +1,137 @@
+# Filename: grep.py
+# Author: Ian N. Schenck
+# Version: 8/23/2005
+#
+# This script accepts regular expressions, as well as an "invert"
+# option, and applies the regular expression using grep.  This wrapper
+# provides security and pipeline.
+#
+# Grep is launched based on these inputs:
+# -i Input file
+# -o Output file
+# -pattern RegEx pattern
+# -v true or false (output NON-matching lines)
+from __future__ import print_function
+
+import os
+import re
+import subprocess
+import sys
+from subprocess import PIPE, Popen
+from tempfile import NamedTemporaryFile
+
+
+# This function is exceedingly useful, perhaps package for reuse?
+def getopts(argv):
+    opts = {}
+    while argv:
+        if argv[0][0] == '-':
+            opts[argv[0]] = argv[1]
+            argv = argv[2:]
+        else:
+            argv = argv[1:]
+    return opts
+
+
+def main():
+    args = sys.argv[1:]
+
+    try:
+        opts = getopts(args)
+    except IndexError:
+        print("Usage:")
+        print(" -i Input file")
+        print(" -o Output file")
+        print(" -pattern RegEx pattern")
+        print(" -v true or false (Invert match)")
+        return 0
+
+    outputfile = opts.get("-o")
+    if outputfile is None:
+        print("No output file specified.")
+        return -1
+
+    inputfile = opts.get("-i")
+    if inputfile is None:
+        print("No input file specified.")
+        return -2
+
+    invert = opts.get("-v")
+    if invert is None:
+        print("Match style (Invert or normal) not specified.")
+        return -3
+
+    pattern = opts.get("-pattern")
+    if pattern is None:
+        print("RegEx pattern not specified.")
+        return -4
+
+    # All inputs have been specified at this point, now validate.
+
+    # replace if input has been escaped, remove sq
+    # characters that are allowed but need to be escaped
+    mapped_chars = {'>' : '__gt__',
+                    '<' : '__lt__',
+                    '\'': '__sq__',
+                    '"' : '__dq__',
+                    '[' : '__ob__',
+                    ']' : '__cb__',
+                    '{' : '__oc__',
+                    '}' : '__cc__'}
+
+    # with new sanitizing we only need to replace for single quote,
+    # but this needs to remain for backwards compatibility
+    for key, value in mapped_chars.items():
+        pattern = pattern.replace(value, key)
+
+    # match filename and invert flag
+    fileRegEx = re.compile(r"^[A-Za-z0-9./\-_]+$")
+    invertRegEx = re.compile(r"(true)|(false)")
+
+    # verify that filename and inversion flag are in the correct format
+    if not fileRegEx.match(outputfile):
+        print("Illegal output filename.")
+        return -5
+    if not fileRegEx.match(inputfile):
+        print("Illegal input filename.")
+        return -6
+    if not invertRegEx.match(invert):
+        print("Illegal invert option.")
+        return -7
+
+    # invert grep search?
+    if invert == "true":
+        invertflag = "-v"
+        print("Not matching pattern: %s" % pattern)
+    else:
+        invertflag = ""
+        print("Matching pattern: %s" % pattern)
+
+    # set version flag
+    versionflag = "-P"
+
+    # MacOS 10.8.2 does not support -P option for perl-regex anymore
+    versionmatch = Popen("grep -V | grep 'BSD'", shell=True, stdout=PIPE).communicate()[0]
+    if versionmatch:
+        versionflag = "-E"
+
+    # create temp file holding pattern
+    # by using a file to hold the pattern, we don't have worry about sanitizing grep commandline and can include single quotes in pattern
+    pattern_file_name = NamedTemporaryFile().name
+    open(pattern_file_name, 'w').write(pattern)
+
+    # generate grep command
+    commandline = "grep %s %s -f %s %s > %s" % (versionflag, invertflag, pattern_file_name, inputfile, outputfile)
+
+    # run grep
+    errorcode = subprocess.call(commandline, shell=True)
+
+    # remove temp pattern file
+    os.unlink(pattern_file_name)
+
+    # return error code
+    return errorcode
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/filters/grep.py
+++ b/tools/filters/grep.py
@@ -70,14 +70,14 @@ def main():
 
     # replace if input has been escaped, remove sq
     # characters that are allowed but need to be escaped
-    mapped_chars = {'>' : '__gt__',
-                    '<' : '__lt__',
+    mapped_chars = {'>': '__gt__',
+                    '<': '__lt__',
                     '\'': '__sq__',
-                    '"' : '__dq__',
-                    '[' : '__ob__',
-                    ']' : '__cb__',
-                    '{' : '__oc__',
-                    '}' : '__cc__'}
+                    '"': '__dq__',
+                    '[': '__ob__',
+                    ']': '__cb__',
+                    '{': '__oc__',
+                    '}': '__cc__'}
 
     # with new sanitizing we only need to replace for single quote,
     # but this needs to remain for backwards compatibility

--- a/tools/filters/grep_1.0.1.xml
+++ b/tools/filters/grep_1.0.1.xml
@@ -1,0 +1,85 @@
+<tool id="Grep1" name="Select" version="1.0.1">
+  <description>lines that match an expression</description>
+  <edam_operations>
+    <edam_operation>operation_3695</edam_operation>
+  </edam_operations>
+  <command interpreter="python">grep.py -i $input -o $out_file1 -pattern '$pattern' -v $invert</command>
+  <inputs>
+    <param format="txt" name="input" type="data" label="Select lines from"/>
+    <param name="invert" type="select" label="that">
+      <option value="false">Matching</option>
+      <option value="true">NOT Matching</option>
+    </param>
+    <param name="pattern" type="text" value="^chr([0-9A-Za-z])+" label="the pattern" help="here you can enter text or regular expression (for syntax check lower part of this frame)">
+      <sanitizer>
+        <valid initial="string.printable">
+         <remove value="&apos;"/>
+        </valid>
+        <mapping initial="none">
+          <add source="&apos;" target="__sq__"/>
+        </mapping>
+      </sanitizer>
+    </param>
+  </inputs>
+  <outputs>
+    <data format="input" name="out_file1" metadata_source="input"/>
+  </outputs>
+  <tests>
+    <test>
+      <param name="input" value="1.bed"/>
+      <param name="invert" value="false"/>
+      <param name="pattern" value="^chr[0-9]*"/>
+      <output name="out_file1" file="fs-grep.dat"/>
+    </test>
+  </tests>
+  <help>
+
+.. class:: infomark
+
+**TIP:** If your data is not TAB delimited, use *Text Manipulation-&gt;Convert*
+
+-----
+
+**Syntax**
+
+The select tool searches the data for lines containing or not containing a match to the given pattern. Regular Expression is introduced in this tool. A Regular Expression is a pattern describing a certain amount of text.
+
+- **( ) { } [ ] . * ? + \ ^ $** are all special characters. **\\** can be used to "escape" a special character, allowing that special character to be searched for.
+- **\\A** matches the beginning of a string(but not an internal line).
+- **\\d** matches a digit, same as [0-9].
+- **\\D** matches a non-digit.
+- **\\s** matches a whitespace character.
+- **\\S** matches anything BUT a whitespace.
+- **\\t** matches a tab.
+- **\\w** matches an alphanumeric character.
+- **\\W** matches anything but an alphanumeric character.
+- **(** .. **)** groups a particular pattern.
+- **\\Z** matches the end of a string(but not a internal line).
+- **{** n or n, or n,m **}** specifies an expected number of repetitions of the preceding pattern.
+
+  - **{n}** The preceding item is matched exactly n times.
+  - **{n,}** The preceding item is matched n or more times.
+  - **{n,m}** The preceding item is matched at least n times but not more than m times.
+
+- **[** ... **]** creates a character class. Within the brackets, single characters can be placed. A dash (-) may be used to indicate a range such as **a-z**.
+- **.** Matches any single character except a newline.
+- ***** The preceding item will be matched zero or more times.
+- **?** The preceding item is optional and matched at most once.
+- **+** The preceding item will be matched one or more times.
+- **^** has two meaning:
+  - matches the beginning of a line or string.
+  - indicates negation in a character class. For example, [^...] matches every character except the ones inside brackets.
+- **$** matches the end of a line or string.
+- **\|** Separates alternate possibilities.
+
+-----
+
+**Example**
+
+- **^chr([0-9A-Za-z])+** would match lines that begin with chromosomes, such as lines in a BED format file.
+- **(ACGT){1,5}** would match at least 1 "ACGT" and at most 5 "ACGT" consecutively.
+- **([^,][0-9]{1,3})(,[0-9]{3})\*** would match a large integer that is properly separated with commas such as 23,078,651.
+- **(abc)|(def)** would match either "abc" or "def".
+- **^\\W+#** would match any line that is a comment.
+</help>
+</tool>


### PR DESCRIPTION
The select option value for inverting results changed from `true` to
`-v`, so if you don't update your workflow you'll run grep without
the `-v` flag.
I don't think there's a way around this change (that is now part of
21.05 for a while, so we can't just switch the option value back).

Addresses https://github.com/galaxyproject/galaxy/issues/12249.
We should also require an additional confirmation.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
