### PR TITLE
Removing unused poolsize from code and config. 

### DIFF
--- a/lib/galaxy/config/sample/object_store_conf.xml.sample
+++ b/lib/galaxy/config/sample/object_store_conf.xml.sample
@@ -48,7 +48,7 @@
             <auth username="rods" password="rods" />
             <resource name="demoResc" />
             <zone name="tempZone" />
-            <connection host="localhost" port="1247" timeout="30" poolsize="3" refresh_time="300"/>
+            <connection host="localhost" port="1247" timeout="30" refresh_time="300"/>
             <cache path="database/object_store_cache_irods" size="1000" />
             <extra_dir type="job_work" path="database/job_working_directory_irods"/>
             <extra_dir type="temp" path="database/tmp_irods"/>

--- a/lib/galaxy/objectstore/irods.py
+++ b/lib/galaxy/objectstore/irods.py
@@ -62,7 +62,6 @@ def parse_config_xml(config_xml):
         host = c_xml[0].get('host', None)
         port = int(c_xml[0].get('port', 0))
         timeout = int(c_xml[0].get('timeout', 30))
-        poolsize = int(c_xml[0].get('poolsize', 3))
         refresh_time = int(c_xml[0].get('refresh_time', 300))
 
         c_xml = config_xml.findall('cache')
@@ -92,7 +91,6 @@ def parse_config_xml(config_xml):
                 'host': host,
                 'port': port,
                 'timeout': timeout,
-                'poolsize': poolsize,
                 'refresh_time': refresh_time,
             },
             'cache': {
@@ -125,7 +123,6 @@ class CloudConfigMixin:
                 'host': self.host,
                 'port': self.port,
                 'timeout': self.timeout,
-                'poolsize': self.poolsize,
                 'refresh_time': self.refresh_time,
             },
             'cache': {
@@ -184,9 +181,6 @@ class IRODSObjectStore(DiskObjectStore, CloudConfigMixin):
         self.timeout = connection_dict.get('timeout')
         if self.timeout is None:
             _config_dict_error('connection->timeout')
-        self.poolsize = connection_dict.get('poolsize')
-        if self.poolsize is None:
-            _config_dict_error('connection->poolsize')
         self.refresh_time = connection_dict.get('refresh_time')
         if self.refresh_time is None:
             _config_dict_error('connection->refresh_time')


### PR DESCRIPTION
This seems to be stale code for a previous effort to manage connection pool size by Galaxy (which was abandoned)

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
