### PR TITLE
Added check to install 'fs.sshfs' package

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -227,6 +227,9 @@ class ConditionalDependencies:
         # pyfilesystem plugin access to terra on anvil
         return 'anvil' in self.file_sources
 
+    def check_fs_sshfs(self):
+        return 'ssh' in self.file_sources
+
     def check_s3fs(self):
         # use s3fs directly (skipping pyfilesystem) for direct access to more options
         return 's3fs' in self.file_sources


### PR DESCRIPTION
I have added a necessary check to install the "fs.sshfs" package (which is listed in "lib/galaxy/dependencies/conditional-requirements.txt") if a data source of type "ssh" is configured in "file_sources_conf.yml". Methods to perform checks were already included for all the other packages, so I just followed the same pattern for "fs.sshfs".

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Check out a clean Galaxy (or use an existing one that does not have the "fs.sshfs" package in the virtual environment)
  2. Copy the file "config/file_sources_conf.yml.sample" to "config/file_sources_conf.yml" (or use another config file that includes a data source of type "ssh")
  3. Either leave the "file_sources_config_file" setting in "galaxy.yml" commented out or specify the _full_ path to the "file_sources_conf.yml" file here.
  4. Start Galaxy with "sh run.sh"

With the new check method submitted with this pull request, the "fs.sshfs" package should be installed in the virtual environment,
but without this method you will get the following error:

```python
Traceback (most recent call last):
  File "lib/galaxy/webapps/galaxy/buildapp.py", line 60, in app_pair
    app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
  File "lib/galaxy/app.py", line 209, in __init__
    super().__init__(fsmon=True, **kwargs)
  File "lib/galaxy/app.py", line 184, in __init__
    self.file_sources = self._register_singleton(ConfiguredFileSources, ConfiguredFileSources.from_app_config(self.config))
  File "lib/galaxy/files/__init__.py", line 165, in from_app_config
    return ConfiguredFileSources(file_sources_config, config_file, load_stock_plugins=True)
  File "lib/galaxy/files/__init__.py", line 26, in __init__
    file_sources = self._load_plugins_from_file(conf_file)
  File "lib/galaxy/files/__init__.py", line 60, in _load_plugins_from_file
    return self._parse_plugin_source(plugin_source)
  File "lib/galaxy/files/__init__.py", line 74, in _parse_plugin_source
    dict_to_list_key="id",
  File "lib/galaxy/util/plugin_config.py", line 39, in load_plugins
    dict_to_list_key=dict_to_list_key,
  File "lib/galaxy/util/plugin_config.py", line 93, in __load_plugins_from_dicts
    plugin = plugins_dict[plugin_type](**plugin_kwds)
  File "lib/galaxy/files/sources/_pyfilesystem2.py", line 17, in __init__
    raise Exception(PACKAGE_MESSAGE % self.required_package)
Exception: FilesSource plugin is missing required Python PyFilesystem2 plugin package [fs.sshfs]
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.