### PR TITLE
Drop unused models: DeferredJob and TransferJob

### DIFF
--- a/lib/galaxy/model/migrate/versions/0178_drop_deferredjob_table.py
+++ b/lib/galaxy/model/migrate/versions/0178_drop_deferredjob_table.py
@@ -1,0 +1,65 @@
+"""
+Drop unused DeferredJob table and foreign key column on genome_index_tool_data.
+"""
+
+import logging
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    TEXT,
+)
+
+from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    create_table,
+    drop_column,
+    drop_table,
+)
+from galaxy.model.orm.now import now
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+DeferredJob_table = Table(
+    "deferred_job",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("state", String(64), index=True),
+    Column("plugin", String(128), index=True),
+    Column("params", JSONType),
+    Column("info", TEXT)
+)
+
+deferred_job_id = Column('deferred_job_id', Integer, ForeignKey('deferred_job.id'), index=True)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        drop_column(deferred_job_id.name, 'genome_index_tool_data', metadata)
+        drop_table(DeferredJob_table)
+    except Exception:
+        log.exception("Dropping deferred_job table failed")
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        create_table(DeferredJob_table)
+        add_column(deferred_job_id, 'genome_index_tool_data', metadata, index_name='ix_genome_index_tool_data_deferred_job_id')
+    except Exception:
+        log.exception("Creating deferred_job table failed")

--- a/lib/galaxy/model/migrate/versions/0179_drop_transferjob_table.py
+++ b/lib/galaxy/model/migrate/versions/0179_drop_transferjob_table.py
@@ -1,0 +1,64 @@
+"""
+Drop unused TransferJob table and foreign key column on genome_index_tool_data.
+"""
+
+import logging
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+)
+
+from galaxy.model.custom_types import JSONType
+from galaxy.model.migrate.versions.util import (
+    add_column,
+    create_table,
+    drop_column,
+    drop_table,
+)
+from galaxy.model.orm.now import now
+
+log = logging.getLogger(__name__)
+metadata = MetaData()
+
+TransferJob_table = Table(
+    "transfer_job",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column("create_time", DateTime, default=now),
+    Column("update_time", DateTime, default=now, onupdate=now),
+    Column("state", String(64), index=True),
+    Column("path", String(1024)),
+    Column("params", JSONType),
+    Column("pid", Integer),
+    Column("socket", Integer))
+
+transfer_job_id = Column('transfer_job_id', Integer, ForeignKey('transfer_job.id'), index=True)
+
+
+def upgrade(migrate_engine):
+    print(__doc__)
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        drop_column(transfer_job_id.name, 'genome_index_tool_data', metadata)
+        drop_table(TransferJob_table)
+    except Exception:
+        log.exception("Dropping transfer_job table failed")
+
+
+def downgrade(migrate_engine):
+    metadata.bind = migrate_engine
+    metadata.reflect()
+
+    try:
+        create_table(TransferJob_table)
+        add_column(transfer_job_id, 'genome_index_tool_data', metadata, index_name='ix_genome_index_tool_data_transfer_job_id')
+    except Exception:
+        log.exception("Creating transfer_job table failed")

--- a/test/unit/model/test_mapping.py
+++ b/test/unit/model/test_mapping.py
@@ -848,40 +848,6 @@ class TestDefaultUserPermissions(BaseTest):
             assert stored_obj.role.id == role.id
 
 
-class TestDeferredJob(BaseTest):
-
-    def test_table(self, cls_):
-        assert cls_.__tablename__ == 'deferred_job'
-
-    def test_columns(self, session, cls_):
-        create_time = datetime.now()
-        update_time = create_time + timedelta(hours=1)
-        state, plugin, params = 'a', 'b', 'c'
-        obj = cls_()
-        obj.state = state
-        obj.plugin = plugin
-        obj.params = params
-        obj.create_time = create_time
-        obj.update_time = update_time
-
-        with dbcleanup(session, obj) as obj_id:
-            stored_obj = get_stored_obj(session, cls_, obj_id)
-            assert stored_obj.id == obj_id
-            assert stored_obj.create_time == create_time
-            assert stored_obj.update_time == update_time
-            assert stored_obj.state == state
-            assert stored_obj.plugin == plugin
-            assert stored_obj.params == params
-
-    def test_relationships(self, session, cls_, genome_index_tool_data):
-        obj = cls_()
-        obj.deferred_job.append(genome_index_tool_data)
-
-        with dbcleanup(session, obj) as obj_id:
-            stored_obj = get_stored_obj(session, cls_, obj_id)
-            assert stored_obj.deferred_job == [genome_index_tool_data]
-
-
 class TestDynamicTool(BaseTest):
 
     def test_table(self, cls_):
@@ -1232,15 +1198,13 @@ class TestGenomeIndexToolData(BaseTest):
     def test_table(self, cls_):
         assert cls_.__tablename__ == 'genome_index_tool_data'
 
