### PR TITLE
Fix sorting on disk_usage column in admin panel

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -88,6 +88,18 @@ class UserListGrid(grids.Grid):
         def get_value(self, trans, grid, user):
             return user.get_disk_usage(nice_size=True)
 
+        def sort(self, trans, query, ascending, column_name=None):
+            if column_name is None:
+                column_name = self.key
+            column = self.model_class.table.c.get(column_name)
+            if column is None:
+                column = getattr(self.model_class, column_name)
+            if ascending:
+                query = query.order_by(column.asc().nullsfirst())
+            else:
+                query = query.order_by(column.desc().nullslast())
+            return query
+
     # Grid definition
     title = "Users"
     title_id = "users-grid"

--- a/lib/galaxy/webapps/galaxy/controllers/admin.py
+++ b/lib/galaxy/webapps/galaxy/controllers/admin.py
@@ -2,7 +2,7 @@ import imp
 import logging
 import os
 
-from sqlalchemy import false
+from sqlalchemy import false, func
 
 from galaxy import (
     model,
@@ -95,9 +95,9 @@ class UserListGrid(grids.Grid):
             if column is None:
                 column = getattr(self.model_class, column_name)
             if ascending:
-                query = query.order_by(column.asc().nullsfirst())
+                query = query.order_by(func.coalesce(column, 0).asc())
             else:
-                query = query.order_by(column.desc().nullslast())
+                query = query.order_by(func.coalesce(column, 0).desc())
             return query
 
     # Grid definition


### PR DESCRIPTION
Potential bugfix for https://github.com/galaxyproject/galaxy/issues/12367.  Users with no data have null disk_usage and when it is sorted by disk_usage SQL nulls are sorted as higher than any other value.

An alternative and possibly better solution would be to set disk_usage to have default 0 in the user model and write a migration.

I haven't written a test for this.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
