### PR TITLE
Remove default value string from ``/api/genomes`` endpoint

### DIFF
--- a/lib/galaxy/util/dbkeys.py
+++ b/lib/galaxy/util/dbkeys.py
@@ -58,8 +58,6 @@ def read_dbnames(filename):
             ucsc_builds[db_base].reverse()
             ucsc_builds[db_base] = [(build, name) for _, build, name in ucsc_builds[db_base]]
             db_names = list(db_names + ucsc_builds[db_base])
-        if len(db_names) > 1 and len(man_builds) > 0:
-            db_names.append((GenomeBuilds.default_value, '----- Additional Species Are Below -----'))
         man_builds.sort()
         man_builds = [(build, name) for name, build in man_builds]
         db_names = list(db_names + man_builds)

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -16,7 +16,7 @@ class CollectionEditTestCase(SeleniumTestCase):
         self.create_simple_list_collection()
         self.open_collection_edit_view()
         self.navigate_to_database_tab()
-        dbkeyValue = "Additional"
+        dbkeyValue = "unspecified"
         self.check_current_dbkey_value(dbkeyValue)
         dbkeyNew = "hg17"
         self.change_dbkey_value_and_click_submit(dbkeyValue, dbkeyNew)


### PR DESCRIPTION
Fix for #8612; removed appended field for default name. Here's what it looks like in various places where the dbkey dropdown is available. It now reads "unspecified (?)"

![Screenshot from 2021-09-16 11-35-14](https://user-images.githubusercontent.com/26912553/133649300-2885620b-3faa-4eab-9590-57407d90d136.png)
![Screenshot from 2021-09-16 11-40-16](https://user-images.githubusercontent.com/26912553/133649307-8a2fcd40-9a56-4342-b5a1-6786a7b6c4d1.png)
![Screenshot from 2021-09-16 11-32-35](https://user-images.githubusercontent.com/26912553/133649292-3f3d2971-a7b0-4dd6-8449-3046467f23bb.png)
<img width="1086" alt="Screenshot 2021-09-16 at 17 44 18" src="https://user-images.githubusercontent.com/26912553/133649713-fe4d2293-4ecb-4f47-868b-047a54cbe9d1.png">

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
