### PR TITLE
[PROCEDURES] Add David López to committers group

### DIFF
--- a/doc/source/project/organization.rst
+++ b/doc/source/project/organization.rst
@@ -56,6 +56,7 @@ Members
 - Björn Grüning (@bgruening)
 - Aysam Guerler (@guerler)
 - Jennifer Hillman Jackson (@jennaj)
+- David López (@davelopez)
 - Anton Nekrutenko (@nekrut)
 - Helena Rasche (@hexylena)
 - Nicola Soranzo (@nsoranzo)


### PR DESCRIPTION
David has taken on the migration to fastAPI as his first big project within the Galaxy codebase and has gained a very good understanding of Galaxy's backend and the new server stack. His PRs are well-crafted and contain rigorous tests.
David is also the maintainer of the [Galaxy language server](https://github.com/galaxyproject/galaxy-language-server), has presented his work at this years' GCC and is a member of the backend working group. So I'm proposing to add David to the committers group.

@galaxyproject/core please vote