### PR TITLE
Remove default pagination in `LibraryPopulator.get_permissions()`

### DIFF
--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -110,8 +110,8 @@ class LibrariesApiTestCase(ApiTestCase):
         library_id = library["id"]
         role_id = self.library_populator.user_private_role_id()
         # As we can manage this library our role will be available
-        current = self.library_populator.get_permissions(library_id, scope="available")
-        available_role_ids = [role["id"] for role in current["roles"]]
+        available = self.library_populator.get_permissions(library_id, scope="available")
+        available_role_ids = [role["id"] for role in available["roles"]]
         assert role_id in available_role_ids
 
     def test_get_library_available_permissions_with_query(self):
@@ -122,14 +122,14 @@ class LibrariesApiTestCase(ApiTestCase):
             email = self.library_populator.user_email()
 
         # test at least 2 user roles should be available now
-        current = self.library_populator.get_permissions(library_id, scope="available")
-        available_role_ids = [role["id"] for role in current["roles"]]
+        available = self.library_populator.get_permissions(library_id, scope="available")
+        available_role_ids = [role["id"] for role in available["roles"]]
         assert len(available_role_ids) > 1
 
         # test query for specific role/email
-        current = self.library_populator.get_permissions(library_id, scope="available", q=email)
-        available_role_emails = [role["name"] for role in current["roles"]]
-        assert current["total"] == 1
+        available = self.library_populator.get_permissions(library_id, scope="available", q=email)
+        available_role_emails = [role["name"] for role in available["roles"]]
+        assert available["total"] == 1
         assert available_role_emails[0] == email
 
     def test_create_dataset_denied(self):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1231,14 +1231,15 @@ class LibraryPopulator:
         library_id,
         scope: Optional[str] = "current",
         is_library_access: Optional[bool] = False,
-        page: Optional[int] = 1,
-        page_limit: Optional[int] = 10,
+        page: Optional[int] = None,
+        page_limit: Optional[int] = None,
         q: Optional[str] = None,
         admin: Optional[bool] = True
     ):
         query = f"&q={q}" if q else ""
+        pagination = f"&page={page}&page_limit={page_limit}" if page and page_limit else ""
         response = self.galaxy_interactor.get(
-            f"libraries/{library_id}/permissions?scope={scope}&is_library_access={is_library_access}&page={page}&page_limit={page_limit}{query}",
+            f"libraries/{library_id}/permissions?scope={scope}&is_library_access={is_library_access}{pagination}{query}",
             admin=admin,
         )
         api_asserts.assert_status_code_is(response, 200)


### PR DESCRIPTION
The default values for pagination were introduced by a slightly more naive @davelopez in https://github.com/galaxyproject/galaxy/pull/12057 but now I realized that as the test cases grow there can be more roles created and [this test](https://github.com/galaxyproject/galaxy/blob/bbbe3be1c7487f0bba4caefbc665919f1a0521f4/lib/galaxy_test/api/test_libraries.py#L108) is relying on checking if a particular role is in the available roles that may be left out by the pagination.

This was detected because it started to fail [here](https://github.com/galaxyproject/galaxy/pull/11701/checks?check_run_id=3600013189#step:6:1334) in https://github.com/galaxyproject/galaxy/pull/11701


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
