### PR TITLE
Add linting for tool parameter validators

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -17,6 +17,33 @@ FILTER_TYPES = [
     'sort_by',
 ]
 
+ATTRIB_VALIDATOR_COMPATIBILITY = {
+    "check": ["metadata"],
+    "expression": ["regex"],
+    "table_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
+    "filename": ["dataset_metadata_in_file"],
+    "metadata_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "dataset_metadata_in_file"],
+    "metadata_column": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_file options"],
+    "line_startswith": ["dataset_metadata_in_file", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
+    "min": ["in_range"],
+    "max": ["in_range"],
+    "exclude_min": ["in_range"],
+    "exclude_max": ["in_range"],
+    "split": ["dataset_metadata_in_file"],
+    "skip": ["metadata"]
+}
+
+PARAMETER_VALIDATOR_TYPE_COMPATIBILITY = {
+    "integer": ["in_range", "expression"],
+    "float": ["in_range", "expression"],
+    "data": ["metadata", "unspecified_build", "dataset_ok_validator", "dataset_metadata_in_range", "dataset_metadata_in_file", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "expression"],
+    "data_collection": ["metadata", "unspecified_build", "dataset_ok_validator", "dataset_metadata_in_range", "dataset_metadata_in_file", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "expression"],
+    "text": ["regex", "length", "empty_field", "value_in_data_table", "value_not_in_data_table", "expression"],
+    "select": ["no_options", "regex", "length", "empty_field", "value_in_data_table", "value_not_in_data_table", "expression"],
+    "drill_down": ["no_options", "regex", "length", "empty_field", "value_in_data_table", "value_not_in_data_table", "expression"],
+    "data_column": ["no_options", "regex", "length", "empty_field", "value_in_data_table", "value_not_in_data_table", "expression"]
+}
+
 
 def lint_inputs(tool_xml, lint_ctx):
     """Lint parameters in a tool's inputs block."""
@@ -120,8 +147,22 @@ def lint_inputs(tool_xml, lint_ctx):
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with multiple="true"')
                 if string_as_bool(param_attrib.get("optional", "false")):
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with optional="true"')
-
         # TODO: Validate type, much more...
+
+        # validate validators :)
+        validators = param.findall("./validator")
+        for validator in validators:
+            vtype = validator.attrib['type']
+            if vtype == "expression" and validator.text == "":
+                lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
+            if vtype != "expression" and validator.text != "":
+                lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text")
+            if param_type in PARAMETER_VALIDATOR_TYPE_COMPATIBILITY:
+                if vtype not in PARAMETER_VALIDATOR_TYPE_COMPATIBILITY[param_type]:
+                    lint_ctx.error(f"Parameter [{param_name}]: validator with an incompatible type '{vtype}'")
+            for attrib in ATTRIB_VALIDATOR_COMPATIBILITY:
+                if attrib in validator.attrib and vtype not in ATTRIB_VALIDATOR_COMPATIBILITY[attrib]:
+                    lint_ctx.error(f"Parameter [{param_name}]: attribute '{attrib}' is in compatible with validator of type '{vtype}'")
 
     conditional_selects = tool_xml.findall("./inputs//conditional")
     for conditional in conditional_selects:

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -25,8 +25,8 @@ ATTRIB_VALIDATOR_COMPATIBILITY = {
     "metadata_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "dataset_metadata_in_file"],
     "metadata_column": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_file options"],
     "line_startswith": ["dataset_metadata_in_file", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
-    "min": ["in_range"],
-    "max": ["in_range"],
+    "min": ["in_range", "length"],
+    "max": ["in_range", "length"],
     "exclude_min": ["in_range"],
     "exclude_max": ["in_range"],
     "split": ["dataset_metadata_in_file"],
@@ -149,20 +149,28 @@ def lint_inputs(tool_xml, lint_ctx):
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with optional="true"')
         # TODO: Validate type, much more...
 
-        # validate validators :)
+        # lint validators
         validators = param.findall("./validator")
         for validator in validators:
             vtype = validator.attrib['type']
-            if vtype == "expression" and validator.text == "":
-                lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
-            if vtype != "expression" and validator.text != "":
-                lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text")
             if param_type in PARAMETER_VALIDATOR_TYPE_COMPATIBILITY:
                 if vtype not in PARAMETER_VALIDATOR_TYPE_COMPATIBILITY[param_type]:
                     lint_ctx.error(f"Parameter [{param_name}]: validator with an incompatible type '{vtype}'")
             for attrib in ATTRIB_VALIDATOR_COMPATIBILITY:
                 if attrib in validator.attrib and vtype not in ATTRIB_VALIDATOR_COMPATIBILITY[attrib]:
-                    lint_ctx.error(f"Parameter [{param_name}]: attribute '{attrib}' is in compatible with validator of type '{vtype}'")
+                    lint_ctx.error(f"Parameter [{param_name}]: attribute '{attrib}' is incompatible with validator of type '{vtype}'")
+            if vtype == "expression" and validator.text is None:
+                lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
+            if vtype != "expression" and validator.text is not None:
+                lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')")
+            if vtype == "regex" and "expression" not in validator.attrib:
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define an 'expression' attribute")
+            if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib or "max" not in validator.attrib):
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)")
+            if vtype in ["metadata"] and ("check" not in validator.attrib or "skip" not in validator.attrib):
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'check' or 'skip' attribute(s)")
+            if vtype in ["value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table"] and "table_name" not in validator.attrib:
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'table_name' attribute")
 
     conditional_selects = tool_xml.findall("./inputs//conditional")
     for conditional in conditional_selects:

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3753,7 +3753,7 @@ specified by the ``skip`` attribute.</xs:documentation>
         <xs:attribute name="table_name" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Tool data table name to check against
-if ``type`` is ``dataset_metadata_in_tool_data``, ``dataset_metadata_not_in_tool_data``, ``value_in_tool_data``, or ``value_not_in_tool_data``. See the documentation for
+if ``type`` is ``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, ``value_in_data_table``, or ``value_not_in_data_table``. See the documentation for
 [tool data tables](https://galaxyproject.org/admin/tools/data-tables)
 and [data managers](https://galaxyproject.org/admin/tools/data-managers/) for
 more information.</xs:documentation>
@@ -3775,14 +3775,15 @@ if ``type`` is ``dataset_metadata_in_file``. File should be present Galaxy's
         <xs:attribute name="metadata_column" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Target column for metadata attribute
-in ``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, ``value_in_data_table``, ``value__not_in_data_table``, and ``dataset_metadata_in_file`` options.
+in ``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, ``value_in_data_table``, ``value_not_in_data_table``, and ``dataset_metadata_in_file`` options.
 This can be an integer index to the column or a column name.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="line_startswith" type="xs:string">
           <xs:annotation>
             <xs:documentation xml:lang="en">Used to indicate lines in the file
-being used for validation start with a this attribute value.</xs:documentation>
+being used for validation start with a this attribute value.
+For use with validators of type ``dataset_metadata_in_file``, ``dataset_metadata_in_data_table``, ``dataset_metadata_not_in_data_table``, ``value_in_data_table``, ``value_not_in_data_tabl``</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="min" type="xs:decimal">

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3789,25 +3789,25 @@ For use with validators of type ``dataset_metadata_in_file``, ``dataset_metadata
         <xs:attribute name="min" type="xs:decimal">
           <xs:annotation>
             <xs:documentation xml:lang="en">When the ``type`` attribute value is
-``in_range`` - this is the minimum number allowed.</xs:documentation>
+``in_range``, ``length``, or ``dataset_metadata_in_range`` - this is the minimum number allowed.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="max" type="xs:decimal">
           <xs:annotation>
             <xs:documentation xml:lang="en">When the ``type`` attribute value is
-``in_range`` - this is the maximum number allowed.</xs:documentation>
+``in_range``, ``length``, or ``dataset_metadata_in_range`` - this is the maximum number allowed.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="exclude_min" type="xs:boolean" default="false">
           <xs:annotation>
             <xs:documentation xml:lang="en">When the ``type`` attribute value is
-``in_range`` - this boolean indicates if the ``min`` value is allowed.</xs:documentation>
+``in_range``, ``length``, or ``dataset_metadata_in_range`` - this boolean indicates if the ``min`` value is allowed.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="exclude_max" type="xs:boolean" default="false">
           <xs:annotation>
             <xs:documentation xml:lang="en">When the ``type`` attribute value is
-``in_range`` - this boolean indicates if the ``max`` value is allowed.</xs:documentation>
+``in_range``, ``length``, or ``dataset_metadata_in_range`` - this boolean indicates if the ``max`` value is allowed.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
         <xs:attribute name="split" type="xs:string">

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -612,7 +612,7 @@ validator_types = dict(
     dataset_metadata_not_in_data_table=MetadataNotInDataTableColumnValidator,
     dataset_metadata_in_range=MetadataInRangeValidator,
     value_in_data_table=ValueInDataTableColumnValidator,
-    value_not_in_data_table=ValueInDataTableColumnValidator,
+    value_not_in_data_table=ValueNotInDataTableColumnValidator,
     dataset_ok_validator=DatasetOkValidator,
 )
 

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -466,7 +466,7 @@ class ValueInDataTableColumnValidator(Validator):
         if not value:
             return
         if not self._tool_data_table.is_current_version(self._data_table_content_version):
-            log.debug('MetadataInDataTableColumnValidator values are out of sync with data table (%s), updating validator.', self._tool_data_table.name)
+            log.debug('ValueInDataTableColumnValidator: values are out of sync with data table (%s), updating validator.', self._tool_data_table.name)
             self._load_values()
         if value in self.valid_values:
             return

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -121,6 +121,19 @@ WHITESPACE_IN_VERSIONS_AND_NAMES = """
 </tool>
 """
 
+VALIDATOR_INCOMPATIBILITIES = """
+<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+    <description>The BWA Mapper</description>
+    <version_command interpreter="python">bwa.py --version</version_command>
+    <inputs>
+        <param name="param_name" type="text">
+            <validator type="in_range">TEXT</validator>
+            <validator type="regex" filename="blah"/>
+        </param>
+    </inputs>
+</tool>
+"""
+
 TESTS = [
     (
         NO_SECTIONS_XML, inputs.lint_inputs,
@@ -179,6 +192,14 @@ TESTS = [
             and "Tool ID contains whitespace - this is discouraged: [bwa tool]."
             and len(x.warn_messages) == 4 and len(x.error_messages) == 0
     ),
+    (
+        VALIDATOR_INCOMPATIBILITIES, inputs.lint_inputs,
+        lambda x:
+            "Parameter [param_name]: validator with an incompatible type 'in_range'" in x.error_messages
+            and "Parameter [param_name]: attribute 'filename' is in compatible with validator of type 'regex'" in x.error_messages
+            and "Parameter [param_name]: 'in_range' validators are not expected to contain text" in x.warn_messages
+            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+    ),
 ]
 
 TEST_IDS = [
@@ -189,6 +210,7 @@ TEST_IDS = [
     'select deprecations',
     'select option definitions',
     'hazardous whitespace',
+    'validator imcompatibilities'
 ]
 
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -195,10 +195,12 @@ TESTS = [
     (
         VALIDATOR_INCOMPATIBILITIES, inputs.lint_inputs,
         lambda x:
-            "Parameter [param_name]: validator with an incompatible type 'in_range'" in x.error_messages
-            and "Parameter [param_name]: attribute 'filename' is in compatible with validator of type 'regex'" in x.error_messages
-            and "Parameter [param_name]: 'in_range' validators are not expected to contain text" in x.warn_messages
-            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+            "Parameter [param_name]: 'in_range' validators are not expected to contain text (found 'TEXT')" in x.warn_messages
+            and "Parameter [param_name]: validator with an incompatible type 'in_range'" in x.error_messages
+            and "Parameter [param_name]: 'in_range' validators need to define the 'min' or 'max' attribute(s)" in x.error_messages
+            and "Parameter [param_name]: attribute 'filename' is incompatible with validator of type 'regex'" in x.error_messages
+            and "Parameter [param_name]: 'regex' validators need to define an 'expression' attribute" in x.error_messages
+            and len(x.warn_messages) == 1 and len(x.error_messages) == 4
     ),
 ]
 


### PR DESCRIPTION
After searching for a bug in a tool for hours which was caused by a copy paste mistake in a validator I thought that it might be a good idea to spend some time to implement linting for validators checking for incompatibilities of:

- parameter and validator types
- present attributes and validator type

Validators of some parameter types (eg color) or not linted yet.

Also fixed (minor) mistakes in xsd and the validators itself.



## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
