### PR TITLE
Gitlab Error report - Remove previously required urllib

### DIFF
--- a/lib/galaxy/dependencies/conditional-requirements.txt
+++ b/lib/galaxy/dependencies/conditional-requirements.txt
@@ -33,7 +33,7 @@ kamaki
 watchdog
 
 # Error reporters optional modules
-python-gitlab
+python-gitlab>=2.10.0
 pygithub
 influxdb
 

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -2,9 +2,9 @@
 
 import logging
 import os
+import urllib.parse
 
 import requests
-import urllib.parse
 
 try:
     import gitlab

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -2,9 +2,9 @@
 
 import logging
 import os
-import sys
 
 import requests
+import urllib.parse
 
 try:
     import gitlab
@@ -39,7 +39,8 @@ class GitLabPlugin(BaseGitPlugin):
 
         try:
             if gitlab is None:
-                raise Exception("GitLab error reporting plugin is configured, but gitlab is not installed. Please install python-gitlab.")
+                raise Exception("GitLab error reporting plugin is configured, but gitlab is not installed. "
+                                "Please install python-gitlab v2.10.0 or higher.")
             self.gitlab = self.gitlab_connect()
             self.gitlab.auth()
 
@@ -93,7 +94,7 @@ class GitLabPlugin(BaseGitPlugin):
                 # this will be detected by requests and used further down the line. Also cache this so everything is
                 # as fast as possible
                 ts_url = self._determine_ts_url(tool)
-                log.info("GitLab error reporting - Determined ToolShed is %s", ts_url)
+                log.info("GitLab error reporting - Determined ToolShed is {ts_url}")
 
                 # Find the repo inside the ToolShed
                 ts_repourl = self._get_gitrepo_from_ts(job, ts_url)
@@ -102,10 +103,10 @@ class GitLabPlugin(BaseGitPlugin):
                 if ts_repourl is not None and ts_repourl.endswith(".git"):
                     ts_repourl = ts_repourl[:-4]
 
-                log.info("GitLab error reporting - Determine ToolShed Repository URL: %s", ts_repourl)
+                log.info(f"GitLab error reporting - Determine ToolShed Repository URL: {ts_repourl}")
 
                 # Determine the GitLab project URL and the issue cache key
-                gitlab_projecturl = urlparse.urlparse(ts_repourl).path[1:] if (ts_repourl and not self.git_default_repo_only)\
+                gitlab_projecturl = urllib.parse.urlparse(ts_repourl).path[1:] if (ts_repourl and not self.git_default_repo_only)\
                     else "/".join((self.git_default_repo_owner, self.git_default_repo_name))
                 issue_cache_key = self._get_issue_cache_key(job, ts_repourl)
 
@@ -143,8 +144,7 @@ class GitLabPlugin(BaseGitPlugin):
                         gl_emailquery = self.gitlab.users.list(search=gl_useremail)
                         log.debug(f"GitLab error reporting - User list: {gl_emailquery}")
                         if len(gl_emailquery) > 0:
-                            log.debug("GitLab error reporting - Last Committer user ID: %d" %
-                                      gl_emailquery[0].get_id())
+                            log.debug("GitLab error reporting - Last Committer user ID: " % gl_emailquery[0].get_id())
                             self.git_username_id_cache[gl_useremail] = gl_emailquery[0].get_id()
                     gl_userid = self.git_username_id_cache.get(gl_useremail, None)
 

--- a/lib/galaxy/tools/error_reports/plugins/gitlab.py
+++ b/lib/galaxy/tools/error_reports/plugins/gitlab.py
@@ -94,7 +94,7 @@ class GitLabPlugin(BaseGitPlugin):
                 # this will be detected by requests and used further down the line. Also cache this so everything is
                 # as fast as possible
                 ts_url = self._determine_ts_url(tool)
-                log.info("GitLab error reporting - Determined ToolShed is {ts_url}")
+                log.info(f"GitLab error reporting - Determined ToolShed is {ts_url}")
 
                 # Find the repo inside the ToolShed
                 ts_repourl = self._get_gitrepo_from_ts(job, ts_url)
@@ -144,7 +144,7 @@ class GitLabPlugin(BaseGitPlugin):
                         gl_emailquery = self.gitlab.users.list(search=gl_useremail)
                         log.debug(f"GitLab error reporting - User list: {gl_emailquery}")
                         if len(gl_emailquery) > 0:
-                            log.debug("GitLab error reporting - Last Committer user ID: " % gl_emailquery[0].get_id())
+                            log.debug("GitLab error reporting - Last Committer user ID: %s" % gl_emailquery[0].get_id())
                             self.git_username_id_cache[gl_useremail] = gl_emailquery[0].get_id()
                     gl_userid = self.git_username_id_cache.get(gl_useremail, None)
 


### PR DESCRIPTION
(If fixing a bug, please add any relevant error or traceback)
This pull request makes Galaxy's implementation compliant with python-gitlab v2.10.0, which now takes care of the urlencoding. This would cause double urlencoding with the previous code.
Traceback:
```
galaxy.tools.error_reports.plugins.gitlab WARNING 2021-08-10 11:07:34,039 [pN:main.web.1,p:1868,w:1,m:0,tN:uWSGIWorker1Core0] GitLab error reporting - Repository '[REDACTED]' doesn't exist, using default repository.
galaxy.tools.error_reports.plugins.gitlab ERROR 2021-08-10 11:07:34,100 [pN:main.web.1,p:1868,w:1,m:0,tN:uWSGIWorker1Core0] GitLab error reporting - General error communicating with GitLab.
Traceback (most recent call last):
  File "[REDACTED]/.venv/lib/python3.7/site-packages/gitlab/exceptions.py", line 304, in wrapped_f
    return f(*args, **kwargs)
  File "[REDACTED]/.venv/lib/python3.7/site-packages/gitlab/mixins.py", line 112, in get
    server_data = self.gitlab.http_get(path, **kwargs)
  File "[REDACTED]/.venv/lib/python3.7/site-packages/gitlab/client.py", line 663, in http_get
    "get", path, query_data=query_data, streamed=streamed, **kwargs
  File "[REDACTED]/.venv/lib/python3.7/site-packages/gitlab/client.py", line 631, in http_request
    response_body=result.content,
gitlab.exceptions.GitlabHttpError: 404: 404 Project Not Found
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Install Galaxy ensuring python-gitlab is version v2.10.0 or higher.
  2. Ensure `config/error_reports.yml` is set up to report the issue to Gitlab.
  3. Run a tool in a way that makes it fail.
  4. Try reporting an issue into Gitlab.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
