### PR TITLE
Implement model store option for importing DISCARDED datasets that are undeleted.

### DIFF
--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from enum import Enum
 from json import (
     dump,
     dumps,
@@ -37,14 +38,32 @@ ATTRS_FILENAME_LIBRARIES = 'libraries_attrs.txt'
 GALAXY_EXPORT_VERSION = "2"
 
 
-class ImportOptions:
+class ImportDiscardedDataType(Enum):
+    # Don't allow discarded 'okay' datasets on import, datasets will be marked deleted.
+    FORBID = 'forbid'
+    # Allow datasets to be imported as experimental DISCARDED datasets that are not deleted if file data unavailable.
+    ALLOW = 'allow'
+    # Import all datasets as discarded regardless of whether file data is available in the store.
+    FORCE = 'force'
 
-    def __init__(self, allow_edit=False, allow_library_creation=False, allow_dataset_object_edit=None):
+
+DEFAULT_DISCARDED_DATA_TYPE = ImportDiscardedDataType.FORBID
+
+
+class ImportOptions:
+    allow_edit: bool
+    allow_library_creation: bool
+    allow_dataset_object_edit: bool
+    discarded_data: ImportDiscardedDataType
+
+    def __init__(self, allow_edit=False, allow_library_creation=False, allow_dataset_object_edit=None, discarded_data=DEFAULT_DISCARDED_DATA_TYPE):
         self.allow_edit = allow_edit
         self.allow_library_creation = allow_library_creation
         if allow_dataset_object_edit is None:
-            allow_dataset_object_edit = allow_edit
-        self.allow_dataset_object_edit = allow_dataset_object_edit
+            self.allow_dataset_object_edit = allow_edit
+        else:
+            self.allow_dataset_object_edit = allow_dataset_object_edit
+        self.discarded_data = discarded_data
 
 
 class SessionlessContext:
@@ -323,12 +342,14 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         if not in_directory(temp_dataset_file_name, self.archive_dir):
                             raise MalformedContents(f"Invalid dataset path: {temp_dataset_file_name}")
 
-                    if not file_name or not os.path.exists(temp_dataset_file_name):
+                    discarded_data = self.import_options.discarded_data
+                    if not file_name or not os.path.exists(temp_dataset_file_name) or discarded_data is ImportDiscardedDataType.FORCE:
                         dataset_instance.state = dataset_instance.states.DISCARDED
-                        dataset_instance.deleted = True
-                        dataset_instance.purged = True
-                        dataset_instance.dataset.deleted = True
-                        dataset_instance.dataset.purged = True
+                        deleted = discarded_data == ImportDiscardedDataType.FORBID
+                        dataset_instance.deleted = deleted
+                        dataset_instance.purged = deleted
+                        dataset_instance.dataset.deleted = deleted
+                        dataset_instance.dataset.purged = deleted
                     else:
                         dataset_instance.state = dataset_attrs.get('state', dataset_instance.states.OK)
                         self.object_store.update_from_file(dataset_instance.dataset, file_name=temp_dataset_file_name, create=True)


### PR DESCRIPTION
Useful for viewing histories (and in the future workflow invocations) that just include metadata and not actual files.

An atomically useful change from #9024 I believe.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
