### PR TITLE
Guard against instance of GenomeIndexToolData

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1142,10 +1142,10 @@ class JobWrapper(HasResourceParameters):
         job = self._load_job()
 
         def get_special():
-            special = self.sa_session.query(model.JobExportHistoryArchive).filter_by(job=job).first()
-            if not special:
-                special = self.sa_session.query(model.GenomeIndexToolData).filter_by(job=job).first()
-            return special
+            jeha = self.sa_session.query(model.JobExportHistoryArchive).filter_by(job=job).first()
+            if jeha:
+                return jeha.fda
+            return self.sa_session.query(model.GenomeIndexToolData).filter_by(job=job).first()
 
         tool_evaluator = self._get_tool_evaluator(job)
         compute_environment = compute_environment or self.default_compute_environment(job)

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -85,7 +85,7 @@ class ToolEvaluator:
         if get_special:
             special = get_special()
             if special:
-                out_data["output_file"] = special.fda
+                out_data["output_file"] = getattr(special, 'fda', None)
 
         # These can be passed on the command line if wanted as $__user_*__
         incoming.update(model.User.user_template_environment(job.history and job.history.user))

--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -85,7 +85,7 @@ class ToolEvaluator:
         if get_special:
             special = get_special()
             if special:
-                out_data["output_file"] = getattr(special, 'fda', None)
+                out_data["output_file"] = special
 
         # These can be passed on the command line if wanted as $__user_*__
         incoming.update(model.User.user_template_environment(job.history and job.history.user))


### PR DESCRIPTION
The value of `special` can be tracked to [this function definition](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/jobs/__init__.py#L1144). The result of the function call may be an instance of `GenomeIndexToolData`, which, unlike `JobExportHistoryArchive`, does *not* have an `fda` attribute. This change guards against such a case which would raise an AttributeError.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
