### PR TITLE
Add fallback condition to data table updates.

### DIFF
--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -617,13 +617,12 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
         # No toolshed data table entry was found, try the first file found on disk
         else:
             for filename in self.filenames.keys():
-                if os.path.exists(filename):
-                    fmt_dict = dict(source_repo_info)
-                    fmt_dict['filename'] = filename
+                if source_repo_info is not None:
+                    source_repo_info['filename'] = filename
                     message = 'No exact match found in the data table registry for '
                     message += '{tool_shed}/repos/{owner}/{name}/{installed_changeset_revision}, '
                     message += 'falling back to {filename}'
-                    log.debug(message.format(**fmt_dict))
+                    log.debug(message.format(**source_repo_info))
                     return filename
         return filename
 

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -614,7 +614,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             if source_repo_info and repo_info and source_repo_info == repo_info:
                 filename = name
                 break
-        # No toolshed data table entry was found, try the first file found in the OS
+        # No toolshed data table entry was found, try the first file found on disk
         else:
             for filename in self.filenames.keys():
                 if os.path.exists(filename):

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -617,7 +617,10 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
         # No toolshed data table entry was found, try the first file found on disk
         else:
             for filename in self.filenames.keys():
-                if source_repo_info is not None:
+                # If the path to the file exists, that's good enough. This function
+                # is only called from _add_entry below, which handles creating the
+                # file, but would return an error if the path doesn't exist.
+                if source_repo_info is not None and os.path.exists(os.path.split(filename)[0]):
                     source_repo_info['filename'] = filename
                     message = 'No exact match found in the data table registry for '
                     message += '{tool_shed}/repos/{owner}/{name}/{installed_changeset_revision}, '

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -620,7 +620,6 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
                 if os.path.exists(filename):
                     fmt_dict = dict(source_repo_info)
                     fmt_dict['filename'] = filename
-                    log.debug(fmt_dict)
                     message = 'No exact match found in the data table registry for '
                     message += '{tool_shed}/repos/{owner}/{name}/{installed_changeset_revision}, '
                     message += 'falling back to {filename}'


### PR DESCRIPTION
With this change, if the specific data table .loc file installed with a toolshed repository is missing when data is added to a data table, the data manager framework will try to locate a matching data table definition with a valid file. Previously there would be an error message in the log and no entry added to any data table definition, but the data manager job would appear to complete successfully.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
