### PR TITLE
Display Tabular datasets as sortable tables, and PDF and HTML in embedded frames in Pages

### DIFF
--- a/client/src/components/Markdown/Elements/HistoryDatasetCollection/CollectionDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetCollection/CollectionDisplay.vue
@@ -1,54 +1,52 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card body-class="p-0">
-            <b-card-header>
-                <span class="float-right">
-                    <b-button
-                        :href="downloadUrl"
-                        variant="link"
-                        size="sm"
-                        role="button"
-                        title="Download Collection"
-                        type="button"
-                        class="py-0 px-1"
-                        v-b-tooltip.hover
-                    >
-                        <span class="fa fa-download" />
-                    </b-button>
-                    <CurrentUser v-slot="{ user }">
-                        <UserHistories v-if="user" :user="user" v-slot="{ currentHistoryId }">
-                            <b-button
-                                v-if="currentHistoryId"
-                                @click="onCopyCollection(currentHistoryId)"
-                                href="#"
-                                role="button"
-                                variant="link"
-                                title="Import Collection"
-                                type="button"
-                                class="py-0 px-1"
-                                v-b-tooltip.hover
-                            >
-                                <span class="fa fa-file-import" />
-                            </b-button>
-                        </UserHistories>
-                    </CurrentUser>
-                </span>
-                <span>
-                    <span>Dataset Collection:</span>
-                    <span class="font-weight-light">{{ collectionName }}</span>
-                </span>
-            </b-card-header>
-            <b-card-body>
-                <LoadingSpan v-if="loading" message="Loading Collection" />
-                <div v-else class="content-height">
-                    <b-alert v-if="!!messageText" :variant="messageVariant" show>
-                        {{ messageText }}
-                    </b-alert>
-                    <CollectionTree :node="itemContent" :skip-head="true" />
-                </div>
-            </b-card-body>
-        </b-card>
-    </div>
+    <b-card body-class="p-0">
+        <b-card-header>
+            <span class="float-right">
+                <b-button
+                    :href="downloadUrl"
+                    variant="link"
+                    size="sm"
+                    role="button"
+                    title="Download Collection"
+                    type="button"
+                    class="py-0 px-1"
+                    v-b-tooltip.hover
+                >
+                    <span class="fa fa-download" />
+                </b-button>
+                <CurrentUser v-slot="{ user }">
+                    <UserHistories v-if="user" :user="user" v-slot="{ currentHistoryId }">
+                        <b-button
+                            v-if="currentHistoryId"
+                            @click="onCopyCollection(currentHistoryId)"
+                            href="#"
+                            role="button"
+                            variant="link"
+                            title="Import Collection"
+                            type="button"
+                            class="py-0 px-1"
+                            v-b-tooltip.hover
+                        >
+                            <span class="fa fa-file-import" />
+                        </b-button>
+                    </UserHistories>
+                </CurrentUser>
+            </span>
+            <span>
+                <span>Dataset Collection:</span>
+                <span class="font-weight-light">{{ collectionName }}</span>
+            </span>
+        </b-card-header>
+        <b-card-body>
+            <LoadingSpan v-if="loading" message="Loading Collection" />
+            <div v-else class="content-height">
+                <b-alert v-if="!!messageText" :variant="messageVariant" show>
+                    {{ messageText }}
+                </b-alert>
+                <CollectionTree :node="itemContent" :skip-head="true" />
+            </div>
+        </b-card-body>
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -37,41 +37,45 @@
                     <LoadingSpan v-if="loading" message="Loading Dataset" />
                     <div v-else-if="error">{{ error }}</div>
                     <div v-else class="embedded-dataset content-height">
