### PR TITLE
[21.05] Add PostgreSQL < 9.5 deprecation notice to 21.05 release announce

### DIFF
--- a/doc/source/releases/21.05_announce.rst
+++ b/doc/source/releases/21.05_announce.rst
@@ -35,6 +35,14 @@ Highlights
 
 Also check out the `21.05 user release notes <21.05_announce_user.html>`__
 
+Deprecation Notices
+===========================================================
+
+**Deprecation of support for PostgreSQL < 9.5**
+  When using PostgreSQL as database server, Galaxy now requires PostgreSQL 9.5
+  or newer. Instructions for updating PostgreSQL can be found in the
+  `official documentation <https://www.postgresql.org/docs/current/upgrading.html>`__.
+
 Upcoming Deprecation Notices
 ===========================================================
 


### PR DESCRIPTION
xref. https://github.com/galaxyproject/galaxy/issues/12095#issuecomment-921669954

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
