### PR TITLE
Fix flaky failing workflow editor selenium test.

### DIFF
--- a/lib/galaxy_test/selenium/test_workflow_editor.py
+++ b/lib/galaxy_test/selenium/test_workflow_editor.py
@@ -100,7 +100,12 @@ class WorkflowEditorTestCase(SeleniumTestCase):
         node = editor.node._(label="select_from_dataset_optional")
         node.title.wait_for_and_click()
         self.components.tool_form.parameter_checkbox(parameter='select_single').wait_for_and_click()
-        self.components.tool_form.parameter_input(parameter='select_single').wait_for_and_send_keys('parameter value')
+        # External (selenium-side) debounce hack for old backbone input
+        # TODO: remove when form elements are all converted.
+        self.components.tool_form.parameter_input(parameter='select_single').wait_for_and_send_keys('parameter valu')
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.components.tool_form.parameter_input(parameter='select_single').wait_for_and_send_keys('e')
+        self.sleep_for(self.wait_types.UX_RENDER)
         self.assert_has_changes_and_save()
         self.sleep_for(self.wait_types.UX_RENDER)
         workflow = self.workflow_populator.download_workflow(workflow_id)


### PR DESCRIPTION
Add a selenium-side debounce (effectively) to fix the failing selenium test for the optional select data field in the workflow editor.

I honestly don't love it, but these fields are going away rapidly as we convert the tool form.  Might be okay to give the test a little helping hand for now?  Thinking about it more, I don't think it's particularly unfair in terms of a test, either; it's just a 1ms delay between the first bit of a string and the last character.

This is another way to cut at https://github.com/galaxyproject/galaxy/pull/12219

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
