### PR TITLE
Trim spaces from around email addresses and usernames when registering

### DIFF
--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -150,6 +150,9 @@ class MockAppConfig(GalaxyDataTestConfig, CommonConfigurationMixin):
 
         self.expose_dataset_path = True
         self.allow_user_dataset_purge = True
+        self.allow_user_creation = True
+        self.email_domain_allowlist_content = None
+        self.email_domain_blocklist_content = None
         self.enable_old_display_applications = True
         self.redact_username_in_logs = False
         self.auth_config_file = "config/auth_conf.xml.sample"

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -82,17 +82,17 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
             return None, message
         if not email or not username or not password or not confirm:
             return None, "Please provide email, username and password."
-        message = "\n".join(
-            (
-                validate_email(trans, email),
-                validate_password(trans, password, confirm),
-                validate_publicname(trans, username),
-            )
-        ).rstrip()
+
+        email = util.restore_text(email).strip()
+        username = util.restore_text(username).strip()
+        # We could add a separate option here for enabling or disabling domain validation (DNS resolution test)
+        validate_domain = trans.app.config.user_activation_on
+        message = "\n".join((validate_email(trans, email, validate_domain=validate_domain),
+                             validate_password(trans, password, confirm),
+                             validate_publicname(trans, username))).rstrip()
+
         if message:
             return None, message
-        email = util.restore_text(email)
-        username = util.restore_text(username)
         message, status = trans.app.auth_manager.check_registration_allowed(email, username, password)
         if message:
             return None, message

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -87,9 +87,13 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         username = util.restore_text(username).strip()
         # We could add a separate option here for enabling or disabling domain validation (DNS resolution test)
         validate_domain = trans.app.config.user_activation_on
-        message = "\n".join((validate_email(trans, email, validate_domain=validate_domain),
-                             validate_password(trans, password, confirm),
-                             validate_publicname(trans, username))).rstrip()
+        message = "\n".join(
+            (
+                validate_email(trans, email, validate_domain=validate_domain),
+                validate_password(trans, password, confirm),
+                validate_publicname(trans, username),
+            )
+        ).rstrip()
 
         if message:
             return None, message

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -69,28 +69,25 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
     if (user and user.email == email) or (email == "" and allow_empty):
         return ""
     message = validate_email_str(email)
-    if message:
-        pass
-    elif (
-        check_dup
-        and trans.sa_session.query(trans.app.model.User)
-        .filter(func.lower(trans.app.model.User.table.c.email) == email.lower())
-        .first()
-    ):
-        message = f"User with email '{email}' already exists."
-    #  If the allowlist is not empty filter out any domain not in the list and ignore blocklist.
-    elif trans.app.config.email_domain_allowlist_content is not None:
-        domain = extract_domain(email)
-        if domain not in trans.app.config.email_domain_allowlist_content:
-            message = "Please enter an allowed domain email address for this server."
-    #  If the blocklist is not empty filter out the disposable domains.
-    elif trans.app.config.email_domain_blocklist_content is not None:
-        domain = extract_domain(email, base_only=True)
-        if domain in trans.app.config.email_domain_blocklist_content:
-            message = "Please enter your permanent email address."
     if not message and validate_domain:
         domain = extract_domain(email)
         message = validate_domain(domain)
+
+    if not message and check_dup and trans.sa_session.query(trans.app.model.User).filter(func.lower(trans.app.model.User.table.c.email) == email.lower()).first():
+        message = f"User with email '{email}' already exists."
+
+    if not message
+        # If the allowlist is not empty filter out any domain not in the list and ignore blocklist.
+        if trans.app.config.email_domain_allowlist_content is not None:
+            domain = extract_domain(email)
+            if domain not in trans.app.config.email_domain_allowlist_content:
+                message = "Please enter an allowed domain email address for this server."
+        # If the blocklist is not empty filter out the disposable domains.
+        elif trans.app.config.email_domain_blocklist_content is not None:
+            domain = extract_domain(email, base_only=True)
+            if domain in trans.app.config.email_domain_blocklist_content:
+                message = "Please enter your permanent email address."
+
     return message
 
 

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -89,7 +89,7 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
         if domain in trans.app.config.email_domain_blocklist_content:
             message = "Please enter your permanent email address."
     if not message and validate_domain:
