### PR TITLE
Beta history: Dataset Collection API fix for updating tags

### DIFF
--- a/test/unit/managers/test_CollectionManager.py
+++ b/test/unit/managers/test_CollectionManager.py
@@ -100,14 +100,16 @@ class DatasetCollectionManagerTestCase(BaseTestCase, CreatesCollectionsMixin):
             'deleted': True,
             'visible': False,
             'name': 'New Name',
+            'tags': ['name:one', 'group:two', 'three']
             # TODO: doesn't work
-            # 'tags'      : [ 'one', 'two', 'three' ]
             # 'annotations'      : [?]
         })
         self.assertEqual(hdca.name, 'New Name')
         self.assertTrue(hdca.deleted)
         self.assertFalse(hdca.visible)
-        # self.assertEqual( hdca.tags, [ 'one', 'two', 'three' ] )
+
+        tag_names = hdca.make_tag_string_list()
+        self.assertEqual(tag_names, ['name:one', 'group:two', 'three'])
         # self.assertEqual( hdca.annotations, [ 'one', 'two', 'three' ] )
 
     # def test_validation( self ):


### PR DESCRIPTION
## Normalized history contents api response for tags field

The history contents api is inconsistent in the sense that the "normal" way to update tags for a element of the history is to update the item via a 
```
PUT /api/histories/[history_id]/contents/[datasets|dataset_collections]/[hda_id|hdca_id], 
```
...which generally returns the changed fields. In the case of a dataset collection however, the changed tags were not being returned and the standard client-side functions that updated the dataset collection failed because they expected the changed fields to exist in the response.

I've modified the update endpoint to return the new tag strings both for API consistency and because it's always good policy to return fresh data from the server during a PUT in the event that business logic running on the server needs to massage the response (generated IDs, update times, etc.).

There are significant UI problems associated with this api change that will be addressed here:
https://github.com/galaxyproject/galaxy/pull/12299


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  
## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
