### PR TITLE
Fail data manager job when processing table entry fails

### DIFF
--- a/client/src/components/JobInformation/JobInformation.vue
+++ b/client/src/components/JobInformation/JobInformation.vue
@@ -39,6 +39,12 @@
                 <code-row id="command-line" v-if="job" :code-label="'Command Line'" :code-item="job.command_line" />
                 <code-row id="stdout" v-if="job" :code-label="'Tool Standard Output'" :code-item="job.tool_stdout" />
                 <code-row id="stderr" v-if="job" :code-label="'Tool Standard Error'" :code-item="job.tool_stderr" />
+                <code-row
+                    id="traceback"
+                    v-if="job && job.traceback"
+                    :code-label="'Unexpected Job Errors'"
+                    :code-item="job.traceback"
+                />
                 <tr v-if="job">
                     <td>Tool Exit Code:</td>
                     <td id="exist-code">{{ job.exit_code }}</td>

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -30,6 +30,7 @@ from galaxy import (
 )
 from galaxy.datatypes import sniff
 from galaxy.exceptions import (
+    MessageException,
     ObjectInvalid,
     ObjectNotFound,
 )
@@ -1637,8 +1638,11 @@ class JobWrapper(HasResourceParameters):
         self.sa_session.expunge_all()
         job = self.get_job()
 
-        def fail():
-            return self.fail(job.info, tool_stdout=tool_stdout, tool_stderr=tool_stderr, exit_code=tool_exit_code, job_stdout=job_stdout, job_stderr=job_stderr)
+        def fail(message=job.info, exception=None):
+            if not isinstance(exception, (AssertionError, MessageException)):
+                # Only attach MessageException and AssertionErrors to job.traceback
+                exception = None
+            return self.fail(message, tool_stdout=tool_stdout, tool_stderr=tool_stderr, exit_code=tool_exit_code, job_stdout=job_stdout, job_stderr=job_stderr, exception=exception)
 
         # TODO: After failing here, consider returning from the function.
         try:
@@ -1770,9 +1774,10 @@ class JobWrapper(HasResourceParameters):
         param_dict = self.get_param_dict(job)
         try:
             self.tool.exec_after_process(self.app, inp_data, out_data, param_dict, job=job, final_job_state=final_job_state)
-        except Exception:
+        except Exception as e:
             log.exception(f"exec_after_process hook failed for job {self.job_id}")
