### PR TITLE
Provide more context in EDAM Tool Panel

### DIFF
--- a/client/src/components/Panels/Common/Tool.vue
+++ b/client/src/components/Panels/Common/Tool.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="toolTitle">
-        <a v-if="tool.disabled" class="name text-muted">
+        <a v-if="tool.disabled" class="title-link name text-muted">
             <span v-if="!hideName">{{ tool.name }}</span>
             <span class="description">{{ tool.description }}</span>
         </a>
@@ -61,9 +61,9 @@ export default {
     computed: {
         targetClass() {
             if (this.toolKey) {
-                return `tool-menu-item-${this.tool[this.toolKey]}`;
+                return `tool-menu-item-${this.tool[this.toolKey]} title-link`;
             } else {
-                return null;
+                return `title-link`;
             }
         },
     },

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -1,0 +1,16 @@
+<template>
+    <div class="tool-panel-label">
+        {{ definition.text }}
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        definition: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>

--- a/client/src/components/Panels/Common/ToolPanelLabel.vue
+++ b/client/src/components/Panels/Common/ToolPanelLabel.vue
@@ -1,15 +1,35 @@
 <template>
-    <div class="tool-panel-label">
+    <div
+        class="tool-panel-label"
+        :title="description"
+        v-b-tooltip.topright.hover
+        @mouseover="hover = true"
+        @mouseleave="hover = false"
+    >
         {{ definition.text }}
+        <ToolPanelLinks :show="hover" :links="definition.links" />
     </div>
 </template>
 
 <script>
+import ToolPanelLinks from "./ToolPanelLinks";
+
 export default {
+    components: { ToolPanelLinks },
     props: {
         definition: {
             type: Object,
             required: true,
+        },
+    },
+    data() {
+        return {
+            hover: false,
+        };
+    },
+    computed: {
+        description() {
+            return this.definition.description;
         },
     },
 };

--- a/client/src/components/Panels/Common/ToolPanelLinks.vue
+++ b/client/src/components/Panels/Common/ToolPanelLinks.vue
@@ -1,0 +1,33 @@
+<template>
+    <span v-if="link">
+        <a :href="link" target="_blank" style="display: inline">
+            <font-awesome-icon v-b-tooltip.hover title="Link" icon="external-link-alt" v-show="show" />
+        </a>
+    </span>
+</template>
+
+<script>
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faExternalLinkAlt);
+
+export default {
+    components: { FontAwesomeIcon },
+    props: {
+        links: {
+            type: Object,
+        },
+        show: {
+            type: Boolean,
+        },
+    },
+    computed: {
+        link() {
+            const links = Object.values(this.links || {});
+            return links.length > 0 ? links[0] : null;
+        },
+    },
+};
+</script>

