### PR TITLE
reword history import button text

### DIFF
--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -290,7 +290,7 @@ collection_builders:
 
 histories:
   labels:
-    import_button: 'Import from file'
+    import_button: 'Import history'
 
   sharing:
     selectors:

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -118,7 +118,7 @@ class HistoryListGrid(grids.Grid):
             key="free-text-search", visible=False, filterable="standard")
     )
     global_actions = [
-        grids.GridAction("Import from file", dict(controller="", action="histories/import"))
+        grids.GridAction("Import history", dict(controller="", action="histories/import"))
     ]
     operations = [
         grids.GridOperation("Switch", allow_multiple=False, condition=(lambda item: not item.deleted), async_compatible=True),


### PR DESCRIPTION
`Import from file` seems outdated.

Before:

![Screenshot from 2021-07-29 11-03-47](https://user-images.githubusercontent.com/25689525/127467148-41019512-9f43-423b-abff-465ec7fa2598.png)

After:

![Screenshot from 2021-07-29 11-04-19](https://user-images.githubusercontent.com/25689525/127467173-552e1343-15b1-4a2b-a15e-ed2da46f87ec.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
