### PR TITLE
Allow various configuration parameters to be set per host.

### DIFF
--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -564,6 +564,19 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         if string_as_bool(kwargs.get("override_tempdir", "True")):
             tempfile.tempdir = self.new_file_path
 
+    def config_value_for_host(self, config_option, host):
+        val = getattr(self, config_option)
+        if config_option in self.schema.per_host_options:
+            per_host_option = f"{config_option}_by_host"
+            if per_host_option in self.config_dict:
+                per_host = self.config_dict[per_host_option] or {}
+                for host_key, host_val in per_host.items():
+                    if host_key in host:
+                        val = host_val
+                        break
+
+        return val
+
     def _process_config(self, kwargs):
         # Backwards compatibility for names used in too many places to fix
         self.datatypes_config = self.datatypes_config_file

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -534,7 +534,7 @@ def _validate(args, app_desc):
         ordered_dump(raw_config, config_p)
 
     def _clean(p, k, v):
-        return k not in ['reloadable', 'path_resolves_to']
+        return k not in ['reloadable', 'path_resolves_to', 'per_host']
 
     clean_schema = remap(app_desc.schema.raw_schema, _clean)
     with tempfile.NamedTemporaryFile('w', suffix=".yml") as fp:

--- a/lib/galaxy/config/schema.py
+++ b/lib/galaxy/config/schema.py
@@ -53,10 +53,13 @@ class AppSchema(Schema):
         self._defaults = {}  # {config option: default value or null}
         self._reloadable_options = set()  # config options we can reload at runtime
         self._paths_to_resolve = {}  # {config option: referenced config option}
+        self._per_host_options = set()  # config options that can be set using a per_host config parameter
         for key, data in app_schema.items():
             self._defaults[key] = data.get('default')
             if data.get('reloadable'):
                 self._reloadable_options.add(key)
+            if data.get('per_host'):
+                self._per_host_options.add(key)
             if data.get('path_resolves_to'):
                 self._paths_to_resolve[key] = data.get('path_resolves_to')
 
@@ -71,6 +74,10 @@ class AppSchema(Schema):
     @property
     def reloadable_options(self):
         return self._reloadable_options
