### PR TITLE
Fix cmap sniffer

### DIFF
--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -1362,13 +1362,13 @@ class CMAP(TabularData):
     file_ext = "cmap"
 
     def sniff_prefix(self, file_prefix):
-        start = file_prefix.string_io().read(3000).strip().split('\n')
-        for line in start:
-            if '# CMAP File Version' in line:
+        handle = file_prefix.string_io()
+        for line in handle:
+            if not line.startswith('#'):
+                return False
+            if line.startswith('# CMAP File Version:')
                 return True
-            else:
-                pass
-        return file_prefix.startswith('# CMAP File Version:')
+        return False
 
     def set_meta(self, dataset, overwrite=True, skip=None, max_data_lines=7, **kwd):
         if dataset.has_data():

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -1366,7 +1366,7 @@ class CMAP(TabularData):
         for line in handle:
             if not line.startswith('#'):
                 return False
-            if line.startswith('# CMAP File Version:')
+            if line.startswith('# CMAP File Version:'):
                 return True
         return False
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -1362,6 +1362,12 @@ class CMAP(TabularData):
     file_ext = "cmap"
 
     def sniff_prefix(self, file_prefix):
+        start = file_prefix.string_io().read(3000).strip().split('\n')
+        for line in start:
+            if '# CMAP File Version' in line:
+                return True
+            else:
+                pass
         return file_prefix.startswith('# CMAP File Version:')
 
     def set_meta(self, dataset, overwrite=True, skip=None, max_data_lines=7, **kwd):


### PR DESCRIPTION
Current CMAP sniffer only looks at first line of the file. Some cmap files contain other commented lines beforehand, such as the command used to generate the file. This changes that sniffer to read the first few thousand characters, then check for lines that include the cmap version string instead.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
