### PR TITLE
Fix bug when restarting Galaxy in selenium integration tests.

### DIFF
--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -307,6 +307,7 @@ class TestWithSeleniumMixin(GalaxyTestSeleniumContext, UsesApiTestCaseMixin):
 
     def reset_driver_and_session(self):
         self.tear_down_driver()
+        self.target_url_from_selenium = self._target_url_from_selenium()
         self.setup_driver_and_session()
         self._try_setup_with_driver()
 

--- a/test/integration_selenium/framework.py
+++ b/test/integration_selenium/framework.py
@@ -16,6 +16,10 @@ class SeleniumIntegrationTestCase(integration_util.IntegrationTestCase, framewor
         self.tear_down_selenium()
         super().tearDown()
 
+    def restart(self, handle_reconfig=None):
+        super().restart(handle_reconfig=handle_reconfig)
+        self.reset_driver_and_session()
+
 
 __all__ = (
     'selenium_test',


### PR DESCRIPTION
I was trying to implement a test case for https://github.com/galaxyproject/galaxy/pull/12488 but with Galaxy change URLs during restart - the local storage is going to be lost anyway so the bug was exhibited. Still getting that far was frustrating because of the bug fixed here so I'd like to fix up the framework.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
