### PR TITLE
[21.05] Continue handler startup even if job working directory can't be recovered

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -21,6 +21,7 @@ from sqlalchemy.sql.expression import (
 )
 
 from galaxy import model
+from galaxy.exceptions import ObjectNotFound
 from galaxy.jobs import (
     JobDestination,
     JobWrapper,
@@ -1087,6 +1088,10 @@ class DefaultJobDispatcher:
         except KeyError:
             log.error(f'recover(): ({job_wrapper.job_id}) Invalid job runner: {runner_name}')
             job_wrapper.fail(DEFAULT_JOB_PUT_FAILURE_MESSAGE)
+        except ObjectNotFound:
+            msg = "Could not recover job working directory after Galaxy restart"
+            log.exception(f"recover(): ({job_wrapper.job_id}) {msg}")
+            job_wrapper.fail(msg)
 
     def shutdown(self):
         failures = []


### PR DESCRIPTION
Fixes the job handler startup error that @scholtalbers experienced in https://github.com/galaxyproject/galaxy/issues/5339#issuecomment-890917151 

The relevant traceback:
```
Aug  2 16:35:40 gbcs-srv03 supervisord: Failed to initialize Galaxy application
Aug  2 16:35:40 gbcs-srv03 supervisord: Traceback (most recent call last):
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/./scripts/galaxy-main", line 140, in app_loop
Aug  2 16:35:40 gbcs-srv03 supervisord: galaxy_app = load_galaxy_app(
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/./scripts/galaxy-main", line 108, in load_galaxy_app
Aug  2 16:35:40 gbcs-srv03 supervisord: app = UniverseApplication(
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/app.py", line 322, in __init__
Aug  2 16:35:40 gbcs-srv03 supervisord: self.application_stack.register_postfork_function(self.job_manager.start)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/web_stack/__init__.py", line 67, in register_postfork_function
Aug  2 16:35:40 gbcs-srv03 supervisord: f(*args, **kwargs)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/manager.py", line 50, in start
Aug  2 16:35:40 gbcs-srv03 supervisord: self.job_handler.start()
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/handler.py", line 66, in start
Aug  2 16:35:40 gbcs-srv03 supervisord: self.job_queue.start()
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/handler.py", line 202, in start
Aug  2 16:35:40 gbcs-srv03 supervisord: self.__check_jobs_at_startup()
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/handler.py", line 275, in __check_jobs_at_startup
Aug  2 16:35:40 gbcs-srv03 supervisord: self.dispatcher.recover(job, job_wrapper)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/handler.py", line 1086, in recover
Aug  2 16:35:40 gbcs-srv03 supervisord: self.job_runners[runner_name].recover(job, job_wrapper)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/runners/drmaa.py", line 383, in recover
Aug  2 16:35:40 gbcs-srv03 supervisord: ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/jobs/__init__.py", line 1201, in working_directory
Aug  2 16:35:40 gbcs-srv03 supervisord: self.__working_directory = self.app.object_store.get_filename(
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/objectstore/__init__.py", line 312, in get_filename
Aug  2 16:35:40 gbcs-srv03 supervisord: return self._invoke('get_filename', obj, **kwargs)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/objectstore/__init__.py", line 291, in _invoke
Aug  2 16:35:40 gbcs-srv03 supervisord: return self.__getattribute__("_" + delegate)(obj=obj, **kwargs)
Aug  2 16:35:40 gbcs-srv03 supervisord: File "/g/funcgen/galaxy-production/lib/galaxy/objectstore/__init__.py", line 609, in _get_filename
Aug  2 16:35:40 gbcs-srv03 supervisord: raise ObjectNotFound
Aug  2 16:35:40 gbcs-srv03 supervisord: galaxy.exceptions.ObjectNotFound: No such object found.
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Create a long running job with an external DRM, stop galaxy, delete the job working directory, and start back up.
The job handler should be alive and the job should be marked as failed.
@scholtalbers confirmed that the commit works for him, and we ruled out a configuration issue.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
