### PR TITLE
Add DEFERRED datasets to Galaxy.

### DIFF
--- a/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
+++ b/client/src/components/Dataset/DatasetStorage/DatasetStorage.vue
@@ -3,6 +3,18 @@
         <h3 v-if="includeTitle">Dataset Storage</h3>
         <div v-if="errorMessage" class="error">{{ errorMessage }}</div>
         <loading-span v-else-if="storageInfo == null"> </loading-span>
+        <div v-else-if="discarded">
+            <p>This dataset has been discarded and its files are not available to Galaxy.</p>
+        </div>
+        <div v-else-if="deferred">
+            <p>
+                This dataset is remote and deferred. The dataset's files are not available to Galaxy.
+                <span v-if="sourceUri">
+                    This dataset will be downloaded from <b class="deferred-dataset-source-uri">{{ sourceUri }}</b> when
+                    jobs use this dataset.
+                </span>
+            </p>
+        </div>
         <div v-else>
             <p>
                 This dataset is stored in
@@ -49,6 +61,25 @@ export default {
             descriptionRendered: null,
             errorMessage: null,
         };
+    },
+    computed: {
+        discarded() {
+            return this.storageInfo.dataset_state == "discarded";
+        },
+        deferred() {
+            return this.storageInfo.dataset_state == "deferred";
+        },
+        sourceUri() {
+            const sources = this.storageInfo.sources;
+            if (!sources) {
+                return null;
+            }
+            const rootSources = sources.filter((source) => !source.extra_files_path);
+            if (rootSources.length == 0) {
+                return null;
+            }
+            return rootSources[0].source_uri;
+        },
     },
     created() {
         const datasetId = this.datasetId;

--- a/client/src/components/History/Content/model/states.js
+++ b/client/src/components/History/Content/model/states.js
@@ -6,7 +6,12 @@ export const STATES = {
     /** deleted while uploading */
     discarded: {
         status: "danger",
-        text: "The job creating this dataset was cancelled before completion.",
+        text: "This dataset is discarded - the job creating it may have been cancelled or it may have been imported without file data.",
+        icon: "exclamation-triangle",
+    },
+    deferred: {
+        status: "danger",
+        text: "This dataset is remote, has not be ingested by Galaxy, and full metadata may not be available.",
         icon: "exclamation-triangle",
     },
     /** has no data */

--- a/client/src/components/RuleCollectionBuilder.vue
+++ b/client/src/components/RuleCollectionBuilder.vue
@@ -980,8 +980,8 @@ export default {
             } else if (this.elementsType == "ftp") {
                 metadataOptions["path"] = _l("Path");
             } else if (this.elementsType == "remote_files") {
-                // IS THIS NEEDED?
                 metadataOptions["url"] = _l("URL");
+                metadataOptions["url_deferred"] = _l("URL (deferred)");
             } else if (this.elementsType == "library_datasets") {
                 metadataOptions["name"] = _l("Name");
             } else if (this.elementsType == "datasets") {
@@ -1034,7 +1034,17 @@ export default {
         validOnlyOnePath() {
             let valid = true;
             const mappingAsDict = this.mappingAsDict;
-            if (mappingAsDict.ftp_path && mappingAsDict.url) {
+            let pathSourceCount = 0;
+            if (mappingAsDict.ftp_path) {
+                pathSourceCount += 1;
+            }
+            if (mappingAsDict.url) {
+                pathSourceCount += 1;
+            }
+            if (mappingAsDict.url_deferred) {
+                pathSourceCount += 1;
+            }
+            if (pathSourceCount > 1) {
                 // Can only specify one of these.
                 valid = false;
             }
@@ -1045,7 +1055,7 @@ export default {
             const mappingAsDict = this.mappingAsDict;
             const requiresSourceColumn =
                 this.elementsType == "ftp" || this.elementsType == "raw" || this.elementsType == "remote_files";
-            if (requiresSourceColumn && !mappingAsDict.ftp_path && !mappingAsDict.url) {
+            if (requiresSourceColumn && !mappingAsDict.ftp_path && !mappingAsDict.url && !mappingAsDict.url_deferred) {
                 valid = false;
             }
             return valid;
@@ -1662,8 +1672,13 @@ export default {
         },
         _datasetFor(dataIndex, data, mappingAsDict) {
             const res = {};
-            if (mappingAsDict.url) {
-                const urlColumn = mappingAsDict.url.columns[0];
+            if (mappingAsDict.url || mappingAsDict.url_deferred) {
+                let urlColumn;
+                if (mappingAsDict.url) {
+                    urlColumn = mappingAsDict.url.columns[0];
+                } else {
+                    urlColumn = mappingAsDict.url_deferred.columns[0];
+                }
                 let url = data[dataIndex][urlColumn];
                 url = url.trim();
                 if (url.indexOf("://") == -1) {
@@ -1677,6 +1692,9 @@ export default {
                 }
                 res["url"] = url;
                 res["src"] = "url";
+                if (mappingAsDict.url_deferred) {
+                    res["deferred"] = true;
+                }
             } else if (mappingAsDict.ftp_path) {
                 const ftpPathColumn = mappingAsDict.ftp_path.columns[0];
                 const ftpPath = data[dataIndex][ftpPathColumn];

--- a/client/src/components/Upload/helpers.js
+++ b/client/src/components/Upload/helpers.js
@@ -25,6 +25,7 @@ export function uploadModelsToPayload(items, history_id, composite = false) {
                 ext: item.get("extension", "auto"),
                 space_to_tab: item.get("space_to_tab"),
                 to_posix_lines: item.get("to_posix_lines"),
+                deferred: item.get("deferred"),
             };
             switch (item.get("file_mode")) {
                 case "new":
@@ -84,7 +85,6 @@ export function uploadModelsToPayload(items, history_id, composite = false) {
         })
         .filter((item) => item)
         .flat();
-
     const target = {
         destination: { type: "hdas" },
         elements: elements,

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -525,7 +525,21 @@ DatasetListItemView.prototype.templates = (() => {
         "dataset"
     );
     summaryTemplates[STATES.DISCARDED] = BASE_MVC.wrapTemplate(
-        ["<div>", _l("The job creating this dataset was cancelled before completion"), "</div>"],
+        [
+            "<div>",
+            _l(
+                "This dataset is discarded - the job creating it may have been cancelled or it may have been imported with file data"
+            ),
+            "</div>",
+        ],
+        "dataset"
+    );
+    summaryTemplates[STATES.DEFERRED] = BASE_MVC.wrapTemplate(
+        [
+            "<div>",
+            _l("This dataset is remote, has not be ingested by Galaxy, and full metadata may not be available"),
+            "</div>",
+        ],
         "dataset"
     );
     summaryTemplates[STATES.QUEUED] = BASE_MVC.wrapTemplate(

--- a/client/src/mvc/dataset/states.js
+++ b/client/src/mvc/dataset/states.js
@@ -30,6 +30,8 @@ var STATES = {
     NOT_VIEWABLE: "noPermission",
     /** deleted while uploading */
     DISCARDED: "discarded",
+    /** remote dataset not ingested yet */
+    DEFERRED: "deferred",
     /** the tool producing this dataset failed */
     ERROR: "error",
 };
@@ -40,6 +42,7 @@ STATES.READY_STATES = [
     STATES.PAUSED,
     STATES.FAILED_METADATA,
     STATES.NOT_VIEWABLE,
+    STATES.DEFERRED,
     STATES.DISCARDED,
     STATES.ERROR,
 ];

--- a/client/src/mvc/rules/rule-definitions.js
+++ b/client/src/mvc/rules/rule-definitions.js
@@ -820,7 +820,14 @@ const MAPPING_TARGETS = {
     url: {
         label: _l("URL"),
         modes: ["raw"],
-        help: _l("This should be a URL the file can be downloaded from."),
+        help: _l("This should be a URL (or Galaxy-aware URI) the file can be downloaded from."),
+    },
+    url_deferred: {
+        label: _l("Deferred URL"),
+        modes: ["raw"],
+        help: _l(
+            "This should be a URL (or Galaxy-aware URI) th efile can be downloaded from - the file will not be downloaded until it used by a tool."
+        ),
     },
     info: {
         label: _l("Info"),

--- a/client/src/mvc/upload/upload-settings.js
+++ b/client/src/mvc/upload/upload-settings.js
@@ -15,6 +15,10 @@ export default Backbone.View.extend({
                 id: "to_posix_lines",
                 title: "Use POSIX standard",
             },
+            {
+                id: "deferred",
+                title: "Defer dataset resolution",
+            },
         ],
     },
 

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -107,7 +107,6 @@ class MockApp(di.Container, GalaxyDataTestApp):
         self.auth_manager = AuthManager(self.config)
         self.user_manager = UserManager(self)
         self.execution_timer_factory = Bunch(get_timer=StructuredExecutionTimer)
-        self.file_sources = Bunch(to_dict=lambda *args, **kwargs: {})
         self.interactivetool_manager = Bunch(create_interactivetool=lambda *args, **kwargs: None)
         self.is_job_handler = False
         self.biotools_metadata_source = None

--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -125,6 +125,7 @@
     <datatype extension="dbn" type="galaxy.datatypes.sequence:DotBracket" display_in_upload="true" description="Dot-Bracket format is a text-based format for storing both an RNA sequence and its corresponding 2D structure." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Dbn"/>
     <datatype extension="fai" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true" subclass="true" description="A Fasta Index File is a text file consisting of lines each with five TAB-delimited columns : Name, Length, offset, linebases, Linewidth" description_url="http://www.htslib.org/doc/faidx.html"/>
     <datatype extension="fasta" auto_compressed_types="gz" type="galaxy.datatypes.sequence:Fasta" display_in_upload="true" description="A sequence in FASTA format consists of a single-line description, followed by lines of sequence data. The first character of the description line is a greater-than ('&gt;') symbol in the first column. All lines should be shorter than 80 characters." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Fasta">
+      <infer_from suffix="fa" />
       <converter file="fasta_to_tabular_converter.xml" target_datatype="tabular"/>
       <converter file="fasta_to_bowtie_base_index_converter.xml" target_datatype="bowtie_base_index"/>
       <converter file="fasta_to_bowtie_color_index_converter.xml" target_datatype="bowtie_color_index"/>
@@ -138,6 +139,8 @@
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
     <datatype extension="fastqsanger" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSanger" display_in_upload="true" description="Sanger variant of the FASTQ format: phred+33">
+      <infer_from suffix="fq" />
+      <infer_from suffix="fastq" />
       <converter file="fastq_to_fqtoc.xml" target_datatype="fqtoc"/>
     </datatype>
     <datatype extension="fastqsolexa" auto_compressed_types="gz,bz2" type="galaxy.datatypes.sequence:FastqSolexa" display_in_upload="true" description="Solexa variant of the FASTQ format: solexa+64" description_url="https://wiki.galaxyproject.org/Learn/Datatypes#FastqSolexa">

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -49,6 +49,7 @@ class Registry:
         self.log.addHandler(logging.NullHandler())
         self.config = config
         self.datatypes_by_extension = {}
+        self.datatypes_by_suffix_inferences = {}
         self.mimetypes_by_extension = {}
         self.datatype_converters = {}
         # Converters defined in local datatypes_conf.xml
@@ -340,6 +341,16 @@ class Registry:
                                 self.datatypes_by_extension[extension].max_optional_metadata_filesize = elem.get(
                                     "max_optional_metadata_filesize", None
                                 )
+                                infer_from_suffixes = []
+                                # read from element instead of attribute so we can customize references to
+                                # compressed files in the future (e.g. maybe some day faz will be a compressed fasta
+                                # or something along those lines)
+                                for infer_from in elem.findall("infer_from"):
+                                    suffix = infer_from.get("suffix", None)
+                                    if suffix is None:
+                                        raise Exception("Failed to parse infer_from datatype element")
+                                    infer_from_suffixes.append(suffix)
+                                    self.datatypes_by_suffix_inferences[suffix] = datatype_instance
                                 for converter in elem.findall("converter"):
                                     # Build the list of datatype converters which will later be loaded into the calling app's toolbox.
                                     converter_config = converter.get("file", None)
@@ -413,6 +424,10 @@ class Registry:
                                         compressed_datatype_class.edam_data = edam_data
                                     compressed_datatype_instance = compressed_datatype_class()
                                     self.datatypes_by_extension[compressed_extension] = compressed_datatype_instance
+                                    for suffix in infer_from_suffixes:
+                                        self.datatypes_by_suffix_inferences[
+                                            f"{suffix}.{auto_compressed_type}"
+                                        ] = compressed_datatype_instance
                                     if display_in_upload and compressed_extension not in self.upload_file_formats:
                                         self.upload_file_formats.append(compressed_extension)
                                     self.datatype_info_dicts.append(
@@ -630,6 +645,27 @@ class Registry:
                                     if sniffer_class is not None:
                                         if sniffer_class not in sniffer_elem_classes:
                                             self.sniffer_elems.append(elem)
+
+    def get_datatype_from_filename(self, name):
+        max_extension_parts = 3
+        generic_datatype_instance = self.get_datatype_by_extension("data")
+        if "." not in name:
+            return generic_datatype_instance
+        extension_parts = name.rsplit(".", max_extension_parts)[1:]
+        possible_extensions = []
+        for n, _ in enumerate(extension_parts):
+            possible_extensions.append(".".join(extension_parts[n:]))
+
+        infer_from = self.datatypes_by_suffix_inferences
+        for possible_extension in possible_extensions:
+            if possible_extension in infer_from:
+                return infer_from[possible_extension]
+
+        for possible_extension in possible_extensions:
+            if possible_extension in self.datatypes_by_extension:
+                return self.datatypes_by_extension[possible_extension]
+
+        return generic_datatype_instance
 
     def is_extension_unsniffable_binary(self, ext):
         datatype = self.get_datatype_by_extension(ext)

--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -539,6 +539,12 @@ def guess_ext(fname_or_file_prefix: Union[str, "FilePrefix"], sniff_order, is_bi
     return "txt"  # default text data type file extension
 
 
+def guess_ext_from_file_name(fname, registry, requested_ext="auto"):
+    if requested_ext != "auto":
+        return requested_ext
+    return registry.get_datatype_from_filename(fname).file_ext
+
+
 class FilePrefix:
     def __init__(self, filename, auto_decompress=True):
         non_utf8_error = None

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -207,6 +207,13 @@ class ConfiguredFileSources:
         return ConfiguredFileSources(file_sources_config, conf_dict=sources_as_dict)
 
 
+class NullConfiguredFileSources(ConfiguredFileSources):
+    def __init__(
+        self,
+    ):
+        super().__init__(ConfiguredFileSourcesConfig())
+
+
 class ConfiguredFileSourcesConfig:
     def __init__(
         self,

--- a/lib/galaxy/files/unittest_utils/__init__.py
+++ b/lib/galaxy/files/unittest_utils/__init__.py
@@ -14,6 +14,18 @@ class TestConfiguredFileSources(ConfiguredFileSources):
         self.test_root = test_root
 
 
+class TestPosixConfiguredFileSources(TestConfiguredFileSources):
+    """A posix file source at test1 rooted on supplied root."""
+
+    def __init__(self, root: str):
+        plugin = {
+            "type": "posix",
+            "root": root,
+        }
+        file_sources_config = ConfiguredFileSourcesConfig({})
+        super().__init__(file_sources_config, {"test1": plugin}, root)
+
+
 def setup_root():
     tmp = os.path.realpath(tempfile.mkdtemp())
     root = os.path.join(tmp, "root")

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -199,14 +199,14 @@ class BaseJobContext(ModelPersistenceContext):
     def add_dataset_collection(self, collection):
         pass
 
-    def find_files(self, output_name, collection, dataset_collectors):
-        filenames = {}
+    def find_files(self, output_name, collection, dataset_collectors) -> list:
+        discovered_files = []
         for discovered_file in discover_files(
             output_name, self.tool_provided_metadata, dataset_collectors, self.job_working_directory, collection
         ):
             self.increment_discovered_file_count()
-            filenames[discovered_file.path] = discovered_file
-        return filenames
+            discovered_files.append(discovered_file)
+        return discovered_files
 
     def get_job_id(self):
         return None  # overwritten in subclasses

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1871,6 +1871,7 @@ class JobWrapper(HasResourceParameters):
                 if (
                     not final_job_state == job.states.ERROR
                     and not dataset_assoc.dataset.dataset.state == job.states.ERROR
+                    and not dataset_assoc.dataset.dataset.state == model.Dataset.states.DEFERRED
                 ):
                     # We don't set datsets in error state to OK because discover_outputs may have already set the state to error
                     dataset_assoc.dataset.dataset.state = model.Dataset.states.OK

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import OperationalError
 from sqlalchemy.sql.expression import (
     and_,
     func,
+    not_,
     null,
     or_,
     select,
@@ -596,7 +597,12 @@ class JobHandlerQueue(Monitors):
                 .filter(
                     or_(
                         model.Dataset.deleted == true(),
-                        model.Dataset.state != model.Dataset.states.OK,
+                        not_(
+                            or_(
+                                model.Dataset.state == model.Dataset.states.OK,
+                                model.Dataset.state == model.Dataset.states.DEFERRED,
+                            )
+                        ),
                         input_association.deleted == true(),
                         input_association._state == input_association.states.FAILED_METADATA,
                     )

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -43,7 +43,10 @@ from typing import (
     Optional,
 )
 
-from galaxy.exceptions import UserActivationRequiredException
+from galaxy.exceptions import (
+    AuthenticationRequired,
+    UserActivationRequiredException,
+)
 from galaxy.model import (
     Dataset,
     History,
@@ -52,6 +55,7 @@ from galaxy.model import (
 )
 from galaxy.model.base import ModelMapping
 from galaxy.model.scoped_session import galaxy_scoped_session
+from galaxy.schema.tasks import RequestUser
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.security.vault import UserVaultWrapper
 from galaxy.structured_app import MinimalManagerApp
@@ -196,6 +200,12 @@ class ProvidesUserContext(ProvidesAppContext):
     Mixed in class must provide `user` and `app`
     properties.
     """
+
+    @property
+    def async_request_user(self) -> RequestUser:
+        if self.user is None:
+            raise AuthenticationRequired("The async task requires user authentication.")
+        return RequestUser(user_id=self.user.id)
 
     @abc.abstractproperty
     def user(self):

--- a/lib/galaxy/managers/executables.py
+++ b/lib/galaxy/managers/executables.py
@@ -1,17 +1,29 @@
 """Utilities for loading tools and workflows from paths for admin user requests."""
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
 
 import yaml
 
 from galaxy import exceptions
+from galaxy.util import in_directory
 
 
-def artifact_class(trans, as_dict):
+def artifact_class(trans, as_dict: Dict[str, Any], allow_in_directory: Optional[str] = None):
     object_id = as_dict.get("object_id", None)
     if as_dict.get("src", None) == "from_path":
-        if trans and not trans.user_is_admin:
+        workflow_path = as_dict.get("path")
+        allow = not trans or trans.user_is_admin
+        allow = allow or (allow_in_directory and in_directory(workflow_path, allow_in_directory))
+
+        if not allow:
             raise exceptions.AdminRequiredException()
 
-        workflow_path = as_dict.get("path")
+        if not isinstance(workflow_path, str):
+            raise exceptions.RequestParameterInvalidException()
+
         with open(workflow_path) as f:
             as_dict = yaml.safe_load(f)
 

--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -569,7 +569,7 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
                 state = states.QUEUED
             elif hda_state_counts[states.ERROR] > 0 or hda_state_counts[states.FAILED_METADATA] > 0:
                 state = states.ERROR
-            elif hda_state_counts[states.OK] == num_hdas:
+            elif (hda_state_counts[states.OK] + hda_state_counts[states.DEFERRED]) == num_hdas:
                 state = states.OK
 
         return state

--- a/lib/galaxy/managers/model_stores.py
+++ b/lib/galaxy/managers/model_stores.py
@@ -1,9 +1,32 @@
+from typing import Optional
+
 from galaxy import model
+from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.jobs.manager import JobManager
 from galaxy.managers.histories import HistoryManager
 from galaxy.model.scoped_session import galaxy_scoped_session
-from galaxy.schema.tasks import SetupHistoryExportJob
+from galaxy.model.store import (
+    ImportDiscardedDataType,
+    ImportOptions,
+    ObjectImportTracker,
+    source_to_import_store,
+)
+from galaxy.schema.schema import HistoryContentType
+from galaxy.schema.tasks import (
+    GenerateHistoryContentDownload,
+    GenerateHistoryDownload,
+    GenerateInvocationDownload,
+    ImportModelStoreTaskRequest,
+    SetupHistoryExportJob,
+    WriteHistoryContentTo,
+    WriteHistoryTo,
+    WriteInvocationTo,
+)
 from galaxy.structured_app import MinimalManagerApp
+from galaxy.web.short_term_storage import (
+    ShortTermStorageMonitor,
+    storage_context,
+)
 
 
 class ModelStoreManager:
@@ -13,11 +36,13 @@ class ModelStoreManager:
         history_manager: HistoryManager,
         sa_session: galaxy_scoped_session,
         job_manager: JobManager,
+        short_term_storage_monitor: ShortTermStorageMonitor,
     ):
         self._app = app
         self._sa_session = sa_session
         self._job_manager = job_manager
         self._history_manager = history_manager
+        self._short_term_storage_monitor = short_term_storage_monitor
 
     def setup_history_export_job(self, request: SetupHistoryExportJob):
         history_id = request.history_id
@@ -36,3 +61,157 @@ class ModelStoreManager:
         job.state = model.Job.states.NEW
         self._sa_session.flush()
         self._job_manager.enqueue(job)
+
+    def prepare_history_download(self, request: GenerateHistoryDownload):
+        model_store_format = request.model_store_format
+        history = self._history_manager.by_id(request.history_id)
+        export_files = "symlink" if request.include_files else None
+        include_hidden = request.include_hidden
+        include_deleted = request.include_deleted
+        with storage_context(
+            request.short_term_storage_request_id, self._short_term_storage_monitor
+        ) as short_term_storage_target:
+            with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
+                short_term_storage_target.path
+            ) as export_store:
+                export_store.export_history(history, include_hidden=include_hidden, include_deleted=include_deleted)
+
+    def prepare_history_content_download(self, request: GenerateHistoryContentDownload):
+        model_store_format = request.model_store_format
+        export_files = "symlink" if request.include_files else None
+        with storage_context(
+            request.short_term_storage_request_id, self._short_term_storage_monitor
+        ) as short_term_storage_target:
+            with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
+                short_term_storage_target.path
+            ) as export_store:
+                if request.content_type == HistoryContentType.dataset:
+                    hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
+                    export_store.add_dataset(hda)
+                else:
+                    hdca = self._sa_session.query(model.HistoryDatasetCollectionAssociation).get(request.content_id)
+                    export_store.export_collection(
+                        hdca, include_hidden=request.include_hidden, include_deleted=request.include_deleted
+                    )
+
+    def prepare_invocation_download(self, request: GenerateInvocationDownload):
+        model_store_format = request.model_store_format
+        export_files = "symlink" if request.include_files else None
+        with storage_context(
+            request.short_term_storage_request_id, self._short_term_storage_monitor
+        ) as short_term_storage_target:
+            with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
+                short_term_storage_target.path
+            ) as export_store:
+                invocation = self._sa_session.query(model.WorkflowInvocation).get(request.invocation_id)
+                export_store.export_workflow_invocation(
+                    invocation, include_hidden=request.include_hidden, include_deleted=request.include_deleted
+                )
+
+    def write_invocation_to(self, request: WriteInvocationTo):
+        model_store_format = request.model_store_format
+        export_files = "symlink" if request.include_files else None
+        target_uri = request.target_uri
+        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
+            target_uri
+        ) as export_store:
+            invocation = self._sa_session.query(model.WorkflowInvocation).get(request.invocation_id)
+            export_store.export_workflow_invocation(
+                invocation, include_hidden=request.include_hidden, include_deleted=request.include_deleted
+            )
+
+    def write_history_content_to(self, request: WriteHistoryContentTo):
+        model_store_format = request.model_store_format
+        export_files = "symlink" if request.include_files else None
+        target_uri = request.target_uri
+        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
+            target_uri
+        ) as export_store:
+            if request.content_type == HistoryContentType.dataset:
+                hda = self._sa_session.query(model.HistoryDatasetAssociation).get(request.content_id)
+                export_store.add_dataset(hda)
+            else:
+                hdca = self._sa_session.query(model.HistoryDatasetCollectionAssociation).get(request.content_id)
+                export_store.export_collection(
+                    hdca, include_hidden=request.include_hidden, include_deleted=request.include_deleted
+                )
+
+    def write_history_to(self, request: WriteHistoryTo):
+        model_store_format = request.model_store_format
+        export_files = "symlink" if request.include_files else None
+        target_uri = request.target_uri
+        with model.store.get_export_store_factory(self._app, model_store_format, export_files=export_files)(
+            target_uri
+        ) as export_store:
+            history = self._history_manager.by_id(request.history_id)
+            export_store.export_history(
+                history, include_hidden=request.include_hidden, include_deleted=request.include_deleted
+            )
+
+    def import_model_store(self, request: ImportModelStoreTaskRequest):
+        import_options = ImportOptions(
+            discarded_data=ImportDiscardedDataType.FORCE,
+            allow_library_creation=request.for_library,
+        )
+        history_id = request.history_id
+        if history_id:
+            history = self._sa_session.query(model.History).get(history_id)
+        else:
+            history = None
+        user_id = request.user.user_id
+        if user_id:
+            galaxy_user = self._sa_session.query(model.User).get(user_id)
+        else:
+            galaxy_user = None
+        model_import_store = source_to_import_store(
+            request.source_uri,
+            self._app,
+            galaxy_user,
+            import_options,
+        )
+        new_history = history is None and not request.for_library
+        if new_history:
+            if not model_import_store.defines_new_history():
+                raise RequestParameterInvalidException("Supplied model store doesn't define new history to import.")
+            with model_import_store.target_history(legacy_history_naming=False) as new_history:
+                object_tracker = model_import_store.perform_import(new_history, new_history=True)
+                object_tracker.new_history = new_history
+        else:
+            object_tracker = model_import_store.perform_import(
+                history=history,
+                new_history=new_history,
+            )
+        return object_tracker
+
+
+def create_objects_from_store(
+    app: MinimalManagerApp,
+    galaxy_user: Optional[model.User],
+    payload,
+    history: Optional[model.History] = None,
+    for_library: bool = False,
+) -> ObjectImportTracker:
+    import_options = ImportOptions(
+        discarded_data=ImportDiscardedDataType.FORCE,
+        allow_library_creation=for_library,
+    )
+    model_import_store = source_to_import_store(
+        payload.store_content_uri or payload.store_dict,
+        app=app,
+        galaxy_user=galaxy_user,
+        import_options=import_options,
+        model_store_format=payload.model_store_format,
+    )
+    new_history = history is None and not for_library
+    if new_history:
+        if not model_import_store.defines_new_history():
+            raise RequestParameterInvalidException("Supplied model store doesn't define new history to import.")
+        with model_import_store.target_history(legacy_history_naming=False) as new_history:
+            object_tracker = model_import_store.perform_import(new_history, new_history=True)
+            object_tracker.new_history = new_history
+    else:
+        object_tracker = model_import_store.perform_import(
+            history=history,
+            new_history=new_history,
+        )
+    return object_tracker

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2662,9 +2662,9 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
         else:
             if set_hid:
                 dataset.hid = self._next_hid()
+        add_object_to_object_session(dataset, self)
         if quota and is_dataset and self.user:
             self.user.adjust_total_disk_usage(dataset.quota_amount(self.user))
-        add_object_to_object_session(dataset, self)
         dataset.history = self
         if is_dataset and genome_build not in [None, "?"]:
             self.genome_build = genome_build
@@ -3412,10 +3412,17 @@ class Dataset(Base, StorableObject, Serializable, _HasTable):
         OK = "ok"
         EMPTY = "empty"
         ERROR = "error"
-        DISCARDED = "discarded"
         PAUSED = "paused"
         SETTING_METADATA = "setting_metadata"
         FAILED_METADATA = "failed_metadata"
+        # Non-deleted, non-purged datasets that don't have physical files.
+        # These shouldn't have objectstores attached -
+        # 'deferred' can be materialized for jobs using
+        # attached DatasetSource objects but 'discarded'
+        # cannot (e.g. imported histories). These should still
+        # be able to have history contents associated (normal HDAs?)
+        DEFERRED = "deferred"
+        DISCARDED = "discarded"
 
         @classmethod
         def values(self):
@@ -3430,6 +3437,7 @@ class Dataset(Base, StorableObject, Serializable, _HasTable):
         states.OK,
         states.EMPTY,
         states.ERROR,
+        states.DEFERRED,
         states.DISCARDED,
         states.FAILED_METADATA,
     )
@@ -3721,6 +3729,14 @@ class DatasetSource(Base, Dictifiable, Serializable):
         serialization_options.attach_identifier(id_encoder, self, rval)
         return rval
 
+    def copy(self) -> "DatasetSource":
+        new_source = DatasetSource()
+        new_source.source_uri = self.source_uri
+        new_source.extra_files_path = self.extra_files_path
+        new_source.transform = self.transform
+        new_source.hashes = [h.copy() for h in self.hashes]
+        return new_source
+
 
 class DatasetSourceHash(Base, Serializable):
     __tablename__ = "dataset_source_hash"
@@ -3739,6 +3755,12 @@ class DatasetSourceHash(Base, Serializable):
         )
         serialization_options.attach_identifier(id_encoder, self, rval)
         return rval
+
+    def copy(self) -> "DatasetSourceHash":
+        new_hash = DatasetSourceHash()
+        new_hash.hash_function = self.hash_function
+        new_hash.hash_value = self.hash_value
+        return new_hash
 
 
 class DatasetHash(Base, Dictifiable, Serializable):
@@ -3762,6 +3784,13 @@ class DatasetHash(Base, Dictifiable, Serializable):
         )
         serialization_options.attach_identifier(id_encoder, self, rval)
         return rval
+
+    def copy(self) -> "DatasetHash":
+        new_hash = DatasetHash()
+        new_hash.hash_function = self.hash_function
+        new_hash.hash_value = self.hash_value
+        new_hash.extra_files_path = self.extra_files_path
+        return new_hash
 
 
 def datatype_for_extension(extension, datatypes_registry=None) -> "Data":
@@ -3814,6 +3843,7 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
         sa_session=None,
         extended_metadata=None,
         flush=True,
+        metadata_deferred=False,
         creating_job_id=None,
     ):
         self.name = name or "Unnamed dataset"
@@ -3827,6 +3857,7 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
         # set private variable to None here, since the attribute may be needed in by MetadataCollection.__init__
         self._metadata = None
         self.metadata = metadata or dict()
+        self.metadata_deferred = metadata_deferred
         self.extended_metadata = extended_metadata
         if (
             dbkey
@@ -3844,7 +3875,8 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
             if flush:
                 sa_session.add(dataset)
                 sa_session.flush()
-        add_object_to_object_session(self, dataset)
+        elif dataset:
+            add_object_to_object_session(self, dataset)
         self.dataset = dataset
         self.parent_id = parent_id
 
@@ -3859,6 +3891,10 @@ class DatasetInstance(UsesCreateAndUpdateTime, _HasTable):
     @property
     def ext(self):
         return self.extension
+
+    @property
+    def has_deferred_data(self):
+        return self.get_dataset_state() == Dataset.states.DEFERRED
 
     def get_dataset_state(self):
         # self._state is currently only used when setting metadata externally
@@ -4436,12 +4472,13 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
             self.version = self.version + 1 if self.version else 1
             session.add(past_hda)
 
-    def copy_from(self, other_hda):
+    def copy_from(self, other_hda, new_dataset=None, include_tags=True, include_metadata=False):
         # This deletes the old dataset, so make sure to only call this on new things
         # in the history (e.g. during job finishing).
         old_dataset = self.dataset
-        self._metadata = None
-        self.metadata = other_hda.metadata
+        if include_metadata:
+            self._metadata = other_hda._metadata
+        self.metadata_deferred = other_hda.metadata_deferred
         self.info = other_hda.info
         self.blurb = other_hda.blurb
         self.peek = other_hda.peek
@@ -4451,9 +4488,11 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
         self.visible = other_hda.visible
         self.validated_state = other_hda.validated_state
         self.validated_state_message = other_hda.validated_state_message
-        self.copy_tags_from(self.history.user, other_hda)
-        self.dataset = other_hda.dataset
-        old_dataset.full_delete()
+        if include_tags and self.history:
+            self.copy_tags_from(self.history.user, other_hda)
+        self.dataset = new_dataset or other_hda.dataset
+        if old_dataset:
+            old_dataset.full_delete()
 
     def copy(self, parent_id=None, copy_tags=None, flush=True, copy_hid=True, new_name=None):
         """
@@ -5679,6 +5718,27 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         return self._dataset_states_and_extensions_summary
 
     @property
+    def has_deferred_data(self):
+        if not hasattr(self, "_has_deferred_data"):
+            has_deferred_data = False
+            if object_session(self):
+                # TODO: Optimize by just querying without returning the states...
+                q = self._get_nested_collection_attributes(dataset_attributes=("state",))
+                for (state,) in q:
+                    if state == Dataset.states.DEFERRED:
+                        has_deferred_data = True
+                        break
+            else:
+                # This will be in a remote tool evaluation context, so can't query database
+                for dataset_element in self.dataset_elements_and_identifiers():
+                    if dataset_element.hda.state == Dataset.states.DEFERRED:
+                        has_deferred_data = True
+                        break
+            self._has_deferred_data = has_deferred_data
+
+        return self._has_deferred_data
+
+    @property
     def populated_optimized(self):
         if not hasattr(self, "_populated_optimized"):
             _populated_optimized = True
@@ -5960,6 +6020,10 @@ class DatasetCollectionInstance(HasName, UsesCreateAndUpdateTime):
             changed[key] = new_val
 
         return changed
+
+    @property
+    def has_deferred_data(self):
+        return self.collection.has_deferred_data
 
 
 class HistoryDatasetCollectionAssociation(
@@ -6437,6 +6501,10 @@ class DatasetCollectionElement(Base, Dictifiable, Serializable):
             return element_object.dataset_instances
         else:
             return [element_object]
+
+    @property
+    def has_deferred_data(self):
+        return self.element_object.has_deferred_data
 
     def copy_to_collection(
         self,
@@ -7260,7 +7328,7 @@ class WorkflowStepConnection(Base, RepresentById):
         return copied_connection
 
 
-class WorkflowOutput(Base, RepresentById):
+class WorkflowOutput(Base, Serializable):
     __tablename__ = "workflow_output"
 
     id = Column(Integer, primary_key=True)
@@ -7285,6 +7353,14 @@ class WorkflowOutput(Base, RepresentById):
         copied_output.output_name = self.output_name
         copied_output.label = self.label
         return copied_output
+
+    def _serialize(self, id_encoder, serialization_options):
+        return dict_for(
+            self,
+            output_name=self.output_name,
+            label=self.label,
+            uuid=str(self.uuid),
+        )
 
 
 class StoredWorkflowUserShareAssociation(Base, UserShareAssociation):
@@ -7317,7 +7393,7 @@ class StoredWorkflowMenuEntry(Base, RepresentById):
     )
 
 
-class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
+class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, Serializable):
     __tablename__ = "workflow_invocation"
 
     id = Column(Integer, primary_key=True)
@@ -7553,6 +7629,60 @@ class WorkflowInvocation(Base, UsesCreateAndUpdateTime, Dictifiable, RepresentBy
             inputs.append(input_dataset_collection_assoc)
         return inputs
 
+    def _serialize(self, id_encoder, serialization_options):
+        invocation_attrs = dict_for(self)
+        invocation_attrs["state"] = self.state
+        invocation_attrs["create_time"] = self.create_time.__str__()
+        invocation_attrs["update_time"] = self.update_time.__str__()
+
+        steps = []
+        for step in self.steps:
+            steps.append(step.serialize(id_encoder, serialization_options))
+        invocation_attrs["steps"] = steps
+
+        input_parameters = []
+        for input_parameter in self.input_parameters:
+            input_parameters.append(input_parameter.serialize(id_encoder, serialization_options))
+        invocation_attrs["input_parameters"] = input_parameters
+
+        step_states = []
+        for step_state in self.step_states:
+            step_states.append(step_state.serialize(id_encoder, serialization_options))
+        invocation_attrs["step_states"] = step_states
+
+        input_step_parameters = []
+        for input_step_parameter in self.input_step_parameters:
+            input_step_parameters.append(input_step_parameter.serialize(id_encoder, serialization_options))
+        invocation_attrs["input_step_parameters"] = input_step_parameters
+
+        input_datasets = []
+        for input_dataset in self.input_datasets:
+            input_datasets.append(input_dataset.serialize(id_encoder, serialization_options))
+        invocation_attrs["input_datasets"] = input_datasets
+
+        input_dataset_collections = []
+        for input_dataset_collection in self.input_dataset_collections:
+            input_dataset_collections.append(input_dataset_collection.serialize(id_encoder, serialization_options))
+        invocation_attrs["input_dataset_collections"] = input_dataset_collections
+
+        output_dataset_collections = []
+        for output_dataset_collection in self.output_dataset_collections:
+            output_dataset_collections.append(output_dataset_collection.serialize(id_encoder, serialization_options))
+        invocation_attrs["output_dataset_collections"] = output_dataset_collections
+
+        output_datasets = []
+        for output_dataset in self.output_datasets:
+            output_datasets.append(output_dataset.serialize(id_encoder, serialization_options))
+        invocation_attrs["output_datasets"] = output_datasets
+
+        output_values = []
+        for output_value in self.output_values:
+            output_values.append(output_value.serialize(id_encoder, serialization_options))
+        invocation_attrs["output_values"] = output_values
+
+        serialization_options.attach_identifier(id_encoder, self, invocation_attrs)
+        return invocation_attrs
+
     def to_dict(self, view="collection", value_mapper=None, step_details=False, legacy_job_state=False):
         rval = super().to_dict(view=view, value_mapper=value_mapper)
         if view == "element":
@@ -7735,7 +7865,7 @@ class WorkflowInvocationToSubworkflowInvocationAssociation(Base, Dictifiable, Re
     dict_element_visible_keys = ["id", "workflow_step_id", "workflow_invocation_id", "subworkflow_invocation_id"]
 
 
-class WorkflowInvocationStep(Base, Dictifiable, RepresentById):
+class WorkflowInvocationStep(Base, Dictifiable, Serializable):
     __tablename__ = "workflow_invocation_step"
 
     id = Column(Integer, primary_key=True)
@@ -7828,6 +7958,46 @@ class WorkflowInvocationStep(Base, Dictifiable, RepresentById):
         else:
             return []
 
+    def _serialize(self, id_encoder, serialization_options):
+        step_attrs = dict_for(self)
+        step_attrs["state"] = self.state
+        step_attrs["create_time"] = self.create_time.__str__()
+        step_attrs["update_time"] = self.update_time.__str__()
+        step_attrs["order_index"] = self.workflow_step.order_index
+        step_attrs["action"] = self.action
+        if self.job:
+            step_attrs["job"] = self.job.serialize(id_encoder, serialization_options, for_link=True)
+        elif self.implicit_collection_jobs:
+            step_attrs["implicit_collection_jobs"] = self.implicit_collection_jobs.serialize(
+                id_encoder, serialization_options, for_link=True
+            )
+
+        outputs = []
+        for output_dataset_assoc in self.output_datasets:
+            output = dict(
+                output_name=output_dataset_assoc.output_name,
+            )
+            dataset = output_dataset_assoc.dataset
+            if dataset:
+                output["dataset"] = dataset.serialize(id_encoder, serialization_options, for_link=True)
+            outputs.append(output)
+        step_attrs["outputs"] = outputs
+
+        output_collections = []
+        for output_dataset_collection_assoc in self.output_dataset_collections:
+            output_collection = dict(
+                output_name=output_dataset_collection_assoc.output_name,
+            )
+            dataset_collection = output_dataset_collection_assoc.dataset_collection
+            if dataset_collection:
+                output_collection["dataset_collection"] = dataset_collection.serialize(
+                    id_encoder, serialization_options, for_link=True
+                )
+            output_collections.append(output_collection)
+        step_attrs["output_collections"] = output_collections
+
+        return step_attrs
+
     def to_dict(self, view="collection", value_mapper=None):
         rval = super().to_dict(view=view, value_mapper=value_mapper)
         rval["order_index"] = self.workflow_step.order_index
@@ -7865,7 +8035,7 @@ class WorkflowInvocationStep(Base, Dictifiable, RepresentById):
         return rval
 
 
-class WorkflowRequestInputParameter(Base, Dictifiable, RepresentById):
+class WorkflowRequestInputParameter(Base, Dictifiable, Serializable):
     """Workflow-related parameters not tied to steps or inputs."""
 
     __tablename__ = "workflow_request_input_parameters"
@@ -7887,8 +8057,15 @@ class WorkflowRequestInputParameter(Base, Dictifiable, RepresentById):
         META_PARAMETERS = "meta"
         RESOURCE_PARAMETERS = "resource"
 
+    def _serialize(self, id_encoder, serialization_options):
+        request_input_parameter_attrs = dict_for(self)
+        request_input_parameter_attrs["name"] = self.name
+        request_input_parameter_attrs["value"] = self.value
+        request_input_parameter_attrs["type"] = self.type
+        return request_input_parameter_attrs
 
-class WorkflowRequestStepState(Base, Dictifiable, RepresentById):
+
+class WorkflowRequestStepState(Base, Dictifiable, Serializable):
     """Workflow step value parameters."""
 
     __tablename__ = "workflow_request_step_states"
@@ -7904,8 +8081,14 @@ class WorkflowRequestStepState(Base, Dictifiable, RepresentById):
 
     dict_collection_visible_keys = ["id", "name", "value", "workflow_step_id"]
 
+    def _serialize(self, id_encoder, serialization_options):
+        request_step_state = dict_for(self)
+        request_step_state["value"] = self.value
+        request_step_state["order_index"] = self.workflow_step.order_index
+        return request_step_state
 
-class WorkflowRequestToInputDatasetAssociation(Base, Dictifiable, RepresentById):
+
+class WorkflowRequestToInputDatasetAssociation(Base, Dictifiable, Serializable):
     """Workflow step input dataset parameters."""
 
     __tablename__ = "workflow_request_to_input_dataset"
@@ -7923,8 +8106,17 @@ class WorkflowRequestToInputDatasetAssociation(Base, Dictifiable, RepresentById)
     history_content_type = "dataset"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_id", "name"]
 
+    def _serialize(self, id_encoder, serialization_options):
+        request_input_dataset_attrs = dict_for(self)
+        request_input_dataset_attrs["name"] = self.name
+        request_input_dataset_attrs["dataset"] = self.dataset.serialize(
+            id_encoder, serialization_options, for_link=True
+        )
+        request_input_dataset_attrs["order_index"] = self.workflow_step.order_index
+        return request_input_dataset_attrs
 
-class WorkflowRequestToInputDatasetCollectionAssociation(Base, Dictifiable, RepresentById):
+
+class WorkflowRequestToInputDatasetCollectionAssociation(Base, Dictifiable, Serializable):
     """Workflow step input dataset collection parameters."""
 
     __tablename__ = "workflow_request_to_input_collection_dataset"
@@ -7941,8 +8133,17 @@ class WorkflowRequestToInputDatasetCollectionAssociation(Base, Dictifiable, Repr
     history_content_type = "dataset_collection"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_collection_id", "name"]
 
+    def _serialize(self, id_encoder, serialization_options):
+        request_input_collection_attrs = dict_for(self)
+        request_input_collection_attrs["name"] = self.name
+        request_input_collection_attrs["dataset_collection"] = self.dataset_collection.serialize(
+            id_encoder, serialization_options, for_link=True
+        )
+        request_input_collection_attrs["order_index"] = self.workflow_step.order_index
+        return request_input_collection_attrs
 
-class WorkflowRequestInputStepParameter(Base, Dictifiable, RepresentById):
+
+class WorkflowRequestInputStepParameter(Base, Dictifiable, Serializable):
     """Workflow step parameter inputs."""
 
     __tablename__ = "workflow_request_input_step_parameter"
@@ -7957,8 +8158,14 @@ class WorkflowRequestInputStepParameter(Base, Dictifiable, RepresentById):
 
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "parameter_value"]
 
+    def _serialize(self, id_encoder, serialization_options):
+        request_input_step_parameter_attrs = dict_for(self)
+        request_input_step_parameter_attrs["parameter_value"] = self.parameter_value
+        request_input_step_parameter_attrs["order_index"] = self.workflow_step.order_index
+        return request_input_step_parameter_attrs
 
-class WorkflowInvocationOutputDatasetAssociation(Base, Dictifiable, RepresentById):
+
+class WorkflowInvocationOutputDatasetAssociation(Base, Dictifiable, Serializable):
     """Represents links to output datasets for the workflow."""
 
     __tablename__ = "workflow_invocation_output_dataset_association"
@@ -7977,8 +8184,15 @@ class WorkflowInvocationOutputDatasetAssociation(Base, Dictifiable, RepresentByI
     history_content_type = "dataset"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_id", "name"]
 
+    def _serialize(self, id_encoder, serialization_options):
+        output_dataset_attrs = dict_for(self)
+        output_dataset_attrs["dataset"] = self.dataset.serialize(id_encoder, serialization_options, for_link=True)
+        output_dataset_attrs["order_index"] = self.workflow_step.order_index
+        output_dataset_attrs["workflow_output"] = self.workflow_output.serialize(id_encoder, serialization_options)
+        return output_dataset_attrs
 
-class WorkflowInvocationOutputDatasetCollectionAssociation(Base, Dictifiable, RepresentById):
+
+class WorkflowInvocationOutputDatasetCollectionAssociation(Base, Dictifiable, Serializable):
     """Represents links to output dataset collections for the workflow."""
 
     __tablename__ = "workflow_invocation_output_dataset_collection_association"
@@ -7999,8 +8213,17 @@ class WorkflowInvocationOutputDatasetCollectionAssociation(Base, Dictifiable, Re
     history_content_type = "dataset_collection"
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "dataset_collection_id", "name"]
 
+    def _serialize(self, id_encoder, serialization_options):
+        output_collection_attrs = dict_for(self)
+        output_collection_attrs["dataset_collection"] = self.dataset_collection.serialize(
+            id_encoder, serialization_options, for_link=True
+        )
+        output_collection_attrs["order_index"] = self.workflow_step.order_index
+        output_collection_attrs["workflow_output"] = self.workflow_output.serialize(id_encoder, serialization_options)
+        return output_collection_attrs
 
-class WorkflowInvocationOutputValue(Base, Dictifiable, RepresentById):
+
+class WorkflowInvocationOutputValue(Base, Dictifiable, Serializable):
     """Represents a link to a specified or computed workflow parameter."""
 
     __tablename__ = "workflow_invocation_output_value"
@@ -8030,6 +8253,13 @@ class WorkflowInvocationOutputValue(Base, Dictifiable, RepresentById):
     workflow_output = relationship("WorkflowOutput")
 
     dict_collection_visible_keys = ["id", "workflow_invocation_id", "workflow_step_id", "value"]
+
+    def _serialize(self, id_encoder, serialization_options):
+        output_value_attrs = dict_for(self)
+        output_value_attrs["value"] = self.value
+        output_value_attrs["order_index"] = self.workflow_step.order_index
+        output_value_attrs["workflow_output"] = self.workflow_output.serialize(id_encoder, serialization_options)
+        return output_value_attrs
 
 
 class WorkflowInvocationStepOutputDatasetAssociation(Base, Dictifiable, RepresentById):
@@ -9449,6 +9679,7 @@ HistoryDatasetAssociation.table = Table(
     Column("tool_version", TEXT),
     Column("extension", TrimmedString(64)),
     Column("metadata", MetadataType, key="_metadata"),
+    Column("metadata_deferred", Boolean, key="metadata_deferred"),
     Column("parent_id", Integer, ForeignKey("history_dataset_association.id"), nullable=True),
     Column("designation", TrimmedString(255)),
     Column("deleted", Boolean, index=True, default=False),
@@ -9496,6 +9727,7 @@ LibraryDatasetDatasetAssociation.table = Table(
     Column("tool_version", TEXT),
     Column("extension", TrimmedString(64)),
     Column("metadata", MetadataType, key="_metadata"),
+    Column("metadata_deferred", Boolean, key="metadata_deferred"),
     Column("parent_id", Integer, ForeignKey("library_dataset_dataset_association.id"), nullable=True),
     Column("designation", TrimmedString(255)),
     Column("deleted", Boolean, index=True, default=False),
@@ -9506,6 +9738,7 @@ LibraryDatasetDatasetAssociation.table = Table(
     Column("user_id", Integer, ForeignKey("galaxy_user.id"), index=True),
     Column("message", TrimmedString(255)),
 )
+
 
 mapper_registry.map_imperatively(
     HistoryDatasetAssociation,

--- a/lib/galaxy/model/deferred.py
+++ b/lib/galaxy/model/deferred.py
@@ -1,0 +1,287 @@
+import abc
+import logging
+import os
+import shutil
+from typing import (
+    cast,
+    NamedTuple,
+    Optional,
+    Union,
+)
+
+from sqlalchemy.orm import object_session
+from sqlalchemy.orm.exc import DetachedInstanceError
+from sqlalchemy.orm.scoping import scoped_session
+
+from galaxy.datatypes.sniff import (
+    convert_function,
+    stream_url_to_file,
+)
+from galaxy.exceptions import ObjectAttributeInvalidException
+from galaxy.files import ConfiguredFileSources
+from galaxy.model import (
+    Dataset,
+    DatasetCollection,
+    DatasetCollectionElement,
+    DatasetSource,
+    History,
+    HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
+    LibraryDatasetDatasetAssociation,
+)
+from galaxy.objectstore import (
+    ObjectStore,
+    ObjectStorePopulator,
+)
+
+log = logging.getLogger(__name__)
+
+
+class TransientDatasetPaths(NamedTuple):
+    external_filename: str
+    external_extra_files_path: str
+
+
+class TransientPathMapper:
+    @abc.abstractmethod
+    def transient_paths_for(self, old_dataset: Dataset) -> TransientDatasetPaths:
+        """Map dataset to transient paths for detached HDAs.
+
+        Decide external_filename and external_extra_files_path that the supplied dataset's
+        materialized dataset should have its files written to.
+        """
+
+
+class SimpleTransientPathMapper(TransientPathMapper):
+    def __init__(self, staging_directory: str):
+        self._staging_directory = staging_directory
+
+    def transient_paths_for(self, old_dataset: Dataset) -> TransientDatasetPaths:
+        external_filename_basename = "dataset_%s.dat" % str(old_dataset.uuid)
+        external_filename = os.path.join(self._staging_directory, external_filename_basename)
+        external_extras_basename = "dataset_%s_files" % str(old_dataset.uuid)
+        external_extras = os.path.join(self._staging_directory, external_extras_basename)
+        return TransientDatasetPaths(external_filename, external_extras)
+
+
+class DatasetInstanceMaterializer:
+    """This class is responsible for ensuring dataset instances are not deferred."""
+
+    def __init__(
+        self,
+        attached: bool,
+        object_store_populator: Optional[ObjectStorePopulator] = None,
+        transient_path_mapper: Optional[TransientPathMapper] = None,
+        file_sources: Optional[ConfiguredFileSources] = None,
+        sa_session: Optional[scoped_session] = None,
+    ):
+        """Constructor for DatasetInstanceMaterializer.
+
+        If attached is true, these objects should be created in a supplied object store.
+        If not, this class produces transient HDAs with external_filename and
+        external_extra_files_path set.
+        """
+        self._attached = attached
+        self._transient_path_mapper = transient_path_mapper
+        self._object_store_populator = object_store_populator
+        self._file_sources = file_sources
+        self._sa_session = sa_session
+
+    def ensure_materialized(
+        self,
+        dataset_instance: Union[HistoryDatasetAssociation, LibraryDatasetDatasetAssociation],
+        target_history: Optional[History] = None,
+    ) -> HistoryDatasetAssociation:
+        """Create a new detached dataset instance from the supplied instance.
+
+        There will be times we want it usable as is without an objectstore and times
+        we want to place it in an objectstore.
+        """
+        attached = self._attached
+        dataset = dataset_instance.dataset
+        if dataset.state != Dataset.states.DEFERRED and isinstance(dataset_instance, HistoryDatasetAssociation):
+            return dataset_instance
+
+        materialized_dataset = Dataset()
+        materialized_dataset.state = Dataset.states.OK
+        materialized_dataset.deleted = False
+        materialized_dataset.purged = False
+        materialized_dataset.sources = [s.copy() for s in dataset.sources]
+        materialized_dataset.hashes = [h.copy() for h in dataset.hashes]
+
+        target_source = self._find_closest_dataset_source(dataset)
+        if attached:
+            object_store_populator = self._object_store_populator
+            assert object_store_populator
+            object_store = object_store_populator.object_store
+            store_by = object_store.get_store_by(dataset)
+            if store_by == "id":
+                # we need a flush...
+                sa_session = self._sa_session
+                if sa_session is None:
+                    sa_session = object_session(dataset_instance)
+                sa_session.add(materialized_dataset)
+                sa_session.flush()
+            object_store_populator.set_dataset_object_store_id(materialized_dataset)
+            path = self._stream_source(target_source, datatype=dataset_instance.datatype)
+            object_store.update_from_file(materialized_dataset, file_name=path)
+        else:
+            transient_path_mapper = self._transient_path_mapper
+            assert transient_path_mapper
+            transient_paths = transient_path_mapper.transient_paths_for(dataset)
+            # TODO: optimize this by streaming right to this path...
+            # TODO: take into acount transform and ensure we are and are not modifying the file as appropriate.
+            path = self._stream_source(target_source, datatype=dataset_instance.datatype)
+            shutil.move(path, transient_paths.external_filename)
+            materialized_dataset.external_filename = transient_paths.external_filename
+
+        history = target_history
+        if history is None and isinstance(dataset_instance, HistoryDatasetAssociation):
+            try:
+                history = dataset_instance.history
+            except DetachedInstanceError:
+                history = None
+        materialized_dataset_instance = HistoryDatasetAssociation(
+            create_dataset=False,  # is the default but lets make this really clear...
+            history=history,
+        )
+        if attached:
+            sa_session = self._sa_session
+            if sa_session is None:
+                sa_session = object_session(dataset_instance)
+            sa_session.add(materialized_dataset_instance)
+        materialized_dataset_instance.copy_from(
+            dataset_instance, new_dataset=materialized_dataset, include_tags=attached, include_metadata=True
+        )
+        require_metadata_regeneration = (
+            materialized_dataset_instance.has_metadata_files or materialized_dataset_instance.metadata_deferred
+        )
+        if require_metadata_regeneration:
+            if attached and self._sa_session:
+                # as of mid April 2022, we now get JSON encoding errors if this
+                # isn't bound to the session before metadata generation.
+                self._sa_session.add(materialized_dataset_instance)
+            materialized_dataset_instance.init_meta()
+            materialized_dataset_instance.set_meta()
+            materialized_dataset_instance.metadata_deferred = False
+        return materialized_dataset_instance
+
+    def _stream_source(self, target_source: DatasetSource, datatype) -> str:
+        path = stream_url_to_file(target_source.source_uri, file_sources=self._file_sources)
+        transform = target_source.transform or []
+        to_posix_lines = False
+        spaces_to_tabs = False
+        datatype_groom = False
+        for transform_action in transform:
+            action = transform_action["action"]
+            if action == "to_posix_lines":
+                to_posix_lines = True
+            elif action == "spaces_to_tabs":
+                spaces_to_tabs = True
+            elif action == "datatype_groom":
+                datatype_groom = True
+            else:
+                raise Exception(f"Failed to materialize dataest, unknown transformation action {action} applied.")
+        if to_posix_lines or spaces_to_tabs:
+            convert_fxn = convert_function(to_posix_lines, spaces_to_tabs)
+            convert_result = convert_fxn(path, False)
+            assert convert_result.converted_path
+            path = convert_result.converted_path
+        if datatype_groom:
+            datatype.groom_dataset_content(path)
+        return path
+
+    def _find_closest_dataset_source(self, dataset: Dataset) -> DatasetSource:
+        best_source = None
+        for source in dataset.sources:
+            if source.extra_files_path:
+                continue
+            best_source = source
+            break
+        if best_source is None:
+            # TODO: implement test case...
+            raise ObjectAttributeInvalidException("dataset does not contain any valid dataset sources")
+        return best_source
+
+
+CollectionInputT = Union[HistoryDatasetCollectionAssociation, DatasetCollectionElement]
+
+
+def materialize_collection_input(
+    collection_input: CollectionInputT, materializer: DatasetInstanceMaterializer
+) -> CollectionInputT:
+    if isinstance(collection_input, HistoryDatasetCollectionAssociation):
+        return materialize_collection_instance(
+            cast(HistoryDatasetCollectionAssociation, collection_input), materializer
+        )
+    else:
+        return _materialize_collection_element(cast(DatasetCollectionElement, collection_input), materializer)
+
+
+def materialize_collection_instance(
+    hdca: HistoryDatasetCollectionAssociation, materializer: DatasetInstanceMaterializer
+) -> HistoryDatasetCollectionAssociation:
+    if materializer._attached:
+        raise NotImplementedError("Materializing collections to attached collections unimplemented")
+
+    if not hdca.has_deferred_data:
+        return hdca
+
+    materialized_instance = HistoryDatasetCollectionAssociation()
+    materialized_instance.name = hdca.name
+    materialized_instance.collection = _materialize_collection(hdca.collection, materializer)
+    # TODO: tags
+    return materialized_instance
+
+
+def _materialize_collection(
+    dataset_collection: DatasetCollection, materializer: DatasetInstanceMaterializer
+) -> DatasetCollection:
+    materialized_collection = DatasetCollection()
+
+    materialized_elements = []
+    for element in dataset_collection.elements:
+        materialized_elements.append(_materialize_collection_element(element, materializer))
+    materialized_collection.elements = materialized_elements
+    return materialized_collection
+
+
+def _materialize_collection_element(
+    element: DatasetCollectionElement, materializer: DatasetInstanceMaterializer
+) -> DatasetCollectionElement:
+    materialized_object: Union[DatasetCollection, HistoryDatasetAssociation, LibraryDatasetDatasetAssociation]
+    if element.is_collection:
+        assert element.child_collection
+        materialized_object = _materialize_collection(element.child_collection, materializer)
+    else:
+        element_object = element.dataset_instance
+        assert element_object
+        materialized_object = materializer.ensure_materialized(element_object)
+    materialized_element = DatasetCollectionElement(
+        element=materialized_object,
+        element_index=element.element_index,
+        element_identifier=element.element_identifier,
+    )
+    return materialized_element
+
+
+def materializer_factory(
+    attached: bool,
+    object_store: Optional[ObjectStore] = None,
+    object_store_populator: Optional[ObjectStorePopulator] = None,
+    transient_path_mapper: Optional[TransientPathMapper] = None,
+    transient_directory: Optional[str] = None,
+    file_sources: Optional[ConfiguredFileSources] = None,
+    sa_session: Optional[scoped_session] = None,
+) -> DatasetInstanceMaterializer:
+    if object_store_populator is None and object_store is not None:
+        object_store_populator = ObjectStorePopulator(object_store, None)
+    if transient_path_mapper is None and transient_directory is not None:
+        transient_path_mapper = SimpleTransientPathMapper(transient_directory)
+    return DatasetInstanceMaterializer(
+        attached,
+        object_store_populator=object_store_populator,
+        transient_path_mapper=transient_path_mapper,
+        file_sources=file_sources,
+        sa_session=sa_session,
+    )

--- a/lib/galaxy/model/migrations/alembic/versions_gxy/6a67bf27e6a6_deferred_data_tables.py
+++ b/lib/galaxy/model/migrations/alembic/versions_gxy/6a67bf27e6a6_deferred_data_tables.py
@@ -1,0 +1,30 @@
+"""deferred data tables
+
+Revision ID: 6a67bf27e6a6
+Revises: b182f655505f
+Create Date: 2022-03-14 12:17:55.313830
+
+"""
+from alembic import op
+from sqlalchemy import (
+    Boolean,
+    Column,
+)
+
+from galaxy.model.migrations.util import drop_column
+
+# revision identifiers, used by Alembic.
+revision = "6a67bf27e6a6"
+down_revision = "b182f655505f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("history_dataset_association", Column("metadata_deferred", Boolean(), default=False))
+    op.add_column("library_dataset_dataset_association", Column("metadata_deferred", Boolean(), default=False))
+
+
+def downgrade():
+    drop_column("history_dataset_association", "metadata_deferred")
+    drop_column("library_dataset_dataset_association", "metadata_deferred")

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -6,11 +6,13 @@ import shutil
 import tarfile
 import tempfile
 from collections import defaultdict
+from enum import Enum
 from json import (
     dump,
     dumps,
     load,
 )
+from tempfile import mkdtemp
 from typing import (
     Any,
     Callable,
@@ -20,6 +22,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
     Union,
 )
 
@@ -33,7 +36,10 @@ from galaxy.datatypes.registry import Registry
 from galaxy.exceptions import (
     MalformedContents,
     ObjectNotFound,
+    RequestParameterInvalidException,
 )
+from galaxy.files import ConfiguredFileSources
+from galaxy.files.uris import stream_url_to_file
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.metadata import MetadataCollection
 from galaxy.model.orm.util import (
@@ -46,8 +52,10 @@ from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import (
     FILENAME_VALID_CHARS,
     in_directory,
+    safe_makedirs,
 )
 from galaxy.util.bunch import Bunch
+from galaxy.util.compression_utils import CompressedFile
 from galaxy.util.path import safe_walk
 from ..custom_types import json_encoder
 from ..item_attrs import (
@@ -66,8 +74,17 @@ ATTRS_FILENAME_COLLECTIONS = "collections_attrs.txt"
 ATTRS_FILENAME_EXPORT = "export_attrs.txt"
 ATTRS_FILENAME_LIBRARIES = "libraries_attrs.txt"
 ATTRS_FILENAME_LIBRARY_FOLDERS = "library_folders_attrs.txt"
+ATTRS_FILENAME_INVOCATIONS = "invocation_attrs.txt"
 TRACEBACK = "traceback.txt"
 GALAXY_EXPORT_VERSION = "2"
+
+DICT_STORE_ATTRS_KEY_HISTORY = "history"
+DICT_STORE_ATTRS_KEY_DATASETS = "datasets"
+DICT_STORE_ATTRS_KEY_COLLECTIONS = "collections"
+DICT_STORE_ATTRS_KEY_JOBS = "jobs"
+DICT_STORE_ATTRS_KEY_IMPLICIT_COLLECTION_JOBS = "implicit_collection_jobs"
+DICT_STORE_ATTRS_KEY_LIBRARIES = "libraries"
+DICT_STORE_ATTRS_KEY_INVOCATIONS = "invocations"
 
 
 JsonDictT = Dict[str, Any]
@@ -80,15 +97,41 @@ class StoreAppProtocol(Protocol):
     object_store: ObjectStore
     security: IdEncodingHelper
     model: GalaxyModelMapping
+    file_sources: ConfiguredFileSources
+
+
+class ImportDiscardedDataType(Enum):
+    # Don't allow discarded 'okay' datasets on import, datasets will be marked deleted.
+    FORBID = "forbid"
+    # Allow datasets to be imported as experimental DISCARDED datasets that are not deleted if file data unavailable.
+    ALLOW = "allow"
+    # Import all datasets as discarded regardless of whether file data is available in the store.
+    FORCE = "force"
+
+
+DEFAULT_DISCARDED_DATA_TYPE = ImportDiscardedDataType.FORBID
 
 
 class ImportOptions:
-    def __init__(self, allow_edit=False, allow_library_creation=False, allow_dataset_object_edit=None):
+    allow_edit: bool
+    allow_library_creation: bool
+    allow_dataset_object_edit: bool
+    discarded_data: ImportDiscardedDataType
+
+    def __init__(
+        self,
+        allow_edit=False,
+        allow_library_creation=False,
+        allow_dataset_object_edit=None,
+        discarded_data=DEFAULT_DISCARDED_DATA_TYPE,
+    ):
         self.allow_edit = allow_edit
         self.allow_library_creation = allow_library_creation
         if allow_dataset_object_edit is None:
-            allow_dataset_object_edit = allow_edit
-        self.allow_dataset_object_edit = allow_dataset_object_edit
+            self.allow_dataset_object_edit = allow_edit
+        else:
+            self.allow_dataset_object_edit = allow_dataset_object_edit
+        self.discarded_data = discarded_data
 
 
 class SessionlessContext:
@@ -191,14 +234,16 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         """Trust HID when importing objects into a new History."""
 
     @contextlib.contextmanager
-    def target_history(self, default_history=None):
+    def target_history(self, default_history=None, legacy_history_naming=True):
         new_history = None
 
         if self.defines_new_history():
             history_properties = self.new_history_properties()
             history_name = history_properties.get("name")
-            if history_name:
+            if history_name and legacy_history_naming:
                 history_name = f"imported from archive: {history_name}"
+            elif history_name:
+                pass  # history_name = history_name
             else:
                 history_name = "unnamed imported history"
 
@@ -247,7 +292,9 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         self._reassign_hids(object_import_tracker, history)
         self._import_jobs(object_import_tracker, history)
         self._import_implicit_collection_jobs(object_import_tracker)
+        self._import_workflow_invocations(object_import_tracker, history)
         self._flush()
+        return object_import_tracker
 
     def _attach_dataset_hashes(self, dataset_or_file_attrs, dataset_instance):
         if "hashes" in dataset_or_file_attrs:
@@ -333,7 +380,12 @@ class ModelImportStore(metaclass=abc.ABCMeta):
 
                 handle_dataset_object_edit(dataset_instance)
             else:
-                metadata = dataset_attrs["metadata"]
+                metadata_deferred = dataset_attrs.get("metadata_deferred", False)
+                metadata = dataset_attrs.get("metadata")
+                if metadata is None and not metadata_deferred:
+                    raise MalformedContents("metadata_deferred must be true if no metadata found in dataset attributes")
+                if metadata is None:
+                    metadata = {"dbkey": "?"}
 
                 model_class = dataset_attrs.get("model_class", "HistoryDatasetAssociation")
                 dataset_instance: model.DatasetInstance
@@ -350,6 +402,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         deleted=dataset_attrs.get("deleted", False),
                         dbkey=metadata["dbkey"],
                         tool_version=metadata.get("tool_version"),
+                        metadata_deferred=metadata_deferred,
                         history=history,
                         create_dataset=True,
                         flush=False,
@@ -369,6 +422,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         deleted=dataset_attrs.get("deleted", False),
                         dbkey=metadata["dbkey"],
                         tool_version=metadata.get("tool_version"),
+                        metadata_deferred=metadata_deferred,
                         user=self.user,
                         create_dataset=True,
                         flush=False,
@@ -401,6 +455,10 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         hda.hid = dataset_attrs["hid"]
                     else:
                         object_import_tracker.requires_hid.append(hda)
+                else:
+                    pass
+                    # ldda = cast(model.LibraryDatasetDatasetAssociation, dataset_instance)
+                    # ldda.user = self.user
 
                 file_source_root = self.file_source_root
 
@@ -424,14 +482,41 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         if not in_directory(temp_dataset_file_name, file_source_root):
                             raise MalformedContents(f"Invalid dataset path: {temp_dataset_file_name}")
 
-                    if not file_name or not os.path.exists(temp_dataset_file_name):
-                        dataset_instance.state = dataset_instance.states.DISCARDED
-                        dataset_instance.deleted = True
-                        dataset_instance.purged = True
-                        dataset_instance.dataset.deleted = True
-                        dataset_instance.dataset.purged = True
+                    has_good_source = False
+                    file_metadata = dataset_attrs.get("file_metadata") or {}
+                    if "sources" in file_metadata:
+                        for source_attrs in file_metadata["sources"]:
+                            extra_files_path = source_attrs["extra_files_path"]
+                            if extra_files_path is None:
+                                has_good_source = True
+
+                    discarded_data = self.import_options.discarded_data
+                    dataset_state = dataset_attrs.get("state", dataset_instance.states.OK)
+                    if dataset_state == dataset_instance.states.DEFERRED:
+                        dataset_instance._state = dataset_instance.states.DEFERRED
+                        dataset_instance.deleted = False
+                        dataset_instance.purged = False
+                        dataset_instance.dataset.state = dataset_instance.states.DEFERRED
+                        dataset_instance.dataset.deleted = False
+                        dataset_instance.dataset.purged = False
+                    elif (
+                        not file_name
+                        or not os.path.exists(temp_dataset_file_name)
+                        or discarded_data is ImportDiscardedDataType.FORCE
+                    ):
+                        is_discarded = not has_good_source
+                        target_state = (
+                            dataset_instance.states.DISCARDED if is_discarded else dataset_instance.states.DEFERRED
+                        )
+                        dataset_instance._state = target_state
+                        deleted = is_discarded and (discarded_data == ImportDiscardedDataType.FORBID)
+                        dataset_instance.deleted = deleted
+                        dataset_instance.purged = deleted
+                        dataset_instance.dataset.state = target_state
+                        dataset_instance.dataset.deleted = deleted
+                        dataset_instance.dataset.purged = deleted
                     else:
-                        dataset_instance.state = dataset_attrs.get("state", dataset_instance.states.OK)
+                        dataset_instance.state = dataset_state
                         self.object_store.update_from_file(
                             dataset_instance.dataset, file_name=temp_dataset_file_name, create=True
                         )
@@ -462,7 +547,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
 
                     if dataset_instance.deleted:
                         dataset_instance.dataset.deleted = True
-                    file_metadata = dataset_attrs.get("file_metadata") or {}
                     self._attach_dataset_hashes(file_metadata, dataset_instance)
                     self._attach_dataset_sources(file_metadata, dataset_instance)
                     if "created_from_basename" in file_metadata:
@@ -477,9 +561,26 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         )
 
                 if self.app:
-                    self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
-                        dataset_instance, history, job
-                    )
+                    # If dataset instance is discarded or deferred, don't attempt to regenerate
+                    # metadata for it.
+                    if dataset_instance.state == dataset_instance.states.OK:
+                        regenerate_kwds: Dict[str, Any] = {}
+                        if job:
+                            regenerate_kwds["user"] = job.user
+                            regenerate_kwds["session_id"] = job.session_id
+                        elif history:
+                            user = history.user
+                            regenerate_kwds["user"] = user
+                            if user is None:
+                                regenerate_kwds["session_id"] = history.galaxy_sessions[0].galaxy_session.id
+                            else:
+                                regenerate_kwds["session_id"] = None
+                        else:
+                            # Need a user to run library jobs to generate metadata...
+                            pass
+                        self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(
+                            dataset_instance, history, **regenerate_kwds
+                        )
 
                 if model_class == "HistoryDatasetAssociation":
                     if object_key in dataset_attrs:
@@ -752,6 +853,192 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 history.stage_addition(obj)
             history.add_pending_items()
 
+    def _import_workflow_invocations(self, object_import_tracker, history):
+        #
+        # Create jobs.
+        #
+        object_key = self.object_key
+
+        for workflow_key, workflow_path in self.workflow_paths():
+            workflows_directory = os.path.join(self.archive_dir, "workflows")
+            workflow = self.app.workflow_contents_manager.read_workflow_from_path(
+                self.app, self.user, workflow_path, allow_in_directory=workflows_directory
+            )
+            object_import_tracker.workflows_by_key[workflow_key] = workflow
+
+        invocations_attrs = self.invocations_properties()
+        for invocation_attrs in invocations_attrs:
+            assert not self.import_options.allow_edit
+            imported_invocation = model.WorkflowInvocation()
+            imported_invocation.user = self.user
+            imported_invocation.history = history
+            workflow_key = invocation_attrs["workflow"]
+            if workflow_key not in object_import_tracker.workflows_by_key:
+                raise Exception(f"Failed to find key {workflow_key} in {object_import_tracker.workflows_by_key.keys()}")
+            workflow = object_import_tracker.workflows_by_key[workflow_key]
+            imported_invocation.workflow = workflow
+            state = invocation_attrs["state"]
+            if state in model.WorkflowInvocation.non_terminal_states:
+                state = model.WorkflowInvocation.states.CANCELLED
+            imported_invocation.state = state
+            restore_times(imported_invocation, invocation_attrs)
+
+            self._session_add(imported_invocation)
+            self._flush()
+
+            def attach_workflow_step(imported_object, attrs):
+                order_index = attrs["order_index"]
+                imported_object.workflow_step = workflow.step_by_index(order_index)
+
+            for step_attrs in invocation_attrs["steps"]:
+                imported_invocation_step = model.WorkflowInvocationStep()
+                imported_invocation_step.workflow_invocation = imported_invocation
+                attach_workflow_step(imported_invocation_step, step_attrs)
+                restore_times(imported_invocation_step, step_attrs)
+                imported_invocation_step.action = step_attrs["action"]
+
+                # TODO: ensure terminal...
+                imported_invocation_step.state = step_attrs["state"]
+
+                if "job" in step_attrs:
+                    job = object_import_tracker.jobs_by_key[step_attrs["job"][object_key]]
+                    imported_invocation_step.job = job
+                elif "implicit_collection_jobs" in step_attrs:
+                    icj = object_import_tracker.implicit_collection_jobs_by_key[
+                        step_attrs["implicit_collection_jobs"][object_key]
+                    ]
+                    imported_invocation_step.implicit_collection_jobs = icj
+
+                # TODO: handle step outputs...
+                output_dicts = step_attrs["outputs"]
+                step_outputs = []
+                for output_dict in output_dicts:
+                    step_output = model.WorkflowInvocationStepOutputDatasetAssociation()
+                    step_output.output_name = output_dict["output_name"]
+                    dataset_link_attrs = output_dict["dataset"]
+                    if dataset_link_attrs:
+                        dataset = object_import_tracker.find_hda(dataset_link_attrs[object_key])
+                        assert dataset
+                        step_output.dataset = dataset
+
+                    step_outputs.append(step_output)
+
+                imported_invocation_step.output_datasets = step_outputs
+
+                output_collection_dicts = step_attrs["output_collections"]
+                step_output_collections = []
+                for output_collection_dict in output_collection_dicts:
+                    step_output_collection = model.WorkflowInvocationStepOutputDatasetCollectionAssociation()
+                    step_output_collection.output_name = output_collection_dict["output_name"]
+                    dataset_collection_link_attrs = output_collection_dict["dataset_collection"]
+                    if dataset_collection_link_attrs:
+                        dataset_collection = object_import_tracker.find_hdca(dataset_collection_link_attrs[object_key])
+                        assert dataset_collection
+                        step_output_collection.dataset_collection = dataset_collection
+
+                    step_output_collections.append(step_output_collection)
+
+                imported_invocation_step.output_dataset_collections = step_output_collections
+
+            input_parameters = []
+            for input_parameter_attrs in invocation_attrs["input_parameters"]:
+                input_parameter = model.WorkflowRequestInputParameter()
+                input_parameter.value = input_parameter_attrs["value"]
+                input_parameter.name = input_parameter_attrs["name"]
+                input_parameter.type = input_parameter_attrs["type"]
+                input_parameter.workflow_invocation = imported_invocation
+                self._session_add(input_parameter)
+                input_parameters.append(input_parameter)
+
+            # invocation_attrs["input_parameters"] = input_parameters
+
+            step_states = []
+            for step_state_attrs in invocation_attrs["step_states"]:
+                step_state = model.WorkflowRequestStepState()
+                step_state.value = step_state_attrs["value"]
+                attach_workflow_step(step_state, step_state_attrs)
+                step_state.workflow_invocation = imported_invocation
+                self._session_add(step_state)
+                step_states.append(step_state)
+
+            input_step_parameters = []
+            for input_step_parameter_attrs in invocation_attrs["input_step_parameters"]:
+                input_step_parameter = model.WorkflowRequestInputStepParameter()
+                input_step_parameter.parameter_value = input_step_parameter_attrs["parameter_value"]
+                attach_workflow_step(input_step_parameter, input_step_parameter_attrs)
+                input_step_parameter.workflow_invocation = imported_invocation
+                self._session_add(input_step_parameter)
+                input_step_parameters.append(input_step_parameter)
+
+            input_datasets = []
+            for input_dataset_attrs in invocation_attrs["input_datasets"]:
+                input_dataset = model.WorkflowRequestToInputDatasetAssociation()
+                attach_workflow_step(input_dataset, input_dataset_attrs)
+                input_dataset.workflow_invocation = imported_invocation
+                input_dataset.name = input_dataset_attrs["name"]
+                dataset_link_attrs = input_dataset_attrs["dataset"]
+                if dataset_link_attrs:
+                    dataset = object_import_tracker.find_hda(dataset_link_attrs[object_key])
+                    assert dataset
+                    input_dataset.dataset = dataset
+                self._session_add(input_dataset)
+                input_datasets.append(input_dataset)
+
+            input_dataset_collections = []
+            for input_dataset_collection_attrs in invocation_attrs["input_dataset_collections"]:
+                input_dataset_collection = model.WorkflowRequestToInputDatasetCollectionAssociation()
+                attach_workflow_step(input_dataset_collection, input_dataset_collection_attrs)
+                input_dataset_collection.workflow_invocation = imported_invocation
+                input_dataset_collection.name = input_dataset_collection_attrs["name"]
+                dataset_collection_link_attrs = input_dataset_collection_attrs["dataset_collection"]
+                if dataset_collection_link_attrs:
+                    dataset_collection = object_import_tracker.find_hdca(dataset_collection_link_attrs[object_key])
+                    assert dataset_collection
+                    input_dataset_collection.dataset_collection = dataset_collection
+
+                self._session_add(input_dataset_collection)
+                input_dataset_collections.append(input_dataset_collection)
+
+            output_dataset_collections = []
+            for output_dataset_collection_attrs in invocation_attrs["output_dataset_collections"]:
+                output_dataset_collection = model.WorkflowInvocationOutputDatasetCollectionAssociation()
+                output_dataset_collection.workflow_invocation = imported_invocation
+                attach_workflow_step(output_dataset_collection, output_dataset_collection_attrs)
+                workflow_output = output_dataset_collection_attrs["workflow_output"]
+                label = workflow_output.get("label")
+                workflow_output = workflow.workflow_output_for(label)
+                output_dataset_collection.workflow_output = workflow_output
+                self._session_add(output_dataset_collection)
+                output_dataset_collections.append(output_dataset_collection)
+
+            output_datasets = []
+            for output_dataset_attrs in invocation_attrs["output_datasets"]:
+                output_dataset = model.WorkflowInvocationOutputDatasetAssociation()
+                output_dataset.workflow_invocation = imported_invocation
+                attach_workflow_step(output_dataset, output_dataset_attrs)
+                workflow_output = output_dataset_attrs["workflow_output"]
+                label = workflow_output.get("label")
+                workflow_output = workflow.workflow_output_for(label)
+                output_dataset.workflow_output = workflow_output
+                self._session_add(output_dataset)
+                output_datasets.append(output_dataset)
+
+            output_values = []
+            for output_value_attrs in invocation_attrs["output_values"]:
+                output_value = model.WorkflowInvocationOutputValue()
+                output_value.workflow_invocation = imported_invocation
+                output_value.value = output_value_attrs["value"]
+                attach_workflow_step(output_value, output_value_attrs)
+                workflow_output = output_value_attrs["workflow_output"]
+                label = workflow_output.get("label")
+                workflow_output = workflow.workflow_output_for(label)
+                output_value.workflow_output = workflow_output
+                self._session_add(output_value)
+                output_values.append(output_value)
+
+            if object_key in invocation_attrs:
+                object_import_tracker.invocations_by_key[invocation_attrs[object_key]] = imported_invocation
+
     def _import_jobs(self, object_import_tracker, history):
         self._flush()
         object_key = self.object_key
@@ -786,11 +1073,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             imported_job.tool_version = job_attrs["tool_version"]
             self._set_job_attributes(imported_job, job_attrs, force_terminal=True)
 
-            try:
-                imported_job.create_time = datetime.datetime.strptime(job_attrs["create_time"], "%Y-%m-%dT%H:%M:%S.%f")
-                imported_job.update_time = datetime.datetime.strptime(job_attrs["update_time"], "%Y-%m-%dT%H:%M:%S.%f")
-            except Exception:
-                pass
+            restore_times(imported_job, job_attrs)
             self._session_add(imported_job)
 
             # Connect jobs to input and output datasets.
@@ -805,6 +1088,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 object_import_tracker.jobs_by_key[job_attrs[object_key]] = imported_job
 
     def _import_implicit_collection_jobs(self, object_import_tracker):
+        object_key = self.object_key
+
         implicit_collection_jobs_attrs = self.implicit_collection_jobs_properties()
         for icj_attrs in implicit_collection_jobs_attrs:
             icj = model.ImplicitCollectionJobs()
@@ -822,6 +1107,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 icja.order_index = order_index
                 icj.jobs.append(icja)
                 self._session_add(icja)
+
+            object_import_tracker.implicit_collection_jobs_by_key[icj_attrs[object_key]] = icj
 
             self._session_add(icj)
 
@@ -885,7 +1172,12 @@ class ObjectImportTracker:
         self.hda_copied_from_sinks = {}
         self.hdca_copied_from_sinks = {}
         self.jobs_by_key = {}
+        self.invocations_by_key = {}
+        self.implicit_collection_jobs_by_key = {}
+        self.workflows_by_key = {}
         self.requires_hid = []
+
+        self.new_history = None
 
     def find_hda(
         self, input_key: ObjectKeyType, hda_id: Optional[int] = None
@@ -939,6 +1231,45 @@ def get_import_model_store_for_directory(archive_dir, **kwd):
         return DirectoryImportModelStore1901(archive_dir, **kwd)
 
 
+class DictImportModelStore(ModelImportStore):
+    object_key = "encoded_id"
+
+    def __init__(self, store_as_dict, **kwd):
+        self._store_as_dict = store_as_dict
+        super().__init__(**kwd)
+
+    def defines_new_history(self) -> bool:
+        return DICT_STORE_ATTRS_KEY_HISTORY in self._store_as_dict
+
+    def new_history_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_HISTORY) or {}
+
+    def datasets_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_DATASETS) or []
+
+    def collections_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_COLLECTIONS) or []
+
+    def library_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_LIBRARIES) or []
+
+    def jobs_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_JOBS) or []
+
+    def implicit_collection_jobs_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_IMPLICIT_COLLECTION_JOBS) or []
+
+    def invocations_properties(self):
+        return self._store_as_dict.get(DICT_STORE_ATTRS_KEY_INVOCATIONS) or []
+
+    def workflow_paths(self):
+        return []
+
+
+def get_import_model_store_for_dict(as_dict, **kwd):
+    return DictImportModelStore(as_dict, **kwd)
+
+
 class BaseDirectoryImportModelStore(ModelImportStore):
     @property
     def file_source_root(self):
@@ -965,32 +1296,15 @@ class BaseDirectoryImportModelStore(ModelImportStore):
         return datasets_attrs
 
     def collections_properties(self):
-        collections_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_COLLECTIONS)
-        if os.path.exists(collections_attrs_file_name):
-            collections_attrs = load(open(collections_attrs_file_name))
-        else:
-            collections_attrs = []
-        return collections_attrs
+        return self._read_list_if_exists(ATTRS_FILENAME_COLLECTIONS)
 
     def library_properties(self):
-        libraries_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_LIBRARIES)
-        if os.path.exists(libraries_attrs_file_name):
-            libraries_attrs = load(open(libraries_attrs_file_name))
-        else:
-            libraries_attrs = []
-
-        library_folder_attrs_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_LIBRARY_FOLDERS)
-        if os.path.exists(library_folder_attrs_file_name):
-            libraries_attrs += load(open(library_folder_attrs_file_name))
-
+        libraries_attrs = self._read_list_if_exists(ATTRS_FILENAME_LIBRARIES)
+        libraries_attrs.extend(self._read_list_if_exists(ATTRS_FILENAME_LIBRARY_FOLDERS))
         return libraries_attrs
 
     def jobs_properties(self):
-        jobs_attr_file_name = os.path.join(self.archive_dir, ATTRS_FILENAME_JOBS)
-        try:
-            return load(open(jobs_attr_file_name))
-        except FileNotFoundError:
-            return []
+        return self._read_list_if_exists(ATTRS_FILENAME_JOBS)
 
     def implicit_collection_jobs_properties(self):
         implicit_collection_jobs_attrs_file_name = os.path.join(
@@ -1000,6 +1314,21 @@ class BaseDirectoryImportModelStore(ModelImportStore):
             return load(open(implicit_collection_jobs_attrs_file_name))
         except FileNotFoundError:
             return []
+
+    def invocations_properties(self):
+        return self._read_list_if_exists(ATTRS_FILENAME_INVOCATIONS)
+
+    def workflow_paths(self):
+        workflows_directory = os.path.join(self.archive_dir, "workflows")
+        if not os.path.exists(workflows_directory):
+            return []
+
+        for name in os.listdir(workflows_directory):
+            if name.endswith(".ga") or name.endswith(".abstract.cwl") or name.endswith(".html"):
+                continue
+            assert name.endswith(".gxwf.yml")
+            workflow_key = name[0 : -len(".gxwf.yml")]
+            yield workflow_key, os.path.join(workflows_directory, name)
 
     def _set_job_attributes(self, imported_job, job_attrs, force_terminal=False):
         ATTRIBUTES = (
@@ -1023,6 +1352,27 @@ class BaseDirectoryImportModelStore(ModelImportStore):
         if force_terminal and raw_state and raw_state not in model.Job.terminal_states:
             raw_state = model.Job.states.ERROR
         imported_job.set_state(raw_state)
+
+    def _read_list_if_exists(self, file_name, required=False):
+        file_name = os.path.join(self.archive_dir, file_name)
+        if os.path.exists(file_name):
+            attrs = load(open(file_name))
+        else:
+            if required:
+                raise Exception("Failed to find file [%s] in model store archive" % file_name)
+            attrs = []
+        return attrs
+
+
+def restore_times(model_object, attrs):
+    try:
+        model_object.create_time = datetime.datetime.strptime(attrs["create_time"], "%Y-%m-%dT%H:%M:%S.%f")
+    except Exception:
+        pass
+    try:
+        model_object.update_time = datetime.datetime.strptime(attrs["update_time"], "%Y-%m-%dT%H:%M:%S.%f")
+    except Exception:
+        pass
 
 
 class DirectoryImportModelStore1901(BaseDirectoryImportModelStore):
@@ -1190,6 +1540,14 @@ class ModelExportStore(metaclass=abc.ABCMeta):
         """Export history to store."""
 
     @abc.abstractmethod
+    def export_library(self, history, include_hidden=False, include_deleted=False):
+        """Export library to store."""
+
+    @abc.abstractmethod
+    def export_workflow_invocation(self, workflow_invocation, include_hidden=False, include_deleted=False):
+        """Export workflow invocation to store."""
+
+    @abc.abstractmethod
     def add_dataset_collection(
         self, collection: Union[model.DatasetCollection, model.HistoryDatasetCollectionAssociation]
     ):
@@ -1214,11 +1572,13 @@ class ModelExportStore(metaclass=abc.ABCMeta):
 
 class DirectoryModelExportStore(ModelExportStore):
     app: Optional[StoreAppProtocol]
+    file_sources: Optional[ConfiguredFileSources]
 
     def __init__(
         self,
         export_directory: str,
         app: Optional[StoreAppProtocol] = None,
+        file_sources: Optional[ConfiguredFileSources] = None,
         for_edit: bool = False,
         serialize_dataset_objects=None,
         export_files: Optional[str] = None,
@@ -1242,10 +1602,13 @@ class DirectoryModelExportStore(ModelExportStore):
             self.app = app
             security = app.security
             sessionless = False
+            if file_sources is None:
+                file_sources = app.file_sources
         else:
             sessionless = True
             security = IdEncodingHelper(id_secret="randomdoesntmatter")
 
+        self.file_sources = file_sources
         self.serialize_jobs = serialize_jobs
         self.sessionless = sessionless
         self.security = security
@@ -1262,11 +1625,16 @@ class DirectoryModelExportStore(ModelExportStore):
         self.included_collections: List[Union[model.DatasetCollection, model.HistoryDatasetCollectionAssociation]] = []
         self.included_libraries: List[model.Library] = []
         self.included_library_folders: List[model.LibraryFolder] = []
+        self.included_invocations: List[model.WorkflowInvocation] = []
         self.collection_datasets: Set[int] = set()
         self.collections_attrs: List[Union[model.DatasetCollection, model.HistoryDatasetCollectionAssociation]] = []
         self.dataset_id_to_path: Dict[int, Tuple[Optional[str], Optional[str]]] = {}
 
         self.job_output_dataset_associations: Dict[int, Dict[str, model.DatasetInstance]] = {}
+
+    @property
+    def workflows_directory(self):
+        return os.path.join(self.export_directory, "workflows")
 
     def serialize_files(self, dataset: model.DatasetInstance, as_dict: JsonDictT) -> None:
         if self.export_files is None:
@@ -1473,7 +1841,9 @@ class DirectoryModelExportStore(ModelExportStore):
             jobs_attrs_out.write(json_encoder.encode(jobs_attrs))
         return jobs_attrs
 
-    def export_history(self, history: model.History, include_hidden: bool = False, include_deleted: bool = False):
+    def export_history(
+        self, history: model.History, include_hidden: bool = False, include_deleted: bool = False
+    ) -> None:
         app = self.app
         assert app, "exporting histories requires being bound to a session and Galaxy app object"
         export_directory = self.export_directory
@@ -1500,24 +1870,15 @@ class DirectoryModelExportStore(ModelExportStore):
             if collection.state != "ok":
                 break
 
-            self.add_dataset_collection(collection)
-
-            # export jobs for these datasets
-            for collection_dataset in collection.dataset_instances:
-                if collection_dataset.deleted and not include_deleted:
-                    include_files = False
-                else:
-                    include_files = True
-
-                self.add_dataset(collection_dataset, include_files=include_files)
-                self.collection_datasets.add(collection_dataset.id)
+            self.export_collection(collection, include_deleted=include_deleted)
 
         # Write datasets' attributes to file.
+        actions_backref = model.Dataset.actions  # type: ignore[attr-defined]
         query = (
             sa_session.query(model.HistoryDatasetAssociation)
             .filter(model.HistoryDatasetAssociation.history == history)
             .join(model.Dataset)
-            .options(joinedload(model.HistoryDatasetAssociation.dataset).joinedload(model.Dataset.actions))  # type: ignore[attr-defined]
+            .options(joinedload(model.HistoryDatasetAssociation.dataset).joinedload(actions_backref))
             .order_by(model.HistoryDatasetAssociation.hid)
             .filter(model.Dataset.purged == expression.false())
         )
@@ -1552,6 +1913,24 @@ class DirectoryModelExportStore(ModelExportStore):
         for folder in library_folder.folders:
             self.export_library_folder_contents(folder, include_hidden=include_hidden, include_deleted=include_deleted)
 
+    def export_workflow_invocation(
+        self, workflow_invocation: model.WorkflowInvocation, include_hidden=False, include_deleted=False
+    ):
+        self.included_invocations.append(workflow_invocation)
+        for input_dataset in workflow_invocation.input_datasets:
+            self.add_dataset(input_dataset.dataset)
+        for output_dataset in workflow_invocation.output_datasets:
+            self.add_dataset(output_dataset.dataset)
+        for input_dataset_collection in workflow_invocation.input_dataset_collections:
+            self.export_collection(input_dataset_collection.dataset_collection)
+        for output_dataset_collection in workflow_invocation.output_dataset_collections:
+            self.export_collection(output_dataset_collection.dataset_collection)
+        for workflow_invocation_step in workflow_invocation.steps:
+            for assoc in workflow_invocation_step.output_datasets:
+                self.add_dataset(assoc.dataset)
+            for assoc in workflow_invocation_step.output_dataset_collections:
+                self.export_collection(assoc.dataset_collection)
+
     def add_job_output_dataset_associations(
         self, job_id: int, name: str, dataset_instance: model.DatasetInstance
     ) -> None:
@@ -1564,6 +1943,7 @@ class DirectoryModelExportStore(ModelExportStore):
         self,
         collection: Union[model.DatasetCollection, model.HistoryDatasetCollectionAssociation],
         include_deleted: bool = False,
+        include_hidden: bool = False,
     ) -> None:
         self.add_dataset_collection(collection)
 
@@ -1572,6 +1952,7 @@ class DirectoryModelExportStore(ModelExportStore):
             collection.collection if isinstance(collection, model.HistoryDatasetCollectionAssociation) else collection
         )
         for collection_dataset in has_collection.dataset_instances:
+            # ignoring include_hidden since the datasets will default to hidden for this collection.
             if collection_dataset.deleted and not include_deleted:
                 include_files = False
             else:
@@ -1641,13 +2022,7 @@ class DirectoryModelExportStore(ModelExportStore):
             jobs_dict = {}
             implicit_collection_jobs_dict = {}
 
-            def record_associated_jobs(obj):
-                # Get the job object.
-                job = None
-                for assoc in getattr(obj, "creating_job_associations", []):
-                    # For mapped over jobs obj could be DatasetCollection, which has no creating_job_association
-                    job = assoc.job
-                    break
+            def record_job(job):
                 if not job:
                     # No viable job.
                     return
@@ -1658,7 +2033,16 @@ class DirectoryModelExportStore(ModelExportStore):
                     implicit_collection_jobs = icja.implicit_collection_jobs
                     implicit_collection_jobs_dict[implicit_collection_jobs.id] = implicit_collection_jobs
 
-            for hda, _ in self.included_datasets.values():
+            def record_associated_jobs(obj):
+                # Get the job object.
+                job = None
+                for assoc in getattr(obj, "creating_job_associations", []):
+                    # For mapped over jobs obj could be DatasetCollection, which has no creating_job_association
+                    job = assoc.job
+                    break
+                record_job(job)
+
+            for hda, _include_files in self.included_datasets.values():
                 # Get the associated job, if any. If this hda was copied from another,
                 # we need to find the job that created the original hda
                 job_hda = hda
@@ -1674,6 +2058,15 @@ class DirectoryModelExportStore(ModelExportStore):
                 record_associated_jobs(hdca)
 
             self.export_jobs(jobs_dict.values(), jobs_attrs=jobs_attrs)
+
+            for invocation in self.included_invocations:
+                for step in invocation.steps:
+                    for job in step.jobs:
+                        record_job(job)
+                    if step.implicit_collection_jobs:
+                        implicit_collection_jobs = step.implicit_collection_jobs
+                        implicit_collection_jobs_dict[implicit_collection_jobs.id] = implicit_collection_jobs
+
             # Get jobs' attributes.
 
             icjs_attrs = []
@@ -1684,6 +2077,29 @@ class DirectoryModelExportStore(ModelExportStore):
             icjs_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_IMPLICIT_COLLECTION_JOBS)
             with open(icjs_attrs_filename, "w") as icjs_attrs_out:
                 icjs_attrs_out.write(json_encoder.encode(icjs_attrs))
+
+        invocations_attrs = []
+
+        for invocation in self.included_invocations:
+            invocation_attrs = invocation.serialize(self.security, self.serialization_options)
+
+            workflows_directory = self.workflows_directory
+            safe_makedirs(workflows_directory)
+
+            workflow = invocation.workflow
+            workflow_key = self.serialization_options.get_identifier(self.security, workflow)
+            history = invocation.history
+            assert invocation_attrs
+            invocation_attrs["workflow"] = workflow_key
+
+            self.app.workflow_contents_manager.store_workflow_artifacts(
+                workflows_directory, workflow_key, workflow, user=history.user, history=history
+            )
+            invocations_attrs.append(invocation_attrs)
+
+        invocations_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_INVOCATIONS)
+        with open(invocations_attrs_filename, "w") as invocations_attrs_out:
+            dump(invocations_attrs, invocations_attrs_out)
 
         export_attrs_filename = os.path.join(export_directory, ATTRS_FILENAME_EXPORT)
         with open(export_attrs_filename, "w") as export_attrs_out:
@@ -1698,16 +2114,29 @@ class DirectoryModelExportStore(ModelExportStore):
 
 
 class TarModelExportStore(DirectoryModelExportStore):
-    def __init__(self, out_file, gzip=True, **kwds):
+    def __init__(self, uri, gzip=True, **kwds):
         self.gzip = gzip
-        self.out_file = out_file
         temp_output_dir = tempfile.mkdtemp()
-        super().__init__(temp_output_dir, **kwds)
+        self.temp_output_dir = temp_output_dir
+        if "://" in str(uri):
+            self.out_file = os.path.join(temp_output_dir, "out")
+            self.file_source_uri = uri
+            export_directory = os.path.join(temp_output_dir, "export")
+        else:
+            self.out_file = uri
+            self.file_source_uri = None
+            export_directory = temp_output_dir
+        super().__init__(export_directory, **kwds)
 
     def _finalize(self):
         super()._finalize()
         tar_export_directory(self.export_directory, self.out_file, self.gzip)
-        shutil.rmtree(self.export_directory)
+        if self.file_source_uri:
+            file_source_path = self.file_sources.get_file_source_path(self.file_source_uri)
+            file_source = file_source_path.file_source
+            assert os.path.exists(self.out_file)
+            file_source.write_from(file_source_path.path, self.out_file)
+        shutil.rmtree(self.temp_output_dir)
 
 
 class BagDirectoryModelExportStore(DirectoryModelExportStore):
@@ -1721,18 +2150,56 @@ class BagDirectoryModelExportStore(DirectoryModelExportStore):
 
 
 class BagArchiveModelExportStore(BagDirectoryModelExportStore):
-    def __init__(self, out_file, bag_archiver="tgz", **kwds):
+    def __init__(self, uri, bag_archiver="tgz", **kwds):
         # bag_archiver in tgz, zip, tar
         self.bag_archiver = bag_archiver
-        self.out_file = out_file
         temp_output_dir = tempfile.mkdtemp()
-        super().__init__(temp_output_dir, **kwds)
+        self.temp_output_dir = temp_output_dir
+        if "://" in str(uri):
+            # self.out_file = os.path.join(temp_output_dir, "out")
+            self.file_source_uri = uri
+            export_directory = os.path.join(temp_output_dir, "export")
+        else:
+            self.out_file = uri
+            self.file_source_uri = None
+            export_directory = temp_output_dir
+        super().__init__(export_directory, **kwds)
 
     def _finalize(self):
         super()._finalize()
         rval = bdb.archive_bag(self.export_directory, self.bag_archiver)
-        shutil.move(rval, self.out_file)
-        shutil.rmtree(self.export_directory)
+        if not self.file_source_uri:
+            shutil.move(rval, self.out_file)
+        else:
+            file_source_path = self.file_sources.get_file_source_path(self.file_source_uri)
+            file_source = file_source_path.file_source
+            assert os.path.exists(rval)
+            file_source.write_from(file_source_path.path, rval)
+        shutil.rmtree(self.temp_output_dir)
+
+
+def get_export_store_factory(app, download_format: str, export_files=None) -> Callable[[str], ModelExportStore]:
+    export_store_class: Union[Type[TarModelExportStore], Type[BagArchiveModelExportStore]]
+    export_store_class_kwds = {
+        "app": app,
+        "export_files": export_files,
+        "serialize_dataset_objects": False,
+    }
+    if download_format in ["tar.gz", "tgz"]:
+        export_store_class = TarModelExportStore
+        export_store_class_kwds["gzip"] = True
+    elif download_format in ["tar"]:
+        export_store_class = TarModelExportStore
+        export_store_class_kwds["gzip"] = False
+    elif download_format.startswith("bag."):
+        bag_archiver = download_format[len("bag.") :]
+        if bag_archiver not in ["zip", "tar", "tgz"]:
+            raise RequestParameterInvalidException(f"Unknown download format [{download_format}]")
+        export_store_class = BagArchiveModelExportStore
+        export_store_class_kwds["bag_archiver"] = bag_archiver
+    else:
+        raise RequestParameterInvalidException(f"Unknown download format [{download_format}]")
+    return lambda path: export_store_class(path, **export_store_class_kwds)
 
 
 def tar_export_directory(export_directory: str, out_file: str, gzip: bool) -> None:
@@ -1760,3 +2227,80 @@ def imported_store_for_metadata(directory, object_store=None):
     )
     import_model_store.perform_import()
     return import_model_store
+
+
+def source_to_import_store(
+    source: Union[str, dict],
+    app: StoreAppProtocol,
+    galaxy_user: Optional[model.User],
+    import_options: Optional[ImportOptions],
+    model_store_format: Optional[str] = None,
+) -> ModelImportStore:
+    if isinstance(source, dict):
+        if model_store_format is not None:
+            raise Exception(
+                "Can only specify a model_store_format as an argument to source_to_import_store in conjuction with URIs"
+            )
+        model_import_store = get_import_model_store_for_dict(
+            source,
+            import_options=import_options,
+            app=app,
+            user=galaxy_user,
+        )
+    else:
+        source_uri: str = str(source)
+        delete = False
+        if source_uri.startswith("file://"):
+            source_uri = source_uri[len("file://") :]
+        if "://" in source_uri:
+            source_uri = stream_url_to_file(source_uri, app.file_sources, prefix="gx_import_model_store")
+            delete = True
+        target_path = source_uri
+        if target_path.endswith(".json"):
+            with open(target_path, "r") as f:
+                store_dict = load(f)
+            assert isinstance(store_dict, dict)
+            model_import_store = get_import_model_store_for_dict(
+                store_dict,
+                import_options=import_options,
+                app=app,
+                user=galaxy_user,
+            )
+        elif os.path.isdir(target_path):
+            model_import_store = get_import_model_store_for_directory(
+                target_path, import_options=import_options, app=app, user=galaxy_user
+            )
+        else:
+            model_store_format = model_store_format or "tgz"
+            if model_store_format in ["tar.gz", "tgz", "tar"]:
+                try:
+                    temp_dir = mkdtemp()
+                    target_dir = CompressedFile(target_path).extract(temp_dir)
+                finally:
+                    if delete:
+                        os.remove(target_path)
+                model_import_store = get_import_model_store_for_directory(
+                    target_dir, import_options=import_options, app=app, user=galaxy_user
+                )
+            elif model_store_format in ["bag.gz", "bag.tar", "bag.zip"]:
+                model_import_store = BagArchiveImportModelStore(
+                    target_path, import_options=import_options, app=app, user=galaxy_user
+                )
+            else:
+                raise Exception(f"Unknown model_store_format type encountered {model_store_format}")
+
+    return model_import_store
+
+
+def payload_to_source_uri(payload) -> str:
+    if payload.store_content_uri:
+        source_uri = payload.store_content_uri
+    else:
+        store_dict = payload.store_dict
+        assert isinstance(store_dict, dict)
+        temp_dir = mkdtemp()
+        import_json = os.path.join(temp_dir, "import_store.json")
+        with open(import_json, "w") as f:
+            dump(store_dict, f)
+        source_uri = f"file://{import_json}"
+    return source_uri

--- a/lib/galaxy/model/store/load_objects.py
+++ b/lib/galaxy/model/store/load_objects.py
@@ -1,0 +1,76 @@
+import argparse
+import base64
+import logging
+import os
+import sys
+from typing import (
+    Any,
+    Dict,
+)
+
+import requests
+import yaml
+
+DESCRIPTION = """Load a Galaxy model store into a running Galaxy instance.
+
+See the corresponding galaxy-build-objects script for one possible way to
+create a model store to use with this script.
+
+This script creates all datasets in "discarded"/"deferred" states (depending on if
+source URIs are available). To actually load the datasets into a Galaxy instance's
+object store the underlying libraries need to be used directly and fed your Galaxy's
+database configuration and objectstore setup.
+"""
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    args = _arg_parser().parse_args(argv)
+
+    galaxy_url = args.galaxy_url
+    api_url = f"{galaxy_url.rstrip('/')}/api"
+    api_key = args.key
+    assert api_key
+    history_id = args.history_id
+    if history_id:
+        create_url = f"{api_url}/histories/{history_id}/contents_from_store?key={api_key}"
+    else:
+        create_url = f"{api_url}/histories/from_store?key={api_key}"
+
+    store_path = args.store
+    assert os.path.exists(store_path)
+    is_json = False
+    for json_ext in [".yml", ".yaml", ".json"]:
+        if store_path.endswith(json_ext):
+            is_json = True
+
+    data: Dict[str, Any] = {}
+    if is_json:
+        with open(store_path, "r") as f:
+            store_dict = yaml.safe_load(f)
+        data["store_dict"] = store_dict
+    else:
+        with open(store_path, "rb") as fb:
+            store_contents = fb.read()
+        data["store_content_base64"] = base64.b64encode(store_contents)
+    response = requests.post(create_url, json=data)
+    response.raise_for_status()
+
+
+def _arg_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("store", metavar="STORE", help="file or directory containing the model store to connect to")
+    # copied from test script in galaxy-tool-util...
+    parser.add_argument("-u", "--galaxy-url", default="http://localhost:8080", help="Galaxy URL")
+    parser.add_argument("-k", "--key", default=None, help="Galaxy User API Key")
+    parser.add_argument("-t", "--history-id", default=None, help="Encoded history ID to load model store into")
+
+    return parser
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/galaxy/model/unittest_utils/data_app.py
+++ b/lib/galaxy/model/unittest_utils/data_app.py
@@ -15,6 +15,10 @@ from galaxy import (
     objectstore,
 )
 from galaxy.datatypes import registry
+from galaxy.files import (
+    ConfiguredFileSources,
+    NullConfiguredFileSources,
+)
 from galaxy.model.mapping import (
     GalaxyModelMapping,
     init,
@@ -76,6 +80,7 @@ class GalaxyDataTestApp:
     security: IdEncodingHelper
     model: GalaxyModelMapping
     security_agent: GalaxyRBACAgent
+    file_sources: ConfiguredFileSources = NullConfiguredFileSources()
 
     def __init__(self, config: Optional[GalaxyDataTestConfig] = None, **kwd):
         config = config or GalaxyDataTestConfig(**kwd)

--- a/lib/galaxy/model/unittest_utils/store_fixtures.py
+++ b/lib/galaxy/model/unittest_utils/store_fixtures.py
@@ -1,0 +1,382 @@
+"""Fixtures for populating model stores."""
+from typing import (
+    Any,
+    Dict,
+)
+from uuid import uuid4
+
+from galaxy.model.orm.now import now
+
+TEST_SOURCE_URI = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/2.bed"
+TEST_SOURCE_URI_BAM = "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bam"
+TEST_HASH_FUNCTION = "MD5"
+TEST_HASH_VALUE = "moocowpretendthisisahas"
+TEST_HISTORY_NAME = "My history in a model store"
+TEST_EXTENSION = "bed"
+TEST_LIBRARY_NAME = "My cool library"
+TEST_LIBRARY_DESCRIPTION = "My cool library - a description"
+TEST_LIBRARY_SYNOPSIS = "My cool library - a synopsis"
+TEST_ROOT_FOLDER_NAME = "The root folder"
+TEST_ROOT_FOLDER_DESCRIPTION = "The root folder description"
+TEST_LDDA_ID = "id_ldda1"
+TEST_LIBRARY_ID = "id_library1"
+TEST_LIBRARY_DATASET_NAME = "my cool library dataset"
+TEST_LIBRARY_DATASET_INFO = "important info about the library dataset"
+
+BED_2_METADATA = {
+    "dbkey": "?",
+    "data_lines": 68,
+    "comment_lines": 0,
+    "columns": 6,
+}
+
+
+def one_ld_library_model_store_dict():
+    dataset_hash = dict(
+        model_class="DatasetHash",
+        hash_function=TEST_HASH_FUNCTION,
+        hash_value=TEST_HASH_VALUE,
+        extra_files_path=None,
+    )
+    dataset_source: Dict[str, Any] = dict(
+        model_class="DatasetSource",
+        source_uri=TEST_SOURCE_URI,
+        extra_files_path=None,
+        transform=None,
+        hashes=[],
+    )
+    metadata = BED_2_METADATA
+    file_metadata = dict(
+        hashes=[dataset_hash],
+        sources=[dataset_source],
+        created_from_basename="dataset.txt",
+    )
+    serialized_ldda = dict(
+        encoded_id=TEST_LDDA_ID,
+        model_class="LibraryDatasetDatasetAssociation",
+        create_time=now().__str__(),
+        update_time=now().__str__(),
+        name="my cool name",
+        info="my cool info",
+        blurb="a blurb goes here...",
+        peek="A bit of the data...",
+        extension=TEST_EXTENSION,
+        metadata=metadata,
+        designation=None,
+        deleted=False,
+        visible=True,
+        dataset_uuid=str(uuid4()),
+        annotation="my cool annotation",
+        file_metadata=file_metadata,
+    )
+
+    ld = {
+        "name": TEST_LIBRARY_DATASET_NAME,
+        "info": TEST_LIBRARY_DATASET_INFO,
+        "order_id": 0,
+        "ldda": {
+            "model_class": "LibraryDatasetDatasetAssocation",
+            "encoded_id": TEST_LDDA_ID,
+        },
+    }
+
+    root_folder: Dict[str, Any] = {
+        "model_class": "LibraryFolder",
+        "name": TEST_ROOT_FOLDER_NAME,
+        "description": TEST_ROOT_FOLDER_DESCRIPTION,
+        "genome_build": None,
+        "deleted": False,
+        "folders": [],
+        "datasets": [ld],
+    }
+    serialized_library = {
+        "model_class": "Library",
+        "encoded_id": TEST_LIBRARY_ID,
+        "name": TEST_LIBRARY_NAME,
+        "description": TEST_LIBRARY_DESCRIPTION,
+        "synopsis": TEST_LIBRARY_SYNOPSIS,
+        "root_folder": root_folder,
+    }
+    return {
+        "libraries": [
+            serialized_library,
+        ],
+        "datasets": [
+            serialized_ldda,
+        ],
+    }
+
+
+def one_ld_library_deferred_model_store_dict():
+    dataset_hash = dict(
+        model_class="DatasetHash",
+        hash_function=TEST_HASH_FUNCTION,
+        hash_value=TEST_HASH_VALUE,
+        extra_files_path=None,
+    )
+    dataset_source: Dict[str, Any] = dict(
+        model_class="DatasetSource",
+        source_uri=TEST_SOURCE_URI,
+        extra_files_path=None,
+        transform=None,
+        hashes=[],
+    )
+    metadata = BED_2_METADATA
+    file_metadata = dict(
+        hashes=[dataset_hash],
+        sources=[dataset_source],
+        created_from_basename="dataset.txt",
+    )
+    serialized_ldda = dict(
+        encoded_id=TEST_LDDA_ID,
+        model_class="LibraryDatasetDatasetAssociation",
+        create_time=now().__str__(),
+        update_time=now().__str__(),
+        name="my cool name",
+        info="my cool info",
+        blurb="a blurb goes here...",
+        peek="A bit of the data...",
+        extension=TEST_EXTENSION,
+        metadata=metadata,
+        designation=None,
+        deleted=False,
+        visible=True,
+        dataset_uuid=str(uuid4()),
+        annotation="my cool annotation",
+        file_metadata=file_metadata,
+        state="deferred",
+    )
+
+    ld = {
+        "name": TEST_LIBRARY_DATASET_NAME,
+        "info": TEST_LIBRARY_DATASET_INFO,
+        "order_id": 0,
+        "ldda": {
+            "model_class": "LibraryDatasetDatasetAssocation",
+            "encoded_id": TEST_LDDA_ID,
+        },
+    }
+
+    root_folder: Dict[str, Any] = {
+        "model_class": "LibraryFolder",
+        "name": TEST_ROOT_FOLDER_NAME,
+        "description": TEST_ROOT_FOLDER_DESCRIPTION,
+        "genome_build": None,
+        "deleted": False,
+        "folders": [],
+        "datasets": [ld],
+    }
+    serialized_library = {
+        "model_class": "Library",
+        "encoded_id": TEST_LIBRARY_ID,
+        "name": TEST_LIBRARY_NAME,
+        "description": TEST_LIBRARY_DESCRIPTION,
+        "synopsis": TEST_LIBRARY_SYNOPSIS,
+        "root_folder": root_folder,
+    }
+    return {
+        "libraries": [
+            serialized_library,
+        ],
+        "datasets": [
+            serialized_ldda,
+        ],
+    }
+
+
+def one_hda_model_store_dict(
+    include_source=True,
+):
+    dataset_hash = dict(
+        model_class="DatasetHash",
+        hash_function=TEST_HASH_FUNCTION,
+        hash_value=TEST_HASH_VALUE,
+        extra_files_path=None,
+    )
+    dataset_source: Dict[str, Any] = dict(
+        model_class="DatasetSource",
+        source_uri=TEST_SOURCE_URI,
+        extra_files_path=None,
+        transform=None,
+        hashes=[],
+    )
+    metadata = BED_2_METADATA
+    file_metadata = dict(
+        hashes=[dataset_hash],
+        sources=[dataset_source] if include_source else [],
+        created_from_basename="dataset.txt",
+    )
+    serialized_hda = dict(
+        encoded_id="id_hda1",
+        model_class="HistoryDatasetAssociation",
+        create_time=now().__str__(),
+        update_time=now().__str__(),
+        name="my cool name",
+        info="my cool info",
+        blurb="a blurb goes here...",
+        peek="A bit of the data...",
+        extension=TEST_EXTENSION,
+        metadata=metadata,
+        designation=None,
+        deleted=False,
+        visible=True,
+        dataset_uuid=str(uuid4()),
+        annotation="my cool annotation",
+        file_metadata=file_metadata,
+    )
+
+    return {
+        "datasets": [
+            serialized_hda,
+        ]
+    }
+
+
+def history_model_store_dict():
+    dataset_hash = dict(
+        model_class="DatasetHash",
+        hash_function=TEST_HASH_FUNCTION,
+        hash_value=TEST_HASH_VALUE,
+        extra_files_path=None,
+    )
+    dataset_source: Dict[str, Any] = dict(
+        model_class="DatasetSource",
+        source_uri=TEST_SOURCE_URI,
+        extra_files_path=None,
+        transform=None,
+        hashes=[],
+    )
+    metadata = BED_2_METADATA
+    file_metadata = dict(
+        hashes=[dataset_hash],
+        sources=[dataset_source],
+        created_from_basename="dataset.txt",
+    )
+    serialized_hda = dict(
+        encoded_id="id_hda1",
+        model_class="HistoryDatasetAssociation",
+        create_time=now().__str__(),
+        update_time=now().__str__(),
+        name="my cool name",
+        info="my cool info",
+        blurb="a blurb goes here...",
+        peek="A bit of the data...",
+        extension=TEST_EXTENSION,
+        metadata=metadata,
+        designation=None,
+        visible=True,
+        dataset_uuid=str(uuid4()),
+        annotation="my cool annotation",
+        file_metadata=file_metadata,
+    )
+
+    return {
+        "datasets": [
+            serialized_hda,
+        ],
+        "history": {
+            "name": TEST_HISTORY_NAME,
+        },
+    }
+
+
+def deferred_hda_model_store_dict(
+    source_uri=TEST_SOURCE_URI,
+    metadata_deferred=False,
+):
+    dataset_hash = dict(
+        model_class="DatasetHash",
+        hash_function=TEST_HASH_FUNCTION,
+        hash_value=TEST_HASH_VALUE,
+        extra_files_path=None,
+    )
+    dataset_source: Dict[str, Any] = dict(
+        model_class="DatasetSource",
+        source_uri=source_uri,
+        extra_files_path=None,
+        transform=None,
+        hashes=[],
+    )
+    metadata = BED_2_METADATA
+    file_metadata = dict(
+        hashes=[dataset_hash],
+        sources=[dataset_source],
+        created_from_basename="dataset.txt",
+    )
+    serialized_hda = dict(
+        encoded_id="id_hda1",
+        model_class="HistoryDatasetAssociation",
+        create_time=now().__str__(),
+        update_time=now().__str__(),
+        name="my cool name",
+        info="my cool info",
+        blurb="a blurb goes here...",
+        peek="A bit of the data...",
+        extension=TEST_EXTENSION,
+        designation=None,
+        deleted=False,
+        visible=True,
+        dataset_uuid=str(uuid4()),
+        annotation="my cool annotation",
+        file_metadata=file_metadata,
+        state="deferred",
+        metadata_deferred=metadata_deferred,
+    )
+    if not metadata_deferred:
+        serialized_hda["metadata"] = metadata
+    return {
+        "datasets": [
+            serialized_hda,
+        ]
+    }
+
+
+def deferred_hda_model_store_dict_bam(
+    source_uri=TEST_SOURCE_URI_BAM,
+    metadata_deferred=False,
+):
+    dataset_hash = dict(
+        model_class="DatasetHash",
+        hash_function=TEST_HASH_FUNCTION,
+        hash_value=TEST_HASH_VALUE,
+        extra_files_path=None,
+    )
+    dataset_source: Dict[str, Any] = dict(
+        model_class="DatasetSource",
+        source_uri=source_uri,
+        extra_files_path=None,
+        transform=None,
+        hashes=[],
+    )
+    metadata = {"dbkey": "?"}
+    file_metadata = dict(
+        hashes=[dataset_hash],
+        sources=[dataset_source],
+        created_from_basename="dataset.txt",
+    )
+    serialized_hda = dict(
+        encoded_id="id_hda1",
+        model_class="HistoryDatasetAssociation",
+        create_time=now().__str__(),
+        update_time=now().__str__(),
+        name="my cool name",
+        info="my cool info",
+        blurb="a blurb goes here...",
+        peek="A bit of the data...",
+        extension="bam",
+        designation=None,
+        deleted=False,
+        visible=True,
+        dataset_uuid=str(uuid4()),
+        annotation="my cool annotation",
+        file_metadata=file_metadata,
+        state="deferred",
+        metadata_deferred=metadata_deferred,
+    )
+    if not metadata_deferred:
+        serialized_hda["metadata"] = metadata
+    return {
+        "datasets": [
+            serialized_hda,
+        ]
+    }

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -1229,18 +1229,25 @@ class ObjectStorePopulator:
     datasets from a job end up with the same object_store_id.
     """
 
-    def __init__(self, app, user):
-        self.object_store = app.object_store
+    def __init__(self, has_object_store, user):
+        if hasattr(has_object_store, "object_store"):
+            object_store = has_object_store.object_store
+        else:
+            object_store = has_object_store
+        self.object_store = object_store
         self.object_store_id = None
         self.user = user
 
     def set_object_store_id(self, data):
+        self.set_dataset_object_store_id(data.dataset)
+
+    def set_dataset_object_store_id(self, dataset):
         # Create an empty file immediately.  The first dataset will be
         # created in the "default" store, all others will be created in
         # the same store as the first.
-        data.dataset.object_store_id = self.object_store_id
+        dataset.object_store_id = self.object_store_id
         try:
-            self.object_store.create(data.dataset)
+            self.object_store.create(dataset)
         except ObjectInvalid:
             raise Exception("Unable to create output dataset: object store is full")
-        self.object_store_id = data.dataset.object_store_id  # these will be the same thing after the first output
+        self.object_store_id = dataset.object_store_id  # these will be the same thing after the first output

--- a/lib/galaxy/schema/fetch_data.py
+++ b/lib/galaxy/schema/fetch_data.py
@@ -109,6 +109,7 @@ class BaseDataElement(FetchBaseModel):
     ext: str = Field("auto")
     space_to_tab: bool = False
     to_posix_lines: bool = False
+    deferred: bool = False
     tags: Optional[List[str]]
     created_from_basename: Optional[str]
     extra_files: Optional[ExtraFiles]

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1221,6 +1221,56 @@ class CreateNewCollectionPayload(Model):
     )
 
 
+class ModelStoreFormat(str, Enum):
+    """Available types of model stores for export."""
+
+    TGZ = "tgz"
+    TAR = "tar"
+    TAR_DOT_GZ = "tar.gz"
+    BAG_DOT_ZIP = "bag.zip"
+    BAG_DOT_TAR = "bag.tar"
+    BAG_DOT_TGZ = "bag.tgz"
+
+
+class StoreContentSource(Model):
+    store_content_uri: Optional[str]
+    store_dict: Optional[Dict[str, Any]]
+    model_store_format: Optional["ModelStoreFormat"] = None
+
+
+class CreateHistoryFromStore(StoreContentSource):
+    pass
+
+
+class StoreExportPayload(Model):
+    model_store_format: ModelStoreFormat = Field(
+        default=ModelStoreFormat.TAR_DOT_GZ,
+        description="format of model store to export",
+    )
+    include_files: bool = Field(
+        default=True,
+        description="include materialized files in export when available",
+    )
+    include_deleted: bool = Field(
+        default=False,
+        title="Include deleted",
+        description="Include file contents for deleted datasets (if include_files is True).",
+    )
+    include_hidden: bool = Field(
+        default=False,
+        title="Include hidden",
+        description="Include file contents for hidden datasets (if include_files is True).",
+    )
+
+
+class WriteStoreToPayload(StoreExportPayload):
+    target_uri: str = Field(
+        ...,
+        title="Target URI",
+        description="Galaxy Files URI to write mode store content to.",
+    )
+
+
 class JobExportHistoryArchiveModel(Model):
     id: EncodedDatabaseIdField = Field(
         ...,
@@ -2173,6 +2223,10 @@ class CreateLibraryPayload(BaseModel):
     )
 
 
+class CreateLibrariesFromStore(StoreContentSource):
+    pass
+
+
 class UpdateLibraryPayload(BaseModel):
     name: Optional[str] = Field(
         None,
@@ -2798,6 +2852,27 @@ class PageSummaryBase(BaseModel):
         description="The title slug for the page URL, must be unique.",
         regex=r"^[a-z0-9\-]+$",
     )
+
+
+class MaterializeDatasetInstanceAPIRequest(Model):
+    source: DatasetSourceType = Field(
+        None,
+        title="Source",
+        description="The source of the content. Can be other history element to be copied or library elements.",
+    )
+    content: EncodedDatabaseIdField = Field(
+        None,
+        title="Content",
+        description=(
+            "Depending on the `source` it can be:\n"
+            "- The encoded id of the source library dataset\n"
+            "- The encoded id of the the HDA\n"
+        ),
+    )
+
+
+class MaterializeDatasetInstanceRequest(MaterializeDatasetInstanceAPIRequest):
+    history_id: EncodedDatabaseIdField
 
 
 class CreatePagePayload(PageSummaryBase):

--- a/lib/galaxy/schema/tasks.py
+++ b/lib/galaxy/schema/tasks.py
@@ -1,5 +1,16 @@
-from pydantic import BaseModel
+from typing import Optional
 
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+from .schema import (
+    DatasetSourceType,
+    HistoryContentType,
+    StoreExportPayload,
+    WriteStoreToPayload,
+)
 from ..schema import PdfDocumentType
 
 
@@ -22,3 +33,71 @@ class GeneratePdfDownload(BaseModel):
     # basic markdown - Galaxy directives need to be processed before handing off to this task
     basic_markdown: str
     document_type: PdfDocumentType
+
+
+# serialize user info for tasks
+class RequestUser(BaseModel):
+    user_id: int
+    # TODO: allow make the above optional and allow a session_id for anonymous users...
+    # session_id: Optional[str]
+
+
+class GenerateHistoryDownload(StoreExportPayload):
+    history_id: int
+    short_term_storage_request_id: str
+    user: RequestUser
+
+
+class GenerateHistoryContentDownload(StoreExportPayload):
+    content_type: HistoryContentType
+    content_id: int
+    short_term_storage_request_id: str
+    user: RequestUser
+
+
+class GenerateInvocationDownload(StoreExportPayload):
+    invocation_id: int
+    short_term_storage_request_id: str
+    user: RequestUser
+
+
+class WriteInvocationTo(WriteStoreToPayload):
+    invocation_id: int
+    user: RequestUser
+
+
+class WriteHistoryContentTo(WriteStoreToPayload):
+    content_type: HistoryContentType
+    content_id: int
+    user: RequestUser
+
+
+class WriteHistoryTo(WriteStoreToPayload):
+    history_id: int
+    user: RequestUser
+
+
+class ImportModelStoreTaskRequest(BaseModel):
+    user: RequestUser
+    history_id: Optional[int]
+    source_uri: str
+    for_library: bool
+
+
+class MaterializeDatasetInstanceTaskRequest(BaseModel):
+    history_id: int
+    user: RequestUser
+    source: DatasetSourceType = Field(
+        None,
+        title="Source",
+        description="The source of the content. Can be other history element to be copied or library elements.",
+    )
+    content: int = Field(
+        None,
+        title="Content",
+        description=(
+            "Depending on the `source` it can be:\n"
+            "- The encoded id of the source library dataset\n"
+            "- The encoded id of the the HDA\n"
+        ),
+    )

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -417,6 +417,9 @@ class NavigatesGalaxy(HasDriver):
     def history_panel_wait_for_hid_ok(self, hid, allowed_force_refreshes=0):
         return self.history_panel_wait_for_hid_state(hid, "ok", allowed_force_refreshes=allowed_force_refreshes)
 
+    def history_panel_wait_for_hid_deferred(self, hid, allowed_force_refreshes=0):
+        return self.history_panel_wait_for_hid_state(hid, "deferred", allowed_force_refreshes=allowed_force_refreshes)
+
     def history_panel_item_component(self, history_item=None, hid=None, multi_history_panel=False):
         if self.is_beta_history():
             assert hid
@@ -701,7 +704,9 @@ class NavigatesGalaxy(HasDriver):
     def perform_upload_of_pasted_content(self, paste_data, **kwd):
         self._perform_upload(paste_data=paste_data, **kwd)
 
-    def _perform_upload(self, test_path=None, paste_data=None, ext=None, genome=None, ext_all=None, genome_all=None):
+    def _perform_upload(
+        self, test_path=None, paste_data=None, ext=None, genome=None, ext_all=None, genome_all=None, deferred=None
+    ):
         self.home()
         self.upload_start_click()
 
@@ -721,6 +726,17 @@ class NavigatesGalaxy(HasDriver):
         if genome is not None:
             self.wait_for_selector_visible(".upload-genome")
             self.select2_set_value(".upload-genome", genome)
+
+        if deferred is not None:
+            upload = self.components.upload
+            upload.settings_button(n=0).wait_for_and_click()
+            upload.settings.wait_for_visible()
+            setting = upload.setting_deferred.wait_for_visible()
+            classes = setting.get_attribute("class").split(" ")
+            if deferred is True and "fa-check-square-o" not in classes:
+                setting.click()
+            elif deferred is False and "fa-check-square-o" in classes:
+                setting.click()
 
         self.upload_start()
 

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -113,6 +113,7 @@ dataset_details:
     _: 'table#dataset-details'
     tool_parameters: 'table#tool-parameters'
     transform_action: '[data-transform-action="${action}"]'
+    deferred_source_uri: '.deferred-dataset-source-uri'
 
 history_panel:
   menu:
@@ -871,6 +872,9 @@ upload:
     ftp_items: '.upload-ftp-row'
     ftp_close: '.popover-header .popover-close'
     row: '#upload-row-${n}'
+    settings_button: '#upload-row-${n} .upload-settings'
+    settings: '.upload-settings-table'
+    setting_deferred: '.upload-deferred'
     start: '.upload-button'
     rule_source_content: 'textarea.upload-rule-source-content'
     rule_select_data_type: '.rule-data-type'

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -2879,10 +2879,16 @@ class SetMetadataTool(Tool):
     requires_setting_metadata = False
     tool_action: "SetMetadataToolAction"
 
-    def regenerate_imported_metadata_if_needed(self, hda, history, job):
+    def regenerate_imported_metadata_if_needed(self, hda, history, user, session_id):
         if hda.has_metadata_files:
             job, *_ = self.tool_action.execute_via_app(
-                self, self.app, job.session_id, history.id, job.user, incoming={"input1": hda}, overwrite=False
+                self,
+                self.app,
+                session_id,
+                history.id,
+                user,
+                incoming={"input1": hda},
+                overwrite=False,
             )
             self.app.job_manager.enqueue(job=job, tool=self)
 

--- a/lib/galaxy/tools/imp_exp/__init__.py
+++ b/lib/galaxy/tools/imp_exp/__init__.py
@@ -98,10 +98,11 @@ class JobExportHistoryArchiveWrapper:
         """
         Perform setup for job to export a history into an archive.
         """
-        app = self.app
         # TODO: prevent circular import here...
         from galaxy.celery.tasks import export_history
 
+        app = self.app
+        # TODO: parameterize API on include_files here...
         request = SetupHistoryExportJob(
             history_id=history.id,
             job_id=self.job_id,

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -69,7 +69,7 @@ def query_serialization_params(
     keys: Optional[str] = SerializationKeysQueryParam,
     default_view: Optional[str] = SerializationDefaultViewQueryParam,
 ) -> SerializationParams:
-    return parse_serialization_params(view=view, keys=keys, default_view=default_view)
+    return parse_serialization_params(view=view, keys=keys, default_view=default_view, format=format)
 
 
 def get_value_filter_query_params(

--- a/lib/galaxy/webapps/galaxy/api/libraries.py
+++ b/lib/galaxy/webapps/galaxy/api/libraries.py
@@ -3,6 +3,7 @@ API operations on a data library.
 """
 import logging
 from typing import (
+    List,
     Optional,
     Union,
 )
@@ -16,6 +17,7 @@ from fastapi import (
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
+    CreateLibrariesFromStore,
     CreateLibraryPayload,
     DeleteLibraryPayload,
     LegacyLibraryPermissionsPayload,
@@ -104,6 +106,18 @@ class FastAPILibraries:
     ) -> LibrarySummary:
         """Creates a new library and returns its summary information. Currently, only admin users can create libraries."""
         return self.service.create(trans, payload)
+
+    @router.post(
+        "/api/libraries/from_store",
+        summary="Create libraries from a model store.",
+        require_admin=True,
+    )
+    def create_from_store(
+        self,
+        trans: ProvidesUserContext = DependsOnTrans,
+        payload: CreateLibrariesFromStore = Body(...),
+    ) -> List[LibrarySummary]:
+        return self.service.create_from_store(trans, payload)
 
     @router.patch(
         "/api/libraries/{id}",

--- a/lib/galaxy/webapps/galaxy/api/tasks.py
+++ b/lib/galaxy/webapps/galaxy/api/tasks.py
@@ -1,0 +1,24 @@
+"""
+API Controller providing experimental access to Celery Task State.
+"""
+import logging
+
+from celery.result import AsyncResult
+
+from . import Router
+
+log = logging.getLogger(__name__)
+
+router = Router(tags=["tasks"])
+
+
+@router.cbv
+class FastAPITasks:
+    @router.get(
+        "/api/tasks/{task_id}/state",
+        summary="Determine state of task ID",
+        response_description="String indicating task state.",
+    )
+    def state(self, task_id: str) -> str:
+        res = AsyncResult(str(task_id))
+        return str(res.state)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -582,6 +582,7 @@ def populate_api_routes(webapp, app):
         "/api/workflows/{id}/refactor", action="refactor", controller="workflows", conditions=dict(method=["PUT"])
     )
     webapp.mapper.resource("workflow", "workflows", path_prefix="/api")
+
     webapp.mapper.resource("search", "search", path_prefix="/api")
 
     # ---- visualizations registry ---- generic template renderer
@@ -689,6 +690,14 @@ def populate_api_routes(webapp, app):
         controller="workflows",
         action="index_invocations",
         conditions=dict(method=["GET"]),
+    )
+
+    webapp.mapper.connect(
+        "create_invovactions_from_store",
+        "/api/invocations/from_store",
+        controller="workflows",
+        action="create_invocations_from_store",
+        conditions=dict(method=["POST"]),
     )
 
     # API refers to usages and invocations - these mean the same thing but the

--- a/lib/galaxy/webapps/galaxy/services/base.py
+++ b/lib/galaxy/webapps/galaxy/services/base.py
@@ -1,6 +1,9 @@
+from tempfile import NamedTemporaryFile
 from typing import (
+    Any,
     cast,
     List,
+    NamedTuple,
     Optional,
 )
 
@@ -18,10 +21,20 @@ from galaxy.managers.base import (
     SortableManager,
 )
 from galaxy.managers.context import ProvidesUserContext
+from galaxy.managers.model_stores import create_objects_from_store
 from galaxy.model import User
+from galaxy.model.store import (
+    get_export_store_factory,
+    ModelExportStore,
+)
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import AsyncTaskResultSummary
 from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.util import ready_name_for_url
+from galaxy.web.short_term_storage import (
+    ShortTermStorageAllocator,
+    ShortTermStorageTarget,
+)
 
 
 def ensure_celery_tasks_enabled(config):
@@ -102,6 +115,53 @@ class ServiceBase:
         return cast(User, trans.user)
 
 
+class ServedExportStore(NamedTuple):
+    export_store: ModelExportStore
+    export_target: Any
+
+
+def model_store_storage_target(
+    short_term_storage_allocator: ShortTermStorageAllocator, file_name: str, model_store_format: str
+) -> ShortTermStorageTarget:
+    cleaned_filename = ready_name_for_url(f"{file_name}.{model_store_format}")
+    if model_store_format.endswith("gz"):
+        mime_type = "application/x-gzip"
+    else:
+        mime_type = "application/x-tar"
+
+    return short_term_storage_allocator.new_target(
+        cleaned_filename,
+        mime_type,
+    )
+
+
+class ServesExportStores:
+    def serve_export_store(self, app, download_format: str):
+        export_target = NamedTemporaryFile("wb")
+        export_store = get_export_store_factory(app, download_format)(export_target.name)
+        return ServedExportStore(export_store, export_target)
+
+
+class ConsumesModelStores:
+    def create_objects_from_store(
+        self,
+        trans,
+        payload,
+        history=None,
+        for_library=False,
+    ):
+        galaxy_user = None
+        if isinstance(trans.user, User):
+            galaxy_user = trans.user
+        return create_objects_from_store(
+            app=trans.app,
+            galaxy_user=galaxy_user,
+            payload=payload,
+            history=history,
+            for_library=for_library,
+        )
+
+
 def async_task_summary(async_result: AsyncResult) -> AsyncTaskResultSummary:
     name = None
     try:
@@ -117,7 +177,7 @@ def async_task_summary(async_result: AsyncResult) -> AsyncTaskResultSummary:
         pass
 
     return AsyncTaskResultSummary(
-        id=async_result.id,
+        id=str(async_result.id),
         ignored=async_result.ignored,
         name=name,
         queue=queue,

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -95,6 +95,11 @@ class DatasetStorageDetails(Model):
     percent_used: Optional[float] = Field(
         description="The percentage indicating how full the store is.",
     )
+    dataset_state: str = Field(
+        description="The model state of the supplied dataset instance.",
+    )
+    hashes: List[dict] = Field(description="The file contents hashes associated with the supplied dataset instance.")
+    sources: List[dict] = Field(description="The file sources associated with the supplied dataset instance.")
 
 
 class DatasetInheritanceChainEntry(Model):
@@ -341,12 +346,20 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         except AttributeError:
             # not implemented on nestedobjectstores yet.
             percent_used = None
-
+        except FileNotFoundError:
+            # uninitalized directory (emtpy) disk object store can cause this...
+            percent_used = None
+        dataset_state = dataset.state
+        hashes = [h.to_dict() for h in dataset.hashes]
+        sources = [s.to_dict() for s in dataset.sources]
         return DatasetStorageDetails(
             object_store_id=object_store_id,
             name=name,
             description=description,
             percent_used=percent_used,
+            dataset_state=dataset_state,
+            hashes=hashes,
+            sources=sources,
         )
 
     def show_inheritance_chain(

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -294,6 +294,34 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         assert element0["element_identifier"] == "4.bed"
         assert element0["object"]["file_size"] == 61
 
+    def test_upload_collection_deferred(self):
+        elements = [
+            {
+                "src": "url",
+                "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/4.bed",
+                "info": "my cool bed",
+                "deferred": True,
+            }
+        ]
+        targets = [
+            {
+                "destination": {"type": "hdca"},
+                "elements": elements,
+                "collection_type": "list",
+            }
+        ]
+        payload = {
+            "history_id": self.history_id,
+            "targets": targets,
+        }
+        self.dataset_populator.fetch(payload)
+        hdca = self._assert_one_collection_created_in_history()
+        assert len(hdca["elements"]) == 1, hdca
+        element0 = hdca["elements"][0]
+        assert element0["element_identifier"] == "4.bed"
+        object0 = element0["object"]
+        assert object0["state"] == "deferred"
+
     @skip_if_github_down
     def test_upload_collection_failed_expansion_url(self):
         targets = [

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -17,6 +17,10 @@ from galaxy_test.base.populators import (
 )
 from ._framework import ApiTestCase
 
+TEST_SOURCE_URI = "http://google.com/dataset.txt"
+TEST_HASH_FUNCTION = "MD5"
+TEST_HASH_VALUE = "moocowpretendthisisahas"
+
 
 # TODO: Test anonymous access.
 class HistoryContentsApiTestCase(ApiTestCase):

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -3,11 +3,16 @@ import unittest
 import pytest
 import requests
 
+from galaxy.model.unittest_utils.store_fixtures import (
+    one_ld_library_model_store_dict,
+    TEST_LIBRARY_NAME,
+)
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
     LibraryPopulator,
     skip_if_github_down,
+    skip_without_asgi,
 )
 from ._framework import ApiTestCase
 
@@ -29,6 +34,17 @@ class LibrariesApiTestCase(ApiTestCase):
         library = create_response.json()
         self._assert_has_keys(library, "name")
         assert library["name"] == "CreateTestLibrary"
+
+    @skip_without_asgi
+    def test_create_from_store(self):
+        response = self.library_populator.create_from_store(store_dict=one_ld_library_model_store_dict())
+        assert isinstance(response, list)
+        assert len(response) == 1
+        library_summary = response[0]
+        assert library_summary["name"] == TEST_LIBRARY_NAME
+        assert "id" in library_summary
+        ld = self.library_populator.get_library_contents_with_path(library_summary["id"], "/my cool name")
+        assert ld
 
     def test_delete(self):
         library = self.library_populator.new_library("DeleteTestLibrary")

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -936,3 +936,11 @@ class ToolsUploadTestCase(ApiTestCase):
             assert hda["name"] == "1.fastqsanger.gz"
             assert hda["file_ext"] == "fastqsanger.gz"
             assert hda["state"] == "ok"
+
+    @uses_test_history(require_new=False)
+    def test_upload_deferred(self, history_id):
+        details = self.dataset_populator.create_deferred_hda(
+            history_id, "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/1.bam", ext="bam"
+        )
+        assert details["state"] == "deferred"
+        assert details["file_ext"] == "bam"

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -37,11 +37,14 @@ API tests and Selenium tests routinely use requests directly and that is totally
 requests should just be filtered through the verb abstractions if that functionality
 is then added to populators to be shared across tests or across testing frameworks.
 """
+import base64
 import contextlib
 import json
 import os
 import random
 import string
+import tarfile
+import tempfile
 import time
 import unittest
 import urllib.parse
@@ -61,6 +64,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Union,
 )
 
 import cwltest
@@ -144,6 +148,18 @@ def skip_without_tool(tool_id):
     return method_wrapper
 
 
+def skip_without_asgi(method):
+    @wraps(method)
+    def wrapped_method(api_test_case, *args, **kwd):
+        config = api_test_case.galaxy_interactor.get("configuration").json()
+        asgi_enabled = config.get("asgi_enabled", False)
+        if not asgi_enabled:
+            raise unittest.SkipTest("ASGI not enabled, skipping test")
+        return method(api_test_case, *args, **kwd)
+
+    return wrapped_method
+
+
 def skip_without_datatype(extension):
     """Decorate an API test method as requiring a specific datatype.
 
@@ -220,9 +236,7 @@ def uses_test_history(**test_history_kwd):
 
 def _raise_skip_if(check, *args):
     if check:
-        from nose.plugins.skip import SkipTest
-
-        raise SkipTest(*args)
+        raise unittest.SkipTest(*args)
 
 
 def conformance_tests_gen(directory, filename="conformance_tests.yaml"):
@@ -288,6 +302,15 @@ class BasePopulator(metaclass=ABCMeta):
     @abstractmethod
     def _delete(self, route, data=None, headers=None, admin=False, json: bool = False) -> Response:
         """DELETE against target Galaxy instance on specified route."""
+
+    def _get_to_tempfile(self, route, suffix=None, **kwd) -> str:
+        """Perform a _get and store the result in a tempfile."""
+        get_response = self._get(route, **kwd)
+        get_response.raise_for_status()
+        temp_file = tempfile.NamedTemporaryFile("wb", delete=False, suffix=suffix)
+        temp_file.write(get_response.content)
+        temp_file.flush()
+        return temp_file.name
 
 
 class BaseDatasetPopulator(BasePopulator):
@@ -383,11 +406,82 @@ class BaseDatasetPopulator(BasePopulator):
         assert len(hdas) == 1
         return hdas[0]
 
+    def create_deferred_hda(self, history_id, uri: str, ext: Optional[str] = None) -> Dict[str, Any]:
+        item = {
+            "src": "url",
+            "url": uri,
+            "deferred": True,
+        }
+        if ext:
+            item["ext"] = ext
+        output = self.fetch_hda(history_id, item)
+        details = self.get_history_dataset_details(history_id, dataset=output)
+        return details
+
     def tag_dataset(self, history_id, hda_id, tags):
         url = f"histories/{history_id}/contents/{hda_id}"
         response = self._put(url, {"tags": tags}, json=True)
         response.raise_for_status()
         return response.json()
+
+    def create_from_store_raw(self, payload: Dict[str, Any]) -> Response:
+        create_response = self._post("histories/from_store", payload, json=True)
+        return create_response
+
+    def create_from_store_raw_async(self, payload: Dict[str, Any]) -> Response:
+        create_response = self._post("histories/from_store_async", payload, json=True)
+        return create_response
+
+    def create_from_store(
+        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+    ) -> Dict[str, Any]:
+        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        create_response = self.create_from_store_raw(payload)
+        api_asserts.assert_status_code_is_ok(create_response)
+        return create_response.json()
+
+    def create_from_store_async(
+        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+    ) -> Dict[str, Any]:
+        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        create_response = self.create_from_store_raw_async(payload)
+        create_response.raise_for_status()
+        return create_response.json()
+
+    def create_contents_from_store_raw(self, history_id: str, payload: Dict[str, Any]) -> Response:
+        create_response = self._post(f"histories/{history_id}/contents_from_store", payload, json=True)
+        return create_response
+
+    def create_contents_from_store(
+        self, history_id: str, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        if store_dict is not None:
+            assert isinstance(store_dict, dict)
+        if store_path is not None:
+            assert isinstance(store_path, str)
+        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        create_response = self.create_contents_from_store_raw(history_id, payload)
+        create_response.raise_for_status()
+        return create_response.json()
+
+    def download_contents_to_store(self, history_id: str, history_content: Dict[str, Any], extension=".tgz") -> str:
+        url = f"histories/{history_id}/contents/{history_content['history_content_type']}s/{history_content['id']}/prepare_store_download"
+        download_response = self._post(url, dict(include_files=False, model_store_format=extension), json=True)
+        storage_request_id = self.assert_download_request_ok(download_response)
+        self.wait_for_download_ready(storage_request_id)
+        return self._get_to_tempfile(f"short_term_storage/{storage_request_id}")
+
+    def reupload_contents(self, history_content: Dict[str, Any]):
+        history_id = history_content["history_id"]
+        temp_tar = self.download_contents_to_store(history_id, history_content, "tgz")
+        with tarfile.open(name=temp_tar) as tf:
+            assert "datasets_attrs.txt" in tf.getnames()
+        new_history_id = self.new_history()
+        as_list = self.create_contents_from_store(
+            new_history_id,
+            store_path=temp_tar,
+        )
+        return new_history_id, as_list
 
     def wait_for_tool_run(
         self,
@@ -441,6 +535,16 @@ class BaseDatasetPopulator(BasePopulator):
 
         if assert_ok:
             self.wait_for_history(history_id, assert_ok=True, timeout=timeout)
+
+    def wait_for_jobs(
+        self, jobs: Union[List[dict], List[str]], assert_ok: bool = False, timeout: timeout_type = DEFAULT_TIMEOUT
+    ):
+        for job in jobs:
+            if isinstance(job, dict):
+                job_id = job["id"]
+            else:
+                job_id = job
+            self.wait_for_job(job_id, assert_ok=assert_ok, timeout=timeout)
 
     def wait_for_job(self, job_id: str, assert_ok: bool = False, timeout: timeout_type = DEFAULT_TIMEOUT):
         return wait_on_state(
@@ -672,6 +776,23 @@ class BaseDatasetPopulator(BasePopulator):
         tool_response = self._post(url, data=payload)
         return tool_response
 
+    def materialize_dataset_instance(self, history_id: str, id: str, source: str = "hda"):
+        payload: Dict[str, Any]
+        if source == "ldda":
+            url = f"histories/{history_id}/materialize"
+            payload = {
+                "source": "ldda",
+                "content": id,
+            }
+        else:
+            url = f"histories/{history_id}/contents/datasets/{id}/materialize"
+            payload = {}
+        create_response = self._post(url, payload, json=True)
+        api_asserts.assert_status_code_is_ok(create_response)
+        create_response_json = create_response.json()
+        assert "id" in create_response_json
+        return create_response_json
+
     def get_history_dataset_content(self, history_id: str, wait=True, filename=None, type="text", raw=False, **kwds):
         dataset_id = self.__history_content_id(history_id, wait=wait, **kwds)
         data = {}
@@ -774,6 +895,11 @@ class BaseDatasetPopulator(BasePopulator):
                 history_content_id = history_contents[-1]["id"]
         return history_content_id
 
+    def get_history_contents(self, history_id: str) -> List[Dict[str, Any]]:
+        contents_response = self._get_contents_request(history_id)
+        contents_response.raise_for_status()
+        return contents_response.json()
+
     def _get_contents_request(self, history_id: str, suffix: str = "", data=None) -> Response:
         if data is None:
             data = {}
@@ -791,10 +917,15 @@ class BaseDatasetPopulator(BasePopulator):
             src = "hdca"
         return dict(src=src, id=history_content["id"])
 
-    def dataset_storage_info(self, dataset_id: str) -> dict:
-        storage_response = self._get(f"datasets/{dataset_id}/storage")
-        storage_response.raise_for_status()
-        return storage_response.json()
+    def dataset_storage_info(self, dataset_id: str) -> Dict[str, Any]:
+        response = self.dataset_storage_info_raw(dataset_id)
+        response.raise_for_status()
+        return response.json()
+
+    def dataset_storage_info_raw(self, dataset_id: str) -> Response:
+        storage_url = f"datasets/{dataset_id}/storage"
+        get_storage_response = self._get(storage_url)
+        return get_storage_response
 
     def get_roles(self) -> list:
         roles_response = self._get("roles", admin=True)
@@ -942,24 +1073,28 @@ class BaseDatasetPopulator(BasePopulator):
         api_asserts.assert_status_code_is(import_response, 200)
         return import_response.json()["id"]
 
-    def import_history_and_wait_for_name(self, import_data, history_name):
-        def history_names():
-            return {h["name"]: h for h in self.get_histories()}
+    def wait_for_history_with_name(self, history_name: str, desc: str) -> Dict[str, Any]:
+        def has_history_with_name():
+            histories = self.history_names()
+            return histories.get(history_name, None)
 
+        target_history = wait_on(has_history_with_name, desc=desc)
+        return target_history
+
+    def import_history_and_wait_for_name(self, import_data, history_name):
         import_name = f"imported from archive: {history_name}"
-        assert import_name not in history_names()
+        assert import_name not in self.history_names()
 
         job_id = self.import_history(import_data)
         self.wait_for_job(job_id, assert_ok=True)
 
-        def has_history_with_name():
-            histories = history_names()
-            return histories.get(import_name, None)
-
-        imported_history = wait_on(has_history_with_name, desc="import history")
+        imported_history = self.wait_for_history_with_name(import_name, "import history")
         imported_history_id = imported_history["id"]
         self.wait_for_history(imported_history_id)
         return imported_history_id
+
+    def history_names(self) -> Dict[str, Dict]:
+        return {h["name"]: h for h in self.get_histories()}
 
     def rename_history(self, history_id, new_name):
         update_url = f"histories/{history_id}"
@@ -971,7 +1106,7 @@ class BaseDatasetPopulator(BasePopulator):
         api_asserts.assert_status_code_is(history_index_response, 200)
         return history_index_response.json()
 
-    def wait_on_history_length(self, history_id, wait_on_history_length):
+    def wait_on_history_length(self, history_id: str, wait_on_history_length: int):
         def history_has_length():
             history_length = self.history_length(history_id)
             return None if history_length != wait_on_history_length else True
@@ -979,13 +1114,18 @@ class BaseDatasetPopulator(BasePopulator):
         wait_on(history_has_length, desc="import history population")
 
     def wait_on_download(self, download_request_response: Response) -> Response:
+        storage_request_id = self.assert_download_request_ok(download_request_response)
+        return self.wait_on_download_request(storage_request_id)
+
+    def assert_download_request_ok(self, download_request_response: Response) -> str:
+        """Assert response is valid and okay and extract storage request ID."""
         api_asserts.assert_status_code_is(download_request_response, 200)
         download_async = download_request_response.json()
         assert "storage_request_id" in download_async
         storage_request_id = download_async["storage_request_id"]
-        return self.wait_on_download_request(storage_request_id)
+        return storage_request_id
 
-    def wait_on_download_request(self, storage_request_id: str) -> Response:
+    def wait_for_download_ready(self, storage_request_id: str):
         def is_ready():
             is_ready_response = self._get(f"short_term_storage/{storage_request_id}/ready")
             is_ready_response.raise_for_status()
@@ -995,6 +1135,23 @@ class BaseDatasetPopulator(BasePopulator):
         wait_on(is_ready, "waiting for download to become ready")
         assert is_ready()
 
+    def wait_on_task(self, async_task_response: Response):
+        task_id = async_task_response.json()["id"]
+
+        def state():
+            state_response = self._get(f"tasks/{task_id}/state")
+            state_response.raise_for_status()
+            return state_response.json()
+
+        def is_ready():
+            is_complete = state() in ["SUCCESS", "FAILURE"]
+            return True if is_complete else None
+
+        wait_on(is_ready, "waiting for task to complete")
+        return state() == "SUCCESS"
+
+    def wait_on_download_request(self, storage_request_id: str) -> Response:
+        self.wait_for_download_ready(storage_request_id)
         download_contents_response = self._get(f"short_term_storage/{storage_request_id}")
         download_contents_response.raise_for_status()
         return download_contents_response
@@ -1005,13 +1162,31 @@ class BaseDatasetPopulator(BasePopulator):
         contents = contents_response.json()
         return len(contents)
 
-    def reimport_history(self, history_id, history_name, wait_on_history_length, export_kwds):
+    def reimport_history(self, history_id, history_name, wait_on_history_length, export_kwds, task_based=False):
         # Make history public so we can import by url
         self.make_public(history_id)
-        # Export the history.
-        download_url = self.export_url(history_id, export_kwds, check_download=True)
+        if not task_based:
+            # Export the history.
+            full_download_url = self.export_url(history_id, export_kwds, check_download=True)
+        else:
+            # Give modern endpoint the legacy endpoint defaults for kwds...
+            if "include_files" in export_kwds:
+                export_kwds["include_files"] = True
+            if "include_hidden" not in export_kwds:
+                export_kwds["include_hidden"] = True
+            if "include_deleted" not in export_kwds:
+                export_kwds["include_hidden"] = False
+            prepare_download_response = self._post(
+                f"histories/{history_id}/prepare_store_download", export_kwds, json=True
+            )
+            storage_request_id = self.assert_download_request_ok(prepare_download_response)
+            self.wait_for_download_ready(storage_request_id)
+            api_key = self.galaxy_interactor.api_key
+            full_download_url = urllib.parse.urljoin(
+                self.galaxy_interactor.api_url, f"api/short_term_storage/{storage_request_id}?key={api_key}"
+            )
 
-        import_data = dict(archive_source=download_url, archive_type="url")
+        import_data = dict(archive_source=full_download_url, archive_type="url")
 
         imported_history_id = self.import_history_and_wait_for_name(import_data, history_name)
 
@@ -1181,7 +1356,12 @@ class BaseWorkflowPopulator(BasePopulator):
 
         return wait_on_state(workflow_state, desc="workflow invocation state", timeout=timeout, assert_ok=assert_ok)
 
-    def history_invocations(self, history_id: str) -> list:
+    def workflow_invocations(self, workflow_id: str) -> List[Dict[str, Any]]:
+        response = self._get(f"workflows/{workflow_id}/invocations")
+        api_asserts.assert_status_code_is(response, 200)
+        return response.json()
+
+    def history_invocations(self, history_id: str) -> List[Dict[str, Any]]:
         history_invocations_response = self._get("invocations", {"history_id": history_id})
         api_asserts.assert_status_code_is(history_invocations_response, 200)
         return history_invocations_response.json()
@@ -1223,6 +1403,48 @@ class BaseWorkflowPopulator(BasePopulator):
         r = self._get(f"invocations/{invocation_id}", data={"step_details": step_details})
         r.raise_for_status()
         return r.json()
+
+    def download_invocation_to_store(self, invocation_id, extension="tgz"):
+        url = f"invocations/{invocation_id}/prepare_store_download"
+        download_response = self._post(url, dict(include_files=False, model_store_format=extension), json=True)
+        storage_request_id = self.dataset_populator.assert_download_request_ok(download_response)
+        self.dataset_populator.wait_for_download_ready(storage_request_id)
+        return self._get_to_tempfile(f"short_term_storage/{storage_request_id}")
+
+    def download_invocation_to_uri(self, invocation_id, target_uri, extension="tgz"):
+        url = f"invocations/{invocation_id}/write_store"
+        download_response = self._post(
+            url, dict(target_uri=target_uri, include_files=False, model_store_format=extension), json=True
+        )
+        api_asserts.assert_status_code_is_ok(download_response)
+        task_ok = self.dataset_populator.wait_on_task(download_response)
+        assert task_ok, f"waiting on task to write invocation to {target_uri} that failed"
+
+    def create_invocation_from_store_raw(
+        self,
+        history_id: str,
+        store_dict: Optional[Dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        model_store_format: Optional[str] = None,
+    ) -> Response:
+        url = "invocations/from_store"
+        payload = _store_payload(store_dict=store_dict, store_path=store_path, model_store_format=model_store_format)
+        payload["history_id"] = history_id
+        create_response = self._post(url, payload, json=True)
+        return create_response
+
+    def create_invocation_from_store(
+        self,
+        history_id: str,
+        store_dict: Optional[Dict[str, Any]] = None,
+        store_path: Optional[str] = None,
+        model_store_format: Optional[str] = None,
+    ) -> Response:
+        create_response = self.create_invocation_from_store_raw(
+            history_id, store_dict=store_dict, store_path=store_path, model_store_format=model_store_format
+        )
+        api_asserts.assert_status_code_is_ok(create_response)
+        return create_response.json()
 
     def get_biocompute_object(self, invocation_id):
         bco_response = self._get(f"invocations/{invocation_id}/biocompute")
@@ -1903,6 +2125,18 @@ class LibraryPopulator:
         self.set_permissions(library_id, role_id)
         return library
 
+    def create_from_store_raw(self, payload: Dict[str, Any]) -> Response:
+        create_response = self.galaxy_interactor.post("libraries/from_store", payload, json=True, admin=True)
+        return create_response
+
+    def create_from_store(
+        self, store_dict: Optional[Dict[str, Any]] = None, store_path: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        payload = _store_payload(store_dict=store_dict, store_path=store_path)
+        create_response = self.create_from_store_raw(payload)
+        api_asserts.assert_status_code_is_ok(create_response)
+        return create_response.json()
+
     def new_library(self, name):
         data = dict(name=name)
         create_response = self.galaxy_interactor.post("libraries", data=data, admin=True, json=True)
@@ -2247,9 +2481,14 @@ class BaseDatasetCollectionPopulator:
         )
         return payload
 
-    def wait_for_fetched_collection(self, fetch_response):
-        self.dataset_populator.wait_for_job(fetch_response["jobs"][0]["id"], assert_ok=True)
-        initial_dataset_collection = fetch_response["output_collections"][0]
+    def wait_for_fetched_collection(self, fetch_response: Union[Dict[str, Any], Response]):
+        fetch_response_dict: Dict[str, Any]
+        if isinstance(fetch_response, Response):
+            fetch_response_dict = fetch_response.json()
+        else:
+            fetch_response_dict = fetch_response
+        self.dataset_populator.wait_for_job(fetch_response_dict["jobs"][0]["id"], assert_ok=True)
+        initial_dataset_collection = fetch_response_dict["output_collections"][0]
         dataset_collection = self.dataset_populator.get_history_collection_details(
             initial_dataset_collection["history_id"], hid=initial_dataset_collection["hid"]
         )
@@ -2499,12 +2738,32 @@ def wait_on_state(
     if skip_states is None:
         skip_states = ["running", "queued", "new", "ready", "stop", "stopped", "setting_metadata", "waiting"]
     if ok_states is None:
-        ok_states = ["ok", "scheduled"]
+        ok_states = ["ok", "scheduled", "deferred"]
     try:
         return wait_on(get_state, desc=desc, timeout=timeout)
     except TimeoutAssertionError as e:
         response = state_func()
         raise TimeoutAssertionError(f"{e} Current response containing state [{response.json()}].")
+
+
+def _store_payload(
+    store_dict: Optional[Dict[str, Any]] = None,
+    store_path: Optional[str] = None,
+    model_store_format: Optional[str] = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    # Ensure only one store method set.
+    assert store_dict is not None or store_path is not None
+    assert store_dict is None or store_path is None
+    if store_dict is not None:
+        payload["store_dict"] = store_dict
+    if store_path is not None and "://" not in store_path:
+        payload["store_content_uri"] = "base64://" + base64.b64encode(open(store_path, "rb").read()).decode("utf-8")
+    else:
+        payload["store_content_uri"] = store_path
+    if model_store_format is not None:
+        payload["model_store_format"] = model_store_format
+    return payload
 
 
 class GiHttpMixin:

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -178,6 +178,21 @@ test_data:
     d
 """
 
+WORKFLOW_WITH_MAPPED_OUTPUT_COLLECTION = """
+class: GalaxyWorkflow
+inputs:
+  input1:
+    type: data_collection_input
+    collection_type: list
+outputs:
+  wf_output_1:
+    outputSource: first_cat/out_file1
+steps:
+  first_cat:
+    tool_id: cat
+    in:
+      input1: input1
+"""
 
 WORKFLOW_WITH_DYNAMIC_OUTPUT_COLLECTION = """
 class: GalaxyWorkflow
@@ -448,6 +463,18 @@ steps:
       input1: first_cat/out_file1
 """
 
+WORKFLOW_INPUTS_AS_OUTPUTS = """
+class: GalaxyWorkflow
+inputs:
+  input1: data
+  text_input: text
+outputs:
+  wf_output_1:
+    outputSource: input1
+  wf_output_param:
+    outputSource: text_input
+steps: []
+"""
 
 WORKFLOW_PARAMETER_INPUT_INTEGER_REQUIRED = """
 class: GalaxyWorkflow
@@ -897,4 +924,35 @@ input_list:
     - identifier: i1
       content: "0"
   name: example list
+"""
+
+
+WORKFLOW_WITH_BAD_COLUMN_PARAMETER = """
+class: GalaxyWorkflow
+inputs:
+    bed_input: data
+steps:
+  cat1:
+    tool_id: cat1
+    in:
+      input1: bed_input
+  column_param_list:
+    tool_id: column_param
+    in:
+      input1: cat1/out_file1
+    state:
+      col: 9
+      col_names: notacolumn
+"""
+
+
+WORKFLOW_WITH_BAD_COLUMN_PARAMETER_GOOD_TEST_DATA = """
+step_parameters:
+  '2':
+    'col': 1
+    'col_names': 'c1: chr1'
+bed_input:
+  value: 1.bed
+  file_type: bed
+  type: File
 """

--- a/lib/galaxy_test/driver/integration_setup.py
+++ b/lib/galaxy_test/driver/integration_setup.py
@@ -49,12 +49,15 @@ class PosixFileSourceSetup:
     include_test_data_dir: ClassVar[bool] = False
 
     @classmethod
-    def handle_galaxy_config_kwds(cls, config):
+    def handle_galaxy_config_kwds(cls, config, clazz_=None):
         temp_dir = os.path.realpath(mkdtemp())
-        cls._test_driver.temp_directories.append(temp_dir)
-        cls.root_dir = os.path.join(temp_dir, "root")
+        clazz_ = clazz_ or cls
+        clazz_._test_driver.temp_directories.append(temp_dir)
+        clazz_.root_dir = os.path.join(temp_dir, "root")
 
-        file_sources_config_file = create_file_source_config_file_on(temp_dir, cls.root_dir, cls.include_test_data_dir)
+        file_sources_config_file = create_file_source_config_file_on(
+            temp_dir, clazz_.root_dir, clazz_.include_test_data_dir
+        )
         config["file_sources_config_file"] = file_sources_config_file
 
         # Disable all stock plugins

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -1,3 +1,8 @@
+from galaxy.model.unittest_utils.store_fixtures import (
+    deferred_hda_model_store_dict,
+    one_hda_model_store_dict,
+    TEST_SOURCE_URI,
+)
 from .framework import (
     selenium_test,
     SeleniumTestCase,
@@ -72,6 +77,58 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
             self.sleep_for(self.wait_types.JOB_COMPLETION)
         self.history_panel_wait_for_hid_ok(FIRST_HID)
         self.assert_item_dbkey_displayed_as(FIRST_HID, "apiMel3")
+
+    @selenium_test
+    def test_dataset_state_discarded(self):
+        self.history_panel_create_new()
+        history_id = self.current_history_id()
+        self.dataset_populator.create_contents_from_store(
+            history_id,
+            store_dict=one_hda_model_store_dict(include_source=False),
+        )
+        if not self.is_beta_history():
+            self.history_panel_refresh_click()
+        else:
+            # regression after 3/24/2022 - explicit refresh now required.
+            self.home()
+        self.history_panel_wait_for_hid_state(FIRST_HID, state="discarded", allowed_force_refreshes=1)
+        self.history_panel_click_item_title(hid=FIRST_HID, wait=True)
+        self.screenshot("history_panel_dataset_discarded")
+        # Next if is a hack for recent changes to beta history...
+        # https://github.com/galaxyproject/galaxy/pull/13477/files#r823842897
+        if not self.is_beta_history():
+            self.assert_item_summary_includes(FIRST_HID, "job creating")
+        self._assert_downloadable(FIRST_HID, is_downloadable=False)
+
+        self.history_panel_item_view_dataset_details(FIRST_HID)
+        self.screenshot("dataset_details_discarded")
+
+    @selenium_test
+    def test_dataset_state_deferred(self):
+        self.history_panel_create_new()
+        history_id = self.current_history_id()
+        self.dataset_populator.create_contents_from_store(
+            history_id,
+            store_dict=deferred_hda_model_store_dict(),
+        )
+        if not self.is_beta_history():
+            self.history_panel_refresh_click()
+        else:
+            # regression after 3/24/2022 - explicit refresh now required.
+            self.home()
+        self.history_panel_wait_for_hid_state(FIRST_HID, state="deferred", allowed_force_refreshes=1)
+        self.history_panel_click_item_title(hid=FIRST_HID, wait=True)
+        self.screenshot("history_panel_dataset_deferred")
+        # Next if is a hack for recent changes to beta history...
+        # https://github.com/galaxyproject/galaxy/pull/13477/files#r823842897
+        if not self.is_beta_history():
+            self.assert_item_summary_includes(FIRST_HID, "This dataset is remote")
+        self._assert_downloadable(FIRST_HID, is_downloadable=False)
+
+        self.history_panel_item_view_dataset_details(FIRST_HID)
+        self.screenshot("dataset_details_deferred")
+        details = self.components.dataset_details
+        assert details.deferred_source_uri.wait_for_text() == TEST_SOURCE_URI
 
     def _prepare_dataset(self):
         self.history_panel_create_new()

--- a/packages/data/setup.py
+++ b/packages/data/setup.py
@@ -59,6 +59,7 @@ PACKAGES = [
 ENTRY_POINTS = """
         [console_scripts]
         galaxy-build-objects=galaxy.model.store.build_objects:main
+        galaxy-load-objects=galaxy.model.store.load_objects:main
         galaxy-manage-db=galaxy.model.orm.scripts:manage_db
 """
 PACKAGE_DATA = {

--- a/test/integration/test_history_import_export.py
+++ b/test/integration/test_history_import_export.py
@@ -1,15 +1,170 @@
+import tarfile
+
+from galaxy.model.unittest_utils.store_fixtures import (
+    deferred_hda_model_store_dict,
+    history_model_store_dict,
+    one_hda_model_store_dict,
+)
 from galaxy_test.api.test_histories import ImportExportTests
-from galaxy_test.driver.integration_util import IntegrationTestCase
+from galaxy_test.base.api_asserts import assert_has_keys
+from galaxy_test.base.populators import (
+    DatasetCollectionPopulator,
+    DatasetPopulator,
+)
+from galaxy_test.driver.integration_util import (
+    IntegrationTestCase,
+    setup_celery_includes,
+    UsesCeleryTasks,
+)
+
+celery_includes = setup_celery_includes()
 
 
-class ImportExportHistoryOutputsToWorkingDirTestCase(ImportExportTests, IntegrationTestCase):
+class ImportExportHistoryOutputsToWorkingDirIntegrationTestCase(ImportExportTests, IntegrationTestCase):
+    task_based = False
     framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["outputs_to_working_directory"] = True
+        config["metadata_strategy"] = "extended"
 
     def setUp(self):
         super().setUp()
         self._set_up_populators()
 
+
+class ImportExportHistoryViaTasksIntegrationTestCase(ImportExportTests, IntegrationTestCase, UsesCeleryTasks):
+    task_based = True
+    framework_tool_and_types = True
+
     @classmethod
     def handle_galaxy_config_kwds(cls, config):
-        config["metadata_strategy"] = "extended"
-        config["outputs_to_working_directory"] = True
+        cls.setup_celery_config(config)
+
+    def setUp(self):
+        super().setUp()
+        self._set_up_populators()
+
+    def test_import_from_model_store_async(self):
+        async_history_name = "Model store imported history"
+        store_dict = history_model_store_dict()
+        store_dict["history"]["name"] = async_history_name
+        response = self.dataset_populator.create_from_store_async(store_dict=store_dict)
+        assert_has_keys(response, "id")
+        self.dataset_populator.wait_for_history_with_name(
+            async_history_name,
+            "task based import history",
+        )
+
+
+class ImportExportHistoryContentsViaTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):
+    task_based = True
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls.setup_celery_config(config)
+
+    def setUp(self):
+        super().setUp()
+        self._set_up_populators()
+        self.history_id = self.dataset_populator.new_history()
+
+    def _set_up_populators(self):
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
+
+    def test_export_and_imported_discarded(self):
+        hda1 = self.dataset_populator.new_dataset(self.history_id, wait=True)
+
+        second_history_id, as_list = self.dataset_populator.reupload_contents(hda1)
+
+        assert len(as_list) == 1
+        new_hda = as_list[0]
+        assert new_hda["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda["state"] == "discarded"
+        assert not new_hda["deleted"]
+
+    def test_export_and_imported_discarded_bam(self):
+        contents = self.dataset_populator.new_dataset(
+            self.history_id,
+            content=open(self.test_data_resolver.get_filename("1.bam"), "rb"),
+            file_type="bam",
+            wait=True,
+        )
+        second_history_id, as_list = self.dataset_populator.reupload_contents(contents)
+        assert len(as_list) == 1
+        new_hda = as_list[0]
+        assert new_hda["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda["state"] == "discarded"
+        assert not new_hda["deleted"]
+
+    def test_import_as_discarded_from_dict(self):
+        as_list = self.dataset_populator.create_contents_from_store(
+            self.history_id,
+            store_dict=one_hda_model_store_dict(
+                include_source=False,
+            ),
+        )
+        assert len(as_list) == 1
+        new_hda = as_list[0]
+        assert new_hda["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda["state"] == "discarded"
+        assert not new_hda["deleted"]
+
+        contents_response = self._get(f"histories/{self.history_id}/contents?v=dev")
+        contents_response.raise_for_status()
+
+    def test_import_as_deferred_from_discarded_with_source_dict(self):
+        as_list = self.dataset_populator.create_contents_from_store(
+            self.history_id,
+            store_dict=one_hda_model_store_dict(
+                include_source=True,
+            ),
+        )
+        assert len(as_list) == 1
+        new_hda = as_list[0]
+        assert new_hda["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda["state"] == "deferred"
+        assert not new_hda["deleted"]
+
+        contents_response = self._get(f"histories/{self.history_id}/contents?v=dev")
+        contents_response.raise_for_status()
+
+    def test_export_and_imported_discarded_collection(self):
+        create_response = self.dataset_collection_populator.create_list_in_history(
+            history_id=self.history_id,
+            direct_upload=True,
+            wait=True,
+        ).json()
+        self.dataset_populator.wait_for_history(self.history_id)
+        contents = create_response["outputs"][0]
+        temp_tar = self.dataset_populator.download_contents_to_store(self.history_id, contents, "tgz")
+        with tarfile.open(name=temp_tar) as tf:
+            assert "datasets_attrs.txt" in tf.getnames()
+            assert "collections_attrs.txt" in tf.getnames()
+
+        second_history_id = self.dataset_populator.new_history()
+        as_list = self.dataset_populator.create_contents_from_store(
+            second_history_id,
+            store_path=temp_tar,
+        )
+        as_list = self.dataset_populator.get_history_contents(second_history_id)
+        assert len(as_list) == 4
+        hdcas = [e for e in as_list if e["history_content_type"] == "dataset_collection"]
+        assert len(hdcas) == 1
+
+    def test_import_as_deferred_from_dict(self):
+        as_list = self.dataset_populator.create_contents_from_store(
+            self.history_id,
+            store_dict=deferred_hda_model_store_dict(),
+        )
+        assert len(as_list) == 1
+        new_hda = as_list[0]
+        assert new_hda["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda["state"] == "deferred"
+        assert not new_hda["deleted"]
+
+        contents_response = self._get(f"histories/{self.history_id}/contents?v=dev")
+        contents_response.raise_for_status()

--- a/test/integration/test_materialize_dataset_instance_tasks.py
+++ b/test/integration/test_materialize_dataset_instance_tasks.py
@@ -1,0 +1,269 @@
+import os
+
+from galaxy.model.unittest_utils.store_fixtures import (
+    deferred_hda_model_store_dict,
+    deferred_hda_model_store_dict_bam,
+    one_ld_library_deferred_model_store_dict,
+    TEST_LIBRARY_NAME,
+)
+from galaxy.util import galaxy_directory
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    LibraryPopulator,
+    uses_test_history,
+)
+from galaxy_test.driver.integration_util import (
+    IntegrationTestCase,
+    setup_celery_includes,
+    UsesCeleryTasks,
+)
+
+celery_includes = setup_celery_includes()
+
+
+class MaterializeDatasetInstanceTasaksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        cls.setup_celery_config(config)
+        test_data_root = os.path.join(galaxy_directory(), "test-data")
+        config["file_sources"] = [
+            {
+                "id": "testdatafiles",
+                "type": "posix",
+                "root": test_data_root,
+            }
+        ]
+
+    def setUp(self):
+        super().setUp()
+        self.library_populator = LibraryPopulator(self.galaxy_interactor)
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    @uses_test_history(require_new=True)
+    def test_materialize_history_dataset(self, history_id: str):
+        as_list = self.dataset_populator.create_contents_from_store(
+            history_id,
+            store_dict=deferred_hda_model_store_dict(),
+        )
+        assert len(as_list) == 1
+        deferred_hda = as_list[0]
+        assert deferred_hda["model_class"] == "HistoryDatasetAssociation"
+        assert deferred_hda["state"] == "deferred"
+        assert not deferred_hda["deleted"]
+        self.dataset_populator.materialize_dataset_instance(history_id, deferred_hda["id"])
+        self.dataset_populator.wait_on_history_length(history_id, 2)
+        new_hda_details = self.dataset_populator.get_history_dataset_details(
+            history_id, hid=2, assert_ok=False, wait=False
+        )
+        assert new_hda_details["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda_details["state"] == "ok"
+        assert not new_hda_details["deleted"]
+
+    @uses_test_history(require_new=True)
+    def test_materialize_gxfiles_uri(self, history_id: str):
+        as_list = self.dataset_populator.create_contents_from_store(
+            history_id,
+            store_dict=deferred_hda_model_store_dict(source_uri="gxfiles://testdatafiles/2.bed"),
+        )
+        assert len(as_list) == 1
+        deferred_hda = as_list[0]
+        assert deferred_hda["model_class"] == "HistoryDatasetAssociation"
+        assert deferred_hda["state"] == "deferred"
+        assert not deferred_hda["deleted"]
+
+        self.dataset_populator.materialize_dataset_instance(history_id, deferred_hda["id"])
+        self.dataset_populator.wait_on_history_length(history_id, 2)
+        new_hda_details = self.dataset_populator.get_history_dataset_details(
+            history_id, hid=2, assert_ok=False, wait=False
+        )
+        assert new_hda_details["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda_details["state"] == "ok"
+        assert not new_hda_details["deleted"]
+
+    @uses_test_history(require_new=True)
+    def test_materialize_history_dataset_bam(self, history_id: str):
+        as_list = self.dataset_populator.create_contents_from_store(
+            history_id,
+            store_dict=deferred_hda_model_store_dict_bam(),
+        )
+
+        assert len(as_list) == 1
+        deferred_hda = as_list[0]
+        assert deferred_hda["model_class"] == "HistoryDatasetAssociation"
+        assert deferred_hda["state"] == "deferred"
+        assert not deferred_hda["deleted"]
+
+        # assert bam metadata and such deferred...
+        deferred_hda_details = self.dataset_populator.get_history_dataset_details(
+            history_id, hid=1, assert_ok=False, wait=False
+        )
+        assert ">chrM" not in deferred_hda_details["metadata_reference_names"]
+        assert "metadata_bam_index" not in deferred_hda_details
+
+        self.dataset_populator.materialize_dataset_instance(history_id, deferred_hda["id"])
+        self.dataset_populator.wait_on_history_length(history_id, 2)
+        new_hda_details = self.dataset_populator.get_history_dataset_details(
+            history_id, hid=2, assert_ok=False, wait=False
+        )
+        assert new_hda_details["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda_details["state"] == "ok"
+        assert not new_hda_details["deleted"]
+
+        assert ">chrM" in new_hda_details["metadata_reference_names"]
+        assert "metadata_bam_index" in new_hda_details
+
+    @uses_test_history(require_new=True)
+    def test_materialize_library_dataset(self, history_id: str):
+        response = self.library_populator.create_from_store(store_dict=one_ld_library_deferred_model_store_dict())
+        assert isinstance(response, list)
+        assert len(response) == 1
+        library_summary = response[0]
+        assert library_summary["name"] == TEST_LIBRARY_NAME
+        assert "id" in library_summary
+        ld = self.library_populator.get_library_contents_with_path(library_summary["id"], "/my cool name")
+        assert ld
+        self.dataset_populator.materialize_dataset_instance(history_id, ld["id"], "ldda")
+        self.dataset_populator.wait_on_history_length(history_id, 1)
+        new_hda_details = self.dataset_populator.get_history_dataset_details(
+            history_id, hid=1, assert_ok=False, wait=False
+        )
+        assert new_hda_details["model_class"] == "HistoryDatasetAssociation"
+        assert new_hda_details["state"] == "ok"
+        assert not new_hda_details["deleted"]
+
+    @uses_test_history(require_new=True)
+    def test_upload_vs_materialize_simplest_upload(self, history_id: str):
+        item = {"src": "url", "url": "gxfiles://testdatafiles//simple_line_no_newline.txt", "ext": "txt"}
+        output = self.dataset_populator.fetch_hda(history_id, item)
+        uploaded_details = self.dataset_populator.get_history_dataset_details(
+            history_id, dataset=output, assert_ok=True
+        )
+        assert "sources" in uploaded_details
+        assert len(uploaded_details["sources"]) == 1
+        content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output, assert_ok=True)
+        assert content == "This is a line of text."
+        new_history_id = self._reupload_and_then_materialize(history_id, output)
+        content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
+        assert content == "This is a line of text."
+
+    @uses_test_history(require_new=True)
+    def test_upload_vs_materialize_to_posix_lines(self, history_id: str):
+        item = {
+            "src": "url",
+            "url": "gxfiles://testdatafiles//simple_line_no_newline.txt",
+            "ext": "txt",
+            "to_posix_lines": True,
+        }
+        output = self.dataset_populator.fetch_hda(history_id, item)
+        uploaded_details = self.dataset_populator.get_history_dataset_details(
+            history_id, dataset=output, assert_ok=True
+        )
+        assert "sources" in uploaded_details
+        sources = uploaded_details["sources"]
+        assert len(sources) == 1
+        source_0 = sources[0]
+        assert "transform" in source_0
+        transform = source_0["transform"]
+        assert isinstance(transform, list)
+        assert len(transform) == 1
+        content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output, assert_ok=True)
+        assert content == "This is a line of text.\n"
+        new_history_id = self._reupload_and_then_materialize(history_id, output)
+        content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
+        assert content == "This is a line of text.\n"
+
+    @uses_test_history(require_new=True)
+    def test_upload_vs_materialize_space_to_tab(self, history_id: str):
+        item = {
+            "src": "url",
+            "url": "gxfiles://testdatafiles//simple_line_no_newline.txt",
+            "ext": "txt",
+            "space_to_tab": True,
+        }
+        output = self.dataset_populator.fetch_hda(history_id, item)
+        uploaded_details = self.dataset_populator.get_history_dataset_details(
+            history_id, dataset=output, assert_ok=True
+        )
+        assert "sources" in uploaded_details
+        sources = uploaded_details["sources"]
+        assert len(sources) == 1
+        source_0 = sources[0]
+        assert "transform" in source_0
+        transform = source_0["transform"]
+        assert isinstance(transform, list)
+        assert len(transform) == 1
+        content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output, assert_ok=True)
+        assert content == "This\tis\ta\tline\tof\ttext."
+        new_history_id = self._reupload_and_then_materialize(history_id, output)
+        content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
+        assert content == "This\tis\ta\tline\tof\ttext."
+
+    @uses_test_history(require_new=True)
+    def test_upload_vs_materialize_to_posix_and_space_to_tab(self, history_id: str):
+        item = {
+            "src": "url",
+            "url": "gxfiles://testdatafiles//simple_line_no_newline.txt",
+            "ext": "txt",
+            "space_to_tab": True,
+            "to_posix_lines": True,
+        }
+        output = self.dataset_populator.fetch_hda(history_id, item)
+        uploaded_details = self.dataset_populator.get_history_dataset_details(
+            history_id, dataset=output, assert_ok=True
+        )
+        assert "sources" in uploaded_details
+        sources = uploaded_details["sources"]
+        assert len(sources) == 1
+        source_0 = sources[0]
+        assert "transform" in source_0
+        transform = source_0["transform"]
+        assert isinstance(transform, list)
+        assert len(transform) == 2
+        content = self.dataset_populator.get_history_dataset_content(history_id, dataset=output, assert_ok=True)
+        assert content == "This\tis\ta\tline\tof\ttext.\n"
+        new_history_id = self._reupload_and_then_materialize(history_id, output)
+        content = self.dataset_populator.get_history_dataset_content(new_history_id, hid=2, assert_ok=False)
+        assert content == "This\tis\ta\tline\tof\ttext.\n"
+
+    @uses_test_history(require_new=True)
+    def test_upload_vs_materialize_grooming(self, history_id: str):
+        item = {
+            "src": "url",
+            "url": "gxfiles://testdatafiles/qname_sorted.bam",
+            "ext": "bam",
+        }
+        output = self.dataset_populator.fetch_hda(history_id, item)
+        uploaded_details = self.dataset_populator.get_history_dataset_details(
+            history_id, dataset=output, assert_ok=True
+        )
+        assert "sources" in uploaded_details
+        sources = uploaded_details["sources"]
+        assert len(sources) == 1
+        source_0 = sources[0]
+        assert "transform" in source_0
+        transform = source_0["transform"]
+        assert isinstance(transform, list)
+        assert len(transform) == 1
+        original_details = self.dataset_populator.get_history_dataset_details(
+            history_id, dataset=output, assert_ok=True
+        )
+        new_history_id = self._reupload_and_then_materialize(history_id, output)
+        new_details = self.dataset_populator.get_history_dataset_details(new_history_id, hid=2, assert_ok=False)
+        for key in original_details.keys():
+            if key in ["metadata_bam_header", "metadata_bam_index"]:
+                # differs because command-line different, index path different, and such...
+                continue
+            if key.startswith("metadata_"):
+                assert original_details[key] == new_details[key], f"Mismatched on key {key}"
+        assert original_details["file_ext"] == new_details["file_ext"]
+
+    def _reupload_and_then_materialize(self, history_id, dataset):
+        new_history_id, uploaded_hdas = self.dataset_populator.reupload_contents(dataset)
+        assert len(uploaded_hdas) == 1
+        deferred_hda = uploaded_hdas[0]
+        assert deferred_hda["state"] == "deferred"
+
+        self.dataset_populator.wait_on_history_length(new_history_id, 1)
+        self.dataset_populator.materialize_dataset_instance(new_history_id, deferred_hda["id"])
+        self.dataset_populator.wait_on_history_length(new_history_id, 2)
+        return new_history_id

--- a/test/integration/test_model_store_scripts.py
+++ b/test/integration/test_model_store_scripts.py
@@ -1,0 +1,39 @@
+import json
+import os
+
+from galaxy.model.store.load_objects import main
+from galaxy.model.unittest_utils.store_fixtures import (
+    history_model_store_dict,
+    one_hda_model_store_dict,
+    TEST_HISTORY_NAME,
+)
+from galaxy_test.base.populators import DatasetPopulator
+from galaxy_test.driver.integration_util import IntegrationTestCase
+
+
+class ModelStoreScriptsIntegrationTestCase(IntegrationTestCase):
+    # TODO: test build_objects also...
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.json_store_path = os.path.join(self._tempdir, "store.json")
+
+    def test_import_contents_from_json(self):
+        self._write_store_json(one_hda_model_store_dict())
+        history_id = self.dataset_populator.new_history()
+        script_args = ["-t", history_id, "-u", self.url, "-k", self.galaxy_interactor.api_key, self.json_store_path]
+        main(script_args)
+
+    def test_import_history_from_json(self):
+        self._write_store_json(history_model_store_dict())
+        script_args = ["-u", self.url, "-k", self.galaxy_interactor.api_key, self.json_store_path]
+        history_names = [h["name"] for h in self.dataset_populator.get_histories()]
+        assert TEST_HISTORY_NAME not in history_names
+        main(script_args)
+        history_names = [h["name"] for h in self.dataset_populator.get_histories()]
+        assert TEST_HISTORY_NAME in history_names
+
+    def _write_store_json(self, as_dict) -> None:
+        with open(self.json_store_path, "w") as f:
+            json.dump(as_dict, f)

--- a/test/integration/test_workflow_tasks.py
+++ b/test/integration/test_workflow_tasks.py
@@ -1,0 +1,144 @@
+"""Workflow invocation model store tests.
+
+Someday when the API tests can safely assume the target Galaxy has tasks enabled, this should be moved
+into the API test suite.
+"""
+import os
+from typing import (
+    Any,
+    Dict,
+)
+
+from galaxy_test.api.test_workflows import RunsWorkflowFixtures
+from galaxy_test.base import api_asserts
+from galaxy_test.base.populators import (
+    DatasetPopulator,
+    RunJobsSummary,
+    WorkflowPopulator,
+)
+from galaxy_test.driver.integration_setup import PosixFileSourceSetup
+from galaxy_test.driver.integration_util import (
+    IntegrationTestCase,
+    setup_celery_includes,
+    UsesCeleryTasks,
+)
+
+celery_includes = setup_celery_includes()
+
+
+class WorkflowTasksIntegrationTestCase(
+    PosixFileSourceSetup, IntegrationTestCase, UsesCeleryTasks, RunsWorkflowFixtures
+):
+
+    framework_tool_and_types = True
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        PosixFileSourceSetup.handle_galaxy_config_kwds(config, cls)
+        cls.setup_celery_config(config)
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.workflow_populator = WorkflowPopulator(self.galaxy_interactor)
+        self._write_file_fixtures()
+
+    def test_export_import_invocation_collection_input_uris(self):
+        self._test_export_import_invocation_collection_input(True)
+
+    def test_export_import_invocation_collection_input_uris_bag_zip(self):
+        self._test_export_import_invocation_collection_input(True, "bag.zip")
+
+    def test_export_import_invocation_collection_input_sts(self):
+        self._test_export_import_invocation_collection_input(False)
+
+    def test_export_import_invocation_with_input_as_output_uris(self):
+        self._test_export_import_invocation_with_input_as_output(True)
+
+    def test_export_import_invocation_with_input_as_output_sts(self):
+        self._test_export_import_invocation_with_input_as_output(False)
+
+    def _test_export_import_invocation_collection_input(self, use_uris, model_store_format="tgz"):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow_with_output_collections(history_id)
+            invocation_details = self._export_and_import_worklflow_invocation(
+                summary, use_uris, model_store_format=model_store_format
+            )
+            output_collections = invocation_details["output_collections"]
+            assert len(output_collections) == 1
+            assert "wf_output_1" in output_collections
+            out = output_collections["wf_output_1"]
+            assert out["src"] == "hdca"
+
+            inputs = invocation_details["inputs"]
+            assert inputs["0"]["src"] == "hdca"
+
+            self._rerun_imported_workflow(summary, invocation_details)
+
+    def _test_export_import_invocation_with_input_as_output(self, use_uris):
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow_with_inputs_as_outputs(history_id)
+            invocation_details = self._export_and_import_worklflow_invocation(summary, use_uris)
+            output_values = invocation_details["output_values"]
+            assert len(output_values) == 1
+            assert "wf_output_param" in output_values
+            out = output_values["wf_output_param"]
+            assert out == "A text variable"
+            inputs = invocation_details["input_step_parameters"]
+            assert "text_input" in inputs
+
+            self._rerun_imported_workflow(summary, invocation_details)
+
+    def test_export_import_invocation_with_step_parameter(self):
+        use_uris = False
+        # Run this to ensure order indices are preserved.
+        with self.dataset_populator.test_history() as history_id:
+            summary = self._run_workflow_with_runtime_data_column_parameter(history_id)
+            invocation_details = self._export_and_import_worklflow_invocation(summary, use_uris)
+            self._rerun_imported_workflow(summary, invocation_details)
+
+    def _export_and_import_worklflow_invocation(
+        self, summary: RunJobsSummary, use_uris: bool = True, model_store_format="tgz"
+    ) -> Dict[str, Any]:
+        invocation_id = summary.invocation_id
+        extension = model_store_format or "tgz"
+        if use_uris:
+            uri = f"gxfiles://posix_test/invocation.{extension}"
+            self.workflow_populator.download_invocation_to_uri(invocation_id, uri, extension=extension)
+            root = self.root_dir
+            invocation_path = os.path.join(root, f"invocation.{extension}")
+            assert os.path.exists(invocation_path)
+            uri = invocation_path
+        else:
+            temp_tar = self.workflow_populator.download_invocation_to_store(invocation_id, extension=extension)
+            uri = temp_tar
+
+        with self.dataset_populator.test_history() as history_id:
+            response = self.workflow_populator.create_invocation_from_store(
+                history_id, store_path=uri, model_store_format=model_store_format
+            )
+
+        imported_invocation_details = self._assert_one_invocation_created_and_get_details(response)
+        return imported_invocation_details
+
+    def _rerun_imported_workflow(self, summary: RunJobsSummary, create_response: Dict[str, Any]):
+        workflow_id = create_response["workflow_id"]
+        history_id = self.dataset_populator.new_history()
+        new_workflow_request = summary.workflow_request.copy()
+        new_workflow_request["history"] = f"hist_id={history_id}"
+        invocation_response = self.workflow_populator.invoke_workflow_raw(workflow_id, new_workflow_request)
+        invocation_response.raise_for_status()
+        invocation_id = invocation_response.json()["id"]
+        self.workflow_populator.wait_for_workflow(workflow_id, invocation_id, history_id, assert_ok=True)
+
+    def _assert_one_invocation_created_and_get_details(self, response: Any) -> Dict[str, Any]:
+        assert isinstance(response, list)
+        assert len(response) == 1
+        invocation = response[0]
+        assert "state" in invocation
+        assert invocation["state"] == "scheduled"
+        imported_invocation_id = invocation["id"]
+
+        invocation_details = self.workflow_populator.get_invocation(imported_invocation_id, step_details="true")
+        api_asserts.assert_has_keys(invocation_details, "inputs", "steps", "workflow_id")
+        return invocation_details

--- a/test/unit/app/tools/test_data_fetch.py
+++ b/test/unit/app/tools/test_data_fetch.py
@@ -35,6 +35,31 @@ def test_simple_path_get():
         assert output
 
 
+def test_deferred_uri_get():
+    with _execute_context() as execute_context:
+        request = {
+            "targets": [
+                {
+                    "destination": {
+                        "type": "hdas",
+                    },
+                    "elements": [
+                        {
+                            "src": "url",
+                            "url": "https://raw.githubusercontent.com/galaxyproject/galaxy/dev/test-data/12.bed",
+                            "deferred": True,
+                        }
+                    ],
+                }
+            ]
+        }
+        execute_context.execute_request(request)
+        output = _unnamed_output(execute_context)
+        hda_result = output["elements"][0]
+        assert hda_result["state"] == "deferred"
+        assert hda_result["ext"] == "bed"
+
+
 def test_simple_list_path_get():
     with _execute_context() as execute_context:
         job_directory = execute_context.job_directory

--- a/test/unit/data/datatypes/test_sniff.py
+++ b/test/unit/data/datatypes/test_sniff.py
@@ -2,6 +2,7 @@ import tempfile
 
 import pytest
 
+from galaxy.datatypes.registry import example_datatype_registry_for_sample
 from galaxy.datatypes.sniff import (
     convert_newlines,
     convert_newlines_sep2tabs,
@@ -97,3 +98,14 @@ def test_convert_sep2tabs_only():
     assert_converts_to_1234_convert_sep2tabs_only(b"1 2\r3 4", b"1\t2\r3\t4")
     assert_converts_to_1234_convert_sep2tabs_only(b"1 2\n3 4", b"1\t2\n3\t4")
     assert_converts_to_1234_convert_sep2tabs_only(b"1    2\n3    4", b"1\t2\n3\t4")
+
+
+def test_infer_from_filename():
+    datatypes_registry = example_datatype_registry_for_sample()
+    assert datatypes_registry.get_datatype_from_filename("mycool.fa").file_ext == "fasta"
+    assert datatypes_registry.get_datatype_from_filename("mycool.fasta").file_ext == "fasta"
+    assert datatypes_registry.get_datatype_from_filename("mycool.fasta.gz").file_ext == "fasta.gz"
+    assert datatypes_registry.get_datatype_from_filename("mycool.fa.gz").file_ext == "fasta.gz"
+    assert datatypes_registry.get_datatype_from_filename("mycool.fq").file_ext == "fastqsanger"
+    assert datatypes_registry.get_datatype_from_filename("mycool.fq.gz").file_ext == "fastqsanger.gz"
+    assert datatypes_registry.get_datatype_from_filename("mycool.fastq").file_ext == "fastqsanger"

--- a/test/unit/data/model/mapping/test_gxy_model_mapping.py
+++ b/test/unit/data/model/mapping/test_gxy_model_mapping.py
@@ -1491,6 +1491,7 @@ class TestHistoryDatasetAssociation(BaseTest):
         purged = False
         validated_state = "j"
         validated_state_message = "k"
+        metadata_deferred = False
 
         obj = cls_()
         obj.history = history
@@ -1518,6 +1519,7 @@ class TestHistoryDatasetAssociation(BaseTest):
         obj.validated_state = validated_state
         obj.validated_state_message = validated_state_message
         obj.hidden_beneath_collection_instance = history_dataset_collection_association
+        obj.metadata_deferred = metadata_deferred
 
         with dbcleanup(session, obj) as obj_id:
             stored_obj = get_stored_obj(session, cls_, obj_id)
@@ -1548,6 +1550,7 @@ class TestHistoryDatasetAssociation(BaseTest):
             assert stored_obj.purged == purged
             assert stored_obj.validated_state == validated_state
             assert stored_obj.validated_state_message == validated_state_message
+            assert stored_obj.metadata_deferred is metadata_deferred
             assert stored_obj.hidden_beneath_collection_instance_id == history_dataset_collection_association.id
 
         delete_from_database(session, [copied_from_hda, parent])
@@ -3297,6 +3300,7 @@ class TestLibraryDatasetDatasetAssociation(BaseTest):
         validated_state_message = "k"
         visible = True
         message = "m"
+        metadata_deferred = False
         _metadata = {"key": "value"}
         copied_from_ldda = library_dataset_dataset_association_factory()
         parent = library_dataset_dataset_association_factory()
@@ -3324,6 +3328,7 @@ class TestLibraryDatasetDatasetAssociation(BaseTest):
         obj.validated_state_message = validated_state_message
         obj.visible = visible
         obj.extended_metadata = extended_metadata
+        obj.metadata_deferred = metadata_deferred
         obj.user = user
         obj.message = message
         obj._metadata = _metadata
@@ -3357,6 +3362,7 @@ class TestLibraryDatasetDatasetAssociation(BaseTest):
             # However, the following assertion verifies that it exists and has been initialized correctly.
             assert stored_obj.metadata.parent.id == obj_id
             assert stored_obj._metadata == _metadata
+            assert stored_obj.metadata_deferred is metadata_deferred
 
         delete_from_database(session, [copied_from_ldda, parent])
 

--- a/test/unit/data/test_dataset_materialization.py
+++ b/test/unit/data/test_dataset_materialization.py
@@ -1,0 +1,342 @@
+from pkg_resources import resource_string
+
+from galaxy.files.unittest_utils import TestPosixConfiguredFileSources
+from galaxy.model import (
+    DatasetCollection,
+    DatasetCollectionElement,
+    HistoryDatasetAssociation,
+    HistoryDatasetCollectionAssociation,
+    LibraryDatasetDatasetAssociation,
+    store,
+)
+from galaxy.model.deferred import (
+    materialize_collection_instance,
+    materializer_factory,
+)
+from galaxy.model.unittest_utils.store_fixtures import (
+    deferred_hda_model_store_dict,
+    one_ld_library_deferred_model_store_dict,
+)
+from .model.test_model_store import (
+    perform_import_from_store_dict,
+    setup_fixture_context_with_history,
+    StoreFixtureContextWithHistory,
+)
+from .test_model_copy import _create_hda
+
+CONTENTS_2_BED = resource_string(__name__, "model/2.bed").decode("UTF-8")
+
+
+def test_undeferred_hdas_untouched(tmpdir):
+    app, sa_session, user, history = setup_fixture_context_with_history()
+    hda_fh = tmpdir.join("file.txt")
+    hda_fh.write("Moo Cow")
+    hda = _create_hda(sa_session, app.object_store, history, hda_fh, include_metadata_file=False)
+    sa_session.flush()
+
+    materializer = materializer_factory(True, object_store=app.object_store)
+    assert materializer.ensure_materialized(hda) == hda
+
+
+def test_deferred_hdas_basic_attached():
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    _assert_2_bed_metadata(deferred_hda)
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    # only detached datasets would be created with an external_filename
+    assert not materialized_dataset.external_filename
+    object_store = fixture_context.app.object_store
+    path = object_store.get_filename(materialized_dataset)
+    assert path
+    _assert_path_contains_2_bed(path)
+    _assert_2_bed_metadata(materialized_hda)
+
+
+def test_deferred_hdas_basic_attached_store_by_uuid():
+    # skip a flush here so this is a different path...
+    fixture_context = setup_fixture_context_with_history(store_by="uuid")
+    store_dict = deferred_hda_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    _assert_2_bed_metadata(deferred_hda)
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    # only detached datasets would be created with an external_filename
+    assert not materialized_dataset.external_filename
+    object_store = fixture_context.app.object_store
+    path = object_store.get_filename(materialized_dataset)
+    assert path
+    _assert_path_contains_2_bed(path)
+
+
+def test_deferred_hdas_basic_detached(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    _assert_2_bed_metadata(deferred_hda)
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    external_filename = materialized_dataset.external_filename
+    assert external_filename
+    assert external_filename.startswith(str(tmpdir))
+    _assert_path_contains_2_bed(external_filename)
+    _assert_2_bed_metadata(materialized_hda)
+
+
+def test_deferred_hdas_basic_detached_from_detached_hda(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+
+    _ensure_relations_attached_and_expunge(deferred_hda, fixture_context)
+
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    external_filename = materialized_dataset.external_filename
+    assert external_filename
+    assert external_filename.startswith(str(tmpdir))
+    _assert_path_contains_2_bed(external_filename)
+    _assert_2_bed_metadata(materialized_hda)
+
+
+def test_deferred_hdas_basic_attached_from_detached_hda():
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+
+    _ensure_relations_attached_and_expunge(deferred_hda, fixture_context)
+
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(
+        True, object_store=fixture_context.app.object_store, sa_session=fixture_context.sa_session
+    )
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    # only detached datasets would be created with an external_filename
+    assert not materialized_dataset.external_filename
+    object_store = fixture_context.app.object_store
+    path = object_store.get_filename(materialized_dataset)
+    assert path
+    _assert_path_contains_2_bed(path)
+    _assert_2_bed_metadata(materialized_hda)
+
+
+def test_deferred_ldda_basic_attached():
+    import_options = store.ImportOptions(
+        allow_library_creation=True,
+    )
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = one_ld_library_deferred_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict, import_options=import_options)
+    deferred_ldda = fixture_context.sa_session.query(LibraryDatasetDatasetAssociation).all()[0]
+    assert deferred_ldda
+    assert deferred_ldda.dataset.state == "deferred"
+
+    materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
+    materialized_hda = materializer.ensure_materialized(deferred_ldda)
+    assert materialized_hda.history is None
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    # only detached datasets would be created with an external_filename
+    assert not materialized_dataset.external_filename
+    object_store = fixture_context.app.object_store
+    path = object_store.get_filename(materialized_dataset)
+    assert path
+    _assert_path_contains_2_bed(path)
+
+
+def test_deferred_hdas_basic_attached_file_sources(tmpdir):
+    root = tmpdir / "root"
+    root.mkdir()
+    content_path = root / "2.bed"
+    content_path.write_text(CONTENTS_2_BED, encoding="utf-8")
+    file_sources = TestPosixConfiguredFileSources(root)
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict(
+        source_uri="gxfiles://test1/2.bed",
+    )
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(True, object_store=fixture_context.app.object_store, file_sources=file_sources)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert materialized_dataset.state == "ok"
+    # only detached datasets would be created with an external_filename
+    assert not materialized_dataset.external_filename
+    object_store = fixture_context.app.object_store
+    path = object_store.get_filename(materialized_dataset)
+    assert path
+    _assert_path_contains_2_bed(path)
+    _assert_2_bed_metadata(materialized_hda)
+
+
+def test_deferred_hdas_with_deferred_metadata():
+    fixture_context = setup_fixture_context_with_history()
+    store_dict = deferred_hda_model_store_dict(metadata_deferred=True)
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    assert deferred_hda
+    assert deferred_hda.dataset.state == "deferred"
+    materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
+    materialized_hda = materializer.ensure_materialized(deferred_hda)
+    materialized_dataset = materialized_hda.dataset
+    assert not materialized_hda.metadata_deferred
+    assert materialized_dataset.state == "ok"
+    # only detached datasets would be created with an external_filename
+    assert not materialized_dataset.external_filename
+    object_store = fixture_context.app.object_store
+    path = object_store.get_filename(materialized_dataset)
+    assert path
+    _assert_path_contains_2_bed(path)
+    _assert_2_bed_metadata(materialized_hda)
+
+
+def test_materialize_attached_hdcas_unimplemented(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    materializer = materializer_factory(True, object_store=fixture_context.app.object_store)
+    hdca = _test_hdca(tmpdir, fixture_context)
+    exception_found = False
+    try:
+        materialize_collection_instance(hdca, materializer)
+    except NotImplementedError:
+        exception_found = True
+    assert exception_found
+
+
+def test_materialize_unattached_undeferred_hdcas_noop(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    input_hdca = _test_hdca(tmpdir, fixture_context, include_element_deferred=False)
+    materialized_hdca = materialize_collection_instance(input_hdca, materializer)
+    assert input_hdca == materialized_hdca  # doesn't have deferred data so just assert it is input.
+
+
+def test_materialize_unattached_deferred_hdcas(tmpdir):
+    fixture_context = setup_fixture_context_with_history()
+    materializer = materializer_factory(False, transient_directory=tmpdir)
+    deferred_hdca = _test_hdca(tmpdir, fixture_context)
+    assert deferred_hdca.has_deferred_data
+    assert len(deferred_hdca.collection.elements) == 2
+    assert _deferred_element_count(deferred_hdca.collection) == 1
+    materialized_hdca = materialize_collection_instance(deferred_hdca, materializer)
+    assert not materialized_hdca.has_deferred_data
+    assert materialized_hdca.name == deferred_hdca.name
+    materialized_collection = materialized_hdca.collection
+    assert materialized_collection
+    materialized_elements = materialized_collection.elements
+    assert len(materialized_elements) == 2
+    assert _deferred_element_count(materialized_collection) == 0
+
+
+def _test_hdca(
+    tmpdir,
+    fixture_context: StoreFixtureContextWithHistory,
+    include_element_deferred: bool = True,
+    include_element_ok: bool = True,
+) -> HistoryDatasetCollectionAssociation:
+    app, sa_session, _, history = fixture_context
+    store_dict = deferred_hda_model_store_dict()
+    perform_import_from_store_dict(fixture_context, store_dict)
+    deferred_hda = fixture_context.history.datasets[0]
+    sa_session.add(deferred_hda)
+    assert deferred_hda.dataset.state == "deferred"
+    hda_fh = tmpdir.join("file.txt")
+    hda_fh.write("Moo Cow")
+    hda = _create_hda(sa_session, app.object_store, history, hda_fh, include_metadata_file=False)
+    elements = []
+    element_index = 0
+    if include_element_deferred:
+        elements.append(
+            DatasetCollectionElement(
+                element=deferred_hda,
+                element_identifier="deferred_hda",
+                element_index=element_index,
+            )
+        )
+        element_index += 1
+    if include_element_ok:
+        elements.append(
+            DatasetCollectionElement(
+                element=hda,
+                element_identifier="ok_hda",
+                element_index=element_index,
+            )
+        )
+        element_index += 1
+    collection = DatasetCollection(collection_type="list", populated=True)
+    collection.elements = elements
+    hdca = HistoryDatasetCollectionAssociation(
+        history=history,
+        hid=1,
+        collection=collection,
+        name="HistoryCollectionTest1",
+    )
+    sa_session.add(hdca)
+    sa_session.add(collection)
+    sa_session.flush()
+    return hdca
+
+
+def _deferred_element_count(dataset_collection: DatasetCollection) -> int:
+    count = 0
+    for element in dataset_collection.elements:
+        if element.is_collection:
+            count += _deferred_element_count(element.child_collection)
+        else:
+            dataset_instance = element.dataset_instance
+            print(dataset_instance.dataset.state)
+            if dataset_instance.dataset.state == "deferred":
+                count += 1
+    return count
+
+
+def _ensure_relations_attached_and_expunge(deferred_hda: HistoryDatasetAssociation, fixture_context) -> None:
+    # make sure everything needed is in session (sources, hashes, and metadata)...
+    # point here is exercise deferred_hda.history throws a detached error.
+    [s.hashes for s in deferred_hda.dataset.sources]
+    deferred_hda.dataset.hashes
+    deferred_hda._metadata
+    sa_session = fixture_context.sa_session
+    sa_session.expunge_all()
+
+
+def _assert_2_bed_metadata(hda: HistoryDatasetAssociation) -> None:
+    assert hda.metadata.columns == 6
+    assert hda.metadata.data_lines == 68
+    assert hda.metadata.comment_lines == 0
+    assert hda.metadata.chromCol == 1
+    assert hda.metadata.startCol == 2
+    assert hda.metadata.endCol == 3
+    assert hda.metadata.viz_filter_cols == [4]
+
+
+def _assert_path_contains_2_bed(path) -> None:
+    with open(path, "r") as f:
+        contents = f.read()
+    assert contents == CONTENTS_2_BED

--- a/test/unit/data/test_model_copy.py
+++ b/test/unit/data/test_model_copy.py
@@ -1,6 +1,9 @@
 import contextlib
 import os
 import threading
+from typing import Union
+
+from sqlalchemy.orm.scoping import scoped_session
 
 import galaxy.datatypes.registry
 import galaxy.model
@@ -131,18 +134,29 @@ def _setup_mapping_and_user():
         yield test_config, object_store, model, h1
 
 
-def _create_hda(model, object_store, history, path, visible=True, include_metadata_file=False):
-    hda = HistoryDatasetAssociation(extension="bam", create_dataset=True, sa_session=model.context)
+def _create_hda(
+    has_session: Union[mapping.GalaxyModelMapping, scoped_session],
+    object_store,
+    history,
+    path,
+    visible=True,
+    include_metadata_file=False,
+):
+    if hasattr(has_session, "context"):
+        sa_session = has_session.context
+    else:
+        sa_session = has_session
+    hda = HistoryDatasetAssociation(extension="bam", create_dataset=True, sa_session=sa_session)
     hda.visible = visible
-    model.context.add(hda)
-    model.context.flush([hda])
+    sa_session.add(hda)
+    sa_session.flush([hda])
     object_store.update_from_file(hda, file_name=path, create=True)
     if include_metadata_file:
         hda.metadata.from_JSON_dict(json_dict={"bam_index": MetadataTempFile.from_JSON({"kwds": {}, "filename": path})})
         _check_metadata_file(hda)
     hda.set_size()
     history.add_dataset(hda)
-    hda.add_item_annotation(model.context, history.user, hda, "annotation #%d" % hda.hid)
+    hda.add_item_annotation(sa_session, history.user, hda, "annotation #%d" % hda.hid)
     return hda
 
 

--- a/test/unit/webapps/test_routes.py
+++ b/test/unit/webapps/test_routes.py
@@ -42,7 +42,9 @@ def test_galaxy_routes():
     test_webapp.assert_maps("/api/dependency_resolvers", controller="tool_dependencies", action="index")
 
     test_webapp.assert_maps(
-        "/api/dependency_resolvers/dependency", controller="tool_dependencies", action="manager_dependency"
+        "/api/dependency_resolvers/dependency",
+        controller="tool_dependencies",
+        action="manager_dependency",
     )
 
     test_webapp.assert_maps("/api/dependency_resolvers/0", controller="tool_dependencies", action="show")


### PR DESCRIPTION
- Improves options and display around discarded datasets.
- Adds new APIs for importing model stores.
- Adds support to model store layer for importing/exporting workflow invocations and APIs and tests to support this.
- Add new DEFERRED dataset state - with APIs for materializing them or the option to defer them on the worker node if using ``tool_evaluation_strategy=remote`` on the job destination.
- UI and API options for uploading deferred datasets individually or into collections.


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
