### PR TITLE
[WIP] Link or copy inputs to working directory if inputs_to_working_directory is 'link' or 'copy'

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4149,9 +4149,25 @@
     This is necessary (for example) if jobs run on a cluster and
     datasets can not be created by the user running the jobs (e.g. if
     the filesystem is mounted read-only or the jobs are run by a
-    different user than the galaxy user).
+    different user than the galaxy user). This can be set as a job
+    destination/environment parameter in the job configuration.
 :Default: ``false``
 :Type: bool
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``inputs_to_working_directory``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    This option will override tool input paths to read inputs from the
+    job working directory (instead of to the file_path). Set to 'link'
+    to symbolically link to inputs, or set to 'copy' to copy inputs
+    (warning: copying can be very slow and should not be necessary in
+    most cases). This can be set as a job destination/environment
+    parameter in the job configuration.
+:Default: ``false``
+:Type: any
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2036,8 +2036,17 @@ galaxy:
   # necessary (for example) if jobs run on a cluster and datasets can
   # not be created by the user running the jobs (e.g. if the filesystem
   # is mounted read-only or the jobs are run by a different user than
-  # the galaxy user).
+  # the galaxy user). This can be set as a job destination/environment
+  # parameter in the job configuration.
   #outputs_to_working_directory: false
+
+  # This option will override tool input paths to read inputs from the
+  # job working directory (instead of to the file_path). Set to 'link'
+  # to symbolically link to inputs, or set to 'copy' to copy inputs
+  # (warning: copying can be very slow and should not be necessary in
+  # most cases). This can be set as a job destination/environment
+  # parameter in the job configuration.
+  #inputs_to_working_directory: false
 
   # If your network filesystem's caching prevents the Galaxy server from
   # seeing the job's stdout and stderr files when it completes, you can

--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -63,6 +63,17 @@ class DatasetPath:
         return dataset_path
 
 
+class DatasetPathRewriterRouter:
+    def __init__(self, path_rewriters):
+        self.path_rewriters = path_rewriters
+
+    def rewrite_dataset_path(self, dataset, dataset_type):
+        rewriter = self.path_rewriters.get(dataset_type)
+        if rewriter:
+            return rewriter.rewrite_dataset_path(dataset, dataset_type)
+        return None
+
+
 class DatasetPathRewriter(metaclass=ABCMeta):
     """ Used by runner to rewrite paths. """
 
@@ -82,14 +93,6 @@ class NullDatasetPathRewriter:
         """ Keep path the same.
         """
         return None
-
-
-class INeedANameForThis:
-    def __init__(self, path_rewriters):
-        self.path_rewriters = path_rewriters
-
-    def rewrite_dataset_path(self, dataset, dataset_type):
-        return self.path_rewriters[dataset_type].rewrite_dataset_path(dataset, dataset_type)
 
 
 class InputsToWorkingDirectoryPathRewriter:

--- a/lib/galaxy/job_execution/datasets.py
+++ b/lib/galaxy/job_execution/datasets.py
@@ -1,11 +1,16 @@
 """
 Utility classes allowing Job interface to reason about datasets.
 """
+import logging
+import os
 import os.path
+import shutil
 from abc import (
     ABCMeta,
     abstractmethod
 )
+
+log = logging.getLogger(__name__)
 
 
 def dataset_path_rewrites(dataset_paths):
@@ -77,6 +82,43 @@ class NullDatasetPathRewriter:
         """ Keep path the same.
         """
         return None
