### PR TITLE
Migrate group_roles endpoints to fastapi

### DIFF
--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -106,8 +106,12 @@ class GroupRolesManager:
 
     def _serialize_group_role(self, encoded_group_id: EncodedDatabaseIdField, role: model.Role):
         encoded_role_id = self._app.security.encode_id(role.id)
+        try:
+            url  = url_for('role', group_id=encoded_group_id, id=encoded_role_id)
+        except AttributeError:
+            url  = "*deprecated attribute not filled in by FastAPI server*"
         return {
             "id": encoded_role_id,
             "name": role.name,
-            "url": url_for('group_role', group_id=encoded_group_id, id=encoded_role_id)
+            "url": url
         }

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -1,11 +1,8 @@
 import logging
 from typing import (
     Any,
-    Dict,
     Optional,
 )
-
-from lib.galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 
 from galaxy import model
 from galaxy.app import MinimalManagerApp
@@ -15,6 +12,7 @@ from galaxy.exceptions import (
 from galaxy.managers.base import decode_id
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 from galaxy.web import url_for
 
 log = logging.getLogger(__name__)
@@ -37,7 +35,7 @@ class GroupRolesManager:
             rval.append(group_role)
         return GroupRoleListModel(__root__=rval)
 
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField) -> Dict[str, Any]:
+    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
         """
         Returns information about a group role.
         """

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -107,9 +107,9 @@ class GroupRolesManager:
     def _serialize_group_role(self, encoded_group_id: EncodedDatabaseIdField, role: model.Role):
         encoded_role_id = self._app.security.encode_id(role.id)
         try:
-            url  = url_for('role', group_id=encoded_group_id, id=encoded_role_id)
+            url = url_for('role', group_id=encoded_group_id, id=encoded_role_id)
         except AttributeError:
