### PR TITLE
Hide details header in dataset error page if details are unavailable

### DIFF
--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -21,10 +21,10 @@
                         <b id="dataset-error-tool-id" class="text-break">{{ jobDetails.tool_id }}</b
                         >.
                     </p>
-                    <div v-if="jobDetails.tool_stderr || jobDetails.job_stderr || jobDetails.job_messages">
+                    <div v-if="jobDetails.tool_stderr || jobDetails.job_stderr || hasMessages(jobDetails)">
                         <h3>Details</h3>
                     </div>
-                    <div v-if="jobDetails.job_messages" id="dataset-error-job-messages">
+                    <div v-if="hasMessages(jobDetails)" id="dataset-error-job-messages">
                         <p>Execution resulted in the following messages:</p>
                         <div v-for="(job_message, index) in jobDetails.job_messages" :key="index">
                             <pre class="rounded code">{{ job_message["desc"] }}</pre>
@@ -130,6 +130,9 @@ export default {
         };
     },
     methods: {
+        hasMessages(jobDetails) {
+            return jobDetails.job_messages && jobDetails.job_messages.length > 0;
+        },
         onError(err) {
             this.errorMessage = err;
         },

--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -21,23 +21,11 @@
                         <b id="dataset-error-tool-id" class="text-break">{{ jobDetails.tool_id }}</b
                         >.
                     </p>
-                    <div v-if="jobDetails.tool_stderr || jobDetails.job_stderr || hasMessages(jobDetails)">
-                        <h3>Details</h3>
-                    </div>
-                    <div v-if="hasMessages(jobDetails)" id="dataset-error-job-messages">
-                        <p>Execution resulted in the following messages:</p>
-                        <div v-for="(job_message, index) in jobDetails.job_messages" :key="index">
-                            <pre class="rounded code">{{ job_message["desc"] }}</pre>
-                        </div>
-                    </div>
-                    <div v-if="jobDetails.tool_stderr">
-                        <p>Tool generated the following standard error:</p>
-                        <pre id="dataset-error-tool-stderr" class="rounded code">{{ jobDetails.tool_stderr }}</pre>
-                    </div>
-                    <div v-if="jobDetails.job_stderr">
-                        <p>Galaxy job runner generated the following standard error:</p>
-                        <pre id="dataset-error-job-stderr" class="rounded code">{{ jobDetails.job_stderr }}</pre>
-                    </div>
+                    <DatasetErrorDetails
+                        :tool-stderr="jobDetails.tool_stderr"
+                        :job-stderr="jobDetails.job_stderr"
+                        :job-messages="jobDetails.job_messages"
+                    />
                     <JobProblemProvider :jobid="dataset.creating_job" v-slot="{ result: jobProblems }" @error="onError">
                         <div v-if="jobProblems && (jobProblems.has_duplicate_inputs || jobProblems.has_empty_inputs)">
                             <h3 class="common_problems mt-3">Detected Common Potential Problems</h3>
@@ -97,6 +85,7 @@
 </template>
 
 <script>
+import DatasetErrorDetails from "./DatasetErrorDetails";
 import FormElement from "components/Form/FormElement";
 import { DatasetProvider } from "components/WorkflowInvocationState/providers";
 import { JobDetailsProvider, JobProblemProvider } from "components/providers/JobProvider";
@@ -110,6 +99,7 @@ library.add(faBug);
 export default {
     components: {
         DatasetProvider,
+        DatasetErrorDetails,
         FontAwesomeIcon,
         FormElement,
         JobDetailsProvider,

--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -120,9 +120,6 @@ export default {
         };
     },
     methods: {
-        hasMessages(jobDetails) {
-            return jobDetails.job_messages && jobDetails.job_messages.length > 0;
-        },
         onError(err) {
             this.errorMessage = err;
         },

--- a/client/src/components/DatasetInformation/DatasetErrorDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetErrorDetails.vue
@@ -1,0 +1,62 @@
+<template>
+    <div>
+        <div v-if="toolStderr || jobStderr || hasMessages">
+            <h3>Details</h3>
+        </div>
+        <div v-if="hasMessages" id="dataset-error-job-messages">
+            <p>Execution resulted in the following messages:</p>
+            <div v-for="(jobMessage, index) in jobMessages" :key="index">
+                <pre class="rounded code">{{ jobMessage["desc"] }}</pre>
+            </div>
+        </div>
+        <div v-if="toolStderr">
+            <p>Tool generated the following standard error:</p>
+            <pre id="dataset-error-tool-stderr" class="rounded code">{{ toolStderr }}</pre>
+        </div>
+        <div v-if="jobStderr">
+            <p>Galaxy job runner generated the following standard error:</p>
+            <pre id="dataset-error-job-stderr" class="rounded code">{{ jobStderr }}</pre>
+        </div>
+    </div>
+</template>
+
+<script>
+import FormElement from "components/Form/FormElement";
+import { DatasetProvider } from "components/WorkflowInvocationState/providers";
+import { JobDetailsProvider, JobProblemProvider } from "components/providers/JobProvider";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faBug } from "@fortawesome/free-solid-svg-icons";
+import { sendErrorReport } from "./services";
+
+library.add(faBug);
+
+export default {
+    components: {
+        DatasetProvider,
+        FontAwesomeIcon,
+        FormElement,
+        JobDetailsProvider,
+        JobProblemProvider,
+    },
+    props: {
+        toolStderr: {
+            type: String,
+            required: true,
+        },
+        jobStderr: {
+            type: String,
+            required: true,
+        },
+        jobMessages: {
+            type: Array,
+            required: true,
+        },
+    },
+    computed: {
+        hasMessages() {
+            return this.jobMessages && this.jobMessages.length > 0;
+        },
+    },
+};
+</script>

--- a/client/src/components/DatasetInformation/DatasetErrorDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetErrorDetails.vue
@@ -21,24 +21,7 @@
 </template>
 
 <script>
-import FormElement from "components/Form/FormElement";
-import { DatasetProvider } from "components/WorkflowInvocationState/providers";
-import { JobDetailsProvider, JobProblemProvider } from "components/providers/JobProvider";
-import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-import { library } from "@fortawesome/fontawesome-svg-core";
-import { faBug } from "@fortawesome/free-solid-svg-icons";
-import { sendErrorReport } from "./services";
-
-library.add(faBug);
-
 export default {
-    components: {
-        DatasetProvider,
-        FontAwesomeIcon,
-        FormElement,
-        JobDetailsProvider,
-        JobProblemProvider,
-    },
     props: {
         toolStderr: {
             type: String,

--- a/client/src/components/DatasetInformation/DatasetErrorDetails.vue
+++ b/client/src/components/DatasetInformation/DatasetErrorDetails.vue
@@ -1,8 +1,6 @@
 <template>
-    <div>
-        <div v-if="toolStderr || jobStderr || hasMessages">
-            <h3>Details</h3>
-        </div>
+    <div v-if="hasDetails">
+        <h3>Details</h3>
         <div v-if="hasMessages" id="dataset-error-job-messages">
             <p>Execution resulted in the following messages:</p>
             <div v-for="(jobMessage, index) in jobMessages" :key="index">
@@ -25,18 +23,21 @@ export default {
     props: {
         toolStderr: {
             type: String,
-            required: true,
+            default: null,
         },
         jobStderr: {
             type: String,
-            required: true,
+            default: null,
         },
         jobMessages: {
             type: Array,
-            required: true,
+            default: null,
         },
     },
     computed: {
+        hasDetails() {
+            return this.toolStderr || this.jobStderr || this.hasMessages;
+        },
         hasMessages() {
             return this.jobMessages && this.jobMessages.length > 0;
         },


### PR DESCRIPTION
Minor fix to hide the dataset error `Details` header if error details are unavailable.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Attempt to upload data from a restricted url source
  2. Click on the `bug` icon to display the error report
  3. If the `fetch_data` tool did not produce any error details, the `Details` header will be hidden in the report

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
