### PR TITLE
Selenium abstractions for dataset information.

### DIFF
--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1511,11 +1511,14 @@ class NavigatesGalaxy(HasDriver):
             details_component.wait_for_visible()
         return details_component
 
-    def hda_click_primary_action_button(self, hid, button_key):
+    def hda_click_primary_action_button(self, hid: int, button_key: str):
         item_component = self.history_panel_click_item_title(hid=hid, wait=True)
         item_component.primary_action_buttons.wait_for_visible()
         button_component = item_component[f"{button_key}_button"]
         button_component.wait_for_and_click()
+
+    def hda_click_details(self, hid: int):
+        self.hda_click_primary_action_button(hid, "info")
 
     def history_panel_click_item_title(self, hid, **kwds):
         item_component = self.history_panel_item_component(hid=hid)

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -107,6 +107,11 @@ sign_out:
     cancel_button: '.modal-footer .buttons #button-0'
     sign_out_button: '.modal-footer .buttons #button-1'
 
+dataset_details:
+  selectors:
+    _: 'table#dataset-details'
+    tool_parameters: 'table#tool-parameters'
+
 history_panel:
   menu:
     labels:

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -157,9 +157,9 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.screenshot("tool_form_citations_formatted")
 
     def _check_dataset_details_for_inttest_value(self, hid, expected_value="42"):
-        self.hda_click_primary_action_button(hid, "info")
-        self.wait_for_selector_visible("table#dataset-details")
-        tool_parameters_table = self.wait_for_selector_visible("table#tool-parameters")
+        self.hda_click_details(hid)
+        self.components.dataset_details._.wait_for_visible()
+        tool_parameters_table = self.components.dataset_details.tool_parameters.wait_for_visible()
         tbody_element = tool_parameters_table.find_element_by_css_selector("tbody")
         tds = tbody_element.find_elements_by_css_selector("td")
         assert tds


### PR DESCRIPTION
This is better for reuse.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
