### PR TITLE
Remove invalid syntax from tool schema

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -2521,13 +2521,11 @@ In output filters sections are represented as dictionary with the same name as t
 <filter>section_name['parameter_name']</filter>
 ```
 
-In order to reference parameters in sections from tags in the `<outputs>` section, e.g. in the `format_source` attribute of `<data>` tags, the syntax is:
+In order to reference parameters in sections from tags in the `<outputs>` section, e.g. in the `format_source` attribute of `<data>` tags, the syntax is currently:
 
 ```
-<data name="output" format_source="section_name|parameter_name" metadata_source="section_name|parameter_name"/>
+<data name="output" format_source="parameter_name" metadata_source="parameter_name"/>
 ```
-
-Until profile 21.01 `parameter_name` was sufficient (https://github.com/galaxyproject/galaxy/pull/9493/files).
 
 Note that references to other parameters in the `<inputs>` section are only possible if the reference is in the same section or its parents (and is defined earlier), therefore only `parameter_name` is used.
 


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/11026 extended the description on how parameters in sections are referenced.

this already included syntax that is not merged yet: https://github.com/galaxyproject/galaxy/pull/9493

this PR reverts this, see https://github.com/galaxyproject/galaxy/pull/9493#issuecomment-912588302

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
