### PR TITLE
Deprecate data manager version

### DIFF
--- a/doc/source/dev/data_managers.rst
+++ b/doc/source/dev/data_managers.rst
@@ -101,6 +101,8 @@ This tag defines a particular Data Manager. Any number of
 +---------------+------------+-----------+--------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | ``id``        | A string*  | no        | ``id="twobit_builder"``                          | Must be unique across all Data Managers; should be lowercase and contain only letters, numbers, and underscores. While technically optional, it is a best-practice to specify this value. When not specified, it will use the id of the underlying Data Manager Tool. |
 +---------------+------------+-----------+--------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``version``   | A string*  | no        | ``version="0.0.1"``                              | Deprecated with release 21.09. The version of the data manager defaults to the version of the data manager tool                                                                                                                                                       |
++---------------+------------+-----------+--------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 The following is an example that contains all of the attributes
 described above.
@@ -616,7 +618,7 @@ the ``extra_files_path`` of ``out_file``.
 
 .. code-block:: xml
 
-    <tool id="data_manager_fetch_genome_all_fasta" name="Reference Genome" version="0.0.1" tool_type="manage_data">
+    <tool id="data_manager_fetch_genome_all_fasta" name="Reference Genome" tool_type="manage_data">
         <description>fetching</description>
         <command interpreter="python">data_manager_fetch_genome_all_fasta.py "${out_file}" --dbkey_description ${ dbkey.get_display_text() }</command>
         <inputs>

--- a/lib/galaxy/tools/data_manager/manager.py
+++ b/lib/galaxy/tools/data_manager/manager.py
@@ -140,7 +140,6 @@ class DataManager:
         self.declared_id = elem.get('id')
         self.guid = elem.get('guid')
         path = elem.get('tool_file')
-        self.version = elem.get('version', self.version)
         tool_shed_repository = None
         tool_guid = None
 
@@ -169,6 +168,7 @@ class DataManager:
         self.name = elem.get('name', self.tool.name)
         self.description = elem.get('description', self.tool.description)
         self.undeclared_tables = util.asbool(elem.get('undeclared_tables', self.undeclared_tables))
+        self.version = elem.get('version', self.tool.version)
 
         for data_table_elem in elem.findall('data_table'):
             data_table_name = data_table_elem.get("name")

--- a/scripts/fix_dm_versions.py
+++ b/scripts/fix_dm_versions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+import argparse
+import shutil
+from datetime import datetime
+
+from lxml import etree
+
+desc = """
+Fix shed_data_manager_conf.xml
+
+Modifies the guid and version attribute of data_manager tags:
+
+- the version in the guid (text after the last slash) is replaced
+  by the data manager tool version
+- the version attribute is set to the data manager tool version
+
+By default only data managers with duplicated guid are modified
+and version attributes are not added if absent.
+
+A copy of the original file with a time stamp appended to the name
+is created.
+
+Note, if there are versions of the data manager tool that have the
+same version there will still be DMs with duplicated guids. These
+need to be corrected manually.
+"""
+
+parser = argparse.ArgumentParser(description=desc)
+parser.add_argument('shed_data_manager_conf', metavar='CONFIG_FILE', type=str,
+                    default="config/shed_data_manager_conf.xml",
+                    help='an integer for the accumulator')
+parser.add_argument('--all-entries', action='store_true',
+                    help='modify all entries (default only those with duplicated guid)')
+parser.add_argument('--add-version', action='store_true',
+                    help='also add version attribute if absent')
+parser.add_argument('--dry-run', action='store_true',
+                    help='do not write resulting config file')
+args = parser.parse_args()
+
+with open(args.shed_data_manager_conf) as fh:
+    tree = etree.parse(args.shed_data_manager_conf)
+root = tree.getroot()
+
+guid_mapping = dict()
+for dm in root.iter('data_manager'):
+    guid = dm.attrib["guid"]
+    if guid not in guid_mapping:
+        guid_mapping[guid] = [dm]
+    else:
+        guid_mapping[guid].append(dm)
+
+for guid in guid_mapping:
+    if len(guid_mapping[guid]) > 1:
+        print(f'{guid} found {len(guid_mapping[guid])}x')
+    elif not args.all_entries:
+        continue
+
+    for dm in guid_mapping[guid]:
+        tool_version = dm.find("./tool/version")
+        tool_version = tool_version.text
+
+        new_guid = f"{guid[:guid.rfind('/')]}/{tool_version}"
+        dm.attrib['guid'] = new_guid
+        print(f"changing guid: {guid} -> {new_guid}")
+        if "version" in dm.attrib:
+            print(f"changing version: {dm.attrib['version']} -> {tool_version}")
+            dm.attrib['version'] = tool_version
+        elif args.add_version:
+            print(f"adding version: {tool_version}")
+            dm.attrib['version'] = tool_version
+
+if not args.dry_run:
+    nfn = args.shed_data_manager_conf + datetime.now().isoformat()
+    print(f"save copy at {nfn}")
+    shutil.copyfile(args.shed_data_manager_conf, nfn)
+    print(f"saving {args.shed_data_manager_conf}")
+    tree.write(args.shed_data_manager_conf)


### PR DESCRIPTION
Data managers (DM) can define a version for the data manager (`<data_manager version="0.0.1">`) and for the data manager tool (DMT).

The version attribute of the data manager was undocumented and only used seldomly (for IUC in 24 out of 88 and in many of these cases the DM version was never bumped). If no version was set for the DM it defaults to 0.0.1. Hence in shed_data_manager_conf.xml` multiple versions of the (DM) with version 0.0.1 are listed.

This leads to loading only one DM (I guess the oldest) and a warning like the following on startup: `A data manager has been defined twice: toolshed.g2.bx.psu.edu/repos/galaxyp/data_manager_eggnog_mapper/data_manager/data_manager_eggnog/0.0.1 ` which is easily overlooked. See also https://gitter.im/galaxyproject/admins?at=60eea6fe7473bf3d7824e3ec

With the change the DM version 

- still defaults to `0.0.1`
- is overwritten by the DM version if defined and the tool version otherwise

TODO / discussion:

- we can discuss if we want to ignore the DMs version completely, of if we leave it to admins to remove it.
- not sure if entries in the DB need to be changed (e.g. tool ids of past runs)

For the **release notes** we might want to mention that admins should check their logs / config files and that there is a dedicated script for fixing DMs with duplicated GUIDs / versions.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
