### PR TITLE
API test case to ensure model attributes get escaped during tool evaluation

### DIFF
--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -6,7 +6,7 @@ import zipfile
 from io import BytesIO
 
 import pytest
-from requests import get
+from requests import get, put
 
 from galaxy.util import galaxy_root_path
 from galaxy_test.base import rules_test_data
@@ -307,6 +307,40 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         tool_info = tool_show_response.json()
         self._assert_has_keys(tool_info, "inputs", "outputs", "panel_section_id")
         return tool_info
+
+    @skip_without_tool("model_attributes")
+    @uses_test_history(require_new=False)
+    def test_model_attributes_sanitization(self, history_id):
+        cool_name_with_quote = "cool name with a quo\"te"
+        cool_name_without_quote = "cool name with a quo__dq__te"
+
+        current_user = self._get("users/current").json()
+        user_info_url = self._api_url(f"users/{current_user['id']}/information/inputs", use_key=True)
+        put_response = put(user_info_url, data=json.dumps({"address_0|desc": cool_name_with_quote}))
+        put_response.raise_for_status()
+
+        response = get(user_info_url).json()
+        self.assertEqual(len(response["addresses"]), 1)
+        self.assertEqual(response["addresses"][0]["desc"], cool_name_with_quote)
+
+        hda1 = self.dataset_populator.new_dataset(history_id, content='1\t2\t3', name=cool_name_with_quote)
+        assert hda1["name"] == cool_name_with_quote
+
+        rval = self._run(
+            tool_id="model_attributes",
+            inputs={"input1": dataset_to_param(hda1)},
+            history_id=history_id,
+            assert_ok=True,
+            wait_for_job=True,
+        )
+        sanitized_dataset_name = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][0])
+        assert sanitized_dataset_name.strip() == cool_name_without_quote
+
+        sanitized_email = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][1])
+        assert '"' not in sanitized_email
+
+        sanitized_address = self.dataset_populator.get_history_dataset_content(history_id, dataset=rval["outputs"][2])
+        assert sanitized_address.strip() == cool_name_without_quote
 
     @skip_without_tool("composite_output")
     def test_test_data_filepath_security(self):

--- a/test/functional/tools/model_attributes.xml
+++ b/test/functional/tools/model_attributes.xml
@@ -1,0 +1,15 @@
+<tool id="model_attributes" name="model_attributes" version="0.1.0">
+    <command><![CDATA[
+        echo '$input1.name' > "$out_file1";
+        echo '$__user__.email' > "$out_file2";
+        echo '$__user__.addresses[0].desc' > "$out_file3";
+    ]]></command>
+    <inputs>
+        <param name="input1" type="data" label="Dataset with a name to output"/>
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="txt" />
+        <data name="out_file2" format="txt" />
+        <data name="out_file3" format="txt" />
+    </outputs>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -195,6 +195,7 @@
   <tool file="cheetah_problem_unbound_var.xml" />
   <tool file="cheetah_problem_unbound_var_input.xml" />
   <tool file="cheetah_problem_syntax_error.xml" />
+  <tool file="model_attributes.xml" />
   <tool file="python_environment_problem.xml" />
   <tool file="config_vars.xml" />
 


### PR DESCRIPTION
I think other sanitization properties aren't testing that model properties are escaped.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
