### PR TITLE
Added missing triggers package to galaxy data

### DIFF
--- a/packages/data/setup.py
+++ b/packages/data/setup.py
@@ -40,6 +40,7 @@ PACKAGES = [
     'galaxy.model.dataset_collections',
     'galaxy.model.dataset_collections.types',
     'galaxy.model.migrate',
+    'galaxy.model.migrate.triggers',
     'galaxy.model.migrate.versions',
     'galaxy.model.orm',
     'galaxy.model.store',


### PR DESCRIPTION

The triggers package is not included in galaxy-data, resulting in a missing import error.
```
======================================================================

ERROR: Failure: ModuleNotFoundError (No module named 'galaxy.model.migrate.triggers')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/nose/loader.py", line 417, in loadTestsFromName
    module = self.importer.importFromPath(
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/imp.py", line 234, in load_module
    return load_source(name, filename, file)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/vortex/tests/test_mapper.py", line 4, in <module>
    from . import mock_galaxy
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/vortex/tests/mock_galaxy.py", line 4, in <module>
    from galaxy.jobs import JobConfiguration
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/galaxy/jobs/__init__.py", line 62, in <module>
    from galaxy.structured_app import MinimalManagerApp
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/galaxy/structured_app.py", line 12, in <module>
    from galaxy.model.mapping import GalaxyModelMapping
  File "/home/runner/work/total-perspective-vortex/total-perspective-vortex/.tox/py3.8/lib/python3.8/site-packages/galaxy/model/mapping.py", line 50, in <module>
    from galaxy.model.migrate.triggers.update_audit_table import install as install_timestamp_triggers
ModuleNotFoundError: No module named 'galaxy.model.migrate.triggers'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
