### PR TITLE
Identify tool by name, owner, toolshed

### DIFF
--- a/client/src/components/Toolshed/InstalledList/Details.vue
+++ b/client/src/components/Toolshed/InstalledList/Details.vue
@@ -20,7 +20,12 @@ import RepositoryDetails from "../RepositoryDetails/Index.vue";
 import LoadingSpan from "components/LoadingSpan";
 
 export default {
-    props: ["repo"],
+    props: {
+      repo: {
+        type: Object,
+        required: true
+      }
+    },
     components: {
         LoadingSpan,
         RepositoryDetails,

--- a/client/src/components/Toolshed/InstalledList/Details.vue
+++ b/client/src/components/Toolshed/InstalledList/Details.vue
@@ -21,10 +21,10 @@ import LoadingSpan from "components/LoadingSpan";
 
 export default {
     props: {
-      repo: {
-        type: Object,
-        required: true
-      }
+        repo: {
+            type: Object,
+            required: true,
+        },
     },
     components: {
         LoadingSpan,
@@ -39,7 +39,7 @@ export default {
     },
     created() {
         this.root = getAppRoot();
-        this.services = new Services({ root: this.root });
+        this.services = new Services();
         this.load();
     },
     methods: {

--- a/client/src/components/Toolshed/InstalledList/Index.test.js
+++ b/client/src/components/Toolshed/InstalledList/Index.test.js
@@ -28,7 +28,7 @@ Services.mockImplementation(() => {
                 {
                     name: "name_1",
                     description: "description_1",
-                    tool_shed: "toolshed_1",
+                    tool_shed: "toolshed_2",
                     tool_shed_status: {
                         latest_installable_revision: true,
                     },
@@ -60,5 +60,6 @@ describe("InstalledList", () => {
         expect(links.length).toBe(3);
         const badge = links.at(1).find(".badge");
         expect(badge.text()).toBe("Newer version available!");
+        expect(wrapper.find('th[role="columnheader"][aria-colindex="3"] > div').text()).toBe("Tool Shed");
     });
 });

--- a/client/src/components/Toolshed/InstalledList/Index.test.js
+++ b/client/src/components/Toolshed/InstalledList/Index.test.js
@@ -20,6 +20,7 @@ Services.mockImplementation(() => {
                 {
                     name: "name_0",
                     description: "description_0",
+                    tool_shed: "toolshed_1",
                     tool_shed_status: {
                         latest_installable_revision: false,
                     },
@@ -27,6 +28,7 @@ Services.mockImplementation(() => {
                 {
                     name: "name_1",
                     description: "description_1",
+                    tool_shed: "toolshed_1",
                     tool_shed_status: {
                         latest_installable_revision: true,
                     },

--- a/client/src/components/Toolshed/InstalledList/Index.vue
+++ b/client/src/components/Toolshed/InstalledList/Index.vue
@@ -60,7 +60,6 @@ import { Services } from "../services";
 import LoadingSpan from "components/LoadingSpan";
 import Monitor from "./Monitor";
 import RepositoryDetails from "./Details";
-import {getGalaxyInstance} from "../../../app";
 
 Vue.use(BootstrapVue);
 
@@ -70,7 +69,12 @@ export default {
         Monitor,
         RepositoryDetails,
     },
-    props: ["filter"],
+    props: {
+      filter: {
+        type: String,
+        required: true
+      }
+    },
     data() {
 
         return {

--- a/client/src/components/Toolshed/InstalledList/Index.vue
+++ b/client/src/components/Toolshed/InstalledList/Index.vue
@@ -70,13 +70,12 @@ export default {
         RepositoryDetails,
     },
     props: {
-      filter: {
-        type: String,
-        required: true
-      }
+        filter: {
+            type: String,
+            required: true,
+        },
     },
     data() {
-
         return {
             error: null,
             loading: true,
@@ -101,36 +100,36 @@ export default {
         numToolsheds() {
             const toolsheds = new Set();
             this.repositories.forEach((x) => {
-              toolsheds.add(x.tool_shed)
+                toolsheds.add(x.tool_shed);
             });
-            return toolsheds.size
+            return toolsheds.size;
         },
         fields() {
             const fields = [
-                  {
+                {
                     key: "name",
                     sortable: true,
                     sortByFormatted: (value, key, item) => {
-                      return `${this.isLatest(item)}_${value}`;
+                        return `${this.isLatest(item)}_${value}`;
                     },
-                  },
-                  {
+                },
+                {
                     key: "owner",
                     sortable: true,
-                  },
-                ];
+                },
+            ];
             if (this.numToolsheds > 1) {
                 fields.push({
-                  key: "tool_shed",
-                  sortable: true,
+                    key: "tool_shed",
+                    sortable: true,
                 });
             }
             return fields;
-        }
+        },
     },
     created() {
         this.root = getAppRoot();
-        this.services = new Services({ root: this.root });
+        this.services = new Services();
         this.load();
     },
     methods: {

--- a/client/src/components/Toolshed/InstalledList/Index.vue
+++ b/client/src/components/Toolshed/InstalledList/Index.vue
@@ -60,6 +60,7 @@ import { Services } from "../services";
 import LoadingSpan from "components/LoadingSpan";
 import Monitor from "./Monitor";
 import RepositoryDetails from "./Details";
+import {getGalaxyInstance} from "../../../app";
 
 Vue.use(BootstrapVue);
 
@@ -71,21 +72,9 @@ export default {
     },
     props: ["filter"],
     data() {
+
         return {
             error: null,
-            fields: [
-                {
-                    key: "name",
-                    sortable: true,
-                    sortByFormatted: (value, key, item) => {
-                        return `${this.isLatest(item)}_${value}`;
-                    },
-                },
-                {
-                    key: "owner",
-                    sortable: true,
-                },
-            ],
             loading: true,
             message: null,
             messageVariant: null,
@@ -105,6 +94,35 @@ export default {
         showMessage() {
             return !!this.message;
         },
+        numToolsheds() {
+            const toolsheds = new Set();
+            this.repositories.forEach((x) => {
+              toolsheds.add(x.tool_shed)
+            });
+            return toolsheds.size
+        },
+        fields() {
+            const fields = [
+                  {
+                    key: "name",
+                    sortable: true,
+                    sortByFormatted: (value, key, item) => {
+                      return `${this.isLatest(item)}_${value}`;
+                    },
+                  },
+                  {
+                    key: "owner",
+                    sortable: true,
+                  },
+                ];
+            if (this.numToolsheds > 1) {
+                fields.push({
+                  key: "tool_shed",
+                  sortable: true,
+                });
+            }
+            return fields;
+        }
     },
     created() {
         this.root = getAppRoot();

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -30,7 +30,6 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
-import { getAppRoot } from "onload/loadConfig";
 import { Services } from "../services";
 import InstallationButton from "../RepositoryDetails/InstallationButton";
 
@@ -58,7 +57,6 @@ export default {
         },
     },
     created() {
-        this.root = getAppRoot();
         this.services = new Services();
         this.load();
     },

--- a/client/src/components/Toolshed/InstalledList/Monitor.vue
+++ b/client/src/components/Toolshed/InstalledList/Monitor.vue
@@ -59,7 +59,7 @@ export default {
     },
     created() {
         this.root = getAppRoot();
-        this.services = new Services({ root: this.root });
+        this.services = new Services();
         this.load();
     },
     destroyed() {

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -30,7 +30,6 @@
                         </template>
                         <template v-slot:cell(actions)="row">
                             <InstallationButton
-                                :installed="row.item.installed"
                                 :status="row.item.status"
                                 @onInstall="setupRepository(row.item)"
                                 @onUninstall="uninstallRepository(row.item)"

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -68,14 +68,14 @@ export default {
         RepositoryTools,
     },
     props: {
-      repo: {
-        type: Object,
-        required: true
-      },
-      toolshedUrl: {
-        type: String,
-        required: true
-      },
+        repo: {
+            type: Object,
+            required: true,
+        },
+        toolshedUrl: {
+            type: String,
+            required: true,
+        },
     },
     data() {
         return {

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -67,7 +67,16 @@ export default {
         InstallationButton,
         RepositoryTools,
     },
-    props: ["repo", "toolshedUrl"],
+    props: {
+      repo: {
+        type: Object,
+        required: true
+      },
+      toolshedUrl: {
+        type: String,
+        required: true
+      },
+    },
     data() {
         return {
             repoChecked: "fa fa-check text-success",

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
@@ -20,10 +20,6 @@ Vue.use(BootstrapVue);
 
 export default {
     props: {
-        installed: {
-            type: Boolean,
-            required: false,
-        },
         status: {
             type: String,
             required: true,

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
@@ -20,14 +20,14 @@ Vue.use(BootstrapVue);
 
 export default {
     props: {
-      installed: {
-        type: Boolean,
-        required: false
-      },
-      status: {
-        type: String,
-        required: true
-      }
+        installed: {
+            type: Boolean,
+            required: false,
+        },
+        status: {
+            type: String,
+            required: true,
+        },
     },
     data() {
         return {

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
@@ -19,7 +19,16 @@ import BootstrapVue from "bootstrap-vue";
 Vue.use(BootstrapVue);
 
 export default {
-    props: ["installed", "status"],
+    props: {
+      installed: {
+        type: Boolean,
+        required: false
+      },
+      status: {
+        type: String,
+        required: true
+      }
+    },
     data() {
         return {
             buttonClass: "btn-sm text-nowrap",

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -56,26 +56,26 @@ Vue.use(BootstrapVue);
 
 export default {
     props: {
-      repo: {
-        type: Object,
-        required: true,
-      },
-      changesetRevision: {
-        type: String,
-        required: true,
-      },
-      requiresPanel: {
-        type: Boolean,
-        required: true,
-      },
-      toolshedUrl: {
-        type: String,
-        required: true,
-      },
-      modalStatic: {
-        type: Boolean,
-        required: true,
-      },
+        repo: {
+            type: Object,
+            required: true,
+        },
+        changesetRevision: {
+            type: String,
+            required: true,
+        },
+        requiresPanel: {
+            type: Boolean,
+            required: true,
+        },
+        toolshedUrl: {
+            type: String,
+            required: true,
+        },
+        modalStatic: {
+            type: Boolean,
+            required: true,
+        },
     },
     data() {
         return {

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -55,7 +55,28 @@ import { getGalaxyInstance } from "app";
 Vue.use(BootstrapVue);
 
 export default {
-    props: ["repo", "changesetRevision", "requiresPanel", "toolshedUrl", "modalStatic"],
+    props: {
+      repo: {
+        type: Object,
+        required: true,
+      },
+      changesetRevision: {
+        type: String,
+        required: true,
+      },
+      requiresPanel: {
+        type: Boolean,
+        required: true,
+      },
+      toolshedUrl: {
+        type: String,
+        required: true,
+      },
+      modalStatic: {
+        type: Boolean,
+        required: true,
+      },
+    },
     data() {
         return {
             modalShow: true,

--- a/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.vue
@@ -34,10 +34,10 @@
 <script>
 export default {
     props: {
-      tools: {
-        type: Array,
-        required: true
-      },
+        tools: {
+            type: Array,
+            required: true,
+        },
     },
     data() {
         return {

--- a/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/RepositoryTools.vue
@@ -33,7 +33,12 @@
 </template>
 <script>
 export default {
-    props: ["tools"],
+    props: {
+      tools: {
+        type: Array,
+        required: true
+      },
+    },
     data() {
         return {
             clsExpanded: "bg-transparent border-bottom",

--- a/client/src/components/Toolshed/SearchList/Categories.vue
+++ b/client/src/components/Toolshed/SearchList/Categories.vue
@@ -24,7 +24,16 @@ import LoadingSpan from "components/LoadingSpan";
 Vue.use(BootstrapVue);
 
 export default {
-    props: ["toolshedUrl", "loading"],
+    props: {
+      toolshedUrl: {
+        type: String,
+        required: true
+      },
+      loading: {
+        type: Boolean,
+        required: true
+      },
+    },
     components: { LoadingSpan },
     data() {
         return {

--- a/client/src/components/Toolshed/SearchList/Categories.vue
+++ b/client/src/components/Toolshed/SearchList/Categories.vue
@@ -25,14 +25,14 @@ Vue.use(BootstrapVue);
 
 export default {
     props: {
-      toolshedUrl: {
-        type: String,
-        required: true
-      },
-      loading: {
-        type: Boolean,
-        required: true
-      },
+        toolshedUrl: {
+            type: String,
+            required: true,
+        },
+        loading: {
+            type: Boolean,
+            required: true,
+        },
     },
     components: { LoadingSpan },
     data() {

--- a/client/src/components/Toolshed/SearchList/Index.vue
+++ b/client/src/components/Toolshed/SearchList/Index.vue
@@ -35,14 +35,14 @@ import Repositories from "./Repositories.vue";
 import ServerSelection from "./ServerSelection.vue";
 export default {
     props: {
-      query: {
-        type: String,
-        required: true
-      },
-      scrolled: {
-        type: Boolean,
-        required: true
-      },
+        query: {
+            type: String,
+            required: true,
+        },
+        scrolled: {
+            type: Boolean,
+            required: true,
+        },
     },
     components: {
         Categories,

--- a/client/src/components/Toolshed/SearchList/Index.vue
+++ b/client/src/components/Toolshed/SearchList/Index.vue
@@ -34,7 +34,16 @@ import Categories from "./Categories.vue";
 import Repositories from "./Repositories.vue";
 import ServerSelection from "./ServerSelection.vue";
 export default {
-    props: ["query", "scrolled"],
+    props: {
+      query: {
+        type: String,
+        required: true
+      },
+      scrolled: {
+        type: Boolean,
+        required: true
+      },
+    },
     components: {
         Categories,
         Repositories,

--- a/client/src/components/Toolshed/SearchList/Repositories.test.js
+++ b/client/src/components/Toolshed/SearchList/Repositories.test.js
@@ -33,7 +33,7 @@ describe("Repositories", () => {
     it("test repository details loading", async () => {
         const wrapper = mount(Repositories, {
             propsData: {
-                query: true,
+                query: "toolname",
                 scrolled: false,
                 toolshedUrl: "toolshedUrl",
             },

--- a/client/src/components/Toolshed/SearchList/Repositories.vue
+++ b/client/src/components/Toolshed/SearchList/Repositories.vue
@@ -33,18 +33,18 @@ export default {
         RepositoryDetails,
     },
     props: {
-      query: {
-        type: String,
-        required: true
-      },
-      scrolled: {
-        type: Boolean,
-        required: true,
-      },
-      toolshedUrl: {
-        type: String,
-        required: true
-      },
+        query: {
+            type: String,
+            required: true,
+        },
+        scrolled: {
+            type: Boolean,
+            required: true,
+        },
+        toolshedUrl: {
+            type: String,
+            required: true,
+        },
     },
     data() {
         return {

--- a/client/src/components/Toolshed/SearchList/Repositories.vue
+++ b/client/src/components/Toolshed/SearchList/Repositories.vue
@@ -32,7 +32,20 @@ export default {
         LoadingSpan,
         RepositoryDetails,
     },
-    props: ["query", "scrolled", "toolshedUrl"],
+    props: {
+      query: {
+        type: String,
+        required: true
+      },
+      scrolled: {
+        type: Boolean,
+        required: true,
+      },
+      toolshedUrl: {
+        type: String,
+        required: true
+      },
+    },
     data() {
         return {
             repositories: [],

--- a/client/src/components/Toolshed/SearchList/ServerSelection.test.js
+++ b/client/src/components/Toolshed/SearchList/ServerSelection.test.js
@@ -11,11 +11,11 @@ describe("ServerSelection", () => {
                 toolshedUrl: "url_0",
                 toolshedUrls: ["url_0", "url_1"],
                 loading: false,
-                total: "total",
+                total: 10,
             },
             localVue,
         });
-        expect(wrapper.find(".description").text()).toBe("total repositories available at");
+        expect(wrapper.find(".description").text()).toBe("10 repositories available at");
         const $options = wrapper.findAll("a");
         expect($options.at(0).text()).toBe("url_0");
         expect($options.at(1).text()).toBe("url_0");

--- a/client/src/components/Toolshed/SearchList/ServerSelection.vue
+++ b/client/src/components/Toolshed/SearchList/ServerSelection.vue
@@ -39,22 +39,22 @@ Vue.use(BootstrapVue);
 
 export default {
     props: {
-      toolshedUrl: {
-        type: String,
-        required: true,
-      },
-      toolshedUrls: {
-        type: Array,
-        required: true,
-      },
-      loading: {
-        type: Boolean,
-        required: true,
-      },
-      total: {
-        type: Number,
-        required: true
-      },
+        toolshedUrl: {
+            type: String,
+            required: true,
+        },
+        toolshedUrls: {
+            type: Array,
+            required: true,
+        },
+        loading: {
+            type: Boolean,
+            required: true,
+        },
+        total: {
+            type: Number,
+            required: true,
+        },
     },
     computed: {
         showDropdown() {

--- a/client/src/components/Toolshed/SearchList/ServerSelection.vue
+++ b/client/src/components/Toolshed/SearchList/ServerSelection.vue
@@ -38,7 +38,24 @@ import BootstrapVue from "bootstrap-vue";
 Vue.use(BootstrapVue);
 
 export default {
-    props: ["toolshedUrl", "toolshedUrls", "loading", "total"],
+    props: {
+      toolshedUrl: {
+        type: String,
+        required: true,
+      },
+      toolshedUrls: {
+        type: Array,
+        required: true,
+      },
+      loading: {
+        type: Boolean,
+        required: true,
+      },
+      total: {
+        type: Number,
+        required: true
+      },
+    },
     computed: {
         showDropdown() {
             return this.toolshedUrls.length > 1;

--- a/client/src/components/Toolshed/services.js
+++ b/client/src/components/Toolshed/services.js
@@ -128,7 +128,7 @@ export class Services {
     _groupByNameOwnerToolshed(incoming, filter, selectLatest) {
         if (selectLatest) {
             const getSortValue = (x, y) => {
-                return x == y ? 0 : x < y ? -1 : 1;
+                return x === y ? 0 : x < y ? -1 : 1;
             };
             incoming = incoming.sort((a, b) => {
                 return (

--- a/client/src/components/Toolshed/services.js
+++ b/client/src/components/Toolshed/services.js
@@ -134,6 +134,7 @@ export class Services {
                 return (
                     getSortValue(a.name, b.name) ||
                     getSortValue(a.owner, b.owner) ||
+                    getSortValue(a.tool_shed, b.tool_shed) ||
                     getSortValue(parseInt(b.ctx_rev), parseInt(a.ctx_rev))
                 );
             });
@@ -141,7 +142,7 @@ export class Services {
         const hash = {};
         const repositories = [];
         incoming.forEach((x) => {
-            const hashCode = `${x.name}_${x.owner}`;
+            const hashCode = `${x.name}_${x.owner}_${x.tool_shed}`;
             if (!filter || filter(x)) {
                 if (!hash[hashCode]) {
                     hash[hashCode] = true;

--- a/client/src/components/Toolshed/services.js
+++ b/client/src/components/Toolshed/services.js
@@ -78,7 +78,7 @@ export class Services {
         const url = `${getAppRoot()}api/tool_shed_repositories/?uninstalled=False`;
         try {
             const response = await axios.get(url);
-            const repositories = this._groupByNameOwner(response.data, options.filter, options.selectLatest);
+            const repositories = this._groupByNameOwnerToolshed(response.data, options.filter, options.selectLatest);
             this._fixToolshedUrls(repositories, Galaxy.config.tool_shed_urls);
             return repositories;
         } catch (e) {
@@ -125,7 +125,7 @@ export class Services {
             rethrowSimple(e);
         }
     }
-    _groupByNameOwner(incoming, filter, selectLatest) {
+    _groupByNameOwnerToolshed(incoming, filter, selectLatest) {
         if (selectLatest) {
             const getSortValue = (x, y) => {
                 return x == y ? 0 : x < y ? -1 : 1;

--- a/client/src/components/Toolshed/services.test.js
+++ b/client/src/components/Toolshed/services.test.js
@@ -40,7 +40,7 @@ describe("Toolshed service helpers", () => {
     it("test fix toolshed helper", () => {
         const services = new Services();
         const filter = (x) => x.status !== "Installed";
-        const grouped = services._groupByNameOwner(incoming, filter, true);
+        const grouped = services._groupByNameOwnerToolshed(incoming, filter, true);
         services._fixToolshedUrls(grouped, urls);
         expect(grouped.length).toBe(2);
         expect(grouped[0].name).toBe("name_0");


### PR DESCRIPTION
This is a fix for #12335 in two parts:

1. It address the masking of tools by replacing the `${name}_${owner}` hash key with `${name}_${owner}_${tool_shed}`
2. If tools from more than 1 toolshed are installed it shows a "Tool Shed" column on the list of installed tools

![image](https://user-images.githubusercontent.com/4154788/129076188-8140adc1-3a09-4dd8-b768-f555140098e0.png)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
