### PR TITLE
Improvements to Selenium testing

### DIFF
--- a/client/src/mvc/annotation.js
+++ b/client/src/mvc/annotation.js
@@ -34,6 +34,7 @@ var AnnotationEditor = Backbone.View.extend(baseMVC.LoggableMixin)
             //TODO: handle empties better
             this.$annotation().make_text_editable({
                 use_textarea: true,
+                data_description: "annotation input",
                 on_finish: function (newAnnotation) {
                     view.$annotation().text(newAnnotation);
                     view.model.save({ annotation: newAnnotation }, { silent: true }).fail(() => {
@@ -53,7 +54,7 @@ var AnnotationEditor = Backbone.View.extend(baseMVC.LoggableMixin)
                 _l("Annotation"),
                 "</label>",
                 // set up initial tags by adding as CSV to input vals (necc. to init select2)
-                '<div class="annotation">',
+                '<div class="annotation" data-description="history annotation">',
                 _.escape(annotation),
                 "</div>",
             ].join("");

--- a/client/src/mvc/history/history-view-edit.js
+++ b/client/src/mvc/history/history-view-edit.js
@@ -230,6 +230,7 @@ var HistoryViewEdit = _super.extend(
                 .attr("title", _l("Rename history..."))
                 .tooltip({ placement: "bottom" })
                 .make_text_editable({
+                    data_description: "name input",
                     on_finish: function (newName) {
                         var previousName = panel.model.get("name");
                         if (newName && newName !== previousName) {

--- a/client/src/mvc/history/history-view.js
+++ b/client/src/mvc/history/history-view.js
@@ -530,7 +530,7 @@ HistoryView.prototype.templates = (() => {
         [
             '<div class="controls history-details">',
             '<div class="title">',
-            '<div class="name"><%- history.name %></div>',
+            '<div class="name history-title"><%- history.name %></div>',
             "</div>",
             '<div class="subtitle"></div>',
             '<div class="history-size"><%- history.nice_size %></div>',

--- a/client/src/ui/editable-text.js
+++ b/client/src/ui/editable-text.js
@@ -20,6 +20,8 @@ $.fn.make_text_editable = function (config_dict) {
     var on_finish = "on_finish" in config_dict ? config_dict.on_finish : null;
     var help_text = "help_text" in config_dict ? config_dict.help_text : null;
 
+    const data_description = "data_description" in config_dict ? config_dict.data_description : null;
+
     // Add element behavior.
     var container = $(this);
     container.addClass("editable-text").click(function (e) {
@@ -97,6 +99,9 @@ $.fn.make_text_editable = function (config_dict) {
         container.append(input_elt);
         if (button_elt) {
             container.append(button_elt);
+        }
+        if (data_description != null) {
+            input_elt.attr("data-description", data_description);
         }
         input_elt.focus();
         input_elt.select();

--- a/lib/galaxy/selenium/components.py
+++ b/lib/galaxy/selenium/components.py
@@ -23,7 +23,10 @@ class Target(metaclass=ABCMeta):
 
 class SelectorTemplate(Target):
 
-    def __init__(self, selector, selector_type, children=None, kwds=None, with_classes=None, with_data=None):
+    def __init__(self, selector: str, selector_type: str, children=None, kwds=None, with_classes=None, with_data=None):
+        if selector_type == "data-description":
+            selector_type = "css"
+            selector = f'[data-description="{selector}"]'
         self._selector = selector
         self.selector_type = selector_type
         self._children = children or {}
@@ -93,7 +96,7 @@ class SelectorTemplate(Target):
         elif self.selector_type == "id":
             by = By.ID
         else:
-            raise Exception("Unknown selector type")
+            raise Exception(f"Unknown selector type {self.selector_type}")
         return (by, self.selector)
 
     @property

--- a/lib/galaxy/selenium/data.py
+++ b/lib/galaxy/selenium/data.py
@@ -4,7 +4,7 @@ from pkg_resources import resource_string
 from .components import Component
 
 
-def load_root_component():
+def load_root_component() -> Component:
     new_data_yaml = resource_string(__name__, 'navigation.yml').decode("UTF-8")
     navigation_raw = yaml.safe_load(new_data_yaml)
     return Component.from_dict("root", navigation_raw)

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1370,10 +1370,11 @@ class NavigatesGalaxy(HasDriver):
         return editable_text_input_element
 
     def history_panel_name_input(self):
-        if self.is_beta_history():
-            editable_text_input_element = self.beta_history_element("name input").wait_for_visible()
-        else:
+        if not self.is_beta_history():
             editable_text_input_element = self.history_panel_click_to_rename()
+        history_panel = self.components.history_panel
+        edit = history_panel.name_edit_input
+        editable_text_input_element = edit.wait_for_visible()
         return editable_text_input_element
 
     def history_panel_click_to_rename(self):

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -8,11 +8,14 @@ import contextlib
 import random
 import string
 import time
+from abc import abstractmethod
 from functools import partial, wraps
+from typing import Union
 
 import requests
 import yaml
 from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.remote.webdriver import WebDriver
 
 from galaxy.util import DEFAULT_SOCKET_TIMEOUT
 from . import sizzle
@@ -33,6 +36,8 @@ DEFAULT_PASSWORD = '123456'
 
 RETRY_DURING_TRANSITIONS_SLEEP_DEFAULT = .1
 RETRY_DURING_TRANSITIONS_ATTEMPTS_DEFAULT = 10
+
+GALAXY_MAIN_FRAME_ID = "galaxy_main"
 
 WaitType = collections.namedtuple("WaitType", ["name", "default_length"])
 
@@ -147,13 +152,21 @@ class NavigatesGalaxy(HasDriver):
     class. For instance, the method for clicking an option in the workflow editor is
     workflow_editor_click_option instead of click_workflow_editor_option.
     """
+    timeout_multiplier: float
+    driver: WebDriver
+
+    @abstractmethod
+    def build_url(self, url: str, for_selenium: bool = True) -> str:
+        """Build URL to the target Galaxy."""
+
     default_password = DEFAULT_PASSWORD
     wait_types = WAIT_TYPES
     # set to True to reload each invocation (good for interactive test building)
     _interactive_components: bool = False
     _root_component: Component = load_root_component()
 
-    def get(self, url=""):
+    def get(self, url: str = ""):
+        """Expand supplied relative URL and navigate to page using Selenium driver."""
         full_url = self.build_url(url)
         return self.driver.get(full_url)
 
@@ -165,41 +178,55 @@ class NavigatesGalaxy(HasDriver):
             return self._root_component
 
     @property
-    def components(self):
+    def components(self) -> SmartComponent:
+        """Fetch root component describing the Galaxy DOM."""
         return SmartComponent(self.navigation, self)
 
-    def wait_length(self, wait_type):
+    def wait_length(self, wait_type: WaitType) -> float:
+        """Return the wait time specified by wait_type after applying `timeout_multipler`.
+
+        `timeout_multiplier` is used in production CI tests to reduce transient failures
+        in a uniform way across test suites to expand waiting.
+        """
         return wait_type.default_length * self.timeout_multiplier
 
-    def sleep_for(self, wait_type):
+    def sleep_for(self, wait_type: WaitType) -> None:
+        """Sleep on the Python client side for the specified wait_type.
+
+        This method uses `wait_length` to apply any `timeout_multiplier`.
+        """
         self.sleep_for_seconds(self.wait_length(wait_type))
 
-    def sleep_for_seconds(self, duration):
+    def sleep_for_seconds(self, duration: float) -> None:
+        """Sleep in the local thread for specified number of seconds.
+
+        Ideally, we would be sleeping on the Selenium server instead of in the local client
+        (e.g. test) thread.
+        """
         time.sleep(duration)
 
-    def timeout_for(self, **kwds):
-        wait_type = kwds.get("wait_type", DEFAULT_WAIT_TYPE)
+    def timeout_for(self, wait_type: WaitType = DEFAULT_WAIT_TYPE) -> float:
         return self.wait_length(wait_type)
 
-    def home(self):
+    def home(self) -> None:
+        """Return to root Galaxy page and wait for some basic widgets to appear."""
         self.get()
-        self.wait_for_visible(self.navigation.masthead.selector)
-        if not self.is_beta_history():
-            self.wait_for_visible(self.navigation.history_panel.selector)
+        self.components.masthead._.wait_for_visible()
 
-    def trs_search(self):
+    def trs_search(self) -> None:
         self.driver.get(self.build_url('workflows/trs_search'))
-        self.wait_for_visible(self.navigation.masthead.selector)
+        self.components.masthead._.wait_for_visible()
 
-    def trs_by_id(self):
+    def trs_by_id(self) -> None:
         self.driver.get(self.build_url('workflows/trs_import'))
-        self.wait_for_visible(self.navigation.masthead.selector)
+        self.components.masthead._.wait_for_visible()
 
     def switch_to_main_panel(self):
-        self.driver.switch_to.frame("galaxy_main")
+        self.driver.switch_to.frame(GALAXY_MAIN_FRAME_ID)
 
     @contextlib.contextmanager
-    def local_storage(self, key, value):
+    def local_storage(self, key: str, value: Union[float, str]):
+        """Method decorator to modify localStorage for the scope of the supplied context."""
         self.driver.execute_script(f'''window.localStorage.setItem("{key}", {value});''')
         try:
             yield
@@ -208,6 +235,7 @@ class NavigatesGalaxy(HasDriver):
 
     @contextlib.contextmanager
     def main_panel(self):
+        """Decorator to operate within the context of Galaxy's main frame."""
         try:
             self.switch_to_main_panel()
             yield

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -220,6 +220,7 @@ history_panel:
       elements_warning: '.dataset-collection-panel .controls .elements-warning'
       tag_area_input: '.controls .tags-display .tags-input input'
       list_items: '.dataset-collection-panel .list-items .list-item'
+      list_items_beta: '.dataset-collection-panel .listing .content-item'
 
   selectors:
     beta: '.beta.history'
@@ -228,8 +229,9 @@ history_panel:
     refresh_button: '.history-refresh-button'
     name: '.title .name'
     name_beta: '.history-title span:last-child'
-    name_edit_input: '.name input'
-    name_edit_input_beta: '.history-title input'
+    name_edit_input: 
+      selector: 'name input'
+      type: data-description
     contents: '#current-history-panel .history-content'
 
     empty_message: '.empty-message'
@@ -242,10 +244,13 @@ history_panel:
 
     annotation_icon: '.actions .history-annotate-btn'
     annotation_area: '.history-details .history-annotation'
-    annotation_editable_text: '.history-details .history-annotation .annotation.editable-text'
-    annotation_editable_text_beta: '.history-details .history-annotation.clickToEdit'
-    annotation_edit: '.history-details .history-annotation .annotation textarea'
-    annotation_edit_beta: '.history-details .history-annotation textarea'
+    annotation_editable_text:
+      selector: 'history annotation'
+      type: data-description
+    annotation_edit:
+      selector: 'annotation input'
+      type: data-description
+
     annotation_done: '.history-details .history-annotation .annotation button'
 
     options_button: '#history-options-button'

--- a/lib/galaxy_test/selenium/test_history_panel.py
+++ b/lib/galaxy_test/selenium/test_history_panel.py
@@ -20,7 +20,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
     @selenium_test
     def test_history_panel_landing_state(self):
         self.assert_initial_history_panel_state_correct()
-
+        name_element = self.history_panel_name_element()
         if self.is_beta_history():
             # look for the editor icon
             editor = self.components.history_panel.editor.selector(scope=".beta.history")
@@ -31,19 +31,12 @@ class HistoryPanelTestCase(SeleniumTestCase):
             annotation_icon_selector = self.navigation.history_panel.selectors.annotation_icon
             self.wait_for_visible(tag_icon_selector)
             self.wait_for_visible(annotation_icon_selector)
-            name_element = self.history_panel_name_element()
             self.assert_tooltip_text(name_element, self.navigation.history_panel.text.tooltip_name)
 
     @selenium_test
     def test_history_panel_rename(self):
-        if self.is_beta_history():
-            self.history_panel_rename(NEW_HISTORY_NAME)
-            self.assert_name_changed()
-        else:
-            editable_text_input_element = self.history_panel_click_to_rename()
-            editable_text_input_element.send_keys(NEW_HISTORY_NAME)
-            self.send_enter(editable_text_input_element)
-            self.assert_name_changed()
+        self.history_panel_rename(NEW_HISTORY_NAME)
+        self.assert_name_changed()
 
     @selenium_test
     def test_history_rename_confirm_with_click(self):
@@ -61,10 +54,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
         editable_text_input_element = self.history_panel_name_input()
         editable_text_input_element.send_keys(NEW_HISTORY_NAME)
         self.send_escape(editable_text_input_element)
-        if self.is_beta_history():
-            self.components.history_panel.editor.selector(scope=".beta.history").form.wait_for_absent_or_hidden()
-        else:
-            self.assert_absent(self.navigation.history_panel.selectors.name_edit_input)
+        self.components.history_panel.name_edit_input.wait_for_absent_or_hidden()
         assert NEW_HISTORY_NAME not in self.history_panel_name()
 
     @selenium_test
@@ -113,10 +103,7 @@ class HistoryPanelTestCase(SeleniumTestCase):
         def assert_current_annotation(expected, error_message="History annotation",
                                       is_equal=True):
 
-            if self.is_beta_history():
-                text_component = self.beta_history_element("history annotation")
-            else:
-                text_component = history_panel.annotation_editable_text
+            text_component = history_panel.annotation_editable_text
             current_annotation = text_component.wait_for_visible()
             error_message += " given: [%s] expected [%s] "
             if is_equal:

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -205,17 +205,17 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
         # Test setting a name tag and viewing it from the outer history panel.
         input_collection = self._populated_paired_and_wait_for_it()
         collection_hid = input_collection["hid"]
-        collection_view = self._click_and_wait_for_collection_view(collection_hid)
+        self._click_and_wait_for_collection_view(collection_hid)
 
         if self.is_beta_history():
             self.history_panel_add_tags(["#moo"])
-            self.screenshot("history_panel_collection_view_add_nametag_beta")
-            self._back_to_history()
         else:
             # the space on the end of the parent_selector is important
             self.tagging_add(["#moo"], parent_selector=".dataset-collection-panel .controls ")
-            self.screenshot("history_panel_collection_view_add_nametag")
-            collection_view.back.wait_for_and_click()
+
+        self.sleep_for(WAIT_TYPES.HISTORY_POLL)
+        self.screenshot("history_panel_collection_view_add_nametag")
+        self._back_to_history()
 
         self.history_panel_wait_for_hid_state(collection_hid, "ok")
         nametags = self.history_panel_item_get_nametags(collection_hid)
@@ -243,34 +243,24 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
     @flakey  # Fails only in Jenkins full suite - possibly due to #3782
     def test_list_display(self):
         input_collection, failed_collection = self._generate_partially_failed_collection_with_input()
-        input_collection_hid = input_collection['hid']
         failed_hid = failed_collection["hid"]
 
-        if self.is_beta_history():
-            self.content_item_by_attributes(hid=input_collection_hid).wait_for_present()
-            self.content_item_by_attributes(hid=failed_hid, state="error").wait_for_present()
-            self._click_and_wait_for_collection_view(failed_hid)
-            self.content_item_by_attributes(index=3).wait_for_present()
+        self.home()
+        self.history_panel_wait_for_hid_state(failed_hid, "error")
+        collection_view = self._click_and_wait_for_collection_view(failed_hid)
 
-            dataset_elements = self.content_item_by_attributes().all()
-            assert len(dataset_elements) == 4
+        @retry_assertion_during_transitions
+        def check_four_datasets_shown():
+            if self.is_beta_history():
+                self.sleep_for(WAIT_TYPES.HISTORY_POLL)
+                dataset_elements = collection_view.list_items_beta.all()
+            else:
+                dataset_elements = collection_view.list_items.all()
+            assert len(dataset_elements) == 4, dataset_elements
             title_elements = [de.find_element_by_css_selector(".title .name").text for de in dataset_elements]
             assert title_elements == ["data1", "data2", "data3", "data4"]
 
-        else:
-            self.home()
-            self.history_panel_wait_for_hid_state(failed_hid, "error")
-            collection_view = self._click_and_wait_for_collection_view(failed_hid)
-
-            @retry_assertion_during_transitions
-            def check_four_datasets_shown():
-                dataset_elements = collection_view.list_items.all()
-                assert len(dataset_elements) == 4, dataset_elements
-                title_elements = [de.find_element_by_css_selector(".title .name").text for de in dataset_elements]
-                assert title_elements == ["data1", "data2", "data3", "data4"]
-
-            check_four_datasets_shown()
-
+        check_four_datasets_shown()
         self.screenshot("history_panel_collection_view_list")
 
     @selenium_test

--- a/lib/galaxy_test/selenium/test_library_contents.py
+++ b/lib/galaxy_test/selenium/test_library_contents.py
@@ -161,8 +161,9 @@ class LibraryContentsTestCase(SeleniumTestCase, UsesLibraryAssertions):
         self.wait_for_selector_clickable(".toolbtn-show-locinfo").click()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.wait_for_selector_clickable(".ui-modal #button-0").click()
-        self.wait_for_overlays_cleared()
         self.screenshot("libraries_show_details")
+        self.wait_for_overlays_cleared()
+        self.screenshot("libraries_show_details_done")
 
     @retry_during_transitions
     def _select_history_option(self, select_id, label_text):


### PR DESCRIPTION
Two commits:
- one reduces the divergence between the beta history panel and the old history panel in terms of DOM and Selenium testing.
- the other adds more docs and typing to Selenium support code

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
