### PR TITLE
Allow specifying useful classes of tools for mapping in job conf YAML/XML

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -82,6 +82,7 @@ DEFAULT_JOB_SHELL = '/bin/bash'
 DEFAULT_LOCAL_WORKERS = 4
 
 DEFAULT_CLEANUP_JOB = "always"
+VALID_TOOL_CLASSES = ["local", "requires_galaxy"]
 
 
 class JobDestination(Bunch):
@@ -244,10 +245,10 @@ def job_config_xml_to_dict(config, root):
     tools = root.find('tools')
     config_dict['tools'] = []
     if tools is not None:
-        for tool in ConfiguresHandlers._findall_with_required(tools, 'tool'):
+        for tool in tools.findall('tool'):
             # There can be multiple definitions with identical ids, but different params
             tool_mapping_conf = {}
-            for key in ['handler', 'destination', 'id', 'resources']:
+            for key in ['handler', 'destination', 'id', 'resources', 'class']:
                 value = tool.get(key)
                 if value:
                     if key == "destination":
@@ -283,6 +284,7 @@ class JobConfiguration(ConfiguresHandlers):
     handlers: dict
     handler_runner_plugins: Dict[str, str]
     tools: Dict[str, list]
+    tool_classes: Dict[str, list]
     resource_groups: Dict[str, list]
     destinations: Dict[str, tuple]
     resource_parameters: Dict[str, Any]
@@ -317,6 +319,7 @@ class JobConfiguration(ConfiguresHandlers):
         self.destinations = {}
         self.default_destination_id = None
         self.tools = {}
+        self.tool_classes = {}
         self.resource_groups = {}
         self.default_resource_group = None
         self.resource_parameters = {}
@@ -473,9 +476,18 @@ class JobConfiguration(ConfiguresHandlers):
 
         tools = job_config_dict.get('tools', [])
         for tool in tools:
-            tool_id = tool.get('id').lower().rstrip('/')
-            if tool_id not in self.tools:
-                self.tools[tool_id] = list()
+            raw_tool_id = tool.get('id')
+            tool_class = tool.get('class')
+            if raw_tool_id is not None:
+                assert tool_class is None
+                tool_id = raw_tool_id.lower().rstrip('/')
+                if tool_id not in self.tools:
+                    self.tools[tool_id] = list()
+            else:
+                assert tool_class in VALID_TOOL_CLASSES, tool_class
+                if tool_class not in self.tool_classes:
+                    self.tool_classes[tool_class] = list()
+
             params = tool.get("params")
             if params is None:
                 params = {}
@@ -486,7 +498,12 @@ class JobConfiguration(ConfiguresHandlers):
                 tool["params"] = params
             if "environment" in tool:
                 tool["destination"] = tool.pop("environment")
