### PR TITLE
Replace form-view imports in Visualizations with Vue component layer

### DIFF
--- a/client/src/mvc/dataset/dataset-edit-attributes.js
+++ b/client/src/mvc/dataset/dataset-edit-attributes.js
@@ -5,7 +5,6 @@ import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import _l from "utils/localization";
-// import Utils from "utils/utils";
 import Tabs from "mvc/ui/ui-tabs";
 import Ui from "mvc/ui/ui-misc";
 import Form from "mvc/form/form-view";

--- a/client/src/mvc/visualization/chart/views/groups.js
+++ b/client/src/mvc/visualization/chart/views/groups.js
@@ -5,9 +5,10 @@ import $ from "jquery";
 import Backbone from "backbone";
 import { getAppRoot } from "onload/loadConfig";
 import Utils from "utils/utils";
-import Form from "mvc/form/form-view";
 import Repeat from "mvc/form/form-repeat";
 import FormData from "mvc/form/form-data";
+import FormDisplay from "components/Form/FormDisplay";
+import { appendVueComponent } from "utils/mountVueComponent";
 
 var GroupView = Backbone.View.extend({
     initialize: function (app, options) {
@@ -66,18 +67,15 @@ var GroupView = Backbone.View.extend({
                             value: data_columns,
                         });
                         self.chart.state("ok", "Metadata initialized...");
-                        self.form = new Form({
+                        const instance = appendVueComponent(self.$el, FormDisplay, {
                             inputs: inputs,
-                            onchange: function () {
-                                self.group.set(self.form.data.create());
-                                self.chart.set("modified", true);
-                                self.chart.trigger("redraw");
-                            },
                         });
-                        self.group.set(self.form.data.create());
-                        self.$el.empty().append(self.form.$el);
+                        instance.$on("onChange", (data) => {
+                            self.group.set(data);
+                            self.chart.set("modified", true);
+                            self.chart.trigger("redraw");
+                        });
                         process.resolve();
-                        self.chart.trigger("redraw");
                     },
                 });
             });

--- a/client/src/mvc/visualization/chart/views/settings.js
+++ b/client/src/mvc/visualization/chart/views/settings.js
@@ -2,8 +2,8 @@
 import _ from "underscore";
 import Backbone from "backbone";
 import Utils from "utils/utils";
-import FormDisplay from "components/Form/FormDisplay";
 import FormData from "mvc/form/form-data";
+import FormDisplay from "components/Form/FormDisplay";
 import { appendVueComponent } from "utils/mountVueComponent";
 
 export default Backbone.View.extend({

--- a/client/src/mvc/visualization/chart/views/settings.js
+++ b/client/src/mvc/visualization/chart/views/settings.js
@@ -2,11 +2,12 @@
 import _ from "underscore";
 import Backbone from "backbone";
 import Utils from "utils/utils";
-import Form from "mvc/form/form-view";
+import FormDisplay from "components/Form/FormDisplay";
 import FormData from "mvc/form/form-data";
+import { appendVueComponent } from "utils/mountVueComponent";
 
 export default Backbone.View.extend({
-    initialize: function (app, options) {
+    initialize: function (app) {
         var self = this;
         this.chart = app.chart;
         this.setElement("<div/>");
@@ -37,15 +38,13 @@ export default Backbone.View.extend({
                     input.value = model_value;
                 }
             });
-            this.form = new Form({
+            const instance = appendVueComponent(this.$el, FormDisplay, {
                 inputs: inputs,
-                onchange: function () {
-                    self.chart.settings.set(self.form.data.create());
-                    self.chart.trigger("redraw");
-                },
             });
-            this.chart.settings.set(this.form.data.create());
-            this.$el.append(this.form.$el);
+            instance.$on("onChange", (data) => {
+                this.chart.settings.set(data);
+                this.chart.trigger("redraw");
+            });
         }
     },
 });

--- a/client/src/utils/mountVueComponent.js
+++ b/client/src/utils/mountVueComponent.js
@@ -28,3 +28,11 @@ export const mountVueComponent = (ComponentDefinition) => {
     const component = Vue.extend(ComponentDefinition);
     return (propsData, el) => new component({ store, propsData, el });
 };
+
+export const appendVueComponent = ($el, ComponentDefinition, propsData = {}) => {
+    const container = document.createElement("div");
+    $el.empty().append(container);
+    const component = Vue.extend(ComponentDefinition);
+    const mountFn = (propsData, el) => new component({ propsData, el });
+    return mountFn(propsData, container);
+};

--- a/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_shared.xml
+++ b/config/plugins/visualizations/nvd3/nvd3_bar/config/nvd3_shared.xml
@@ -26,6 +26,7 @@
             <label>Pick a series color</label>
             <name>color</name>
             <type>color</type>
+            <optional>true</optional>
         </input>
         <input>
             <label>Column of data point labels</label>


### PR DESCRIPTION
Requires #12227, related to #11076. Now that we have transformed all Tool and Workflow related Form wrappers to Vue, we are removing the remaining direct imports of the `form-view` Backbone module and replace them with `FormDisplay` Vue component. In this PR we replace the Settings and Data Group Forms in Chart visualizations.

## How to test the changes?
Create a Charts Visualization e.g. a Bar Diagram or NGL viewer and change the Settings or add new Data Groups.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