+
+    @property
+    def per_host_options(self):
+        return self._per_host_options
 
     def validate_path_resolution_graph(self):
         """This method is for tests only: we SHOULD validate the schema's path resolution graph

--- a/lib/galaxy/managers/configuration.py
+++ b/lib/galaxy/managers/configuration.py
@@ -39,8 +39,10 @@ class ConfigurationManager:
         serialization_params: SerializationParams
     ) -> Dict[str, Any]:
         is_admin = trans.user_is_admin
-        serializer = AdminConfigSerializer(self._app) if is_admin else ConfigSerializer(self._app)
-        return serializer.serialize_to_view(self._app.config, **serialization_params)
+        host = getattr(trans, "host", None)
+        serializer_class = AdminConfigSerializer if is_admin else ConfigSerializer
+        serializer = serializer_class(self._app)
+        return serializer.serialize_to_view(self._app.config, host=host, **serialization_params)
 
     def version(self) -> Dict[str, Any]:
         version_info = {
@@ -120,7 +122,7 @@ class ConfigSerializer(base.ModelSerializer):
         def _use_config(config, key, **context):
             """Let config object determine the value for key"""
             assert hasattr(config, key)
-            return getattr(config, key)
+            return config.config_value_for_host(key, context.get("host"))
 
         def _config_is_truthy(config, key, **context):
             return True if config.get(key) else False
@@ -217,7 +219,7 @@ class AdminConfigSerializer(ConfigSerializer):
 
         self.serializers.update({
             # TODO: this is available from user serialization: remove
-            'is_admin_user': lambda *a: True,
+            'is_admin_user': lambda *a, **context: True,
 
             'library_import_dir': _defaults_to(None),
             'user_library_import_dir': _defaults_to(None),

--- a/lib/galaxy/webapps/base/controller.py
+++ b/lib/galaxy/webapps/base/controller.py
@@ -336,7 +336,7 @@ class JSAppLauncher(BaseUIController):
             serializer = self.config_serializer
             if self.user_manager.is_admin(trans.user, trans=trans):
                 serializer = self.admin_config_serializer
-            return serializer.serialize_to_view(self.app.config, view='all')
+            return serializer.serialize_to_view(self.app.config, view='all', host=trans.host)
         except Exception as exc:
             log.exception(exc)
             return {}

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -218,6 +218,7 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         self.__user = None
         self.galaxy_session = None
         self.error_message = None
+        self.host = self.request.host
 
         # set any cross origin resource sharing headers if configured to do so
         self.set_cors_headers()

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -140,7 +140,7 @@ def get_trans(request: Request, app: StructuredApp = DependsOnApp, user: Optiona
               galaxy_session: Optional[model.GalaxySession] = Depends(get_session),
               ) -> SessionRequestContext:
     qualified_url_builder = QualifiedUrlBuilder(request)
-    return SessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, qualified_url_builder=qualified_url_builder)
+    return SessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, qualified_url_builder=qualified_url_builder, host=request.client.host)
 
 
 DependsOnTrans = Depends(get_trans)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1237,6 +1237,7 @@ mapping:
       brand:
         type: str
         required: false
+        per_host: true
         desc: |
           Append "{brand}" text to the masthead.
 
@@ -1244,6 +1245,7 @@ mapping:
         type: bool
         default: true
         required: false
+        per_host: true
         desc: |
           Display the "Galaxy" text in the masthead.
 
@@ -1327,6 +1329,7 @@ mapping:
         default: /static/welcome.html
         required: false
         reloadable: true
+        per_host: true
         desc: |
           The URL of the page to display in Galaxy's middle pane when loaded.  This can
           be an absolute or relative URL.
@@ -1335,6 +1338,7 @@ mapping:
         type: str
         default: /
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Galaxy/brand" text.
 
@@ -1342,18 +1346,21 @@ mapping:
         type: str
         default: /static/favicon.png
         required: false
+        per_host: true
         desc: |
           The brand image source.
 
       logo_src_secondary:
         type: str
         required: false
+        per_host: true
         desc: |
           The custom brand image source.
 
       helpsite_url:
         type: str
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Galaxy Help" link in the "Help" menu.
 
@@ -1361,6 +1368,7 @@ mapping:
         type: str
         default: https://galaxyproject.org/
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Wiki" link in the "Help" menu.
 
@@ -1375,6 +1383,7 @@ mapping:
         type: str
         default: https://galaxyproject.org/support/
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Support" link in the "Help" menu.
 
@@ -1382,6 +1391,7 @@ mapping:
         type: str
         default: https://galaxyproject.org/citing-galaxy
         required: false
+        per_host: true
         desc: |
           The URL linked by the "How to Cite Galaxy" link in the "Help" menu.
 
@@ -1396,6 +1406,7 @@ mapping:
         type: str
         default: https://galaxyproject.org/search/
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Search" link in the "Help" menu.
 
@@ -1403,6 +1414,7 @@ mapping:
         type: str
         default: https://galaxyproject.org/mailing-lists/
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Mailing Lists" link in the "Help" menu.
 
@@ -1410,12 +1422,14 @@ mapping:
         type: str
         default: https://vimeo.com/galaxyproject
         required: false
+        per_host: true
         desc: |
           The URL linked by the "Videos" link in the "Help" menu.
 
       terms_url:
         type: str
         required: false
+        per_host: true        
         desc: |
           The URL linked by the "Terms and Conditions" link in the "Help" menu, as well
           as on the user registration and login forms and in the activation emails.
@@ -2638,6 +2652,7 @@ mapping:
         default: 'prefer'
         enum: ['off', 'prefer']
         required: false
+        per_host: true
         desc: |
           If set to 'off' by default, always use the traditional workflow form that renders
           all steps in the GUI and serializes the tool state of all steps during
@@ -2652,6 +2667,7 @@ mapping:
         default: 'current'
         enum: ['current', 'new']
         required: false
+        per_host: true
         desc: |
           When the simplified workflow run form is rendered, should the invocation outputs
           be sent to the 'current' history or a 'new' history.
@@ -2661,6 +2677,7 @@ mapping:
         default: 'off'
         enum: ['on', 'off']
         required: false
+        per_host: true
         desc: |
           When the simplified workflow run form is rendered, should the invocation use job
           caching. This isn't a boolean so an option for 'show-selection' can be added later.
@@ -2675,6 +2692,7 @@ mapping:
       ftp_upload_site:
         type: str
         required: false
+        per_host: true
         desc: |
           Enable Galaxy's "Upload via FTP" interface.  You'll need to install and
           configure an FTP server (we've used ProFTPd since it can use Galaxy's

--- a/lib/galaxy/webapps/galaxy/controllers/root.py
+++ b/lib/galaxy/webapps/galaxy/controllers/root.py
@@ -252,5 +252,5 @@ class RootController(controller.JSAppLauncher, UsesAnnotations):
 
     @web.expose
     def welcome(self, trans):
-        welcome_url = trans.app.config.welcome_url
+        welcome_url = trans.app.config.config_value_for_host("welcome_url", trans.host)
         return trans.response.send_redirect(web.url_for(welcome_url))

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -62,7 +62,12 @@ class SessionRequestContext(WorkRequestContext):
     """Like WorkRequestContext, but provides access to galaxy session and session."""
     def __init__(self, **kwargs):
         self.galaxy_session = kwargs.pop('galaxy_session', None)
+        self._host = kwargs.pop("host")
         super().__init__(**kwargs)
+
+    @property
+    def host(self):
+        return self._host
 
     def get_galaxy_session(self):
         return self.galaxy_session


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/12327 implements nifty tool panel views that are generalizations of the toolbox filters used by *.usegalaxy.eu (e.g. https://rna.usegalaxy.eu or https://covid19.usegalaxy.eu). To generalize that experience of different panel defaults depending on the subdomain Galaxy is hosted on though I want to be able to swap the new parameter `default_panel_view` on a per-domain basis.

This PR implements that pretty easily by simply annotating a variety of parameters as `per_host: true` in the configuration schema. Galaxy will then accept `<config_param>_by_host` variants of the parameters annotated this that accept dicts of the form ``{host: val_for_host}``. This should make it possible to serve a bunch of flavored Galaxies from a single set of server process with slightly different client configurations.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Update galaxy.yml to include:
  ```
  support_url_by_host:
    'localhost': https://twitter.com/
    '127.0.0.1': https://google.com/
   ```
  2. Start Galaxy and navigate to both localhost:8080 and 127.0.0.1:8080 and notice how the support url in the Help menu changes between Twitter and Google.
 
## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
