### PR TITLE
Remove NetworkException catch clauses, so if irods server is down, NetworkException percolates up, preventing a silent failure and alerting us

### DIFF
--- a/lib/galaxy/config/sample/object_store_conf.xml.sample
+++ b/lib/galaxy/config/sample/object_store_conf.xml.sample
@@ -48,7 +48,7 @@
             <auth username="rods" password="rods" />
             <resource name="demoResc" />
             <zone name="tempZone" />
-            <connection host="localhost" port="1247" timeout="30" poolsize="3" refresh_time="300"/>
+            <connection host="localhost" port="1247" timeout="30" poolsize="3" refresh_time="300" healthcheck_time="300" />
             <cache path="database/object_store_cache_irods" size="1000" />
             <extra_dir type="job_work" path="database/job_working_directory_irods"/>
             <extra_dir type="temp" path="database/tmp_irods"/>

--- a/lib/galaxy/config/sample/object_store_conf.xml.sample
+++ b/lib/galaxy/config/sample/object_store_conf.xml.sample
@@ -48,7 +48,7 @@
             <auth username="rods" password="rods" />
             <resource name="demoResc" />
             <zone name="tempZone" />
-            <connection host="localhost" port="1247" timeout="30" poolsize="3" refresh_time="300" healthcheck_time="300" />
+            <connection host="localhost" port="1247" timeout="30" poolsize="3" refresh_time="300"/>
             <cache path="database/object_store_cache_irods" size="1000" />
             <extra_dir type="job_work" path="database/job_working_directory_irods"/>
             <extra_dir type="temp" path="database/tmp_irods"/>

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -64,7 +64,6 @@ def parse_config_xml(config_xml):
         timeout = int(c_xml[0].get('timeout', 30))
         poolsize = int(c_xml[0].get('poolsize', 3))
         refresh_time = int(c_xml[0].get('refresh_time', 300))
-        healthcheck_time = int(c_xml[0].get('healthcheck_time', 300))
 
         c_xml = config_xml.findall('cache')
         if not c_xml:
@@ -95,7 +94,6 @@ def parse_config_xml(config_xml):
                 'timeout': timeout,
                 'poolsize': poolsize,
                 'refresh_time': refresh_time,
-                'healthcheck_time': healthcheck_time,
             },
             'cache': {
                 'size': cache_size,
@@ -129,7 +127,6 @@ class CloudConfigMixin:
                 'timeout': self.timeout,
                 'poolsize': self.poolsize,
                 'refresh_time': self.refresh_time,
-                'healthcheck_time': self.healthcheck_time,
             },
             'cache': {
                 'size': self.cache_size,
@@ -193,9 +190,6 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
         self.refresh_time = connection_dict.get('refresh_time')
         if self.refresh_time is None:
             _config_dict_error('connection->refresh_time')
-        self.healthcheck_time = connection_dict.get('healthcheck_time')
-        if self.healthcheck_time is None:
-            _config_dict_error('connection->healthcheck_time')
 
         cache_dict = config_dict['cache']
         if cache_dict is None:
@@ -211,8 +205,6 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
         if not extra_dirs:
             _config_dict_error('extra_dirs')
         self.extra_dirs.update(extra_dirs)
-
-        self.last_healthcheck_time = datetime.now()
 
         if irods is None:
             raise Exception(IRODS_IMPORT_MESSAGE)


### PR DESCRIPTION
(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
