### PR TITLE
Improve k8s docker image

### DIFF
--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -18,11 +18,8 @@
 ARG ROOT_DIR=/galaxy
 ARG SERVER_DIR=$ROOT_DIR/server
 
-# For much faster build time override this with image0 (Dockerfile.0 build):
-#   docker build --build-arg BASE=<image0 name>...
 ARG STAGE1_BASE=python:3.7-slim
 ARG FINAL_STAGE_BASE=$STAGE1_BASE
-# NOTE: the value of GALAXY_USER must be also hardcoded in COPY in final stage
 ARG GALAXY_USER=galaxy
 ARG GALAXY_PLAYBOOK_REPO=https://github.com/galaxyproject/galaxy-docker-k8s
 
@@ -153,9 +150,9 @@ RUN set -xe; \
 
 WORKDIR $ROOT_DIR
 # Copy galaxy files to final image
-# The chown value MUST be hardcoded (see #35018 at github.com/moby/moby)
-COPY --chown=galaxy:galaxy --from=server_build $ROOT_DIR .
-COPY --chown=galaxy:galaxy --from=client_build $SERVER_DIR/static ./server/static
+# The chown value MUST be hardcoded (see https://github.com/moby/moby/issues/35018)
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=server_build $ROOT_DIR .
+COPY --chown=$GALAXY_USER:$GALAXY_USER --from=client_build $SERVER_DIR/static ./server/static
 
 WORKDIR $SERVER_DIR
 EXPOSE 8080

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -134,6 +134,7 @@ RUN set -xe; \
         procps \
         less \
         bzip2 \
+        tini \
     && update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 0 \
     && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 0 \
     && echo "set nocompatible\nset backspace=indent,eol,start" >> /usr/share/vim/vimrc.tiny \
@@ -160,6 +161,8 @@ USER $GALAXY_USER
 
 ENV PATH="$SERVER_DIR/.venv/bin:${PATH}"
 ENV GALAXY_CONFIG_CONDA_AUTO_INIT=False
+
+ENTRYPOINT ["tini", "--"]
 
 # [optional] to run:
 CMD uwsgi --yaml config/galaxy.yml

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -136,7 +136,7 @@ RUN set -xe; \
         bzip2 \
     && update-alternatives --install /usr/bin/nano nano /bin/nano-tiny 0 \
     && update-alternatives --install /usr/bin/vim vim /usr/bin/vim.tiny 0 \
-    && echo "set nocompatible" >> /usr/share/vim/vimrc.tiny \
+    && echo "set nocompatible\nset backspace=indent,eol,start" >> /usr/share/vim/vimrc.tiny \
     && echo "$LANG UTF-8" > /etc/locale.gen \
     && locale-gen $LANG && update-locale LANG=$LANG \
     && apt-get autoremove -y && apt-get clean \


### PR DESCRIPTION
* Use env var when performing chown in k8s docker instead of hardcoded username (no longer an issue on newer docker versions)
* Enable use of backspace in k8s docker vim
* Change entrypoint to tini in k8s docker (uwsgi doesn't need tini, but the remaining processes do)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
