### PR TITLE
FastAPI: deprecate url attribute (again)

### DIFF
--- a/lib/galaxy/managers/base.py
+++ b/lib/galaxy/managers/base.py
@@ -39,7 +39,6 @@ from typing import (
     Type,
 )
 
-import routes
 import sqlalchemy
 from sqlalchemy.orm.scoping import scoped_session
 
@@ -51,6 +50,7 @@ from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import BasicApp, MinimalManagerApp
 from galaxy.util import namedtuple
+from galaxy.web import url_for as gx_url_for
 
 log = logging.getLogger(__name__)
 
@@ -554,7 +554,7 @@ class ModelSerializer(HasAModelManager):
         item_dict = MySerializer.serialize( my_item, keys_to_serialize )
     """
     #: 'service' to use for getting urls - use class var to allow overriding when testing
-    url_for = staticmethod(routes.url_for)
+    url_for = staticmethod(gx_url_for)
     default_view: Optional[str]
     views: Dict[str, List[str]]
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -51,7 +51,7 @@ RelativeUrlField: RelativeUrl = Field(
     ...,
     title="URL",
     description="The relative URL to access this item.",
-    deprecated=False  # TODO Should this field be deprecated in FastAPI?
+    deprecated=True,
 )
 
 DownloadUrlField: RelativeUrl = Field(

--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -4,4 +4,19 @@ Galaxy web application framework
 
 from . import base
 
-url_for = base.routes.url_for
+DEPRECATED_URL_ATTRIBUTE_MESSAGE = "*deprecated attribute, URL not filled in by server*"
+
+
+def handle_url_for(*args, **kargs) -> str:
+    """Tries to resolve the URL using the `routes` module.
+
+    This only works in a WSGI app so a deprecation message is returned
+    when running an ASGI app.
+    """
+    try:
+        return base.routes.url_for(*args, **kargs)
+    except AttributeError:
+        return DEPRECATED_URL_ATTRIBUTE_MESSAGE
+
+
+url_for = handle_url_for

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -28,7 +28,3 @@ def parse_serialization_params(
     if keys:
         key_list = keys.split(',')
     return dict(view=view, keys=key_list, default_view=default_view)
-
-
-def fastapi_deprecation_message():
-    return "*deprecated attribute not filled in by FastAPI server*"

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -5,7 +5,6 @@ API operations on Group objects.
 import logging
 
 from fastapi import Path
-from routes.util import url_for
 
 from galaxy.managers.context import ProvidesAppContext
 from galaxy.managers.group_roles import GroupRolesManager
@@ -14,8 +13,8 @@ from galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 from galaxy.web import (
     expose_api,
     require_admin,
+    url_for,
 )
-from galaxy.webapps.galaxy.api.common import fastapi_deprecation_message
 from . import (
     BaseGalaxyAPIController,
     depends,
@@ -43,11 +42,7 @@ RoleIDParam: EncodedDatabaseIdField = Path(
 
 def group_role_to_model(trans, encoded_group_id, role):
     encoded_role_id = trans.security.encode_id(role.id)
-    try:
-        url = url_for('group_role', group_id=encoded_group_id, id=encoded_role_id)
-    except AttributeError:
-        url = fastapi_deprecation_message()
-
+    url = url_for('group_role', group_id=encoded_group_id, id=encoded_role_id)
     return GroupRoleModel(
         id=encoded_role_id,
         name=role.name,

--- a/lib/galaxy/webapps/galaxy/api/roles.py
+++ b/lib/galaxy/webapps/galaxy/api/roles.py
@@ -19,7 +19,6 @@ from galaxy.schema.schema import (
     RoleModel,
 )
 from galaxy.webapps.base.controller import url_for
-from galaxy.webapps.galaxy.api.common import fastapi_deprecation_message
 from . import (
     BaseGalaxyAPIController,
     depends,
@@ -38,10 +37,7 @@ router = Router(tags=["roles"])
 def role_to_model(trans, role):
     item = role.to_dict(view='element', value_mapper={'id': trans.security.encode_id})
     role_id = trans.security.encode_id(role.id)
-    try:
-        item['url'] = url_for('role', id=role_id)
-    except AttributeError:
-        item['url'] = fastapi_deprecation_message()
+    item['url'] = url_for('role', id=role_id)
     return RoleModel(**item)
 
 

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from galaxy.web.framework import DEPRECATED_URL_ATTRIBUTE_MESSAGE
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -67,7 +68,10 @@ class GroupRolesApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_role = update_response.json()
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
-        assert (group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}" or group_role["url"] == "*deprecated attribute not filled in by FastAPI server*")
+        assert (
+            group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}"
+            or group_role["url"] == DEPRECATED_URL_ATTRIBUTE_MESSAGE
+        )
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"


### PR DESCRIPTION
This is a revival of https://github.com/galaxyproject/galaxy/pull/11608

It handles the deprecation of the URL attribute in API responses in a global way. This should simplify our current approach of handling the `AttributeError` on each serializer. Also, the new `DEPRECATED_URL_ATTRIBUTE_MESSAGE` makes the error message slightly clearer in the sense that the deprecated attribute is always an URL that cannot be generated.

## Reasons
I figured out that I closed the [old PR](https://github.com/galaxyproject/galaxy/pull/11608) too soon, as https://github.com/galaxyproject/galaxy/pull/11904 fixes the [subjacent issue](https://github.com/galaxyproject/galaxy/pull/11608/files#r601625363) with qualified URLs in data source tools but we may still want to deprecate the URL attributes in the response models when moving to FastAPI or, at least, reopen the discussion about it.

## Concerns
It is worth noting that `routes.url_for` doesn't work in a FastAPI/ASGI context but it is heavily used across the codebase so there may be some use cases where an URL must be generated and not just filled in with a deprecation message. In those particular cases, we can try to use the #11904 approach when the need arises.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
