### PR TITLE
Beta History: persist expanded items in session between page loads

### DIFF
--- a/client/src/components/History/providers/ExpandedItems.js
+++ b/client/src/components/History/providers/ExpandedItems.js
@@ -1,3 +1,5 @@
+import { saveSet, loadSet } from "./setCache";
+
 export default {
     props: {
         scopeKey: { type: String, required: true },
@@ -7,6 +9,11 @@ export default {
         return {
             items: new Set(),
         };
+    },
+    computed: {
+        expandedCount() {
+            return this.items.size;
+        },
     },
     methods: {
         isExpanded(item) {
@@ -29,11 +36,23 @@ export default {
                 this.reset();
             }
         },
+        items(newSet) {
+            saveSet(this.key, newSet);
+        },
+    },
+    created() {
+        this.key = "expanded-history-items";
+        const cachedSet = loadSet(this.key);
+        if (cachedSet) {
+            this.items = cachedSet;
+        }
     },
     render() {
         return this.$scopedSlots.default({
             isExpanded: this.isExpanded,
             setExpanded: this.setExpanded,
+            collapseAll: this.reset,
+            expandedCount: this.expandedCount,
         });
     },
 };

--- a/client/src/components/History/providers/setCache.js
+++ b/client/src/components/History/providers/setCache.js
@@ -1,0 +1,25 @@
+// Caches expanded/selected Sets in sessionStorage
+// Putting this in separate file for ease of mocking
+
+export function saveSet(key, setObject) {
+    try {
+        const setToArray = Array.from(setObject);
+        const json = JSON.stringify(setToArray);
+        sessionStorage.setItem(key, json);
+    } catch (err) {
+        console.log("error saving stuff to cache", err);
+        sessionStorage.removeItem(key);
+    }
+}
+
+export function loadSet(key) {
+    try {
+        const arrJson = sessionStorage.getItem(key) || [];
+        const cachedArray = JSON.parse(arrJson);
+        return Array.isArray(cachedArray) ? new Set(cachedArray) : new Set();
+    } catch (err) {
+        console.log("erorr loading cached list", err);
+        sessionStorage.removeItem(key);
+        return null;
+    }
+}

--- a/client/src/components/History/providers/setCache.js
+++ b/client/src/components/History/providers/setCache.js
@@ -1,5 +1,4 @@
 // Caches expanded/selected Sets in sessionStorage
-// Putting this in separate file for ease of mocking
 
 export function saveSet(key, setObject) {
     try {
@@ -7,7 +6,7 @@ export function saveSet(key, setObject) {
         const json = JSON.stringify(setToArray);
         sessionStorage.setItem(key, json);
     } catch (err) {
-        console.log("error saving stuff to cache", err);
+        console.warn("Error saving set to cache", key, err);
         sessionStorage.removeItem(key);
     }
 }
@@ -18,7 +17,7 @@ export function loadSet(key) {
         const cachedArray = JSON.parse(arrJson);
         return Array.isArray(cachedArray) ? new Set(cachedArray) : new Set();
     } catch (err) {
-        console.log("erorr loading cached list", err);
+        console.warn("Error loading cached list", key, err);
         sessionStorage.removeItem(key);
         return null;
     }


### PR DESCRIPTION
The provider which determines which items on the history are open/closed now persists between page loads.

Addresses:
https://github.com/galaxyproject/galaxy/issues/12119

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
