### PR TITLE
Fixes to contents/near api endpoint

### DIFF
--- a/client/src/components/History/caching/loadHistoryContents.js
+++ b/client/src/components/History/caching/loadHistoryContents.js
@@ -22,7 +22,7 @@ export const clearHistoryDateStore = async () => {
  */
 // prettier-ignore
 export const loadHistoryContents = (cfg = {}) => (rawInputs$) => {
-    const { 
+    const {
         noInitial = false,
         windowSize = SearchParams.pageSize
     } = cfg;
@@ -39,7 +39,7 @@ export const loadHistoryContents = (cfg = {}) => (rawInputs$) => {
             return `${baseUrl}?${params.historyContentQueryString}`;
         }),
         map(prependPath),
-        requestWithUpdateTime({ dateStore, noInitial, responseQualifier }),
+        requestWithUpdateTime({ dateStore, noInitial, responseQualifier, dateFieldName: "since" }),
     );
 
     const validResponses$ = ajaxResponse$.pipe(
@@ -81,7 +81,7 @@ export const loadHistoryContents = (cfg = {}) => (rawInputs$) => {
 
             const matches = areDefined(matchesUp, matchesDown) ? matchesUp + matchesDown : undefined;
             const totalMatches = areDefined(totalMatchesUp, totalMatchesDown) ? totalMatchesUp + totalMatchesDown : undefined;
-            
+
             return {
                 summary,
                 matches,

--- a/lib/galaxy/model/migrate/versions/0177_update_job_state_summary.py
+++ b/lib/galaxy/model/migrate/versions/0177_update_job_state_summary.py
@@ -16,7 +16,6 @@ def upgrade(migrate_engine):
     downgrade(migrate_engine)
     view = HistoryDatasetCollectionJobStateSummary
     create_view = CreateView(view.name, view.__view__)
-    # print(str(create_view.compile(migrate_engine)))
     migrate_engine.execute(create_view)
 
 

--- a/lib/galaxy/model/migrate/versions/0177_update_job_state_summary.py
+++ b/lib/galaxy/model/migrate/versions/0177_update_job_state_summary.py
@@ -1,0 +1,26 @@
+"""
+Update job-state-summary view for hdca elements to include job directly tied with the hdca
+"""
+
+import logging
+
+from galaxy.model.view import HistoryDatasetCollectionJobStateSummary
+from galaxy.model.view.utils import CreateView, DropView
+
+log = logging.getLogger(__name__)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    # drop first because sqlite does not support or_replace
+    downgrade(migrate_engine)
+    view = HistoryDatasetCollectionJobStateSummary
+    create_view = CreateView(view.name, view.__view__)
+    # print(str(create_view.compile(migrate_engine)))
+    migrate_engine.execute(create_view)
+
+
+def downgrade(migrate_engine):
+    drop_view = DropView(HistoryDatasetCollectionJobStateSummary.name)
+    # print(str(drop_view.compile(migrate_engine)))
+    migrate_engine.execute(drop_view)

--- a/lib/galaxy/model/migrate/versions/0177_update_job_state_summary.py
+++ b/lib/galaxy/model/migrate/versions/0177_update_job_state_summary.py
@@ -21,5 +21,4 @@ def upgrade(migrate_engine):
 
 def downgrade(migrate_engine):
     drop_view = DropView(HistoryDatasetCollectionJobStateSummary.name)
-    # print(str(drop_view.compile(migrate_engine)))
     migrate_engine.execute(drop_view)

--- a/lib/galaxy/model/view/__init__.py
+++ b/lib/galaxy/model/view/__init__.py
@@ -9,7 +9,7 @@ from galaxy.model.view.utils import View
 
 AGGREGATE_STATE_QUERY = """
 SELECT
-    hdca.id as hdca_id,
+    hdca_id,
     SUM(CASE WHEN state = 'new' THEN 1 ELSE 0 END) AS new,
     SUM(CASE WHEN state = 'resubmitted' THEN 1 ELSE 0 END) AS resubmitted,
     SUM(CASE WHEN state = 'waiting' THEN 1 ELSE 0 END) AS waiting,
@@ -22,15 +22,25 @@ SELECT
     SUM(CASE WHEN state = 'deleted' THEN 1 ELSE 0 END) AS deleted,
     SUM(CASE WHEN state = 'deleted_new' THEN 1 ELSE 0 END) AS deleted_new,
     SUM(CASE WHEN state = 'upload' THEN 1 ELSE 0 END) AS upload,
-    SUM(CASE WHEN job.id IS NOT NULL THEN 1 ELSE 0 END) AS all_jobs
-FROM history_dataset_collection_association hdca
-LEFT JOIN implicit_collection_jobs icj
-    ON icj.id = hdca.implicit_collection_jobs_id
-LEFT JOIN implicit_collection_jobs_job_association icjja
-    ON icj.id = icjja.implicit_collection_jobs_id
-LEFT JOIN job
-    ON icjja.job_id = job.id
-GROUP BY hdca.id
+    SUM(CASE WHEN job_id IS NOT NULL THEN 1 ELSE 0 END) AS all_jobs
+FROM (
+    SELECT hdca.id AS hdca_id, job.id AS job_id, job.state as state
+    FROM history_dataset_collection_association hdca
+    LEFT JOIN implicit_collection_jobs icj
+        ON icj.id = hdca.implicit_collection_jobs_id
+    LEFT JOIN implicit_collection_jobs_job_association icjja
+        ON icj.id = icjja.implicit_collection_jobs_id
+    LEFT JOIN job
+        ON icjja.job_id = job.id
+
+    UNION
+
+    SELECT hdca.id AS hdca_id, job.id AS job_id, job.state AS state
+    FROM history_dataset_collection_association hdca
+    LEFT JOIN job
+        ON hdca.job_id = job.id
+) jobstates
+GROUP BY jobstates.hdca_id
 """
 
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -792,7 +792,7 @@ class HistoriesContentsService(ServiceBase):
             # To avoid having to manually process every IS08601 date format, simply convert
             # history.update_time to UTC/timezone aware before performing the inequality
 
-            since = since if since.tzinfo is not None else since.replace(tzinfo=datetime.timezone.utc)
+            since = since.replace(tzinfo=datetime.timezone.utc) if since.tzinfo is None else since
             history_update_time_tz = history.update_time.replace(tzinfo=datetime.timezone.utc)
 
             if history_update_time_tz <= since:

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -1772,7 +1772,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         filter_params = self._parse_rest_params(kwd)
         hid = int(hid)
         limit = int(limit)
-        since = kwd.get('update_time-gt', None)
+        since = kwd.get('since', None)
         if since:
             since = dateutil.parser.isoparse(since)
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -789,13 +789,9 @@ class HistoriesContentsService(ServiceBase):
         if since:
             # sqlalchemy DateTime columns are not timezone aware, but `since` may be a timezone aware
             # DateTime object if a timezone offset is provided (https://github.com/samuelcolvin/pydantic/blob/5ccbdcb5904f35834300b01432a665c75dc02296/pydantic/datetime_parse.py#L179).
-            # To avoid having to manually process every IS08601 date format, simply convert
-            # history.update_time to UTC/timezone aware before performing the inequality
-
-            since = since.replace(tzinfo=datetime.timezone.utc) if since.tzinfo is None else since
-            history_update_time_tz = history.update_time.replace(tzinfo=datetime.timezone.utc)
-
-            if history_update_time_tz <= since:
+            # If a timezone is provided (since.tzinfo is not None) we convert to UTC and remove tzinfo so that comparison with history.update_time is correct.
+            since = since if since.tzinfo is None else since.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+            if history.update_time <= since:
                 trans.response.status = 204
                 return
 

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -649,11 +649,11 @@ class HistoryContentsApiTestCase(ApiTestCase):
             assert history_contents.status_code == 204
 
             # test parsing for other standard is08601 formats
-            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z', '2002-10-10T12:00:00−05:00']
+            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z', '2002-10-10T12:00:00-05:00']
             for date_str in sample_formats:
                 encoded_date = urllib.parse.quote_plus(date_str)  # handles pluses, minuses
                 history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={encoded_date}")
-                assert history_contents.status_code != 400
+                self._assert_status_code_is_ok(history_contents)
 
     @skip_without_tool('cat_data_and_sleep')
     def test_history_contents_near_with_update_time_implicit_collection(self):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -639,16 +639,18 @@ class HistoryContentsApiTestCase(ApiTestCase):
             # this is the standard date format that javascript will emit using .toISOString(), it
             # should be the expected date format for any modern api
             # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+
+            # checking to make sure that the same exact history.update_time returns a "not changed"
+            # result after date parsing
             valid_iso8601_date = original_history_stamp + 'Z'
             history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={valid_iso8601_date}")
-            status = history_contents.status_code
-            assert status == 204
+            assert history_contents.status_code == 204
 
-            # Javascript has less date precision than python, here's a common sample
-            javascript_iso_date = '2021-08-25T21:46:49.091Z'
-            history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={javascript_iso_date}")
-            status = history_contents.status_code
-            assert status == 204 or status == 200
+            # test parsing for other standard is08601 formats
+            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z']
+            for date_str in sample_formats:
+                history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={date_str}")
+                assert history_contents.status_code != 400
 
     @skip_without_tool('cat_data_and_sleep')
     def test_history_contents_near_with_update_time_implicit_collection(self):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -585,7 +585,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             assert isinstance(c['job_state_summary'], dict)
 
     def _get_content(self, history_id, update_time):
-        return self._get(f"/api/histories/{history_id}/contents/near/100/100?update_time-ge={update_time}").json()
+        return self._get(f"/api/histories/{history_id}/contents/near/100/100?update_time-gt={update_time}").json()
 
     def test_history_contents_near_with_update_time(self):
         with self.dataset_populator.test_history() as history_id:

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -2,6 +2,7 @@ import json
 import time
 import urllib
 from datetime import datetime
+
 from requests import delete, put
 
 from galaxy_test.base.populators import (
@@ -650,7 +651,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             # test parsing for other standard is08601 formats
             sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z', '2002-10-10T12:00:00−05:00']
             for date_str in sample_formats:
-                encoded_date = urllib.parse.quote_plus(date_str) # handles pluses, minuses
+                encoded_date = urllib.parse.quote_plus(date_str)  # handles pluses, minuses
                 history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={encoded_date}")
                 assert history_contents.status_code != 400
 

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -597,6 +597,18 @@ class HistoryContentsApiTestCase(ApiTestCase):
             all_datasets_finished = first_time = datetime.utcnow().isoformat()
             assert len(self._get_content(history_id, update_time=all_datasets_finished)) == 0
 
+    def test_history_contents_near_with_since(self):
+        with self.dataset_populator.test_history() as history_id:
+            first_time = datetime.utcnow().isoformat()
+            assert len(self._get_content(history_id, update_time=first_time)) == 0
+            self.dataset_collection_populator.create_list_in_history(history_id=history_id)
+            assert len(self._get_content(history_id, update_time=first_time)) == 4  # 3 datasets
+            self.dataset_populator.wait_for_history(history_id)
+            all_datasets_finished = datetime.utcnow().isoformat()
+            # should return a 204 if history has not changed at all
+            response = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={all_datasets_finished}")
+            assert response.status_code == 204
+
     @skip_without_tool('cat_data_and_sleep')
     def test_history_contents_near_with_update_time_implicit_collection(self):
         with self.dataset_populator.test_history() as history_id:

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1,7 +1,7 @@
 import json
 import time
+import urllib
 from datetime import datetime
-
 from requests import delete, put
 
 from galaxy_test.base.populators import (
@@ -643,13 +643,15 @@ class HistoryContentsApiTestCase(ApiTestCase):
             # checking to make sure that the same exact history.update_time returns a "not changed"
             # result after date parsing
             valid_iso8601_date = original_history_stamp + 'Z'
-            history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={valid_iso8601_date}")
+            encoded_valid_date = urllib.parse.quote_plus(valid_iso8601_date)
+            history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={encoded_valid_date}")
             assert history_contents.status_code == 204
 
             # test parsing for other standard is08601 formats
-            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z']
+            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z', '2002-10-10T12:00:00−05:00']
             for date_str in sample_formats:
-                history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={date_str}")
+                encoded_date = urllib.parse.quote_plus(date_str) # handles pluses, minuses
+                history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={encoded_date}")
                 assert history_contents.status_code != 400
 
     @skip_without_tool('cat_data_and_sleep')


### PR DESCRIPTION
## Fixes to beta history api

### Expanded collection job state summary view

Updated the job state summary for a collection to include the state of the job directly attached to the hdca. 

This summary hash is attached to the contents/near api for the beta history and its purpose is to eliminate the need to do a secondary set of polls (to receive job status updates) when a job is executed against the history. The results of this joined view appear in the contents/near API result as follows:


```
// http://localhost:8080/api/histories/5e4434cba401361d/contents/near/2100/60?visible=True&deleted=False

[
    {
        "url": "/api/histories/5e4434cba401361d/contents/dataset_collections/36ddb788a0f14eb3",
        "create_time": "2021-08-25T19:07:30.638208",
        "collection_id": 48,
        "contents_url": "/api/dataset_collections/36ddb788a0f14eb3/contents/eafb646da3b7aac5",
        "id": "36ddb788a0f14eb3",
        "deleted": false,
        "visible": true,
        "job_source_type": "Job",
        "hid": 2110,
        "populated_state_message": null,
        "job_source_id": "52d6bdfafedbb5e5",
        "type": "collection",
        "collection_type": "list",
        "update_time": "2021-08-25T19:07:30.638212",
        "type_id": "dataset_collection-36ddb788a0f14eb3",
        "populated_state": "new",
        "history_content_type": "dataset_collection",
        "tags": [],
        "job_state_summary": {
            "new": 0,
            "waiting": 0,
            "running": 1,
            "ok": 0,
            "failed": 0,
            "deleted": 0,
            "upload": 0,
            "queued": 0,
            "resubmitted": 0,
            "error": 0,
            "paused": 0,
            "deleted_new": 0,
            "all_jobs": 1
        },
        "element_count": null,
        "populated": false,
        "history_id": "5e4434cba401361d",
        "name": "Split file on data 3"
    }
]
```

This is important because as you can see from the above output, intermediate states like "running" are not otherwise exposed (without the second set of job-state polls which I am trying to avoid).


###  Fixed a bug with since parameter on contents/near

A "since" parameter on contents/near is used during polling to figure out whether or not the history has been updated since a given date. If the history is unchanged, the endpoint completely bypasses a bunch of expensive content queries.

Having a proper history.update_time was a source of a lot of work this last year and this is the place where it is intended to be used, however it looks like a recent refactoring of the history API rendered this parameter non-functional.

The existing parameter handling had 2 problems:
1. A passed since parameter made it into the filter parameters because it was still in the keywords dictionary following parsing. This threw an undefined filter error for the field "since".

2. It attempted to convert the otherwise accurate UTC date to a version of a datetime without a timezone because that's the format that SqlAlchemy requires for date comparisons. However, the conversion process resulted in fundamental data changes which resulted in logical errors in the follow-up date comparison inequality. I added some API tests for those scenarios. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
