### PR TITLE
Mention collection name and element identifier when test comparison fails

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -142,13 +142,16 @@ class GalaxyInteractorApi:
 
         def verify_dataset(element, element_attrib, element_outfile):
             hda = element["object"]
-            self.verify_output_dataset(
-                history,
-                hda_id=hda["id"],
-                outfile=element_outfile,
-                attributes=element_attrib,
-                tool_id=tool_id
-            )
+            try:
+                self.verify_output_dataset(
+                    history,
+                    hda_id=hda["id"],
+                    outfile=element_outfile,
+                    attributes=element_attrib,
+                    tool_id=tool_id
+                )
+            except AssertionError as e:
+                raise AssertionError(f"Collection element {element.get('element_identifier', '')} of collection {output_collection_def.name}: {e}")
 
         verify_collection(output_collection_def, data_collection, verify_dataset)
 
@@ -869,7 +872,7 @@ def verify_collection(output_collection_def, data_collection, verify_dataset):
             element_type = element["element_type"]
             if element_type != "dataset_collection":
                 verify_dataset(element, element_attrib, element_outfile)
-            if element_type == "dataset_collection":
+            else:
                 elements = element["object"]["elements"]
                 verify_elements(elements, element_attrib.get("elements", {}))
 


### PR DESCRIPTION
For collections `planemo test` output for found file diff is `History item  different than expected...` which is not really helpful.

This PR adds the collection name and element identifier to the output.

Essentially a follow up to https://github.com/galaxyproject/galaxy/pull/9771

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
