### PR TITLE
Separated data PVC

### DIFF
--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -198,9 +198,11 @@
                  -->
             <param id="k8s_data_volume_claim">galaxy_pvc:/mount_point</param>
             <!-- Persistent Volume Claim (PVC) to container mount point mappings, in the format 'PVC:mount_path'
+                 If specified, the job inputs will be individually mounted from this PVC. -->
 
-                 Typically this is used for the PVC used for data inputs and outputs for each job -->
-
+            <param id="k8s_working_volume_claim">galaxy_pvc:/mount_point</param>
+            <!-- Persistent Volume Claim (PVC) to container mount point mappings, in the format 'PVC:mount_path'
+                 If specified, the job's working directory will be mounted from this PVC. -->
 
             <param id="k8s_persistent_volume_claims">galaxy_pvc1:/mount_point1,galaxy_pvc2:/mount_point2</param>
             <!-- Comma separated list of Persistent Volume Claim (PVC) to container mount point mappings, in the format

--- a/lib/galaxy/config/sample/job_conf.xml.sample_advanced
+++ b/lib/galaxy/config/sample/job_conf.xml.sample_advanced
@@ -196,12 +196,18 @@
                  Kubernetes 1.2 and on. Changing this a much newer version in the future might require changes to the
                  plugin runner code. Value extensions/v1beta1 is also supported for pre 1.2 legacy installations.
                  -->
+            <param id="k8s_data_volume_claim">galaxy_pvc:/mount_point</param>
+            <!-- Persistent Volume Claim (PVC) to container mount point mappings, in the format 'PVC:mount_path'
+
+                 Typically this is used for the PVC used for data inputs and outputs for each job -->
+
+
             <param id="k8s_persistent_volume_claims">galaxy_pvc1:/mount_point1,galaxy_pvc2:/mount_point2</param>
             <!-- Comma separated list of Persistent Volume Claim (PVC) to container mount point mappings, in the format
                  PVC:mount point
 
-                 Typical mount paths are the file_path, job_working_directory, all paths containing tools and scripts
-                 and all library paths set in galaxy.yml (or equivalent general galaxy config file). -->
+                 Typical mount paths are extra mounts that are expected to be mounted for all jobs, such as 
+                 tool scripts, the CVMFS, and all library paths set in galaxy.yml (or equivalent general galaxy config file). -->
 
             <!-- <param id="k8s_namespace">default</param> -->
             <!-- The namespace to be used on the Kubernetes cluster, if different from default, this needs to be set

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -129,7 +129,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             try:
                 param_claim = self.runner_params['k8s_data_volume_claim'].split(":")
                 princip_claim_name = param_claim[0]
-                base_mount = param_claim[1]
             except Exception as e:
                 log.debug('Failed to parse `k8s_data_volume_claim` parameter in the kubernetes runner configuration')
                 raise e
@@ -480,16 +479,16 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             for i in list(inputs):
                 file_path = str(i)
                 subpath = file_path.lstrip(base_mount).lstrip('/').rstrip('/')
-                volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath })
+                volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath})
             for o in list(outputs):
                 file_path = str(o).rstrip('/').split('/')
                 file_path = "/".join(file_path[:-1])
                 subpath = str(file_path).lstrip(base_mount).lstrip('/')
-                volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath })
+                volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath})
             wd_subpath = str(job_wrapper.working_directory).lstrip(base_mount).lstrip('/').rstrip('/')
             volume_mounts.append({'name': claim_name,
                                   'mountPath': str(job_wrapper.working_directory),
-                                  'subPath': wd_subpath })
+                                  'subPath': wd_subpath})
             return volume_mounts
         else:
             return {}

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -484,7 +484,9 @@ class KubernetesJobRunner(AsynchronousJobRunner):
                 file_path = str(o).rstrip('/').split('/')
                 file_path = "/".join(file_path[:-1])
                 subpath = str(file_path).lstrip(base_mount).lstrip('/')