-            url  = "*deprecated attribute not filled in by FastAPI server*"
+            url = "*deprecated attribute not filled in by FastAPI server*"
         return {
             "id": encoded_role_id,
             "name": role.name,

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -37,10 +37,9 @@ class GroupRolesManager:
         group = self._get_group(trans, group_id)
         role = self._get_role(trans, role_id)
         group_role = self._get_group_role(trans, group, role)
-        if group_role is None:
+        if not group_role:
             raise ObjectNotFound(f"Role {role.name} not in group {group.name}")
         return role
-        # return self._serialize_group_role(group_id, role)
 
     def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
         """
@@ -50,7 +49,7 @@ class GroupRolesManager:
         group = self._get_group(trans, group_id)
         role = self._get_role(trans, role_id)
         group_role = self._get_group_role(trans, group, role)
-        if group_role is None:
+        if not group_role:
             self._add_role_to_group(trans, group, role)
         return role
 
@@ -62,7 +61,7 @@ class GroupRolesManager:
         group = self._get_group(trans, group_id)
         role = self._get_role(trans, role_id)
         group_role = self._get_group_role(trans, group, role)
-        if group_role is None:
+        if not group_role:
             raise ObjectNotFound(f"Role {role.name} not in group {group.name}")
         self._remove_role_from_group(trans, group_role)
         return role
@@ -70,14 +69,14 @@ class GroupRolesManager:
     def _get_group(self, trans: ProvidesAppContext, encoded_group_id: EncodedDatabaseIdField) -> Any:
         decoded_group_id = decode_id(self._app, encoded_group_id)
         group = trans.sa_session.query(model.Group).get(decoded_group_id)
-        if group is None:
+        if not group:
             raise ObjectNotFound(f"Group with id {encoded_group_id} was not found.")
         return group
 
     def _get_role(self, trans: ProvidesAppContext, encoded_role_id: EncodedDatabaseIdField) -> model.Role:
         decoded_role_id = decode_id(self._app, encoded_role_id)
         role = trans.sa_session.query(model.Role).get(decoded_role_id)
-        if role is None:
+        if not role:
             raise ObjectNotFound(f"Role with id {encoded_role_id} was not found.")
         return role
 

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -2,9 +2,10 @@ import logging
 from typing import (
     Any,
     Dict,
-    List,
     Optional,
 )
+
+from lib.galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 
 from galaxy import model
 from galaxy.app import MinimalManagerApp
@@ -25,7 +26,7 @@ class GroupRolesManager:
     def __init__(self, app: MinimalManagerApp) -> None:
         self._app = app
 
-    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField) -> List[Dict[str, Any]]:
+    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField):
         """
         Returns a collection roles associated with the given group.
         """
@@ -34,7 +35,7 @@ class GroupRolesManager:
         for gra in group.roles:
             group_role = self._serialize_group_role(group_id, gra.role)
             rval.append(group_role)
-        return rval
+        return GroupRoleListModel(__root__=rval)
 
     def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField) -> Dict[str, Any]:
         """
@@ -110,8 +111,9 @@ class GroupRolesManager:
             url = url_for('role', group_id=encoded_group_id, id=encoded_role_id)
         except AttributeError:
             url = "*deprecated attribute not filled in by FastAPI server*"
-        return {
+
+        return GroupRoleModel(**{
             "id": encoded_role_id,
             "name": role.name,
             "url": url
-        }
+        })

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -106,7 +106,7 @@ class GroupRolesManager:
     def _serialize_group_role(self, encoded_group_id: EncodedDatabaseIdField, role: model.Role):
         encoded_role_id = self._app.security.encode_id(role.id)
         try:
-            url = url_for('role', group_id=encoded_group_id, id=encoded_role_id)
+            url = url_for('group_role', group_id=encoded_group_id, id=encoded_role_id)
         except AttributeError:
             url = "*deprecated attribute not filled in by FastAPI server*"
 

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -14,6 +14,7 @@ from galaxy.managers.context import ProvidesAppContext
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 from galaxy.web import url_for
+from galaxy.webapps.galaxy.api.common import fastapi_deprecation_message
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +109,7 @@ class GroupRolesManager:
         try:
             url = url_for('group_role', group_id=encoded_group_id, id=encoded_role_id)
         except AttributeError:
-            url = "*deprecated attribute not filled in by FastAPI server*"
+            url = fastapi_deprecation_message()
 
         return GroupRoleModel(
             id=encoded_role_id,

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -24,7 +24,7 @@ class GroupRolesManager:
     def __init__(self, app: MinimalManagerApp) -> None:
         self._app = app
 
-    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField):
+    def index(self, trans: ProvidesAppContext, group_id: EncodedDatabaseIdField) -> GroupRoleListModel:
         """
         Returns a collection roles associated with the given group.
         """
@@ -110,8 +110,8 @@ class GroupRolesManager:
         except AttributeError:
             url = "*deprecated attribute not filled in by FastAPI server*"
 
-        return GroupRoleModel(**{
-            "id": encoded_role_id,
-            "name": role.name,
-            "url": url
-        })
+        return GroupRoleModel(
+            id=encoded_role_id,
+            name=role.name,
+            url=url
+        )

--- a/lib/galaxy/managers/group_roles.py
+++ b/lib/galaxy/managers/group_roles.py
@@ -35,7 +35,7 @@ class GroupRolesManager:
             rval.append(group_role)
         return GroupRoleListModel(__root__=rval)
 
-    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def show(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField) -> GroupRoleModel:
         """
         Returns information about a group role.
         """
@@ -48,7 +48,7 @@ class GroupRolesManager:
 
         return self._serialize_group_role(group_id, role)
 
-    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def update(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField) -> GroupRoleModel:
         """
         Adds a role to a group if it is not already associated.
         """
@@ -61,7 +61,7 @@ class GroupRolesManager:
 
         return self._serialize_group_role(group_id, role)
 
-    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField):
+    def delete(self, trans: ProvidesAppContext, id: EncodedDatabaseIdField, group_id: EncodedDatabaseIdField) -> GroupRoleModel:
         """
         Removes a role from a group.
         """

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1909,7 +1909,8 @@ class GroupRoleModel(BaseModel):
     id: EncodedDatabaseIdField = RoleIdField
     name: str = RoleNameField
     url: str = Field(title="URL", description="URL for the group role")
-    
+
+
 class GroupRoleListModel(BaseModel):
     __root__: List[GroupRoleModel]
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1908,7 +1908,7 @@ RoleNameIdTuple = Tuple[str, EncodedDatabaseIdField]
 class GroupRoleModel(BaseModel):
     id: EncodedDatabaseIdField = RoleIdField
     name: str = RoleNameField
-    url: str = Field(title="URL", description="URL for the group role")
+    url: RelativeUrl = RelativeUrlField
 
 
 class GroupRoleListModel(BaseModel):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1902,6 +1902,16 @@ class RoleListModel(BaseModel):
 # Keeping it as a Tuple for now for backward compatibility
 RoleNameIdTuple = Tuple[str, EncodedDatabaseIdField]
 
