### PR TITLE
[21.05] Add docker image auto-building in github workflow

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -1,9 +1,17 @@
-name: Build Image
-on: push
+name: Build Container Image
+on:
+  push:
+    branches:
+      - 'release*'
+      - anvil
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
-  test:
-    name: Build image
+  build:
+    name: Build container image
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'galaxyproject'
     steps:
       - uses: actions/checkout@v2
       # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -1,0 +1,45 @@
+name: Build Image
+on: push
+jobs:
+  test:
+    name: Build image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
+      - name: Set outputs
+        id: vars
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      - name: Set branch name
+        id: branch
+        run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/}-auto)"
+      - name: Login to docker hub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - run: docker build . -t galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} -f .k8s_ci.Dockerfile
+      - name: Push to docker hub with commit ID
+        uses: actions-hub/docker@master
+        with:
+          args: push galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }}
+      - run: docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} galaxy/galaxy-min:${{ steps.branch.outputs.name }}
+      - name: Push to docker hub with branch name
+        uses: actions-hub/docker@master
+        with:
+          args: push galaxy/galaxy-min:${{ steps.branch.outputs.name }}
+      - run: docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-k8s/galaxy:${{ steps.branch.outputs.name }} && docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-k8s/galaxy:${{ steps.vars.outputs.sha_short }}
+      - name: Login to docker hub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+          DOCKER_REGISTRY_URL: quay.io
+      - name: Push to quay.io with commit ID
+        uses: actions-hub/docker@master
+        with:
+          args: push quay.io/galaxy-k8s/galaxy:${{ steps.vars.outputs.sha_short }}
+      - name: Push to quay.io with branch name
+        uses: actions-hub/docker@master
+        with:
+          args: push quay.io/galaxy-k8s/galaxy:${{ steps.branch.outputs.name }}


### PR DESCRIPTION
Dockerhub autobuilds were discontinued this past summer: https://www.docker.com/blog/changes-to-docker-hub-autobuilds/.
We applied for the Docker Open Source program but have yet to hear back.

This adds autobuilding back pushing to both Dockerhub and quay.io

Each commit will be pushed under both the short commit hash and the branch name suffixed with `-auto` (with `release_` removed)

Eg: for branch `dev`
`galaxy/galaxy-min:[short-commit-hash]` on Dockerhub 
`galaxy/galaxy-min:dev-auto` on Dockerhub 
`quay.io/galaxy-k8s/galaxy:[short-commit-hash]` on quay
`quay.io/galaxy-k8s/galaxy:dev-auto` on quay

Eg: for branch `release_21.05`
`galaxy/galaxy-min:[short-commit-hash]` on Dockerhub 
`galaxy/galaxy-min:21.05-auto` on Dockerhub 
`quay.io/galaxy-k8s/galaxy:[short-commit-hash]` on quay
`quay.io/galaxy-k8s/galaxy:21.05-auto` on quay

If anyone else on the team owns `galaxy` org on quay, it would be great to switch to that (@bgruening ?). I created `galaxy-k8s` in the meantime.

Example successful run: https://github.com/almahmoud/galaxy/runs/3665965761?check_suite_focus=true

Needed secrets:
```
DOCKER_USERNAME
DOCKER_PASSWORD
QUAY_USERNAME
QUAY_PASSWORD
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
