### PR TITLE
Document how to run a local UI client against a remote Galaxy server

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -83,7 +83,7 @@ environment variable:
 
     GALAXY_URL="http://localhost:8000" make client-dev-server
 
-Sometimes you want to run your UI against a remote Galaxy server. This is also possible, if you enable `CHANGE_ORIGIN` flag 
+Sometimes you want to run your local UI against a remote Galaxy server. This is also possible, if you enable `CHANGE_ORIGIN` flag 
 
     CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.org/" make client-dev-server
 

--- a/client/README.md
+++ b/client/README.md
@@ -83,6 +83,10 @@ environment variable:
 
     GALAXY_URL="http://localhost:8000" make client-dev-server
 
+Sometimes you want to run your UI against a remote Galaxy server. This is also possible, if you enable `CHANGE_ORIGIN` flag 
+
+    CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.org/" make client-dev-server
+
 ## Changing Styles/CSS
 
 Galaxy uses Sass for its styling, which is a superset of CSS that compiles down

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -232,6 +232,8 @@ module.exports = (env = {}, argv = {}) => {
             proxy: {
                 "/": {
                     target: process.env.GALAXY_URL || "http://localhost:8080",
+                    secure: process.env.CHANGE_ORIGIN ? !process.env.CHANGE_ORIGIN : true,
+                    changeOrigin: !!process.env.CHANGE_ORIGIN,
                 },
             },
         },


### PR DESCRIPTION
A great feature discovered by @pvanheus. This PR introduces `CHANGE_ORIGIN` flag, that you need to enable to start webpack-dev-server on remote galaxy server

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. run ```CHANGE_ORIGIN=true GALAXY_URL="https://usegalaxy.eu/" make client-dev-server```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
