### PR TITLE
[21.05] Delay start of job runners

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -64,6 +64,7 @@ class JobHandler(JobHandlerI):
         self.job_stop_queue = JobHandlerStopQueue(app, self.dispatcher)
 
     def start(self):
+        self.dispatcher.start()
         self.job_queue.start()
         self.job_stop_queue.start()
 
@@ -1024,6 +1025,10 @@ class DefaultJobDispatcher:
         # dict by the plugin.
         self.app.job_config.convert_legacy_destinations(self.job_runners)
         log.debug("Loaded job runners plugins: " + ':'.join(self.job_runners.keys()))
+
+    def start(self):
+        for runner in self.job_runners.values():
+            runner.start()
 
     def __get_runner_name(self, job_wrapper):
         if job_wrapper.can_split():

--- a/lib/galaxy/jobs/manager.py
+++ b/lib/galaxy/jobs/manager.py
@@ -24,11 +24,7 @@ class JobManager:
     def __init__(self, app: MinimalManagerApp):
         self.app = app
         self.job_lock = False
-        if self.app.is_job_handler:
-            log.debug("Initializing job handler")
-            self.job_handler = handler.JobHandler(app)
-        else:
-            self.job_handler = NoopHandler()
+        self.job_handler = NoopHandler()
 
     def _check_jobs_at_startup(self):
         if not self.app.is_job_handler:
@@ -47,7 +43,10 @@ class JobManager:
                 self.enqueue(job, tool)
 
     def start(self):
-        self.job_handler.start()
+        if self.app.is_job_handler:
+            log.debug("Initializing job handler")
+            self.job_handler = handler.JobHandler(self.app)
+            self.job_handler.start()
 
     def _queue_callback(self, job, tool_id):
         self.job_handler.job_queue.put(job.id, tool_id)

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -67,6 +67,8 @@ class RunnerParams(ParamsWithSpecs):
 
 
 class BaseJobRunner:
+
+    start_methods = ['_init_monitor_thread', '_init_worker_threads']
     DEFAULT_SPECS = dict(recheck_missing_job_retries=dict(map=int, valid=lambda x: int(x) >= 0, default=0))
 
     def __init__(self, app, nworkers, **kwargs):
@@ -83,6 +85,10 @@ class BaseJobRunner:
             log.debug('Loading %s with params: %s', self.runner_name, kwargs)
         self.runner_params = RunnerParams(specs=runner_param_specs, params=kwargs)
         self.runner_state_handlers = build_state_handlers()
+
+    def start(self):
+        for start_method in self.start_methods:
+            getattr(self, start_method, lambda: None)()
 
     def _init_worker_threads(self):
         """Start ``nworkers`` worker threads.

--- a/lib/galaxy/jobs/runners/__init__.py
+++ b/lib/galaxy/jobs/runners/__init__.py
@@ -93,7 +93,7 @@ class BaseJobRunner:
         for i in range(self.nworkers):
             worker = threading.Thread(name="%s.work_thread-%d" % (self.runner_name, i), target=self.run_next)
             worker.daemon = True
-            self.app.application_stack.register_postfork_function(worker.start)
+            worker.start()
             self.work_threads.append(worker)
 
     def _alive_worker_threads(self, cycle=False):

--- a/lib/galaxy/jobs/runners/chronos.py
+++ b/lib/galaxy/jobs/runners/chronos.py
@@ -142,8 +142,6 @@ class ChronosJobRunner(AsynchronousJobRunner):
             username=self.runner_params.get('username'),
             password=self.runner_params.get('password'),
             proto=protocol)
-        self._init_monitor_thread()
-        self._init_worker_threads()
 
     @handle_exception_call
     def queue_job(self, job_wrapper):

--- a/lib/galaxy/jobs/runners/cli.py
+++ b/lib/galaxy/jobs/runners/cli.py
@@ -33,8 +33,6 @@ class ShellJobRunner(AsynchronousJobRunner):
         super().__init__(app, nworkers)
 
         self.cli_interface = CliInterface()
-        self._init_monitor_thread()
-        self._init_worker_threads()
 
     def get_cli_plugins(self, shell_params, job_params):
         return self.cli_interface.get_plugins(shell_params, job_params)

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -51,12 +51,6 @@ class CondorJobRunner(AsynchronousJobRunner):
     """
     runner_name = "CondorRunner"
 
-    def __init__(self, app, nworkers):
-        """Initialize this job runner and start the monitor thread"""
-        super().__init__(app, nworkers)
-        self._init_monitor_thread()
-        self._init_worker_threads()
-
     def queue_job(self, job_wrapper):
         """Create job script and submit it to the DRM"""
 

--- a/lib/galaxy/jobs/runners/drmaa.py
+++ b/lib/galaxy/jobs/runners/drmaa.py
@@ -95,8 +95,6 @@ class DRMAAJobRunner(AsynchronousJobRunner):
 
         self.userid = None
 
-        self._init_monitor_thread()
-        self._init_worker_threads()
         self.redact_email_in_job_name = self.app.config.redact_email_in_job_name
 
     def url_to_destination(self, url):

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -138,16 +138,6 @@ class GodockerJobRunner(AsynchronousJobRunner):
         # godocker API login call
         self.auth = self.login(self.runner_params["key"], self.runner_params["user"], self.runner_params["godocker_master"])
 