+# Group_Roles -----------------------------------------------------------------
+
+
+class GroupRoleModel(BaseModel):
+    id: EncodedDatabaseIdField = RoleIdField
+    name: str = RoleNameField
+    url: str = Field(title="URL", description="URL for the group role")
+    
+class GroupRoleListModel(BaseModel):
+    __root__: List[GroupRoleModel]
 
 # Libraries -----------------------------------------------------------------
 

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -28,3 +28,7 @@ def parse_serialization_params(
     if keys:
         key_list = keys.split(',')
     return dict(view=view, keys=key_list, default_view=default_view)
+
+
+def fastapi_deprecation_message():
+    return "*deprecated attribute not filled in by FastAPI server*"

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -15,9 +15,9 @@ from galaxy.web import (
     require_admin,
 )
 from . import (
-    BaseGalaxyAPIController, 
-    depends, 
-    Router, 
+    BaseGalaxyAPIController,
+    depends,
+    Router,
     DependsOnTrans
 )
 
@@ -46,13 +46,13 @@ class FastAPIGroupRoles:
     @router.get('/api/groups/{group_id}/roles',
                 require_admin=True,
                 summary='Displays a collection (list) of groups.')
-    def index(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam) -> GroupRoleListModel:
+    def indexAfe(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam) -> GroupRoleListModel:
         return self.manager.index(trans, group_id)
 
     @router.get('/api/groups/{group_id}/roles/{role_id}',
                 require_admin=True,
                 summary='Displays information about a group role.')
-    def show(self,  trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
+    def show(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
         return self.manager.show(trans, role_id, group_id)
 
     @router.put('/api/groups/{group_id}/roles/{role_id}',
@@ -62,8 +62,8 @@ class FastAPIGroupRoles:
         return self.manager.update(trans, role_id, group_id)
 
     @router.delete('/api/groups/{group_id}/roles/{role_id}',
-                    require_admin=True,
-                    summary='Removes a role from a group')
+                   require_admin=True,
+                   summary='Removes a role from a group')
     def delete(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam):
         return self.manager.delete(trans, role_id, group_id)
 

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -98,7 +98,8 @@ class GroupRolesAPIController(BaseGalaxyAPIController):
         GET /api/groups/{encoded_group_id}/roles
         Displays a collection (list) of groups.
         """
-        return self.manager.index(trans, group_id)
+        group_roles = self.manager.index(trans, group_id)
+        return GroupRoleListModel(__root__=[group_role_to_model(trans, group_id, gr.role) for gr in group_roles])
 
     @require_admin
     @expose_api
@@ -107,7 +108,8 @@ class GroupRolesAPIController(BaseGalaxyAPIController):
         GET /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Displays information about a group role.
         """
-        return self.manager.show(trans, id, group_id)
+        role = self.manager.show(trans, id, group_id)
+        return group_role_to_model(trans, group_id, role)
 
     @require_admin
     @expose_api
@@ -116,7 +118,8 @@ class GroupRolesAPIController(BaseGalaxyAPIController):
         PUT /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Adds a role to a group
         """
-        return self.manager.update(trans, id, group_id)
+        role = self.manager.update(trans, id, group_id)
+        return group_role_to_model(trans, group_id, role)
 
     @require_admin
     @expose_api
@@ -125,4 +128,5 @@ class GroupRolesAPIController(BaseGalaxyAPIController):
         DELETE /api/groups/{encoded_group_id}/roles/{encoded_role_id}
         Removes a role from a group
         """
-        return self.manager.delete(trans, id, group_id)
+        role = self.manager.delete(trans, id, group_id)
+        return group_role_to_model(trans, group_id, role)

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -45,7 +45,7 @@ class FastAPIGroupRoles:
     @router.get('/api/groups/{group_id}/roles',
                 require_admin=True,
                 summary='Displays a collection (list) of groups.')
-    def indexAfe(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam) -> GroupRoleListModel:
+    def index(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam) -> GroupRoleListModel:
         return self.manager.index(trans, group_id)
 
     @router.get('/api/groups/{group_id}/roles/{role_id}',

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -4,11 +4,11 @@ API operations on Group objects.
 import logging
 
 from fastapi import Path
-from lib.galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_roles import GroupRolesManager
 from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 from galaxy.web import (
     expose_api,
     require_admin,

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -62,28 +62,35 @@ class FastAPIGroupRoles:
     @router.get('/api/groups/{group_id}/roles',
                 require_admin=True,
                 summary='Displays a collection (list) of groups.')
-    def index(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam) -> GroupRoleListModel:
+    def index(self, trans: ProvidesAppContext = DependsOnTrans,
+              group_id: EncodedDatabaseIdField = GroupIDParam) -> GroupRoleListModel:
         group_roles = self.manager.index(trans, group_id)
         return GroupRoleListModel(__root__=[group_role_to_model(trans, group_id, gr.role) for gr in group_roles])
 
     @router.get('/api/groups/{group_id}/roles/{role_id}',
                 require_admin=True,
                 summary='Displays information about a group role.')
-    def show(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
+    def show(self, trans: ProvidesAppContext = DependsOnTrans,
+             group_id: EncodedDatabaseIdField = GroupIDParam,
+             role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
         role = self.manager.show(trans, role_id, group_id)
         return group_role_to_model(trans, group_id, role)
 
     @router.put('/api/groups/{group_id}/roles/{role_id}',
                 require_admin=True,
                 summary='Adds a role to a group')
-    def update(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
+    def update(self, trans: ProvidesAppContext = DependsOnTrans,
+               group_id: EncodedDatabaseIdField = GroupIDParam,
+               role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
         role = self.manager.update(trans, role_id, group_id)
         return group_role_to_model(trans, group_id, role)
 
     @router.delete('/api/groups/{group_id}/roles/{role_id}',
                    require_admin=True,
                    summary='Removes a role from a group')
-    def delete(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
+    def delete(self, trans: ProvidesAppContext = DependsOnTrans,
+               group_id: EncodedDatabaseIdField = GroupIDParam,
+               role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
         role = self.manager.delete(trans, role_id, group_id)
         return group_role_to_model(trans, group_id, role)
 

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -1,11 +1,10 @@
 """
 API operations on Group objects.
 """
-
-from lib.galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 import logging
 
 from fastapi import Path
+from lib.galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_roles import GroupRolesManager
@@ -17,8 +16,8 @@ from galaxy.web import (
 from . import (
     BaseGalaxyAPIController,
     depends,
-    Router,
-    DependsOnTrans
+    DependsOnTrans,
+    Router
 )
 
 

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -57,13 +57,13 @@ class FastAPIGroupRoles:
     @router.put('/api/groups/{group_id}/roles/{role_id}',
                 require_admin=True,
                 summary='Adds a role to a group')
-    def update(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam):
+    def update(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
         return self.manager.update(trans, role_id, group_id)
 
     @router.delete('/api/groups/{group_id}/roles/{role_id}',
                    require_admin=True,
                    summary='Removes a role from a group')
-    def delete(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam):
+    def delete(self, trans: ProvidesAppContext = DependsOnTrans, group_id: EncodedDatabaseIdField = GroupIDParam, role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
         return self.manager.delete(trans, role_id, group_id)
 
 

--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -19,6 +19,7 @@ from galaxy.schema.schema import (
     RoleModel,
 )
 from galaxy.webapps.base.controller import url_for
+from galaxy.webapps.galaxy.api.common import fastapi_deprecation_message
 from . import (
     BaseGalaxyAPIController,
     depends,
@@ -40,7 +41,7 @@ def role_to_model(trans, role):
     try:
         item['url'] = url_for('role', id=role_id)
     except AttributeError:
-        item['url'] = "*deprecated attribute not filled in by FastAPI server*"
+        item['url'] = fastapi_deprecation_message()
     return RoleModel(**item)
 
 

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -26,6 +26,10 @@ api_tags_metadata = [
         "description": "Operations with genome data.",
     },
     {
+        "name": "group_roles",
+        "description": "Operations with group roles.",
+    },
+    {
         "name": "licenses",
         "description": "Operations with [SPDX licenses](https://spdx.org/licenses/).",
     },

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -67,7 +67,6 @@ class GroupRolesApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_role = update_response.json()
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
-        assert (group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}" or group_role["url"] == "*deprecated attribute not filled in by FastAPI server*")
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -67,7 +67,7 @@ class GroupRolesApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_role = update_response.json()
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
-        assert group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}"
+        assert (group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}" or group_role["url"] == "*deprecated attribute not filled in by FastAPI server*")
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -1,6 +1,5 @@
 from typing import List
 
-from galaxy.webapps.galaxy.api.common import fastapi_deprecation_message
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -68,7 +67,7 @@ class GroupRolesApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_role = update_response.json()
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
-        assert (group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}" or group_role["url"] == fastapi_deprecation_message())
+        assert (group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}" or group_role["url"] == "*deprecated attribute not filled in by FastAPI server*")
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from galaxy.webapps.galaxy.api.common import fastapi_deprecation_message
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -67,6 +68,7 @@ class GroupRolesApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_role = update_response.json()
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
+        assert (group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}" or group_role["url"] == fastapi_deprecation_message())
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"


### PR DESCRIPTION
This is a draft PR of my first attempt on migrating some endpoints to fastapi as part of the FastAPI migration process (see https://github.com/galaxyproject/galaxy/issues/10889).

As stated in the test section, I still need to write tests.
I would be really happy about any kind of feedback!

## What did you do?
- Create fastapi endpoints in group_roles.py
- Create pydantic models for GroupRole and GroupeRoleList in schema.py
- Slight changes to the _serialize_group_role method of GroupRolesManager to leave out the url field when running fastapi for now

## How to test the changes?
Since this is my first time contributing, I'm going to need some help with writing tests for this. I tried looking at other test cases, but I couldn't quite figure out how to start.
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
