### PR TITLE
Return `tool_name` only when `show_job` is full

### DIFF
--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -409,7 +409,7 @@ def view_show_job(trans, job, full: bool) -> typing.Dict:
             job_messages=job.job_messages,
             dependencies=job.dependencies
         ))
-        
+
         tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
         job_dict.update(tool_name=tool.name)
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -409,6 +409,9 @@ def view_show_job(trans, job, full: bool) -> typing.Dict:
             job_messages=job.job_messages,
             dependencies=job.dependencies
         ))
+        
+        tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
+        job_dict.update(tool_name=tool.name)
 
         if is_admin:
             if job.user:
@@ -417,8 +420,6 @@ def view_show_job(trans, job, full: bool) -> typing.Dict:
                 job_dict['user_email'] = None
 
             job_dict['job_metrics'] = summarize_job_metrics(trans, job)
-    tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
-    job_dict.update(tool_name=tool.name)
     return job_dict
 
 

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -193,8 +193,9 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         """
         GET /api/datasets/{dataset_id}/inheritance_chain
 
-        Display user-facing storage details related to the objectstore a
-        dataset resides in.
+        Display inheritance chain for the given dataset
+
+        @Deprecated, we want to return dataset and job ids in the future.
         """
         dataset_instance = self.get_hda_or_ldda(trans, hda_ldda=hda_ldda, dataset_id=dataset_id)
         inherit_chain = dataset_instance.source_dataset_chain

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -195,7 +195,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         Display inheritance chain for the given dataset
 
-        @Deprecated, we want to return dataset and job ids in the future.
+        For internal use, this endpoint may change without warning.
         """
         dataset_instance = self.get_hda_or_ldda(trans, hda_ldda=hda_ldda, dataset_id=dataset_id)
         inherit_chain = dataset_instance.source_dataset_chain


### PR DESCRIPTION
This is a follow up after https://github.com/galaxyproject/galaxy/pull/12432

make `tool_name` optional and leave deprated note in `show_inheritance_chain`

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Click on dataset
  2. press on `i` button (old history)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
