### PR TITLE
[21.05] Fix admin user manage

### DIFF
--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -1,15 +1,16 @@
 import { getGalaxyInstance } from "app";
 import _l from "utils/localization";
 
-export const getUserPreferencesModel = () => {
+export const getUserPreferencesModel = (user_id) => {
     const Galaxy = getGalaxyInstance();
     const config = Galaxy.config;
+    user_id = user_id || Galaxy.user.id;
     return {
         information: {
             title: _l("Manage Information"),
             id: "edit-preferences-information",
             description: "Edit your email, addresses and custom parameters or change your public name.",
-            url: `api/users/${Galaxy.user.id}/information/inputs`,
+            url: `api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "user",
             shouldRender: !config.use_remote_user,
@@ -19,7 +20,7 @@ export const getUserPreferencesModel = () => {
             id: "edit-preferences-password",
             description: _l("Allows you to change your login credentials."),
             icon: "fa-unlock-alt",
-            url: `api/users/${Galaxy.user.id}/password/inputs`,
+            url: `api/users/${user_id}/password/inputs`,
             submit_title: "Save Password",
             redirect: "user",
             shouldRender: !config.use_remote_user,
@@ -38,7 +39,7 @@ export const getUserPreferencesModel = () => {
             id: "edit-preferences-permissions",
             description:
                 "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored.",
-            url: `api/users/${Galaxy.user.id}/permissions/inputs`,
+            url: `api/users/${user_id}/permissions/inputs`,
             icon: "fa-users",
             submit_title: "Save Permissions",
             redirect: "user",
@@ -55,7 +56,7 @@ export const getUserPreferencesModel = () => {
             title: _l("Manage API Key"),
             id: "edit-preferences-api-key",
             description: _l("Access your current API key or create a new one."),
-            url: `api/users/${Galaxy.user.id}/api_key/inputs`,
+            url: `api/users/${user_id}/api_key/inputs`,
             icon: "fa-key",
             submit_title: "Create a new Key",
             submit_icon: "fa-check",
@@ -72,7 +73,7 @@ export const getUserPreferencesModel = () => {
             title: _l("Manage Toolbox Filters"),
             id: "edit-preferences-toolbox-filters",
             description: _l("Customize your Toolbox by displaying or omitting sets of Tools."),
-            url: `api/users/${Galaxy.user.id}/toolbox_filters/inputs`,
+            url: `api/users/${user_id}/toolbox_filters/inputs`,
             icon: "fa-filter",
             submit_title: "Save Filters",
             redirect: "user",

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -150,9 +150,8 @@ export const getAnalysisRouter = (Galaxy) => {
             });
         },
 
-        show_user_form: function (form_id) {
-            const Galaxy = getGalaxyInstance();
-            const model = getUserPreferencesModel(Galaxy.params.id);
+        show_user_form: function (form_id, params) {
+            const model = getUserPreferencesModel(params.id);
             this.page.display(new FormWrapper.View(_.extend(model[form_id], { active_tab: "user" })));
         },
 

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -152,8 +152,7 @@ export const getAnalysisRouter = (Galaxy) => {
 
         show_user_form: function (form_id) {
             const Galaxy = getGalaxyInstance();
-            const model = getUserPreferencesModel();
-            model.user_id = Galaxy.params.id;
+            const model = getUserPreferencesModel(Galaxy.params.id);
             this.page.display(new FormWrapper.View(_.extend(model[form_id], { active_tab: "user" })));
         },
 


### PR DESCRIPTION
Fixes #12046 and #12294

This is still somewhat clunky because it dumps you into the analysis interface after coming from the admin app, but it at least works.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Go to admin interface, manage users, change user info (on a user that isn't you).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
