### PR TITLE
Fix sample job_config file to reflect that tmp_dir can be an expression or the string ``True``

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2043,10 +2043,14 @@ class JobWrapper(HasResourceParameters):
     @property
     def tmp_dir_creation_statement(self):
         tmp_dir = self.get_destination_configuration("tmp_dir", None)
-        if not tmp_dir or tmp_dir.lower() == "true":
-            working_directory = self.working_directory
-            return '''$([ ! -e '{0}/tmp' ] || mv '{0}/tmp' '{0}'/tmp.$(date +%Y%m%d-%H%M%S) ; mkdir '{0}/tmp'; echo '{0}/tmp')'''.format(working_directory)
-        else:
+        try:
+            if not tmp_dir or util.asbool(tmp_dir):
+                working_directory = self.working_directory
+                return '''$([ ! -e '{0}/tmp' ] || mv '{0}/tmp' '{0}'/tmp.$(date +%Y%m%d-%H%M%S) ; mkdir '{0}/tmp'; echo '{0}/tmp')'''.format(working_directory)
+            else:
+                return tmp_dir
+        except ValueError:
+            # Catch case where tmp_dir is a complex expression and not a boolean value
             return tmp_dir
 
     def home_directory(self):


### PR DESCRIPTION
… to reflect

Specifying it as a boolean actually fails on this line: https://github.com/galaxyproject/galaxy/blob/85d5e1269a1df056285aa0b831ba805b11ad2d61/lib/galaxy/jobs/__init__.py#L2046 as it expects a string.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
