### PR TITLE
Enhance page functionalities in data-library folder

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -220,10 +220,10 @@
                         </b-button>
                         <b-button
                             v-if="row.item.can_manage && !row.item.deleted"
-                            @click="navigateToPermission(row.item)"
                             size="sm"
                             class="lib-btn permission_lib_btn"
                             :title="`Permissions of ${row.item.name}`"
+                            :to="{ path: `${navigateToPermission(row.item)}` }"
                         >
                             <font-awesome-icon icon="users" />
                             Manage
@@ -241,10 +241,17 @@
                     </div>
                 </template>
             </b-table>
+            <!-- hide pagination if the table is loading-->
             <b-container>
-                <b-row class="justify-content-md-center">
+                <b-row align-v="center" class="justify-content-md-center">
                     <b-col md="auto">
+                        <div v-if="isBusy">
+                            <b-spinner small type="grow"></b-spinner>
+                            <b-spinner small type="grow"></b-spinner>
+                            <b-spinner small type="grow"></b-spinner>
+                        </div>
                         <b-pagination
+                            v-else
                             v-model="currentPage"
                             :total-rows="total_rows"
                             :per-page="perPage"
@@ -252,6 +259,7 @@
                         >
                         </b-pagination>
                     </b-col>
+
                     <b-col cols="1.5">
                         <table>
                             <tr>
