### PR TITLE
[21.09] Add profile that strips whitespace in from_work_dir outputs

### DIFF
--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -438,6 +438,11 @@ class XmlToolSource(ToolSource):
         output.filters = data_elem.findall('filter')
         output.tool = tool
         output.from_work_dir = data_elem.get("from_work_dir", None)
+        if output.from_work_dir and getattr(tool, 'profile', 0) < 21.09:
+            # We started quoting from_work_dir outputs in 21.09.
+            # Prior to quoting, trailing spaces had no effect.
+            # This ensures that old tools continue to work.
+            output.from_work_dir = output.from_work_dir.strip()
         output.hidden = string_as_bool(data_elem.get("hidden", ""))
         output.actions = ToolOutputActionGroup(output, data_elem.find('actions'))
         output.dataset_collector_descriptions = dataset_collector_descriptions_from_elem(data_elem, legacy=self.legacy_defaults)

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -55,6 +55,10 @@ List of behavior changes associated with profile versions:
 - Exit immediately if a command exits with a non-zero status (`set -e`).
 - Assume sort order for collection elements.
 
+### 21.09
+
+- Do not strip leading and trailing whitespaces in `from_work_dir` attribute.
+
 ### Examples
 
 A normal tool:


### PR DESCRIPTION
Deals with
https://github.com/galaxyproject/tools-iuc/issues/3974#issuecomment-925121844.
Which is a bug on the tool side, but I don't think we should break this given it has worked in the past.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Run https://github.com/galaxyproject/tools-iuc/blob/f1cba7ded102943419ebe4282c7e290145d890ff/tools/mothur/unifrac.unweighted.xml against this branch.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
