### PR TITLE
Restore Upload dialog in global Galaxy object

### DIFF
--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -8,7 +8,7 @@ import addLogging from "utils/add-logging";
 import localize from "utils/localization";
 import { getGalaxyInstance } from "app";
 import { create, dialog } from "utils/data";
-import { openGlobalUploadModal } from "components/upload/mount";
+import { openGlobalUploadModal } from "components/Upload";
 
 // ============================================================================
 /** Base galaxy client-side application.

--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -8,7 +8,6 @@ import addLogging from "utils/add-logging";
 import localize from "utils/localization";
 import { getGalaxyInstance } from "app";
 import { create, dialog } from "utils/data";
-import { openGlobalUploadModal } from "components/Upload";
 
 // ============================================================================
 /** Base galaxy client-side application.
@@ -292,11 +291,6 @@ GalaxyApp.prototype.debuggingNamespaces = function _debuggingNamespaces(namespac
     } catch (storageErr) {
         console.log(localize("localStorage not available for debug namespace retrieval"));
     }
-};
-
-/** Open Upload Dialog */
-GalaxyApp.prototype.uploadDialog = function uploadDialog() {
-    openGlobalUploadModal();
 };
 
 /** string rep */

--- a/client/src/app/galaxy.js
+++ b/client/src/app/galaxy.js
@@ -8,6 +8,7 @@ import addLogging from "utils/add-logging";
 import localize from "utils/localization";
 import { getGalaxyInstance } from "app";
 import { create, dialog } from "utils/data";
+import { openGlobalUploadModal } from "components/upload/mount";
 
 // ============================================================================
 /** Base galaxy client-side application.
@@ -291,6 +292,11 @@ GalaxyApp.prototype.debuggingNamespaces = function _debuggingNamespaces(namespac
     } catch (storageErr) {
         console.log(localize("localStorage not available for debug namespace retrieval"));
     }
+};
+
+/** Open Upload Dialog */
+GalaxyApp.prototype.uploadDialog = function uploadDialog() {
+    openGlobalUploadModal();
 };
 
 /** string rep */

--- a/client/src/bundleEntries.js
+++ b/client/src/bundleEntries.js
@@ -32,6 +32,7 @@ export { default as LegacyGridView } from "legacy/grid/grid-view";
 export { create_chart, create_histogram } from "reports/run_stats";
 export { default as ToolshedGroups } from "toolshed/toolshed.groups";
 export { default as IES } from "galaxy.interactive_environments";
+export { openGlobalUploadModal } from "components/Upload";
 
 export { Toast } from "ui/toast"; // TODO: remove when external consumers are updated/gone (IES right now)
 


### PR DESCRIPTION
In order to be able to use the upload dialog on Welcome Pages, the upload dialog needs to remain available in the Galaxy object. This was previously the case but has recently been dropped as part of the Upload dialog refactoring.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