-                        <b-embed
-                            v-if="['pdf', 'html'].includes(datasetType)"
-                            type="iframe"
-                            aspect="16by9"
-                            :src="displayUrl"
-                        />
-                        <div v-else-if="itemContent.item_data">
-                            <UrlDataProvider
-                                :url="datatypesUrl"
-                                v-slot="{ result: datatypesModel, loading: datatypesLoading }"
-                            >
-                                <LoadingSpan v-if="datatypesLoading" message="Loading Datatypes" />
-                                <div v-else-if="isSubType('tabular', datasetType, datatypesModel)">
-                                    <UrlDataProvider
-                                        :url="metaUrl"
-                                        v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
-                                    >
-                                        <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
-                                        <div v-else-if="metaError">{{ metaError }}</div>
-                                        <b-table
-                                            v-else
-                                            striped
-                                            hover
-                                            :fields="getFields(metaData)"
-                                            :items="getItems(itemContent.item_data, metaData)"
-                                        />
-                                    </UrlDataProvider>
+                        <UrlDataProvider
+                            :url="datatypesUrl"
+                            v-slot="{ result: datatypesModel, loading: datatypesLoading }"
+                        >
+                            <LoadingSpan v-if="datatypesLoading" message="Loading Datatypes" />
+                            <div v-else>
+                                <b-embed
+                                    v-if="isSubTypeOfAny(datasetType, ['pdf', 'html'], datatypesModel)"
+                                    type="iframe"
+                                    aspect="16by9"
+                                    :src="displayUrl"
+                                />
+                                <div v-else-if="itemContent.item_data">
+                                    <div v-if="isSubTypeOfAny(datasetType, ['tabular'], datatypesModel)">
+                                        <UrlDataProvider
+                                            :url="metaUrl"
+                                            v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
+                                        >
+                                            <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
+                                            <div v-else-if="metaError">{{ metaError }}</div>
+                                            <b-table
+                                                v-else
+                                                striped
+                                                hover
+                                                :fields="getFields(metaData)"
+                                                :items="getItems(itemContent.item_data, metaData)"
+                                            />
+                                        </UrlDataProvider>
+                                    </div>
+                                    <pre v-else>
+                                            <code class="text-normalwrap">{{ itemContent.item_data }}</code>
+                                        </pre>
                                 </div>
-                                <pre v-else>
-                                    <code class="text-normalwrap">{{ itemContent.item_data }}</code>
-                                </pre>
-                            </UrlDataProvider>
-                        </div>
-                        <div v-else>No content found.</div>
-                        <b-link v-if="itemContent.truncated" :href="itemContent.item_url"> Show More... </b-link>
+                                <div v-else>No content found.</div>
+                                <b-link v-if="itemContent.truncated" :href="itemContent.item_url">
+                                    Show More...
+                                </b-link>
+                            </div>
+                        </UrlDataProvider>
                     </div>
                 </UrlDataProvider>
             </b-card-body>