-        domain = email.split('@', 1)[1]
+        domain = extract_domain(email)
         message = validate_domain(domain)
     return message
 

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -73,7 +73,13 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
         domain = extract_domain(email)
         message = validate_domain(domain)
 
-    if not message and check_dup and trans.sa_session.query(trans.app.model.User).filter(func.lower(trans.app.model.User.table.c.email) == email.lower()).first():
+    if (
+        not message
+        and check_dup
+        and trans.sa_session.query(trans.app.model.User)
+        .filter(func.lower(trans.app.model.User.table.c.email) == email.lower())
+        .first()
+    ):
         message = f"User with email '{email}' already exists."
 
     if not message:
@@ -101,7 +107,7 @@ def validate_domain(domain):
 
 
 def extract_domain(email, base_only=False):
-    domain = email.rsplit('@', 1)[-1]
+    domain = email.rsplit("@", 1)[-1]
     parts = domain.split(".")
     if len(parts) > 2 and base_only:
         return (".").join(parts[-2:])

--- a/lib/galaxy/security/validate_user_input.py
+++ b/lib/galaxy/security/validate_user_input.py
@@ -76,7 +76,7 @@ def validate_email(trans, email, user=None, check_dup=True, allow_empty=False, v
     if not message and check_dup and trans.sa_session.query(trans.app.model.User).filter(func.lower(trans.app.model.User.table.c.email) == email.lower()).first():
         message = f"User with email '{email}' already exists."
 
-    if not message
+    if not message:
         # If the allowlist is not empty filter out any domain not in the list and ignore blocklist.
         if trans.app.config.email_domain_allowlist_content is not None:
             domain = extract_domain(email)
@@ -101,7 +101,7 @@ def validate_domain(domain):
 
 
 def extract_domain(email, base_only=False):
-    domain = email.split('@', 1)[1]
+    domain = email.rsplit('@', 1)[-1]
     parts = domain.split(".")
     if len(parts) > 2 and base_only:
         return (".").join(parts[-2:])

--- a/lib/galaxy_test/selenium/test_registration.py
+++ b/lib/galaxy_test/selenium/test_registration.py
@@ -54,7 +54,7 @@ class RegistrationTestCase(SeleniumTestCase):
 
     @selenium_test
     def test_bad_emails(self):
-        bad_emails = ["bob", "bob@", "bob@idontwanttocleanup", "bob.cantmakeme"]
+        bad_emails = ["bob", "bob@", "bob.cantmakeme"]
         good_email = self._get_random_email()
         password = self.default_password
         confirm = password

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -82,6 +82,18 @@ class UserManagerTestCase(BaseTestCase):
             **dict(email="user2a@user2.user2", username="user2", password=default_password),
         )
 
+    def test_trimming(self):
+        self.log("emails must be trimmed")
+        user2b, message = self.user_manager.register(self.trans, email=' user2b@user2.user2 ', username='user2b',
+                                                     password=default_password, confirm=default_password)
+        self.assertIsNone(message)
+        self.assertEqual(user2b.email, 'user2b@user2.user2')
+        self.log("usernames must be trimmed")
+        user2c, message = self.user_manager.register(self.trans, email='user2c@user2.user2', username=' user2c ',
+                                                     password=default_password, confirm=default_password)
+        self.assertIsNone(message)
+        self.assertEqual(user2c.username, 'user2c')
+
     def test_email_queries(self):
         user2 = self.user_manager.create(**user2_data)
 

--- a/test/unit/app/managers/test_UserManager.py
+++ b/test/unit/app/managers/test_UserManager.py
@@ -84,15 +84,25 @@ class UserManagerTestCase(BaseTestCase):
 
     def test_trimming(self):
         self.log("emails must be trimmed")
-        user2b, message = self.user_manager.register(self.trans, email=' user2b@user2.user2 ', username='user2b',
-                                                     password=default_password, confirm=default_password)
+        user2b, message = self.user_manager.register(
+            self.trans,
+            email=" user2b@user2.user2 ",
+            username="user2b",
+            password=default_password,
+            confirm=default_password,
+        )
         self.assertIsNone(message)
