### PR TITLE
Fix histories content filtering by type

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -166,6 +166,7 @@ class Model(BaseModel):
     """Base model definition with common configuration used by all derived models."""
     class Config:
         use_enum_values = True  # when using .dict()
+        allow_population_by_field_name = True
 
 
 class UserModel(Model):
@@ -2089,11 +2090,7 @@ class DatasetPermissionAction(str, Enum):
     remove_restrictions = "remove_restrictions"
 
 
-class LibraryPermissionsPayloadBase(BaseModel):
-    class Config:
-        use_enum_values = True  # When using .dict()
-        allow_population_by_alias = True
-
+class LibraryPermissionsPayloadBase(Model):
     add_ids: Optional[RoleIdList] = Field(
         [],
         alias="add_ids[]",
@@ -2281,11 +2278,7 @@ class DatasetAssociationRoles(Model):
     )
 
 
-class UpdateDatasetPermissionsPayload(BaseModel):
-    class Config:
-        use_enum_values = True  # When using .dict()
-        allow_population_by_alias = True
-
+class UpdateDatasetPermissionsPayload(Model):
     action: Optional[DatasetPermissionAction] = Field(
         ...,
         title="Action",

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -141,12 +141,12 @@ class HistoryContentsIndexLegacyParams(HistoryContentsIndexLegacyParamsBase):
             "specific datasets will be provided. Also, setting this value will set `dataset_details` to `all`."
         ),
     )
-    types: Optional[str] = Field(
+    types: Optional[Union[List[HistoryContentType], str]] = Field(
         default=None,
         alias="type",  # Legacy alias
         title="Types",
         description=(
-            "A comma separated list of kinds of contents to return "
+            "A list or comma separated list of kinds of contents to return "
             "(currently just `dataset` and `dataset_collection` are available)."
         ),
     )

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -621,3 +621,18 @@ class HistoryContentsApiTestCase(ApiTestCase):
                 if any(c for c in update if c['history_content_type'] == 'dataset_collection' and c['populated_state'] == 'ok'):
                     return
             raise Exception(f"History content update time query did not include populated_state update for dynamic nested collection {collection_id}")
+
+    def test_index_filter_by_type(self):
+        history_id = self.dataset_populator.new_history()
+        self.dataset_populator.new_dataset(history_id)
+        self.dataset_collection_populator.create_list_in_history(history_id=history_id)
+
+        contents_response = self._get(f"histories/{history_id}/contents").json()
+        num_items = len(contents_response)
+        expected_num_collections = 1
+        expected_num_datasets = num_items - expected_num_collections
+
+        contents_response = self._get(f"histories/{history_id}/contents?types=dataset").json()
+        assert len(contents_response) == expected_num_datasets
+        contents_response = self._get(f"histories/{history_id}/contents?types=dataset_collection").json()
+        assert len(contents_response) == expected_num_collections


### PR DESCRIPTION
This should fix the filtering by type in the histories API after the last refactoring that was breaking the BioBlend tests (see https://github.com/galaxyproject/galaxy/pull/12231#issuecomment-882972041).
The issue was caused by the `types` field not being populated in the model because it was expecting only the alias `type`, so it was always `None` when invoked with `types`. After adding the `allow_population_by_field_name = True` in the model config it should work with both names. Also, the type restriction has been changed to allow lists of content types (thanks @simonbray for noticing!) in addition to comma-separated strings.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run BioBlend tests

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
