### PR TITLE
Fix recursive file list in posix remote files

### DIFF
--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -39,7 +39,8 @@ class PosixFilesSource(BaseFilesSource):
         if recursive:
             res = []
             for (p, dirs, files) in safe_walk(dir_path, allowlist=self._allowlist):
-                rel_dir = os.path.relpath(p, dir_path)
+                dir_path_root = os.path.split(dir_path)[0]
+                rel_dir = os.path.relpath(p, dir_path_root)
                 to_dict = functools.partial(self._resource_info_to_dict, rel_dir, user_context=user_context)
                 res.extend(map(to_dict, dirs))
                 res.extend(map(to_dict, files))

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -39,8 +39,7 @@ class PosixFilesSource(BaseFilesSource):
         if recursive:
             res = []
             for (p, dirs, files) in safe_walk(dir_path, allowlist=self._allowlist):
-                dir_path_root = os.path.split(dir_path)[0]
-                rel_dir = os.path.relpath(p, dir_path_root)
+                rel_dir = os.path.relpath(p, self.root)
                 to_dict = functools.partial(self._resource_info_to_dict, rel_dir, user_context=user_context)
                 res.extend(map(to_dict, dirs))
                 res.extend(map(to_dict, files))

--- a/lib/galaxy/files/sources/posix.py
+++ b/lib/galaxy/files/sources/posix.py
@@ -38,8 +38,9 @@ class PosixFilesSource(BaseFilesSource):
             raise exceptions.ObjectNotFound(f'The specified directory does not exist [{dir_path}].')
         if recursive:
             res = []
+            effective_root = self._effective_root(user_context)
             for (p, dirs, files) in safe_walk(dir_path, allowlist=self._allowlist):
-                rel_dir = os.path.relpath(p, self.root)
+                rel_dir = os.path.relpath(p, effective_root)
                 to_dict = functools.partial(self._resource_info_to_dict, rel_dir, user_context=user_context)
                 res.extend(map(to_dict, dirs))
                 res.extend(map(to_dict, files))


### PR DESCRIPTION
### How to reproduce the bug:
please open your galaxy.yml, add this line:
```file_sources_config_file: file_sources_conf.yml```

then create `file_sources_conf.yml` with this content:

```
- type: posix
  id: posix1
  label: Posix
  doc: Files from local path
  root: /tmp
```


then to go your `/tmp` and create this file tree:
```
|-- folder
|   |-- file1
|   |-- file2
|   |-- file3
|   |-- subfolder1
|   |   `-- subsubfolder
|   |       `-- subsubfile
|   `-- subfolder2

````


start the server and open this link:
```{your_root_url}/api/remote_files?target=gxfiles://posix1/folder&recursive=true```

You will get this stacktrace:
```
Traceback (most recent call last):
  File "/home/oleg/galaxy/lib/galaxy/managers/remote_files.py", line 85, in index
    index = file_source.list(file_source_path.path, recursive=recursive, user_context=user_file_source_context)
  File "/home/oleg/galaxy/lib/galaxy/files/sources/__init__.py", line 142, in list
    return self._list(path, recursive, user_context)
  File "/home/oleg/galaxy/lib/galaxy/files/sources/posix.py", line 45, in _list
    res.extend(map(to_dict, dirs))
  File "/home/oleg/galaxy/lib/galaxy/files/sources/posix.py", line 103, in _resource_info_to_dict
    statinfo = os.lstat(full_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/subfolder2'
```


This PR fixes the root folder retrieval at `posix.py`


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
