### PR TITLE
Modify description of the "database" label

### DIFF
--- a/doc/source/project/issues.rst
+++ b/doc/source/project/issues.rst
@@ -127,7 +127,7 @@ particular domain, as well as more organized release notes.
 - ``area/compliance``
 - ``area/configuration`` - Galaxy's configuration system
 - ``area/cwl`` - changes related to supporting the common workflow language in Galaxy
-- ``area/database`` - Change requires a modification to Galaxy's database
+- ``area/database`` - Change to Galaxy's database or data access layer
 - ``area/dataset-collections``
 - ``area/datatypes`` - Changes to Galaxy's datatypes
 - ``area/datatype-framework`` - Changes to Galaxy's datatype and metadata framework


### PR DESCRIPTION
We've been using the "database" label in a much wider sense than its current description suggests. The proposed change is a more accurate description of the label's de facto usage. This also eliminates the potential need for an additional label that would cover  the model and the data access layer in general.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