-                volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath})
+                # Avoid mounting the same output directory twice for two output files using same dir
+                if subpath not in [v.get('subPath') for v in [v for v in volume_mounts if v.get('name') == claim_name]]:
+                    volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath})
             wd_subpath = str(job_wrapper.working_directory).lstrip(base_mount).lstrip('/').rstrip('/')
             volume_mounts.append({'name': claim_name,
                                   'mountPath': str(job_wrapper.working_directory),

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -34,7 +34,7 @@ from galaxy.jobs.runners.util.pykube_util import (
     is_pod_unschedulable,
     Job,
     job_object_dict,
-    parse_pvc_param_line
+    parse_pvc_param_line,
     Pod,
     produce_k8s_job_prefix,
     pull_policy,
@@ -109,7 +109,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
 
         self.setup_base_volumes()
 
-
     def setup_base_volumes(self):
         if self.runner_params.get('k8s_persistent_volume_claims'):
             pvc_params = [parse_pvc_param_line(each) for each in self.runner_params['k8s_persistent_volume_claims'].split(',')]
@@ -142,7 +141,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             working_volume = {'name': param_claim['claim'], 'persistentVolumeClaim': {'claimName': param_claim['claim']}}
             if param_claim['claim'] not in [v.get('persistentVolumeClaim', {}).get('claimName') for v in self.runner_params['k8s_mountable_volumes']]:
                 self.runner_params['k8s_mountable_volumes'].append(working_volume)
-
 
     def queue_job(self, job_wrapper):
         """Create job script and submit it to Kubernetes cluster"""

--- a/lib/galaxy/jobs/runners/util/pykube_util.py
+++ b/lib/galaxy/jobs/runners/util/pykube_util.py
@@ -183,6 +183,7 @@ def ingress_object_dict(params, ingress_name, spec):
     k8s_ingress_obj.update(spec)
     return k8s_ingress_obj
 
+
 # takes "pvc-name/subpath/desired:/mountpath/desired[:r]"
 # and returns {"claim": "pvc-name",
 #              "subpath": "subpath/desired",
@@ -207,11 +208,12 @@ def parse_pvc_param_line(paramstring):
     retdict["readonly"] = readonly
     return retdict
 
+
 def get_volume_mounts_for_job(job_wrapper, data_claim=None, working_claim=None):
     DATA_BASE_PATH = "objects/"
     volume_mounts = []
     if data_claim:
-        param_claim = _parse_pvc_param_line(data_claim)
+        param_claim = parse_pvc_param_line(data_claim)
         claim_name = param_claim['claim']
         base_subpath = param_claim.get('subpath', "")
         base_mount = param_claim["mountpath"]
@@ -230,11 +232,12 @@ def get_volume_mounts_for_job(job_wrapper, data_claim=None, working_claim=None):
             file_path = "/".join(file_path[:-1])
             subpath = str(file_path).lstrip(base_mount).lstrip('/')
             # Avoid mounting the same output directory twice for two output files using same dir
-            if DATA_BASE_PATH in subpath and subpath not in [v.get('subPath') for v in [v for v in volume_mounts if v.get('name') == claim_name]]:
+            if (DATA_BASE_PATH in subpath and subpath not in
+                    [v.get('subPath') for v in [v for v in volume_mounts if v.get('name') == claim_name]]):
                 volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath})
 
     if working_claim:
-        param_claim = _parse_pvc_param_line(working_claim)
+        param_claim = parse_pvc_param_line(working_claim)
         claim_name = param_claim['claim']
         wd_base_subpath = param_claim.get('subpath', "")
         base_mount = param_claim["mountpath"]
@@ -250,9 +253,11 @@ def get_volume_mounts_for_job(job_wrapper, data_claim=None, working_claim=None):
             file_path = "/".join(file_path[:-1])
             subpath = str(file_path).lstrip(base_mount).lstrip('/')
             # Avoid mounting the same output directory twice for two output files using same dir
-            if wd_subpath not in subpath and DATA_BASE_PATH not in subpath and subpath not in [v.get('subPath') for v in [v for v in volume_mounts if v.get('name') == claim_name]]:
+            if (wd_subpath not in subpath and DATA_BASE_PATH not in subpath and subpath not in
+                    [v.get('subPath') for v in [v for v in volume_mounts if v.get('name') == claim_name]]):
                 volume_mounts.append({'name': claim_name, 'mountPath': file_path, 'subPath': subpath})
     return volume_mounts
+
 
 def galaxy_instance_id(params):
     """Parse and validate the id of the Galaxy instance from supplied dict.


### PR DESCRIPTION
Separates the volumes that should be mounted in all jobs (cvmfs, scripts, cache, etc...) vs the pvcs that should be mounted per job (input data + job directory).

Friends with https://github.com/galaxyproject/galaxy-helm/pull/314

Example volume mounts per job:
```

## Unique to job (generated from `k8s_data_volume_mount`)
[{'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/objects/4/1/5/dataset_415a97d5-2b27-4b10-9626-4eb60372e46d.dat', 'subPath': 'objects/4/1/5/dataset_415a97d5-2b27-4b10-9626-4eb60372e46d.dat'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/jobs_directory/000/19/outputs', 'subPath': 'jobs_directory/000/19/outputs'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/jobs_directory/000/19', 'subPath': 'jobs_directory/000/19'},

## Common among jobs (from `k8s_persistent_volume_claims`)
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/cache', 'subPath': 'cache'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/config', 'subPath': 'config'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/deps', 'subPath': 'deps'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/object_store_cache', 'subPath': 'object_store_cache'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/tmp', 'subPath': 'tmp'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/tool-data', 'subPath': 'tool-data'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/tools', 'subPath': 'tools'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/galaxy/server/database/tool_search_index', 'subPath': 'tool_search_index'},
 {'name': 'k8sfiles-gxy-rls-galaxy-cvmfs-gxy-data-pvc', 'mountPath': '/cvmfs/data.galaxyproject.org'},
 {'name': 'k8sfiles-gxy-rls-galaxy-pvc', 'mountPath': '/cvmfs/cloud.galaxyproject.org', 'subPath': 'cvmfsclone'}]
```


## Todo
- [x] Make sure config is backwards compatible (conceptually should be since we can still use `k8s_persistent_volume_claims` to mount the entire shared FS in all jobs as before, but want to test that it handles empty/null values for `k8s_data_volume_claim` properly)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
