### PR TITLE
Add options to override the history name and reuse histories in the tool test script

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -268,6 +268,14 @@ class GalaxyInteractorApi:
     def __get_job_stdio(self, job_id):
         return self._get(f'jobs/{job_id}?full=true')
 
+    def get_history(self, history_name='test_history'):
+        # Return the most recent non-deleted history matching the provided name
+        response = self._get(f"histories?q=name&qv={history_name}&order=update_time")
+        try:
+            return response.json()[-1]
+        except IndexError:
+            return None
+
     def new_history(self, history_name='test_history', publish_history=False):
         create_response = self._post("histories", {"name": history_name})
         try:

--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -173,6 +173,8 @@ def test_tools(
     log=None,
     parallel_tests=1,
     history_per_test_case=False,
+    history_name=None,
+    no_history_reuse=False,
     no_history_cleanup=False,
     publish_history=False,
     retries=0,
@@ -185,11 +187,23 @@ def test_tools(
     verify_kwds = (verify_kwds or {}).copy()
     tool_test_start = dt.datetime.now()
     history_created = False
-    if history_per_test_case:
-        test_history = None
-    else:
-        history_created = True
-        test_history = galaxy_interactor.new_history(history_name=f"History for {results.suitename}", publish_history=publish_history)
+    test_history = None
+    if not history_per_test_case:
+        if not history_name:
+            history_name = f"History for {results.suitename}"
+        if log:
+            log.info(f"History name is '{history_name}'")
+        if not no_history_reuse:
+            history = galaxy_interactor.get_history(history_name=history_name)
+            if history:
+                test_history = history['id']
+                if log:
+                    log.info(f"Using existing history with id '{test_history}', last updated: {history['update_time']}")
+        if not test_history:
+            history_created = True
+            test_history = galaxy_interactor.new_history(history_name=history_name, publish_history=publish_history)
+            if log:
+                log.info(f"History created with id '{test_history}'")
     verify_kwds.update({
         "no_history_cleanup": no_history_cleanup,
         "test_history": test_history,
@@ -435,6 +449,8 @@ def run_tests(args, test_filters=None, log=None):
         log=log,
         parallel_tests=args.parallel_tests,
         history_per_test_case=args.history_per_test_case,
+        history_name=args.history_name,
+        no_history_reuse=args.no_history_reuse,
         no_history_cleanup=args.no_history_cleanup,
         publish_history=get_option("publish_history"),
         verify_kwds=verify_kwds,
@@ -491,6 +507,8 @@ def arg_parser():
     history_per_group = parser.add_mutually_exclusive_group()
     history_per_group.add_argument('--history-per-suite', dest="history_per_test_case", default=False, action="store_false", help="Create new history per test suite (all tests in same history).")
     history_per_group.add_argument('--history-per-test-case', dest="history_per_test_case", action="store_true", help="Create new history per test case.")
+    history_per_group.add_argument('--history-name', default=None, help="Override default history name")
+    parser.add_argument('--no-history-reuse', default=False, action="store_true", help="Do not reuse histories if a matchine one already exists.")
     parser.add_argument('--no-history-cleanup', default=False, action="store_true", help="Perserve histories created for testing.")
     parser.add_argument('--publish-history', default=False, action="store_true", help="Publish test history. Useful for CI testing.")
     parser.add_argument('--parallel-tests', default=1, type=int, help="Parallel tests.")

--- a/lib/galaxy/tool_util/verify/script.py
+++ b/lib/galaxy/tool_util/verify/script.py
@@ -508,7 +508,7 @@ def arg_parser():
     history_per_group.add_argument('--history-per-suite', dest="history_per_test_case", default=False, action="store_false", help="Create new history per test suite (all tests in same history).")
     history_per_group.add_argument('--history-per-test-case', dest="history_per_test_case", action="store_true", help="Create new history per test case.")
     history_per_group.add_argument('--history-name', default=None, help="Override default history name")
-    parser.add_argument('--no-history-reuse', default=False, action="store_true", help="Do not reuse histories if a matchine one already exists.")
+    parser.add_argument('--no-history-reuse', default=False, action="store_true", help="Do not reuse histories if a matching one already exists.")
     parser.add_argument('--no-history-cleanup', default=False, action="store_true", help="Perserve histories created for testing.")
     parser.add_argument('--publish-history', default=False, action="store_true", help="Publish test history. Useful for CI testing.")
     parser.add_argument('--parallel-tests', default=1, type=int, help="Parallel tests.")

--- a/test/unit/tool_util/test_verify_script.py
+++ b/test/unit/tool_util/test_verify_script.py
@@ -13,6 +13,10 @@ from galaxy.tool_util.verify.script import (
 
 VT_PATH = 'galaxy.tool_util.verify.script.verify_tool'
 NEW_HISTORY = object()
+NEW_HISTORY_ID = 'new'
+EXISTING_HISTORY = {'id': 'existing'}
+EXISTING_SUITE_NAME = "existing suite"
+EXISTING_HISTORY_NAME = f"History for {EXISTING_SUITE_NAME}"
 
 
 def test_arg_parse():
@@ -100,6 +104,81 @@ def test_test_tools_no_history_cleanup():
         assert_results_written(results)
         assert interactor.history_created
         assert not interactor.history_deleted
+
+
+def test_test_tools_history_reuse():
+    interactor = MockGalaxyInteractor()
+    f = NamedTemporaryFile()
+    results = Results(EXISTING_SUITE_NAME, f.name)
+    test_references = [
+        TestReference("cat", "0.1.0", 0),
+    ]
+    with mock.patch(VT_PATH) as mock_verify:
+        assert_results_not_written(results)
+        run(
+            interactor,
+            test_references,
+            results,
+            no_history_reuse=False,
+        )
+        calls = mock_verify.call_args_list
+        assert len(calls) == 1
+        assert len(results.test_exceptions) == 0
+        assert_results_written(results)
+        assert interactor.history_id == EXISTING_HISTORY['id']
+        assert interactor.history_name == EXISTING_HISTORY_NAME
+        assert not interactor.history_created
+        assert not interactor.history_deleted
+
+
+def test_test_tools_no_history_reuse():
+    interactor = MockGalaxyInteractor()
+    f = NamedTemporaryFile()
+    results = Results("existing suite", f.name)
+    test_references = [
+        TestReference("cat", "0.1.0", 0),
+    ]
+    with mock.patch(VT_PATH) as mock_verify:
+        assert_results_not_written(results)
+        run(
+            interactor,
+            test_references,
+            results,
+            no_history_reuse=True,
+        )
+        calls = mock_verify.call_args_list
+        assert len(calls) == 1
+        assert len(results.test_exceptions) == 0
+        assert_results_written(results)
+        assert interactor.history_id == NEW_HISTORY_ID
+        assert interactor.history_name == EXISTING_HISTORY_NAME
+        assert interactor.history_created
+        assert interactor.history_deleted
+
+
+def test_test_tools_history_name():
+    interactor = MockGalaxyInteractor()
+    f = NamedTemporaryFile()
+    results = Results("my suite", f.name)
+    test_references = [
+        TestReference("cat", "0.1.0", 0),
+    ]
+    with mock.patch(VT_PATH) as mock_verify:
+        assert_results_not_written(results)
+        run(
+            interactor,
+            test_references,
+            results,
+            history_name="testfoo",
+        )
+        calls = mock_verify.call_args_list
+        assert len(calls) == 1
+        assert len(results.test_exceptions) == 0
+        assert_results_written(results)
+        assert interactor.history_id == NEW_HISTORY_ID
+        assert interactor.history_name == "testfoo"
+        assert interactor.history_created
+        assert interactor.history_deleted
 
 
 def test_test_tool_per_test_history():
@@ -266,9 +345,21 @@ class MockGalaxyInteractor:
     def __init__(self):
         self.history_deleted = False
         self.history_created = False
+        self.history_name = None
+        self.history_id = None
+
+    def get_history(self, history_name=""):
+        if history_name == EXISTING_HISTORY_NAME:
+            self.history_name = history_name
+            self.history_id = EXISTING_HISTORY['id']
+            return EXISTING_HISTORY
+        else:
+            return None
 
     def new_history(self, history_name="", publish_history=False):
         self.history_created = True
+        self.history_name = history_name
+        self.history_id = NEW_HISTORY_ID
         return NEW_HISTORY
 
     def delete_history(self, history):


### PR DESCRIPTION
By default the script will now reuse non-deleted histories matching the history name, this can be overridden with `--no-history-reuse`. Since the default is to always delete histories after running tests this change to default behavior is likely only to be noticed if using `--no-history-cleanup`. Additionally you can now explicitly set the history name (if not using per-suite or per-test histories) with `--history-name`.

Related to galaxyproject/ephemeris#173, which added the same functionality to `shed-tools test`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