-            final_job_state = job.states.ERROR
+            return fail("exec_after_process hook failed", exception=e)
+
         # Call 'exec_after_process' hook
         self.tool.call_hook('exec_after_process', self.app, inp_data=inp_data,
                             out_data=out_data, param_dict=param_dict,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1362,12 +1362,12 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
             # System level details that only admins should have.
             rval['external_id'] = self.job_runner_external_id
             rval['command_line'] = self.command_line
+            rval['traceback'] = self.traceback
         if view == 'admin_job_list':
             rval['user_email'] = self.user.email if self.user else None
             rval['handler'] = self.handler
             rval['job_runner_name'] = self.job_runner_name
             rval['info'] = self.info
-            rval['traceback'] = self.traceback
             rval['session_id'] = self.session_id
             if self.galaxy_session and self.galaxy_session.remote_host:
                 rval['remote_host'] = self.galaxy_session.remote_host

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -277,16 +277,16 @@ class ToolDataTable:
     def get_empty_field_by_name(self, name):
         return self.empty_field_values.get(name, self.empty_field_value)
 
-    def _add_entry(self, entry, allow_duplicates=True, persist=False, persist_on_error=False, entry_source=None, **kwd):
+    def _add_entry(self, entry, allow_duplicates=True, persist=False, entry_source=None, **kwd):
         raise NotImplementedError("Abstract method")
 
-    def add_entry(self, entry, allow_duplicates=True, persist=False, persist_on_error=False, entry_source=None, **kwd):
-        self._add_entry(entry, allow_duplicates=allow_duplicates, persist=persist, persist_on_error=persist_on_error, entry_source=entry_source, **kwd)
+    def add_entry(self, entry, allow_duplicates=True, persist=False, entry_source=None, **kwd):
+        self._add_entry(entry, allow_duplicates=allow_duplicates, persist=persist, entry_source=entry_source, **kwd)
         return self._update_version()
 
-    def add_entries(self, entries, allow_duplicates=True, persist=False, persist_on_error=False, entry_source=None, **kwd):
+    def add_entries(self, entries, allow_duplicates=True, persist=False, entry_source=None, **kwd):
         for entry in entries:
-            self.add_entry(entry, allow_duplicates=allow_duplicates, persist=persist, persist_on_error=persist_on_error, entry_source=entry_source, **kwd)
+            self.add_entry(entry, allow_duplicates=allow_duplicates, persist=persist, entry_source=entry_source, **kwd)
         return self._loaded_content_version
 
     def _remove_entry(self, values):
@@ -299,7 +299,7 @@ class ToolDataTable:
     def is_current_version(self, other_version):
         return self._loaded_content_version == other_version
 
-    def merge_tool_data_table(self, other_table, allow_duplicates=True, persist=False, persist_on_error=False, entry_source=None, **kwd):
+    def merge_tool_data_table(self, other_table, allow_duplicates=True, persist=False, entry_source=None, **kwd):
         raise NotImplementedError("Abstract method")
 
     def reload_from_files(self):
@@ -434,7 +434,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             if tmp_file is not None:
                 tmp_file.close()
 
-    def merge_tool_data_table(self, other_table, allow_duplicates=True, persist=False, persist_on_error=False, entry_source=None, **kwd):
+    def merge_tool_data_table(self, other_table, allow_duplicates=True, persist=False, entry_source=None, **kwd):
         assert self.columns == other_table.columns, f"Merging tabular data tables with non matching columns is not allowed: {self.name}:{self.columns} != {other_table.name}:{other_table.columns}"
         # merge filename info
         for filename, info in other_table.filenames.items():
@@ -448,7 +448,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             self.allow_duplicate_entries = False
             self._deduplicate_data()
         # add data entries and return current data table version
-        return self.add_entries(other_table.data, allow_duplicates=allow_duplicates, persist=persist, persist_on_error=persist_on_error, entry_source=entry_source, **kwd)
+        return self.add_entries(other_table.data, allow_duplicates=allow_duplicates, persist=persist, entry_source=entry_source, **kwd)
 
     def handle_found_index_file(self, filename):
         self.missing_index_file = None
@@ -616,7 +616,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
                 break
         return filename
 
-    def _add_entry(self, entry, allow_duplicates=True, persist=False, persist_on_error=False, entry_source=None, **kwd):
+    def _add_entry(self, entry, allow_duplicates=True, persist=False, entry_source=None, **kwd):
         # accepts dict or list of columns
         if isinstance(entry, dict):
             fields = []
@@ -642,7 +642,7 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             is_error = True
         filename = None
 
-        if persist and (not is_error or persist_on_error):
+        if persist and not is_error:
             filename = self.get_filename_for_source(entry_source)
             if filename is None:
                 # should we default to using any filename here instead?

--- a/lib/galaxy/tools/data/__init__.py
+++ b/lib/galaxy/tools/data/__init__.py
@@ -22,6 +22,7 @@ import refgenconf
 import requests
 
 from galaxy import util
+from galaxy.exceptions import MessageException
 from galaxy.util import RW_R__R__
 from galaxy.util.dictifiable import Dictifiable
 from galaxy.util.filelock import FileLock
@@ -637,16 +638,16 @@ class TabularToolDataTable(ToolDataTable, Dictifiable):
             if (allow_duplicates and self.allow_duplicate_entries) or fields not in self.get_fields():
                 self.data.append(fields)
             else:
-                raise Exception(f"Attempted to add fields ({fields}) to data table '{self.name}', but this entry already exists and allow_duplicates is False.")
+                raise MessageException(f"Attempted to add fields ({fields}) to data table '{self.name}', but this entry already exists and allow_duplicates is False.")
         else:
-            raise Exception(f"Attempted to add fields ({fields}) to data table '{self.name}', but there were not enough fields specified ( {len(fields)} < {self.largest_index + 1} ).")
+            raise MessageException(f"Attempted to add fields ({fields}) to data table '{self.name}', but there were not enough fields specified ( {len(fields)} < {self.largest_index + 1} ).")
         filename = None
 
         if persist:
             filename = self.get_filename_for_source(entry_source)
             if filename is None:
                 # If we reach this point, there is no data table with a corresponding .loc file.
-                raise Exception(f"Unable to determine filename for persisting data table '{self.name}' values: '{self.fields}'.")
+                raise MessageException(f"Unable to determine filename for persisting data table '{self.name}' values: '{self.fields}'.")
             else:
                 log.debug("Persisting changes to file: %s", filename)
                 with FileLock(filename):


### PR DESCRIPTION
For instance when adding a dbkey twice, or when the loc file for a data manager can't be found.
I think that's a win on its own, and could be complementary to https://github.com/galaxyproject/galaxy/pull/12452 or replace it.

Also exposes the job.traceback object in the job information.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
