### PR TITLE
Default k8s_unschedulable_walltime_limit to None and allow for unlimi…

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -322,6 +322,9 @@
             <!-- Whether to enabled HTTPS access in the k8s ingress spec generated for each interactive tools -->
             <!-- <param id="k8s_interactivetools_ingress_annotations">{'cert-manager.io/cluster-issuer': 'letsencrypt-prod'}</param> -->
             <!-- Annotations to add to the metadata section in the k8s ingress generated for each interactive tools -->
+            <!-- <param id="k8s_unschedulable_walltime_limit">172800</param> -->
+            <!-- The amount of time (in seconds) to let a job remain in an unschedulable state before being flagged
+                 as having failed. The default is None (unlimited time). -->
 
         </plugin>
         <plugin id="godocker" type="runner" load="galaxy.jobs.runners.godocker:GodockerJobRunner">


### PR DESCRIPTION
…ted queue wait time

`k8s_unschedulable_walltime_limit` Does not have to be enforced, and it may be difficult to set a reasonable time frame for how long a job should remain in the queue. This allows the `k8s_unschedulable_walltime_limit` to be unlimited and sets the default to None, as it's more likely that admins won't want to enforce a limit here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
