### PR TITLE
Strip whitespace on urls when uploading

### DIFF
--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -1635,6 +1635,7 @@ export default {
             if (mappingAsDict.url) {
                 const urlColumn = mappingAsDict.url.columns[0];
                 let url = data[dataIndex][urlColumn];
+                url = url.trim()
                 if (url.indexOf("://") == -1) {
                     // special case columns containing SRA links. EBI serves these a lot
                     // faster over FTP.

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -1635,7 +1635,7 @@ export default {
             if (mappingAsDict.url) {
                 const urlColumn = mappingAsDict.url.columns[0];
                 let url = data[dataIndex][urlColumn];
-                url = url.trim()
+                url = url.trim();
                 if (url.indexOf("://") == -1) {
                     // special case columns containing SRA links. EBI serves these a lot
                     // faster over FTP.

--- a/lib/galaxy/webapps/galaxy/api/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/api/_fetch_util.py
@@ -161,6 +161,7 @@ def validate_and_normalize_targets(trans, payload):
             item["purge_source"] = purge_ftp_source
         elif src == "url":
             url = item["url"]
+            url = url.strip()
             looks_like_url = False
             for url_prefix in ["http://", "https://", "ftp://", "ftps://"]:
                 if url.startswith(url_prefix):

--- a/lib/galaxy/webapps/galaxy/api/_fetch_util.py
+++ b/lib/galaxy/webapps/galaxy/api/_fetch_util.py
@@ -161,7 +161,6 @@ def validate_and_normalize_targets(trans, payload):
             item["purge_source"] = purge_ftp_source
         elif src == "url":
             url = item["url"]
-            url = url.strip()
             looks_like_url = False
             for url_prefix in ["http://", "https://", "ftp://", "ftps://"]:
                 if url.startswith(url_prefix):


### PR DESCRIPTION
Fix for #11809
I added a strip to the URL before it attempts to fetch.

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. Begin the first hands-on exercies in the Rule Based Uploader tutorial https://training.galaxyproject.org/training-material/topics/galaxy-interface/tutorials/upload-rules/tutorial.html
  2. After copying the data, choose a random entry and add a whitespace to the beginning of the URL field
  3. Run through the rest of the tutorial, and click Upload
  4. The uploads should all complete successfully. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
