### PR TITLE
FastAPI: explicitly return empty response with 204 status

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/pages.py
+++ b/lib/galaxy/webapps/galaxy/api/pages.py
@@ -8,6 +8,7 @@ from fastapi import (
     Body,
     Path,
     Query,
+    Response,
     status,
 )
 from starlette.responses import StreamingResponse
@@ -93,6 +94,7 @@ class FastAPIPages:
     ):
         """Marks the Page with the given ID as deleted."""
         self.service.delete(trans, id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @router.get(
         '/api/pages/{id}',

--- a/lib/galaxy/webapps/galaxy/api/tags.py
+++ b/lib/galaxy/webapps/galaxy/api/tags.py
@@ -5,6 +5,7 @@ import logging
 
 from fastapi import (
     Body,
+    Response,
     status,
 )
 
@@ -50,6 +51,7 @@ class FastAPITags:
         - If no tags are provided in the request body, the currently associated tags will also be __deleted__.
         """
         self.manager.update(trans, payload)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 class TagsController(BaseGalaxyAPIController):


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/11701#issuecomment-923036272

This should avoid `LocalProtocolError: Too much data for declared Content-Length` exception when returning a 204 status code in FastAPI.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
