### PR TITLE
Preserve important dataset metadata when importing/exporting histories.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3974,6 +3974,11 @@ class DatasetInstance:
             rval["dataset"] = self.dataset.serialize(id_encoder, serialization_options)
         else:
             serialization_options.serialize_files(self, rval)
+            file_metadata = {}
+            hashes = self.dataset.hashes
+            if hashes:
+                file_metadata["hashes"] = [h.serialize(id_encoder, serialization_options) for h in hashes]
+            rval["file_metadata"] = file_metadata
 
 
 class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnotations,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3400,6 +3400,17 @@ class DatasetSource(Base, RepresentById):
     dataset = relationship('Dataset', back_populates='sources')
     hashes = relationship('DatasetSourceHash', back_populates='source')
 
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            source_uri=self.source_uri,
+            extra_files_path=self.extra_files_path,
+            transform=self.transform,
+            hashes=[h.serialize(id_encoder, serialization_options) for h in self.hashes],
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
+
 
 class DatasetSourceHash(Base, RepresentById):
     __tablename__ = 'dataset_source_hash'
@@ -3409,6 +3420,15 @@ class DatasetSourceHash(Base, RepresentById):
     hash_function = Column(TEXT)
     hash_value = Column(TEXT)
     source = relationship('DatasetSource', back_populates='hashes')
+
+    def serialize(self, id_encoder, serialization_options):
+        rval = dict_for(
+            self,
+            hash_function=self.hash_function,
+            hash_value=self.hash_value,
+        )
+        serialization_options.attach_identifier(id_encoder, self, rval)
+        return rval
 
 
 class DatasetHash(Base, RepresentById):
@@ -3422,7 +3442,6 @@ class DatasetHash(Base, RepresentById):
     dataset = relationship('Dataset', back_populates='hashes')
 
     def serialize(self, id_encoder, serialization_options):
