### PR TITLE
Let invalid tool profile trigger linter error

### DIFF
--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -55,7 +55,7 @@ def lint_general(tool_source, lint_ctx):
     profile = tool_source.parse_profile()
     profile_valid = PROFILE_PATTERN.match(profile) is not None
     if not profile_valid:
-        lint_ctx.warn(PROFILE_INVALID_MSG)
+        lint_ctx.error(PROFILE_INVALID_MSG)
     elif profile == "16.01":
         lint_ctx.valid(PROFILE_INFO_DEFAULT_MSG)
     else:


### PR DESCRIPTION
see https://github.com/galaxyproject/tools-iuc/pull/3969#issuecomment-922756692

alternatively / additionally we should https://github.com/galaxyproject/planemo-ci-action/pull/23 and https://github.com/galaxyproject/galaxy-tool-repository-template/pull/8

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
