### PR TITLE
[21.05] Fix for empty docker_volumes/singularity_volumes in job config

### DIFF
--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -117,6 +117,10 @@ def preprocess_volumes(volumes_raw_str, container_type):
     ro for Singularity iff no subdirectories are rw (Singularity does not allow ro
     parent directories with rw subdirectories).
 
+    >>> preprocess_volumes(None, DOCKER_CONTAINER_TYPE)
+    []
+    >>> preprocess_volumes("", DOCKER_CONTAINER_TYPE)
+    []
     >>> preprocess_volumes("/a/b", DOCKER_CONTAINER_TYPE)
     ['/a/b:rw']
     >>> preprocess_volumes("/a/b:ro,/a/b/c:rw", DOCKER_CONTAINER_TYPE)
@@ -130,6 +134,9 @@ def preprocess_volumes(volumes_raw_str, container_type):
     >>> preprocess_volumes("/a/b:default_ro,/a/b/c:rw", SINGULARITY_CONTAINER_TYPE)
     ['/a/b', '/a/b/c']
     """
+
+    if not volumes_raw_str:
+        return []
 
     volumes_raw_strs = [v.strip() for v in volumes_raw_str.split(",")]
     volumes = []


### PR DESCRIPTION
Probably not a common case, but it should work. For example, TACC sets up Singularity on their HPC systems to automatically mount all the shared filesystems.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
