### PR TITLE
Allow HTML in DatasetStorage view

### DIFF
--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -66,7 +66,7 @@ export default {
             const description = storageInfo.description;
             this.storageInfo = storageInfo;
             if (description) {
-                this.descriptionRendered = MarkdownIt({html: true}).render(storageInfo.description);
+                this.descriptionRendered = MarkdownIt({ html: true }).render(storageInfo.description);
             } else {
                 this.descriptionRendered = null;
             }

--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -66,7 +66,7 @@ export default {
             const description = storageInfo.description;
             this.storageInfo = storageInfo;
             if (description) {
-                this.descriptionRendered = MarkdownIt().render(storageInfo.description);
+                this.descriptionRendered = MarkdownIt({html: true}).render(storageInfo.description);
             } else {
                 this.descriptionRendered = null;
             }


### PR DESCRIPTION
This PR will allows HTML in the DatasetStorage view component. Since this is configured by the admin I think it's save to enable it. See also the documentation here: https://github.com/markdown-it/markdown-it#init-with-presets-and-options

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. add the following to your object_store_config.xml

```
<div align="center">
    <table width="100%" border="0">
        <tr>
        <td width="50%" align="center">
            <img src="https://raw.githubusercontent.com/usegalaxy-eu/website/master/assets/media/storage/IMG_1512.jpg" width="90%" />
        </td><td width="50%" align="center">
            <img src="https://raw.githubusercontent.com/usegalaxy-eu/website/master/assets/media/storage/IMG_1507.jpg" width="50%" />
        </td>
        </tr>
    </table>
</div>
```

And see if it gets rendered correctly.



## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
