### PR TITLE
Parse edam operation and topic data from bio.tools if available.

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1140,6 +1140,66 @@
 :Type: bool
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``biotools_content_directory``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Point Galaxy at a repository consisting of a copy of the bio.tools
+    database (e.g. https://github.com/bio-tools/content/) to resolve
+    bio.tools data for tool metadata.
+:Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~
+``biotools_use_api``
+~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Set this to true to attempt to resolve bio.tools metadata for
+    tools for tool not resovled via biotools_content_directory.
+:Default: ``false``
+:Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``biotools_service_cache_type``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    bio.tools web service request related caching. The type of beaker
+    cache used.
+:Default: ``file``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``biotools_service_cache_data_dir``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    bio.tools web service request related caching. The data directory
+    to point beaker cache at.
+    The value of this option will be resolved with respect to
+    <cache_dir>.
+:Default: ``biotools/data``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``biotools_service_cache_lock_dir``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    bio.tools web service request related caching. The lock directory
+    to point beaker cache at.
+    The value of this option will be resolved with respect to
+    <cache_dir>.
+:Default: ``biotools/locks``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``citation_cache_type``
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -3367,26 +3427,68 @@
 :Type: bool
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enable_beta_edam_toolbox``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
+``edam_panel_views``
+~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable beta EDAM organised toolbox which ignores admin managed
-    sections in lieu of EDAM topics only.
-:Default: ``false``
-:Type: bool
+    Comma-separated list of the EDAM panel views to load - choose from
+    merged, operations, topics. Set to empty string to disable EDAM
+    all together. Set default_panel_view to 'ontology:edam_topics' to
+    override default tool panel to use an EDAM view.
+:Default: ``operations,topics``
+:Type: str
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``beta_edam_toolbox_ontology_path``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``edam_toolbox_ontology_path``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Sets the path to EDAM ontology file.
+    Sets the path to EDAM ontology file - if the path doesn't exist
+    PyPI package data will be loaded.
     The value of this option will be resolved with respect to
     <data_dir>.
 :Default: ``EDAM.tsv``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~
+``panel_views_dir``
+~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Directory to check out for toolbox tool panel views. The path is
+    relative to the Galaxy root dir.  To use an absolute path begin
+    the path with '/'.  This is a comma-separated list.
+:Default: ``config/plugins/activities``
+:Type: str
+
+
+~~~~~~~~~~~~~~~
+``panel_views``
+~~~~~~~~~~~~~~~
+
+:Description:
+    Definitions of static toolbox panel views embedded directly in the
+    config instead of reading YAML from directory with
+    panel_views_dir.
+:Default: ``None``
+:Type: seq
+
+
+~~~~~~~~~~~~~~~~~~~~~~
+``default_panel_view``
+~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Default tool panel view for the current Galaxy configuration. This
+    should refer to an id of a panel view defined using the
+    panel_views or panel_views_dir configuration options or an EDAM
+    panel view. The default panel view is simply called `default` and
+    refers to the tool panel state defined by the integrated tool
+    panel.
+:Default: ``default``
 :Type: str
 
 

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1168,12 +1168,14 @@ class ConfiguresGalaxyMixin:
 
     def _configure_toolbox(self):
         from galaxy import tools
+        from galaxy.tools.biotools import get_galaxy_biotools_metadata_source
         from galaxy.managers.citations import CitationsManager
         from galaxy.tool_util.deps import containers
         from galaxy.tool_util.deps.dependencies import AppInfo
         import galaxy.tools.search
 
         self.citations_manager = CitationsManager(self)
+        self.biotools_metadata_source = get_galaxy_biotools_metadata_source(self.config)
 
         from galaxy.managers.tools import DynamicToolManager
         self.dynamic_tools_manager = DynamicToolManager(self)

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -659,6 +659,31 @@ galaxy:
   # memory when using forked Galaxy processes.
   #delay_tool_initialization: false
 
+  # Point Galaxy at a repository consisting of a copy of the bio.tools
+  # database (e.g. https://github.com/bio-tools/content/) to resolve
+  # bio.tools data for tool metadata.
+  #biotools_content_directory: null
+
+  # Set this to true to attempt to resolve bio.tools metadata for tools
+  # for tool not resovled via biotools_content_directory.
+  #biotools_use_api: false
+
+  # bio.tools web service request related caching. The type of beaker
+  # cache used.
+  #biotools_service_cache_type: file
+
+  # bio.tools web service request related caching. The data directory to
+  # point beaker cache at.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #biotools_service_cache_data_dir: biotools/data
+
+  # bio.tools web service request related caching. The lock directory to
+  # point beaker cache at.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #biotools_service_cache_lock_dir: biotools/locks
+
   # Citation related caching.  Tool citations information maybe fetched
   # from external sources such as https://doi.org/ by Galaxy - the
   # following parameters can be used to control the caching used to
@@ -1668,14 +1693,33 @@ galaxy:
   # workflows built using these modules may not function in the future.)
   #enable_beta_workflow_modules: false
 
-  # Enable beta EDAM organised toolbox which ignores admin managed
-  # sections in lieu of EDAM topics only.
-  #enable_beta_edam_toolbox: false
+  # Comma-separated list of the EDAM panel views to load - choose from
+  # merged, operations, topics. Set to empty string to disable EDAM all
+  # together. Set default_panel_view to 'ontology:edam_topics' to
+  # override default tool panel to use an EDAM view.
+  #edam_panel_views: operations,topics
 
-  # Sets the path to EDAM ontology file.
+  # Sets the path to EDAM ontology file - if the path doesn't exist PyPI
+  # package data will be loaded.
   # The value of this option will be resolved with respect to
   # <data_dir>.
-  #beta_edam_toolbox_ontology_path: EDAM.tsv
+  #edam_toolbox_ontology_path: EDAM.tsv
+
+  # Directory to check out for toolbox tool panel views. The path is
+  # relative to the Galaxy root dir.  To use an absolute path begin the
+  # path with '/'.  This is a comma-separated list.
+  #panel_views_dir: config/plugins/activities
+
+  # Definitions of static toolbox panel views embedded directly in the
+  # config instead of reading YAML from directory with panel_views_dir.
+  #panel_views: null
+
+  # Default tool panel view for the current Galaxy configuration. This
+  # should refer to an id of a panel view defined using the panel_views
+  # or panel_views_dir configuration options or an EDAM panel view. The
+  # default panel view is simply called `default` and refers to the tool
+  # panel state defined by the integrated tool panel.
+  #default_panel_view: default
 
   # Default format for the export of workflows. Possible values are 'ga'
   # or 'format2'.

--- a/lib/galaxy/tool_util/biotools/__init__.py
+++ b/lib/galaxy/tool_util/biotools/__init__.py
@@ -1,0 +1,13 @@
+from .interface import ParsedBiotoolsEntry
+from .source import (
+    BiotoolsMetadataSource,
+    BiotoolsMetadataSourceConfig,
+    get_biotools_metadata_source,
+)
+
+__all__ = (
+    "BiotoolsMetadataSource",
+    "BiotoolsMetadataSourceConfig",
+    "get_biotools_metadata_source",
+    "ParsedBiotoolsEntry",
+)

--- a/lib/galaxy/tool_util/biotools/interface.py
+++ b/lib/galaxy/tool_util/biotools/interface.py
@@ -1,0 +1,56 @@
+import re
+from typing import Any, Dict, List, Optional
+
+TERM_PATTERN = re.compile(r"https?://edamontology.org/(.*)")
+
+
+class ParsedBiotoolsEntry:
+    """Provide XML wrapper relevant entities from a bio.tool entry - topics and operations."""
+    biotoolsID: str
+    edam_topics: List[str]
+    edam_operations: List[str]
+
+
+class BiotoolsEntry:
+    """Parse the RAW entries of interest for Galaxy from a bio.tools entry."""
+    biotoolsID: str
+    topic: List[dict]
+    function: List[dict]
+
+    @staticmethod
+    def from_json(from_json: Dict[str, Any]) -> 'BiotoolsEntry':
+        entry = BiotoolsEntry()
+        entry.biotoolsID = from_json["biotoolsID"]
+        entry.topic = from_json["topic"]
+        entry.function = from_json["function"]
+        return entry
+
+    @property
+    def edam_info(self) -> ParsedBiotoolsEntry:
+        parsed = ParsedBiotoolsEntry()
+        parsed.biotoolsID = self.biotoolsID
+        parsed.edam_topics = list(set(simplify_edam_dicts(self.topic)))
+        operations = []
+        for function in self.function:
+            if "operation" in function:
+                operations.extend(simplify_edam_dicts(function["operation"]))
+        parsed.edam_operations = list(set(operations))
+        return parsed
+
+
+def simplify_edam_dicts(a_list: List[Dict[str, str]]):
+    terms = []
+    for term in map(simplify_edam_dict, a_list):
+        if term:
+            terms.append(term)
+    return terms
+
+
+def simplify_edam_dict(as_dict: Dict[str, str]) -> Optional[str]:
+    uri = as_dict["uri"]
+    match = TERM_PATTERN.match(uri)
+    if match:
+        return match.group(1)
+    else:
+        # TODO: log problem...
+        return None

--- a/lib/galaxy/tool_util/biotools/source.py
+++ b/lib/galaxy/tool_util/biotools/source.py
@@ -1,0 +1,100 @@
+import functools
+import json
+import os
+from typing import Callable, Dict, List, Optional
+
+import requests
+
+from galaxy.util import DEFAULT_SOCKET_TIMEOUT
+from .interface import BiotoolsEntry
+
+
+class BiotoolsMetadataSource:
+
+    def get_biotools_metadata(self, biotools_reference: str) -> Optional[BiotoolsEntry]:
+        """Return a BiotoolsEntry if available."""
+
+
+class GitContentBiotoolsMetadataSource(BiotoolsMetadataSource):
+    """Parse entries from a repository clone of https://github.com/bio-tools/content."""
+
+    def __init__(self, content_directory):
+        self._content_directory = content_directory
+
+    def get_biotools_metadata(self, biotools_reference: str) -> Optional[BiotoolsEntry]:
+        """Return a BiotoolsEntry if available."""
+        path = os.path.join(self._content_directory, "data", biotools_reference, f"{biotools_reference}.biotools.json")
+        if not os.path.exists(path):
+            return None
+        with open(path, "r") as f:
+            content_json = json.load(f)
+            return BiotoolsEntry.from_json(content_json)
+
+
+class InMemoryCache:
+    backend: Dict[str, Optional[str]] = {}
+
+    def get(self, key: str, createfunc: Callable[[], Optional[str]]):
+        backend = self.backend
+        if key not in backend:
+            backend[key] = createfunc()
+
+        return backend.get(key)
+
+
+class ApiBiotoolsMetadataSource(BiotoolsMetadataSource):
+    """Parse entries from bio.tools API."""
+
+    def __init__(self, cache=None):
+        self._cache = cache or InMemoryCache()
+
+    def _raw_get_metadata(self, biotools_reference) -> Optional[str]:
+        api_url = f"https://bio.tools/api/tool/{biotools_reference}?format=json"
+        req = requests.get(api_url, timeout=DEFAULT_SOCKET_TIMEOUT)
+        req.encoding = req.apparent_encoding
+        if req.status_code == 404:
+            return None
+        else:
+            return req.text
+
+    def get_biotools_metadata(self, biotools_reference: str) -> Optional[BiotoolsEntry]:
+        createfunc = functools.partial(self._raw_get_metadata, biotools_reference)
+        content = self._cache.get(key=biotools_reference, createfunc=createfunc)
+        if content is not None:
+            return BiotoolsEntry.from_json(json.loads(content))
+        else:
+            return None
+
+
+class CascadingBiotoolsMetadataSource(BiotoolsMetadataSource):
+
+    def __init__(self, use_api=False, cache=None, content_directory: Optional[str] = None):
+        sources: List[BiotoolsMetadataSource] = []
+        if content_directory:
+            git_content_source = GitContentBiotoolsMetadataSource(content_directory)
+            sources.append(git_content_source)
+        if use_api:
+            api_metadata_source = ApiBiotoolsMetadataSource(cache=cache)
+            sources.append(api_metadata_source)
+        self._sources = sources
+
+    def get_biotools_metadata(self, biotools_reference: str) -> Optional[BiotoolsEntry]:
+        for source in self._sources:
+            entry = source.get_biotools_metadata(biotools_reference)
+            if entry is not None:
+                return entry
+        return None
+
+
+class BiotoolsMetadataSourceConfig:
+    use_api: bool = False
+    content_directory: Optional[str] = None
+    cache = None
+
+
+def get_biotools_metadata_source(metadata_source_config: BiotoolsMetadataSourceConfig) -> BiotoolsMetadataSource:
+    return CascadingBiotoolsMetadataSource(
+        use_api=metadata_source_config.use_api,
+        content_directory=metadata_source_config.content_directory,
+        cache=metadata_source_config.cache,
+    )

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -59,6 +59,17 @@ class ToolSource(metaclass=ABCMeta):
     def parse_description(self):
         """ Parse a description for tool. Longer than name, shorted than help. """
 
+    def parse_edam_operations(self) -> List[str]:
+        """Parse list of edam operation codes."""
+        return []
+
+    def parse_edam_topics(self) -> List[str]:
+        """Parse list of edam topic codes."""
+        return []
+
+    def parse_xrefs(self) -> List[Dict[str, str]]:
+        """Parse list of external resource URIs and types."""
+
     def parse_is_multi_byte(self):
         """ Parse is_multi_byte from tool - TODO: figure out what this is and
         document.

--- a/lib/galaxy/tools/biotools.py
+++ b/lib/galaxy/tools/biotools.py
@@ -1,0 +1,25 @@
+"""Adapt Galaxy-agnostic abstraction galaxy.tool_util.biotools to Galaxy config and dependencies."""
+
+from beaker.cache import CacheManager
+from beaker.util import parse_cache_config_options
+
+from galaxy.tool_util.biotools import (
+    BiotoolsMetadataSource,
+    BiotoolsMetadataSourceConfig,
+    get_biotools_metadata_source,
+)
+
+
+def get_galaxy_biotools_metadata_source(config) -> BiotoolsMetadataSource:
+    """Build a BiotoolsMetadataSource from a Galaxy configuration object."""
+    biotools_metadata_source_config = BiotoolsMetadataSourceConfig()
+    biotools_metadata_source_config.content_directory = config.biotools_content_directory
+    biotools_metadata_source_config.use_api = config.biotools_use_api
+    cache_opts = {
+        'cache.type': getattr(config, 'biotools_service_cache_type', 'file'),
+        'cache.data_dir': getattr(config, 'biotools_service_cache_data_dir', None),
+        'cache.lock_dir': getattr(config, 'biotools_service_cache_lock_dir', None),
+    }
+    cache = CacheManager(**parse_cache_config_options(cache_opts)).get_cache('doi')
+    biotools_metadata_source_config.cache = cache
+    return get_biotools_metadata_source(biotools_metadata_source_config)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -831,6 +831,46 @@ mapping:
           This results in faster startup times but uses more memory when using forked Galaxy
           processes.
 
+      biotools_content_directory:
+        type: str
+        required: false
+        desc: |
+          Point Galaxy at a repository consisting of a copy of the bio.tools database (e.g.
+          https://github.com/bio-tools/content/) to resolve bio.tools data for tool metadata.
+
+      biotools_use_api:
+        type: bool
+        default: false
+        required: false
+        desc: |
+          Set this to true to attempt to resolve bio.tools metadata for tools for tool not
+          resovled via biotools_content_directory.
+
+      biotools_service_cache_type:
+        type: str
+        default: file
+        required: false
+        desc: |
+          bio.tools web service request related caching. The type of beaker cache used.
+
+      biotools_service_cache_data_dir:
+        type: str
+        default: biotools/data
+        path_resolves_to: cache_dir
+        required: false
+        desc: |
+          bio.tools web service request related caching. The data directory to point
+          beaker cache at.
+
+      biotools_service_cache_lock_dir:
+        type: str
+        default: biotools/locks
+        path_resolves_to: cache_dir
+        required: false
+        desc: |
+          bio.tools web service request related caching. The lock directory to point
+          beaker cache at.
+
       citation_cache_type:
         type: str
         default: file

--- a/test/integration/mock_biotools_content/data/Citation.js/Citation.js.biotools.json
+++ b/test/integration/mock_biotools_content/data/Citation.js/Citation.js.biotools.json
@@ -1,0 +1,515 @@
+{
+    "additionDate": "2017-01-13T13:13:56Z",
+    "biotoolsCURIE": "biotools:Citation.js",
+    "biotoolsID": "Citation.js",
+    "collectionID": [
+        "BWA"
+    ],
+    "credit": [
+        {
+            "email": "bio-bwa-help@sourceforge.net",
+            "name": "bwa team",
+            "typeEntity": "Person",
+            "typeRole": [
+                "Primary contact"
+            ]
+        },
+        {
+            "email": "me@liheng.org",
+            "name": "Heng Li",
+            "orcidid": "http://orcid.org/0000-0003-4874-2874",
+            "typeEntity": "Person",
+            "typeRole": [
+                "Contributor"
+            ],
+            "url": "http://www.liheng.org/"
+        }
+    ],
+    "description": "Fast, accurate, memory-efficient aligner for short and long sequencing reads",
+    "documentation": [
+        {
+            "type": [
+                "User manual"
+            ],
+            "url": "http://bio-bwa.sourceforge.net/bwa.shtml"
+        }
+    ],
+    "download": [
+        {
+            "type": "Tool wrapper (CWL)",
+            "url": "https://gitlab.com/sibyllewohlgemuth/cwl_files/raw/master/bwa_index.cwl"
+        },
+        {
+            "type": "Tool wrapper (CWL)",
+            "url": "https://gitlab.com/sibyllewohlgemuth/cwl_files/raw/master/bwa_mem.cwl"
+        },
+        {
+            "type": "Container file",
+            "url": "https://docker-ui.genouest.org/app/#/container/bioconda/bwa"
+        },
+        {
+            "type": "Container file",
+            "url": "https://anaconda.org/bioconda/bwa"
+        }
+    ],
+    "editPermission": {
+        "authors": [
+            "swohlgemuth"
+        ],
+        "type": "group"
+    },
+    "function": [
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                }
+            ],
+            "note": "Index database sequences in the FASTA format. database",
+            "operation": [
+                {
+                    "term": "Genome indexing",
+                    "uri": "http://edamontology.org/operation_3211"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Genome index",
+                        "uri": "http://edamontology.org/data_3210"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Genome index",
+                        "uri": "http://edamontology.org/data_3210"
+                    }
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Align 70bp-1Mbp query sequences with the BWA-MEM algorithm. Briefly, the algorithm works by seeding alignments with maximal exact matches (MEMs) and then extending seeds with the affine-gap Smith-Waterman algorithm (SW). The BWA-MEM algorithm performs local alignment. It may produce multiple primary alignments for different part of a query sequence. This is a crucial feature for long sequences. However, some tools such as Picards markDuplicates does not work with split alignments. One may consider to use option -M to flag shorter split hits as secondary.",
+            "operation": [
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Alignment",
+                        "uri": "http://edamontology.org/data_1916"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA search results format",
+                            "uri": "http://edamontology.org/format_1332"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Find the SA coordinates of the input reads. reference sequence query sequence",
+            "operation": [
+                {
+                    "term": "Read mapping",
+                    "uri": "http://edamontology.org/operation_3198"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence coordinates",
+                        "uri": "http://edamontology.org/data_2012"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    }
+                }
+            ],
+            "note": "Generate alignments in the SAM format given single-end reads. Repetitive hits will be randomly chosen reference sequence query sequence",
+            "operation": [
+                {
+                    "term": "Generation",
+                    "uri": "http://edamontology.org/operation_3429"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    },
+                    "format": [
+                        {
+                            "term": "SAM",
+                            "uri": "http://edamontology.org/format_2573"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    }
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Generate alignments in the SAM format given paired-end reads. Repetitive read pairs will be placed randomly. reference sequence",
+            "operation": [
+                {
+                    "term": "Generation",
+                    "uri": "http://edamontology.org/operation_3429"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    },
+                    "format": [
+                        {
+                            "term": "SAM",
+                            "uri": "http://edamontology.org/format_2573"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Align query sequences in the in.fq file reference sequence",
+            "operation": [
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    }
+                }
+            ]
+        }
+    ],
+    "homepage": "http://bio-bwa.sourceforge.net",
+    "language": [
+        "C"
+    ],
+    "lastUpdate": "2019-06-26T12:31:54Z",
+    "license": "MIT",
+    "maturity": "Mature",
+    "name": "BWA",
+    "operatingSystem": [
+        "Linux",
+        "Mac"
+    ],
+    "owner": "seqwiki_import",
+    "publication": [
+        {
+            "doi": "10.1093/bioinformatics/btp324",
+            "metadata": {
+                "abstract": "Motivation: The enormous amount of short reads generated by the new DNA sequencing technologies call for the development of fast and accurate read alignment programs. A first generation of hash table-based methods has been developed, including MAQ, which is accurate, feature rich and fast enough to align short reads from a single individual. However, MAQ does not support gapped alignment for single-end reads, which makes it unsuitable for alignment of longer reads where indels may occur frequently. The speed of MAQ is also a concern when the alignment is scaled up to the resequencing of hundreds of individuals. Results: We implemented Burrows-Wheeler Alignment tool (BWA), a new read alignment package that is based on backward search with Burrows-Wheeler Transform (BWT), to efficiently align short sequencing reads against a large reference sequence such as the human genome, allowing mismatches and gaps. BWA supports both base space reads, e.g. from Illumina sequencing machines, and color space reads from AB SOLiD machines. Evaluations on both simulated and real data suggest that BWA is \u223c10-20\u00d7 faster than MAQ, while achieving similar accuracy. In addition, BWA outputs alignment in the new standard SAM (Sequence Alignment/Map) format. Variant calling and other downstream analyses after the alignment can be achieved with the open source SAMtools software package. \u00a9 2009 The Author(s).",
+                "authors": [
+                    {
+                        "name": "Li H."
+                    },
+                    {
+                        "name": "Durbin R."
+                    }
+                ],
+                "citationCount": 19268,
+                "date": "2009-07-01T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Fast and accurate short read alignment with Burrows-Wheeler transform"
+            },
+            "pmcid": "PMC2705234",
+            "pmid": "19451168",
+            "type": [
+                "Primary"
+            ]
+        },
+        {
+            "doi": "10.1186/1471-2105-14-184",
+            "metadata": {
+                "abstract": "Background: The development of next-generation sequencing instruments has led to the generation of millions of short sequences in a single run. The process of aligning these reads to a reference genome is time consuming and demands the development of fast and accurate alignment tools. However, the current proposed tools make different compromises between the accuracy and the speed of mapping. Moreover, many important aspects are overlooked while comparing the performance of a newly developed tool to the state of the art. Therefore, there is a need for an objective evaluation method that covers all the aspects. In this work, we introduce a benchmarking suite to extensively analyze sequencing tools with respect to various aspects and provide an objective comparison.Results: We applied our benchmarking tests on 9 well known mapping tools, namely, Bowtie, Bowtie2, BWA, SOAP2, MAQ, RMAP, GSNAP, Novoalign, and mrsFAST (mrFAST) using synthetic data and real RNA-Seq data. MAQ and RMAP are based on building hash tables for the reads, whereas the remaining tools are based on indexing the reference genome. The benchmarking tests reveal the strengths and weaknesses of each tool. The results show that no single tool outperforms all others in all metrics. However, Bowtie maintained the best throughput for most of the tests while BWA performed better for longer read lengths. The benchmarking tests are not restricted to the mentioned tools and can be further applied to others.Conclusion: The mapping process is still a hard problem that is affected by many factors. In this work, we provided a benchmarking suite that reveals and evaluates the different factors affecting the mapping process. Still, there is no tool that outperforms all of the others in all the tests. Therefore, the end user should clearly specify his needs in order to choose the tool that provides the best results. \u00a9 2013 Hatem et al.; licensee BioMed Central Ltd.",
+                "authors": [
+                    {
+                        "name": "Hatem A."
+                    },
+                    {
+                        "name": "Bozdag D."
+                    },
+                    {
+                        "name": "Toland A.E."
+                    },
+                    {
+                        "name": "Catalyurek U.V."
+                    }
+                ],
+                "citationCount": 119,
+                "date": "2013-06-07T00:00:00Z",
+                "journal": "BMC Bioinformatics",
+                "title": "Benchmarking short sequence mapping tools"
+            },
+            "pmcid": "PMC3694458",
+            "pmid": "23758764",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1016/j.ygeno.2017.03.001",
+            "metadata": {
+                "abstract": "\u00a9 2017 Elsevier Inc.Massive data produced due to the advent of next-generation sequencing (NGS) technology is widely used for biological researches and medical diagnosis. The crucial step in NGS analysis is read alignment or mapping which is computationally intensive and complex. The mapping bias tends to affect the downstream analysis, including detection of polymorphisms. In order to provide guidelines to the biologist for suitable selection of aligners; we have evaluated and benchmarked 5 different aligners (BWA, Bowtie2, NovoAlign, Smalt and Stampy) and their mapping bias based on characteristics of 5 microbial genomes. Two million simulated read pairs of various sizes (36 bp, 50 bp, 72 bp, 100 bp, 125 bp, 150 bp, 200 bp, 250 bp and 300 bp) were aligned. Specific alignment features such as sensitivity of mapping, percentage of properly paired reads, alignment time and effect of tandem repeats on incorrectly mapped reads were evaluated. BWA showed faster alignment followed by Bowtie2 and Smalt. NovoAlign and Stampy were comparatively slower. Most of the aligners showed high sensitivity towards long reads (> 100 bp) mapping. On the other hand NovoAlign showed higher sensitivity towards both short reads (36 bp, 50 bp, 72 bp) and long reads (> 100 bp) mappings; It also showed higher sensitivity towards mapping a complex genome like Plasmodium falciparum. The percentage of properly paired reads aligned by NovoAlign, BWA and Stampy were markedly higher. None of the aligners outperforms the others in the benchmark, however the aligners perform differently with genome characteristics. We expect that the results from this study will be useful for the end user to choose aligner, thus enhance the accuracy of read mapping.",
+                "authors": [
+                    {
+                        "name": "Thankaswamy-Kosalai S."
+                    },
+                    {
+                        "name": "Sen P."
+                    },
+                    {
+                        "name": "Nookaew I."
+                    }
+                ],
+                "citationCount": 24,
+                "date": "2017-07-01T00:00:00Z",
+                "journal": "Genomics",
+                "title": "Evaluation and assessment of read-mapping by multiple next-generation sequencing aligners based on genome-wide characteristics"
+            },
+            "pmid": "28286147",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1186/1471-2164-15-264",
+            "metadata": {
+                "abstract": "Background: The rapid evolution in high-throughput sequencing (HTS) technologies has opened up new perspectives in several research fields and led to the production of large volumes of sequence data. A fundamental step in HTS data analysis is the mapping of reads onto reference sequences. Choosing a suitable mapper for a given technology and a given application is a subtle task because of the difficulty of evaluating mapping algorithms.Results: In this paper, we present a benchmark procedure to compare mapping algorithms used in HTS using both real and simulated datasets and considering four evaluation criteria: computational resource and time requirements, robustness of mapping, ability to report positions for reads in repetitive regions, and ability to retrieve true genetic variation positions. To measure robustness, we introduced a new definition for a correctly mapped read taking into account not only the expected start position of the read but also the end position and the number of indels and substitutions. We developed CuReSim, a new read simulator, that is able to generate customized benchmark data for any kind of HTS technology by adjusting parameters to the error types. CuReSim and CuReSimEval, a tool to evaluate the mapping quality of the CuReSim simulated reads, are freely available. We applied our benchmark procedure to evaluate 14 mappers in the context of whole genome sequencing of small genomes with Ion Torrent data for which such a comparison has not yet been established.Conclusions: A benchmark procedure to compare HTS data mappers is introduced with a new definition for the mapping correctness as well as tools to generate simulated reads and evaluate mapping quality. The application of this procedure to Ion Torrent data from the whole genome sequencing of small genomes has allowed us to validate our benchmark procedure and demonstrate that it is helpful for selecting a mapper based on the intended application, questions to be addressed, and the technology used. This benchmark procedure can be used to evaluate existing or in-development mappers as well as to optimize parameters of a chosen mapper for any application and any sequencing platform. \u00a9 2014 Caboche et al.; licensee BioMed Central Ltd.",
+                "authors": [
+                    {
+                        "name": "Caboche S."
+                    },
+                    {
+                        "name": "Audebert C."
+                    },
+                    {
+                        "name": "Lemoine Y."
+                    },
+                    {
+                        "name": "Hot D."
+                    }
+                ],
+                "citationCount": 51,
+                "date": "2014-04-05T00:00:00Z",
+                "journal": "BMC Genomics",
+                "title": "Comparison of mapping algorithms used in high-throughput sequencing: Application to Ion Torrent data"
+            },
+            "pmcid": "PMC4051166",
+            "pmid": "24708189",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1093/bioinformatics/btu146",
+            "metadata": {
+                "abstract": "Motivation: Next-generation sequencing has become an important tool in molecular biology. Various protocols to investigate genomic, transcriptomic and epigenomic features across virtually all species and tissues have been devised. For most of these experiments, one of the first crucial steps of bioinformatic analysis is the mapping of reads to reference genomes. Results: Here, we present thorough benchmarks of our read aligner segemehl in comparison with other state-of-the-art methods. Furthermore, we introduce the tool lack to rescue unmapped RNA-seq reads which works in conjunction with segemehl and many other frequently used split-read aligners. \u00a9 The Author 2014.",
+                "authors": [
+                    {
+                        "name": "Otto C."
+                    },
+                    {
+                        "name": "Stadler P.F."
+                    },
+                    {
+                        "name": "Hoffmann S."
+                    }
+                ],
+                "citationCount": 43,
+                "date": "2014-07-01T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Lacking alignments? The next-generation sequencing mapper segemehl revisited"
+            },
+            "pmid": "24626854",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1093/bioinformatics/btp698",
+            "metadata": {
+                "abstract": "Motivation: Many programs for aligning short sequencing reads to a reference genome have been developed in the last 2 years. Most of them are very efficient for short reads but inefficient or not applicable for reads >200 bp because the algorithms are heavily and specifically tuned for short queries with low sequencing error rate. However, some sequencing platforms already produce longer reads and others are expected to become available soon. For longer reads, hashingbased software such as BLAT and SSAHA2 remain the only choices. Nonetheless, these methods are substantially slower than short-read aligners in terms of aligned bases per unit time. Results: We designed and implemented a new algorithm, Burrows-Wheeler Aligner's Smith-Waterman Alignment (BWA-SW), to align long sequences up to 1Mb against a large sequence database (e.g. the human genome) with a few gigabytes of memory. The algorithm is as accurate as SSAHA2, more accurate than BLAT, and is several to tens of times faster than both. Availability: http://bio-bwa.sourceforge.net. Contact: rd@sanger.ac.uk \u00a9 The Author(s) 2010. Published by Oxford University Press.",
+                "authors": [
+                    {
+                        "name": "Li H."
+                    },
+                    {
+                        "name": "Durbin R."
+                    }
+                ],
+                "citationCount": 5111,
+                "date": "2010-01-15T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Fast and accurate long-read alignment with Burrows-Wheeler transform"
+            },
+            "pmid": "20080505"
+        }
+    ],
+    "toolType": [
+        "Command-line tool",
+        "Workbench"
+    ],
+    "topic": [
+        {
+            "term": "Mapping",
+            "uri": "http://edamontology.org/topic_0102"
+        }
+    ],
+    "validated": 1
+}

--- a/test/integration/mock_biotools_content/data/bwa/bwa.biotools.json
+++ b/test/integration/mock_biotools_content/data/bwa/bwa.biotools.json
@@ -1,0 +1,515 @@
+{
+    "additionDate": "2017-01-13T13:13:56Z",
+    "biotoolsCURIE": "biotools:bwa",
+    "biotoolsID": "bwa",
+    "collectionID": [
+        "BWA"
+    ],
+    "credit": [
+        {
+            "email": "bio-bwa-help@sourceforge.net",
+            "name": "bwa team",
+            "typeEntity": "Person",
+            "typeRole": [
+                "Primary contact"
+            ]
+        },
+        {
+            "email": "me@liheng.org",
+            "name": "Heng Li",
+            "orcidid": "http://orcid.org/0000-0003-4874-2874",
+            "typeEntity": "Person",
+            "typeRole": [
+                "Contributor"
+            ],
+            "url": "http://www.liheng.org/"
+        }
+    ],
+    "description": "Fast, accurate, memory-efficient aligner for short and long sequencing reads",
+    "documentation": [
+        {
+            "type": [
+                "User manual"
+            ],
+            "url": "http://bio-bwa.sourceforge.net/bwa.shtml"
+        }
+    ],
+    "download": [
+        {
+            "type": "Tool wrapper (CWL)",
+            "url": "https://gitlab.com/sibyllewohlgemuth/cwl_files/raw/master/bwa_index.cwl"
+        },
+        {
+            "type": "Tool wrapper (CWL)",
+            "url": "https://gitlab.com/sibyllewohlgemuth/cwl_files/raw/master/bwa_mem.cwl"
+        },
+        {
+            "type": "Container file",
+            "url": "https://docker-ui.genouest.org/app/#/container/bioconda/bwa"
+        },
+        {
+            "type": "Container file",
+            "url": "https://anaconda.org/bioconda/bwa"
+        }
+    ],
+    "editPermission": {
+        "authors": [
+            "swohlgemuth"
+        ],
+        "type": "group"
+    },
+    "function": [
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                }
+            ],
+            "note": "Index database sequences in the FASTA format. database",
+            "operation": [
+                {
+                    "term": "Genome indexing",
+                    "uri": "http://edamontology.org/operation_3211"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Genome index",
+                        "uri": "http://edamontology.org/data_3210"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Genome index",
+                        "uri": "http://edamontology.org/data_3210"
+                    }
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Align 70bp-1Mbp query sequences with the BWA-MEM algorithm. Briefly, the algorithm works by seeding alignments with maximal exact matches (MEMs) and then extending seeds with the affine-gap Smith-Waterman algorithm (SW). The BWA-MEM algorithm performs local alignment. It may produce multiple primary alignments for different part of a query sequence. This is a crucial feature for long sequences. However, some tools such as Picards markDuplicates does not work with split alignments. One may consider to use option -M to flag shorter split hits as secondary.",
+            "operation": [
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Alignment",
+                        "uri": "http://edamontology.org/data_1916"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA search results format",
+                            "uri": "http://edamontology.org/format_1332"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Find the SA coordinates of the input reads. reference sequence query sequence",
+            "operation": [
+                {
+                    "term": "Read mapping",
+                    "uri": "http://edamontology.org/operation_3198"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence coordinates",
+                        "uri": "http://edamontology.org/data_2012"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    }
+                }
+            ],
+            "note": "Generate alignments in the SAM format given single-end reads. Repetitive hits will be randomly chosen reference sequence query sequence",
+            "operation": [
+                {
+                    "term": "Generation",
+                    "uri": "http://edamontology.org/operation_3429"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    },
+                    "format": [
+                        {
+                            "term": "SAM",
+                            "uri": "http://edamontology.org/format_2573"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    }
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Generate alignments in the SAM format given paired-end reads. Repetitive read pairs will be placed randomly. reference sequence",
+            "operation": [
+                {
+                    "term": "Generation",
+                    "uri": "http://edamontology.org/operation_3429"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    },
+                    "format": [
+                        {
+                            "term": "SAM",
+                            "uri": "http://edamontology.org/format_2573"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Align query sequences in the in.fq file reference sequence",
+            "operation": [
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    }
+                }
+            ]
+        }
+    ],
+    "homepage": "http://bio-bwa.sourceforge.net",
+    "language": [
+        "C"
+    ],
+    "lastUpdate": "2019-06-26T12:31:54Z",
+    "license": "MIT",
+    "maturity": "Mature",
+    "name": "BWA",
+    "operatingSystem": [
+        "Linux",
+        "Mac"
+    ],
+    "owner": "seqwiki_import",
+    "publication": [
+        {
+            "doi": "10.1093/bioinformatics/btp324",
+            "metadata": {
+                "abstract": "Motivation: The enormous amount of short reads generated by the new DNA sequencing technologies call for the development of fast and accurate read alignment programs. A first generation of hash table-based methods has been developed, including MAQ, which is accurate, feature rich and fast enough to align short reads from a single individual. However, MAQ does not support gapped alignment for single-end reads, which makes it unsuitable for alignment of longer reads where indels may occur frequently. The speed of MAQ is also a concern when the alignment is scaled up to the resequencing of hundreds of individuals. Results: We implemented Burrows-Wheeler Alignment tool (BWA), a new read alignment package that is based on backward search with Burrows-Wheeler Transform (BWT), to efficiently align short sequencing reads against a large reference sequence such as the human genome, allowing mismatches and gaps. BWA supports both base space reads, e.g. from Illumina sequencing machines, and color space reads from AB SOLiD machines. Evaluations on both simulated and real data suggest that BWA is \u223c10-20\u00d7 faster than MAQ, while achieving similar accuracy. In addition, BWA outputs alignment in the new standard SAM (Sequence Alignment/Map) format. Variant calling and other downstream analyses after the alignment can be achieved with the open source SAMtools software package. \u00a9 2009 The Author(s).",
+                "authors": [
+                    {
+                        "name": "Li H."
+                    },
+                    {
+                        "name": "Durbin R."
+                    }
+                ],
+                "citationCount": 19268,
+                "date": "2009-07-01T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Fast and accurate short read alignment with Burrows-Wheeler transform"
+            },
+            "pmcid": "PMC2705234",
+            "pmid": "19451168",
+            "type": [
+                "Primary"
+            ]
+        },
+        {
+            "doi": "10.1186/1471-2105-14-184",
+            "metadata": {
+                "abstract": "Background: The development of next-generation sequencing instruments has led to the generation of millions of short sequences in a single run. The process of aligning these reads to a reference genome is time consuming and demands the development of fast and accurate alignment tools. However, the current proposed tools make different compromises between the accuracy and the speed of mapping. Moreover, many important aspects are overlooked while comparing the performance of a newly developed tool to the state of the art. Therefore, there is a need for an objective evaluation method that covers all the aspects. In this work, we introduce a benchmarking suite to extensively analyze sequencing tools with respect to various aspects and provide an objective comparison.Results: We applied our benchmarking tests on 9 well known mapping tools, namely, Bowtie, Bowtie2, BWA, SOAP2, MAQ, RMAP, GSNAP, Novoalign, and mrsFAST (mrFAST) using synthetic data and real RNA-Seq data. MAQ and RMAP are based on building hash tables for the reads, whereas the remaining tools are based on indexing the reference genome. The benchmarking tests reveal the strengths and weaknesses of each tool. The results show that no single tool outperforms all others in all metrics. However, Bowtie maintained the best throughput for most of the tests while BWA performed better for longer read lengths. The benchmarking tests are not restricted to the mentioned tools and can be further applied to others.Conclusion: The mapping process is still a hard problem that is affected by many factors. In this work, we provided a benchmarking suite that reveals and evaluates the different factors affecting the mapping process. Still, there is no tool that outperforms all of the others in all the tests. Therefore, the end user should clearly specify his needs in order to choose the tool that provides the best results. \u00a9 2013 Hatem et al.; licensee BioMed Central Ltd.",
+                "authors": [
+                    {
+                        "name": "Hatem A."
+                    },
+                    {
+                        "name": "Bozdag D."
+                    },
+                    {
+                        "name": "Toland A.E."
+                    },
+                    {
+                        "name": "Catalyurek U.V."
+                    }
+                ],
+                "citationCount": 119,
+                "date": "2013-06-07T00:00:00Z",
+                "journal": "BMC Bioinformatics",
+                "title": "Benchmarking short sequence mapping tools"
+            },
+            "pmcid": "PMC3694458",
+            "pmid": "23758764",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1016/j.ygeno.2017.03.001",
+            "metadata": {
+                "abstract": "\u00a9 2017 Elsevier Inc.Massive data produced due to the advent of next-generation sequencing (NGS) technology is widely used for biological researches and medical diagnosis. The crucial step in NGS analysis is read alignment or mapping which is computationally intensive and complex. The mapping bias tends to affect the downstream analysis, including detection of polymorphisms. In order to provide guidelines to the biologist for suitable selection of aligners; we have evaluated and benchmarked 5 different aligners (BWA, Bowtie2, NovoAlign, Smalt and Stampy) and their mapping bias based on characteristics of 5 microbial genomes. Two million simulated read pairs of various sizes (36 bp, 50 bp, 72 bp, 100 bp, 125 bp, 150 bp, 200 bp, 250 bp and 300 bp) were aligned. Specific alignment features such as sensitivity of mapping, percentage of properly paired reads, alignment time and effect of tandem repeats on incorrectly mapped reads were evaluated. BWA showed faster alignment followed by Bowtie2 and Smalt. NovoAlign and Stampy were comparatively slower. Most of the aligners showed high sensitivity towards long reads (> 100 bp) mapping. On the other hand NovoAlign showed higher sensitivity towards both short reads (36 bp, 50 bp, 72 bp) and long reads (> 100 bp) mappings; It also showed higher sensitivity towards mapping a complex genome like Plasmodium falciparum. The percentage of properly paired reads aligned by NovoAlign, BWA and Stampy were markedly higher. None of the aligners outperforms the others in the benchmark, however the aligners perform differently with genome characteristics. We expect that the results from this study will be useful for the end user to choose aligner, thus enhance the accuracy of read mapping.",
+                "authors": [
+                    {
+                        "name": "Thankaswamy-Kosalai S."
+                    },
+                    {
+                        "name": "Sen P."
+                    },
+                    {
+                        "name": "Nookaew I."
+                    }
+                ],
+                "citationCount": 24,
+                "date": "2017-07-01T00:00:00Z",
+                "journal": "Genomics",
+                "title": "Evaluation and assessment of read-mapping by multiple next-generation sequencing aligners based on genome-wide characteristics"
+            },
+            "pmid": "28286147",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1186/1471-2164-15-264",
+            "metadata": {
+                "abstract": "Background: The rapid evolution in high-throughput sequencing (HTS) technologies has opened up new perspectives in several research fields and led to the production of large volumes of sequence data. A fundamental step in HTS data analysis is the mapping of reads onto reference sequences. Choosing a suitable mapper for a given technology and a given application is a subtle task because of the difficulty of evaluating mapping algorithms.Results: In this paper, we present a benchmark procedure to compare mapping algorithms used in HTS using both real and simulated datasets and considering four evaluation criteria: computational resource and time requirements, robustness of mapping, ability to report positions for reads in repetitive regions, and ability to retrieve true genetic variation positions. To measure robustness, we introduced a new definition for a correctly mapped read taking into account not only the expected start position of the read but also the end position and the number of indels and substitutions. We developed CuReSim, a new read simulator, that is able to generate customized benchmark data for any kind of HTS technology by adjusting parameters to the error types. CuReSim and CuReSimEval, a tool to evaluate the mapping quality of the CuReSim simulated reads, are freely available. We applied our benchmark procedure to evaluate 14 mappers in the context of whole genome sequencing of small genomes with Ion Torrent data for which such a comparison has not yet been established.Conclusions: A benchmark procedure to compare HTS data mappers is introduced with a new definition for the mapping correctness as well as tools to generate simulated reads and evaluate mapping quality. The application of this procedure to Ion Torrent data from the whole genome sequencing of small genomes has allowed us to validate our benchmark procedure and demonstrate that it is helpful for selecting a mapper based on the intended application, questions to be addressed, and the technology used. This benchmark procedure can be used to evaluate existing or in-development mappers as well as to optimize parameters of a chosen mapper for any application and any sequencing platform. \u00a9 2014 Caboche et al.; licensee BioMed Central Ltd.",
+                "authors": [
+                    {
+                        "name": "Caboche S."
+                    },
+                    {
+                        "name": "Audebert C."
+                    },
+                    {
+                        "name": "Lemoine Y."
+                    },
+                    {
+                        "name": "Hot D."
+                    }
+                ],
+                "citationCount": 51,
+                "date": "2014-04-05T00:00:00Z",
+                "journal": "BMC Genomics",
+                "title": "Comparison of mapping algorithms used in high-throughput sequencing: Application to Ion Torrent data"
+            },
+            "pmcid": "PMC4051166",
+            "pmid": "24708189",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1093/bioinformatics/btu146",
+            "metadata": {
+                "abstract": "Motivation: Next-generation sequencing has become an important tool in molecular biology. Various protocols to investigate genomic, transcriptomic and epigenomic features across virtually all species and tissues have been devised. For most of these experiments, one of the first crucial steps of bioinformatic analysis is the mapping of reads to reference genomes. Results: Here, we present thorough benchmarks of our read aligner segemehl in comparison with other state-of-the-art methods. Furthermore, we introduce the tool lack to rescue unmapped RNA-seq reads which works in conjunction with segemehl and many other frequently used split-read aligners. \u00a9 The Author 2014.",
+                "authors": [
+                    {
+                        "name": "Otto C."
+                    },
+                    {
+                        "name": "Stadler P.F."
+                    },
+                    {
+                        "name": "Hoffmann S."
+                    }
+                ],
+                "citationCount": 43,
+                "date": "2014-07-01T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Lacking alignments? The next-generation sequencing mapper segemehl revisited"
+            },
+            "pmid": "24626854",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1093/bioinformatics/btp698",
+            "metadata": {
+                "abstract": "Motivation: Many programs for aligning short sequencing reads to a reference genome have been developed in the last 2 years. Most of them are very efficient for short reads but inefficient or not applicable for reads >200 bp because the algorithms are heavily and specifically tuned for short queries with low sequencing error rate. However, some sequencing platforms already produce longer reads and others are expected to become available soon. For longer reads, hashingbased software such as BLAT and SSAHA2 remain the only choices. Nonetheless, these methods are substantially slower than short-read aligners in terms of aligned bases per unit time. Results: We designed and implemented a new algorithm, Burrows-Wheeler Aligner's Smith-Waterman Alignment (BWA-SW), to align long sequences up to 1Mb against a large sequence database (e.g. the human genome) with a few gigabytes of memory. The algorithm is as accurate as SSAHA2, more accurate than BLAT, and is several to tens of times faster than both. Availability: http://bio-bwa.sourceforge.net. Contact: rd@sanger.ac.uk \u00a9 The Author(s) 2010. Published by Oxford University Press.",
+                "authors": [
+                    {
+                        "name": "Li H."
+                    },
+                    {
+                        "name": "Durbin R."
+                    }
+                ],
+                "citationCount": 5111,
+                "date": "2010-01-15T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Fast and accurate long-read alignment with Burrows-Wheeler transform"
+            },
+            "pmid": "20080505"
+        }
+    ],
+    "toolType": [
+        "Command-line tool",
+        "Workbench"
+    ],
+    "topic": [
+        {
+            "term": "Mapping",
+            "uri": "http://edamontology.org/topic_0102"
+        }
+    ],
+    "validated": 1
+}

--- a/test/integration/test_dynamic_edam_loading.py
+++ b/test/integration/test_dynamic_edam_loading.py
@@ -1,0 +1,37 @@
+import os
+
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+)
+from galaxy_test.driver import integration_util
+
+SCRIPT_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
+MOCK_BIOTOOLS_CONTENT = os.path.join(SCRIPT_DIRECTORY, "mock_biotools_content")
+
+
+class DynamicEdamLoadingIntegrationTestCase(integration_util.IntegrationTestCase):
+    """Test mapping over tools with extended metadata enabled."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["biotools_content_directory"] = MOCK_BIOTOOLS_CONTENT
+        config["biotools_use_api"] = False
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_edam_properties(self):
+        result = self._get("tools/bibtex")
+        result.raise_for_status()
+        result_json = result.json()
+        assert "edam_operations" in result_json
+        assert "edam_topics" in result_json
+        edam_operations = result_json["edam_operations"]
+        edam_topics = result_json["edam_topics"]
+        assert len(edam_operations) == 4
+        assert "operation_3198" in edam_operations
+        assert len(edam_topics) == 1
+        assert "topic_0102" in edam_topics

--- a/test/unit/config/test_config_values.py
+++ b/test/unit/config/test_config_values.py
@@ -99,6 +99,8 @@ class ExpectedValues:
         self._expected_paths = {
             'admin_tool_recommendations_path': self._in_config_dir('tool_recommendations_overwrite.yml'),
             'auth_config_file': self._in_config_dir('auth_conf.xml'),
+            'biotools_service_cache_data_dir': self._in_cache_dir('biotools/data'),
+            'biotools_service_cache_lock_dir': self._in_cache_dir('biotools/locks'),
             'build_sites_config_file': self._in_sample_dir('build_sites.yml.sample'),
             'builds_file_path': self._in_root_dir('tool-data/shared/ucsc/builds.txt'),
             'cache_dir': self._in_data_dir('cache'),

--- a/test/unit/tool_util/biotools/_util.py
+++ b/test/unit/tool_util/biotools/_util.py
@@ -1,0 +1,4 @@
+import os
+
+script_dir = os.path.dirname(__file__)
+content_dir = os.path.join(script_dir, "mock_content")

--- a/test/unit/tool_util/biotools/mock_content/data/bwa/bwa.biotools.json
+++ b/test/unit/tool_util/biotools/mock_content/data/bwa/bwa.biotools.json
@@ -1,0 +1,515 @@
+{
+    "additionDate": "2017-01-13T13:13:56Z",
+    "biotoolsCURIE": "biotools:bwa",
+    "biotoolsID": "bwa",
+    "collectionID": [
+        "BWA"
+    ],
+    "credit": [
+        {
+            "email": "bio-bwa-help@sourceforge.net",
+            "name": "bwa team",
+            "typeEntity": "Person",
+            "typeRole": [
+                "Primary contact"
+            ]
+        },
+        {
+            "email": "me@liheng.org",
+            "name": "Heng Li",
+            "orcidid": "http://orcid.org/0000-0003-4874-2874",
+            "typeEntity": "Person",
+            "typeRole": [
+                "Contributor"
+            ],
+            "url": "http://www.liheng.org/"
+        }
+    ],
+    "description": "Fast, accurate, memory-efficient aligner for short and long sequencing reads",
+    "documentation": [
+        {
+            "type": [
+                "User manual"
+            ],
+            "url": "http://bio-bwa.sourceforge.net/bwa.shtml"
+        }
+    ],
+    "download": [
+        {
+            "type": "Tool wrapper (CWL)",
+            "url": "https://gitlab.com/sibyllewohlgemuth/cwl_files/raw/master/bwa_index.cwl"
+        },
+        {
+            "type": "Tool wrapper (CWL)",
+            "url": "https://gitlab.com/sibyllewohlgemuth/cwl_files/raw/master/bwa_mem.cwl"
+        },
+        {
+            "type": "Container file",
+            "url": "https://docker-ui.genouest.org/app/#/container/bioconda/bwa"
+        },
+        {
+            "type": "Container file",
+            "url": "https://anaconda.org/bioconda/bwa"
+        }
+    ],
+    "editPermission": {
+        "authors": [
+            "swohlgemuth"
+        ],
+        "type": "group"
+    },
+    "function": [
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                }
+            ],
+            "note": "Index database sequences in the FASTA format. database",
+            "operation": [
+                {
+                    "term": "Genome indexing",
+                    "uri": "http://edamontology.org/operation_3211"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Genome index",
+                        "uri": "http://edamontology.org/data_3210"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Genome index",
+                        "uri": "http://edamontology.org/data_3210"
+                    }
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Align 70bp-1Mbp query sequences with the BWA-MEM algorithm. Briefly, the algorithm works by seeding alignments with maximal exact matches (MEMs) and then extending seeds with the affine-gap Smith-Waterman algorithm (SW). The BWA-MEM algorithm performs local alignment. It may produce multiple primary alignments for different part of a query sequence. This is a crucial feature for long sequences. However, some tools such as Picards markDuplicates does not work with split alignments. One may consider to use option -M to flag shorter split hits as secondary.",
+            "operation": [
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Alignment",
+                        "uri": "http://edamontology.org/data_1916"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA search results format",
+                            "uri": "http://edamontology.org/format_1332"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Find the SA coordinates of the input reads. reference sequence query sequence",
+            "operation": [
+                {
+                    "term": "Read mapping",
+                    "uri": "http://edamontology.org/operation_3198"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence coordinates",
+                        "uri": "http://edamontology.org/data_2012"
+                    }
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    }
+                }
+            ],
+            "note": "Generate alignments in the SAM format given single-end reads. Repetitive hits will be randomly chosen reference sequence query sequence",
+            "operation": [
+                {
+                    "term": "Generation",
+                    "uri": "http://edamontology.org/operation_3429"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    },
+                    "format": [
+                        {
+                            "term": "SAM",
+                            "uri": "http://edamontology.org/format_2573"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    }
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Generate alignments in the SAM format given paired-end reads. Repetitive read pairs will be placed randomly. reference sequence",
+            "operation": [
+                {
+                    "term": "Generation",
+                    "uri": "http://edamontology.org/operation_3429"
+                },
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    },
+                    "format": [
+                        {
+                            "term": "SAM",
+                            "uri": "http://edamontology.org/format_2573"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "input": [
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTA",
+                            "uri": "http://edamontology.org/format_1929"
+                        }
+                    ]
+                },
+                {
+                    "data": {
+                        "term": "Sequence",
+                        "uri": "http://edamontology.org/data_2044"
+                    },
+                    "format": [
+                        {
+                            "term": "FASTQ",
+                            "uri": "http://edamontology.org/format_1930"
+                        }
+                    ]
+                }
+            ],
+            "note": "Align query sequences in the in.fq file reference sequence",
+            "operation": [
+                {
+                    "term": "Sequence alignment",
+                    "uri": "http://edamontology.org/operation_0292"
+                }
+            ],
+            "output": [
+                {
+                    "data": {
+                        "term": "Sequence alignment",
+                        "uri": "http://edamontology.org/data_0863"
+                    }
+                }
+            ]
+        }
+    ],
+    "homepage": "http://bio-bwa.sourceforge.net",
+    "language": [
+        "C"
+    ],
+    "lastUpdate": "2019-06-26T12:31:54Z",
+    "license": "MIT",
+    "maturity": "Mature",
+    "name": "BWA",
+    "operatingSystem": [
+        "Linux",
+        "Mac"
+    ],
+    "owner": "seqwiki_import",
+    "publication": [
+        {
+            "doi": "10.1093/bioinformatics/btp324",
+            "metadata": {
+                "abstract": "Motivation: The enormous amount of short reads generated by the new DNA sequencing technologies call for the development of fast and accurate read alignment programs. A first generation of hash table-based methods has been developed, including MAQ, which is accurate, feature rich and fast enough to align short reads from a single individual. However, MAQ does not support gapped alignment for single-end reads, which makes it unsuitable for alignment of longer reads where indels may occur frequently. The speed of MAQ is also a concern when the alignment is scaled up to the resequencing of hundreds of individuals. Results: We implemented Burrows-Wheeler Alignment tool (BWA), a new read alignment package that is based on backward search with Burrows-Wheeler Transform (BWT), to efficiently align short sequencing reads against a large reference sequence such as the human genome, allowing mismatches and gaps. BWA supports both base space reads, e.g. from Illumina sequencing machines, and color space reads from AB SOLiD machines. Evaluations on both simulated and real data suggest that BWA is \u223c10-20\u00d7 faster than MAQ, while achieving similar accuracy. In addition, BWA outputs alignment in the new standard SAM (Sequence Alignment/Map) format. Variant calling and other downstream analyses after the alignment can be achieved with the open source SAMtools software package. \u00a9 2009 The Author(s).",
+                "authors": [
+                    {
+                        "name": "Li H."
+                    },
+                    {
+                        "name": "Durbin R."
+                    }
+                ],
+                "citationCount": 19268,
+                "date": "2009-07-01T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Fast and accurate short read alignment with Burrows-Wheeler transform"
+            },
+            "pmcid": "PMC2705234",
+            "pmid": "19451168",
+            "type": [
+                "Primary"
+            ]
+        },
+        {
+            "doi": "10.1186/1471-2105-14-184",
+            "metadata": {
+                "abstract": "Background: The development of next-generation sequencing instruments has led to the generation of millions of short sequences in a single run. The process of aligning these reads to a reference genome is time consuming and demands the development of fast and accurate alignment tools. However, the current proposed tools make different compromises between the accuracy and the speed of mapping. Moreover, many important aspects are overlooked while comparing the performance of a newly developed tool to the state of the art. Therefore, there is a need for an objective evaluation method that covers all the aspects. In this work, we introduce a benchmarking suite to extensively analyze sequencing tools with respect to various aspects and provide an objective comparison.Results: We applied our benchmarking tests on 9 well known mapping tools, namely, Bowtie, Bowtie2, BWA, SOAP2, MAQ, RMAP, GSNAP, Novoalign, and mrsFAST (mrFAST) using synthetic data and real RNA-Seq data. MAQ and RMAP are based on building hash tables for the reads, whereas the remaining tools are based on indexing the reference genome. The benchmarking tests reveal the strengths and weaknesses of each tool. The results show that no single tool outperforms all others in all metrics. However, Bowtie maintained the best throughput for most of the tests while BWA performed better for longer read lengths. The benchmarking tests are not restricted to the mentioned tools and can be further applied to others.Conclusion: The mapping process is still a hard problem that is affected by many factors. In this work, we provided a benchmarking suite that reveals and evaluates the different factors affecting the mapping process. Still, there is no tool that outperforms all of the others in all the tests. Therefore, the end user should clearly specify his needs in order to choose the tool that provides the best results. \u00a9 2013 Hatem et al.; licensee BioMed Central Ltd.",
+                "authors": [
+                    {
+                        "name": "Hatem A."
+                    },
+                    {
+                        "name": "Bozdag D."
+                    },
+                    {
+                        "name": "Toland A.E."
+                    },
+                    {
+                        "name": "Catalyurek U.V."
+                    }
+                ],
+                "citationCount": 119,
+                "date": "2013-06-07T00:00:00Z",
+                "journal": "BMC Bioinformatics",
+                "title": "Benchmarking short sequence mapping tools"
+            },
+            "pmcid": "PMC3694458",
+            "pmid": "23758764",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1016/j.ygeno.2017.03.001",
+            "metadata": {
+                "abstract": "\u00a9 2017 Elsevier Inc.Massive data produced due to the advent of next-generation sequencing (NGS) technology is widely used for biological researches and medical diagnosis. The crucial step in NGS analysis is read alignment or mapping which is computationally intensive and complex. The mapping bias tends to affect the downstream analysis, including detection of polymorphisms. In order to provide guidelines to the biologist for suitable selection of aligners; we have evaluated and benchmarked 5 different aligners (BWA, Bowtie2, NovoAlign, Smalt and Stampy) and their mapping bias based on characteristics of 5 microbial genomes. Two million simulated read pairs of various sizes (36 bp, 50 bp, 72 bp, 100 bp, 125 bp, 150 bp, 200 bp, 250 bp and 300 bp) were aligned. Specific alignment features such as sensitivity of mapping, percentage of properly paired reads, alignment time and effect of tandem repeats on incorrectly mapped reads were evaluated. BWA showed faster alignment followed by Bowtie2 and Smalt. NovoAlign and Stampy were comparatively slower. Most of the aligners showed high sensitivity towards long reads (> 100 bp) mapping. On the other hand NovoAlign showed higher sensitivity towards both short reads (36 bp, 50 bp, 72 bp) and long reads (> 100 bp) mappings; It also showed higher sensitivity towards mapping a complex genome like Plasmodium falciparum. The percentage of properly paired reads aligned by NovoAlign, BWA and Stampy were markedly higher. None of the aligners outperforms the others in the benchmark, however the aligners perform differently with genome characteristics. We expect that the results from this study will be useful for the end user to choose aligner, thus enhance the accuracy of read mapping.",
+                "authors": [
+                    {
+                        "name": "Thankaswamy-Kosalai S."
+                    },
+                    {
+                        "name": "Sen P."
+                    },
+                    {
+                        "name": "Nookaew I."
+                    }
+                ],
+                "citationCount": 24,
+                "date": "2017-07-01T00:00:00Z",
+                "journal": "Genomics",
+                "title": "Evaluation and assessment of read-mapping by multiple next-generation sequencing aligners based on genome-wide characteristics"
+            },
+            "pmid": "28286147",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1186/1471-2164-15-264",
+            "metadata": {
+                "abstract": "Background: The rapid evolution in high-throughput sequencing (HTS) technologies has opened up new perspectives in several research fields and led to the production of large volumes of sequence data. A fundamental step in HTS data analysis is the mapping of reads onto reference sequences. Choosing a suitable mapper for a given technology and a given application is a subtle task because of the difficulty of evaluating mapping algorithms.Results: In this paper, we present a benchmark procedure to compare mapping algorithms used in HTS using both real and simulated datasets and considering four evaluation criteria: computational resource and time requirements, robustness of mapping, ability to report positions for reads in repetitive regions, and ability to retrieve true genetic variation positions. To measure robustness, we introduced a new definition for a correctly mapped read taking into account not only the expected start position of the read but also the end position and the number of indels and substitutions. We developed CuReSim, a new read simulator, that is able to generate customized benchmark data for any kind of HTS technology by adjusting parameters to the error types. CuReSim and CuReSimEval, a tool to evaluate the mapping quality of the CuReSim simulated reads, are freely available. We applied our benchmark procedure to evaluate 14 mappers in the context of whole genome sequencing of small genomes with Ion Torrent data for which such a comparison has not yet been established.Conclusions: A benchmark procedure to compare HTS data mappers is introduced with a new definition for the mapping correctness as well as tools to generate simulated reads and evaluate mapping quality. The application of this procedure to Ion Torrent data from the whole genome sequencing of small genomes has allowed us to validate our benchmark procedure and demonstrate that it is helpful for selecting a mapper based on the intended application, questions to be addressed, and the technology used. This benchmark procedure can be used to evaluate existing or in-development mappers as well as to optimize parameters of a chosen mapper for any application and any sequencing platform. \u00a9 2014 Caboche et al.; licensee BioMed Central Ltd.",
+                "authors": [
+                    {
+                        "name": "Caboche S."
+                    },
+                    {
+                        "name": "Audebert C."
+                    },
+                    {
+                        "name": "Lemoine Y."
+                    },
+                    {
+                        "name": "Hot D."
+                    }
+                ],
+                "citationCount": 51,
+                "date": "2014-04-05T00:00:00Z",
+                "journal": "BMC Genomics",
+                "title": "Comparison of mapping algorithms used in high-throughput sequencing: Application to Ion Torrent data"
+            },
+            "pmcid": "PMC4051166",
+            "pmid": "24708189",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1093/bioinformatics/btu146",
+            "metadata": {
+                "abstract": "Motivation: Next-generation sequencing has become an important tool in molecular biology. Various protocols to investigate genomic, transcriptomic and epigenomic features across virtually all species and tissues have been devised. For most of these experiments, one of the first crucial steps of bioinformatic analysis is the mapping of reads to reference genomes. Results: Here, we present thorough benchmarks of our read aligner segemehl in comparison with other state-of-the-art methods. Furthermore, we introduce the tool lack to rescue unmapped RNA-seq reads which works in conjunction with segemehl and many other frequently used split-read aligners. \u00a9 The Author 2014.",
+                "authors": [
+                    {
+                        "name": "Otto C."
+                    },
+                    {
+                        "name": "Stadler P.F."
+                    },
+                    {
+                        "name": "Hoffmann S."
+                    }
+                ],
+                "citationCount": 43,
+                "date": "2014-07-01T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Lacking alignments? The next-generation sequencing mapper segemehl revisited"
+            },
+            "pmid": "24626854",
+            "type": [
+                "Benchmarking study"
+            ]
+        },
+        {
+            "doi": "10.1093/bioinformatics/btp698",
+            "metadata": {
+                "abstract": "Motivation: Many programs for aligning short sequencing reads to a reference genome have been developed in the last 2 years. Most of them are very efficient for short reads but inefficient or not applicable for reads >200 bp because the algorithms are heavily and specifically tuned for short queries with low sequencing error rate. However, some sequencing platforms already produce longer reads and others are expected to become available soon. For longer reads, hashingbased software such as BLAT and SSAHA2 remain the only choices. Nonetheless, these methods are substantially slower than short-read aligners in terms of aligned bases per unit time. Results: We designed and implemented a new algorithm, Burrows-Wheeler Aligner's Smith-Waterman Alignment (BWA-SW), to align long sequences up to 1Mb against a large sequence database (e.g. the human genome) with a few gigabytes of memory. The algorithm is as accurate as SSAHA2, more accurate than BLAT, and is several to tens of times faster than both. Availability: http://bio-bwa.sourceforge.net. Contact: rd@sanger.ac.uk \u00a9 The Author(s) 2010. Published by Oxford University Press.",
+                "authors": [
+                    {
+                        "name": "Li H."
+                    },
+                    {
+                        "name": "Durbin R."
+                    }
+                ],
+                "citationCount": 5111,
+                "date": "2010-01-15T00:00:00Z",
+                "journal": "Bioinformatics",
+                "title": "Fast and accurate long-read alignment with Burrows-Wheeler transform"
+            },
+            "pmid": "20080505"
+        }
+    ],
+    "toolType": [
+        "Command-line tool",
+        "Workbench"
+    ],
+    "topic": [
+        {
+            "term": "Mapping",
+            "uri": "http://edamontology.org/topic_0102"
+        }
+    ],
+    "validated": 1
+}

