### PR TITLE
Revert a couple changes to Selenium tests to fix legacy Selenium tests.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1461,17 +1461,15 @@ class NavigatesGalaxy(HasDriver):
 
     def history_panel_click_item_title(self, hid, **kwds):
         item_component = self.history_panel_item_component(hid=hid)
+        details_component = item_component.details
+        details_displayed = details_component.is_displayed
         item_component.title.wait_for_and_click()
+
         if kwds.get("wait", False):
-            if self.is_beta_history():
-                item_component.details.wait_for_present()
+            if details_displayed:
+                details_component.wait_for_absent_or_hidden()
             else:
-                details_component = item_component.details
-                details_displayed = details_component.is_displayed
-                if details_displayed:
-                    details_component.wait_for_absent_or_hidden()
-                else:
-                    details_component.wait_for_visible()
+                details_component.wait_for_visible()
         return item_component
 
     def history_panel_ensure_showing_item_details(self, hid):


### PR DESCRIPTION
I think you need to check for details before running the body to know what to wait on. The selectors might be different for the beta history but I'm pretty sure the logic needs to be the same.

Opening a PR because it was working for me locally consistently. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
