### PR TITLE
Allow bio.tools mappings for legacy tools.

### DIFF
--- a/lib/galaxy/tools/biotools_mappings.tsv
+++ b/lib/galaxy/tools/biotools_mappings.tsv
@@ -1,0 +1,5 @@
+# tool-id <tab> bio.tools-id
+abyss-pe	abyss
+allegro	allegro
+# testing tool mapping for test case
+cheetah_problem_unbound_var_input	bwa

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -216,6 +216,18 @@ class ToolsTestCase(ApiTestCase, TestsTools):
             assert galaxy_url.startswith("http")
             assert galaxy_url.endswith("tool_runner?tool_id=ratmine")
 
+    @skip_without_tool("cheetah_problem_unbound_var_input")
+    def test_legacy_biotools_xref_injection(self):
+        url = self._api_url("tools/cheetah_problem_unbound_var_input")
+        get_response = get(url)
+        get_response.raise_for_status()
+        get_json = get_response.json()
+        assert "xrefs" in get_json
+        assert len(get_json["xrefs"]) == 1
+        xref = get_json["xrefs"][0]
+        assert xref["reftype"] == "bio.tools"
+        assert xref["value"] == "bwa"
+
     @skip_without_tool("test_data_source")
     def test_data_source_ok_request(self):
         with self.dataset_populator.test_history() as history_id:

--- a/packages/app/MANIFEST.in
+++ b/packages/app/MANIFEST.in
@@ -2,3 +2,4 @@ include *.rst *.txt LICENSE
 include galaxy/*.yml
 include galaxy/config/sample/*.sample
 include galaxy/jobs/runners/util/job_script/*.sh
+include galaxy/tools/*tsv


### PR DESCRIPTION
Assigning these in the tools for new tool installs is great (https://github.com/galaxyproject/tools-iuc/pull/3411/files) but there will be thousands of old tools that are missing these and we should have a way to fill in this information as "missing info" bug fixes.

## How to test the changes?
(Select all options that apply)
- [x] Automated tests included.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
