### PR TITLE
Add config options for controlling handler and runner monitor thread sleep.

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4078,17 +4078,35 @@
 :Type: int
 
 
-~~~~~~~~~~~~~~~~~~~~~~~
-``enable_job_recovery``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``job_handler_monitor_sleep``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :Description:
-    Enable job recovery (if Galaxy is restarted while cluster jobs are
-    running, it can "recover" them when it starts).  This is not safe
-    to use if you are running more than one Galaxy server using the
-    same database.
-:Default: ``true``
-:Type: bool
+    Each Galaxy job handler process runs one thread responsible for
+    discovering jobs and dispatching them to runners. This thread
+    operates in a loop and sleeps for the given number of seconds at
+    the end of each iteration. This can be decreased if extremely high
+    job throughput is necessary, but doing so can increase CPU usage
+    of handler processes. Float values are allowed.
+:Default: ``1``
+:Type: float
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``job_runner_monitor_sleep``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    Each Galaxy job handler process runs one thread per job runner
+    plugin responsible for checking the state of queued and running
+    jobs.  This thread operates in a loop and sleeps for the given
+    number of seconds at the end of each iteration. This can be
+    decreased if extremely high job throughput is necessary, but doing
+    so can increase CPU usage of handler processes. Float values are
+    allowed.
+:Default: ``1``
+:Type: float
 
 
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -4089,7 +4089,7 @@
     the end of each iteration. This can be decreased if extremely high
     job throughput is necessary, but doing so can increase CPU usage
     of handler processes. Float values are allowed.
-:Default: ``1``
+:Default: ``1.0``
 :Type: float
 
 
@@ -4105,7 +4105,7 @@
     decreased if extremely high job throughput is necessary, but doing
     so can increase CPU usage of handler processes. Float values are
     allowed.
-:Default: ``1``
+:Default: ``1.0``
 :Type: float
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1999,11 +1999,22 @@ galaxy:
   # for production servers yet.
   #local_task_queue_workers: 2
 
-  # Enable job recovery (if Galaxy is restarted while cluster jobs are
-  # running, it can "recover" them when it starts).  This is not safe to
-  # use if you are running more than one Galaxy server using the same
-  # database.
-  #enable_job_recovery: true
+  # Each Galaxy job handler process runs one thread responsible for
+  # discovering jobs and dispatching them to runners. This thread
+  # operates in a loop and sleeps for the given number of seconds at the
+  # end of each iteration. This can be decreased if extremely high job
+  # throughput is necessary, but doing so can increase CPU usage of
+  # handler processes. Float values are allowed.
+  #job_handler_monitor_sleep: 1
+
+  # Each Galaxy job handler process runs one thread per job runner
+  # plugin responsible for checking the state of queued and running
+  # jobs.  This thread operates in a loop and sleeps for the given
+  # number of seconds at the end of each iteration. This can be
+  # decreased if extremely high job throughput is necessary, but doing
+  # so can increase CPU usage of handler processes. Float values are
+  # allowed.
+  #job_runner_monitor_sleep: 1
 
   # Determines how metadata will be set. Valid values are `directory`
   # and `extended`. In extended mode jobs will decide if a tool run

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -2005,7 +2005,7 @@ galaxy:
   # end of each iteration. This can be decreased if extremely high job
   # throughput is necessary, but doing so can increase CPU usage of
   # handler processes. Float values are allowed.
-  #job_handler_monitor_sleep: 1
+  #job_handler_monitor_sleep: 1.0
 
   # Each Galaxy job handler process runs one thread per job runner
   # plugin responsible for checking the state of queued and running
@@ -2014,7 +2014,7 @@ galaxy:
   # decreased if extremely high job throughput is necessary, but doing
   # so can increase CPU usage of handler processes. Float values are
   # allowed.
-  #job_runner_monitor_sleep: 1
+  #job_runner_monitor_sleep: 1.0
 
   # Determines how metadata will be set. Valid values are `directory`
   # and `extended`. In extended mode jobs will decide if a tool run

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -309,7 +309,7 @@ class JobHandlerQueue(Monitors):
                 # With sqlite backends we can run into locked databases occasionally
                 # To avoid that the monitor step locks again we backoff a little longer.
                 self._monitor_sleep(5)
-            self._monitor_sleep(1)
+            self._monitor_sleep(self.app.config.job_handler_monitor_sleep)
 
     def __monitor_step(self):
         """

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -702,7 +702,7 @@ class AsynchronousJobRunner(BaseJobRunner, Monitors):
             except Exception:
                 log.exception('Unhandled exception checking active jobs')
             # Sleep a bit before the next state check
-            time.sleep(1)
+            time.sleep(self.app.config.job_runner_monitor_sleep)
 
     def monitor_job(self, job_state):
         self.monitor_queue.put(job_state)

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -2998,14 +2998,27 @@ mapping:
           config.
           This is a new feature and not recommended for production servers yet.
 
-      enable_job_recovery:
-        type: bool
-        default: true
+      job_handler_monitor_sleep:
+        type: float
+        default: 1
         required: false
         desc: |
-          Enable job recovery (if Galaxy is restarted while cluster jobs are running,
-          it can "recover" them when it starts).  This is not safe to use if you are
-          running more than one Galaxy server using the same database.
+          Each Galaxy job handler process runs one thread responsible for discovering jobs and
+          dispatching them to runners. This thread operates in a loop and sleeps for the given
+          number of seconds at the end of each iteration. This can be decreased if extremely high
+          job throughput is necessary, but doing so can increase CPU usage of handler processes.
+          Float values are allowed.
+
+      job_runner_monitor_sleep:
+        type: float
+        default: 1
+        required: false
+        desc: |
+          Each Galaxy job handler process runs one thread per job runner plugin responsible for
+          checking the state of queued and running jobs.  This thread operates in a loop and
+          sleeps for the given number of seconds at the end of each iteration. This can be
+          decreased if extremely high job throughput is necessary, but doing so can increase CPU
+          usage of handler processes. Float values are allowed.
 
       metadata_strategy:
         type: str

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -3000,7 +3000,7 @@ mapping:
 
       job_handler_monitor_sleep:
         type: float
-        default: 1
+        default: 1.0
         required: false
         desc: |
           Each Galaxy job handler process runs one thread responsible for discovering jobs and
@@ -3011,7 +3011,7 @@ mapping:
 
       job_runner_monitor_sleep:
         type: float
-        default: 1
+        default: 1.0
         required: false
         desc: |
           Each Galaxy job handler process runs one thread per job runner plugin responsible for


### PR DESCRIPTION
Fixes #12416.

Decreasing these values for tool tests may help them to run a bit faster. On my laptop, an idle handler with the default 1 second sleep for both options used around 6% CPU, at 0.4 seconds it used about 9% CPU, and at 0.2 seconds it used about 15% CPU, but I imagine we'd see different results on different systems.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
