### PR TITLE
Fix busted selenium test_tool_form::history_rerun test

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1461,12 +1461,13 @@ class NavigatesGalaxy(HasDriver):
 
     def history_panel_click_item_title(self, hid, **kwds):
         item_component = self.history_panel_item_component(hid=hid)
-        item_component.title.wait_for_and_click()
         if kwds.get("wait", False):
             if self.is_beta_history():
+                item_component.title.wait_for_and_click()
                 item_component.details.wait_for_present()
             else:
                 details_component = item_component.details
+                item_component.title.wait_for_and_click()
                 details_displayed = details_component.is_displayed
                 if details_displayed:
                     details_component.wait_for_absent_or_hidden()


### PR DESCRIPTION
This broke when I merged #12351.

For the old history, without grabbing a handle to item_component.details before toggling the title this breaks with a stale object handle error.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
