### PR TITLE
FastAPI: add middleware to deal with file downloads

### DIFF
--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import cast
 
 from fastapi import FastAPI, Request
@@ -88,7 +89,8 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
                 return response
             response = cast(FileResponse, response)
             if nginx_x_accel_redirect_base:
-                response.headers['X-Accel-Redirect'] = nginx_x_accel_redirect_base + response.path
+                full_path = Path(nginx_x_accel_redirect_base) / response.path
+                response.headers['X-Accel-Redirect'] = str(full_path)
             if apache_xsendfile:
                 response.headers['X-Sendfile'] = str(response.path)
             return response

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -90,7 +90,7 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
             if nginx_x_accel_redirect_base:
                 response.headers['X-Accel-Redirect'] = nginx_x_accel_redirect_base + response.path
             if apache_xsendfile:
-                response.headers['X-Sendfile'] = response.path
+                response.headers['X-Sendfile'] = str(response.path)
             return response
 
     if gx_app.config.get('allowed_origin_hostnames', None):

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -68,7 +68,7 @@ class GalaxyCORSMiddleware(CORSMiddleware):
 
 
 def add_galaxy_middleware(app: FastAPI, gx_app):
-    x_frame_options = getattr(gx_app.config, 'x_frame_options', None)
+    x_frame_options = gx_app.config.x_frame_options
     if x_frame_options:
 
         @app.middleware("http")
@@ -78,7 +78,7 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
             return response
 
     nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base
-    apache_xsendfile = getattr(gx_app.config, 'apache_xsendfile', None)
+    apache_xsendfile = gx_app.config.apache_xsendfile
     if nginx_x_accel_redirect_base or apache_xsendfile:
 
         @app.middleware("http")

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -77,7 +77,7 @@ def add_galaxy_middleware(app: FastAPI, gx_app):
             response.headers['X-Frame-Options'] = x_frame_options
             return response
 
-    nginx_x_accel_redirect_base = getattr(gx_app.config, 'nginx_x_accel_redirect_base', None)
+    nginx_x_accel_redirect_base = gx_app.config.nginx_x_accel_redirect_base
     apache_xsendfile = getattr(gx_app.config, 'apache_xsendfile', None)
     if nginx_x_accel_redirect_base or apache_xsendfile:
 


### PR DESCRIPTION
This adds a new FastAPI/Starlette middleware to deal with file downloads if the `nginx_x_accel_redirect_base` or the `apache_xsendfile` are set in the configuration.

Follow-up on https://github.com/galaxyproject/galaxy/pull/11167#discussion_r559535763 and needed for https://github.com/galaxyproject/galaxy/pull/12386#discussion_r707217463.

Hope this is what is needed, I have no idea how to properly test this :sweat_smile: 

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
