### PR TITLE
add test case verifying misread issue #11291

### DIFF
--- a/test/functional/tools/multi_data_mandatory.xml
+++ b/test/functional/tools/multi_data_mandatory.xml
@@ -1,0 +1,30 @@
+<tool id="multi_data_mandatory" name="multi_data_mandatory" version="0.1.0">
+  <command>
+touch '$out1';
+#if $input1
+    #for $input in $input1
+        #if $input
+            cat '$input' >> '$out1';
+        #end if
+    #end for
+#else
+    echo "No input selected" >> '$out1'
+#end if
+  </command>
+  <inputs>
+    <param name="input1" type="data" format="txt" multiple="true" label="Data 1"/>
+  </inputs>
+  <outputs>
+    <data format="txt" name="out1" />
+  </outputs>
+  <tests>
+    <!-- ensure that `a multiple="true" data parameter requires at least one data input.` -->
+    <test expect_failure="false">
+      <output name="out1">
+        <assert_contents>
+          <has_line line="No input selected" />
+        </assert_contents>
+      </output>
+    </test>
+  </tests>
+</tool>

--- a/test/functional/tools/multi_data_param.xml
+++ b/test/functional/tools/multi_data_param.xml
@@ -6,8 +6,8 @@
     cat ${" ".join(map(str, $f2))} >> $out2
   </command>
   <inputs>
-    <param name="f1" type="data" format="txt" multiple="true" label="Data 1" min="1" max="1235" />
-    <param name="f2" type="data" format="txt" multiple="true" label="Data 2" />
+    <param name="f1" type="data" format="txt" multiple="true" min="1" max="2" label="Data 1"/>
+    <param name="f2" type="data" format="txt" multiple="true" optional="false" label="Data 2" />
     <conditional name="advanced">
       <param name="full" type="select" label="Parameter Settings">
         <option value="no">Use defaults</option>
@@ -41,12 +41,34 @@
         </assert_contents>
       </output>
     </test>
-    <!-- UI widget can do this next one, but API can. -->
+    <!-- UI widget can't do this next one, but API can. -->
     <test>
       <param name="f1" value="simple_line.txt,simple_line.txt" />
       <param name="f2" value="simple_line_alternative.txt" />
       <output name="out1" file="simple_line_x2.txt" />
       <output name="out2" file="simple_line_alternative.txt" />
+    </test>
+    <!-- ensure that `a multiple="true" data parameter requires at least one data input.` -->
+    <test expect_failure="true">
+      <param name="f1" value="simple_line.txt,simple_line_alternative.txt" />
+      <!-- <param name="f2" value="" /> -->
+      <output name="out1">
+        <assert_contents>
+          <has_line line="This is a line of text." />
+          <has_line line="This is a different line of text." />
+        </assert_contents>
+      </output>
+    </test>
+    <!-- ensure that the `max` attribute of f1 is evaluated -->
+    <test expect_failure="true">
+      <param name="f1" value="simple_line.txt,simple_line_alternative.txt,simple_line.txt" />
+      <param name="f2" value="simple_line_alternative.txt" />
+      <output name="out1">
+        <assert_contents>
+          <has_line line="This is a line of text." />
+          <has_line line="This is a different line of text." />
+        </assert_contents>
+      </output>
     </test>
   </tests>
 </tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -116,6 +116,7 @@
   <tool file="multi_data_param.xml" />
   <tool file="multi_data_repeat.xml" />
   <tool file="multi_data_optional.xml" />
+  <tool file="multi_data_mandatory.xml" />
   <tool file="paths_as_file.xml" />
   <tool file="param_text_option.xml" />
   <tool file="column_param.xml" />


### PR DESCRIPTION
I misread  https://github.com/galaxyproject/galaxy/issues/11291 .. actually missing the point that its about empty collections .. and tried to add a test case that submits a tool with a mandatory data parameter without specifying a dataset for this parameter in the test. 

What is happening is that Galaxy selects input data sets automatically. Certainly this can be an advantage if only one fitting data set is available for an input (and it is the data set that the user wants to submit .. ). But in other instances it may be annoying. An example is if you start a number of uploads then the input is updated with each finished upload that fits.

**Main question is, if this is a bug.**

The PR so far adds two tests https://github.com/galaxyproject/galaxy/issues/11291

- multi_data_mandatory
  - the test shows that it works in principle
- multi_data_param 
  - the 4th test shows that the problem occurs if there is any dataset in the history (debugging shows that f2 is automatically filled with the last added history element)
  - uncommenting the f2 line in the 4th test also shows that f2 is submitted with a zip file of the test data folder which is odd / undocumented
  - the 5th test actually checks the max attribute of f1 .. **at least this may be useful**

The trace leading to the observed behavior is:

- `Tool.handle_input` https://github.com/galaxyproject/galaxy/blob/41ed9d5c28f4d385edf6dfed570759818fde13ad/lib/galaxy/tools/__init__.py#L1666
- `Tool.expand_incoming` https://github.com/galaxyproject/galaxy/blob/41ed9d5c28f4d385edf6dfed570759818fde13ad/lib/galaxy/tools/__init__.py#L1613
- `populate_state` -> `_populate_state_legacy` https://github.com/galaxyproject/galaxy/blob/41ed9d5c28f4d385edf6dfed570759818fde13ad/lib/galaxy/tools/parameters/__init__.py#L405 gets an initial value for each parameter via
- `BaseDataToolParameter.get_initial_value` https://github.com/galaxyproject/galaxy/blob/41ed9d5c28f4d385edf6dfed570759818fde13ad/lib/galaxy/tools/parameters/basic.py#L1719

the last function sets a default value for each non optional parameter. 


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
