### PR TITLE
Fix is_of_type for datasets in a collection

### DIFF
--- a/lib/galaxy/tools/wrappers.py
+++ b/lib/galaxy/tools/wrappers.py
@@ -462,12 +462,13 @@ class DatasetListWrapper(list, ToolParameterValueWrapper, HasDatasets):
 
 class DatasetCollectionWrapper(ToolParameterValueWrapper, HasDatasets):
 
-    def __init__(self, job_working_directory, has_collection, datatypes_registry=None, **kwargs):
+    def __init__(self, job_working_directory, has_collection, datatypes_registry, **kwargs):
         super().__init__()
         self.job_working_directory = job_working_directory
         self._dataset_elements_cache = {}
         self._element_identifiers_extensions_paths_and_metadata_files = None
         self.datatypes_registry = datatypes_registry
+        kwargs['datatypes_registry'] = datatypes_registry
         self.kwargs = kwargs
 
         if has_collection is None:

--- a/test/functional/tools/is_of_type.xml
+++ b/test/functional/tools/is_of_type.xml
@@ -1,0 +1,29 @@
+<tool id="is_of_type" name="is_of_type" version="1.0.0">
+    <command><![CDATA[
+#for $dataset in $collection:  
+    #if $dataset.is_of_type('txt')
+        echo "true" >> '$is_txt'
+    #end if
+#end for
+    ]]></command>
+    <inputs>
+        <param name="collection" type="data_collection" collection_type="list" format="txt"/>
+    </inputs>
+    <outputs>
+        <data name="is_txt" format="txt"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="collection">
+                <collection type="list">
+                    <element name="forward" value="1.fasta" ftype="fasta"/>
+                </collection>
+            </param>
+            <output name="is_txt">
+                <assert_contents>
+                    <has_text text="true"/>
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -41,6 +41,7 @@
   <tool file="tool_provided_metadata_11.xml" />
   <tool file="tool_provided_metadata_12.xml" />
   <tool file="empty_datasets.xml" />
+  <tool file="is_of_type.xml" />
   <tool file="inputs_as_json.xml" />
   <tool file="inputs_as_json_profile.xml" />
   <tool file="inputs_as_json_with_paths.xml" />


### PR DESCRIPTION
Include a test tool that fails like this without the fix:

```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/template.py", line 80, in fill_template
    return unicodify(t, log_exception=False)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/__init__.py", line 1060, in unicodify
    value = str(value)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1631180564_759418_48584.py", line 89, in respond
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 342, in is_of_type
    datatype = self.datatypes_registry.get_datatype_by_extension(e)
AttributeError: 'NoneType' object has no attribute 'get_datatype_by_extension'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/jobs/runners/__init__.py", line 237, in prepare_job
    job_wrapper.prepare()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/jobs/__init__.py", line 1160, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/evaluation.py", line 463, in build
    raise e
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/evaluation.py", line 459, in build
    self.__build_command_line()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/evaluation.py", line 484, in __build_command_line
    command_line = fill_template(command, context=param_dict, python_template_version=self.tool.python_template_version)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/template.py", line 118, in fill_template
    return fill_template(template_text=template_text,
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/template.py", line 126, in fill_template
    raise first_exception or e
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/template.py", line 80, in fill_template
    return unicodify(t, log_exception=False)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/util/__init__.py", line 1060, in unicodify
    value = str(value)
  File "/Users/mvandenb/src/galaxy/.venv/lib/python3.9/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1631180564_725492_78593.py", line 87, in respond
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/wrappers.py", line 342, in is_of_type
    datatype = self.datatypes_registry.get_datatype_by_extension(e)
AttributeError: 'NoneType' object has no attribute 'get_datatype_by_extension'
```

Broken in https://github.com/galaxyproject/galaxy/pull/11613

Reported by @natefoo on gitter.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
