### PR TITLE
Make Role description field optional

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1905,9 +1905,9 @@ class BasicRoleModel(BaseModel):
 
 
 class RoleModel(BasicRoleModel):
-    description: str = RoleDescriptionField
+    description: Optional[str] = RoleDescriptionField
     url: str = Field(title="URL", description="URL for the role")
-    model_class: str = Field(title="Model class", description="Database model class (Role)")
+    model_class: str = ModelClassField("Role")
 
 
 class RoleDefinitionModel(BaseModel):


### PR DESCRIPTION
When a "sharing role" is created it doesn't provide a description, so the [model validation](https://github.com/galaxyproject/galaxy/compare/dev...davelopez:make_role_desc_optional?expand=1#diff-a14c374c5acadf6b78f75edfc6626737be3f60422f447ffa6d40253e454bfa17L1908) will fail for those kinds of roles.

https://github.com/galaxyproject/galaxy/blob/bf80b94d2f80a4b3c92b0489cafc4ac72265d590/lib/galaxy/model/security.py#L914

This was causing all the API tests that were calling `BaseDatasetPopulator.user_private_role_id()` to fail after one of those roles was created. Like [here](https://github.com/galaxyproject/galaxy/pull/11701/checks?check_run_id=3585218683).

We can still leave the description as required if needed, in that case, we can provide a default description for those roles.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
