### PR TITLE
Fix hids, alignment, other style issues in beta history.

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -16,11 +16,8 @@ either through the props, and make updates through the events -->
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
     >
         <!-- name, state buttons, menus -->
-        <nav
-            class="content-top-menu p-1 d-flex align-items-baseline cursor-pointer"
-            @click.stop="$emit('update:expanded', !expanded)"
-        >
-            <div class="d-flex align-items-baseline flex-grow-1 overflow-hidden">
+        <nav class="content-top-menu p-1 d-flex cursor-pointer" @click.stop="$emit('update:expanded', !expanded)">
+            <div class="d-flex flex-grow-1 overflow-hidden">
                 <div class="pl-1" v-if="showSelectionBox">
                     <b-check class="selector" :checked="selected" @change="$emit('update:selected', $event)"></b-check>
                 </div>

--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -16,7 +16,10 @@ either through the props, and make updates through the events -->
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
     >
         <!-- name, state buttons, menus -->
-        <nav class="p-1 d-flex align-items-baseline cursor-pointer" @click.stop="$emit('update:expanded', !expanded)">
+        <nav
+            class="content-top-menu p-1 d-flex align-items-baseline cursor-pointer"
+            @click.stop="$emit('update:expanded', !expanded)"
+        >
             <div class="d-flex align-items-baseline flex-grow-1 overflow-hidden">
                 <div class="pl-1" v-if="showSelectionBox">
                     <b-check class="selector" :checked="selected" @change="$emit('update:selected', $event)"></b-check>

--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -49,7 +49,7 @@ either through the props, and make updates through the events -->
 
                 <div class="content-title title p-1 overflow-hidden">
                     <h5 class="text-truncate" v-if="collapsed">
-                        <span class="hid sr-only" data-description="dataset hid">{{ dataset.hid }}</span>
+                        <span class="hid" data-description="dataset hid">{{ dataset.hid }}</span>
                         <span class="name" data-description="dataset name">{{ dataset.title }}</span>
                     </h5>
                 </div>

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -10,7 +10,7 @@
         @keydown.arrow-right.self.stop="$emit('viewCollection')"
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
     >
-        <nav class="p-1 d-flex align-items-baseline cursor-pointer">
+        <nav class="content-top-menu p-1 d-flex align-items-baseline cursor-pointer">
             <div class="d-flex align-items-baseline flex-grow-1 overflow-hidden">
                 <div class="pl-1" v-if="showSelection">
                     <b-check

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -10,8 +10,8 @@
         @keydown.arrow-right.self.stop="$emit('viewCollection')"
         @keydown.space.self.stop.prevent="$emit('update:selected', !selected)"
     >
-        <nav class="content-top-menu p-1 d-flex align-items-baseline cursor-pointer">
-            <div class="d-flex align-items-baseline flex-grow-1 overflow-hidden">
+        <nav class="content-top-menu p-1 d-flex cursor-pointer">
+            <div class="d-flex flex-grow-1 overflow-hidden">
                 <div class="pl-1" v-if="showSelection">
                     <b-check
                         class="selector"

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -57,7 +57,7 @@
 
                 <div class="content-title title flex-grow-1 overflow-hidden" @click.stop="$emit('viewCollection')">
                     <h5 class="text-truncate">
-                        <span class="hid sr-only">{{ dsc.hid }}</span>
+                        <span class="hid">{{ dsc.hid }}</span>
                         <span class="name">{{ dsc.name }}</span>
                         <span class="description">
                             ({{ dsc.collectionType | localize }} {{ dsc.collectionCountDescription | localize }})


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/155398/132047131-1c5b19bd-336a-4a8b-8f6c-5e3973605ed5.png)

After:
![image](https://user-images.githubusercontent.com/155398/132047262-9be1d227-7ce3-4d83-8056-a319f25451db.png)

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Open beta history, note that it has hids displayed.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
