### PR TITLE
[21.09] Fix populated state for collections without members

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5071,6 +5071,8 @@ class ImplicitlyConvertedDatasetAssociation(Base, RepresentById):
 
 
 DEFAULT_COLLECTION_NAME = "Unnamed Collection"
+
+
 class InnerCollectionFilter(NamedTuple):
     column: str
     operator_function: Callable

--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -65,7 +65,7 @@ class EdamToolPanelView(ToolPanelView):
 
         for tool_id, key, val, val_name in walk_loaded_tools(base_tool_panel, toolbox_registry):
             for term in self._get_edam_sec(val):
-                if term == 'uncategorized':
+                if term == 'uncategorized' or term not in self.edam:
                     uncategorized.append((tool_id, key, val, val_name))
                 else:
                     for path in self.edam[term]['path']:


### PR DESCRIPTION
`populated_optimized` would previously return False for a collection that has been finalized, but doesn't contain any members (which is in disagreement with the simple `populated` method). Since workflow scheduling (among others) will only proceed if all step input collections are populated an invocation would be blocked at this step.

Fixes https://github.com/mvdbeek/iwc/runs/3666442891?check_suite_focus=true, which tests https://github.com/galaxyproject/iwc/tree/main/workflows/data-fetching/parallel-accession-download against the release_21.09 branch.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