+
+
+class INeedANameForThis:
+    def __init__(self, path_rewriters):
+        self.path_rewriters = path_rewriters
+
+    def rewrite_dataset_path(self, dataset, dataset_type):
+        return self.path_rewriters[dataset_type].rewrite_dataset_path(dataset, dataset_type)
+
+
+class InputsToWorkingDirectoryPathRewriter:
+    def __init__(self, working_directory, inputs_directory_name, style='link'):
+        self.working_directory = working_directory
+        self.inputs_directory_name = inputs_directory_name
+        assert style in ('link', 'copy'), f"Unknown input rewrite style: {style}"
+        self.style = style
+
+    def rewrite_dataset_path(self, dataset, dataset_type):
+        """ Keep path the same.
+        """
+        # TODO: what about efps?
+        if dataset_type == 'input':
+            base_input_directory = os.path.abspath(self.working_directory)
+            if self.inputs_directory_name is not None:
+                base_input_directory = os.path.join(base_input_directory, self.inputs_directory_name)
+            # set false_path to uuid, no harm even if object store uses id
+            false_path = os.path.join(base_input_directory, f"galaxy_dataset_{dataset.dataset.uuid}.{dataset.ext}")
+            os.makedirs(base_input_directory, exist_ok=True)
+            if self.style == 'link':
+                log.debug(f"Linking '{dataset.file_name}' to '{false_path}'")
+                os.symlink(dataset.file_name, false_path)
+            elif self.style == 'copy':
+                log.debug(f"Copying '{dataset.file_name}' to '{false_path}'")
+                shutil.copy(dataset.file_name, false_path)
+            return false_path
+        else:
+            return None
 
 
 class OutputsToWorkingDirectoryPathRewriter:

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -35,6 +35,8 @@ from galaxy.exceptions import (
 )
 from galaxy.job_execution.datasets import (
     DatasetPath,
+    INeedANameForThis,
+    InputsToWorkingDirectoryPathRewriter,
     NullDatasetPathRewriter,
     OutputsToWorkingDirectoryPathRewriter,
     TaskPathRewriter
@@ -982,9 +984,20 @@ class JobWrapper(HasResourceParameters):
     def _job_dataset_path_rewriter(self):
         if self._dataset_path_rewriter is None:
             outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
+            #inputs_to_working_directory = util.asbool(self.get_destination_configuration("inputs_to_working_directory", False))
+            inputs_to_working_directory = self.get_destination_configuration("inputs_to_working_directory", False)
+            path_rewriters = {}
             if outputs_to_working_directory:
                 output_directory = self.outputs_directory
-                self._dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory, output_directory)
+                #self._dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory, output_directory)
+                path_rewriters['output'] = OutputsToWorkingDirectoryPathRewriter(self.working_directory, output_directory)
+            if inputs_to_working_directory:
+                input_directory = self.inputs_directory
+                path_rewriters['input'] = InputsToWorkingDirectoryPathRewriter(self.working_directory, input_directory)
+            #else:
+            #    self._dataset_path_rewriter = NullDatasetPathRewriter()
+            if path_rewriters:
+                self._dataset_path_rewriter = INeedANameForThis(path_rewriters)
             else:
                 self._dataset_path_rewriter = NullDatasetPathRewriter()
         return self._dataset_path_rewriter
@@ -998,6 +1011,10 @@ class JobWrapper(HasResourceParameters):
         """Default location of ``outputs_to_working_directory``.
         """
         return None if self.created_with_galaxy_version < packaging.version.parse("20.01") else "outputs"
