### PR TITLE
Handle deleted panel views in the UI.

### DIFF
--- a/client/src/store/panelStore.js
+++ b/client/src/store/panelStore.js
@@ -22,13 +22,20 @@ const getters = {
 };
 
 const actions = {
-    initCurrentPanelView: async ({ commit, state }, siteDefaultPanelView) => {
-        const panelView = state.currentPanelView || siteDefaultPanelView;
+    initCurrentPanelView: async ({ commit, state, dispatch }, siteDefaultPanelView) => {
+        let panelView = state.currentPanelView || siteDefaultPanelView;
         if (state.currentPanelView == null) {
             commit("setCurrentPanelView", { panelView });
         }
-        const { data } = await axios.get(`${getAppRoot()}api/tools?in_panel=true&view=${panelView}`);
-        commit("savePanelView", { panelView, panel: data });
+        const response = await axios.get(`${getAppRoot()}api/tools?in_panel=true&view=${panelView}`).catch((error) => {
+            if (error.response && error.response.status == 400) {
+                // Assume the stored panelView disappeared, revert to the panel default for this site.
+                dispatch("setCurrentPanelView", siteDefaultPanelView);
+            }
+        });
+        if (response !== undefined) {
+            commit("savePanelView", { panelView, panel: response.data });
+        }
     },
     setCurrentPanelView: async ({ commit }, panelView) => {
         commit("setCurrentPanelView", { panelView });

--- a/client/src/store/panelStore.js
+++ b/client/src/store/panelStore.js
@@ -23,7 +23,7 @@ const getters = {
 
 const actions = {
     initCurrentPanelView: async ({ commit, state, dispatch }, siteDefaultPanelView) => {
-        let panelView = state.currentPanelView || siteDefaultPanelView;
+        const panelView = state.currentPanelView || siteDefaultPanelView;
         if (state.currentPanelView == null) {
             commit("setCurrentPanelView", { panelView });
         }

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -96,6 +96,8 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         # Return everything.
         try:
             return self.app.toolbox.to_dict(trans, in_panel=in_panel, trackster=trackster, tool_help=tool_help, view=view)
+        except exceptions.MessageException:
+            raise
         except Exception:
             raise exceptions.InternalServerError("Error: Could not convert toolbox to dictionary")
 


### PR DESCRIPTION
The tool panel wouldn't render without this without a lot of recourse for the user.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Add a panel view file (say ``filtering.yml``) to ``config/plugins/activities`` with contents like:

```
name: Custom Panel Filter
type: generic
items:
- type: label
  text: The Start
- type: tool
  id: empty_list
- type: label
  text: The Middle
- type: tool
  id: count_list
- type: label
  text: The End
```
  2. Startup Galaxy and switch to the tool panel as a user (using the new menu dropdown on the tool panel).
  3. Shutdown Galaxy.
  4. Remove the tool panel view.
  5. Startup Galaxy.
  6. Notice the default tool panel is restored.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
