### PR TITLE
[21.09] Fix scratchbook on dataset details pages 

### DIFF
--- a/client/src/app/singleton.js
+++ b/client/src/app/singleton.js
@@ -39,5 +39,5 @@ export function galaxyIsInitialized() {
 // Having a CORS issue in the toolshed iframe, store separate versions
 // of galaxy in each window for the short-term
 export function getStorage() {
-    return window.parent;
+    return window;
 }

--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -273,14 +273,14 @@ export default {
             }
         },
 
-      showDetails() {
+        showDetails() {
             const redirectParams = {
                 path: this.dataset.getUrl("show_params"),
                 title: "Dataset details",
                 tryIframe: false,
             };
             if (!this.iframeAdd(redirectParams)) {
-                this.backboneRoute(this.dataset.getUrl('show_params'))
+                this.backboneRoute(this.dataset.getUrl("show_params"));
             }
         },
 

--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -129,7 +129,7 @@
                     v-if="notIn(STATES.NOT_VIEWABLE)"
                     key="dataset-details"
                     title="View Dataset Details"
-                    @click.stop.prevent="backboneRoute(dataset.getUrl('show_params'))"
+                    @click.stop.prevent="showDetails"
                 >
                     <Icon icon="info-circle" class="mr-1" />
                     <span v-localize>View Dataset Details</span>
@@ -270,6 +270,17 @@ export default {
                 this.backboneRoute("visualizations", {
                     dataset_id: this.dataset.id,
                 });
+            }
+        },
+
+      showDetails() {
+            const redirectParams = {
+                path: this.dataset.getUrl("show_params"),
+                title: "Dataset details",
+                tryIframe: false,
+            };
+            if (!this.iframeAdd(redirectParams)) {
+                this.backboneRoute(this.dataset.getUrl('show_params'))
             }
         },
 

--- a/client/src/components/plugins/legacyNavigation.js
+++ b/client/src/components/plugins/legacyNavigation.js
@@ -36,7 +36,7 @@ export const legacyNavigationMixin = {
         // straight ifrme redirect
         iframeRedirect(path, target = "galaxy_main") {
             try {
-                const targetFrame = window.frames[target] || window.parent.frames[target];
+                const targetFrame = window.frames[target];
                 if (!targetFrame) {
                     throw new Error(`Requested frame ${target} doesn't exist`);
                 }

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -285,7 +285,10 @@ export var DatasetListItemView = _super.extend(
                     const Galaxy = getGalaxyInstance();
                     if (Galaxy.frame && Galaxy.frame.active) {
                         ev.preventDefault();
-                        Galaxy.frame.add({ url: `${getAppRoot()}${url}`, title: "Dataset Details" });
+                        Galaxy.frame.add({
+                            url: `${getAppRoot()}${url}`,
+                            title: `Dataset Details of ${this.model.get("name")}`,
+                        });
                     } else if (Galaxy.router) {
                         ev.preventDefault();
                         Galaxy.router.push(url);

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -9,6 +9,7 @@ import BASE_MVC from "mvc/base-mvc";
 import _l from "utils/localization";
 import { mountNametags } from "components/Nametags";
 import { Toast } from "ui/toast";
+import { getAppRoot } from "onload/loadConfig";
 
 var logNamespace = "dataset";
 /*==============================================================================
@@ -272,7 +273,8 @@ export var DatasetListItemView = _super.extend(
          *  @returns {jQuery} rendered DOM
          */
         _renderShowParamsButton: function () {
-            // gen. safe to show in all cases
+            const url = `datasets/${this.model.get("id")}/details`;
+
             return faIconButton({
                 title: _l("View details"),
                 classes: "params-btn",
@@ -281,9 +283,13 @@ export var DatasetListItemView = _super.extend(
                 faIcon: "fa-info-circle",
                 onclick: (ev) => {
                     const Galaxy = getGalaxyInstance();
-                    if (Galaxy.router) {
+                    if (Galaxy.frame && Galaxy.frame.active) {
                         ev.preventDefault();
-                        Galaxy.router.push(`/datasets/${this.model.get("id")}/details`);
+                        Galaxy.frame.add({ url: `${getAppRoot()}${url}`, title: "Dataset Details" });
+                    } else if (Galaxy.router) {
+                        ev.preventDefault();
+                        Galaxy.router.push(url);
+                        Galaxy.trigger("activate-hda", this.model.get("id"));
                     }
                 },
             });


### PR DESCRIPTION
This PR fixes scatchbook on dataset details https://github.com/galaxyproject/galaxy/issues/12558.

Additionally, it adds dataset name to scratch title (I just thought it's useful, if not I can just leave "dataset details" how it was before) 

![image](https://user-images.githubusercontent.com/15801412/134944637-4c4f55bc-d302-4c98-be76-f6120b55b100.png)

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Click on scratchbook button: 
![image](https://user-images.githubusercontent.com/15801412/134944280-28cbf4f7-01a7-48b0-8ea9-813daaae8abe.png)
  2. Click on `i` button on history dataset.
  3. Click out and repeat step 2 on different dataset


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
