### PR TITLE
[21.05] Fix async controller

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/async.py
+++ b/lib/galaxy/webapps/galaxy/controllers/async.py
@@ -150,7 +150,7 @@ class ASync(BaseUIController):
             trans.sa_session.add(trans.history)
             trans.sa_session.flush()
             # Need to explicitly create the file
-            data.dataset.object_store.create(data)
+            data.dataset.object_store.create(data.dataset)
             trans.log_event("Added dataset %d to history %d" % (data.id, trans.history.id), tool_id=tool_id)
 
             try:


### PR DESCRIPTION
Fixes https://sentry.galaxyproject.org/organizations/galaxy/issues/45939
```
AttributeError: 'HistoryDatasetAssociation' object has no attribute 'object_store_id'
  File "galaxy/web/framework/middleware/sentry.py", line 43, in __call__
    iterable = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 35, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 138, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 217, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/async.py", line 153, in index
    data.dataset.object_store.create(data)
  File "galaxy/objectstore/__init__.py", line 297, in create
    return self._invoke('create', obj, **kwargs)
  File "galaxy/objectstore/__init__.py", line 291, in _invoke
    return self.__getattribute__(f"_{delegate}")(obj=obj, **kwargs)
  File "galaxy/objectstore/__init__.py", line 882, in _create
    if obj.object_store_id is None or not self._exists(obj, **kwargs):
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Don't really know how to test this, and I'm sure we don't have existing tests.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
