### PR TITLE
Drop bcftools requirement from set_metadata tool

### DIFF
--- a/lib/galaxy/datatypes/set_metadata_tool.xml
+++ b/lib/galaxy/datatypes/set_metadata_tool.xml
@@ -1,8 +1,5 @@
-<tool id="__SET_METADATA__" name="Set External Metadata" version="1.0.2" tool_type="set_metadata">
+<tool id="__SET_METADATA__" name="Set External Metadata" version="1.0.3" tool_type="set_metadata">
     <type class="SetMetadataTool" module="galaxy.tools"/>
-    <requirements>
-        <requirement type="package" version="1.5">bcftools</requirement>
-    </requirements>
     <action module="galaxy.tools.actions.metadata" class="SetMetadataToolAction"/>
     <command detect_errors="exit_code">
 cd ..; "\${GALAXY_PYTHON:-python}" '${set_metadata}' ${__SET_EXTERNAL_METADATA_COMMAND_LINE__}


### PR DESCRIPTION
The only use of bcftools is in
https://github.com/galaxyproject/galaxy/blob/c7142af7a9c895c33fd00912f7a00db60bbc6da2/lib/galaxy/datatypes/tabular.py#L799,
which is never called from within the set_metadata tool.

Replaces https://github.com/galaxyproject/galaxy/pull/12226

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
