### PR TITLE
Fix indention for admin panel links

### DIFF
--- a/client/src/entry/panels/admin-panel.js
+++ b/client/src/entry/panels/admin-panel.js
@@ -154,6 +154,7 @@ const AdminPanel = Backbone.View.extend({
             _.each(category.get("items"), (item) => {
                 if (item.enabled === undefined || item.enabled) {
                     const $link = $("<a/>")
+                        .addClass("title-link")
                         .attr({ href: this.root + item.url })
                         .text(_l(item.title));
                     if (item.id) {


### PR DESCRIPTION
The labels in the admin side panel are misaligned. This PR adds a style class to the label in order to fix it.