### PR TITLE
Drop tool_name from dataset details

### DIFF
--- a/client/src/components/Details/DatasetDetails.vue
+++ b/client/src/components/Details/DatasetDetails.vue
@@ -8,14 +8,9 @@
                     v-slot="{ result: job, loading: isJobLoading }"
                 >
                     <div v-if="!isJobLoading">
-                        <h2 class="tool-title">{{ job.tool_name }}</h2>
                         <dataset-information class="detail" :hda_id="datasetId" />
                         <job-parameters class="detail" dataset_type="hda" :dataset-id="datasetId" />
-                        <job-information
-                            class="detail"
-                            :job_id="dataset.creating_job"
-                            @current_tool_name="tool_name = $event"
-                        />
+                        <job-information class="detail" :job_id="dataset.creating_job" />
                         <dataset-storage class="detail" :dataset-id="datasetId" />
                         <inheritance-chain class="detail" :dataset-id="datasetId" :dataset-name="dataset.name" />
                         <job-metrics

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -410,9 +410,6 @@ def view_show_job(trans, job, full: bool) -> typing.Dict:
             dependencies=job.dependencies
         ))
 
-        tool = trans.app.toolbox.get_tool(job.tool_id, tool_version=job.tool_version)
-        job_dict.update(tool_name=tool.name)
-
         if is_admin:
             if job.user:
                 job_dict['user_email'] = job.user.email


### PR DESCRIPTION
I don't think it makes sense to have the tool name as the header for a
dataset details view. The tool is listed in the job info anyway.

Fixes:
```
galaxy.web.framework.decorators ERROR 2021-09-15 16:36:53,119 [pN:main,p:3215,tN:ThreadPoolExecutor-24_7] Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/web/framework/decorators.py", line 312, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/webapps/galaxy/api/jobs.py", line 236, in show
    return view_show_job(trans, job, full_output)
  File "/home/runner/work/galaxy/galaxy/galaxy root/lib/galaxy/managers/jobs.py", line 421, in view_show_job
    job_dict.update(tool_name=tool.name)
AttributeError: 'NoneType' object has no attribute 'name'
```
If the tool is not loaded.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
