### PR TITLE
Set default constructor for SA models

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -147,6 +147,7 @@ class Base(metaclass=DeclarativeMeta):
     __abstract__ = True
     registry = mapper_registry
     metadata = mapper_registry.metadata
+    __init__ = mapper_registry.constructor
 
     @classmethod
     def __declare_last__(cls):
@@ -816,15 +817,17 @@ class DynamicTool(Base, Dictifiable, RepresentById):
             self.uuid = UUID(str(uuid))
 
 
-class BaseJobMetric:
+class BaseJobMetric(Base):
+    __abstract__ = True
 
     def __init__(self, plugin, metric_name, metric_value):
+        super().__init__()
         self.plugin = plugin
         self.metric_name = metric_name
         self.metric_value = metric_value
 
 
-class JobMetricText(Base, BaseJobMetric, RepresentById):
+class JobMetricText(BaseJobMetric, RepresentById):
     __tablename__ = 'job_metric_text'
 
     id = Column(Integer, primary_key=True)
@@ -835,7 +838,7 @@ class JobMetricText(Base, BaseJobMetric, RepresentById):
     job = relationship('Job', back_populates='text_metrics')
 
 
-class JobMetricNumeric(Base, BaseJobMetric, RepresentById):
+class JobMetricNumeric(BaseJobMetric, RepresentById):
     __tablename__ = 'job_metric_numeric'
 
     id = Column(Integer, primary_key=True)
@@ -846,7 +849,7 @@ class JobMetricNumeric(Base, BaseJobMetric, RepresentById):
     job = relationship('Job', back_populates='numeric_metrics')
 
 
-class TaskMetricText(Base, BaseJobMetric, RepresentById):
+class TaskMetricText(BaseJobMetric, RepresentById):
     __tablename__ = 'task_metric_text'
 
     id = Column(Integer, primary_key=True)
@@ -857,7 +860,7 @@ class TaskMetricText(Base, BaseJobMetric, RepresentById):
     task = relationship('Task', back_populates='text_metrics')
 
 
-class TaskMetricNumeric(Base, BaseJobMetric, RepresentById):
+class TaskMetricNumeric(BaseJobMetric, RepresentById):
     __tablename__ = 'task_metric_numeric'
 
     id = Column(Integer, primary_key=True)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5562,20 +5562,6 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, RepresentById):
 
 
 class DatasetCollectionInstance(HasName):
-    """
-    """
-
-    def __init__(
-        self,
-        collection=None,
-        deleted=False,
-    ):
-        # Relationships
-        self.collection = collection
-        # Since deleted property is shared between history and dataset collections,
-        # it could be on either table - some places in the code however it is convient
-        # it is on instance instead of collection.
-        self.deleted = deleted
 
     @property
     def state(self):
@@ -5730,10 +5716,11 @@ class HistoryDatasetCollectionAssociation(
     ):
         if implicit_input_collections is None:
             implicit_input_collections = []
-        super().__init__(
-            collection=collection,
-            deleted=deleted,
-        )
+        self.collection = collection
+        # Since deleted property is shared between history and dataset collections,
+        # it could be on either table - some places in the code however it is convient
+        # it is on instance instead of collection.
+        self.deleted = deleted
         self.id = id
         self.hid = hid
         self.history = history
@@ -5953,10 +5940,11 @@ class LibraryDatasetCollectionAssociation(Base, DatasetCollectionInstance, Repre
         deleted=False,
         folder=None,
     ):
-        super().__init__(
-            collection=collection,
-            deleted=deleted,
-        )
+        self.collection = collection
+        # Since deleted property is shared between history and dataset collections,
+        # it could be on either table - some places in the code however it is convient
+        # it is on instance instead of collection.
+        self.deleted = deleted
         self.id = id
         self.folder = folder
         self.name = name

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -143,7 +143,7 @@ else:
     _HasTable = object
 
 
-def get_uuid(uuid):
+def get_uuid(uuid=None):
     if uuid is None:
         return uuid4()
     return UUID(str(uuid))
@@ -817,10 +817,7 @@ class DynamicTool(Base, Dictifiable, RepresentById):
         self.active = active
         self.hidden = hidden
         self.value = value
-        if uuid is None:
-            self.uuid = uuid4()
-        else:
-            self.uuid = UUID(str(uuid))
+        self.uuid = get_uuid(uuid)
 
 
 class BaseJobMetric(Base):
