### PR TITLE
Revert "Install Tempita from a fork due to `use_2to3` deprecation"

### DIFF
--- a/packages/data/requirements.txt
+++ b/packages/data/requirements.txt
@@ -15,6 +15,5 @@ pysam
 social-auth-core[openidconnect]==3.3.0
 SQLAlchemy>=1.4.20,<2
 sqlalchemy-migrate
-tempita @ git+https://git@github.com/nsoranzo/tempita@main#egg=tempita  # Required by sqlalchemy-migrate, see https://github.com/galaxyproject/galaxy/issues/12412
 tifffile<=2020.9.3  # Last version compatible with python 3.6
 WebOb


### PR DESCRIPTION
This reverts commit 314ca33509440f7096e5cccfa08654a61f81f4e8.

Fixed on PyPI as mentioned in https://github.com/pypa/setuptools/issues/2788#issuecomment-921962154

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
