### PR TITLE
FastAPI: support reverse URL lookups

### DIFF
--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -67,8 +67,14 @@ class ProvidesAppContext:
         """
 
     @abc.abstractproperty
-    def qualified_url_builder(self) -> Optional[Callable[[str], str]]:
-        """Provide access to fully qualified Galaxy URLs (if available)."""
+    def url_builder(self) -> Optional[Callable[..., str]]:
+        """
+        Provide access to Galaxy URLs (if available).
+
+        :type   qualified:  bool
+        :param  qualified:  if True, the fully qualified URL is returned,
+                            else a relative URL is returned (default False).
+        """
 
     @property
     def security(self) -> IdEncodingHelper:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -800,7 +800,7 @@ class BaseURLToolParameter(HiddenToolParameter):
         try:
             if not self.value.startswith("/"):
                 raise Exception("baseurl value must start with a /")
-            return trans.qualified_url_builder(self.value)
+            return trans.url_builder(self.value, qualified=True)
         except Exception as e:
             log.debug('Url creation failed for "%s": %s', self.name, unicodify(e))
             return self.value
@@ -1108,6 +1108,7 @@ class SelectTagParameter(SelectToolParameter):
     """
     Select set that is composed of a set of tags available for an input.
     """
+
     def __init__(self, tool, input_source):
         input_source = ensure_input_source(input_source)
         super().__init__(tool, input_source)

--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -7,14 +7,14 @@ from . import base
 DEPRECATED_URL_ATTRIBUTE_MESSAGE = "*deprecated attribute, URL not filled in by server*"
 
 
-def handle_url_for(*args, **kargs) -> str:
+def handle_url_for(*args, **kwargs) -> str:
     """Tries to resolve the URL using the `routes` module.
 
     This only works in a WSGI app so a deprecation message is returned
     when running an ASGI app.
     """
     try:
-        return base.routes.url_for(*args, **kargs)
+        return base.routes.url_for(*args, **kwargs)
     except AttributeError:
         return DEPRECATED_URL_ATTRIBUTE_MESSAGE
 

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -188,8 +188,9 @@ def config_allows_origin(origin_raw, config):
     return False
 
 
-def qualified_url_builder(path):
-    return url_for(path, qualified=True)
+def url_builder(*args, **kwargs) -> str:
+    """Wrapper around the uWSGI version of the function for reversing URLs."""
+    return url_for(*args, **kwargs)
 
 
 class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryContext):
@@ -283,8 +284,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         return self._app
 
     @property
-    def qualified_url_builder(self):
-        return qualified_url_builder
+    def url_builder(self):
+        return url_builder
 
     def setup_i18n(self):
         locales = []

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -124,13 +124,16 @@ def get_user(galaxy_session: Optional[model.GalaxySession] = Depends(get_session
     return api_user
 
 
-class QualifiedUrlBuilder:
+class UrlBuilder:
 
     def __init__(self, request: Request):
         self.request = request
 
-    def __call__(self, path):
-        return self.request.url_for(path)
+    def __call__(self, name: str, **path_params):
+        qualified = path_params.pop("qualified", False)
+        if qualified:
+            return self.request.url_for(name, **path_params)
+        return self.request.app.url_path_for(name, **path_params)
 
 
 DependsOnUser = Depends(get_user)
@@ -139,8 +142,8 @@ DependsOnUser = Depends(get_user)
 def get_trans(request: Request, app: StructuredApp = DependsOnApp, user: Optional[User] = Depends(get_user),
               galaxy_session: Optional[model.GalaxySession] = Depends(get_session),
               ) -> SessionRequestContext:
-    qualified_url_builder = QualifiedUrlBuilder(request)
-    return SessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, qualified_url_builder=qualified_url_builder, host=request.client.host)
+    url_builder = UrlBuilder(request)
+    return SessionRequestContext(app=app, user=user, galaxy_session=galaxy_session, url_builder=url_builder, host=request.client.host)
 
 
 DependsOnTrans = Depends(get_trans)

--- a/lib/galaxy/webapps/galaxy/api/group_roles.py
+++ b/lib/galaxy/webapps/galaxy/api/group_roles.py
@@ -13,7 +13,6 @@ from galaxy.schema.schema import GroupRoleListModel, GroupRoleModel
 from galaxy.web import (
     expose_api,
     require_admin,
-    url_for,
 )
 from . import (
     BaseGalaxyAPIController,
@@ -42,7 +41,7 @@ RoleIDParam: EncodedDatabaseIdField = Path(
 
 def group_role_to_model(trans, encoded_group_id, role):
     encoded_role_id = trans.security.encode_id(role.id)
-    url = url_for('group_role', group_id=encoded_group_id, id=encoded_role_id)
+    url = trans.url_builder('group_role', group_id=encoded_group_id, id=encoded_role_id)
     return GroupRoleModel(
         id=encoded_role_id,
         name=role.name,
@@ -62,13 +61,14 @@ class FastAPIGroupRoles:
         group_roles = self.manager.index(trans, group_id)
         return GroupRoleListModel(__root__=[group_role_to_model(trans, group_id, gr.role) for gr in group_roles])
 
-    @router.get('/api/groups/{group_id}/roles/{role_id}',
+    @router.get('/api/groups/{group_id}/roles/{id}',
+                name="group_role",
                 require_admin=True,
                 summary='Displays information about a group role.')
     def show(self, trans: ProvidesAppContext = DependsOnTrans,
              group_id: EncodedDatabaseIdField = GroupIDParam,
-             role_id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
-        role = self.manager.show(trans, role_id, group_id)
+             id: EncodedDatabaseIdField = RoleIDParam) -> GroupRoleModel:
+        role = self.manager.show(trans, id, group_id)
         return group_role_to_model(trans, group_id, role)
 
     @router.put('/api/groups/{group_id}/roles/{role_id}',

--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -19,12 +19,12 @@ class WorkRequestContext(ProvidesHistoryContext):
     objects.
     """
 
