### PR TITLE
Explicitly set `page_limit` in `test_get_library_available_permissions`

### DIFF
--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -110,7 +110,7 @@ class LibrariesApiTestCase(ApiTestCase):
         library_id = library["id"]
         role_id = self.library_populator.user_private_role_id()
         # As we can manage this library our role will be available
-        available = self.library_populator.get_permissions(library_id, scope="available", page_limit=1000)
+        available = self.library_populator.get_permissions(library_id, scope="available")
         available_role_ids = [role["id"] for role in available["roles"]]
         assert role_id in available_role_ids
 

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -110,7 +110,7 @@ class LibrariesApiTestCase(ApiTestCase):
         library_id = library["id"]
         role_id = self.library_populator.user_private_role_id()
         # As we can manage this library our role will be available
-        available = self.library_populator.get_permissions(library_id, scope="available")
+        available = self.library_populator.get_permissions(library_id, scope="available", page_limit=1000)
         available_role_ids = [role["id"] for role in available["roles"]]
         assert role_id in available_role_ids
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1231,15 +1231,14 @@ class LibraryPopulator:
         library_id,
         scope: Optional[str] = "current",
         is_library_access: Optional[bool] = False,
-        page: Optional[int] = None,
-        page_limit: Optional[int] = None,
+        page: Optional[int] = 1,
+        page_limit: Optional[int] = 1000,
         q: Optional[str] = None,
         admin: Optional[bool] = True
     ):
         query = f"&q={q}" if q else ""
-        pagination = f"&page={page}&page_limit={page_limit}" if page and page_limit else ""
         response = self.galaxy_interactor.get(
-            f"libraries/{library_id}/permissions?scope={scope}&is_library_access={is_library_access}{pagination}{query}",
+            f"libraries/{library_id}/permissions?scope={scope}&is_library_access={is_library_access}&page={page}&page_limit={page_limit}{query}",
             admin=admin,
         )
         api_asserts.assert_status_code_is(response, 200)


### PR DESCRIPTION
This is a follow-up on https://github.com/galaxyproject/galaxy/pull/12463. So it's still needed to explicitly set the `page_limit` here, otherwise, the default values will be applied in the endpoint anyway.

Hopefully, this will finally fix https://github.com/galaxyproject/galaxy/pull/11701/checks?check_run_id=3622736903


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
