### PR TITLE
Linter support for ``format_source`` in static collection elements 

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -38,8 +38,6 @@ def lint_output(tool_xml, lint_ctx):
                 lint_ctx.warn("Collection output with undefined 'type' found.")
             if "structured_like" in output.attrib and "inherit_format" in output.attrib:
                 format_set = True
-        if "format_source" in output.attrib:
-            format_set = True
         for sub in output:
             if __check_pattern(sub):
                 format_set = True
@@ -54,12 +52,16 @@ def lint_output(tool_xml, lint_ctx):
 
 def __check_format(node, lint_ctx, allow_ext=False):
     """
-    check if format/ext attribute is set in a given node
+    check if format/ext/format_source attribute is set in a given node
     issue a warning if the value is input
     return true (node defines format/ext) / false (else)
     """
-    fmt = None
+    if "format_source" in node.attrib and ("ext" in node.attrib or "format" in node.attrib):
+        lint_ctx.warn(f"Tool {node.tag} output {node.attrib.get('name', 'with missing name')} should use either format_source or format/ext")
+    if "format_source" in node.attrib:
+        return True
     # if allowed (e.g. for discover_datasets), ext takes precedence over format
+    fmt = None
     if allow_ext:
         fmt = node.attrib.get("ext")
     if fmt is None:

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -141,7 +141,7 @@ OUTPUTS_COLLECTION_FORMAT_SOURCE = """
     <outputs>
         <collection name="output_collection" type="paired">
             <data name="forward" format_source="input_readpair" />
-            <data name="reverse" format_source="input_readpair" />
+            <data name="reverse" format_source="input_readpair" format="fastq"/>
         </collection>
     </outputs>
 </tool>
@@ -218,7 +218,8 @@ TESTS = [
     (
         OUTPUTS_COLLECTION_FORMAT_SOURCE, outputs.lint_output,
         lambda x:
-            len(x.warn_messages) == 0 and len(x.error_messages) == 0
+            "Tool data output reverse should use either format_source or format/ext" in x.warn_messages
+            and len(x.warn_messages) == 1 and len(x.error_messages) == 0
     ),
 ]
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1,7 +1,7 @@
 import pytest
 
 from galaxy.tool_util.lint import LintContext
-from galaxy.tool_util.linters import general, inputs
+from galaxy.tool_util.linters import general, inputs, outputs
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
 
@@ -134,6 +134,19 @@ VALIDATOR_INCOMPATIBILITIES = """
 </tool>
 """
 
+OUTPUTS_COLLECTION_FORMAT_SOURCE = """
+<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+    <description>The BWA Mapper</description>
+    <version_command interpreter="python">bwa.py --version</version_command>
+    <outputs>
+        <collection name="output_collection" type="paired">
+            <data name="forward" format_source="input_readpair" />
+            <data name="reverse" format_source="input_readpair" />
+        </collection>
+    </outputs>
+</tool>
+"""
+
 TESTS = [
     (
         NO_SECTIONS_XML, inputs.lint_inputs,
@@ -202,6 +215,11 @@ TESTS = [
             and "Parameter [param_name]: 'regex' validators need to define an 'expression' attribute" in x.error_messages
             and len(x.warn_messages) == 1 and len(x.error_messages) == 4
     ),
+    (
+        OUTPUTS_COLLECTION_FORMAT_SOURCE, outputs.lint_output,
+        lambda x:
+            len(x.warn_messages) == 0 and len(x.error_messages) == 0
+    ),
 ]
 
 TEST_IDS = [
@@ -212,7 +230,8 @@ TEST_IDS = [
     'select deprecations',
     'select option definitions',
     'hazardous whitespace',
-    'validator imcompatibilities'
+    'validator imcompatibilities',
+    'outputs collection static elements with format_source'
 ]
 
 


### PR DESCRIPTION
Output linter did not consider `format_source` for statically defined collection element. 

This PR add this and a test .. the first for output linters :(

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
