### PR TITLE
[21.09] Restore truthy/falsy ExpressionValidator behavior

### DIFF
--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -179,6 +179,16 @@ class ExpressionValidator(Validator):
         ...
     ValueError: Not gonna happen
     >>> t = p.validate("Fop")
+    >>> p = ToolParameter.build(None, XML('''
+    ... <param name="blah" type="text" value="10">
+    ...     <validator type="expression" message="Not gonna happen">value</validator>
+    ... </param>
+    ... '''))
+    >>> p.validate("Foo")
+    >>> p.validate("")
+    Traceback (most recent call last):
+        ...
+    ValueError: Not gonna happen
     """
 
     @classmethod
@@ -200,7 +210,7 @@ class ExpressionValidator(Validator):
         except Exception:
             log.debug(f"Validator '{self.expression}' could not be evaluated on '{str(value)}'", exc_info=True)
             super().validate(False, value, f"Validator '{self.expression}' could not be evaluated on '%s'")
-        super().validate(evalresult, value_to_show=value)
+        super().validate(bool(evalresult), value_to_show=value)
 
 
 class InRangeValidator(ExpressionValidator):


### PR DESCRIPTION
Fixes
https://github.com/galaxyproject/tools-iuc/issues/3974#issuecomment-924228314,
broken in https://github.com/galaxyproject/galaxy/commit/a0046e43168c238c9b87b2a996e1f8c06503131a

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
