### PR TITLE
Fix quota `bytes` type in pydantic

### DIFF
--- a/lib/galaxy/quota/_schema.py
+++ b/lib/galaxy/quota/_schema.py
@@ -126,7 +126,7 @@ class QuotaSummaryList(BaseModel):
 
 class QuotaDetails(QuotaBase):
     description: str = QuotaDescriptionField
-    bytes: str = Field(
+    bytes: int = Field(
         ...,
         title="Bytes",
         description="The amount, expressed in bytes, of this Quota.",


### PR DESCRIPTION
Broken in https://github.com/galaxyproject/galaxy/pull/11315

Results in the following failure in BioBlend tests:

```
______________________ TestGalaxyQuotas.test_create_quota ______________________

self = <bioblend._tests.TestGalaxyQuotas.TestGalaxyQuotas testMethod=test_create_quota>

    def test_create_quota(self):
        quota = self.gi.quotas.show_quota(self.quota['id'])
        self.assertEqual(quota['name'], self.quota_name)
>       self.assertEqual(quota['bytes'], 107374182400)
E       AssertionError: '107374182400' != 107374182400

bioblend/_tests/TestGalaxyQuotas.py:26: AssertionError
```

See https://github.com/galaxyproject/bioblend/runs/3593283826

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
