### PR TITLE
Extend per_host configurations to include static directories and files.

### DIFF
--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -1008,13 +1008,19 @@ def build_url_map(app, global_conf, local_conf):
         cache_time = int(cache_time)
     # Send to dynamic app by default
     urlmap["/"] = app
+
+    def get_static_from_config(option_name, default_path):
+        config_val = conf.get(option_name, default_url_path(default_path))
+        return Static(config_val, cache_time)
+
     # Define static mappings from config
-    urlmap["/static"] = Static(conf.get("static_dir", default_url_path("static/")), cache_time)
-    urlmap["/images"] = Static(conf.get("static_images_dir", default_url_path("static/images")), cache_time)
-    urlmap["/static/scripts"] = Static(conf.get("static_scripts_dir", default_url_path("static/scripts/")), cache_time)
-    urlmap["/static/welcome.html"] = Static(conf.get("static_welcome_html", default_url_path("static/welcome.html")), cache_time)
-    urlmap["/favicon.ico"] = Static(conf.get("static_favicon_dir", default_url_path("static/favicon.ico")), cache_time)
-    urlmap["/robots.txt"] = Static(conf.get("static_robots_txt", default_url_path("static/robots.txt")), cache_time)
+    urlmap["/static"] = get_static_from_config("static_dir", "static/")
+    urlmap["/images"] = get_static_from_config("static_images_dir", "static/images")
+    urlmap["/static/scripts"] = get_static_from_config("static_scripts_dir", "static/scripts/")
+    urlmap["/static/welcome.html"] = get_static_from_config("static_welcome_html", "static/welcome.html")
+    urlmap["/favicon.ico"] = get_static_from_config("static_favicon_dir", "static/favicon.ico")
+    urlmap["/robots.txt"] = get_static_from_config("static_robots_txt", "static/robots.txt")
+
     if 'static_local_dir' in conf:
         urlmap["/static_local"] = Static(conf["static_local_dir"], cache_time)
     return urlmap, cache_time

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -1011,7 +1011,9 @@ def build_url_map(app, global_conf, local_conf):
 
     def get_static_from_config(option_name, default_path):
         config_val = conf.get(option_name, default_url_path(default_path))
-        return Static(config_val, cache_time)
+        per_host_config_option = f"{option_name}_by_host"
+        per_host_config = conf.get(per_host_config_option)
+        return Static(config_val, cache_time, directory_per_host=per_host_config)
 
     # Define static mappings from config
     urlmap["/static"] = get_static_from_config("static_dir", "static/")

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -1479,6 +1479,7 @@ mapping:
       static_dir:
         type: str
         default: static/
+        per_host: true
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a
@@ -1489,6 +1490,7 @@ mapping:
       static_images_dir:
         type: str
         default: static/images
+        per_host: true
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a
@@ -1499,6 +1501,7 @@ mapping:
       static_favicon_dir:
         type: str
         default: static/favicon.ico
+        per_host: true
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a
@@ -1509,6 +1512,7 @@ mapping:
       static_scripts_dir:
         type: str
         default: static/scripts/
+        per_host: true
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a
@@ -1519,6 +1523,7 @@ mapping:
       static_style_dir:
         type: str
         default: static/style
+        per_host: true
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a
@@ -1529,6 +1534,7 @@ mapping:
       static_robots_txt:
         type: str
         default: static/robots.txt
+        per_host: true
         required: false
         desc: |
           Serve static content, which must be enabled if you're not serving it via a


### PR DESCRIPTION
Extends https://github.com/galaxyproject/galaxy/pull/12328 to include static files and directories as request by @bgruening on the pull request review.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
 1. Setup a `static_dir_by_host` value in galaxy.yml
```
  static_dir_by_host: 
    'localhost': 'static'
    '127.0.0.1': 'static2'
```
  2. Copy `static/` to `static2/` and add a line to `static2/robots.txt`.
  3. Start Galaxy on localhost.
  3. Verify the change when visiting Galaxy at `localhost:8080/robots.txt` vs `127.0.0.1:8080/robots.txt`.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
