### PR TITLE
Update dataset edit toggle button to refer to dataset instead of coll…

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetUI.vue
@@ -103,7 +103,7 @@ either through the props, and make updates through the events -->
                 <EditorMenu
                     class="ml-3 flex-grow-0 d-flex flex-column"
                     v-if="writable"
-                    model-name="Collection"
+                    model-name="Dataset"
                     :editing.sync="editing"
                     :writable="writable"
                     :valid="valid"


### PR DESCRIPTION
Update dataset edit toggle button to refer to dataset instead of collection

Fixes https://github.com/galaxyproject/galaxy/issues/12480

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
