### PR TITLE
`Select all` button in file source (only end folders)

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -105,9 +105,6 @@ export default {
         },
     },
     methods: {
-        allSelected() {
-            return this.items.some((item) => this.model.exists(item.id));
-        },
         /** Add highlighting for record variations, i.e. datasets vs. libraries/collections **/
         formatRows() {
             for (const item of this.items) {
@@ -141,6 +138,11 @@ export default {
             this.modalShow = false;
             this.callback(results);
         },
+        /** check if all objects in this folders are selected **/
+        allSelected() {
+            return this.items.some((item) => this.model.exists(item.id));
+        },
+        /** select all files in current folder**/
         selectAll: function () {
             this.items.forEach((item) => this.model.add(item));
             this.hasValue = this.model.count() > 0;

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -10,7 +10,7 @@
         </template>
         <template v-if="fileMode && filesOnly && this.multiple && items.length" v-slot:selectAll>
             <b-button @click="toggleSelectAll()" variant="light">
-                <font-awesome-icon icon="th-large" /> {{ `${allSelected() ? "Unselect" : "Select"}` }} entire folder
+                <font-awesome-icon icon="th-large" /> {{ `${allSelected ? "Unselect" : "Select"}` }} entire folder
             </b-button>
         </template>
         <template v-slot:options>
@@ -79,6 +79,7 @@ export default {
     },
     data() {
         return {
+            allSelected: false,
             errorMessage: null,
             filter: null,
             items: [],
@@ -114,6 +115,7 @@ export default {
                 }
                 Vue.set(item, "_rowVariant", _rowVariant);
             }
+            this.allSelected = this.checkIfAllSelected();
         },
         /** Collects selected datasets in value array **/
         clicked: function (record) {
@@ -139,15 +141,14 @@ export default {
             this.callback(results);
         },
         /** check if all objects in this folders are selected **/
-        allSelected() {
+        checkIfAllSelected() {
             return this.items.every((item) => this.model.exists(item.id));
         },
         /** select all files in current folder**/
         toggleSelectAll: function () {
-          const allSelected = this.allSelected()
             for (const item of this.items) {
                 // add item if it's not added already
-                if (allSelected) {
+                if (this.allSelected) {
                     this.model.add(item);
                 } else if (!this.model.exists(item.id)) {
                     this.model.add(item);

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -148,9 +148,9 @@ export default {
         toggleSelectAll: function () {
             for (const item of this.items) {
                 if (this.allSelected) {
-                //  model.add() toggles select. Since all items are selected, we unselect all on this page
+                    //  model.add() toggles select. Since all items are selected, we unselect all on this page
                     this.model.add(item);
-                //  add item if it's not added already
+                    //  add item if it's not added already
                 } else if (!this.model.exists(item.id)) {
                     this.model.add(item);
                 }

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -9,7 +9,7 @@
             <data-dialog-search v-model="filter" />
         </template>
         <template v-if="fileMode && filesOnly && this.multiple && items.length" v-slot:selectAll>
-            <b-button @click="selectAll" variant="light">
+            <b-button @click="toggleSelectAll()" variant="light">
                 <font-awesome-icon icon="th-large" /> {{ `${allSelected() ? "Unselect" : "Select"}` }} entire folder
             </b-button>
         </template>
@@ -140,11 +140,19 @@ export default {
         },
         /** check if all objects in this folders are selected **/
         allSelected() {
-            return this.items.some((item) => this.model.exists(item.id));
+            return this.items.every((item) => this.model.exists(item.id));
         },
         /** select all files in current folder**/
-        selectAll: function () {
-            this.items.forEach((item) => this.model.add(item));
+        toggleSelectAll: function () {
+          const allSelected = this.allSelected()
+            for (const item of this.items) {
+                // add item if it's not added already
+                if (allSelected) {
+                    this.model.add(item);
+                } else if (!this.model.exists(item.id)) {
+                    this.model.add(item);
+                }
+            }
             this.hasValue = this.model.count() > 0;
             this.formatRows();
         },

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -147,9 +147,10 @@ export default {
         /** select all files in current folder**/
         toggleSelectAll: function () {
             for (const item of this.items) {
-                // add item if it's not added already
                 if (this.allSelected) {
+                //  model.add() toggles select. Since all items are selected, we unselect all on this page
                     this.model.add(item);
+                //  add item if it's not added already
                 } else if (!this.model.exists(item.id)) {
                     this.model.add(item);
                 }

--- a/client/src/components/SelectionDialog/SelectionDialog.test.js
+++ b/client/src/components/SelectionDialog/SelectionDialog.test.js
@@ -20,6 +20,7 @@ describe("SelectionDialog.vue", () => {
             slots: {
                 options: "<tree-options />",
                 search: "<cool-search />",
+                selectAll: "<select-all />",
             },
             stubs: {
                 "tree-options": { template: "<div id='tree-options'/>" },

--- a/client/src/components/SelectionDialog/SelectionDialog.test.js
+++ b/client/src/components/SelectionDialog/SelectionDialog.test.js
@@ -24,6 +24,7 @@ describe("SelectionDialog.vue", () => {
             stubs: {
                 "tree-options": { template: "<div id='tree-options'/>" },
                 "cool-search": { template: "<div id='cool-search'/>" },
+                "select-all": { template: "<div id='select-all'/>" },
             },
             propsData: mockOptions,
             localVue,
@@ -40,9 +41,10 @@ describe("SelectionDialog.vue", () => {
         expect(wrapper.get("#tree-options"));
     });
 
-    it("loads search correctly", async () => {
+    it("loads header correctly", async () => {
         await localVue.nextTick();
         expect(wrapper.get("#cool-search"));
+        expect(wrapper.get("#select-all"));
     });
 
     it("hideModal called on click cancel", async () => {

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -10,6 +10,7 @@
     >
         <template v-slot:modal-header>
             <slot name="search"> </slot>
+            <slot name="selectAll"> </slot>
         </template>
         <b-alert v-if="errorMessage" variant="danger" show v-html="errorMessage" />
         <div v-else>


### PR DESCRIPTION
Implemented `Select entire folder` button in file source within Upload Modal. 
Button is NOT shown for folders, that contain subfolders (this feature requires some backend love)

![selectall](https://user-images.githubusercontent.com/15801412/127171378-134c160e-c10c-4a3e-80ee-f344cd5e5513.gif)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. click on `Upload data`
  2. "Choose remote files"
  3. enter any folder that contains only files
  4. Click on `select entire folder`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
