### PR TITLE
FastAPI: Add request wrapper for `SessionRequestContext`

### DIFF
--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -1,3 +1,4 @@
+import abc
 from typing import Optional
 
 from galaxy.managers.context import (
@@ -58,17 +59,33 @@ class WorkRequestContext(ProvidesHistoryContext):
     user = property(get_user, set_user)
 
 
+class GalaxyAbstractRequest:
+    """Abstract interface to provide access to some request properties."""
+
+    @abc.abstractproperty
+    def base(self) -> str:
+        """Base URL of the request."""
+
+    @abc.abstractproperty
+    def host(self) -> str:
+        """The host address."""
+
+
 class SessionRequestContext(WorkRequestContext):
-    """Like WorkRequestContext, but provides access to galaxy session and session."""
+    """Like WorkRequestContext, but provides access to galaxy session and request."""
 
     def __init__(self, **kwargs):
         self.galaxy_session = kwargs.pop('galaxy_session', None)
-        self._host = kwargs.pop("host")
+        self._request: GalaxyAbstractRequest = kwargs.pop("request")
         super().__init__(**kwargs)
 
     @property
     def host(self):
-        return self._host
+        return self._request.host
+
+    @property
+    def request(self) -> GalaxyAbstractRequest:
+        return self._request
 
     def get_galaxy_session(self):
         return self.galaxy_session


### PR DESCRIPTION
There are some parts of the codebase directly using `trans.request.<something>` this will lead to an `AttributeError` in FastAPI mode because the `SessionRequestContext` does not have access to the request object (and we probably don't want to directly access it anyway).

This creates an interface to expose some of the properties that are used across the code in a similar way the legacy request object was doing it without having to modify the usages. Also includes a wrapper around the FastAPI version of the Request object that is now a property of the `SessionRequestContext` that implements this interface.

Only a couple of properties are provided now so this can be extended as necessary. On the other hand, we may want to actually get rid of those `trans.request.<something>` when possible.

Any other suggestions are really appreciated (especially with the naming :laughing:)

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