@@ -304,7 +312,6 @@ function initialFolderState() {
         include_deleted: false,
         search_text: "",
         isAllSelectedMode: false,
-        currentPage: 1,
     };
 }
 export default {
@@ -312,6 +319,11 @@ export default {
         folder_id: {
             type: String,
             required: true,
+        },
+        page: {
+            type: Number,
+            default: 1,
+            required: false,
         },
     },
     components: {
@@ -323,6 +335,7 @@ export default {
         return {
             ...initialFolderState(),
             ...{
+                currentPage: this.page,
                 current_folder_id: null,
                 error: null,
                 isBusy: false,
@@ -486,9 +499,9 @@ export default {
         },
         navigateToPermission(element) {
             if (element.type === "file") {
-                this.$router.push({ path: `${this.folder_id}/dataset/${element.id}/permissions` });
+                return `/folders/${this.folder_id}/dataset/${element.id}/permissions`;
             } else if (element.type === "folder") {
-                this.$router.push({ path: `${element.id}/permissions` });
+                return `/folders/${element.id}/permissions`;
             }
         },
         getMessage(element) {

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -252,9 +252,10 @@
                         </div>
                         <b-pagination
                             v-else
-                            v-model="currentPage"
+                            :value="currentPage"
                             :total-rows="total_rows"
                             :per-page="perPage"
+                            @input="changePage"
                             aria-controls="folder_list_body"
                         >
                         </b-pagination>
@@ -335,7 +336,7 @@ export default {
         return {
             ...initialFolderState(),
             ...{
-                currentPage: this.page,
+                currentPage: null,
                 current_folder_id: null,
                 error: null,
                 isBusy: false,
@@ -351,11 +352,12 @@ export default {
     },
     created() {
         this.services = new Services({ root: this.root });
-        this.initFolder(this.folder_id);
+        this.getFolder(this.folder_id, this.page);
     },
     methods: {
-        initFolder(folder_id) {
+        getFolder(folder_id, page) {
             this.current_folder_id = folder_id;
+            this.currentPage = page;
             this.resetData();
             this.fetchFolderContents(this.include_deleted);
         },
@@ -594,6 +596,9 @@ export default {
                 );
             }
         },
+        changePage(page) {
+            this.$router.push({ name: `LibraryFolder`, params: { folder_id: this.folder_id, page: page } });
+        },
 
         /*
          Former Backbone code, adopted to work with Vue
@@ -637,11 +642,6 @@ export default {
         },
     },
     watch: {
-        currentPage: {
-            handler: function (value) {
-                this.fetchFolderContents(this.include_deleted);
-            },
-        },
         perPage: {
             handler: function (value) {
                 this.fetchFolderContents(this.include_deleted);
@@ -649,7 +649,7 @@ export default {
         },
     },
     beforeRouteUpdate(to, from, next) {
-        this.initFolder(to.params.folder_id);
+        this.getFolder(to.params.folder_id, to.params.page);
         next();
     },
 };

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
@@ -9,7 +9,7 @@
                     <template v-for="path_item in this.dataset.full_path">
                         <b-breadcrumb-item
                             :key="path_item[0]"
-                            :to="{ path: `/folders/${path_item[0]}/` }"
+                            :to="{ path: `/folders/${path_item[0]}` }"
                             :active="path_item[0] === dataset_id"
                             href="#"
                             >{{ path_item[1] }}</b-breadcrumb-item

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
@@ -9,7 +9,7 @@
                     <template v-for="path_item in this.dataset.full_path">
                         <b-breadcrumb-item
                             :key="path_item[0]"
-                            :to="{ path: `/folders/${path_item[0]}` }"
+                            :to="{ path: `/folders/${path_item[0]}/` }"
                             :active="path_item[0] === dataset_id"
                             href="#"
                             >{{ path_item[1] }}</b-breadcrumb-item

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <PermissionsHeader v-if="folder" :name="folder.name" :path="`/folders/${this.folder.parent_id}`" />
+        <PermissionsHeader v-if="folder" :name="folder.name" />
         <b-container fluid>
             <div class="dataset_table">
                 <h2 class="text-center">Folder permissions</h2>

--- a/client/src/components/Libraries/LibraryFolderRouter.js
+++ b/client/src/components/Libraries/LibraryFolderRouter.js
@@ -24,9 +24,10 @@ export default new VueRouter({
             component: LibraryPermissions,
             props: true,
         },
+        // redirect to the 1st page
+        { path: "/folders/:folder_id", redirect: "/folders/:folder_id/page/1" },
         {
-            path: "/folders/:folder_id/(page/)?:page?",
-            // path: "/folders/:folder_id(/?)(page/)?:page?",
+            path: "/folders/:folder_id/page/:page?",
             name: "LibraryFolder",
             component: LibraryFolder,
             props(route) {

--- a/client/src/components/Libraries/LibraryFolderRouter.js
+++ b/client/src/components/Libraries/LibraryFolderRouter.js
@@ -25,10 +25,17 @@ export default new VueRouter({
             props: true,
         },
         {
-            path: "/folders/:folder_id",
+            path: "/folders/:folder_id/(page/)?:page?",
+            // path: "/folders/:folder_id(/?)(page/)?:page?",
             name: "LibraryFolder",
             component: LibraryFolder,
-            props: true,
+            props(route) {
+                const props = { ...route.params };
+                if (props.page) {
+                    props.page = +props.page;
+                }
+                return props;
+            },
         },
         {
             path: "/folders/:folder_id/permissions",

--- a/client/src/components/Libraries/LibraryFolderRouter.js
+++ b/client/src/components/Libraries/LibraryFolderRouter.js
@@ -27,7 +27,7 @@ export default new VueRouter({
         // redirect to the 1st page
         { path: "/folders/:folder_id", redirect: "/folders/:folder_id/page/1" },
         {
-            path: "/folders/:folder_id/page/:page?",
+            path: "/folders/:folder_id/page/:page",
             name: "LibraryFolder",
             component: LibraryFolder,
             props(route) {

--- a/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
+++ b/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <PermissionsHeader v-if="library" :name="library.name"/>
+        <PermissionsHeader v-if="library" :name="library.name" />
         <h2 class="text-center">Library permissions</h2>
         <PermissionsInputField
             v-if="access_library_role_list"

--- a/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
+++ b/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <PermissionsHeader v-if="library" :name="library.name" path="/" />
+        <PermissionsHeader v-if="library" :name="library.name"/>
         <h2 class="text-center">Library permissions</h2>
         <PermissionsInputField
             v-if="access_library_role_list"

--- a/client/src/components/Libraries/LibraryPermissions/PermissionsHeader.vue
+++ b/client/src/components/Libraries/LibraryPermissions/PermissionsHeader.vue
@@ -1,9 +1,6 @@
 <template>
     <div>
         <div v-if="name">
-            <b-button variant="primary" title="back to parent folder" :to="{ path: `${this.path}` }">
-                <font-awesome-icon icon="angle-double-left" />
-            </b-button>
             <div>
                 <div class="header text-center">{{ name }}</div>
             </div>
@@ -15,8 +12,7 @@
 
 <script>
 import { getGalaxyInstance } from "app";
-import LibraryPermissionsWarning from "components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryPermissionsWarning.vue";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import LibraryPermissionsWarning from "components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryPermissionsWarning";
 
 export default {
     props: {
@@ -24,14 +20,9 @@ export default {
             type: String,
             required: true,
         },
-        path: {
-            type: String,
-            required: true,
-        },
     },
     components: {
         LibraryPermissionsWarning,
-        FontAwesomeIcon,
     },
     data() {
         return {

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -668,7 +668,7 @@ libraries:
       import_dir_btn:
         type: xpath
         selector: '//button[contains(text(), "Import")]'
-      manage_dataset_permissions_btn: 'button[title="Permissions of ${name}"]'
+      manage_dataset_permissions_btn: 'a[title="Permissions of ${name}"]'
       make_private_btn: '#make-private'
       access_dataset_roles: '.access_dataset_roles .multiselect__tag span'
       private_dataset_icon: '.fa-key'


### PR DESCRIPTION
fixes https://github.com/galaxyproject/galaxy/issues/12208, thanks for reporting @bebatut!

What it does:
- manage permissions view can be open in the new window (middle mouse button)
- preserve page on browser back button
- navigation to preferred page directly from address bar
- removed  "back" button from permissions. we don't need it anymore, the user should use the browser one, it will even remember the last page.   


## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. go to arbitrary page in data library folder
  2. click on manage (dataset/folder)
  3. click browser back button

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
