### PR TITLE
Allow scrolling in autocomplete options, fix search word filtering

### DIFF
--- a/client/src/mvc/ui/ui-misc.js
+++ b/client/src/mvc/ui/ui-misc.js
@@ -105,9 +105,7 @@ export var Input = Backbone.View.extend({
         var datalist = this.model.get("datalist");
         if (Array.isArray(datalist) && datalist.length > 0) {
             this.$el.autocomplete({
-                source: function (request, response) {
-                    response(self.model.get("datalist"));
-                },
+                source: self.model.get("datalist"),
                 change: function () {
                     self._onchange();
                 },

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -38,6 +38,13 @@ $ui-margin-horizontal: $margin-h;
 $ui-margin-horizontal-small: $margin-h * 0.5;
 $ui-margin-horizontal-large: $margin-v * 2;
 
+.ui-autocomplete {
+    max-height: 9.5rem;
+    position: fixed;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
 .ui-modal {
     display: none;
     overflow: auto;


### PR DESCRIPTION
Reported by @nekrut. When selecting an input dataset module in the workflow editor and changing the `Format(s)` field, the presented autocomplete list 1) does not filter the presented options and 2) the options are not scrollable, the element list is vastly oversized.

With this PR, the list height is limited, the list is scrollable and correctly filters the search word:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/2105447/126719841-b001d6b9-b965-48f4-bd97-1c4f72c4dedf.png">

## How to test the changes?
- Instructions for manual testing are as follows:
  1. Create a Workflow
  2. Add an Input Dataset module
  3. Change the Input Dataset's format (as shown in the figure above)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