@@ -6398,10 +6395,7 @@ class Workflow(Base, Dictifiable, RepresentById):
         self.has_errors = None
         self.steps = []
         self.stored_workflow_id = None
-        if uuid is None:
-            self.uuid = uuid4()
-        else:
-            self.uuid = UUID(str(uuid))
+        self.uuid = get_uuid(uuid)
 
     def has_outputs_defined(self):
         """
@@ -6883,10 +6877,7 @@ class WorkflowOutput(Base, RepresentById):
         self.workflow_step = workflow_step
         self.output_name = output_name
         self.label = label
-        if uuid is None:
-            self.uuid = uuid4()
-        else:
-            self.uuid = UUID(str(uuid))
+        self.uuid = get_uuid(uuid)
 
     def copy(self, copied_step):
         copied_output = WorkflowOutput(copied_step)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -143,6 +143,12 @@ else:
     _HasTable = object
 
 
+def get_uuid(uuid):
+    if uuid is None:
+        return uuid4()
+    return UUID(str(uuid))
+
+
 class Base(metaclass=DeclarativeMeta):
     __abstract__ = True
     registry = mapper_registry
@@ -3267,13 +3273,6 @@ class DefaultHistoryPermissions(Base, RepresentById):
 
 class StorableObject:
 
-    def __init__(self, id, uuid):
-        self.id = id
-        if uuid is None:
-            self.uuid = uuid4()
-        else:
-            self.uuid = UUID(str(uuid))
-
     def flush(self):
         sa_session = object_session(self)
         if sa_session:
@@ -3335,7 +3334,8 @@ class Dataset(StorableObject, RepresentById, _HasTable):
     engine = None
 
     def __init__(self, id=None, state=None, external_filename=None, extra_files_path=None, file_size=None, purgable=True, uuid=None):
-        super().__init__(id=id, uuid=uuid)
+        self.id = id
+        self.uuid = get_uuid(uuid)
         self.state = state
         self.deleted = False
         self.purged = False
@@ -7707,7 +7707,8 @@ class MetadataFile(Base, StorableObject, RepresentById):
     library_dataset = relationship('LibraryDatasetDatasetAssociation')
 
     def __init__(self, dataset=None, name=None, uuid=None):
-        super().__init__(id=None, uuid=uuid)
+        self.id = None
+        self.uuid = get_uuid(uuid)
         if isinstance(dataset, HistoryDatasetAssociation):
             self.history_dataset = dataset
         elif isinstance(dataset, LibraryDatasetDatasetAssociation):

--- a/test/unit/model/test_model.py
+++ b/test/unit/model/test_model.py
@@ -1,0 +1,12 @@
+from uuid import UUID, uuid4
+
+from galaxy import model
+
+
+def test_get_uuid():
+    my_uuid = uuid4()
+    rval = model.get_uuid(my_uuid)
+    assert rval == UUID(str(my_uuid))
+
+    rval = model.get_uuid()
+    assert isinstance(rval, UUID)


### PR DESCRIPTION
Ref: #12355

SQLAlchemy provides a convenient [default constructor](https://docs.sqlalchemy.org/en/14/orm/mapping_styles.html#default-constructor) that accepts all attributes as optional keyword arguments. This constructor can be overwritten to augment it with custom initialization:
```py
class MyModel(Base):
    def __init__(self, myparam, **kwd):
        super().__init__(**kwd)  # let the magic happen
        self.myattr = myparam  # do our custom init stuff
```

For this to happen in our case, we need to set `__init__ = mapper_registry.constructor` in the Base class that we construct explicitly. This detail was omitted from SQLAlchemy's documentation (now fixed after I opened an issue https://github.com/sqlalchemy/sqlalchemy/discussions/7015).

However, this exposed a bug in our code (which would have been exposed if we had used the `declarative_base()` function instead of constructing the Base class directly). When a model class inherits from some parent class, and that parent class *defines a constructor*, that constructor is never called; instead, the constructor set on Base is called. Thus, the following code will produce an error:
```py
Base = declarative_base()  # or construct explicitly, like in our case.

class MyParent:
    def __init__(self, myparam1, myparam2):
        pass

class MyChild(Base, MyParent):
    pass

child = MyChild(myarg1, myarg2)  # BOOM!!! (TypeError: __init__() takes 1 positional argument but 3 were given
```
This PR corrects the declaration of the Base class and fixes this bug.

NOTE: 523b53dc713c13b90f9008725fd337002636d163 commit message contains details for a related fix.



## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