@@ -133,9 +137,9 @@ export default {
         },
     },
     methods: {
-        isSubType(child, parent, datatypesModel) {
+        isSubTypeOfAny(child, parents, datatypesModel) {
             const datatypesMapper = new DatatypesMapperModel(datatypesModel);
-            return datatypesMapper.isSubType(child, parent);
+            return datatypesMapper.isSubTypeOfAny(child, parents);
         },
         getFields(metaData) {
             const fields = [];

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -1,86 +1,79 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card body-class="p-0">
-            <b-card-header v-if="!embedded">
-                <span class="float-right">
-                    <b-button
-                        :href="downloadUrl"
-                        variant="link"
-                        size="sm"
-                        role="button"
-                        title="Download Dataset"
-                        type="button"
-                        class="py-0 px-1"
-                        v-b-tooltip.hover
-                    >
-                        <span class="fa fa-download" />
-                    </b-button>
-                    <b-button
-                        :href="importUrl"
-                        role="button"
-                        variant="link"
-                        title="Import Dataset"
-                        type="button"
-                        class="py-0 px-1"
-                        v-b-tooltip.hover
-                    >
-                        <span class="fa fa-file-import" />
-                    </b-button>
-                </span>
-                <span>
-                    <span>Dataset:</span>
-                    <span class="font-weight-light">{{ datasetName }}</span>
-                </span>
-            </b-card-header>
-            <b-card-body>
-                <UrlDataProvider :url="itemUrl" v-slot="{ result: itemContent, loading, error }">
-                    <LoadingSpan v-if="loading" message="Loading Dataset" />
-                    <div v-else-if="error">{{ error }}</div>
-                    <div v-else class="embedded-dataset content-height">
-                        <UrlDataProvider
-                            :url="datatypesUrl"
-                            v-slot="{ result: datatypesModel, loading: datatypesLoading }"
-                        >
-                            <LoadingSpan v-if="datatypesLoading" message="Loading Datatypes" />
-                            <div v-else>
-                                <b-embed
-                                    v-if="isSubTypeOfAny(datasetType, ['pdf', 'html'], datatypesModel)"
-                                    type="iframe"
-                                    aspect="16by9"
-                                    :src="displayUrl"
-                                />
-                                <div v-else-if="itemContent.item_data">
-                                    <div v-if="isSubTypeOfAny(datasetType, ['tabular'], datatypesModel)">
-                                        <UrlDataProvider
-                                            :url="metaUrl"
-                                            v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
-                                        >
-                                            <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
-                                            <div v-else-if="metaError">{{ metaError }}</div>
-                                            <b-table
-                                                v-else
-                                                striped
-                                                hover
-                                                :fields="getFields(metaData)"
-                                                :items="getItems(itemContent.item_data, metaData)"
-                                            />
-                                        </UrlDataProvider>
-                                    </div>
-                                    <pre v-else>
-                                        <code class="text-normalwrap">{{ itemContent.item_data }}</code>
-                                    </pre>
+    <b-card body-class="p-0">
+        <b-card-header v-if="!embedded">
+            <span class="float-right">
+                <b-button
+                    :href="downloadUrl"
+                    variant="link"
+                    size="sm"
+                    role="button"
+                    title="Download Dataset"
+                    type="button"
+                    class="py-0 px-1"
+                    v-b-tooltip.hover
+                >
+                    <span class="fa fa-download" />
+                </b-button>
+                <b-button
+                    :href="importUrl"
+                    role="button"
+                    variant="link"
+                    title="Import Dataset"
+                    type="button"
+                    class="py-0 px-1"
+                    v-b-tooltip.hover
+                >
+                    <span class="fa fa-file-import" />
+                </b-button>
+            </span>
+            <span>
+                <span>Dataset:</span>
+                <span class="font-weight-light">{{ datasetName }}</span>
+            </span>
+        </b-card-header>
+        <b-card-body>
+            <UrlDataProvider :url="itemUrl" v-slot="{ result: itemContent, loading, error }">
+                <LoadingSpan v-if="loading" message="Loading Dataset" />
+                <div v-else-if="error">{{ error }}</div>
+                <div v-else class="embedded-dataset content-height">
+                    <UrlDataProvider :url="datatypesUrl" v-slot="{ result: datatypesModel, loading: datatypesLoading }">
+                        <LoadingSpan v-if="datatypesLoading" message="Loading Datatypes" />
+                        <div v-else>
+                            <b-embed
+                                v-if="isSubTypeOfAny(datasetType, ['pdf', 'html'], datatypesModel)"
+                                type="iframe"
+                                aspect="16by9"
+                                :src="displayUrl"
+                            />
+                            <div v-else-if="itemContent.item_data">
+                                <div v-if="isSubTypeOfAny(datasetType, ['tabular'], datatypesModel)">
+                                    <UrlDataProvider
+                                        :url="metaUrl"
+                                        v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
+                                    >
+                                        <LoadingSpan v-if="metaLoading" message="Loading Metadata" />
+                                        <div v-else-if="metaError">{{ metaError }}</div>
+                                        <b-table
+                                            v-else
+                                            striped
+                                            hover
+                                            :fields="getFields(metaData)"
+                                            :items="getItems(itemContent.item_data, metaData)"
+                                        />
+                                    </UrlDataProvider>
                                 </div>
-                                <div v-else>No content found.</div>
-                                <b-link v-if="itemContent.truncated" :href="itemContent.item_url">
-                                    Show More...
-                                </b-link>
+                                <pre v-else>
+                                    <code class="text-normalwrap">{{ itemContent.item_data }}</code>
+                                </pre>
                             </div>
-                        </UrlDataProvider>
-                    </div>
-                </UrlDataProvider>
-            </b-card-body>
-        </b-card>
-    </div>
+                            <div v-else>No content found.</div>
+                            <b-link v-if="itemContent.truncated" :href="itemContent.item_url"> Show More... </b-link>
+                        </div>
+                    </UrlDataProvider>
+                </div>
+            </UrlDataProvider>
+        </b-card-body>
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -67,8 +67,8 @@
                                         </UrlDataProvider>
                                     </div>
                                     <pre v-else>
-                                            <code class="text-normalwrap">{{ itemContent.item_data }}</code>
-                                        </pre>
+                                        <code class="text-normalwrap">{{ itemContent.item_data }}</code>
+                                    </pre>
                                 </div>
                                 <div v-else>No content found.</div>
                                 <b-link v-if="itemContent.truncated" :href="itemContent.item_url">

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -37,11 +37,14 @@
                     <LoadingSpan v-if="loading" message="Loading Dataset" />
                     <div v-else-if="error">{{ error }}</div>
                     <div v-else class="embedded-dataset content-height">
-                        <div v-if="itemContent.item_data">
-                            <pre v-if="notTabular">
-                                <code class="text-normalwrap">{{ itemContent.item_data }}</code>
-                            </pre>
-                            <div v-else>
+                        <b-embed
+                            v-if="['pdf', 'html'].includes(datasetType)"
+                            type="iframe"
+                            aspect="16by9"
+                            :src="displayUrl"
+                        />
+                        <div v-else-if="itemContent.item_data">
+                            <div v-if="datasetType == 'tabular'">
                                 <UrlDataProvider
                                     :url="metaUrl"
                                     v-slot="{ result: metaData, loading: metaLoading, error: metaError }"
@@ -57,6 +60,9 @@
                                     />
                                 </UrlDataProvider>
                             </div>
+                            <pre v-else>
+                                <code class="text-normalwrap">{{ itemContent.item_data }}</code>
+                            </pre>
                         </div>
                         <div v-else>No content found.</div>
                         <b-link v-if="itemContent.truncated" :href="itemContent.item_url"> Show More... </b-link>
@@ -92,9 +98,9 @@ export default {
         },
     },
     computed: {
-        notTabular() {
+        datasetType() {
             const dataset = this.datasets[this.args.history_dataset_id];
-            return dataset && dataset.ext != "tabular";
+            return dataset.ext;
         },
         datasetName() {
             const dataset = this.datasets[this.args.history_dataset_id];
@@ -102,6 +108,9 @@ export default {
         },
         downloadUrl() {
             return `${getAppRoot()}dataset/display?dataset_id=${this.args.history_dataset_id}`;
+        },
+        displayUrl() {
+            return `${getAppRoot()}datasets/${this.args.history_dataset_id}/display`;
         },
         importUrl() {
             return `${getAppRoot()}dataset/imp?dataset_id=${this.args.history_dataset_id}`;
@@ -149,6 +158,6 @@ export default {
 </script>
 <style scoped>
 .content-height {
-    max-height: 15rem;
+    max-height: 20rem;
 }
 </style>

--- a/client/src/components/Markdown/Elements/JobMetrics.vue
+++ b/client/src/components/Markdown/Elements/JobMetrics.vue
@@ -1,9 +1,7 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card nobody>
-            <JobMetrics class="job-metrics" :job-id="args.job_id" />
-        </b-card>
-    </div>
+    <b-card nobody>
+        <JobMetrics class="job-metrics" :job-id="args.job_id" />
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/JobParameters.vue
+++ b/client/src/components/Markdown/Elements/JobParameters.vue
@@ -1,9 +1,7 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card nobody>
-            <JobParameters class="job-parameters" :job-id="args.job_id" :param="args.param" :include-title="false" />
-        </b-card>
-    </div>
+    <b-card nobody>
+        <JobParameters class="job-parameters" :job-id="args.job_id" :param="args.param" :include-title="false" />
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/ToolStd.vue
+++ b/client/src/components/Markdown/Elements/ToolStd.vue
@@ -1,11 +1,9 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card nobody class="content-height">
-            <div :class="name" :job_id="args.job_id">
-                <pre><code class="text-normalwrap">{{ jobContent }}</code></pre>
-            </div>
-        </b-card>
-    </div>
+    <b-card nobody class="content-height">
+        <div :class="name" :job_id="args.job_id">
+            <pre><code class="text-normalwrap">{{ jobContent }}</code></pre>
+        </div>
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/Visualization.vue
+++ b/client/src/components/Markdown/Elements/Visualization.vue
@@ -1,11 +1,9 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card body-class="embed-responsive embed-responsive-4by3">
-            <LoadingSpan v-if="loading" class="m-2" message="Loading Visualization" />
-            <div v-else-if="error" class="m-2">{{ error }}</div>
-            <iframe v-else class="embed-responsive-item" :src="visualizationUrl" />
-        </b-card>
-    </div>
+    <b-card body-class="embed-responsive embed-responsive-4by3">
+        <LoadingSpan v-if="loading" class="m-2" message="Loading Visualization" />
+        <div v-else-if="error" class="m-2">{{ error }}</div>
+        <iframe v-else class="embed-responsive-item" :src="visualizationUrl" />
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -1,48 +1,46 @@
 <template>
-    <div class="w-100 p-2">
-        <b-card body-class="p-0">
-            <b-card-header v-if="!embedded">
-                <span class="float-right">
-                    <b-button
-                        :href="downloadUrl"
-                        variant="link"
-                        size="sm"
-                        role="button"
-                        title="Download Workflow"
-                        type="button"
-                        class="py-0 px-1"
-                        v-b-tooltip.hover
-                    >
-                        <span class="fa fa-download" />
-                    </b-button>
-                    <b-button
-                        :href="importUrl"
-                        role="button"
-                        variant="link"
-                        title="Import Workflow"
-                        type="button"
-                        class="py-0 px-1"
-                        v-b-tooltip.hover
-                    >
-                        <span class="fa fa-file-import" />
-                    </b-button>
-                </span>
-                <span>
-                    <span>Workflow:</span>
-                    <span class="font-weight-light">{{ workflowName }}</span>
-                </span>
-            </b-card-header>
-            <b-card-body>
-                <LoadingSpan v-if="loading" message="Loading Workflow" />
-                <div v-else class="content-height">
-                    <div v-for="step in itemContent.steps" :key="step.order_index" class="mb-2">
-                        <div>Step {{ step.order_index + 1 }}: {{ step.label }}</div>
-                        <WorkflowTree :input="step" :skip-head="true" />
-                    </div>
+    <b-card body-class="p-0">
+        <b-card-header v-if="!embedded">
+            <span class="float-right">
+                <b-button
+                    :href="downloadUrl"
+                    variant="link"
+                    size="sm"
+                    role="button"
+                    title="Download Workflow"
+                    type="button"
+                    class="py-0 px-1"
+                    v-b-tooltip.hover
+                >
+                    <span class="fa fa-download" />
+                </b-button>
+                <b-button
+                    :href="importUrl"
+                    role="button"
+                    variant="link"
+                    title="Import Workflow"
+                    type="button"
+                    class="py-0 px-1"
+                    v-b-tooltip.hover
+                >
+                    <span class="fa fa-file-import" />
+                </b-button>
+            </span>
+            <span>
+                <span>Workflow:</span>
+                <span class="font-weight-light">{{ workflowName }}</span>
+            </span>
+        </b-card-header>
+        <b-card-body>
+            <LoadingSpan v-if="loading" message="Loading Workflow" />
+            <div v-else class="content-height">
+                <div v-for="step in itemContent.steps" :key="step.order_index" class="mb-2">
+                    <div>Step {{ step.order_index + 1 }}: {{ step.label }}</div>
+                    <WorkflowTree :input="step" :skip-head="true" />
                 </div>
-            </b-card-body>
-        </b-card>
-    </div>
+            </div>
+        </b-card-body>
+    </b-card>
 </template>
 
 <script>

--- a/client/src/components/Markdown/Markdown.vue
+++ b/client/src/components/Markdown/Markdown.vue
@@ -44,7 +44,7 @@
                     </div>
                 </b-alert>
             </div>
-            <div v-for="(obj, index) in markdownObjects" :key="index">
+            <div v-for="(obj, index) in markdownObjects" :key="index" class="markdown-components">
                 <p v-if="obj.name == 'default'" v-html="obj.content" class="text-justify m-2" />
                 <div v-else-if="obj.name == 'generate_galaxy_version'" class="galaxy-version">
                     <pre><code>{{ getVersion }}</code></pre>

--- a/client/src/components/providers/SingleQueryProvider.js
+++ b/client/src/components/providers/SingleQueryProvider.js
@@ -21,6 +21,7 @@ export const SingleQueryProvider = (lookup) => {
         data() {
             return {
                 result: undefined,
+                error: undefined,
             };
         },
         computed: {
@@ -47,6 +48,8 @@ export const SingleQueryProvider = (lookup) => {
                     this.result = result;
                 },
                 (err) => {
+                    this.result = {};
+                    this.error = err;
                     this.$emit("error", err);
                 }
             );
@@ -55,6 +58,7 @@ export const SingleQueryProvider = (lookup) => {
             return this.$scopedSlots.default({
                 loading: this.loading,
                 result: this.result,
+                error: this.error,
             });
         },
     };

--- a/client/src/style/scss/markdown.scss
+++ b/client/src/style/scss/markdown.scss
@@ -12,3 +12,10 @@
         flex: 1;
     }
 }
+
+.markdown-wrapper {
+    @extend .px-4;
+    .markdown-components {
+        @extend .py-2;
+    }
+}

--- a/lib/galaxy/managers/markdown_util.py
+++ b/lib/galaxy/managers/markdown_util.py
@@ -270,10 +270,11 @@ class ReadyForExportMarkdownDirectiveHandler(GalaxyInternalMarkdownDirectiveHand
         self.ensure_rendering_data_for("history_datasets", obj)[key] = val or default_val
 
     def handle_dataset_display(self, line, hda):
-        self.extend_history_dataset_rendering_data(hda, "name", hda.name, "")
+        self.handle_dataset_name(line, hda)
+        self.handle_dataset_type(line, hda)
 
     def handle_dataset_embedded(self, line, hda):
-        self.extend_history_dataset_rendering_data(hda, "name", hda.name, "")
+        self.handle_dataset_name(line, hda)
 
     def handle_dataset_peek(self, line, hda):
         self.extend_history_dataset_rendering_data(hda, "peek", hda.peek, "*No Dataset Peek Available*")

--- a/templates/webapps/galaxy/dataset/display.mako
+++ b/templates/webapps/galaxy/dataset/display.mako
@@ -100,7 +100,7 @@
 
     <div class="unified-panel-body">
         <div style="overflow: auto; height: 100%;">
-            <div class="page-body">
+            <div class="page-body p-3">
                 <div style="float: right">
                     ${self.render_item_links( item )}
                 </div>


### PR DESCRIPTION
This PR augments the history dataset display component in pages. If the dataset is a tabular dataset a sortable table is displayed instead of the plain text content. Additionally the component has been augmented such that it displays PDF and HTML files in an embedded scrollable frame.

Before:

<img width="600" alt="Screen Shot 2021-08-30 at 10 20 09 AM" src="https://user-images.githubusercontent.com/2105447/131354798-868c81e5-3221-4cf8-981a-6b0dc5d4148e.png">

After:

<img width="600" alt="Screen Shot 2021-08-30 at 10 24 14 AM" src="https://user-images.githubusercontent.com/2105447/131354809-2b6ed4c7-2f56-4f9a-82d3-826c638bdd3d.png">

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Create a page
  2. Insert a History Dataset of the following types: Tabular, PDF, and HTML
  3. View the resulting page

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
