### PR TITLE
Add test for dataset HTML sanitization interface

### DIFF
--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -649,9 +649,9 @@ admin:
       sanitized:
         type: xpath
         selector: '//a[contains(text(), "HTML Sanitized")]'
-      rendered:
+      rendered_active:
         type: xpath
-        selector: '//li[@class="nav-item"]/a[contains(text(), "HTML Rendered")]'
+        selector: '//div[contains(@class, "active")]//a[contains(text(), "HTML Rendered")]'
 
   manage_dependencies:
     selectors:

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -638,6 +638,21 @@ tour:
 
 admin:
 
+  allowlist:
+    selectors:
+      toolshed:
+        type: xpath
+        selector: '//a[contains(text(), "Toolshed Tools")]'
+      local:
+        type: xpath
+        selector: '//a[contains(text(), "Local Tools")]'
+      sanitized:
+        type: xpath
+        selector: '//a[contains(text(), "HTML Sanitized")]'
+      rendered:
+        type: xpath
+        selector: '//li[@class="nav-item"]/a[contains(text(), "HTML Rendered")]'
+
   manage_dependencies:
     selectors:
       dependencies: 'a[contains(text(), "Dependencies")]'

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -9,6 +9,32 @@ class AdminAppTestCase(SeleniumTestCase):
 
     requires_admin = True
 
+    # Marked as flakey because the render_tab selector doesn't work yet.
+    @selenium_test
+    @flakey
+    def test_html_allowlist(self):
+        admin_component = self.components.admin
+        self.admin_login()
+        self.admin_open()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_landing')
+        admin_component.index.allowlist.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_allowlist_landing')
+        admin_component.allowlist.local.wait_for_and_click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_allowlist_local_landing')
+        # This should be updated if the list of built-in converters is changed.
+        render_button = self.driver.find_element_by_xpath("//td[.='CONVERTER_bam_to_bigwig_0']/following::td/button")
+        render_button.click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_allowlist_tool_rendered')
+        render_tab = self.driver.find_element_by_xpath("//a[contains(., 'HTML Rendered')]")
+        self.action_chains().move_to_element(render_tab).click().perform()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_allowlist_render_landing')
+        self.sleep_for(self.wait_types.UX_RENDER)
+
     @selenium_test
     @flakey
     def test_admin_toolshed(self):

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -9,9 +9,7 @@ class AdminAppTestCase(SeleniumTestCase):
 
     requires_admin = True
 
-    # Marked as flakey because the render_tab selector doesn't work yet.
     @selenium_test
-    @flakey
     def test_html_allowlist(self):
         admin_component = self.components.admin
         self.admin_login()
@@ -28,12 +26,15 @@ class AdminAppTestCase(SeleniumTestCase):
         render_button = self.driver.find_element_by_xpath("//td[.='CONVERTER_bam_to_bigwig_0']/following::td/button")
         render_button.click()
         self.sleep_for(self.wait_types.UX_RENDER)
-        self.screenshot('admin_allowlist_tool_rendered')
-        render_tab = self.driver.find_element_by_xpath("//a[contains(., 'HTML Rendered')]")
-        self.action_chains().move_to_element(render_tab).click().perform()
+        self.screenshot('admin_allowlist_converter_html_rendered')
+        admin_component.allowlist.rendered_active.wait_for_and_click()
         self.sleep_for(self.wait_types.UX_RENDER)
         self.screenshot('admin_allowlist_render_landing')
         self.sleep_for(self.wait_types.UX_RENDER)
+        sanitize_button = self.driver.find_element_by_xpath("//td[.='CONVERTER_bam_to_bigwig_0']/following::td/button")
+        sanitize_button.click()
+        self.sleep_for(self.wait_types.UX_RENDER)
+        self.screenshot('admin_allowlist_converter_sanitized')
 
     @selenium_test
     @flakey


### PR DESCRIPTION
Adds a selenium test for the interface implemented in #12283 

## How to test the changes?
(Select all options that apply)
- [x] This _is_ an [automated test](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