-        if not self.auth:
-            log.error("Authentication failure, GoDocker runner cannot be started")
-        else:
-            """ Following methods starts threads.
-                These methods invoke threading.Thread(name,target)
-                      which in turn invokes methods monitor() and run_next().
-            """
-            self._init_monitor_thread()
-            self._init_worker_threads()
-
     def queue_job(self, job_wrapper):
         """ Create job script and submit it to godocker """
         if not self.prepare_job(job_wrapper, include_metadata=False, include_work_dir_outputs=True, modify_command_for_container=False):
@@ -324,7 +314,7 @@ class GodockerJobRunner(AsynchronousJobRunner):
         g_auth = Godocker(server, login, apikey, noCert)
         auth = g_auth.http_post_request("/api/1.0/authenticate", data, {'Content-type': 'application/json', 'Accept': 'application/json'})
         if not auth:
-            log.error("GoDocker authentication Error.")
+            raise Exception("Authentication failure, GoDocker runner cannot be started")
         else:
             log.debug("GoDocker authentication successful.")
             token = auth.json()['token']

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -102,8 +102,6 @@ class KubernetesJobRunner(AsynchronousJobRunner):
         self._fs_group = self.__get_fs_group()
         self._default_pull_policy = self.__get_pull_policy()
 
-        self._init_monitor_thread()
-        self._init_worker_threads()
         self.setup_volumes()
 
     def setup_volumes(self):

--- a/lib/galaxy/jobs/runners/local.py
+++ b/lib/galaxy/jobs/runners/local.py
@@ -52,7 +52,6 @@ class LocalJobRunner(BaseJobRunner):
             self._environ['TEMP'] = os.path.abspath(tempfile.gettempdir())
 
         super().__init__(app, nworkers)
-        self._init_worker_threads()
 
     def __command_line(self, job_wrapper):
         """

--- a/lib/galaxy/jobs/runners/pbs.py
+++ b/lib/galaxy/jobs/runners/pbs.py
@@ -102,8 +102,6 @@ class PBSJobRunner(AsynchronousJobRunner):
 
         # Proceed with general initialization
         super().__init__(app, nworkers)
-        self._init_monitor_thread()
-        self._init_worker_threads()
 
     @property
     def default_pbs_server(self):

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -188,6 +188,7 @@ PARAMETER_SPECIFICATION_IGNORED = object()
 class PulsarJobRunner(AsynchronousJobRunner):
     """Base class for pulsar job runners."""
 
+    start_methods = ['_init_worker_threads', '_init_client_manager', '_monitor']
     runner_name = "PulsarJobRunner"
     default_build_pulsar_app = False
     use_mq = False
@@ -196,15 +197,12 @@ class PulsarJobRunner(AsynchronousJobRunner):
     def __init__(self, app, nworkers, **kwds):
         """Start the job runner."""
         super().__init__(app, nworkers, runner_param_specs=PULSAR_PARAM_SPECS, **kwds)
-        self._init_worker_threads()
         galaxy_url = self.runner_params.galaxy_url
         if not galaxy_url:
             galaxy_url = app.config.galaxy_infrastructure_url
         if galaxy_url:
             galaxy_url = galaxy_url.rstrip("/")
         self.galaxy_url = galaxy_url
-        self.__init_client_manager()
-        self._monitor()
 
     def _monitor(self):
         if self.use_mq:
@@ -218,7 +216,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
         else:
             self._init_noop_monitor()
 
-    def __init_client_manager(self):
+    def _init_client_manager(self):
         pulsar_conf = self.runner_params.get('pulsar_app_config', None)
         pulsar_conf_file = None
         if pulsar_conf is None:

--- a/lib/galaxy/util/monitors.py
+++ b/lib/galaxy/util/monitors.py
@@ -2,7 +2,6 @@ import logging
 import threading
 
 from .sleeper import Sleeper
-from .web_compat import register_postfork_function
 
 log = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class Monitors:
         self.monitor_thread = threading.Thread(name=name, target=monitor_func)
         self.monitor_thread.setDaemon(True)
         self._start = start
-        register_postfork_function(self.start_monitoring)
+        self.start_monitoring()
 
     def _init_noop_monitor(self):
         self.sleeper = None

--- a/test/unit/jobs/test_runner_local.py
+++ b/test/unit/jobs/test_runner_local.py
@@ -93,11 +93,13 @@ class TestLocalJobRunner(TestCase, UsesApp, UsesTools):
     def test_shutdown_no_jobs(self):
         self.app.config.monitor_thread_join_timeout = 5
         runner = local.LocalJobRunner(self.app, 1)
+        runner.start()
         runner.shutdown()
 
     def test_stopping_job_at_shutdown(self):
         self.job_wrapper.command_line = '''python -c "import time; time.sleep(15)"'''
         runner = local.LocalJobRunner(self.app, 1)
+        runner.start()
         self.app.config.monitor_thread_join_timeout = 15
 
         def queue():


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12570.

The problem was that the JobDispatcher also starts the job runners'
`_init_worker_threads` method, which starts the queue worker threads.
This is guarded by `register_postfork_function`, but the standard
implementation (for anything that is not uwsgi pre-fork) just executes
the function right away.

We could alternatively implement a standard register_postfork_function
that we could use to delay functions until after the app is built
correctly. Not sure what is preferable, but this change should be fairly
minimal change.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

I've used @natefoo's excellent https://github.com/natefoo/galaxy-pulsar-dev/ to test this.

1. Submit a job to Pulsar in MQ mode
2. Wait for running status to be reported to Galaxy
3.  Stop handler(s)
4. Wait for job to complete and final status message to be published on Pulsar side
5. Start handler(s)
6. Make sure job finished correctly in Galaxy

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
