### PR TITLE
Added additional guard conditions in k8s runner to prevent KeyError

### DIFF
--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -89,8 +89,8 @@ def find_pod_object_by_name(pykube_api, job_name, namespace=None):
 
 
 def is_pod_unschedulable(pykube_api, pod, namespace=None):
-    is_unschedulable = bool(len([c for c in pod.obj['status']['conditions'] if c.get("reason") == "Unschedulable"]))
-    if pod.obj['status']['phase'] == "Pending" and is_unschedulable:
+    is_unschedulable = bool(len([c for c in pod.obj['status'].get('conditions', []) if c.get("reason") == "Unschedulable"]))
+    if pod.obj['status'].get('phase') == "Pending" and is_unschedulable:
         return True
 
     return False

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -89,7 +89,7 @@ def find_pod_object_by_name(pykube_api, job_name, namespace=None):
 
 
 def is_pod_unschedulable(pykube_api, pod, namespace=None):
-    is_unschedulable = bool(len([c for c in pod.obj['status'].get('conditions', []) if c.get("reason") == "Unschedulable"]))
+    is_unschedulable = any(c.get("reason") == "Unschedulable" for c in pod.obj['status'].get('conditions', []))
     if pod.obj['status'].get('phase') == "Pending" and is_unschedulable:
         return True
 


### PR DESCRIPTION
This fixes the following error by adding additional guard conditions:
```
galaxy.jobs.runners ERROR 2021-07-20 15:42:41,995 [pN:job_handler_0,p:8,tN:KubernetesRunner.monitor_thread] Unhandled exception checking active jobs
Traceback (most recent call last):
  File "/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 701, in monitor
    self.check_watched_items()
  File "/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 728, in check_watched_items
    new_async_job_state = self.check_watched_item(async_job_state)
  File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 647, in check_watched_item
    if self.__job_pending_due_to_unschedulable_pod(job_state):
  File "/galaxy/server/lib/galaxy/jobs/runners/kubernetes.py", line 774, in __job_pending_due_to_unschedulable_pod
    return is_pod_unschedulable(self._pykube_api, pod, self.runner_params['k8s_namespace'])
  File "/galaxy/server/lib/galaxy/jobs/runners/util/pykube_util.py", line 90, in is_pod_unschedulable
    is_unschedulable = bool(len([c for c in pod.obj['status']['conditions'] if c.get("reason") == "Unschedulable"]))
KeyError: 'conditions'
```

In addition, it also fixes an error where `More than one job matches selector` is printed, when in fact, no jobs exist at all.

This should probably be backported to 21.05.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
