### PR TITLE
Make the subject and body of the mailing list join message configurable

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -1370,8 +1370,30 @@
     list. This is the address used to subscribe to the list. Uncomment
     and leave empty if you want to remove this option from the user
     registration form.
-    Example value 'galaxy-announce-join@bx.psu.edu'
+    Example value 'galaxy-announce-join@lists.galaxyproject.org'
 :Default: ``None``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~
+``mailing_join_subject``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The subject of the email sent to the mailing list join address.
+    See the `mailing_join_addr` option for more information.
+:Default: ``Join Mailing List``
+:Type: str
+
+
+~~~~~~~~~~~~~~~~~~~~~
+``mailing_join_body``
+~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The body of the email sent to the mailing list join address. See
+    the `mailing_join_addr` option for more information.
+:Default: ``Join Mailing List``
 :Type: str
 
 

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -765,8 +765,16 @@ galaxy:
   # list. This is the address used to subscribe to the list. Uncomment
   # and leave empty if you want to remove this option from the user
   # registration form.
-  # Example value 'galaxy-announce-join@bx.psu.edu'
+  # Example value 'galaxy-announce-join@lists.galaxyproject.org'
   #mailing_join_addr: null
+
+  # The subject of the email sent to the mailing list join address. See
+  # the `mailing_join_addr` option for more information.
+  #mailing_join_subject: Join Mailing List
+
+  # The body of the email sent to the mailing list join address. See the
+  # `mailing_join_addr` option for more information.
+  #mailing_join_body: Join Mailing List
 
   # Datasets in an error state include a link to report the error.
   # Those reports will be sent to this address.  Error reports are

--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -580,10 +580,10 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         if self.app.config.smtp_server is None:
             return "Subscribing to the mailing list has failed because mail is not configured for this Galaxy instance. Please contact your local Galaxy administrator."
         else:
-            body = 'Join Mailing list.\n'
+            body = (self.app.config.mailing_join_body or '') + '\n'
             to = self.app.config.mailing_join_addr
             frm = email
-            subject = 'Join Mailing List'
+            subject = self.app.config.mailing_join_subject or ''
             try:
                 util.send_mail(frm, to, subject, body, self.app.config)
             except Exception:

--- a/lib/galaxy/webapps/galaxy/config_schema.yml
+++ b/lib/galaxy/webapps/galaxy/config_schema.yml
@@ -985,7 +985,23 @@ mapping:
           is the address used to subscribe to the list. Uncomment and leave empty if you
           want to remove this option from the user registration form.
 
-          Example value 'galaxy-announce-join@bx.psu.edu'
+          Example value 'galaxy-announce-join@lists.galaxyproject.org'
+
+      mailing_join_subject:
+        type: str
+        default: Join Mailing List
+        required: false
+        desc: |
+          The subject of the email sent to the mailing list join address. See the
+          `mailing_join_addr` option for more information.
+
+      mailing_join_body:
+        type: str
+        default: Join Mailing List
+        required: false
+        desc: |
+          The body of the email sent to the mailing list join address. See the
+          `mailing_join_addr` option for more information.
 
       error_email_to:
         type: str


### PR DESCRIPTION
Some mailing list software may care what the subject/body of the subscribe message are.

xref #12268, although it turns out this isn't needed to fix that.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Set `smtp_server`, `mailing_join_addr` plus `mailing_join_subject` and/or `mailing_join_body`
  2. Register an account, check the box at the bottom of the registration page
  3. Hopefully email goes somewhere

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
