### PR TITLE
Some refactoring of interactive tool handling in k8s

### DIFF
--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -150,36 +150,24 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             log.exception(f"({job_wrapper.get_id_tag()}) failure writing job script")
             return
 
-        # Construction of the Kubernetes Job object follows: http://kubernetes.io/docs/user-guide/persistent-volumes/
+        # Construction of Kubernetes objects follow: https://kubernetes.io/docs/concepts/workloads/controllers/job/
+        if self.__is_interactive_tool(ajs):
+            try:
+                self.__configure_interactive_tool_services(ajs)
+            except HTTPError:
+                log.exception("Kubernetes failed to create interactive tool services, HTTP exception encountered")
+                ajs.runner_state = JobState.runner_states.UNKNOWN_ERROR
+                ajs.fail_message = "Kubernetes failed to create interactive tool services."
+                self.mark_as_failed(ajs)
+                return
+
         k8s_job_prefix = self.__produce_k8s_job_prefix()
-        guest_ports = ajs.job_wrapper.guest_ports
-        ports_dict = {}
-        for guest_port in guest_ports:
-            ports_dict[str(guest_port)] = dict(host='manual', port=guest_port, protocol="https")
-        eps = None
-        if ajs.job_wrapper.guest_ports:
-            k8s_job_name = self.__get_k8s_job_name(k8s_job_prefix, ajs.job_wrapper)
-            log.debug(f'Configuring entry points and deploying service/ingress for job with ID {ajs.job_id}')
-            k8s_service_obj = service_object_dict(
-                self.runner_params,
-                k8s_job_name,
-                self.__get_k8s_service_spec(ajs)
-            )
-            eps = self.app.interactivetool_manager.configure_entry_points(ajs.job_wrapper.get_job(), ports_dict)
-            k8s_ingress_obj = ingress_object_dict(
-                self.runner_params,
-                k8s_job_name,
-                self.__get_k8s_ingress_spec(ajs, eps)
-            )
-            service = Service(self._pykube_api, k8s_service_obj)
-            service.create()
-            ingress = Ingress(self._pykube_api, k8s_ingress_obj)
-            ingress.create()
         k8s_job_obj = job_object_dict(
             self.runner_params,
             k8s_job_prefix,
-            self.__get_k8s_job_spec(ajs, eps)
+            self.__get_k8s_job_spec(ajs)
         )
+
         job = Job(self._pykube_api, k8s_job_obj)
         try:
             job.create()
@@ -202,6 +190,37 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         # store runner information for tracking if Galaxy restarts
         job_wrapper.set_external_id(job_id)
         self.monitor_queue.put(ajs)
+
+    def __is_interactive_tool(self, ajs):
+        return bool(ajs.job_wrapper.guest_ports)
+
+    def __configure_interactive_tool_services(self, ajs):
+        # Configure interactive tool entry points first
+        guest_ports = ajs.job_wrapper.guest_ports
+        ports_dict = {}
+        for guest_port in guest_ports:
+            ports_dict[str(guest_port)] = dict(host='manual', port=guest_port, protocol="https")
+        self.app.interactivetool_manager.configure_entry_points(ajs.job_wrapper.get_job(), ports_dict)
+
+        # Configure additional k8s service and ingress for interactive tool
+        k8s_job_prefix = self.__produce_k8s_job_prefix()
+        k8s_job_name = self.__get_k8s_job_name(k8s_job_prefix, ajs.job_wrapper)
+        log.debug(f'Configuring entry points and deploying service/ingress for job with ID {ajs.job_id}')
+        k8s_service_obj = service_object_dict(
+            self.runner_params,
+            k8s_job_name,
+            self.__get_k8s_service_spec(ajs)
+        )
+
+        k8s_ingress_obj = ingress_object_dict(
+            self.runner_params,
+            k8s_job_name,
+            self.__get_k8s_ingress_spec(ajs)
+        )
+        service = Service(self._pykube_api, k8s_service_obj)
+        service.create()
+        ingress = Ingress(self._pykube_api, k8s_ingress_obj)
+        ingress.create()
 
     def __get_overridable_params(self, job_wrapper, param_key):
         dest_params = self.__get_destination_params(job_wrapper)
@@ -265,10 +284,10 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         instance_id = self._galaxy_instance_id or ''
         return produce_k8s_job_prefix(app_prefix='gxy', instance_id=instance_id)
 
-    def __get_k8s_job_spec(self, ajs, eps=None):
+    def __get_k8s_job_spec(self, ajs):
         """Creates the k8s Job spec. For a Job spec, the only requirement is to have a .spec.template.
         If the job hangs around unlimited it will be ended after k8s wall time limit, which sets activeDeadlineSeconds"""
