### PR TITLE
Fix test_sharing_valid_by_id selenium test

### DIFF
--- a/lib/galaxy_test/selenium/test_history_sharing.py
+++ b/lib/galaxy_test/selenium/test_history_sharing.py
@@ -108,14 +108,13 @@ class HistorySharingTestCase(SeleniumTestCase):
         """
         self.navigate_to_history_share_page()
         self.components.histories.sharing.share_with_collapse.wait_for_and_click()
-        self.components.histories.sharing.share_with_multiselect.wait_for_and_click()
+        multiselect = self.components.histories.sharing.share_with_multiselect.wait_for_and_click()
         self.components.histories.sharing.share_with_input.wait_for_and_send_keys(user_id or user_email)
+        self.send_enter(multiselect)
 
         if screenshot:
             self.screenshot("history_sharing_user")
-        # first click to add the item
-        self.components.histories.sharing.submit_sharing_with.wait_for_and_click()
-        # second click to save the sharing preferences
+
         self.components.histories.sharing.submit_sharing_with.wait_for_and_click()
 
         if assert_valid:


### PR DESCRIPTION
looks like making selenium click twice on the same button was the bad idea. Somehow it very rarely ends up with "timeout to be clickable". So this PR uses enter key instead, this supposed to fix the test from failing occasionally.

Example of PR, where  selenium failed https://github.com/galaxyproject/galaxy/pull/12544 (yeah I know, it's is iconic :sweat_smile:)
 

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
