### PR TITLE
Implement news webhook to handle release announcements

### DIFF
--- a/config/plugins/webhooks/news/config.yml
+++ b/config/plugins/webhooks/news/config.yml
@@ -1,0 +1,7 @@
+id: news
+type:
+  - masthead
+activate: true
+
+icon: fa-bell
+tooltip: See the Galaxy Release Notes

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -29,7 +29,9 @@ function addNewsIframe() {
     // now we'll hardcode the version users 'see'. @hexylena will remove this
     // code when she writes the user-facing release notes, and then will file
     // an issue for how we'll fix this properly.
-    if(currentGalaxyVersion == "21.09") {
+    if(currentGalaxyVersion == "22.01") {
+        currentGalaxyVersion = "21.09";
+    } else if(currentGalaxyVersion == "21.09") {
         currentGalaxyVersion = "21.05";
     }
 

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -1,44 +1,41 @@
 function removeNewsOverlay() {
-  document.getElementById("news-container").style.visibility = "hidden";
+    document.getElementById("news-container").style.visibility = "hidden";
 }
 
 function showNewsOverlay() {
-  document.getElementById("news-container").style.visibility = "visible";
-  newsSeen();
+    document.getElementById("news-container").style.visibility = "visible";
+    newsSeen();
 }
 
 function newsSeen() {
-  // When it's seen, remove fa and far, add fas.
-  const newsIconSpan = document.getElementById("news").querySelector(".fa-bell")
-  newsIconSpan.classList.remove("fa");
-  newsIconSpan.classList.add("far");
-  window.localStorage.setItem(
-    "galaxy-news-seen-release",
-    Galaxy.config.version_major
-  );
+    // When it's seen, remove fa and far, add fas.
+    const newsIconSpan = document.getElementById("news").querySelector(".fa-bell");
+    newsIconSpan.classList.remove("fa");
+    newsIconSpan.classList.add("far");
+    window.localStorage.setItem("galaxy-news-seen-release", Galaxy.config.version_major);
 }
 
 function newsUnseen() {
-  // When there is news, set far instead of fa
-  const newsIconSpan = document.getElementById("news").querySelector(".fa-bell")
-  newsIconSpan.classList.remove("far");
-  newsIconSpan.classList.add("fa");
+    // When there is news, set far instead of fa
+    const newsIconSpan = document.getElementById("news").querySelector(".fa-bell");
+    newsIconSpan.classList.remove("far");
+    newsIconSpan.classList.add("fa");
 }
 
 function addNewsIframe() {
-  let currentGalaxyVersion = Galaxy.config.version_major;
-  let releaseNotes = `https://docs.galaxyproject.org/en/master/releases/${currentGalaxyVersion}_announce_user.html`;
-  let lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
-  // Check that they've seen the current version's release notes.
-  if (lastSeenVersion != currentGalaxyVersion) {
-    newsUnseen();
-  } else {
-    newsSeen();
-  }
+    const currentGalaxyVersion = Galaxy.config.version_major;
+    const releaseNotes = `https://docs.galaxyproject.org/en/master/releases/${currentGalaxyVersion}_announce_user.html`;
+    const lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
+    // Check that they've seen the current version's release notes.
+    if (lastSeenVersion != currentGalaxyVersion) {
+        newsUnseen();
+    } else {
+        newsSeen();
+    }
 
-  document.querySelector("body.full-content").insertAdjacentHTML(
-    "afterbegin",
-    `
+    document.querySelector("body.full-content").insertAdjacentHTML(
+        "afterbegin",
+        `
             <div id="news-container" style="visibility: hidden">
                 <div id="news-screen-overlay"></div>
                 <div id="news-screen">
@@ -47,12 +44,12 @@ function addNewsIframe() {
                     </div>
                 </div>
             </div>`
-  );
+    );
 
-  // Clicking outside of GTN closes it
-  document.getElementById("news-screen").addEventListener("click", () => {
-    removeNewsOverlay();
-  });
+    // Clicking outside of GTN closes it
+    document.getElementById("news-screen").addEventListener("click", () => {
+        removeNewsOverlay();
+    });
 }
 
 /* The masthead icon may not exist yet when this webhook executes; we need this to wait for that to happen.
@@ -60,45 +57,45 @@ function addNewsIframe() {
  * https://gist.github.com/jwilson8767/db379026efcbd932f64382db4b02853e
  */
 function elementReadyNews(selector) {
-  return new Promise((resolve, reject) => {
-    let el = document.querySelector(selector);
-    if (el) {
-      resolve(el);
-    }
-    new MutationObserver((mutationRecords, observer) => {
-      // Query for elements matching the specified selector
-      Array.from(document.querySelectorAll(selector)).forEach(element => {
-        resolve(element);
-        //Once we have resolved we don't need the observer anymore.
-        observer.disconnect();
-      });
-    }).observe(document.documentElement, {
-      childList: true,
-      subtree: true
+    return new Promise((resolve, reject) => {
+        const el = document.querySelector(selector);
+        if (el) {
+            resolve(el);
+        }
+        new MutationObserver((mutationRecords, observer) => {
+            // Query for elements matching the specified selector
+            Array.from(document.querySelectorAll(selector)).forEach((element) => {
+                resolve(element);
+                //Once we have resolved we don't need the observer anymore.
+                observer.disconnect();
+            });
+        }).observe(document.documentElement, {
+            childList: true,
+            subtree: true,
+        });
     });
-  });
 }
 
-elementReadyNews("#news a").then(el => {
-  // External stuff may also have attached a click handler here (vue-based masthead)
-  // replace with a clean copy of the node to remove all that cruft.
-  clean = el.cloneNode(true);
-  el.parentNode.replaceChild(clean, el);
+elementReadyNews("#news a").then((el) => {
+    // External stuff may also have attached a click handler here (vue-based masthead)
+    // replace with a clean copy of the node to remove all that cruft.
+    clean = el.cloneNode(true);
+    el.parentNode.replaceChild(clean, el);
 
-  // This gets added by default.
-  addNewsIframe();
+    // This gets added by default.
+    addNewsIframe();
 
-  clean.addEventListener("click", e => {
-    e.preventDefault();
-    e.stopPropagation();
-    showNewsOverlay();
-  });
+    clean.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        showNewsOverlay();
+    });
 });
 
 // Remove the overlay on escape button click
-document.addEventListener("keydown", e => {
-  // Check for escape button - "27"
-  if (e.which === 27 || e.keyCode === 27) {
-    removeNewsOverlay();
-  }
+document.addEventListener("keydown", (e) => {
+    // Check for escape button - "27"
+    if (e.which === 27 || e.keyCode === 27) {
+        removeNewsOverlay();
+    }
 });

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -8,8 +8,10 @@ function showNewsOverlay() {
 }
 
 function newsSeen() {
-  var el = document.getElementById("news-unseen-pip");
-  el.parentNode.removeChild(el);
+  // When it's seen, remove fa and far, add fas.
+  const newsIconSpan = document.getElementById("news").querySelector(".fa-bell")
+  newsIconSpan.classList.remove("fa");
+  newsIconSpan.classList.add("far");
   window.localStorage.setItem(
     "galaxy-news-seen-release",
     Galaxy.config.version_major
@@ -17,13 +19,10 @@ function newsSeen() {
 }
 
 function newsUnseen() {
-  let econtainer = document.getElementById("news").children[0];
-  econtainer.insertAdjacentHTML(
-    "beforeend",
-    `
-        <span id="news-unseen-pip" class="nav-note fa fa-circle"></span>
-        `
-  );
+  // When there is news, set far instead of fa
+  const newsIconSpan = document.getElementById("news").querySelector(".fa-bell")
+  newsIconSpan.classList.remove("far");
+  newsIconSpan.classList.add("fa");
 }
 
 function addNewsIframe() {
@@ -33,6 +32,8 @@ function addNewsIframe() {
   // Check that they've seen the current version's release notes.
   if (lastSeenVersion != currentGalaxyVersion) {
     newsUnseen();
+  } else {
+    newsSeen();
   }
 
   document.querySelector("body.full-content").insertAdjacentHTML(

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -23,7 +23,16 @@ function newsUnseen() {
 }
 
 function addNewsIframe() {
-    const currentGalaxyVersion = Galaxy.config.version_major;
+    var currentGalaxyVersion = Galaxy.config.version_major;
+
+    // TODO/@hexylena: By 21.01 we will have a proper solution for this. For
+    // now we'll hardcode the version users 'see'. @hexylena will remove this
+    // code when she writes the user-facing release notes, and then will file
+    // an issue for how we'll fix this properly.
+    if(currentGalaxyVersion == "21.09") {
+        currentGalaxyVersion = "21.05";
+    }
+
     const releaseNotes = `https://docs.galaxyproject.org/en/master/releases/${currentGalaxyVersion}_announce_user.html`;
     const lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
     // Check that they've seen the current version's release notes.

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -8,16 +8,16 @@ function showNewsOverlay() {
 }
 
 function newsSeen() {
-    // When it's seen, remove fa and far, add fas.
-    const newsIconSpan = document.getElementById("news").querySelector(".fa-bell");
+    // When it's seen, remove fa, add far.
+    const newsIconSpan = document.querySelector("#news .fa-bell");
     newsIconSpan.classList.remove("fa");
     newsIconSpan.classList.add("far");
     window.localStorage.setItem("galaxy-news-seen-release", Galaxy.config.version_major);
 }
 
 function newsUnseen() {
-    // When there is news, set far instead of fa
-    const newsIconSpan = document.getElementById("news").querySelector(".fa-bell");
+    // When there is news, remove far, add fa for (default -- same as fas) solid style.
+    const newsIconSpan = document.querySelector("#news .fa-bell");
     newsIconSpan.classList.remove("far");
     newsIconSpan.classList.add("fa");
 }

--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -1,0 +1,103 @@
+function removeNewsOverlay() {
+  document.getElementById("news-container").style.visibility = "hidden";
+}
+
+function showNewsOverlay() {
+  document.getElementById("news-container").style.visibility = "visible";
+  newsSeen();
+}
+
+function newsSeen() {
+  var el = document.getElementById("news-unseen-pip");
+  el.parentNode.removeChild(el);
+  window.localStorage.setItem(
+    "galaxy-news-seen-release",
+    Galaxy.config.version_major
+  );
+}
+
+function newsUnseen() {
+  let econtainer = document.getElementById("news").children[0];
+  econtainer.insertAdjacentHTML(
+    "beforeend",
+    `
+        <span id="news-unseen-pip" class="nav-note fa fa-circle"></span>
+        `
+  );
+}
+
+function addNewsIframe() {
+  let currentGalaxyVersion = Galaxy.config.version_major;
+  let releaseNotes = `https://docs.galaxyproject.org/en/master/releases/${currentGalaxyVersion}_announce_user.html`;
+  let lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
+  // Check that they've seen the current version's release notes.
+  if (lastSeenVersion != currentGalaxyVersion) {
+    newsUnseen();
+  }
+
+  document.querySelector("body.full-content").insertAdjacentHTML(
+    "afterbegin",
+    `
+            <div id="news-container" style="visibility: hidden">
+                <div id="news-screen-overlay"></div>
+                <div id="news-screen">
+                    <div id="news-header">
+                        <iframe id="news-embed" src="${releaseNotes}" width="80%" height="80%"></iframe>
+                    </div>
+                </div>
+            </div>`
+  );
+
+  // Clicking outside of GTN closes it
+  document.getElementById("news-screen").addEventListener("click", () => {
+    removeNewsOverlay();
+  });
+}
+
+/* The masthead icon may not exist yet when this webhook executes; we need this to wait for that to happen.
+ * elementReady function from gist:
+ * https://gist.github.com/jwilson8767/db379026efcbd932f64382db4b02853e
+ */
+function elementReadyNews(selector) {
+  return new Promise((resolve, reject) => {
+    let el = document.querySelector(selector);
+    if (el) {
+      resolve(el);
+    }
+    new MutationObserver((mutationRecords, observer) => {
+      // Query for elements matching the specified selector
+      Array.from(document.querySelectorAll(selector)).forEach(element => {
+        resolve(element);
+        //Once we have resolved we don't need the observer anymore.
+        observer.disconnect();
+      });
+    }).observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  });
+}
+
+elementReadyNews("#news a").then(el => {
+  // External stuff may also have attached a click handler here (vue-based masthead)
+  // replace with a clean copy of the node to remove all that cruft.
+  clean = el.cloneNode(true);
+  el.parentNode.replaceChild(clean, el);
+
+  // This gets added by default.
+  addNewsIframe();
+
+  clean.addEventListener("click", e => {
+    e.preventDefault();
+    e.stopPropagation();
+    showNewsOverlay();
+  });
+});
+
+// Remove the overlay on escape button click
+document.addEventListener("keydown", e => {
+  // Check for escape button - "27"
+  if (e.which === 27 || e.keyCode === 27) {
+    removeNewsOverlay();
+  }
+});

--- a/config/plugins/webhooks/news/styles.css
+++ b/config/plugins/webhooks/news/styles.css
@@ -1,0 +1,28 @@
+#news-screen {
+	position: fixed;
+	z-index: 202;
+	width:100%;
+	height:100%;
+}
+
+#news-screen-overlay {
+	position: fixed;
+	top:0;
+	left:0;
+	background: rgba(224, 224, 224, 0.75);
+	z-index: 201;
+	width:100%;
+	height:100%;
+	opacity: 2;
+}
+
+#news-header {
+	position: fixed;
+	height: 100%;
+	width: 100%;
+	z-index: 203;
+	display: flex;
+	justify-content: center;
+	flex-direction: column;
+	align-items: center;
+}


### PR DESCRIPTION
This is based off of the version of the Galaxy server, and the version last seen by the user (as reported by localStorage.) When an admin upgrades their server, the users of that server will see a notification icon that will hopefully draw their eyes to seeing the new features in their version of Galaxy.

fixes the comment in https://github.com/galaxyproject/galaxy/issues/3950#issuecomment-744326314 I guess. There's a notification icon. And a pip! And then it gets 'marked read'. Whee.


![Peek 2021-09-01 16-07](https://user-images.githubusercontent.com/458683/131686416-aeb7c534-204f-405a-b4da-ac2dacc79db5.gif)

**Design Commentary**

Discussed with @shiltemann the preferred icon, this bell seemed like a good choice because it would give us a place in the future to put notifications if we implement such a system. We could simply combine it into a multi-item news feed and it'd be fine for users.

I tested out a couple different icons, I wasn't super happy with any, but this seemed like it was OK + worked for the future.

For the pip, I thought about making it the active colour

**Open Question**

Should we do something about dev branch? Either opening the release notes early and updating them as we go along? Or just leave it? 

I guess main users will see this as main updates before we publish our announcements? That really feels like motivation to make the release notes earlier and update them as we go along.


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Open Galaxy (well, not dev, a version before dev since the release notes page doesn't exist for that.)
  2. A notification icon appears in the masthead, along with a little 'pip' I think they're called
  3. Clicking on it opens the release notes for that version of galaxy, and removes the pip
  4. The pip stays removed (assuming one doesn't clear session/etc.)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