+
+    @property
+    def inputs_directory(self):
+        return "inputs"
 
     @property
     def created_with_galaxy_version(self):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -35,7 +35,7 @@ from galaxy.exceptions import (
 )
 from galaxy.job_execution.datasets import (
     DatasetPath,
-    INeedANameForThis,
+    DatasetPathRewriterRouter,
     InputsToWorkingDirectoryPathRewriter,
     NullDatasetPathRewriter,
     OutputsToWorkingDirectoryPathRewriter,
@@ -984,20 +984,20 @@ class JobWrapper(HasResourceParameters):
     def _job_dataset_path_rewriter(self):
         if self._dataset_path_rewriter is None:
             outputs_to_working_directory = util.asbool(self.get_destination_configuration("outputs_to_working_directory", False))
-            #inputs_to_working_directory = util.asbool(self.get_destination_configuration("inputs_to_working_directory", False))
             inputs_to_working_directory = self.get_destination_configuration("inputs_to_working_directory", False)
             path_rewriters = {}
             if outputs_to_working_directory:
                 output_directory = self.outputs_directory
-                #self._dataset_path_rewriter = OutputsToWorkingDirectoryPathRewriter(self.working_directory, output_directory)
                 path_rewriters['output'] = OutputsToWorkingDirectoryPathRewriter(self.working_directory, output_directory)
             if inputs_to_working_directory:
+                # A boolean True is equivalent to 'link'
+                style = 'link' if inputs_to_working_directory is True else inputs_to_working_directory
                 input_directory = self.inputs_directory
-                path_rewriters['input'] = InputsToWorkingDirectoryPathRewriter(self.working_directory, input_directory)
-            #else:
-            #    self._dataset_path_rewriter = NullDatasetPathRewriter()
-            if path_rewriters:
-                self._dataset_path_rewriter = INeedANameForThis(path_rewriters)
+                path_rewriters['input'] = InputsToWorkingDirectoryPathRewriter(self.working_directory, input_directory, style=style)
+            if len(path_rewriters) > 1:
+                self._dataset_path_rewriter = DatasetPathRewriterRouter(path_rewriters)
+            elif path_rewriters:
+                self._dataset_path_rewriter = next(iter(path_rewriters.values()))
             else:
                 self._dataset_path_rewriter = NullDatasetPathRewriter()
         return self._dataset_path_rewriter
@@ -1014,7 +1014,7 @@ class JobWrapper(HasResourceParameters):
 
     @property
     def inputs_directory(self):
-        return "inputs"
+        return None if self.created_with_galaxy_version < packaging.version.parse("22.01") else "inputs"
 
     @property
     def created_with_galaxy_version(self):

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1014,7 +1014,7 @@ class JobWrapper(HasResourceParameters):
 
     @property
     def inputs_directory(self):
-        return None if self.created_with_galaxy_version < packaging.version.parse("22.01") else "inputs"
+        return "inputs"
 
     @property
     def created_with_galaxy_version(self):

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -3054,6 +3054,13 @@ mapping:
           if the filesystem is mounted read-only or the jobs are run by a different
           user than the galaxy user).
 
+      inputs_to_working_directory:
+        type: any
+        default: false
+        required: false
+        desc: |
+          TODO
+
       retry_job_output_collection:
         type: int
         default: 0

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -3052,14 +3052,19 @@ mapping:
           server after the job completes. This is necessary (for example) if jobs run
           on a cluster and datasets can not be created by the user running the jobs (e.g.
           if the filesystem is mounted read-only or the jobs are run by a different
-          user than the galaxy user).
+          user than the galaxy user). This can be set as a job destination/environment
+          parameter in the job configuration.
 
       inputs_to_working_directory:
         type: any
         default: false
         required: false
         desc: |
-          TODO
+          This option will override tool input paths to read inputs from the job
+          working directory (instead of to the file_path). Set to 'link' to symbolically
+          link to inputs, or set to 'copy' to copy inputs (warning: copying can be very
+          slow and should not be necessary in most cases). This can be set as a job
+          destination/environment parameter in the job configuration.
 
       retry_job_output_collection:
         type: int