-    def test_columns(self, session, cls_, job, deferred_job, transfer_job, dataset, user):
+    def test_columns(self, session, cls_, job, dataset, user):
         fasta_path = 'a'
         created_time = datetime.now()
         modified_time = created_time + timedelta(hours=1)
         indexer = 'b'
         obj = cls_()
         obj.job = job
-        obj.deferred = deferred_job
-        obj.transfer = transfer_job
         obj.dataset = dataset
         obj.fasta_path = fasta_path
         obj.created_time = created_time
@@ -1252,8 +1216,6 @@ class TestGenomeIndexToolData(BaseTest):
             stored_obj = get_stored_obj(session, cls_, obj_id)
             assert stored_obj.id == obj_id
             assert stored_obj.job_id == job.id
-            assert stored_obj.deferred_job_id == deferred_job.id
-            assert stored_obj.transfer_job_id == transfer_job.id
             assert stored_obj.dataset_id == dataset.id
             assert stored_obj.fasta_path == fasta_path
             assert stored_obj.created_time == created_time
@@ -1261,19 +1223,15 @@ class TestGenomeIndexToolData(BaseTest):
             assert stored_obj.indexer == indexer
             assert stored_obj.user_id == user.id
 
-    def test_relationships(self, session, cls_, job, deferred_job, transfer_job, dataset, user):
+    def test_relationships(self, session, cls_, job, dataset, user):
         obj = cls_()
         obj.job = job
-        obj.deferred = deferred_job
-        obj.transfer = transfer_job
         obj.dataset = dataset
         obj.user = user
 
         with dbcleanup(session, obj) as obj_id:
             stored_obj = get_stored_obj(session, cls_, obj_id)
             assert stored_obj.job.id == job.id
-            assert stored_obj.deferred.id == deferred_job.id
-            assert stored_obj.transfer.id == transfer_job.id
             assert stored_obj.dataset.id == dataset.id
             assert stored_obj.user.id == user.id
 
@@ -4906,46 +4864,6 @@ class TestToolTagAssociation(BaseTest):
             assert stored_obj.user.id == user.id
 
 
-class TestTransferJob(BaseTest):
-
-    def test_table(self, cls_):
-        assert cls_.__tablename__ == 'transfer_job'
-
-    def test_columns(self, session, cls_):
-        create_time = datetime.now()
-        update_time = create_time + timedelta(hours=1)
-        state, path, info, pid, socket, params = 'd', 'a', 'b', 2, 3, 'c'
-        obj = cls_()
-        obj.state = state
-        obj.path = path
-        obj.info = info
-        obj.pid = pid
-        obj.socket = socket
-        obj.params = params
-        obj.create_time = create_time
-        obj.update_time = update_time
-
-        with dbcleanup(session, obj) as obj_id:
-            stored_obj = get_stored_obj(session, cls_, obj_id)
-            assert stored_obj.id == obj_id
-            assert stored_obj.create_time == create_time
-            assert stored_obj.update_time == update_time
-            assert stored_obj.state == state
-            assert stored_obj.path == path
-            assert stored_obj.info == info
-            assert stored_obj.pid == pid
-            assert stored_obj.socket == socket
-            assert stored_obj.params == params
-
-    def test_relationships(self, session, cls_, genome_index_tool_data):
-        obj = cls_()
-        obj.transfer_job.append(genome_index_tool_data)
-
-        with dbcleanup(session, obj) as obj_id:
-            stored_obj = get_stored_obj(session, cls_, obj_id)
-            assert stored_obj.transfer_job == [genome_index_tool_data]
-
-
 class TestUser(BaseTest):
 
     def test_table(self, cls_):
@@ -6774,12 +6692,6 @@ def default_user_permissions(model, session, user, role):
 
 
 @pytest.fixture
-def deferred_job(model, session):
-    instance = model.DeferredJob()
-    yield from dbcleanup_wrapper(session, instance)
-
-
-@pytest.fixture
 def dynamic_tool(model, session):
     instance = model.DynamicTool()
     yield from dbcleanup_wrapper(session, instance)
@@ -7335,12 +7247,6 @@ def task_metric_text(model, session):
 @pytest.fixture
 def tool_tag_association(model, session):
     instance = model.ToolTagAssociation()
-    yield from dbcleanup_wrapper(session, instance)
-
-
-@pytest.fixture
-def transfer_job(model, session):
-    instance = model.TransferJob()
     yield from dbcleanup_wrapper(session, instance)
 
 


### PR DESCRIPTION
Ref #12355

Both models are unused and were not referenced anywhere in the code base other than the model and the model mapping tests. (Originally introduced in galaxyproject/galaxy@30915f5; I've checked with @natefoo)

NOTE: this can go into 21.09, but doesn't have to, if it's more convenient to leave it for 22.01.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