-        k8s_job_spec = {"template": self.__get_k8s_job_spec_template(ajs, eps),
+        k8s_job_spec = {"template": self.__get_k8s_job_spec_template(ajs),
                         "activeDeadlineSeconds": int(self.runner_params['k8s_walltime_limit'])}
         job_ttl = self.runner_params["k8s_job_ttl_secs_after_finished"]
         if self.runner_params["k8s_cleanup_job"] != "never" and job_ttl is not None:
@@ -289,7 +308,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             label_val += 'x'
         return label_val
 
-    def __get_k8s_job_spec_template(self, ajs, eps=None):
+    def __get_k8s_job_spec_template(self, ajs):
         """The k8s spec template is nothing but a Pod spec, except that it is nested and does not have an apiversion
         nor kind. In addition to required fields for a Pod, a pod template in a job must specify appropriate labels
         (see pod selector) and an appropriate restart policy."""
@@ -314,7 +333,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             "spec": {
                 "volumes": self.runner_params['k8s_mountable_volumes'],
                 "restartPolicy": self.__get_k8s_restart_policy(ajs.job_wrapper),
-                "containers": self.__get_k8s_containers(ajs, eps),
+                "containers": self.__get_k8s_containers(ajs),
                 "priorityClassName": self.runner_params['k8s_pod_priority_class'],
                 "tolerations": yaml.safe_load(self.runner_params['k8s_tolerations'] or "[]"),
                 "affinity": yaml.safe_load(self.__get_overridable_params(ajs.job_wrapper,
@@ -363,19 +382,20 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         }
         return k8s_spec_template
 
-    def __get_k8s_ingress_spec(self, ajs, eps=None):
+    def __get_k8s_ingress_spec(self, ajs):
         """The k8s spec template is nothing but a Ingress spec, except that it is nested and does not have an apiversion
         nor kind."""
         guest_ports = ajs.job_wrapper.guest_ports
         if len(guest_ports) > 0:
             entry_points = []
-            for entry_point in eps.get('configured', []):
+            configured_eps = [ep for ep in ajs.job_wrapper.get_job().interactivetool_entry_points if ep.configured]
+            for entry_point in configured_eps:
                 # sending in self.app as `trans` since it's only used for `.security` so seems to work
                 entry_point_path = self.app.interactivetool_manager.get_entry_point_path(self.app, entry_point)
                 if '?' in entry_point_path:
                     # Removing all the parameters from the ingress path, but they will still be in the database
                     # so the link that the user clicks on will still have them
-                    log.warn("IT urls including parameters (eg: /myit?mykey=myvalue) are only experimentally supported on K8S")
+                    log.warning("IT urls including parameters (eg: /myit?mykey=myvalue) are only experimentally supported on K8S")
                     entry_point_path = entry_point_path.split('?')[0]
                 entry_point_domain = f'{self.app.config.interactivetools_proxy_host}'
                 if entry_point.requires_domain:
@@ -432,7 +452,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         """The default Kubernetes restart policy for Jobs"""
         return "Never"
 
-    def __get_k8s_containers(self, ajs, eps=None):
+    def __get_k8s_containers(self, ajs):
         """Fills in all required for setting up the docker containers to be used, including setting a pull policy if
            this has been set.
            $GALAXY_VIRTUAL_ENV is set to None to avoid the galaxy virtualenv inside the tool container.
@@ -480,14 +500,15 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             extra_envs = yaml.safe_load(self.__get_overridable_params(ajs.job_wrapper, 'k8s_extra_job_envs') or "{}")
             for key in extra_envs:
                 envs.append({'name': key, 'value': extra_envs[key]})
-            if eps:
-                for entry_point in eps.get('configured', []):
+            if self.__is_interactive_tool(ajs):
+                configured_eps = [ep for ep in ajs.job_wrapper.get_job().interactivetool_entry_points if ep.configured]
+                for entry_point in configured_eps:
                     # sending in self.app as `trans` since it's only used for `.security` so seems to work
                     entry_point_path = self.app.interactivetool_manager.get_entry_point_path(self.app, entry_point)
                     if '?' in entry_point_path:
                         # Removing all the parameters from the ingress path, but they will still be in the database
                         # so the link that the user clicks on will still have them
-                        log.warn("IT urls including parameters (eg: /myit?mykey=myvalue) are only experimentally supported on K8S")
+                        log.warning("IT urls including parameters (eg: /myit?mykey=myvalue) are only experimentally supported on K8S")
                         entry_point_path = entry_point_path.split('?')[0]
                     entry_point_domain = f'{self.app.config.interactivetools_proxy_host}'
                     if entry_point.requires_domain:


### PR DESCRIPTION
Some minor refactoring of interactive tool changes in k8s so it's more self-contained.

~~Also bumps up unschedulable wall time limit from 30 minutes to 5 hours.~~

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
