### PR TITLE
Use relative path in recursive ``discover_datasets`` tag

### DIFF
--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -489,24 +489,27 @@ def walk_over_file_collectors(extra_file_collectors, job_working_directory, matc
             yield match, extra_file_collector
 
 
-def walk_over_extra_files(target_dir, extra_file_collector, job_working_directory, matchable):
+def walk_over_extra_files(target_dir, extra_file_collector, job_working_directory, matchable, parent_paths=None):
     """
     Walks through all files in a given directory, and returns all files that
     match the given collector's match criteria. If the collector has the
     recurse flag enabled, will also recursively descend into child folders.
     """
     matches = []
+    parent_paths = parent_paths or []
     directory = discover_target_directory(target_dir, job_working_directory)
     if os.path.isdir(directory):
         for filename in os.listdir(directory):
             path = os.path.join(directory, filename)
             if os.path.isdir(path):
                 if extra_file_collector.recurse:
+                    new_parent_paths = parent_paths[:]
+                    new_parent_paths.append(filename)
                     # The current directory is already validated, so use that as the next job_working_directory when recursing
-                    for match in walk_over_extra_files(filename, extra_file_collector, directory, matchable):
+                    for match in walk_over_extra_files(filename, extra_file_collector, directory, matchable, parent_paths=new_parent_paths):
                         yield match
             else:
-                match = extra_file_collector.match(matchable, filename, path=path)
+                match = extra_file_collector.match(matchable, filename, path=path, parent_paths=parent_paths)
                 if match:
                     matches.append(match)
 
@@ -553,6 +556,7 @@ class DatasetCollector:
         self.directory = dataset_collection_description.directory
         self.assign_primary_output = dataset_collection_description.assign_primary_output
         self.recurse = dataset_collection_description.recurse
+        self.match_relative_path = dataset_collection_description.match_relative_path
 
     def _pattern_for_dataset(self, dataset_instance=None):
         token_replacement = r'\d+'
@@ -560,8 +564,10 @@ class DatasetCollector:
             token_replacement = str(dataset_instance.id)
         return self.pattern.replace(DATASET_ID_TOKEN, token_replacement)
 
-    def match(self, dataset_instance, filename, path=None):
+    def match(self, dataset_instance, filename, path=None, parent_paths=None):
         pattern = self._pattern_for_dataset(dataset_instance)
+        if self.match_relative_path and parent_paths:
+            filename = os.path.join(*parent_paths, filename)
         re_match = re.match(pattern, filename)
         match_object = None
         if re_match:

--- a/lib/galaxy/tool_util/parser/output_collection_def.py
+++ b/lib/galaxy/tool_util/parser/output_collection_def.py
@@ -80,6 +80,7 @@ class DatasetCollectionDescription:
         self.assign_primary_output = asbool(kwargs.get('assign_primary_output', False))
         self.directory = kwargs.get("directory", None)
         self.recurse = False
+        self.match_relative_path = kwargs.get("match_relative_path", False)
 
     def to_dict(self):
         return {
@@ -106,6 +107,7 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
         super().__init__(**kwargs)
         pattern = kwargs.get("pattern", "__default__")
         self.recurse = asbool(kwargs.get("recurse", False))
+        self.match_relative_path = asbool(kwargs.get("match_relative_path", False))
         if pattern in NAMED_PATTERNS:
             pattern = NAMED_PATTERNS.get(pattern)
         self.pattern = pattern

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -4646,6 +4646,11 @@ More information can be found on Planemo's documentation for
         <xs:documentation xml:lang="en">Indicates that the specified directory should be searched recursively for matching files.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="match_relative_path" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Indicates that the entire path of the discovered dataset relative to the specified directory should be available for matching patterns.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="format" type="xs:string" use="optional">
       <xs:annotation>
         <xs:documentation xml:lang="en">Format (or datatype) of discovered datasets (an alias with ``ext``).</xs:documentation>
@@ -4707,6 +4712,11 @@ Galaxy, including:
     <xs:attribute name="recurse" type="xs:boolean" use="optional">
       <xs:annotation>
         <xs:documentation xml:lang="en">Indicates that the specified directory should be searched recursively for matching files.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="match_relative_path" type="xs:boolean" use="optional">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Indicates that the entire path of the discovered dataset relative to the specified directory should be available for matching patterns.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="format" type="xs:string" use="optional">

--- a/test/functional/tools/multi_output_recurse.xml
+++ b/test/functional/tools/multi_output_recurse.xml
@@ -1,39 +1,39 @@
 <tool id="multi_output_recurse" name="multi_output_recurse" version="0.1.0" profile="18.01">
-  <command>
-    echo "Hello" &gt; $report;
+  <command><![CDATA[
+    echo "Hello" > '$report';
     mkdir subdir1;
-    echo "This" &gt; subdir1/this.txt;
-    echo "That" &gt; subdir1/that.txt;
+    echo "This" > subdir1/this.txt;
+    echo "That" > subdir1/that.txt;
     mkdir subdir2;
-    echo "1" &gt; subdir2/CUSTOM_1.txt;
-    echo "2" &gt; subdir2/CUSTOM_2.txt;
+    echo "1" > subdir2/CUSTOM_1.txt;
+    echo "2" > subdir2/CUSTOM_2.txt;
     mkdir subdir3;
-    echo "Foo" &gt; subdir3/Foo;
+    echo "Foo" > subdir3/Foo;
     mkdir subdir3/nested1;
-    echo "Bar" &gt; subdir3/nested1/bar.txt;
-    echo "Hello" &gt; subdir3/nested1/hello;
-    echo "1" &gt; sample1.report.txt;
-    echo "2" &gt; sample2.report.txt;
-  </command>
+    echo "Bar" > subdir3/nested1/bar.txt;
+    echo "Hello" > subdir3/nested1/hello;
+    echo "1" > sample1.report.txt;
+    echo "2" > sample2.report.txt;
+    ]]></command>
   <inputs>
-    <param name="num_param" type="integer" value="7"/>
-    <param name="input" type="data"/>
+    <param type="boolean" name="match_relative"/>
   </inputs>
   <outputs>
     <data auto_format="true" name="report">
+      <filter>not bool(match_relative)</filter>
       <discover_datasets pattern="__designation__" directory="." visible="true" recurse="true"/>
     </data>
     <data auto_format="true" name="report_optional">
+      <filter>not bool(match_relative)</filter>
       <discover_datasets pattern="__designation__" directory="i_do_not_exist" visible="true" recurse="true"/>
     </data>
     <data auto_format="true" name="report_match_relative_path">
+      <filter>bool(match_relative)</filter>
       <discover_datasets pattern="__designation__" directory="." visible="true" recurse="true" match_relative_path="true"/>
     </data>
   </outputs>
   <tests>
     <test>
-      <param name="num_param" value="7"/>
-      <param name="input" ftype="txt" value="simple_line.txt"/>
       <output name="report">
         <assert_contents>
           <has_line line="Hello"/>
@@ -84,6 +84,9 @@
           </assert_contents>
         </discovered_dataset>
       </output>
+    </test>
+    <test>
+      <param name="match_relative" value="true"/>
       <output name="report_match_relative_path">
         <discovered_dataset designation="subdir3/nested1/bar.txt">
           <assert_contents>

--- a/test/functional/tools/multi_output_recurse.xml
+++ b/test/functional/tools/multi_output_recurse.xml
@@ -1,66 +1,94 @@
 <tool id="multi_output_recurse" name="multi_output_recurse" version="0.1.0" profile="18.01">
   <command>
-    echo "Hello" > $report;
+    echo "Hello" &gt; $report;
     mkdir subdir1;
-    echo "This" > subdir1/this.txt;
-    echo "That" > subdir1/that.txt;
+    echo "This" &gt; subdir1/this.txt;
+    echo "That" &gt; subdir1/that.txt;
     mkdir subdir2;
-    echo "1" > subdir2/CUSTOM_1.txt;
-    echo "2" > subdir2/CUSTOM_2.txt;
+    echo "1" &gt; subdir2/CUSTOM_1.txt;
+    echo "2" &gt; subdir2/CUSTOM_2.txt;
     mkdir subdir3;
-    echo "Foo" > subdir3/Foo;
+    echo "Foo" &gt; subdir3/Foo;
     mkdir subdir3/nested1;
-    echo "Bar" > subdir3/nested1/bar.txt;
-    echo "Hello" > subdir3/nested1/hello;
-    echo "1" > sample1.report.txt;
-    echo "2" > sample2.report.txt;
+    echo "Bar" &gt; subdir3/nested1/bar.txt;
+    echo "Hello" &gt; subdir3/nested1/hello;
+    echo "1" &gt; sample1.report.txt;
+    echo "2" &gt; sample2.report.txt;
   </command>
   <inputs>
-    <param name="num_param" type="integer" value="7" />
-    <param name="input" type="data" />
+    <param name="num_param" type="integer" value="7"/>
+    <param name="input" type="data"/>
   </inputs>
   <outputs>
     <data auto_format="true" name="report">
-      <discover_datasets pattern="__designation__" directory="." visible="true" recurse="true" />
+      <discover_datasets pattern="__designation__" directory="." visible="true" recurse="true"/>
     </data>
     <data auto_format="true" name="report_optional">
-      <discover_datasets pattern="__designation__" directory="i_do_not_exist" visible="true" recurse="true" />
+      <discover_datasets pattern="__designation__" directory="i_do_not_exist" visible="true" recurse="true"/>
+    </data>
+    <data auto_format="true" name="report_match_relative_path">
+      <discover_datasets pattern="__designation__" directory="." visible="true" recurse="true" match_relative_path="true"/>
     </data>
   </outputs>
   <tests>
     <test>
-      <param name="num_param" value="7" />
+      <param name="num_param" value="7"/>
       <param name="input" ftype="txt" value="simple_line.txt"/>
       <output name="report">
         <assert_contents>
-          <has_line line="Hello" />
+          <has_line line="Hello"/>
         </assert_contents>
         <discovered_dataset designation="this.txt">
-          <assert_contents><has_line line="This" /></assert_contents>
+          <assert_contents>
+            <has_line line="This"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="that.txt">
-          <assert_contents><has_line line="That" /></assert_contents>
+          <assert_contents>
+            <has_line line="That"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="CUSTOM_1.txt">
-          <assert_contents><has_line line="1" /></assert_contents>
+          <assert_contents>
+            <has_line line="1"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="CUSTOM_2.txt">
-          <assert_contents><has_line line="2" /></assert_contents>
+          <assert_contents>
+            <has_line line="2"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="Foo">
-          <assert_contents><has_line line="Foo" /></assert_contents>
+          <assert_contents>
+            <has_line line="Foo"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="bar.txt">
-          <assert_contents><has_line line="Bar" /></assert_contents>
+          <assert_contents>
+            <has_line line="Bar"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="hello">
-          <assert_contents><has_line line="Hello" /></assert_contents>
+          <assert_contents>
+            <has_line line="Hello"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="sample1.report.txt">
-          <assert_contents><has_line line="1" /></assert_contents>
+          <assert_contents>
+            <has_line line="1"/>
+          </assert_contents>
         </discovered_dataset>
         <discovered_dataset designation="sample2.report.txt">
-          <assert_contents><has_line line="2" /></assert_contents>
+          <assert_contents>
+            <has_line line="2"/>
+          </assert_contents>
+        </discovered_dataset>
+      </output>
+      <output name="report_match_relative_path">
+        <discovered_dataset designation="subdir3/nested1/bar.txt">
+          <assert_contents>
+            <has_line line="Bar"/>
+          </assert_contents>
         </discovered_dataset>
       </output>
     </test>


### PR DESCRIPTION
I've added a new option for this. While this might be the intuitive
default I don't want to break existing tools, so the new option is
`match_relative_path`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