--- a/client/src/components/Panels/Common/ToolSection.test.js
+++ b/client/src/components/Panels/Common/ToolSection.test.js
@@ -44,8 +44,8 @@ describe("ToolSection", () => {
         await wrapper.vm.$nextTick();
         const $names = wrapper.findAll(".name");
         expect($names.at(1).text()).toBe("name");
-        const $label = wrapper.find(".tool-panel-label");
-        expect($label.text()).toBe("text");
+        const $label = wrapper.find(".title-link");
+        expect($label.text()).toBe("tool_section");
         $sectionName.trigger("click");
         await wrapper.vm.$nextTick();
         expect(wrapper.findAll(".name").length).toBe(1);

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -1,10 +1,17 @@
 <template>
     <div v-if="isSection && hasElements" class="tool-panel-section">
-        <div :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]">
-            <a @click="toggleMenu()" href="javascript:void(0)" role="button">
+        <div
+            :class="['toolSectionTitle', `tool-menu-section-${sectionName}`]"
+            :title="title"
+            v-b-tooltip.topright.hover
+            @mouseover="hover = true"
+            @mouseleave="hover = false"
+        >
+            <a class="title-link" @click="toggleMenu()" href="javascript:void(0)">
                 <span class="name">
                     {{ this.name }}
                 </span>
+                <ToolPanelLinks :links="links" :show="hover" />
             </a>
         </div>
         <transition name="slide">
@@ -45,12 +52,14 @@
 import Tool from "./Tool";
 import ToolPanelLabel from "./ToolPanelLabel";
 import ariaAlert from "utils/ariaAlert";
+import ToolPanelLinks from "./ToolPanelLinks";
 
 export default {
     name: "ToolSection",
     components: {
         Tool,
         ToolPanelLabel,
+        ToolPanelLinks,
     },
     props: {
         category: {
@@ -91,6 +100,7 @@ export default {
     data() {
         return {
             opened: this.expanded || this.checkFilter(),
+            hover: false,
         };
     },
     watch: {
@@ -113,6 +123,12 @@ export default {
         },
         hasElements() {
             return this.category.elems && this.category.elems.length > 0;
+        },
+        title() {
+            return this.category.description;
+        },
+        links() {
+            return this.category.links || {};
         },
     },
     methods: {

--- a/client/src/components/Panels/Common/ToolSection.vue
+++ b/client/src/components/Panels/Common/ToolSection.vue
@@ -10,9 +10,7 @@
         <transition name="slide">
             <div v-if="opened">
                 <template v-for="[key, el] in category.elems.entries()">
-                    <div v-if="el.text" class="tool-panel-label" :key="key">
-                        {{ el.text }}
-                    </div>
+                    <ToolPanelLabel v-if="category.text" :definition="el" :key="key" />
                     <tool
                         v-else
                         class="ml-2"
@@ -30,9 +28,7 @@
         </transition>
     </div>
     <div v-else>
-        <div v-if="category.text" class="tool-panel-label">
-            {{ category.text }}
-        </div>
+        <ToolPanelLabel v-if="category.text" :definition="category" />
         <tool
             v-else
             :tool="category"
@@ -47,12 +43,14 @@
 
 <script>
 import Tool from "./Tool";
+import ToolPanelLabel from "./ToolPanelLabel";
 import ariaAlert from "utils/ariaAlert";
 
 export default {
     name: "ToolSection",
     components: {
         Tool,
+        ToolPanelLabel,
     },
     props: {
         category: {

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -51,7 +51,7 @@
                 <div id="internal-workflows" class="toolSectionBody">
                     <div class="toolSectionBg" />
                     <div class="toolTitle" v-for="wf in workflows" :key="wf.id">
-                        <a :href="wf.href">{{ wf.title }}</a>
+                        <a class="title-link" :href="wf.href">{{ wf.title }}</a>
                     </div>
                 </div>
             </div>

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -1271,7 +1271,7 @@ div.toolSectionTitle {
     .labels {
         float: right;
     }
-    a {
+    .title-link {
         @extend .px-3;
         @extend .py-1;
         text-decoration: none;

--- a/lib/galaxy/tool_util/edam_util.py
+++ b/lib/galaxy/tool_util/edam_util.py
@@ -8,9 +8,6 @@ except ImportError:
     tabular_stream = None
 
 EDAM_PREFIX = 'http://edamontology.org/'
-COLUMN_TERM = 0
-COLUMN_LABEL = 1
-COLUMN_PARENTS = 7
 
 ROOT_OPERATION = 'operation_0004'
 ROOT_TOPIC = 'topic_0003'
@@ -36,10 +33,22 @@ def load_edam_tree_from_tsv_stream(tsv_stream: TextIO):
         else:
             yield path
 
+    is_first = True
     for line in tsv_stream.readlines():
         fields = line.split('\t')
+        if is_first:
+            columns = {}
+            for i, field in enumerate(fields):
+                columns[field] = i
+            is_first = False
 
-        term = fields[COLUMN_TERM]
+            defintion_column = columns["http://www.geneontology.org/formats/oboInOwl#hasDefinition"]
+            term_column = columns["Class ID"]
+            label_column = columns["Preferred Label"]
+            parents_column = columns["Parents"]
+            continue
+
+        term = fields[term_column]
         if not term.startswith(EDAM_PREFIX):
             continue
 
@@ -49,9 +58,10 @@ def load_edam_tree_from_tsv_stream(tsv_stream: TextIO):
         if not (term_id.startswith('operation_') or term_id.startswith('topic_')):
             continue
 
-        parents = fields[COLUMN_PARENTS].split('|')
+        parents = fields[parents_column].split('|')
         edam[term_id] = {
-            'label': fields[COLUMN_LABEL],  # preferred label
+            'label': fields[label_column],
+            'definition': fields[defintion_column].strip('"'),
             'parents': [x[len(EDAM_PREFIX):] for x in parents if x.startswith(EDAM_PREFIX)],
         }
 

--- a/lib/galaxy/tool_util/toolbox/panel.py
+++ b/lib/galaxy/tool_util/toolbox/panel.py
@@ -47,7 +47,7 @@ class ToolSection(Dictifiable, HasPanelItems):
     group in the user interface.
     """
 
-    dict_collection_visible_keys = ['id', 'name', 'version']
+    dict_collection_visible_keys = ['id', 'name', 'version', 'description', 'links']
 
     def __init__(self, item=None):
         """ Build a ToolSection from an ElementTree element or a dictionary.
@@ -57,6 +57,8 @@ class ToolSection(Dictifiable, HasPanelItems):
         self.name = item.get('name') or ''
         self.id = item.get('id') or ''
         self.version = item.get('version') or ''
+        self.description = item.get('description') or None
+        self.links = item.get('links') or None
         self.elems = ToolPanelElements()
 
     def copy(self):
@@ -64,6 +66,8 @@ class ToolSection(Dictifiable, HasPanelItems):
         copy.name = self.name
         copy.id = self.id
         copy.version = self.version
+        copy.description = self.description
+        copy.links = self.links
         copy.elems.update(self.elems)
         return copy
 
@@ -95,7 +99,7 @@ class ToolSectionLabel(Dictifiable):
     A label for a set of tools that can be displayed above groups of tools
     and sections in the user interface
     """
-    dict_collection_visible_keys = ['id', 'text', 'version']
+    dict_collection_visible_keys = ['id', 'text', 'version', 'description', 'links']
 
     def __init__(self, item):
         """ Build a ToolSectionLabel from an ElementTree element or a
@@ -105,6 +109,8 @@ class ToolSectionLabel(Dictifiable):
         self.text = item.get("text")
         self.id = item.get("id")
         self.version = item.get("version") or ''
+        self.description = item.get('description') or None
+        self.links = item.get('links', None)
 
     def to_dict(self, **kwds):
         return super().to_dict()
@@ -135,9 +141,9 @@ class ToolPanelElements(odict, HasPanelItems):
                     self[key].elems[tool_key] = new_tool
                     break
 
-    def get_or_create_section(self, sec_id: str, sec_nm: str) -> ToolSection:
+    def get_or_create_section(self, sec_id: str, sec_nm: str, description: Optional[str] = None, links: Optional[Dict[str, str]] = None) -> ToolSection:
         if sec_id not in self:
-            section = ToolSection({'id': sec_id, 'name': sec_nm, 'version': ''})
+            section = ToolSection({'id': sec_id, 'name': sec_nm, 'description': description, 'version': '', 'links': links})
             self[sec_id] = section
         else:
             section = self[sec_id]

--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -80,6 +80,18 @@ class EdamToolPanelView(ToolPanelView):
                             topics[t][tool_id] = (term, tool_id, key, val, val_name)
 
         new_panel = ToolPanelElements()
+
+        def populate_section(term, tool_id, key, val, val_name):
+            edam_def = self.edam[term]
+            description = edam_def['definition']
+            label = edam_def['label']
+            links = {
+                'edam_browser': f"https://edamontology.github.io/edam-browser/#{term}",
+            }
+            section = new_panel.get_or_create_section(term, label, description=description, links=links)
+            toolbox_registry.add_tool_to_tool_panel_view(val, section)
+            new_panel.record_section_for_tool_id(tool_id, key, val_name)
+
         for term in sorted(operations.keys(), key=lambda x: self._sort_edam_key(x)):
             if len(operations[term].keys()) == 0:
                 continue
@@ -87,15 +99,16 @@ class EdamToolPanelView(ToolPanelView):
             label_dict = {
                 'type': 'label',
                 'text': self.edam[term]['label'],
+                'description': self.edam[term]['definition'],
+                'links': {
+                    'edam_browser': f"https://edamontology.github.io/edam-browser/#{term}",
+                },
                 'id': term,
             }
             new_panel[f"label_{term}"] = ToolSectionLabel(label_dict)
 
             for (term, tool_id, key, val, val_name) in operations[term].values():
-                section = new_panel.get_or_create_section(term, self.edam[term]['label'])
-
-                toolbox_registry.add_tool_to_tool_panel_view(val, section)
-                new_panel.record_section_for_tool_id(tool_id, key, val_name)
+                populate_section(term, tool_id, key, val, val_name)
 
         for term in sorted(topics.keys(), key=lambda x: self._sort_edam_key(x)):
             if len(topics[term].keys()) == 0:
@@ -104,14 +117,16 @@ class EdamToolPanelView(ToolPanelView):
             label_dict = {
                 'type': 'label',
                 'text': self.edam[term]['label'],
+                'description': self.edam[term]['definition'],
+                'links': {
+                    'edam_browser': f"https://edamontology.github.io/edam-browser/#{term}",
+                },
                 'id': term,
             }
             new_panel[f"label_{term}"] = ToolSectionLabel(label_dict)
 
             for (term, tool_id, key, val, val_name) in topics[term].values():
-                section = new_panel.get_or_create_section(term, self.edam[term]['label'])
-                toolbox_registry.add_tool_to_tool_panel_view(val, section)
-                new_panel.record_section_for_tool_id(tool_id, key, val_name)
+                populate_section(term, tool_id, key, val, val_name)
 
         section = new_panel.get_or_create_section('uncategorized', 'Uncategorized')
         for (tool_id, key, val, val_name) in uncategorized:

--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -9,7 +9,6 @@ from galaxy.tool_util.edam_util import (
     ROOT_TOPIC,
 )
 from galaxy.util import (
-    etree,
     ExecutionTimer,
 )
 from .interface import (
@@ -85,10 +84,12 @@ class EdamToolPanelView(ToolPanelView):
             if len(operations[term].keys()) == 0:
                 continue
 
-            elem = etree.Element('label')
-            elem.attrib['text'] = self.edam[term]['label']
-            elem.attrib['id'] = term
-            new_panel[f"label_{term}"] = ToolSectionLabel(elem)
+            label_dict = {
+                'type': 'label',
+                'text': self.edam[term]['label'],
+                'id': term,
+            }
+            new_panel[f"label_{term}"] = ToolSectionLabel(label_dict)
 
             for (term, tool_id, key, val, val_name) in operations[term].values():
                 section = new_panel.get_or_create_section(term, self.edam[term]['label'])
@@ -100,10 +101,12 @@ class EdamToolPanelView(ToolPanelView):
             if len(topics[term].keys()) == 0:
                 continue
 
-            elem = etree.Element('label')
-            elem.attrib['text'] = self.edam[term]['label']
-            elem.attrib['id'] = term
-            new_panel[f"label_{term}"] = ToolSectionLabel(elem)
+            label_dict = {
+                'type': 'label',
+                'text': self.edam[term]['label'],
+                'id': term,
+            }
+            new_panel[f"label_{term}"] = ToolSectionLabel(label_dict)
 
             for (term, tool_id, key, val, val_name) in topics[term].values():
                 section = new_panel.get_or_create_section(term, self.edam[term]['label'])

--- a/test/unit/tool_util/test_edam_util.py
+++ b/test/unit/tool_util/test_edam_util.py
@@ -26,3 +26,4 @@ def _verify_tree(tree: Dict[str, Any]):
     assert tree["topic_3974"]["label"] == "Epistasis"
     assert tree["topic_3974"]["parents"] == ['topic_0622', 'topic_3295']
     assert tree["topic_3974"]["path"] == [['topic_3391', 'topic_0003'], ['topic_3070', 'topic_0003']]
+    assert tree["topic_3974"]["definition"] == "The study of the epigenetic modifications of a whole cell, tissue, organism etc."


### PR DESCRIPTION
## How to test the changes?

- [x] Instructions for manual testing are as follows:
  1. Load the EDAM tool panel view and notice there are now more details about EDAM terms and such.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
