### PR TITLE
[21.09] Drop leftover error logging

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -190,7 +190,6 @@ class ExpressionValidator(Validator):
             message = f"Value '%s' does not evaluate to {'True' if negate == 'false' else 'False'} for '{expression}'"
         super().__init__(message, negate)
         # Save compiled expression, code objects are thread safe (right?)
-        log.error(f"ExpressionValidator expression {expression}")
         self.expression = compile(expression, '<string>', 'eval')
 
     def validate(self, value, trans=None):

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -193,11 +193,9 @@ class ExpressionValidator(Validator):
         self.expression = compile(expression, '<string>', 'eval')
 
     def validate(self, value, trans=None):
-        log.error(f"ExpressionValidator.validate value {value} expression {self.expression}")
         try:
             evalresult = eval(self.expression, dict(value=value))
         except Exception:
-            log.debug(f"Validator '{self.expression}' could not be evaluated on '{str(value)}'", exc_info=True)
             super().validate(False, value, f"Validator '{self.expression}' could not be evaluated on '%s'")
         super().validate(evalresult, value_to_show=value)
 


### PR DESCRIPTION
There's no error here, I assume that was used for debugging, but it's
very verbose on startup.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
