### PR TITLE
Accept from_tool_provided_metadata as means to specify the format for discovered datasets in tool linter

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -1,4 +1,5 @@
 """This module contains a linting functions for tool outputs."""
+from galaxy.util import string_as_bool
 from ._util import is_valid_cheetah_placeholder
 
 
@@ -73,10 +74,14 @@ def __check_format(node, lint_ctx, allow_ext=False):
 
 def __check_pattern(node):
     """
-    check if pattern attribute is set and defines the extension
+    check if
+    - pattern attribute is set and defines the extension or
+    - from_tool_provided_metadata is true
     """
     if node.tag != "discover_datasets":
         return False
+    if "from_tool_provided_metadata" in node.attrib and string_as_bool(node.attrib.get("from_tool_provided_metadata", "false")):
+        return True
     if "pattern" not in node.attrib:
         return False
     if node.attrib["pattern"] == "__default__":

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -134,6 +134,8 @@ VALIDATOR_INCOMPATIBILITIES = """
 </tool>
 """
 
+# check that linter accepts format source for collection elements as means to specify format
+# and that the linter warns if format and format_source are used
 OUTPUTS_COLLECTION_FORMAT_SOURCE = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
@@ -147,6 +149,18 @@ OUTPUTS_COLLECTION_FORMAT_SOURCE = """
 </tool>
 """
 
+# check that linter does not complain about missing format if from_tool_provided_metadata is used
+OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA = """
+<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+    <description>The BWA Mapper</description>
+    <version_command interpreter="python">bwa.py --version</version_command>
+    <outputs>
+        <data name="output">
+            <discover_datasets from_tool_provided_metadata="true"/>
+        </data>
+    </outputs>
+</tool>
+"""
 TESTS = [
     (
         NO_SECTIONS_XML, inputs.lint_inputs,
@@ -221,6 +235,11 @@ TESTS = [
             "Tool data output reverse should use either format_source or format/ext" in x.warn_messages
             and len(x.warn_messages) == 1 and len(x.error_messages) == 0
     ),
+    (
+        OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA, outputs.lint_output,
+        lambda x:
+            len(x.warn_messages) == 0 and len(x.error_messages) == 0
+    ),
 ]
 
 TEST_IDS = [
@@ -232,7 +251,8 @@ TEST_IDS = [
     'select option definitions',
     'hazardous whitespace',
     'validator imcompatibilities',
-    'outputs collection static elements with format_source'
+    'outputs collection static elements with format_source',
+    'outputs discover datatsets with tool provided metadata'
 ]
 
 


### PR DESCRIPTION

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