-        self.assertEqual(user2b.email, 'user2b@user2.user2')
+        self.assertEqual(user2b.email, "user2b@user2.user2")
         self.log("usernames must be trimmed")
-        user2c, message = self.user_manager.register(self.trans, email='user2c@user2.user2', username=' user2c ',
-                                                     password=default_password, confirm=default_password)
+        user2c, message = self.user_manager.register(
+            self.trans,
+            email="user2c@user2.user2",
+            username=" user2c ",
+            password=default_password,
+            confirm=default_password,
+        )
         self.assertIsNone(message)
-        self.assertEqual(user2c.username, 'user2c')
+        self.assertEqual(user2c.username, "user2c")
 
     def test_email_queries(self):
         user2 = self.user_manager.create(**user2_data)

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -1,5 +1,6 @@
 from galaxy.security.validate_user_input import (
     extract_domain,
+    validate_domain,
     validate_email_str,
     validate_publicname_str,
 )
@@ -16,6 +17,11 @@ def test_extract_base_domain():
     assert extract_domain("jack@foo.bar.com", base_only=True) == "bar.com"
 
 
+def test_validate_domain():
+    assert validate_domain("example.org") is None
+    assert validate_domain("this is an invalid domain!") is not None
+
+
 def test_validate_username():
     assert validate_publicname_str("testuser") == ""
     assert validate_publicname_str("test.user") == ""
@@ -27,7 +33,13 @@ def test_validate_username():
 def test_validate_email():
     assert validate_email_str("test@foo.com") == ""
     assert validate_email_str("test-dot.user@foo.com") == ""
-    assert validate_email_str("test@com") != ""
-    assert validate_email_str("@not-a-domain") != ""
+    assert validate_email_str("test-plus+user@foo.com") == ""
+    assert validate_email_str("test-ünicode-user@foo.com") == ""
+    assert validate_email_str("test@ünicode-domain.com") == ""
+    assert validate_email_str("test-missing-domain@") != ""
+    assert validate_email_str("@test-missing-local") != ""
+    assert validate_email_str("test-invalid-local\\character@foo.com") != ""
+    assert validate_email_str("test@invalid-domain-character!com") != ""
+    assert validate_email_str("test@newlines.in.address.are.invalid\n\n.com") != ""
     too_long_email = "N" * 255 + "@foo.com"
     assert validate_email_str(too_long_email) != ""

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -10,6 +10,7 @@ def test_extract_full_domain():
     assert extract_domain("jack@foo.com") == "foo.com"
     assert extract_domain("jack@foo.bar.com") == "foo.bar.com"
     assert extract_domain("foo.bar.com") == "foo.bar.com"
+    assert extract_domain('"i-like-to-break-email-valid@tors"@foo.com') == "foo.com"
 
 
 def test_extract_base_domain():
@@ -42,5 +43,6 @@ def test_validate_email():
     assert validate_email_str("test-invalid-local\\character@foo.com") != ""
     assert validate_email_str("test@invalid-domain-character!com") != ""
     assert validate_email_str("test@newlines.in.address.are.invalid\n\n.com") != ""
+    assert validate_email_str('"i-like-to-break-email-valid@tors"@foo.com') != ""
     too_long_email = "N" * 255 + "@foo.com"
     assert validate_email_str(too_long_email) != ""

--- a/test/unit/data/security/test_validate_user_input.py
+++ b/test/unit/data/security/test_validate_user_input.py
@@ -9,6 +9,7 @@ from galaxy.security.validate_user_input import (
 def test_extract_full_domain():
     assert extract_domain("jack@foo.com") == "foo.com"
     assert extract_domain("jack@foo.bar.com") == "foo.bar.com"
+    assert extract_domain("foo.bar.com") == "foo.bar.com"
 
 
 def test_extract_base_domain():


### PR DESCRIPTION
Additionally, include a stricter email address validation, since it was previously possible to have email addresses that contained newlines and other very invalid characters. Also, if user activation is enabled, email domains will be checked to verify that they at least resolve in DNS prior to account creation.

I am uncertain why `util.restore_text()` was previously called *after* validation and I'm also uncertain that it needs to be called at all anymore, so if anyone has any insight there it'd be appreciated.

Fixes #12194

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
