### PR TITLE
[21.01] Install Tempita from a fork due to `use_2to3` deprecation

### DIFF
--- a/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
+++ b/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt
@@ -11,7 +11,7 @@ adal==1.2.5
 amqp==5.0.2; python_version >= '3.6'
 appdirs==1.4.4
 argcomplete==1.12.2
-attmap==0.12.11
+attmap==0.13.0
 attrs==20.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 babel==2.9.0
 bagit==1.7.0

--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -13,4 +13,5 @@ social-auth-core[openidconnect]==3.3.0
 SQLAlchemy>=1.3.0,<1.4.0  # https://github.com/kvesteri/sqlalchemy-utils/issues/474
 sqlalchemy-migrate
 sqlalchemy-utils
+tempita @ git+https://git@github.com/nsoranzo/tempita@main#egg=tempita  # Required by sqlalchemy-migrate, see https://github.com/galaxyproject/galaxy/issues/12412
 WebOb


### PR DESCRIPTION
Fix https://github.com/galaxyproject/galaxy/issues/12412 .

We have a dependency on `Tempita` (through `sqlalchemy-migrate`), which is abandonware and uses the `use_2to3=True` option of `setup()` in its `setup.py` .
The new Setuptools v58.0.0 removed support for 2to3 during builds: https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v5800
As a result Tempita is installed at even older version and importing it raises a SyntaxError.

For Galaxy as a full application this has been solved by creating a wheel on https://wheels.galaxyproject.org . But the `galaxy-data` package (which also depends on `sqlalchemy-migrate`) cannot automatically install the tempita-0.5.2 wheel from our alternative package index when installed via `pip install galaxy-data` as there is no syntax to specify that.

I've therefore resurrected Tempita from the Bitbucket Mercurial repo (thanks to [Software Heritage backups](https://bitbucket-archive.softwareheritage.org/projects/ia/ianb/tempita.html)!), converted to a GitHub repo and updated its code to Python 3.6 with 2to3 and pyupgrade.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
