### PR TITLE
Spanish Translations for remaining untranslated UI components

### DIFF
--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -12,7 +12,7 @@
         <font-awesome-icon
             v-else
             v-b-tooltip.hover
-            title="clear search (esc)"
+            :title="titleClearSearch"
             class="search-clear"
             icon="times-circle"
             @click="setQuery()"
@@ -20,6 +20,7 @@
     </div>
 </template>
 <script>
+import _l from "utils/localization";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faTimesCircle } from "@fortawesome/free-solid-svg-icons";
@@ -53,6 +54,7 @@ export default {
             queryInput: null,
             queryTimer: null,
             queryCurrent: null,
+            titleClearSearch: _l('clear search (esc)'),
         };
     },
     watch: {

--- a/client/src/components/Common/DelayedInput.vue
+++ b/client/src/components/Common/DelayedInput.vue
@@ -54,7 +54,7 @@ export default {
             queryInput: null,
             queryTimer: null,
             queryCurrent: null,
-            titleClearSearch: _l('clear search (esc)'),
+            titleClearSearch: _l("clear search (esc)"),
         };
     },
     watch: {

--- a/client/src/components/DatasetInformation/DatasetAttributes.vue
+++ b/client/src/components/DatasetInformation/DatasetAttributes.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <h4>Edit Dataset Attributes</h4>
+        <h4 v-localize>Edit Dataset Attributes</h4>
         <b-alert v-if="messageText" :variant="messageVariant" show>
             {{ messageText | l }}
         </b-alert>

--- a/client/src/components/History/HistoryDetails.vue
+++ b/client/src/components/History/HistoryDetails.vue
@@ -9,7 +9,7 @@ Emit new History model object when done via .sync syntax
             <h3 data-description="history name display">{{ historyName || "(History Name)" }}</h3>
             <h5 class="history-size">
                 <span v-if="history.size">{{ history.size | niceFileSize }}</span>
-                <span v-else>(empty)</span>
+                <span v-else v-localize>(empty)</span>
             </h5>
 
             <!-- display title, annotation, tags -->

--- a/client/src/components/History/HistoryEmpty.vue
+++ b/client/src/components/History/HistoryEmpty.vue
@@ -5,7 +5,8 @@
             <span>{{ message | l }}</span>
         </h4>
         <p>
-            <a href="#" @click.prevent="openGlobalUploadModal" v-localize>You can load your own data</a> <span v-localize>or</span>
+            <a href="#" @click.prevent="openGlobalUploadModal" v-localize>You can load your own data</a>
+            <span v-localize>or</span>
             <a href="#" @click.prevent="clickDataLink" v-localize>get data from an external source</a>.
         </p>
     </b-alert>

--- a/client/src/components/History/HistoryEmpty.vue
+++ b/client/src/components/History/HistoryEmpty.vue
@@ -5,7 +5,7 @@
             <span>{{ message | l }}</span>
         </h4>
         <p>
-            <a href="#" @click.prevent="openGlobalUploadModal" v-localize>You can load your own data</a> or
+            <a href="#" @click.prevent="openGlobalUploadModal" v-localize>You can load your own data</a> <span v-localize>or</span>
             <a href="#" @click.prevent="clickDataLink" v-localize>get data from an external source</a>.
         </p>
     </b-alert>

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -6,27 +6,23 @@
             </b-button>
             <b-button id="create-new-lib" v-b-toggle.collapse-2 v-if="isAdmin" title="Create new folder" class="mr-1">
                 <font-awesome-icon icon="plus" />
-                Library
+                {{ titleLibrary }}
             </b-button>
             <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
-            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)">
-                include deleted
-            </b-form-checkbox>
-            <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)">
-                exclude restricted
-            </b-form-checkbox>
+            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)" v-localize>include deleted</b-form-checkbox>
+            <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)" v-localize>exclude restricted</b-form-checkbox>
         </div>
         <b-collapse v-model="isNewLibFormVisible" id="collapse-2">
             <b-card>
                 <b-form @submit.prevent="newLibrary">
                     <b-input-group class="mb-2 new-row">
-                        <b-form-input v-model="newLibraryForm.name" required placeholder="Name" />
-                        <b-form-input v-model="newLibraryForm.description" required placeholder="Description" />
-                        <b-form-input v-model="newLibraryForm.synopsis" placeholder="Synopsis" />
+                        <b-form-input v-model="newLibraryForm.name" required :placeholder="titleName" />
+                        <b-form-input v-model="newLibraryForm.description" required :placeholder="titleDescription" />
+                        <b-form-input v-model="newLibraryForm.synopsis" :placeholder="titleSynopsis" />
                         <template v-slot:append>
-                            <b-button id="save_new_library" type="submit" title="save">
+                            <b-button id="save_new_library" type="submit" :title="titleSave">
                                 <font-awesome-icon :icon="['far', 'save']" />
-                                Save
+                                {{ titleSave }}
                             </b-button>
                         </template>
                     </b-input-group>
@@ -88,7 +84,7 @@
             <template v-slot:cell(buttons)="row">
                 <b-button @click="undelete(row.item)" v-if="row.item.deleted" :title="'Undelete ' + row.item.name">
                     <font-awesome-icon icon="unlock" />
-                    Undelete
+                    {{ titleUndelete }}
                 </b-button>
                 <div v-else-if="isAdmin">
                     <b-button
@@ -99,7 +95,7 @@
                         @click="saveChanges(row.item)"
                     >
                         <font-awesome-icon :icon="['far', 'save']" />
-                        Save
+                        {{ titleSave }}
                     </b-button>
                     <b-button
                         v-if="row.item.can_user_modify"
@@ -110,11 +106,11 @@
                     >
                         <div v-if="!row.item.editMode">
                             <font-awesome-icon icon="pencil-alt" />
-                            Edit
+                            {{ titleEdit }}
                         </div>
                         <div v-else>
                             <font-awesome-icon :icon="['fas', 'times']" />
-                            Cancel
+                            {{ titleCancel }}
                         </div>
                     </b-button>
                     <b-button
@@ -135,7 +131,7 @@
                         @click="deleteLibrary(row.item)"
                     >
                         <font-awesome-icon icon="trash" />
-                        Delete
+                        {{ titleDelete }}
                     </b-button>
                 </div>
             </template>
@@ -166,7 +162,7 @@
                                 />
                             </td>
                             <td class="text-muted ml-1 paginator-text">
-                                <span class="pagination-total-pages-text">per page, {{ rows }} total</span>
+                                <span class="pagination-total-pages-text">{{ titlePerPage }}, {{ rows }} {{ titleTotal }}</span>
                             </td>
                         </tr>
                     </table>
@@ -177,6 +173,7 @@
 </template>
 
 <script>
+import _l from "utils/localization";
 import Vue from "vue";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
@@ -228,6 +225,17 @@ export default {
                 description: "",
                 synopsis: "",
             },
+            titleLibrary: _l("Library"),
+            titleName: _l("Name"),
+            titleDescription: _l("Description"),
+            titleSynopsis: _l("Synopsis"),
+            titleSave: _l("Save"),
+            titleUndelete: _l("Undelete"),
+            titleEdit: _l("Edit"),
+            titleCancel: _l("Cancel"),
+            titleDelete: _l("Delete"),
+            titlePerPage: _l("per page"),
+            titleTotal: _l("total"),
         };
     },
     created() {

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -9,8 +9,12 @@
                 {{ titleLibrary }}
             </b-button>
             <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
-            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)" v-localize>include deleted</b-form-checkbox>
-            <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)" v-localize>exclude restricted</b-form-checkbox>
+            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)" v-localize
+                >include deleted</b-form-checkbox
+            >
+            <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)" v-localize
+                >exclude restricted</b-form-checkbox
+            >
         </div>
         <b-collapse v-model="isNewLibFormVisible" id="collapse-2">
             <b-card>
@@ -162,7 +166,9 @@
                                 />
                             </td>
                             <td class="text-muted ml-1 paginator-text">
-                                <span class="pagination-total-pages-text">{{ titlePerPage }}, {{ rows }} {{ titleTotal }}</span>
+                                <span class="pagination-total-pages-text"
+                                    >{{ titlePerPage }}, {{ rows }} {{ titleTotal }}</span
+                                >
                             </td>
                         </tr>
                     </table>

