### PR TITLE
[21.09] Point newly generated urls to datasets/encoded_id/details, add fallback

### DIFF
--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -105,6 +105,8 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)collection(/)edit(/)(:collection_id)": "show_collection_edit_attributes",
             "(/)datasets/error": "show_dataset_error",
             "(/)datasets(/)(:dataset_id)/details": "show_dataset_details",
+            // legacy url for older links
+            "(/)datasets(/)(:dataset_id)/show_params": "show_dataset_details",
             "(/)interactivetool_entry_points(/)list": "show_interactivetool_list",
             "(/)libraries*path": "show_library_folder",
         },

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -505,7 +505,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
                                 dataset_id=encoded_id, to_ext=hda.extension),
             'report_error': url_for(controller='dataset', action='errors', id=encoded_id),
             'rerun': url_for(controller='tool_runner', action='rerun', id=encoded_id),
-            'show_params': url_for(controller='dataset', action='show_params', dataset_id=encoded_id),
+            'show_params': url_for(controller='dataset', action='details', dataset_id=encoded_id),
             'visualization': url_for(controller='visualization', action='index',
                                      id=encoded_id, model='HistoryDatasetAssociation'),
             'meta_download': url_for(controller='dataset', action='get_metadata_file',

--- a/lib/galaxy/tools/error_reports/plugins/sentry.py
+++ b/lib/galaxy/tools/error_reports/plugins/sentry.py
@@ -83,7 +83,7 @@ class SentryPlugin(ErrorPlugin):
             # anything is missing from this report.
             try:
                 url = web.url_for(controller="dataset",
-                                  action="show_params",
+                                  action="details",
                                   dataset_id=self.app.security.encode_id(dataset.id),
                                   qualified=True)
             except AttributeError:

--- a/lib/galaxy/tools/errors.py
+++ b/lib/galaxy/tools/errors.py
@@ -163,7 +163,7 @@ class ErrorReporter:
         history_id_encoded = self.app.security.encode_id(hda.history_id)
         history_view_link = web.url_for("/histories/view", id=history_id_encoded, qualified=True)
         hda_id_encoded = self.app.security.encode_id(hda.id)
-        hda_show_params_link = web.url_for(controller="dataset", action="show_params", dataset_id=hda_id_encoded, qualified=True)
+        hda_show_params_link = web.url_for(controller="dataset", action="details", dataset_id=hda_id_encoded, qualified=True)
         # Build the email message
         if redact_user_details_in_bugreport:
             # This is sub-optimal but it is hard to solve fully. This affects

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -184,6 +184,7 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
     webapp.add_client_route('/datasets/error')
     webapp.add_client_route('/jobs/{job_id}/view')
     webapp.add_client_route('/datasets/{dataset_id}/details')
+    webapp.add_client_route('/datasets/{dataset_id}/show_params')
     webapp.add_client_route('/workflows/list')
     webapp.add_client_route('/workflows/list_published')
     webapp.add_client_route('/workflows/create')

--- a/lib/galaxy/webapps/galaxy/controllers/_create_history_template.py
+++ b/lib/galaxy/webapps/galaxy/controllers/_create_history_template.py
@@ -182,7 +182,7 @@ def inputs_recursive(trans, input_params, param_values, depth=1, upgrade_message
                     if element.history_content_type == "dataset":
                         hda = element
                         encoded_id = trans.security.encode_id(hda.id)
-                        dataset_info_url = url_for(controller="dataset", action="show_params", dataset_id=encoded_id)
+                        dataset_info_url = url_for(controller="dataset", action="details", dataset_id=encoded_id)
                         tool_parameter_template += f"<a target=\"galaxy_main\" data-hda-id=\"{encoded_id}\""
                         tool_parameter_template += f"href=\"{dataset_info_url}\">{str(hda.hid)}:{hda.name}</a>"
                     else:


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12557

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Click the info button and change the url from `<base_url>/details` to `<base_url>/show_params`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
