### PR TITLE
[WIP] Simplify/speedup selenium test test_history_dataset_state.py.

### DIFF
--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -14,20 +14,21 @@ BUTTON_TOOLTIPS = {
 }
 EXPECTED_TOOLHELP_TITLE_TEXT = 'Tool help for Upload File'
 TEST_DBKEY_TEXT = 'Honeybee (Apis mellifera): apiMel3 (apiMel3)'
+FIRST_HID = 1
 
 
 class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
-    hid = 1
+    ensure_registered = True
 
     @selenium_test
-    def test_dataset_state(self, hid=hid):
-        item = self._prepare_dataset(self.hid)
-        self.history_panel_item_body_component(hid, wait=True)
+    def test_dataset_state(self):
+        item = self._prepare_dataset()
+        self.history_panel_item_body_component(FIRST_HID, wait=True)
 
-        self.assert_item_summary_includes(hid, "1 sequence")
-        self.assert_item_dbkey_displayed_as(hid, "?")
-        self.assert_item_info_includes(hid, 'uploaded fasta file')
-        self.assert_item_peek_includes(hid, ">hg17")
+        self.assert_item_summary_includes(FIRST_HID, "1 sequence")
+        self.assert_item_dbkey_displayed_as(FIRST_HID, "?")
+        self.assert_item_info_includes(FIRST_HID, 'uploaded fasta file')
+        self.assert_item_peek_includes(FIRST_HID, ">hg17")
 
         item.dbkey_button.wait_for_and_click()
         toolhelp_title_text = item.toolhelp_title.wait_for_visible().text
@@ -37,31 +38,31 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
 
         self.screenshot("history_panel_dataset_expanded")
 
-        self._assert_action_buttons(hid)
+        self._assert_action_buttons(FIRST_HID)
 
     @selenium_test
-    def test_dataset_change_dbkey(self, hid=hid):
-        item = self._prepare_dataset(hid)
-        self.assert_item_dbkey_displayed_as(hid, "?")
+    def test_dataset_change_dbkey(self):
+        item = self._prepare_dataset()
+        self.assert_item_dbkey_displayed_as(FIRST_HID, "?")
         item.dbkey.wait_for_and_click()
         self.components.edit_dataset_attributes.database_build_dropdown.wait_for_and_click()
         # choose database option from 'Database/Build' dropdown, that equals to dbkey_text
         self.components.edit_dataset_attributes.dbkey_dropdown_results.dbkey_dropdown_option(
             dbkey_text=TEST_DBKEY_TEXT).wait_for_and_click()
         self.components.edit_dataset_attributes.save_btn.wait_for_and_click()
-        self.history_panel_wait_for_hid_ok(hid)
-        self.assert_item_dbkey_displayed_as(hid, "apiMel3")
+        self.history_panel_wait_for_hid_ok(FIRST_HID)
+        self.assert_item_dbkey_displayed_as(FIRST_HID, "apiMel3")
 
-    def _prepare_dataset(self, hid):
-        self.register()
+    def _prepare_dataset(self):
+        self.history_panel_create_new()
         self.perform_upload(self.get_filename("1.fasta"))
-        self.history_panel_wait_for_hid_ok(hid)
-        self.assert_item_name(hid, "1.fasta")
-        self.assert_item_hid_text(hid)
-        self._assert_title_buttons(hid)
+        self.history_panel_wait_for_hid_ok(FIRST_HID)
+        self.assert_item_name(FIRST_HID, "1.fasta")
+        self.assert_item_hid_text(FIRST_HID)
+        self._assert_title_buttons(FIRST_HID)
 
         # Expand HDA and wait for details to show up.
-        return self.history_panel_click_item_title(hid=hid, wait=True)
+        return self.history_panel_click_item_title(hid=FIRST_HID, wait=True)
 
     def _assert_title_buttons(self, hid, expected_buttons=None):
         if expected_buttons is None:


### PR DESCRIPTION
Fewer registrations and fewer parameters being passed around.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