--- a/client/src/components/Libraries/LibraryFolder/SearchField.vue
+++ b/client/src/components/Libraries/LibraryFolder/SearchField.vue
@@ -5,13 +5,15 @@
             class="mr-1"
             type="search"
             id="filterInput"
-            placeholder="Search"
+            :placeholder="titleSearch"
             @keyup.enter="startSearch()"
         />
     </b-input-group>
 </template>
 
 <script>
+import _l from "utils/localization";
+
 export default {
     name: "SearchField",
     props: {
@@ -25,6 +27,7 @@ export default {
         return {
             search: "",
             awaitingSearch: false,
+            titleSearch: _l("Search"),
         };
     },
     methods: {

--- a/client/src/components/Panels/Buttons/FavoritesButton.vue
+++ b/client/src/components/Panels/Buttons/FavoritesButton.vue
@@ -14,6 +14,7 @@
 </template>
 
 <script>
+import _l from "utils/localization";
 import { VBTooltip } from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
@@ -34,7 +35,7 @@ export default {
     data() {
         return {
             searchKey: "#favorites",
-            tooltipToggle: "Show favorites",
+            tooltipToggle: _l("Show favorites"),
             tooltipUntoggle: "Clear",
             toggle: false,
         };

--- a/client/src/components/Panels/ToolBox.vue
+++ b/client/src/components/Panels/ToolBox.vue
@@ -11,14 +11,14 @@
                         v-if="panelViews && Object.keys(panelViews).length > 1"
                     />
                 </div>
-                <div class="panel-header-text">Tools</div>
+                <div class="panel-header-text" v-localize>Tools</div>
             </div>
         </div>
         <div class="unified-panel-controls">
             <tool-search
                 :current-panel-view="currentPanelView"
                 :query="query"
-                placeholder="search tools"
+                :placeholder="titleSearchTools"
                 @onQuery="onQuery"
                 @onResults="onResults"
             />
@@ -87,6 +87,7 @@ export default {
             showSections: false,
             buttonText: "",
             buttonIcon: "",
+            titleSearchTools: _l("search tools"),
         };
     },
     props: {
@@ -179,7 +180,7 @@ export default {
             this.setButtonText();
         },
         setButtonText() {
-            this.buttonText = this.showSections ? "Hide Sections" : "Show Sections";
+            this.buttonText = this.showSections ? _l("Hide Sections") : _l("Show Sections");
             this.buttonIcon = this.showSections ? "fa fa-eye-slash" : "fa fa-eye";
         },
         updatePanelView(panelView) {

--- a/client/src/components/PluginList.vue
+++ b/client/src/components/PluginList.vue
@@ -47,7 +47,8 @@
                                     class="ui-button-default float-left mt-3 btn btn-primary"
                                     @click="create(plugin)"
                                 >
-                                    <i class="icon fa fa-check" /> <span class="title">{{ titleCreateVisualization }}</span>
+                                    <i class="icon fa fa-check" />
+                                    <span class="title">{{ titleCreateVisualization }}</span>
                                 </button>
                             </div>
                             <div v-else class="alert alert-danger" v-localize>

--- a/client/src/components/PluginList.vue
+++ b/client/src/components/PluginList.vue
@@ -6,7 +6,7 @@
                 <input
                     class="search-query parent-width"
                     name="query"
-                    placeholder="search visualizations"
+                    :placeholder="titleSearchVisualizations"
                     autocomplete="off"
                     type="text"
                     v-model="search"
@@ -33,7 +33,7 @@
                         <td />
                         <td v-if="plugin.name == name">
                             <div v-if="hdas && hdas.length > 0">
-                                <div class="font-weight-bold">Select a dataset to visualize:</div>
+                                <div class="font-weight-bold">{{ titleSelectDataset }}</div>
                                 <div class="ui-select">
                                     <select class="select" v-model="selected">
                                         <option v-for="file in hdas" :key="file.id" :value="file.id">
@@ -47,10 +47,10 @@
                                     class="ui-button-default float-left mt-3 btn btn-primary"
                                     @click="create(plugin)"
                                 >
-                                    <i class="icon fa fa-check" /> <span class="title">Create Visualization</span>
+                                    <i class="icon fa fa-check" /> <span class="title">{{ titleCreateVisualization }}</span>
                                 </button>
                             </div>
-                            <div v-else class="alert alert-danger">
+                            <div v-else class="alert alert-danger" v-localize>
                                 There is no suitable dataset in your current history which can be visualized with this
                                 plugin.
                             </div>
@@ -63,6 +63,7 @@
 </template>
 <script>
 import $ from "jquery";
+import _l from "utils/localization";
 import { getAppRoot } from "onload/loadConfig";
 import { getGalaxyInstance } from "app";
 import axios from "axios";
@@ -77,6 +78,9 @@ export default {
             name: null,
             error: null,
             fixed: false,
+            titleSearchVisualizations: _l("search visualizations"),
+            titleCreateVisualization: _l("Create Visualization"),
+            titleSelectDataset: _l("Select a dataset to visualize:"),
         };
     },
     created() {

--- a/client/src/components/Toolshed/Index.vue
+++ b/client/src/components/Toolshed/Index.vue
@@ -53,7 +53,7 @@ export default {
                 { text: "Search All", value: true },
                 { text: "Installed Only", value: false },
             ],
-            titleClearSearch: _l("clear search (esc)")
+            titleClearSearch: _l("clear search (esc)"),
         };
     },
     watch: {

--- a/client/src/components/Toolshed/Index.vue
+++ b/client/src/components/Toolshed/Index.vue
@@ -11,7 +11,7 @@
                     @change="setQuery"
                     @keydown.esc="setQuery()"
                 />
-                <b-input-group-append v-b-tooltip.hover title="clear search (esc)">
+                <b-input-group-append v-b-tooltip.hover :title="titleClearSearch">
                     <b-btn @click="setQuery()">
                         <i class="fa fa-times" />
                     </b-btn>
@@ -28,6 +28,7 @@
     </div>
 </template>
 <script>
+import _l from "utils/localization";
 import SearchList from "./SearchList/Index.vue";
 import InstalledList from "./InstalledList/Index.vue";
 
@@ -52,6 +53,7 @@ export default {
                 { text: "Search All", value: true },
                 { text: "Installed Only", value: false },
             ],
+            titleClearSearch: _l("clear search (esc)")
         };
     },
     watch: {

--- a/client/src/components/User/CloudAuth/CloudAuth.vue
+++ b/client/src/components/User/CloudAuth/CloudAuth.vue
@@ -6,7 +6,7 @@
             </b-alert>
 
             <hgroup class="cloud-auth-title">
-                <h1>Manage Cloud Authorization</h1>
+                <h1 v-localize>Manage Cloud Authorization</h1>
                 <nav class="operations">
                     <ul>
                         <li class="cloudKeyHelp">

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -1,12 +1,11 @@
 <template>
     <b-container fluid class="p-0">
-        <h2>User preferences</h2>
+        <h2 v-localize>User preferences</h2>
         <b-alert :variant="messageVariant" :show="!!message">
             {{ message }}
         </b-alert>
         <p>
-            You are logged in as <strong id="user-preferences-current-email">{{ email }}</strong
-            >.
+            {{ titleLoggedInAs }} <strong id="user-preferences-current-email">{{ email }}</strong>.
         </p>
         <b-row class="ml-3 mb-1" v-for="(link, index) in activeLinks" :key="index">
             <i :class="['pref-icon pt-1 fa fa-lg', link.icon]" />
@@ -25,8 +24,8 @@
         <b-row class="ml-3 mb-1">
             <i class="pref-icon pt-1 fa fa-lg fa-plus-square-o" />
             <div class="pref-content pr-1">
-                <a @click="toggleNotifications" href="javascript:void(0)"><b>Enable notifications</b></a>
-                <div class="form-text text-muted">
+                <a @click="toggleNotifications" href="javascript:void(0)"><b v-localize>Enable notifications</b></a>
+                <div class="form-text text-muted" v-localize>
                     Allow push and tab notifcations on job completion. To disable, revoke the site notification
                     privilege in your browser.
                 </div>
@@ -37,9 +36,9 @@
                 <i class="pref-icon pt-1 fa fa-lg fa-radiation" />
                 <div class="pref-content pr-1">
                     <a id="delete-account" href="javascript:void(0)"
-                        ><b v-b-modal.modal-prevent-closing>Delete Account</b></a
+                        ><b v-b-modal.modal-prevent-closing v-localize>Delete Account</b></a
                     >
-                    <div class="form-text text-muted">Delete your account on this Galaxy server.</div>
+                    <div class="form-text text-muted" v-localize>Delete your account on this Galaxy server.</div>
                     <b-modal
                         id="modal-prevent-closing"
                         centered
@@ -72,11 +71,11 @@
             </b-row>
         </ConfigProvider>
         <p class="mt-2">
-            You are using <strong>{{ diskUsage }}</strong> of disk space in this Galaxy instance.
+            {{ titleYouAreUsing }} <strong>{{ diskUsage }}</strong> {{ titleOfDiskSpace }}
             <span v-html="quotaUsageString"></span>
-            Is your usage more than expected? See the
-            <a href="https://galaxyproject.org/learn/managing-datasets/" target="_blank"><b>documentation</b></a> for
-            tips on how to find all of the data in your account.
+            {{ titleIsYourUsage }}
+            <a href="https://galaxyproject.org/learn/managing-datasets/" target="_blank"><b v-localize>documentation</b></a>
+            {{ titleForTipsOnHow }}
         </p>
     </b-container>
 </template>
@@ -122,6 +121,11 @@ export default {
             nameState: null,
             deleteError: "",
             submittedNames: [],
+            titleYouAreUsing: _l("You are using"),
+            titleOfDiskSpace: _l("of disk space in this Galaxy instance."),
+            titleIsYourUsage: _l("Is your usage more than expected? See the"),
+            titleForTipsOnHow: _l("for tips on how to find all of the data in your account."),
+            titleLoggedInAs: _l("You are logged in as"),
         };
     },
     created() {

--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -5,7 +5,8 @@
             {{ message }}
         </b-alert>
         <p>
-            {{ titleLoggedInAs }} <strong id="user-preferences-current-email">{{ email }}</strong>.
+            {{ titleLoggedInAs }} <strong id="user-preferences-current-email">{{ email }}</strong
+            >.
         </p>
         <b-row class="ml-3 mb-1" v-for="(link, index) in activeLinks" :key="index">
             <i :class="['pref-icon pt-1 fa fa-lg', link.icon]" />
@@ -74,7 +75,9 @@
             {{ titleYouAreUsing }} <strong>{{ diskUsage }}</strong> {{ titleOfDiskSpace }}
             <span v-html="quotaUsageString"></span>
             {{ titleIsYourUsage }}
-            <a href="https://galaxyproject.org/learn/managing-datasets/" target="_blank"><b v-localize>documentation</b></a>
+            <a href="https://galaxyproject.org/learn/managing-datasets/" target="_blank"
+                ><b v-localize>documentation</b></a
+            >
             {{ titleForTipsOnHow }}
         </p>
     </b-container>

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -9,7 +9,7 @@ export const getUserPreferencesModel = (user_id) => {
         information: {
             title: _l("Manage Information"),
             id: "edit-preferences-information",
-            description: "Edit your email, addresses and custom parameters or change your public name.",
+            description: _l("Edit your email, addresses and custom parameters or change your public name."),
             url: `api/users/${user_id}/information/inputs`,
             icon: "fa-user",
             redirect: "user",
@@ -38,7 +38,7 @@ export const getUserPreferencesModel = (user_id) => {
             title: _l("Set Dataset Permissions for New Histories"),
             id: "edit-preferences-permissions",
             description:
-                "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored.",
+                _l("Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored."),
             url: `api/users/${user_id}/permissions/inputs`,
             icon: "fa-users",
             submitTitle: "Save Permissions",
@@ -86,7 +86,7 @@ export const getUserPreferencesModel = (user_id) => {
             icon: "fa-cubes",
         },
         logout: {
-            title: _l("Sign Out"),
+            title: _l("Sign out"),
             id: "edit-preferences-sign-out",
             description: _l("Click here to sign out of all sessions."),
             icon: "fa-sign-out",

--- a/client/src/components/User/UserPreferencesModel.js
+++ b/client/src/components/User/UserPreferencesModel.js
@@ -37,8 +37,9 @@ export const getUserPreferencesModel = (user_id) => {
         permissions: {
             title: _l("Set Dataset Permissions for New Histories"),
             id: "edit-preferences-permissions",
-            description:
-                _l("Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored."),
+            description: _l(
+                "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored."
+            ),
             url: `api/users/${user_id}/permissions/inputs`,
             icon: "fa-users",
             submitTitle: "Save Permissions",

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -14,7 +14,7 @@
                             id="workflow-search"
                             class="m-1"
                             name="query"
-                            placeholder="Search Workflows"
+                            :placeholder="titleSearchWorkflows"
                             autocomplete="off"
                             type="text"
                             v-model="filter"
@@ -24,11 +24,11 @@
                         <span class="float-right">
                             <b-button id="workflow-create" class="m-1" @click="createWorkflow">
                                 <font-awesome-icon icon="plus" />
-                                Create
+                                {{ titleCreate }}
                             </b-button>
                             <b-button id="workflow-import" class="m-1" @click="importWorkflow">
                                 <font-awesome-icon icon="upload" />
-                                Import
+                                {{ titleImport }}
                             </b-button>
                         </span>
                     </b-col>
@@ -70,7 +70,7 @@
                     <template v-slot:cell(execute)="row">
                         <b-button
                             v-b-tooltip.hover.bottom
-                            title="Run Workflow"
+                            :title="titleRunWorkflow"
                             class="workflow-run btn-sm btn-primary fa fa-play"
                             @click.stop="executeWorkflow(row.item)"
                         />
@@ -86,6 +86,7 @@
     </div>
 </template>
 <script>
+import _l from "utils/localization";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
@@ -118,24 +119,26 @@ export default {
             fields: [
                 {
                     key: "name",
+                    label: _l("Name"),
                     sortable: true,
                 },
                 {
                     key: "tags",
+                    label: _l("Tags"),
                     sortable: true,
                 },
                 {
-                    label: "Updated",
+                    label: _l("Updated"),
                     key: "update_time",
                     sortable: true,
                 },
                 {
-                    label: "Sharing",
+                    label: _l("Sharing"),
                     key: "published",
                     sortable: true,
                 },
                 {
-                    label: "Bookmarked",
+                    label: _l("Bookmarked"),
                     key: "show_in_tool_panel",
                     sortable: true,
                 },
@@ -150,6 +153,10 @@ export default {
             messageVariant: null,
             nWorkflows: 0,
             workflows: [],
+            titleSearchWorkflows: _l('Search Workflows'),
+            titleCreate: _l("Create"),
+            titleImport: _l("Import"),
+            titleRunWorkflow: _l("Run workflow"),
         };
     },
     computed: {

--- a/client/src/components/Workflow/WorkflowList.vue
+++ b/client/src/components/Workflow/WorkflowList.vue
@@ -153,7 +153,7 @@ export default {
             messageVariant: null,
             nWorkflows: 0,
             workflows: [],
-            titleSearchWorkflows: _l('Search Workflows'),
+            titleSearchWorkflows: _l("Search Workflows"),
             titleCreate: _l("Create"),
             titleImport: _l("Import"),
             titleRunWorkflow: _l("Run workflow"),

--- a/client/src/nls/de/locale.js
+++ b/client/src/nls/de/locale.js
@@ -94,7 +94,7 @@ define({
     "For all selected": "Für alle ausgewählt",
     // ---- history-view-edit
     "Edit history tags": "Geschichte bearbeiten",
-    "Edit history Annotation": "Historie bearbeiten",
+    "Edit history annotation": "Historie bearbeiten",
     "Click to rename history": "Klicken Sie hier, um den Verlauf umzubenennen",
     // multi operations
     "Operations on multiple datasets": "Operationen auf mehreren Datensätzen",

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -4,6 +4,7 @@ define({
     // ----------------------------------------------------------------------------- masthead
 
     "Analyze Data": "Analizar Datos",
+    "Tools and current history": "Herramientas e historial actual",
 
     Workflow: "Flujo de Trabajo",
 
@@ -45,6 +46,10 @@ define({
 
     "Interactive Tours": "Tours Interactivos",
 
+    "Galaxy Help": "Ayuda de Galaxy",
+
+    "Terms and Conditions": "Términos y Condiciones",
+
     User: "Usuario",
 
     Login: "Iniciar sesión",
@@ -59,6 +64,10 @@ define({
 
     "Custom Builds": "Construcciones personalizadas",
 
+    "Workflow Invocations": "Invocaciones de Flujos de Trabajo",
+
+    "Active InteractiveTools": "Activar Herramientas Interactivas",
+
     Logout: "Cerrar Sesión",
 
     "Saved Histories": "Historiales Guardados",
@@ -66,6 +75,8 @@ define({
     "Saved Datasets": "Conjuntos de Datos Guardados",
 
     "Saved Pages": "Páginas Guardadas",
+
+    "Using ": "Utilizando ",
 
     //Tooltip
 
@@ -85,11 +96,19 @@ define({
 
     "Analysis home view": "Vista de inicio del análisis",
 
+    // ---------------------------------------------------------------------------- toolbox
+    "Tools": "Herramientas (parte superior izquierda)",
+    "Show favorites": "Mostrar favoritos",
     // ---------------------------------------------------------------------------- histories
 
     // ---- history/options-menu
+    "History": "Historial",
 
     "History Lists": "Listas de historiales",
+
+    "History Actions": "Acciones del historial",
+
+    "(empty)": "(vacío)",
 
     // Saved histories is defined above.
 
@@ -102,14 +121,23 @@ define({
     "Current History": "Historial actual",
 
     "Create New": "Crear nuevo",
+    "Create new history": "Crear historial huevo",
 
-    "Copy History": "Copiar Historial",
+    "Copy": "Copiar",
 
     "Share or Publish": "Compartir o Publicar",
 
     "Show Structure": "Mostrar Estructura",
 
     "Extract Workflow": "Extraer Flujo de Trabajo",
+
+    "Set Permissions": "Establecer permisos",
+
+    "Make Private": "Hacer privado",
+
+    "Beta Features": "Características Beta",
+
+    "Use Beta History Panel": "Utilizar el panel de historial Beta",
 
     // Delete is defined elsewhere, but is also in this menu.
 
@@ -146,6 +174,7 @@ define({
     "Import from File": "Importar desde Archivo",
 
     Webhooks: "WebHooks",
+    "See Galaxy Training Materials": "Ver materiales de entrenamiento de Galaxy",
 
     // ---- history-model
 
@@ -168,6 +197,10 @@ define({
     //false,
 
     "search datasets": "buscar conjuntos de datos",
+    "Search tips": "Consejos de búsqueda",
+
+    "clear search (esc)": "limpiar búsqueda (esc)",
+    "clear search": "limpiar búsqueda",
 
     "You are currently viewing a deleted history!": "¡Estás viendo un historial eliminado!",
 
@@ -186,7 +219,7 @@ define({
 
     "Edit history tags": "Editar etiquetas de historial",
 
-    "Edit history Annotation": "Editar anotación del historial",
+    "Edit history annotation": "Editar anotación del historial",
 
     "Click to rename history": "Haz clic para cambiar el nombre del historial",
 
@@ -243,6 +276,15 @@ define({
     //"Include Hidden Datasets" :
 
     //false,
+
+    // ---------------------------------------------------------------------------- workflow list
+    "Search Workflows": "Buscar Flujos de Trabajo",
+    "Name": "Nombre",
+    "Tags": "Etiquetas",
+    "Updated": "Actualizado",
+    "Sharing": "Compartir",
+    "Bookmarked": "Página marcada",
+
 
     // ---------------------------------------------------------------------------- datasets
 
@@ -340,6 +382,10 @@ define({
 
     "This dataset has been hidden": "Este conjunto de datos ha sido ocultado",
 
+    "Copy link": "Copiar vínculo",
+
+    "Visualize this data": "Visualizar estos datos",
+
     format: "formato",
 
     database: "base de datos",
@@ -383,6 +429,29 @@ define({
     "Edit dataset tags": "Editar etiquetas del conjunto de datos",
 
     "Edit dataset annotation": "Editar anotación del conjunto de datos",
+
+    // ---------------------------------------------------------------------------- viz
+
+    "Create Visualization": "Crear Visualización",
+
+    "search visualizations": "buscar visualizaciones",
+
+    // ---------------------------------------------------------------------------- Data library
+
+    "Library": "Biblioteca",
+
+    "exclude restricted": "Excluir restringidos",
+
+    "include deleted": "incluir eliminada",
+
+    // Name is elsewhere
+    "Description": "Descripción",
+
+    "Synopsis": "Sinopsis",
+
+    "per page": "por página",
+
+    "total": "total",
 
     // ---------------------------------------------------------------------------- misc. MVC
 
@@ -440,7 +509,7 @@ define({
     "Convert the datatype to a new format.": "Convertir el tipo de datos a un formato nuevo",
     "Save attributes of the dataset.": "Guardar los atributos del conjunto de datos",
     "Change data type": "Cambiar el tipo de datos",
-    "Edit dataset attributes": "Editar atributos del conjunto de datos",
+    "Edit Dataset Attributes": "Editar atributos del conjunto de datos",
     "Save permissions": "Guardar permisos",
     "Manage dataset permissions": "Administrar permisos del conjunto de datos",
     "Change datatype": "Cambiar tipo de datos",
@@ -451,6 +520,19 @@ define({
     Datatypes: false,
     Convert: false,
     Attributes: false,
+
+    "This will change the datatype of the existing dataset but not modify its contents. Use this if Galaxy has incorrectly guessed the type of your dataset.": "Esto cambiará el tipo de datos del conjunto de datos existente pero no modificará su contenido. Utilícelo si Galaxy identificó incorrectamente el tipo de su conjunto de datos",
+    "Attributes": "Atributos",
+    "Convert": "Convertir",
+    "Datatypes": "Tipos de datos",
+    "Permissions": "Permisos",
+    "Auto-detect": "Autodetectar",
+    "Save": "Guardar",
+    "Name": "Nombre",
+    "Info": "Información",
+    "Annotation": "Anotación",
+    "Add an annotation or notes to a dataset; annotations are available when a history is viewed.": "Agregar una anotación o notas al conjunto de datos; las anotaciones están disponibles cuando se visualiza un historial",
+
     // ---------------------------------------------------------------------------- library-dataset-view
     "Import into History": "Importar al historial",
     // ---------------------------------------------------------------------------- library-foldertoolbar-view
@@ -473,15 +555,82 @@ define({
         "Personalizar Toolbox para mostrar u omitir conjuntos de herramientas",
     "Access your current API key or create a new one.": "Acceder a su clave API actual o crear una nueva",
     "Allows you to change your login credentials.": "Permitir modificar tus credenciales de inicio de sesión ",
-    "User Preferences": "Preferencias de usuario",
+    "Edit your email, addresses and custom parameters or change your public name.": "Edita tus direcciones de correo y personaliza los parámetros o cambia tu nombre público.",
+    "User preferences": "Preferencias de usuario",
+    "You are logged in as": "Iniciaste sesión como",
     "Sign out": "Cerrar sesión",
     "Manage custom builds": "Administrar construcciones personalizadas",
     "Manage OpenIDs": "Administrar OpenIDs",
     "Manage Toolbox filters": "Administrar filtros de Toolbox",
-    "Manage API key": "Administrar clave API",
+    "Manage API Key": "Administrar clave API",
     "Set dataset permissions for new histories": "Establecer permisos de conjuntos de datos para historiales nuevos",
-    "Change password": "Cambiar contraseña",
-    "Manage information": "Administrar información",
+    "Change Password": "Cambiar contraseña",
+    "Manage Information": "Administrar información",
+    "Manage Third-Party Identities": "Manejar identidades de terceros",
+    "Connect or disconnect access to your third-party identities.": "Conectar o desconectar el acceso a tus identidades de terceros.",
+    "Set Dataset Permissions for New Histories": "Establecer los permisos de los conjuntos de datos para los nuevos historiales",
+    "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored.": "Otorga a otras personas acceso predeterminado a los historiales recién creados. Los cambios que aquí realices solo afectarán a los historiales creados después de que se hayan almacenado estos ajustes.",
+    "Make All Data Private": "Privatizar todos mis datos",
+    "Click here to make all data private.": "Haz clic aquí para privatizar todos tus datos",
+    "Manage Cloud Authorization": "Manejar autorización para la nube",
+    "Add or modify the configuration that grants Galaxy to access your cloud-based resources": "Agregar o modificar la configuración que permite que Galaxy acceda a tus recursos en la nube",
+
+    "Manage Toolbox Filters": "Manejar filtros de la caja de herramientas",
+    "Manage Custom Builds": "Administrar compilaciones personalizadas",
+
+    "Enable notifications": "Habilitar notificaciones",
+    "Allow push and tab notifcations on job completion. To disable, revoke the site notification privilege in your browser.": "Permitir las notificaciones automáticas y de pestaña al completar un trabajo. Para deshabilitar, en tu navegador revoca los privilegios de notificaciones de sitio",
+    "Delete Account": "Eliminar cuenta",
+    "Delete your account on this Galaxy server.": "Eliminar tu cuenta del servidor Galaxy.",
+
+    "You are using": "Estás utilizando",
+    "of disk space in this Galaxy instance.": "de espacio de disco en esta instancia de Galaxy.",
+    "Is your usage more than expected? See the": "¿Utilizarás más espacio del que planeabas originalmente? Ve la",
+    "documentation": "documentación",
+    "for tips on how to find all of the data in your account.": "para consultar consejos sobre el cómo encontrar todos los datos de tu cuenta",
+
+
+    // ---------------------------------------------------------------------------- user-prefs/manage information
+    "Manage Information": "Manejar información",
+    "Email address": "Dirección de correo electrónico",
+    "If you change your email address you will receive an activation link in the new mailbox and you have to activate your account by visiting it.": "Si cambias tu dirección de correo electrónico recibirás un vínculo de activación en tu nuevo correo. Debes activar tu cuenta recurriendo a esta notificación.",
+    "Public name": "Nombre público",
+    'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character.': 'Tu nombre público es un identificador que será utilizado para generar direcciones de información que compartas al público. Los nombres públicos deben contener al menos tres caracteres de longitud, solo letras minúsculas, números o el símbolo "-". ',
+    "Address": "Dirección",
+    "Insert address": "Escribir dirección",
+    "Do you want to be able to re-use equivalent jobs ?": "¿Deseas poder reutilizar trabajos equivalentes?",
+    "No": "No",
+    "Yes": "Sí",
+    "If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.": "Si seleccionas ‘sí’, podrás seleccionar si deseas utilizar esta función para cada herramienta y ejecución de flujo de trabajo.",
+    "Localization": "Ubicación",
+    "Prefered language": "Idioma de preferencia",
+    "Use distributed compute resources": "Utilizar recursos de cómputo distribuido",
+    "Remote resource id": "Identificador de recurso remoto",
+    "default - Galaxy will decide where to put your jobs": "Por defecto - Galaxy decidirá en donde colocar tus trabajos",
+    "Your EGA (European Genome Archive) Account": "Tu cuenta EGA (European Genome Archive)",
+    "Username": "Nombre de usuario",
+    "Password": "Contraseña",
+    "Your Dropbox Account": "Tu cuenta Dropbox",
+    "Dropbox access token": "Token de acceso de Dropbox",
+    "Your B2DROP Account": "Tu cuenta B2DROP",
+    "Username": "Nombre de usuario",
+    "Password": "Contraseña",
+    "Your OMERO instance connection details": "Detalles de conección de tu instancia OMERO",
+    "Username": "Nombre de usuario",
+    "Password": "Contraseña",
+    "Your ENA Webin account details": "Detalles de tu cuenta Webin de ENA",
+    "ENA Webin ID": "Identificador Webin de ENA",
+    "Password": "Contraseña",
+    "Your CDS API Key": "Tu llave CDS API",
+    "Key": "Llave",
+    "Save": "Guardar",
+
+
+
+     //X GB  Tu cuota de disco es: X GB.
+    //
+    //
+
     // ---------------------------------------------------------------------------- shed-list-view
     "Configured Tool Sheds": "Tool Sheds configurados",
     // ---------------------------------------------------------------------------- repository-queue-view
@@ -623,7 +772,13 @@ define({
     "Multiple datasets": "Varios conjuntos de datos",
     "Single dataset": "Conjunto de datos único",
     // ---------------------------------------------------------------------------- upload-button
-    "Download from URL or upload files from disk": "Descargar desde URL o descargar desde disco",
+    "Download from URL or upload files from disk": "Descargar desde URL o cargar archivos desde disco",
+
+    // This feels awkward structure wise.
+    "You can load your own data": "Puedes cargar tus propios datos",
+    "or": "u",
+    "get data from an external source": "obtenerlos de una fuente externa",
+
     // ---------------------------------------------------------------------------- workflow_editor_tests
     "tool tooltip": "Mensaje de información sobre herramientas",
     // ----------------------------------------------------------------------------

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -4,7 +4,7 @@ define({
     // ----------------------------------------------------------------------------- masthead
 
     "Analyze Data": "Analizar Datos",
-    "Tools and current history": "Herramientas e historial actual",
+    "Tools and Current History": "Herramientas e Historial Actual",
 
     Workflow: "Flujo de Trabajo",
 
@@ -97,8 +97,15 @@ define({
     "Analysis home view": "Vista de inicio del análisis",
 
     // ---------------------------------------------------------------------------- toolbox
-    "Tools": "Herramientas (parte superior izquierda)",
+    "Tools": "Herramientas",
+
     "Show favorites": "Mostrar favoritos",
+
+    "search tools": "Buscar herramientas",
+
+    "All workflows": "Todos los flujos de trabajo",
+
+    "Upload Data": "Cargar Datos",
     // ---------------------------------------------------------------------------- histories
 
     // ---- history/options-menu
@@ -197,6 +204,8 @@ define({
     //false,
 
     "search datasets": "buscar conjuntos de datos",
+    "search all datasets": "buscar todos los conjuntos de datos",
+    "search histories": "buscar los historiales",
     "Search tips": "Consejos de búsqueda",
 
     "clear search (esc)": "limpiar búsqueda (esc)",
@@ -222,6 +231,10 @@ define({
     "Edit history annotation": "Editar anotación del historial",
 
     "Click to rename history": "Haz clic para cambiar el nombre del historial",
+
+    "Rename history...": "Cambiar el nombre del historial",
+
+    "Switch to": "Cambiar a",
 
     // multi operations
 
@@ -279,11 +292,19 @@ define({
 
     // ---------------------------------------------------------------------------- workflow list
     "Search Workflows": "Buscar Flujos de Trabajo",
-    "Name": "Nombre",
-    "Tags": "Etiquetas",
+    // Defined elsewhere
+    //"Name"
+    //"Tags"
+    //
     "Updated": "Actualizado",
+
     "Sharing": "Compartir",
+
     "Bookmarked": "Página marcada",
+
+    "Create": "Crear",
+
+    "Import": "Importar",
 
 
     // ---------------------------------------------------------------------------- datasets
@@ -452,6 +473,12 @@ define({
     "per page": "por página",
 
     "total": "total",
+
+    "Cancel": "Cancelar",
+
+    "Edit": "Editar",
+
+    "Manage": "Administrar",
 
     // ---------------------------------------------------------------------------- misc. MVC
 
@@ -728,6 +755,7 @@ define({
     Remove: false,
     // ---------------------------------------------------------------------------- visualization
     "Select datasets for new tracks": "Seleccionar conjuntos de datos para nuevas pistas",
+    "Select a dataset to visualize:": "Seleccionar un conjunto de datos para visualizar",
     Libraries: false,
     // ---------------------------------------------------------------------------- phyloviz
     "Zoom out": "Alejar",
@@ -778,6 +806,12 @@ define({
     "You can load your own data": "Puedes cargar tus propios datos",
     "or": "u",
     "get data from an external source": "obtenerlos de una fuente externa",
+
+    // But wait, there's more! An old version of this is still in use with a different structure
+    "You can ": "Puedes ",
+    "load your own data": "cargar tus propios datos",
+    " or ": " u ",
+
 
     // ---------------------------------------------------------------------------- workflow_editor_tests
     "tool tooltip": "Mensaje de información sobre herramientas",

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -97,7 +97,7 @@ define({
     "Analysis home view": "Vista de inicio del análisis",
 
     // ---------------------------------------------------------------------------- toolbox
-    "Tools": "Herramientas",
+    Tools: "Herramientas",
 
     "Show favorites": "Mostrar favoritos",
 
@@ -109,7 +109,7 @@ define({
     // ---------------------------------------------------------------------------- histories
 
     // ---- history/options-menu
-    "History": "Historial",
+    History: "Historial",
 
     "History Lists": "Listas de historiales",
 
@@ -130,7 +130,7 @@ define({
     "Create New": "Crear nuevo",
     "Create new history": "Crear historial huevo",
 
-    "Copy": "Copiar",
+    Copy: "Copiar",
 
     "Share or Publish": "Compartir o Publicar",
 
@@ -296,16 +296,15 @@ define({
     //"Name"
     //"Tags"
     //
-    "Updated": "Actualizado",
+    Updated: "Actualizado",
 
-    "Sharing": "Compartir",
+    Sharing: "Compartir",
 
-    "Bookmarked": "Página marcada",
+    Bookmarked: "Página marcada",
 
-    "Create": "Crear",
+    Create: "Crear",
 
-    "Import": "Importar",
-
+    Import: "Importar",
 
     // ---------------------------------------------------------------------------- datasets
 
@@ -459,26 +458,26 @@ define({
 
     // ---------------------------------------------------------------------------- Data library
 
-    "Library": "Biblioteca",
+    Library: "Biblioteca",
 
     "exclude restricted": "Excluir restringidos",
 
     "include deleted": "incluir eliminada",
 
     // Name is elsewhere
-    "Description": "Descripción",
+    Description: "Descripción",
 
-    "Synopsis": "Sinopsis",
+    Synopsis: "Sinopsis",
 
     "per page": "por página",
 
-    "total": "total",
+    total: "total",
 
-    "Cancel": "Cancelar",
+    Cancel: "Cancelar",
 
-    "Edit": "Editar",
+    Edit: "Editar",
 
-    "Manage": "Administrar",
+    Manage: "Administrar",
 
     // ---------------------------------------------------------------------------- misc. MVC
 
@@ -548,17 +547,19 @@ define({
     Convert: false,
     Attributes: false,
 
-    "This will change the datatype of the existing dataset but not modify its contents. Use this if Galaxy has incorrectly guessed the type of your dataset.": "Esto cambiará el tipo de datos del conjunto de datos existente pero no modificará su contenido. Utilícelo si Galaxy identificó incorrectamente el tipo de su conjunto de datos",
-    "Attributes": "Atributos",
-    "Convert": "Convertir",
-    "Datatypes": "Tipos de datos",
-    "Permissions": "Permisos",
+    "This will change the datatype of the existing dataset but not modify its contents. Use this if Galaxy has incorrectly guessed the type of your dataset.":
+        "Esto cambiará el tipo de datos del conjunto de datos existente pero no modificará su contenido. Utilícelo si Galaxy identificó incorrectamente el tipo de su conjunto de datos",
+    Attributes: "Atributos",
+    Convert: "Convertir",
+    Datatypes: "Tipos de datos",
+    Permissions: "Permisos",
     "Auto-detect": "Autodetectar",
-    "Save": "Guardar",
-    "Name": "Nombre",
-    "Info": "Información",
-    "Annotation": "Anotación",
-    "Add an annotation or notes to a dataset; annotations are available when a history is viewed.": "Agregar una anotación o notas al conjunto de datos; las anotaciones están disponibles cuando se visualiza un historial",
+    Save: "Guardar",
+    Name: "Nombre",
+    Info: "Información",
+    Annotation: "Anotación",
+    "Add an annotation or notes to a dataset; annotations are available when a history is viewed.":
+        "Agregar una anotación o notas al conjunto de datos; las anotaciones están disponibles cuando se visualiza un historial",
 
     // ---------------------------------------------------------------------------- library-dataset-view
     "Import into History": "Importar al historial",
@@ -582,7 +583,8 @@ define({
         "Personalizar Toolbox para mostrar u omitir conjuntos de herramientas",
     "Access your current API key or create a new one.": "Acceder a su clave API actual o crear una nueva",
     "Allows you to change your login credentials.": "Permitir modificar tus credenciales de inicio de sesión ",
-    "Edit your email, addresses and custom parameters or change your public name.": "Edita tus direcciones de correo y personaliza los parámetros o cambia tu nombre público.",
+    "Edit your email, addresses and custom parameters or change your public name.":
+        "Edita tus direcciones de correo y personaliza los parámetros o cambia tu nombre público.",
     "User preferences": "Preferencias de usuario",
     "You are logged in as": "Iniciaste sesión como",
     "Sign out": "Cerrar sesión",
@@ -594,67 +596,74 @@ define({
     "Change Password": "Cambiar contraseña",
     "Manage Information": "Administrar información",
     "Manage Third-Party Identities": "Manejar identidades de terceros",
-    "Connect or disconnect access to your third-party identities.": "Conectar o desconectar el acceso a tus identidades de terceros.",
-    "Set Dataset Permissions for New Histories": "Establecer los permisos de los conjuntos de datos para los nuevos historiales",
-    "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored.": "Otorga a otras personas acceso predeterminado a los historiales recién creados. Los cambios que aquí realices solo afectarán a los historiales creados después de que se hayan almacenado estos ajustes.",
+    "Connect or disconnect access to your third-party identities.":
+        "Conectar o desconectar el acceso a tus identidades de terceros.",
+    "Set Dataset Permissions for New Histories":
+        "Establecer los permisos de los conjuntos de datos para los nuevos historiales",
+    "Grant others default access to newly created histories. Changes made here will only affect histories created after these settings have been stored.":
+        "Otorga a otras personas acceso predeterminado a los historiales recién creados. Los cambios que aquí realices solo afectarán a los historiales creados después de que se hayan almacenado estos ajustes.",
     "Make All Data Private": "Privatizar todos mis datos",
     "Click here to make all data private.": "Haz clic aquí para privatizar todos tus datos",
     "Manage Cloud Authorization": "Manejar autorización para la nube",
-    "Add or modify the configuration that grants Galaxy to access your cloud-based resources": "Agregar o modificar la configuración que permite que Galaxy acceda a tus recursos en la nube",
+    "Add or modify the configuration that grants Galaxy to access your cloud-based resources":
+        "Agregar o modificar la configuración que permite que Galaxy acceda a tus recursos en la nube",
 
     "Manage Toolbox Filters": "Manejar filtros de la caja de herramientas",
     "Manage Custom Builds": "Administrar compilaciones personalizadas",
 
     "Enable notifications": "Habilitar notificaciones",
-    "Allow push and tab notifcations on job completion. To disable, revoke the site notification privilege in your browser.": "Permitir las notificaciones automáticas y de pestaña al completar un trabajo. Para deshabilitar, en tu navegador revoca los privilegios de notificaciones de sitio",
+    "Allow push and tab notifcations on job completion. To disable, revoke the site notification privilege in your browser.":
+        "Permitir las notificaciones automáticas y de pestaña al completar un trabajo. Para deshabilitar, en tu navegador revoca los privilegios de notificaciones de sitio",
     "Delete Account": "Eliminar cuenta",
     "Delete your account on this Galaxy server.": "Eliminar tu cuenta del servidor Galaxy.",
 
     "You are using": "Estás utilizando",
     "of disk space in this Galaxy instance.": "de espacio de disco en esta instancia de Galaxy.",
     "Is your usage more than expected? See the": "¿Utilizarás más espacio del que planeabas originalmente? Ve la",
-    "documentation": "documentación",
-    "for tips on how to find all of the data in your account.": "para consultar consejos sobre el cómo encontrar todos los datos de tu cuenta",
-
+    documentation: "documentación",
+    "for tips on how to find all of the data in your account.":
+        "para consultar consejos sobre el cómo encontrar todos los datos de tu cuenta",
 
     // ---------------------------------------------------------------------------- user-prefs/manage information
     "Manage Information": "Manejar información",
     "Email address": "Dirección de correo electrónico",
-    "If you change your email address you will receive an activation link in the new mailbox and you have to activate your account by visiting it.": "Si cambias tu dirección de correo electrónico recibirás un vínculo de activación en tu nuevo correo. Debes activar tu cuenta recurriendo a esta notificación.",
+    "If you change your email address you will receive an activation link in the new mailbox and you have to activate your account by visiting it.":
+        "Si cambias tu dirección de correo electrónico recibirás un vínculo de activación en tu nuevo correo. Debes activar tu cuenta recurriendo a esta notificación.",
     "Public name": "Nombre público",
-    'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character.': 'Tu nombre público es un identificador que será utilizado para generar direcciones de información que compartas al público. Los nombres públicos deben contener al menos tres caracteres de longitud, solo letras minúsculas, números o el símbolo "-". ',
-    "Address": "Dirección",
+    'Your public name is an identifier that will be used to generate addresses for information you share publicly. Public names must be at least three characters in length and contain only lower-case letters, numbers, and the "-" character.':
+        'Tu nombre público es un identificador que será utilizado para generar direcciones de información que compartas al público. Los nombres públicos deben contener al menos tres caracteres de longitud, solo letras minúsculas, números o el símbolo "-". ',
+    Address: "Dirección",
     "Insert address": "Escribir dirección",
     "Do you want to be able to re-use equivalent jobs ?": "¿Deseas poder reutilizar trabajos equivalentes?",
-    "No": "No",
-    "Yes": "Sí",
-    "If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.": "Si seleccionas ‘sí’, podrás seleccionar si deseas utilizar esta función para cada herramienta y ejecución de flujo de trabajo.",
-    "Localization": "Ubicación",
+    No: "No",
+    Yes: "Sí",
+    "If you select yes, you will be able to select for each tool and workflow run if you would like to use this feature.":
+        "Si seleccionas ‘sí’, podrás seleccionar si deseas utilizar esta función para cada herramienta y ejecución de flujo de trabajo.",
+    Localization: "Ubicación",
     "Prefered language": "Idioma de preferencia",
     "Use distributed compute resources": "Utilizar recursos de cómputo distribuido",
     "Remote resource id": "Identificador de recurso remoto",
-    "default - Galaxy will decide where to put your jobs": "Por defecto - Galaxy decidirá en donde colocar tus trabajos",
+    "default - Galaxy will decide where to put your jobs":
+        "Por defecto - Galaxy decidirá en donde colocar tus trabajos",
     "Your EGA (European Genome Archive) Account": "Tu cuenta EGA (European Genome Archive)",
-    "Username": "Nombre de usuario",
-    "Password": "Contraseña",
+    Username: "Nombre de usuario",
+    Password: "Contraseña",
     "Your Dropbox Account": "Tu cuenta Dropbox",
     "Dropbox access token": "Token de acceso de Dropbox",
     "Your B2DROP Account": "Tu cuenta B2DROP",
-    "Username": "Nombre de usuario",
-    "Password": "Contraseña",
+    Username: "Nombre de usuario",
+    Password: "Contraseña",
     "Your OMERO instance connection details": "Detalles de conección de tu instancia OMERO",
-    "Username": "Nombre de usuario",
-    "Password": "Contraseña",
+    Username: "Nombre de usuario",
+    Password: "Contraseña",
     "Your ENA Webin account details": "Detalles de tu cuenta Webin de ENA",
     "ENA Webin ID": "Identificador Webin de ENA",
-    "Password": "Contraseña",
+    Password: "Contraseña",
     "Your CDS API Key": "Tu llave CDS API",
-    "Key": "Llave",
-    "Save": "Guardar",
+    Key: "Llave",
+    Save: "Guardar",
 
-
-
-     //X GB  Tu cuota de disco es: X GB.
+    //X GB  Tu cuota de disco es: X GB.
     //
     //
 
@@ -804,14 +813,13 @@ define({
 
     // This feels awkward structure wise.
     "You can load your own data": "Puedes cargar tus propios datos",
-    "or": "u",
+    or: "u",
     "get data from an external source": "obtenerlos de una fuente externa",
 
     // But wait, there's more! An old version of this is still in use with a different structure
     "You can ": "Puedes ",
     "load your own data": "cargar tus propios datos",
     " or ": " u ",
-
 
     // ---------------------------------------------------------------------------- workflow_editor_tests
     "tool tooltip": "Mensaje de información sobre herramientas",

--- a/client/src/nls/fr/locale.js
+++ b/client/src/nls/fr/locale.js
@@ -92,7 +92,7 @@ define({
 
     // // ---- history-view-edit
     "Edit history tags": "Editer les mots-clés de l'historique",
-    "Edit history Annotation": "Editer l'annotation de l'historique",
+    "Edit history annotation": "Editer l'annotation de l'historique",
     "Click to rename history": "Cliquer pour renommer l'historique",
     // multi operations
     "Operations on multiple datasets": "Opérer sur plusieurs jeux de données en même temps",
@@ -259,7 +259,7 @@ define({
     "Convert the datatype to a new format.": "Convertir le format de données",
     "Save attributes of the dataset.": "Sauvegarder les attributs du jeu de données",
     "Change data type": "Changer le format de données",
-    "Edit dataset attributes": "Modifier les attributs du jeu de données",
+    "Edit Dataset Attributes": "Modifier les attributs du jeu de données",
     "Save permissions": "Sauvegarder les permissions",
     "Manage dataset permissions": "Gérer les permissions sur les jeux de données",
     "Change datatype": "Changer le format de données",
@@ -293,16 +293,16 @@ define({
     "Access your current API key or create a new one.": false,
     "Enable or disable the communication feature to chat with other users.": false,
     "Allows you to change your login credentials.": false,
-    "User Preferences": false,
+    "User preferences": false,
     "Sign out": false,
     "Manage custom builds": false,
     "Manage OpenIDs": false,
     "Manage Toolbox filters": false,
-    "Manage API key": false,
+    "Manage API Key": false,
     "Set dataset permissions for new histories": false,
     "Change communication settings": false,
-    "Change password": false,
-    "Manage information": false,
+    "Change Password": false,
+    "Manage Information": false,
     // ---------------------------------------------------------------------------- history-list
     Histories: false,
     // ---------------------------------------------------------------------------- shed-list-view

--- a/client/src/nls/locale.js
+++ b/client/src/nls/locale.js
@@ -96,7 +96,7 @@ define({
 
         // ---- history-view-edit
         "Edit history tags": false,
-        "Edit history Annotation": false,
+        "Edit history annotation": false,
         "Click to rename history": false,
         // multi operations
         "Operations on multiple datasets": false,
@@ -292,15 +292,15 @@ define({
         "Customize your Toolbox by displaying or omitting sets of Tools.": false,
         "Access your current API key or create a new one.": false,
         "Allows you to change your login credentials.": false,
-        "User Preferences": false,
+        "User preferences": false,
         "Sign out": false,
         "Manage custom builds": false,
         "Manage OpenIDs": false,
         "Manage Toolbox filters": false,
-        "Manage API key": false,
+        "Manage API Key": false,
         "Set dataset permissions for new histories": false,
-        "Change password": false,
-        "Manage information": false,
+        "Change Password": false,
+        "Manage Information": false,
         // ---------------------------------------------------------------------------- history-list
         Histories: false,
         // ---------------------------------------------------------------------------- shed-list-view

--- a/client/src/nls/zh/locale.js
+++ b/client/src/nls/zh/locale.js
@@ -104,7 +104,7 @@ define({
 
     // ---- history-view-edit
     "Edit history tags": "编辑历史标签",
-    "Edit history Annotation": "编辑历史备注",
+    "Edit history annotation": "编辑历史备注",
     "Click to rename history": "点击以重命名历史",
     // multi operations
     "Operations on multiple datasets": "编辑多个数据集",
@@ -269,7 +269,7 @@ define({
     "Convert the datatype to a new format.": "将数据类型更改为新的格式。",
     "Save attributes of the dataset.": "保存数据集属性。",
     "Change data type": "更改数据类型",
-    "Edit dataset attributes": "编辑数据集属性",
+    "Edit Dataset Attributes": "编辑数据集属性",
     "Save permissions": "保存权限",
     "Manage dataset permissions": "管理数据集权限",
     "Change datatype": "更改数据类型",
@@ -303,16 +303,16 @@ define({
     "Access your current API key or create a new one.": "访问您当前的 API密钥或创建一个新的密钥。",
     "Enable or disable the communication feature to chat with other users.": "启用或禁用与其他用户聊天的通信功能。",
     "Allows you to change your login credentials.": "允许您更改您的登录凭证。",
-    "User Preferences": "用户偏好性",
+    "User preferences": "用户偏好性",
     "Sign out": "退出",
     "Manage custom builds": "管理您自定义的构建集",
     "Manage OpenIDs": "管理 OpenIDs",
     "Manage Toolbox filters": "管理工具箱过滤器",
-    "Manage API key": "管理您的 API 密钥",
+    "Manage API Key": "管理您的 API 密钥",
     "Set dataset permissions for new histories": "为新的历史设置数据集权限",
     "Change communication settings": "修改通信设置",
-    "Change password": "更改密码",
-    "Manage information": "管理您的信息",
+    "Change Password": "更改密码",
+    "Manage Information": "管理您的信息",
     // ---------------------------------------------------------------------------- shed-list-view
     "Configured Galaxy Tool Sheds": "配置 Galaxy Tool Sheds",
     // ---------------------------------------------------------------------------- repository-queue-view

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -24,3 +24,4 @@ A multi-hour long video playlist covering these slides can be found at
   debugging_galaxy
   starting_galaxy
   file_upload
+  translating

--- a/doc/source/dev/translating.rst
+++ b/doc/source/dev/translating.rst
@@ -1,0 +1,142 @@
+Translating the Interface
+=========================
+
+A quick tutorial on translating the Galaxy UI
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Translations in Galaxy are done by simple dictionary lookup of text. Whatever text is written in the interface, the client will look it up in its dictionary, and if it's there, return it. If it's not, it will return the english text that was used to search.
+
+Translations are stored in ``client/src/nls/*/locale.js`` and look like this:
+
+.. code-block:: js
+
+    define({
+        // ----------------------------------------------------------------------------- masthead
+
+        "Analyze Data": "Analizar Datos",
+        "Tools and Current History": "Herramientas e Historial Actual",
+        Workflow: "Flujo de Trabajo",
+
+The last three lines contain a mapping of English text to their Spanish equivalents. But before we can add translations here, we need to know what English text is being used in the interface. Generally this is a process of:
+
+- Find untranslated text in the UI
+- Find the corresponding text in the codebase
+- Ensure that it uses `_l` (localisation) statements
+- Check that that text has a translation in the locale file.
+
+A quick example.
+~~~~~~~~~~~~~~~~
+
+In the user preferences menu I saw the text: "You are logged in as hxr@local.host." I can guess that the email address is templated out, so I'm going to search for "You are logged in as". Running that query I see some results:
+
+.. code-block:: shell
+
+    $ grep 'You are logged in as' -R client/src
+    client/src/mvc/library/library-library-view.js:                        You are logged in as an <strong>administrator</strong> therefore you can manage any library
+    client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryPermissionsWarning.vue:                You are logged in as an <strong>administrator</strong> therefore you can manage any folder on this
+    client/src/components/User/UserPreferences.vue:            You are logged in as <strong id="user-preferences-current-email">{{ email }}</strong
+
+There! That's a hit, the last file has the string we're looking for. Let's open that file and discover the next challenge...
+
+Types of Strings and how to translate them
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are a number of ways text gets used in the codebase, especially the new Vue frontend.
+
+1. Text within an element:
+
+   .. code-block:: js
+
+       <b>Some Text</b>
+
+2. Text within a more complex element:
+
+   .. code-block:: javascript
+
+       <b><icon library>Some Text</b>
+
+3. Attribute or placeholder text
+
+   .. code-block:: javascript
+
+       <b-form-input v-model="newLibraryForm.synopsis" placeholder="Synopsis of the library" />
+
+And each of these have different ways of being updated to support translations:
+
+1. Text within an element:
+
+   .. code-block:: diff
+
+       -<b>Some Text</b>
+       +<b v-localize>Some Text</b>
+
+2. Text within a more complex element:
+
+   .. code-block:: diff
+
+       -<b><icon library>Some Text</b>
+       +<b><icon library>{{ titleSomeText }}</b>
+
+3. Attribute or placeholder text
+
+   .. code-block:: diff
+
+       -<b-form-input v-model="newLibraryForm.synopsis" placeholder="Synopsis of the library" />
+       +<b-form-input v-model="newLibraryForm.synopsis" :placeholder="titleSynopsis" />
+
+The first one is the easiest, we can just add the ``v-localize`` tag and we're done, the library knows how to translate it. The second two are a bit more complicated. You'll notice we introduced a new variable in each (``titleSomeText``, ``titleSynopsis``). Because we can't translate the terms directly there, we need to put the translated text into a variable.
+
+For those you'll need to have a quick overview of the structure of a Vue component to localize the correct place to set the variable. The exact structure will not always be identical but it should be similar. At the top is a ``<template>`` section which contains what will be rendered, and at the bottom is a ``<script>`` section which contains some code that's run as part of rendering that UI component.
+
+.. code-block:: javascript
+
+    <template>
+        <span class="position-relative">
+            <b><font-awesome-icon icon="upload" class="mr-1" /> Upload Data</b>
+        </span>
+    </template>
+
+    <script>
+    import { VBTooltip } from "bootstrap-vue";
+    import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+    import { library } from "@fortawesome/fontawesome-svg-core";
+
+    export default {
+        components: { FontAwesomeIcon },
+        ...
+        data() {
+            return {
+                status: "",
+                percentage: 0,
+            };
+        },
+
+What you're looking for is the ``data()`` block which returns a dictionary. There we can define our new variable. Here's how our localized component would change:
+
+.. code-block:: diff
+
+     <template>
+         <span class="position-relative">
+    -        <b><font-awesome-icon icon="upload" class="mr-1" /> Upload Data</b>
+    +        <b><font-awesome-icon icon="upload" class="mr-1" /> {{ titleUploadData }}</b>
+         </span>
+     </template>
+
+     <script>
+    +import _l from "utils/localization";
+     import { VBTooltip } from "bootstrap-vue";
+     import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+     import { library } from "@fortawesome/fontawesome-svg-core";
+
+     export default {
+         components: { FontAwesomeIcon },
+         ...
+         data() {
+             return {
+                 status: "",
+                 percentage: 0,
+    +            titleUploadData: _l("Upload Data"),
+             };
+         },
+
+Which should result in a translated UI!

--- a/doc/source/dev/translating.rst
+++ b/doc/source/dev/translating.rst
@@ -4,9 +4,9 @@ Translating the Interface
 A quick tutorial on translating the Galaxy UI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Translations in Galaxy are done by simple dictionary lookup of text. Whatever text is written in the interface, the client will look it up in its dictionary, and if it's there, return it. If it's not, it will return the english text that was used to search.
+Translations in Galaxy are done by simple dictionary lookup of text. Whatever text is written in the interface, the client will look it up in its dictionary, and if it's there, return it. If it's not, it will return the English text that was used to search.
 
-Translations are stored in ``client/src/nls/*/locale.js`` and look like this:
+Translations are stored in ``client/src/nls/XX/locale.js`` files where `XX` is the ISO 639 2-letter code for a language. A `locale.js` file looks like this:
 
 .. code-block:: js
 
@@ -21,8 +21,8 @@ The last three lines contain a mapping of English text to their Spanish equivale
 
 - Find untranslated text in the UI
 - Find the corresponding text in the codebase
-- Ensure that it uses `_l` (localisation) statements
-- Check that that text has a translation in the locale file.
+- Ensure that it uses `_l()` localisation statements
+- Add the translation for that text to the `locale.js` file.
 
 A quick example.
 ~~~~~~~~~~~~~~~~
@@ -31,7 +31,7 @@ In the user preferences menu I saw the text: "You are logged in as hxr@local.hos
 
 .. code-block:: shell
 
-    $ grep 'You are logged in as' -R client/src
+    $ grep -R 'You are logged in as' client/src/
     client/src/mvc/library/library-library-view.js:                        You are logged in as an <strong>administrator</strong> therefore you can manage any library
     client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryPermissionsWarning.vue:                You are logged in as an <strong>administrator</strong> therefore you can manage any folder on this
     client/src/components/User/UserPreferences.vue:            You are logged in as <strong id="user-preferences-current-email">{{ email }}</strong
@@ -41,7 +41,7 @@ There! That's a hit, the last file has the string we're looking for. Let's open 
 Types of Strings and how to translate them
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are a number of ways text gets used in the codebase, especially the new Vue frontend.
+There are a number of ways text gets used in the codebase, especially the new Vue JavaScript framework.
 
 1. Text within an element:
 


### PR DESCRIPTION
We have a fantastic @galaxyproject/training-spanish team which have done lots of fantastic work translating (and hopefully continuing to translate UI components in the future.

This PR could use additional review to make sure I'm doing things with JS best practices since I speak more spanish than JS (hah).

All of the translations were done by the GTÑ team here https://docs.google.com/document/d/1cjv_I3toCa11aLbyC5pv17UFID3TH9D7UqTvFCthlCk/edit

Fixes https://github.com/galaxyproject/galaxy/issues/11982

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Change to spanish
  2. Check that the only english is in the toolpanel

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
