### PR TITLE
[21.09] Fix startup if a tool uses an unknown edam term

### DIFF
--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -65,7 +65,7 @@ class EdamToolPanelView(ToolPanelView):
 
         for tool_id, key, val, val_name in walk_loaded_tools(base_tool_panel, toolbox_registry):
             for term in self._get_edam_sec(val):
-                if term == 'uncategorized':
+                if term == 'uncategorized' or term not in self.edam:
                     uncategorized.append((tool_id, key, val, val_name))
                 else:
                     for path in self.edam[term]['path']:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12529:

```
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/webapps/galaxy/buildapp.py", line 60, in app_pair
    app = galaxy.app.UniverseApplication(global_conf=global_conf, **kwargs)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/app.py", line 257, in __init__
    self._configure_toolbox()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/config/__init__.py", line 1181, in _configure_toolbox
    self.toolbox = tools.ToolBox(self.config.tool_configs, self.config.tool_path, self)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tools/__init__.py", line 288, in __init__
    super().__init__(
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/toolbox/base.py", line 1274, in __init__
    super().__init__(config_filenames, tool_root_dir, app, view_sources, default_panel_view, save_integrated_tool_panel)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/toolbox/base.py", line 185, in __init__
    self._load_tool_panel_views()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/toolbox/base.py", line 489, in _load_tool_panel_views
    self._tool_panel_view_rendered[key] = view.apply_view(self._integrated_tool_panel, registry)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/tool_util/toolbox/views/edam.py", line 71, in apply_view
    for path in self.edam[term]['path']:
KeyError: 'operation_3946'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Add a tool with unknown edam term.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