--- a/test/functional/tools/input_in_job_dir.xml
+++ b/test/functional/tools/input_in_job_dir.xml
@@ -1,0 +1,30 @@
+<tool id="input_in_job_dir" name="input_in_job_dir" version="1.0.0">
+    <command><![CDATA[
+input_dir="\$(dirname '$input_data')" &&
+input_parent_dir="\$(dirname "\$input_dir")" &&
+work_parent_dir="\$(dirname "\$(pwd)")" &&
+if [ "\$input_parent_dir" = "\$work_parent_dir" ]; then
+    echo "input dir parent \$input_parent_dir == work dir parent \$work_parent_dir";
+    echo 'OK' > 1;
+else
+    echo "input dir parent \$input_parent_dir != work dir parent \$work_parent_dir";
+    echo 'ERROR' > 1;
+fi
+    ]]></command>
+    <inputs>
+        <param name="input_data" type="data" format="data" label="input_data" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" from_work_dir="1" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input_data" value="1.fastqsanger" ftype="fastqsanger" />
+            <output name="output" ftype="txt">
+                <assert_contents>
+                    <has_line line="OK" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/input_is_symlink.xml
+++ b/test/functional/tools/input_is_symlink.xml
@@ -1,0 +1,27 @@
+<tool id="input_is_symlink" name="input_is_symlink" version="1.0.0">
+    <command><![CDATA[
+if [ -h '$input_data' ]; then
+    echo "input is symlink: $input_data";
+    echo 'OK' > 1;
+else
+    echo "input is not symlink: $input_data";
+    echo 'ERROR' > 1;
+fi
+    ]]></command>
+    <inputs>
+        <param name="input_data" type="data" format="data" label="input_data" />
+    </inputs>
+    <outputs>
+        <data name="output" format="txt" from_work_dir="1" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input_data" value="1.fastqsanger" ftype="fastqsanger" />
+            <output name="output" ftype="txt">
+                <assert_contents>
+                    <has_line line="OK" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -142,6 +142,8 @@
   <tool file="implicit_conversion_format_input.xml" />
   <tool file="implicit_collection_conversion.xml" />
   <tool file="implicit_nested_list_conversion.xml" />
+  <tool file="input_in_job_dir.xml" />
+  <tool file="input_is_symlink.xml" />
   <tool file="explicit_conversion.xml" />
   <tool file="identifier_source.xml" />
   <tool file="identifier_single.xml" />

--- a/test/integration/test_job_inputs_to_working_directory_copy.py
+++ b/test/integration/test_job_inputs_to_working_directory_copy.py
@@ -1,0 +1,18 @@
+"""Run various framework tool tests with inputs_to_working_directory = copy."""
+
+from galaxy_test.driver import integration_util
+
+
+class JobInputsToWorkingDirectoryCopyTestCase(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with inputs_to_working_directory enabled."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["inputs_to_working_directory"] = 'copy'
+
+
+instance = integration_util.integration_module_instance(JobInputsToWorkingDirectoryCopyTestCase)
+
+test_tools = integration_util.integration_tool_runner(["output_format", "input_in_job_dir"])

--- a/test/integration/test_job_inputs_to_working_directory_link.py
+++ b/test/integration/test_job_inputs_to_working_directory_link.py
@@ -1,0 +1,18 @@
+"""Run various framework tool tests with inputs_to_working_directory = link."""
+
+from galaxy_test.driver import integration_util
+
+
+class JobInputsToWorkingDirectoryLinkTestCase(integration_util.IntegrationInstance):
+    """Describe a Galaxy test instance with inputs_to_working_directory enabled."""
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["inputs_to_working_directory"] = 'link'
+
+
+instance = integration_util.integration_module_instance(JobInputsToWorkingDirectoryLinkTestCase)
+
+test_tools = integration_util.integration_tool_runner(["output_format", "input_in_job_dir", "input_is_symlink"])


### PR DESCRIPTION
Rather than fix every tool that writes to its inputs directory, we can just symlink inputs to a subdir of the job directory. Bonus features:

- Inputs are symlinked with their dataset's extension!
- You can set this per-job-destination/environment (e.g. per @pvanheus this could be used to copy inputs for Shovill, which canonicalizes all symlinks in its input paths)

Stuff that should be done/tested before merging:
- [ ] Input extra files paths are not addressed
- [ ] Container volume expansion magic might need some work - I guess we should make it writable (even though the fact that it *shouldn't* be writable is what this change addresses)?
- [ ] Pulsar??
- [x] Tests

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]
- [x] What are tests?

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