-        # serialize Dataset objects only for jobs that can actually modify these models.
         rval = dict_for(
             self,
             hash_function=self.hash_function,
@@ -3981,6 +4000,10 @@ class DatasetInstance:
                 file_metadata["hashes"] = [h.serialize(id_encoder, serialization_options) for h in hashes]
             if dataset.created_from_basename is not None:
                 file_metadata["created_from_basename"] = dataset.created_from_basename
+            sources = dataset.sources
+            if sources:
+                file_metadata["sources"] = [s.serialize(id_encoder, serialization_options) for s in sources]
+
             rval["file_metadata"] = file_metadata
 
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3975,9 +3975,12 @@ class DatasetInstance:
         else:
             serialization_options.serialize_files(self, rval)
             file_metadata = {}
-            hashes = self.dataset.hashes
+            dataset = self.dataset
+            hashes = dataset.hashes
             if hashes:
                 file_metadata["hashes"] = [h.serialize(id_encoder, serialization_options) for h in hashes]
+            if dataset.created_from_basename is not None:
+                file_metadata["created_from_basename"] = dataset.created_from_basename
             rval["file_metadata"] = file_metadata
 
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -307,6 +307,11 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         object_import_tracker.requires_hid.append(dataset_instance)
 
                 self._flush()
+
+                # If dataset is in the dictionary - we will assert this dataset is tied to the Galaxy instance
+                # and the import options are configured for allowing editing the dataset (e.g. for metadata setting).
+                # Otherwise, we will check for "file" information instead of dataset information - currently this includes
+                # "file_name", "extra_files_path".
                 if 'dataset' in dataset_attrs:
                     handle_dataset_object_edit(dataset_instance)
                 else:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -363,6 +363,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         dataset_instance.dataset.deleted = True
                     file_metadata = dataset_attrs.get("file_metadata") or {}
                     self._attach_dataset_hashes(file_metadata, dataset_instance)
+                    if "created_from_basename" in file_metadata:
+                        dataset_instance.dataset.created_from_basename = file_metadata["created_from_basename"]
 
                 if model_class == "HistoryDatasetAssociation" and self.user:
                     add_item_annotation(self.sa_session, self.user, dataset_instance, dataset_attrs['annotation'])

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -10,6 +10,7 @@ from json import (
     dumps,
     load,
 )
+from typing import Any, Dict, List
 from uuid import uuid4
 
 from bdbag import bdbag_api as bdb
@@ -88,38 +89,38 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         self.dataset_state_serialized = True
 
     @abc.abstractmethod
-    def defines_new_history(self):
+    def defines_new_history(self) -> bool:
         """Does this store define a new history to create."""
 
     @abc.abstractmethod
-    def new_history_properties(self):
+    def new_history_properties(self) -> Dict[str, Any]:
         """Dict of history properties if defines_new_history() is truthy."""
 
     @abc.abstractmethod
-    def datasets_properties(self):
+    def datasets_properties(self) -> List[Dict[str, Any]]:
         """Return a list of HDA properties."""
 
-    def library_properties(self):
+    def library_properties(self) -> List[Dict[str, Any]]:
         """Return a list of library properties."""
         return []
 
     @abc.abstractmethod
-    def collections_properties(self):
+    def collections_properties(self) -> List[Dict[str, Any]]:
         """Return a list of HDCA properties."""
 
     @abc.abstractmethod
-    def jobs_properties(self):
+    def jobs_properties(self) -> List[Dict[str, Any]]:
         """Return a list of jobs properties."""
 
     @abc.abstractproperty
-    def object_key(self):
+    def object_key(self) -> str:
         """Key used to connect objects in metadata.
 
         Legacy exports used 'hid' but associated objects may not be from the same history
         and a history may contain multiple objects with the same 'hid'.
         """
 
-    def trust_hid(self, obj_attrs):
+    def trust_hid(self, obj_attrs) -> bool:
         """Trust HID when importing objects into a new History."""
 
     @contextlib.contextmanager

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -192,6 +192,21 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 hash_obj.extra_files_path = hash_attrs["extra_files_path"]
                 dataset_instance.dataset.hashes.append(hash_obj)
 
+    def _attach_dataset_sources(self, dataset_or_file_attrs, dataset_instance):
+        if "sources" in dataset_or_file_attrs:
+            for source_attrs in dataset_or_file_attrs["sources"]:
+                source_obj = model.DatasetSource()
+                source_obj.source_uri = source_attrs["source_uri"]
+                source_obj.transform = source_attrs["transform"]
+                source_obj.extra_files_path = source_attrs["extra_files_path"]
+                for hash_attrs in source_attrs["hashes"]:
+                    hash_obj = model.DatasetSourceHash()
+                    hash_obj.hash_value = hash_attrs["hash_value"]
+                    hash_obj.hash_function = hash_attrs["hash_function"]
+                    source_obj.hashes.append(hash_obj)
+
+                dataset_instance.dataset.sources.append(source_obj)
+
     def _import_datasets(self, object_import_tracker, datasets_attrs, history, new_history, job):
         object_key = self.object_key
 
@@ -220,6 +235,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         if attribute in dataset_attrs["dataset"]:
                             setattr(dataset_instance.dataset, attribute, dataset_attrs["dataset"][attribute])
                     self._attach_dataset_hashes(dataset_attrs["dataset"], dataset_instance)
+                    # TODO: Once we have a test...
+                    #    self._attach_dataset_sources(dataset_attrs["dataset"], dataset_instance)
                     if 'id' in dataset_attrs["dataset"] and self.import_options.allow_edit:
                         dataset_instance.dataset.id = dataset_attrs["dataset"]['id']
 
@@ -363,6 +380,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         dataset_instance.dataset.deleted = True
                     file_metadata = dataset_attrs.get("file_metadata") or {}
                     self._attach_dataset_hashes(file_metadata, dataset_instance)
+                    self._attach_dataset_sources(file_metadata, dataset_instance)
                     if "created_from_basename" in file_metadata:
                         dataset_instance.dataset.created_from_basename = file_metadata["created_from_basename"]
 

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -1074,6 +1074,8 @@ class DirectoryModelExportStore(ModelExportStore):
                     shutil.copytree(src, dest)
                 else:
                     shutil.copyfile(src, dest)
+        else:
+            raise Exception(f"Unknown export_files parameter type encountered {self.export_files}")
 
         export_directory = self.export_directory
 

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -118,6 +118,9 @@ def test_export_dataset():
     d1_hash.hash_value = "foobar"
     d1.dataset.hashes.append(d1_hash)
     d1.dataset.created_from_basename = "my_cool_name.txt"
+    d1_source = model.DatasetSource()
+    d1_source.source_uri = "http://google.com/mycooldata.txt"
+    d1.dataset.sources.append(d1_source)
 
     d1.state = d2.state = 'ok'
 
@@ -157,6 +160,10 @@ def test_export_dataset():
     assert dataset_hash.hash_function == "MD5"
     assert dataset_hash.hash_value == "foobar"
     assert datasets[0].dataset.created_from_basename == "my_cool_name.txt"
+
+    assert len(datasets[0].dataset.sources) == 1
+    dataset_source = datasets[0].dataset.sources[0]
+    assert dataset_source.source_uri == "http://google.com/mycooldata.txt"
 
     with open(datasets[0].file_name) as f:
         assert f.read().startswith("chr1    4225    19670")

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -113,6 +113,10 @@ def test_export_dataset():
     app, sa_session, h = _setup_history_for_export("Datasets History")
 
     d1, d2 = _create_datasets(sa_session, h, 2)
+    d1_hash = model.DatasetHash()
+    d1_hash.hash_function = "MD5"
+    d1_hash.hash_value = "foobar"
+    d1.dataset.hashes.append(d1_hash)
     d1.state = d2.state = 'ok'
 
     j = model.Job()
@@ -146,6 +150,10 @@ def test_export_dataset():
 
     assert datasets[0].state == 'ok'
     assert datasets[1].state == 'ok'
+    assert len(datasets[0].dataset.hashes) == 1
+    dataset_hash = datasets[0].dataset.hashes[0]
+    assert dataset_hash.hash_function == "MD5"
+    assert dataset_hash.hash_value == "foobar"
 
     with open(datasets[0].file_name) as f:
         assert f.read().startswith("chr1    4225    19670")

--- a/test/unit/tools/test_history_imp_exp.py
+++ b/test/unit/tools/test_history_imp_exp.py
@@ -117,6 +117,8 @@ def test_export_dataset():
     d1_hash.hash_function = "MD5"
     d1_hash.hash_value = "foobar"
     d1.dataset.hashes.append(d1_hash)
+    d1.dataset.created_from_basename = "my_cool_name.txt"
+
     d1.state = d2.state = 'ok'
 
     j = model.Job()
@@ -154,6 +156,7 @@ def test_export_dataset():
     dataset_hash = datasets[0].dataset.hashes[0]
     assert dataset_hash.hash_function == "MD5"
     assert dataset_hash.hash_value == "foobar"
+    assert datasets[0].dataset.created_from_basename == "my_cool_name.txt"
 
     with open(datasets[0].file_name) as f:
         assert f.read().startswith("chr1    4225    19670")


### PR DESCRIPTION
The metadata about the physical files (Dataset) will just be recalculated (say file size) or we definitely do not want (say ``object_store_id``). But certain metadata about the physical files (Dataset) are important and should be preserved. This PR fixes up some of these so now ``Dataset.hashes``, ``Dataset.sources``, and ``Dataset.created_from_basename`` are included in the import/export process.

While this PR is important from a provenance tracking and correctness perspective, I think making sure source URIs and hashes are preserved for model store operations will also be an important part of dealing with deferred data in a systematic and structured fashion.

This PR also add some types and comments to the model store code.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