-            self.tools[tool_id].append(JobToolConfiguration(**dict(tool.items())))
+
+            jtc = JobToolConfiguration(**dict(tool.items()))
+            if raw_tool_id:
+                self.tools[tool_id].append(jtc)
+            else:
+                self.tool_classes[tool_class].append(jtc)
 
         types = dict(registered_user_concurrent_jobs=int,
                      anonymous_user_concurrent_jobs=int,
@@ -693,7 +710,7 @@ class JobConfiguration(ConfiguresHandlers):
         return JobToolConfiguration(id='_default_', handler=self.default_handler_id, destination=self.default_destination_id)
 
     # Called upon instantiation of a Tool object
-    def get_job_tool_configurations(self, ids):
+    def get_job_tool_configurations(self, ids, tool_classes):
         """
         Get all configured JobToolConfigurations for a tool ID, or, if given
         a list of IDs, the JobToolConfigurations for the first id in ``ids``
@@ -713,6 +730,7 @@ class JobConfiguration(ConfiguresHandlers):
         * Tool config tool id: ``filter_tool``
         """
         rval = []
+        match_found = False
         # listify if ids is a single (string) id
         ids = util.listify(ids)
         for id in ids:
@@ -723,11 +741,16 @@ class JobConfiguration(ConfiguresHandlers):
                 for job_tool_configuration in self.tools[id]:
                     if not job_tool_configuration.params:
                         break
-                else:
-                    rval.append(self.default_job_tool_configuration)
                 rval.extend(self.tools[id])
-                break
-        else:
+                match_found = True
+
+        if not match_found:
+            for tool_class in tool_classes:
+                if tool_class in self.tool_classes:
+                    rval.extend(self.tool_classes[tool_class])
+                    match_found = True
+                    break
+        if not match_found:
             rval.append(self.default_job_tool_configuration)
         return rval
 

--- a/lib/galaxy/webapps/galaxy/job_config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/job_config_schema.yml
@@ -81,6 +81,8 @@ mapping:
         mapping:
           id:
             type: str
+          class:
+            type: str
           handler:
             type: str
           environment:

--- a/test/integration/delay_job_conf.yml
+++ b/test/integration/delay_job_conf.yml
@@ -14,5 +14,5 @@ execution:
     upload_dest:
       runner: local
 tools:
-  - id: upload1
+  - class: local
     destination: upload_dest

--- a/test/integration/embedded_pulsar_job_conf.xml
+++ b/test/integration/embedded_pulsar_job_conf.xml
@@ -13,6 +13,6 @@
         </destination>
     </destinations>
     <tools>
-        <tool id="upload1" destination="local" />
+        <tool class="local" destination="local" />
     </tools>
 </job_conf>

--- a/test/integration/embedded_pulsar_metadata_extended_job_conf.yml
+++ b/test/integration/embedded_pulsar_metadata_extended_job_conf.yml
@@ -20,5 +20,5 @@ execution:
             action: none
 
 tools:
-- id: upload1
+- class: local
   environment: local

--- a/test/integration/embedded_pulsar_metadata_job_conf.yml
+++ b/test/integration/embedded_pulsar_metadata_job_conf.yml
@@ -15,5 +15,5 @@ execution:
       default_file_action: copy
 
 tools:
-- id: upload1
+- class: local
   environment: local

--- a/test/integration/embedded_pulsar_singularity_job_conf.yml
+++ b/test/integration/embedded_pulsar_singularity_job_conf.yml
@@ -15,5 +15,5 @@ execution:
       singularity_required: true
 
 tools:
-- id: upload1
+- class: local
   environment: local

--- a/test/integration/resubmission_default_job_conf.yml
+++ b/test/integration/resubmission_default_job_conf.yml
@@ -29,6 +29,6 @@ resources:
     test: [test_name,failure_state,initial_target_environment,run_for]
 
 tools:
-  - id: upload1
+  - class: local
     environment: local
     resources: upload

--- a/test/integration/resubmission_dynamic_job_conf.xml
+++ b/test/integration/resubmission_dynamic_job_conf.xml
@@ -26,7 +26,7 @@
     </destinations>
 
     <tools>
-        <tool id="upload1" destination="local" />
+        <tool class="local" destination="local" />
     </tools>
 
 </job_conf>

--- a/test/integration/resubmission_job_conf.yml
+++ b/test/integration/resubmission_job_conf.yml
@@ -109,6 +109,6 @@ resources:
     test: [test_name,failure_state,initial_target_environment,run_for]
 
 tools:
-  - id: upload1
+  - class: local
     environment: local
     resources: upload

--- a/test/integration/resubmission_pulsar_job_conf.xml
+++ b/test/integration/resubmission_pulsar_job_conf.xml
@@ -22,6 +22,6 @@
     </destinations>
 
     <tools>
-        <tool id="upload1" destination="local" resources="upload" />
+        <tool class="local" destination="local" resources="upload" />
     </tools>
 </job_conf>

--- a/test/integration/singularity_job_conf.xml
+++ b/test/integration/singularity_job_conf.xml
@@ -15,7 +15,7 @@
     </destinations>
 
     <tools>
-        <tool id="upload1" destination="local_upload" />
+        <tool class="local" destination="local_upload" />
     </tools>
 
 </job_conf>

--- a/test/unit/jobs/job_conf.sample_advanced.yml
+++ b/test/unit/jobs/job_conf.sample_advanced.yml
@@ -1016,6 +1016,14 @@ tools:
   id: foo
   handler: handler0
   source: trackster
+- 
+  # Classes can be used to map groups of tools - the current classes include
+  # - local (these special tools that aren't parameterized for remote execution - expression tools, upload, etc..)
+  # - requires_galaxy (these special tools require Galaxy's Python environment during execution)
+  # If a tool matches multiple classes, it will match the first class according to the order listed
+  # above in this document (local, requires_galaxy).
+  class: local
+  environment: local
 
 resources:
   default: default

--- a/test/unit/tools_support.py
+++ b/test/unit/tools_support.py
@@ -94,7 +94,7 @@ class UsesTools:
         self.app.config.drmaa_external_runjob_script = ""
         self.app.config.tool_secret = "testsecret"
         self.app.config.track_jobs_in_database = False
-        self.app.job_config["get_job_tool_configurations"] = lambda ids: [Bunch(handler=Bunch())]
+        self.app.job_config["get_job_tool_configurations"] = lambda ids, tool_classes: [Bunch(handler=Bunch())]
 
     def __setup_tool(self):
         tool_source = get_tool_source(self.tool_file)


### PR DESCRIPTION
Various job configurations I've seen in the wild and written for testing have special mappings setup for tools that cannot be used with remote Pulsar (since uploads are local to the web server for instance) or for tool that require Galaxy lib (including hacks like setting dynamic job runners just to import the lists from galaxy.tools and then not applying version restrictions correctly and such).

This provides abstractions to map whole classes of tools at a time to circumvent these hacks. The two classes currently defined are ``local`` and ``requires_galaxy`` as documented in the advanced job config.

``local`` is for tools that we know require job handler files that don't respect compute environment abstractions and aren't setup for remote execution (e.g. won't work with a remote Pulsar instance). This will help deployers route these jobs away from Pulsar quickly and should help cleanup a lot of expected failures in https://github.com/galaxyproject/pulsar/pull/259. This also cleans up a lot of the test configurations I think.

``requires_galaxy`` this is for jobs that use tools that require Galaxy's Python environment. It should provide a more rigorous way to access ``GALAXY_LIB_TOOLS_UNVERSIONED`` and GALAXY_LIB_TOOLS_VERSIONED`` for non-dynamic job configuration mapping.


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage. (Not strictly true - more like I rewrote existing tests to leverage this feature and be cleaner - still it is testing the feature through that usage.)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