-    def __init__(self, app, user=None, history=None, workflow_building_mode=False, qualified_url_builder=None):
+    def __init__(self, app, user=None, history=None, workflow_building_mode=False, url_builder=None):
         self._app = app
         self.__user = user
         self.__user_current_roles = None
         self.__history = history
-        self._qualified_url_builder = qualified_url_builder
+        self._url_builder = url_builder
         self.workflow_building_mode = workflow_building_mode
 
     @property
@@ -32,8 +32,8 @@ class WorkRequestContext(ProvidesHistoryContext):
         return self._app
 
     @property
-    def qualified_url_builder(self):
-        return self._qualified_url_builder
+    def url_builder(self):
+        return self._url_builder
 
     def get_history(self, create=False):
         return self.__history
@@ -60,6 +60,7 @@ class WorkRequestContext(ProvidesHistoryContext):
 
 class SessionRequestContext(WorkRequestContext):
     """Like WorkRequestContext, but provides access to galaxy session and session."""
+
     def __init__(self, **kwargs):
         self.galaxy_session = kwargs.pop('galaxy_session', None)
         self._host = kwargs.pop("host")
@@ -80,4 +81,4 @@ def proxy_work_context_for_history(trans: ProvidesHistoryContext, history: Optio
     history that is different from the user's current history (which also might change during
     the request).
     """
-    return WorkRequestContext(app=trans.app, user=trans.user, history=history or trans.history, qualified_url_builder=trans.qualified_url_builder, workflow_building_mode=workflow_building_mode)
+    return WorkRequestContext(app=trans.app, user=trans.user, history=history or trans.history, url_builder=trans.url_builder, workflow_building_mode=workflow_building_mode)

--- a/lib/galaxy_test/api/test_group_roles.py
+++ b/lib/galaxy_test/api/test_group_roles.py
@@ -1,6 +1,5 @@
 from typing import List
 
-from galaxy.web.framework import DEPRECATED_URL_ATTRIBUTE_MESSAGE
 from galaxy_test.base.populators import DatasetPopulator
 from ._framework import ApiTestCase
 
@@ -68,10 +67,7 @@ class GroupRolesApiTestCase(ApiTestCase):
         self._assert_status_code_is_ok(update_response)
         group_role = update_response.json()
         self._assert_valid_group_role(group_role, assert_id=encoded_role_id)
-        assert (
-            group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}"
-            or group_role["url"] == DEPRECATED_URL_ATTRIBUTE_MESSAGE
-        )
+        assert group_role["url"] == f"/api/groups/{encoded_group_id}/roles/{encoded_role_id}"
 
     def test_update_only_admin(self):
         encoded_group_id = "any-group-id"

--- a/test/unit/tools/test_execution.py
+++ b/test/unit/tools/test_execution.py
@@ -204,7 +204,7 @@ class MockTrans:
         self.workflow_building_mode = False
         self.webapp = Bunch(name="galaxy")
         self.sa_session = self.app.model.context
-        self.qualified_url_builder = None
+        self.url_builder = None
 
     def get_history(self, **kwargs):
         return self.history

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -241,7 +241,7 @@ class MockTrans:
         self.anonymous = False
         self.debug = True
         self.user_is_admin = True
-        self.qualified_url_builder = None
+        self.url_builder = None
 
         self.galaxy_session = None
         self.__user = user


### PR DESCRIPTION
After some digging and debugging I think that I now understand better how the reverse URL lookup works in FastAPI/Starlette. Apart from the fact that the old `url_for` and the equivalent in Starlette have different interfaces, the main point that I was missing is that the `url_for` in FastAPI requires a unique name to reference and map the route along with the exact path parameters needed. This `name` was the name of the action by default, meaning that for `FastAPIGroupRoles.index` and, for example, `FastAPIPages.index` the name was simply `index` in both cases.

This PR is an attempt to expand what @jmchilton did on https://github.com/galaxyproject/galaxy/pull/11904 and try to use it to replace the calls to `url_for` in those cases that we actually require a valid URL. In addition, I had to change it from dealing with only fully qualified URLs to also generate relative URLs using a `qualified` bool parameter similar to the legacy `url_for`. Hopefully, it doesn't break much of the design John had in mind for this :)

The idea is to be able to replace the calls to `url_for` in the API with `trans.url_builder` and try to maintain the same interface so we can keep update changes to a minimum. This can be done by assigning a `name` to the FastAPI route and naming the path parameters exactly like in the old legacy controllers. As an example, I adapted the recent `group_roles` controller (see https://github.com/galaxyproject/galaxy/commit/0569b42959d02c304294483f66d3f7d77e3f3f11) that now generates valid URLs both in the legacy and the new FastAPI routes.

There are still cases that will not work in both legacy and FastAPI controllers without further changes in `UrlBuilder`, for example when the `url_for` method is called like:
```python
url = url_for(controller='dataset', action='edit', dataset_id=encoded_id)
```
One possible solution for this particular case could be that whenever we get the `controller` and `action` parameters in the call to `url_builder` we can assume the unique `name` of the route that we are looking for is `<controller>_<action>` and name the FastAPI route accordingly to match it. But I'm not sure how much we want to mimic the old framework behavior, so I wanted to bring it to discussion first.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