--- a/test/unit/tool_util/biotools/test_edam_parsing.py
+++ b/test/unit/tool_util/biotools/test_edam_parsing.py
@@ -1,0 +1,14 @@
+from galaxy.tool_util.biotools.source import (
+    GitContentBiotoolsMetadataSource,
+)
+from ._util import content_dir
+
+
+def test_edam_parse_bwa():
+    metadata_source = GitContentBiotoolsMetadataSource(content_dir)
+    biotools_entry = metadata_source.get_biotools_metadata("bwa")
+    parsed_edam_info = biotools_entry.edam_info
+    assert len(parsed_edam_info.edam_operations) == 4
+    assert "operation_3198" in parsed_edam_info.edam_operations
+    assert len(parsed_edam_info.edam_topics) == 1
+    assert "topic_0102" in parsed_edam_info.edam_topics

--- a/test/unit/tool_util/biotools/test_metadata_source.py
+++ b/test/unit/tool_util/biotools/test_metadata_source.py
@@ -1,0 +1,49 @@
+from galaxy.tool_util.biotools.source import (
+    ApiBiotoolsMetadataSource,
+    BiotoolsMetadataSourceConfig,
+    get_biotools_metadata_source,
+    GitContentBiotoolsMetadataSource,
+)
+from ._util import content_dir
+
+
+def test_git_content():
+    metadata_source = GitContentBiotoolsMetadataSource(content_dir)
+    bwa_entry = metadata_source.get_biotools_metadata("bwa")
+    assert bwa_entry is not None
+    assert len(bwa_entry.function) == 6
+
+    missing_entry = metadata_source.get_biotools_metadata("johnscoolbowtie")
+    assert missing_entry is None
+
+
+def test_api_content():
+    metadata_source = ApiBiotoolsMetadataSource()
+    bwa_entry = metadata_source.get_biotools_metadata("bwa")
+    assert bwa_entry is not None
+    assert len(bwa_entry.function) >= 6
+
+    missing_entry = metadata_source.get_biotools_metadata("johnscoolbowtie")
+    assert missing_entry is None
+
+
+def test_cascade_content():
+    config = BiotoolsMetadataSourceConfig()
+    config.content_directory = content_dir
+    metadata_source = get_biotools_metadata_source(config)
+    bwa_entry = metadata_source.get_biotools_metadata("bwa")
+    assert bwa_entry is not None
+    assert len(bwa_entry.function) == 6
+
+    # by default API isn't used so bowtie2 empty...
+    bowtie2 = metadata_source.get_biotools_metadata("bowtie2")
+    assert bowtie2 is None
+
+    # but can be enabled with API
+    config = BiotoolsMetadataSourceConfig()
+    config.content_directory = content_dir
+    config.use_api = True
+    metadata_source = get_biotools_metadata_source(config)
+    bowtie2 = metadata_source.get_biotools_metadata("bowtie2")
+    assert bowtie2 is not None
+    assert len(bowtie2.topic) == 3


### PR DESCRIPTION
Two sources for bio.tools data:
- Configurable directory from Github (https://github.com/bio-tools/content/).
- API requests to bio.tools web service (cache-able).

Code is structured into a stand-alone package decouple from Galaxy for dealing with bio.tools data and APIs and then an adapt to Galaxy's config.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
