### PR TITLE
[21.09] Catch datatype conversion exception and return proper error

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -46,6 +46,10 @@ DOWNLOAD_FILENAME_PATTERN_COLLECTION_ELEMENT = "Galaxy${hdca_hid}-[${hdca_name}_
 DEFAULT_MAX_PEEK_SIZE = 1000000  # 1 MB
 
 
+class DatatypeConverterNotFoundException(Exception):
+    pass
+
+
 class DatatypeValidation:
 
     def __init__(self, state, message):
@@ -638,7 +642,7 @@ class Data(metaclass=DataMeta):
         converter = trans.app.datatypes_registry.get_converter_by_target_type(original_dataset.ext, target_type)
 
         if converter is None:
-            raise Exception(f"A converter does not exist for {original_dataset.ext} to {target_type}.")
+            raise DatatypeConverterNotFoundException(f"A converter does not exist for {original_dataset.ext} to {target_type}.")
 
         params, input_name = get_params_and_input_name(converter, deps, target_context)
 

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -15,6 +15,7 @@ from galaxy import (
     web
 )
 from galaxy.datatypes import sniff
+from galaxy.datatypes.data import DatatypeConverterNotFoundException
 from galaxy.datatypes.display_applications.util import decode_dataset_user, encode_dataset_user
 from galaxy.exceptions import RequestParameterInvalidException
 from galaxy.managers.hdas import HDADeserializer, HDAManager
@@ -390,7 +391,10 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         elif operation == 'conversion':
             target_type = payload.get('target_type')
             if target_type:
-                message = data.datatype.convert_dataset(trans, data, target_type)
+                try:
+                    message = data.datatype.convert_dataset(trans, data, target_type)
+                except DatatypeConverterNotFoundException as e:
+                    return self.message_exception(trans, str(e))
         elif operation == 'permission':
             # Adapt form request to API - style.
             payload_permissions = {}


### PR DESCRIPTION
Fixes
https://sentry.galaxyproject.org/organizations/galaxy/issues/45438:
```
Exception: A converter does not exist for tsv to tabular.
  File "galaxy/web/framework/decorators.py", line 312, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/controllers/dataset.py", line 393, in set_edit
    message = data.datatype.convert_dataset(trans, data, target_type)
  File "galaxy/datatypes/data.py", line 641, in convert_dataset
    raise Exception(f"A converter does not exist for {original_dataset.ext} to {target_type}.")
```
which ... is not a valid option in the user interface, but this
can happen if you change the datatype in another browser tab.


## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:

upload a fasta file, open the conversion tab and select convert to tabular. Now in another tab change the datatype to tsv. In the original tab click save and see the red error message saying `A converter does not exist for tsv to tabular.` instead of the generic "A problem happened".

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
