### PR TITLE
Fix history contents API update batch with collections

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -634,7 +634,12 @@ class UpdateHDCAPayload(HDCADetailed):
     pass
 
 
-class UpdateHistoryContentsBatchPayload(Model):
+class UpdateHistoryContentsBatchPayload(BaseModel):
+    class Config:
+        use_enum_values = True  # when using .dict()
+        allow_population_by_field_name = True
+        extra = Extra.allow  # Allow any additional field
+
     items: List[Union[UpdateHDAPayload, UpdateHDCAPayload]] = Field(
         ...,
         title="Items",

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -583,7 +583,7 @@ class HistoriesContentsService(ServiceBase):
                 hda, user=trans.user, trans=trans, **serialization_params
             ))
         for hdca_id in hdca_ids:
-            self.__update_dataset_collection(trans, hdca_id, payload)
+            self.__update_dataset_collection(trans, hdca_id, payload.dict(exclude_defaults=True))
             dataset_collection_instance = self.__get_accessible_collection(trans, hdca_id)
             rval.append(self.__collection_dict(trans, dataset_collection_instance, view="summary"))
         return rval

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -429,13 +429,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert not datasets[1]["visible"]
 
     def test_update_dataset_collection(self):
-        payload = self.dataset_collection_populator.create_pair_payload(
-            self.history_id,
-            type="dataset_collection"
-        )
-        dataset_collection_response = self._post(f"histories/{self.history_id}/contents", payload)
-        self._assert_status_code_is(dataset_collection_response, 200)
-        hdca = dataset_collection_response.json()
+        hdca = self._create_pair_collection()
         update_url = self._api_url(f"histories/{self.history_id}/contents/dataset_collections/{hdca['id']}", use_key=True)
         # Awkward json.dumps required here because of https://trello.com/c/CQwmCeG6
         body = json.dumps(dict(name="newnameforpair"))
@@ -443,6 +437,30 @@ class HistoryContentsApiTestCase(ApiTestCase):
         self._assert_status_code_is(update_response, 200)
         show_response = self.__show(hdca)
         assert str(show_response.json()["name"]) == "newnameforpair"
+
+    def test_update_batch_dataset_collection(self):
+        hdca = self._create_pair_collection()
+        body = {
+            "items": [{
+                "history_content_type": "dataset_collection",
+                "id": hdca["id"]
+            }],
+            "name": "newnameforpair"
+        }
+        update_response = self._put(f"histories/{self.history_id}/contents", data=body, json=True)
+        self._assert_status_code_is(update_response, 200)
+        show_response = self.__show(hdca)
+        assert str(show_response.json()["name"]) == "newnameforpair"
+
+    def _create_pair_collection(self):
+        payload = self.dataset_collection_populator.create_pair_payload(
+            self.history_id,
+            type="dataset_collection"
+        )
+        dataset_collection_response = self._post(f"histories/{self.history_id}/contents", payload)
+        self._assert_status_code_is(dataset_collection_response, 200)
+        hdca = dataset_collection_response.json()
+        return hdca
 
     def test_hdca_copy(self):
         hdca = self.dataset_collection_populator.create_pair_in_history(self.history_id).json()


### PR DESCRIPTION
Fixes #12445

There was a missing model-to-dictionary conversion and the model config needed to allow extra fields to support updating any property of the collection or dataset.

Included an API test for updating in batch but with collections.

@bernt-matthias, thanks a lot for reporting!

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
