### PR TITLE
Better path handling in app unit tests for packaging.

### DIFF
--- a/test/unit/jobs/test_expression_run.py
+++ b/test/unit/jobs/test_expression_run.py
@@ -5,11 +5,9 @@ import subprocess
 import tempfile
 
 from galaxy.tools import expressions
+from galaxy.util import galaxy_directory
 
-THIS_DIRECTORY = os.path.abspath(os.path.dirname(__file__))
-TEST_DIRECTORY = os.path.join(THIS_DIRECTORY, os.path.pardir, os.path.pardir)
-ROOT_DIRECTORY = os.path.join(TEST_DIRECTORY, os.path.pardir)
-LIB_DIRECTORY = os.path.join(ROOT_DIRECTORY, "lib")
+LIB_DIRECTORY = os.path.join(galaxy_directory(), "lib")
 
 
 def test_run_simple():

--- a/test/unit/jobs/test_job_configuration.py
+++ b/test/unit/jobs/test_job_configuration.py
@@ -9,14 +9,14 @@ from pykwalify.core import Core
 
 from galaxy.job_metrics import JobMetrics
 from galaxy.jobs import JobConfiguration
-from galaxy.util import bunch
+from galaxy.util import bunch, galaxy_directory, galaxy_samples_directory
 from galaxy.web_stack import ApplicationStack, UWSGIApplicationStack
 from galaxy.web_stack.handlers import HANDLER_ASSIGNMENT_METHODS
 
 # File would be slightly more readable if contents were embedded directly, but
 # there are advantages to testing the documentation/examples.
-SIMPLE_JOB_CONF = os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib", "galaxy", "config", "sample", "job_conf.xml.sample_basic")
-ADVANCED_JOB_CONF = os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib", "galaxy", "config", "sample", "job_conf.xml.sample_advanced")
+SIMPLE_JOB_CONF = os.path.join(galaxy_samples_directory(), "job_conf.xml.sample_basic")
+ADVANCED_JOB_CONF = os.path.join(galaxy_samples_directory(), "job_conf.xml.sample_advanced")
 ADVANCED_JOB_CONF_YAML = os.path.join(os.path.dirname(__file__), "job_conf.sample_advanced.yml")
 CONDITIONAL_RUNNER_JOB_CONF = os.path.join(os.path.dirname(__file__), "conditional_runners_job_conf.xml")
 HANDLER_TEMPLATE_JOB_CONF = os.path.join(os.path.dirname(__file__), "handler_template_job_conf.xml")
@@ -399,8 +399,8 @@ class AdvancedJobConfYamlParserTestCase(AdvancedJobConfXmlParserTestCase):
 
 
 def test_yaml_advanced_validation():
-    schema = os.path.join(os.path.dirname(__file__), "..", "..", "..", "lib", "galaxy", "webapps", "galaxy", "job_config_schema.yml")
-    integration_tests_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..", "test", "integration")
+    schema = os.path.join(galaxy_directory(), "lib", "galaxy", "webapps", "galaxy", "job_config_schema.yml")
+    integration_tests_dir = os.path.join(galaxy_directory(), "test", "integration")
     valid_files = [
         ADVANCED_JOB_CONF_YAML,
         os.path.join(integration_tests_dir, "delay_job_conf.yml"),

--- a/test/unit/visualizations/plugins/test_VisualizationsRegistry.py
+++ b/test/unit/visualizations/plugins/test_VisualizationsRegistry.py
@@ -6,13 +6,13 @@ import re
 import unittest
 
 from galaxy import model
-from galaxy.util import clean_multiline_string
+from galaxy.util import clean_multiline_string, galaxy_directory
 from galaxy.visualization.plugins import plugin
 from galaxy.visualization.plugins.registry import VisualizationsRegistry
 from . import VisualizationsBase_TestCase
 from ...unittest_utils import galaxy_mock
 
-glx_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, os.pardir))
+glx_dir = galaxy_directory()
 template_cache_dir = os.path.join(glx_dir, 'database', 'compiled_templates')
 addtional_templates_dir = os.path.join(glx_dir, 'config', 'plugins', 'visualizations', 'common', 'templates')
 vis_reg_path = 'config/plugins/visualizations'


### PR DESCRIPTION
Allows refactoring the unit tests into new directories and sets them up to be run as part of the packaged module tests.

A precondition to #12549 and another step along the path toward #8364 (along with #12552, #12551, #12550, etc..).

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
