### PR TITLE
[21.01] Fix repository_update test

### DIFF
--- a/test/integration/test_repository_operations.py
+++ b/test/integration/test_repository_operations.py
@@ -59,7 +59,7 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
 
     def test_repository_update(self):
         response = self._install_repository(revision=REVISION_4, version="0.0.3")[0]
-        assert response['ctx_rev'] == '4'
+        assert int(response['ctx_rev']) >= 4
         repo_response = self._get("/api/tool_shed_repositories/%s" % response['id']).json()
         assert repo_response['tool_shed_status']['revision_update'] == 'False'  # that should really be a boolean
         # now checkout revision 3 and attempt an update
@@ -108,7 +108,8 @@ class TestRepositoryInstallIntegrationTestCase(integration_util.IntegrationTestC
         response = self._install_repository(revision=REVISION_4, version="0.0.3", verify_tool_absent=False)[0]
         assert response['changeset_revision'] == REVISION_4
         assert response['installed_changeset_revision'] == REVISION_3
-        assert response['ctx_rev'] == '4'
+        # should be 4 or newer
+        assert int(response['ctx_rev']) >= 4
 
     def _uninstall_repository(self):
         tool = self._get('/api/tools/collection_column_join').json()


### PR DESCRIPTION
Started breaking after https://github.com/galaxyproject/tools-iuc/pull/3805

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
