### PR TITLE
Automatically sort tools in sections by name

### DIFF
--- a/client/src/components/Panels/Common/ToolSection.test.js
+++ b/client/src/components/Panels/Common/ToolSection.test.js
@@ -2,6 +2,16 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import ToolSection from "./ToolSection";
 
+import { useConfig } from "composables/useConfig";
+
+jest.mock("composables/useConfig");
+useConfig.mockReturnValue({
+    config: {
+        toolbox_auto_sort: true,
+    },
+    isLoaded: true,
+});
+
 const localVue = getLocalVue();
 
 describe("ToolSection", () => {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -117,15 +117,19 @@ export default {
             return this.category.links || {};
         },
         sortedElements() {
-            // This obviously breaks when people have manually inserted labels
-            // into particular spots in the tool section, so if there are any,
-            // just skip the whole section and trust ordering
-            if (this.category.elems.some((el) => el.text !== undefined && el.text !== "")) {
-                return Object.entries(this.category.elems);
-            } else {
+            // If this.config.sortTools is true, sort the tools alphabetically
+            // When administrators have manually inserted labels we respect
+            // the order set and hope for the best from the integrated
+            // panel.
+            if (
+                this.$store.state.config.sortTools &&
+                !this.category.elems.some((el) => el.text !== undefined && el.text !== "")
+            ) {
                 return Object.entries(
                     [...this.category.elems].sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase())
                 );
+            } else {
+                return Object.entries(this.category.elems);
             }
         },
     },

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -15,7 +15,7 @@
         </div>
         <transition name="slide">
             <div v-if="opened">
-                <template v-for="[key, el] in category.elems.entries()">
+                <template v-for="[key, el] in sortedElements">
                     <ToolPanelLabel v-if="category.text" :key="key" :definition="el" />
                     <tool
                         v-else
@@ -116,6 +116,9 @@ export default {
         links() {
             return this.category.links || {};
         },
+        sortedElements() {
+            return Object.entries([...this.category.elems].sort((a, b) => a.name > b.name));
+        }
     },
     watch: {
         queryFilter() {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -51,6 +51,8 @@ import ToolPanelLabel from "./ToolPanelLabel";
 import ariaAlert from "utils/ariaAlert";
 import ToolPanelLinks from "./ToolPanelLinks";
 
+import { useConfig } from "composables/useConfig";
+
 export default {
     name: "ToolSection",
     components: {
@@ -94,6 +96,13 @@ export default {
             default: false,
         },
     },
+    setup() {
+        const { config, isLoaded } = useConfig();
+        return {
+            config,
+            isLoaded,
+        };
+    },
     data() {
         return {
             opened: this.expanded || this.checkFilter(),
@@ -122,7 +131,8 @@ export default {
             // the order set and hope for the best from the integrated
             // panel.
             if (
-                this.$store.state.config.sortTools &&
+                this.isLoaded &&
+                this.config.toolbox_auto_sort === true &&
                 !this.category.elems.some((el) => el.text !== undefined && el.text !== "")
             ) {
                 return Object.entries(

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -5,7 +5,9 @@
             :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]"
             :title="title"
             @mouseover="hover = true"
-            @mouseleave="hover = false">
+            @mouseleave="hover = false"
+            @focus="hover = true"
+            @blur="hover = false">
             <a class="title-link" href="javascript:void(0)" @click="toggleMenu()">
                 <span class="name">
                     {{ name }}

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -117,9 +117,16 @@ export default {
             return this.category.links || {};
         },
         sortedElements() {
-            return Object.entries(
-                [...this.category.elems].sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase())
-            );
+            // This obviously breaks when people have manually inserted labels
+            // into particular spots in the tool section, so if there are any,
+            // just skip the whole section and trust ordering
+            if (this.category.elems.some((el) => el.text !== undefined && el.text !== "")) {
+                return Object.entries(this.category.elems);
+            } else {
+                return Object.entries(
+                    [...this.category.elems].sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase())
+                );
+            }
         },
     },
     watch: {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -117,8 +117,10 @@ export default {
             return this.category.links || {};
         },
         sortedElements() {
-            return Object.entries([...this.category.elems].sort((a, b) => a.name > b.name));
-        }
+            return Object.entries(
+                [...this.category.elems].sort((a, b) => a.name.toLowerCase() > b.name.toLowerCase())
+            );
+        },
     },
     watch: {
         queryFilter() {

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -592,22 +592,6 @@
 :Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``load_tool_shed_datatypes``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:Description:
-    This option controls whether legacy datatypes are loaded from
-    installed tool shed repositories. We're are in the process of
-    disabling Tool Shed datatypes. This option with a default of true
-    will be added in 22.01, we will disable the datatypes on the big
-    public servers during that release. This option will be switched
-    to False by default in 22.05 and this broken functionality will be
-    removed all together during some future release.
-:Default: ``true``
-:Type: bool
-
-
 ~~~~~~~~~~~~~~~
 ``watch_tools``
 ~~~~~~~~~~~~~~~
@@ -4669,6 +4653,20 @@
     possibility that jobs will be dispatched past the configured
     limits if running many handlers.
 :Default: ``false``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~
+``toolbox_auto_sort``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    If true, the toolbox will be sorted by tool id when the toolbox is
+    loaded. This is useful for ensuring that tools are always
+    displayed in the same order in the UI.  If false, the order of
+    tools in the toolbox will be preserved as they are loaded from the
+    tool config files.
+:Default: ``true``
 :Type: bool
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2345,6 +2345,13 @@ galaxy:
   # if running many handlers.
   #cache_user_job_count: false
 
+  # If true, the toolbox will be sorted by tool id when the toolbox is
+  # loaded. This is useful for ensuring that tools are always displayed
+  # in the same order in the UI.  If false, the order of tools in the
+  # toolbox will be preserved as they are loaded from the tool config
+  # files.
+  #toolbox_auto_sort: true
+
   # Define toolbox filters
   # (https://galaxyproject.org/user-defined-toolbox-filters/) that
   # admins may use to restrict the tools to display.

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -3397,6 +3397,17 @@ mapping:
           greater possibility that jobs will be dispatched past the configured limits
           if running many handlers.
 
+      toolbox_auto_sort:
+        type: bool
+        default: true
+        required: false
+        reloadable: true
+        desc: |
+          If true, the toolbox will be sorted by tool id when the toolbox is loaded.
+          This is useful for ensuring that tools are always displayed in the same
+          order in the UI.  If false, the order of tools in the toolbox will be
+          preserved as they are loaded from the tool config files.
+
       tool_filters:
         type: str
         required: false

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -189,6 +189,7 @@ class ConfigSerializer(base.ModelSerializer):
             "python": _defaults_to((sys.version_info.major, sys.version_info.minor)),
             "select_type_workflow_threshold": _use_config,
             "file_sources_configured": lambda item, key, **context: self.app.file_sources.custom_sources_configured,
+            "toolbox_auto_sort": _use_config,
             "panel_views": lambda item, key, **context: self.app.toolbox.panel_view_dicts(),
             "default_panel_view": _use_config,
             "upload_from_form_button": _use_config,


### PR DESCRIPTION
This changes the toolbox sections to show tools in alphabetical order within sections.  The ordering available in integrated tool panel is a pain point for both admins (configuring it manually, having it overwritten, etc.) and users (inconsistent and difficult to predict ordering of tools in sections).

There's a configuration option `toolbox_auto_sort` available if someone wants to disable this behavior.  It defaults to on, per informal survey of folks.

If a section has extra labels manually inserted, we don't attempt to sort (since an admin has attempted to do something here) and rely on whatever is in the file order.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
