### PR TITLE
FastAPI: migrate history contents routes

### DIFF
--- a/lib/galaxy/managers/collections_util.py
+++ b/lib/galaxy/managers/collections_util.py
@@ -1,7 +1,7 @@
 import logging
 import math
 
-from galaxy import exceptions, model, web
+from galaxy import exceptions, model
 from galaxy.util import string_as_bool
 
 log = logging.getLogger(__name__)
@@ -103,20 +103,20 @@ def get_collection_elements(collection, name=""):
     return names, hdas
 
 
-def dictify_dataset_collection_instance(dataset_collection_instance, parent, security, view="element", fuzzy_count=None):
+def dictify_dataset_collection_instance(dataset_collection_instance, parent, security, url_builder, view="element", fuzzy_count=None):
     hdca_view = "element" if view in ["element", "element-reference"] else "collection"
     dict_value = dataset_collection_instance.to_dict(view=hdca_view)
     encoded_id = security.encode_id(dataset_collection_instance.id)
     if isinstance(parent, model.History):
         encoded_history_id = security.encode_id(parent.id)
-        dict_value['url'] = web.url_for('history_content_typed', history_id=encoded_history_id, id=encoded_id, type="dataset_collection")
+        dict_value['url'] = url_builder('history_content_typed', history_id=encoded_history_id, id=encoded_id, type="dataset_collection")
     elif isinstance(parent, model.LibraryFolder):
         encoded_library_id = security.encode_id(parent.library_root.id)
         encoded_folder_id = security.encode_id(parent.id)
         # TODO: Work in progress - this end-point is not right yet...
-        dict_value['url'] = web.url_for('library_content', library_id=encoded_library_id, id=encoded_id, folder_id=encoded_folder_id)
+        dict_value['url'] = url_builder('library_content', library_id=encoded_library_id, id=encoded_id, folder_id=encoded_folder_id)
 
-    dict_value['contents_url'] = web.url_for(
+    dict_value['contents_url'] = url_builder(
         'contents_dataset_collection',
         hdca_id=encoded_id,
         parent_id=security.encode_id(dataset_collection_instance.collection_id)

--- a/lib/galaxy/managers/hdcas.py
+++ b/lib/galaxy/managers/hdcas.py
@@ -320,7 +320,9 @@ class HDCASerializer(
 
     def generate_contents_url(self, item, key, **context):
         encode_id = self.app.security.encode_id
-        contents_url = self.url_for('contents_dataset_collection',
+        trans = context.get("trans")
+        url_for = trans.url_builder if trans and trans.url_builder else self.url_for
+        contents_url = url_for('contents_dataset_collection',
             hdca_id=encode_id(item.id),
             parent_id=encode_id(item.collection_id))
         return contents_url

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -18,7 +18,6 @@ from pydantic import (
     ConstrainedStr,
     Extra,
     Field,
-    FilePath,
     Json,
     UUID4,
 )
@@ -418,13 +417,13 @@ class HDADetailed(HDASummary):
     hda_ldda: DatasetSourceType = HdaLddaField
     accessible: bool = AccessibleField
     genome_build: Optional[str] = GenomeBuildField
-    misc_info: str = Field(
-        ...,
+    misc_info: Optional[str] = Field(
+        default=None,
         title="Miscellaneous Information",
         description="TODO",
     )
-    misc_blurb: str = Field(
-        ...,
+    misc_blurb: Optional[str] = Field(
+        default=None,
         title="Miscellaneous Blurb",
         description="TODO",
     )
@@ -443,13 +442,23 @@ class HDADetailed(HDASummary):
         title="Resubmitted",
         description="Whether the job creating this dataset has been resubmitted.",
     )
-    metadata: Any = Field(  # TODO: create pydantic model for metadata?
-        ...,
+    metadata: Optional[Any] = Field(  # TODO: create pydantic model for metadata?
+        default=None,
         title="Metadata",
         description="The metadata associated with this dataset.",
     )
+    metadata_dbkey: Optional[str] = Field(
+        "?",
+        title="Metadata DBKey",
+        description="TODO",
+    )
+    metadata_data_lines: int = Field(
+        0,
+        title="Metadata Data Lines",
+        description="TODO",
+    )
     meta_files: List[MetadataFile] = Field(
-        [],
+        ...,
         title="Metadata Files",
         description="Collection of metadata files associated with this dataset.",
     )
@@ -459,8 +468,8 @@ class HDADetailed(HDASummary):
         description="The fully qualified name of the class implementing the data type of this dataset.",
         example="galaxy.datatypes.data.Text"
     )
-    peek: str = Field(
-        ...,
+    peek: Optional[str] = Field(
+        default=None,
         title="Peek",
         description="A few lines of contents from the start of the file.",
     )
@@ -480,24 +489,24 @@ class HDADetailed(HDASummary):
         title="Permissions",
         description="Role-based access and manage control permissions for the dataset.",
     )
-    file_name: FilePath = Field(
-        ...,
+    file_name: Optional[str] = Field(
+        default=None,
         title="File Name",
         description="The full path to the dataset file.",
     )
     display_apps: List[DisplayApp] = Field(
-        [],
+        ...,
         title="Display Applications",
         description="Contains new-style display app urls.",
     )
     display_types: List[DisplayApp] = Field(
-        [],
+        ...,
         title="Legacy Display Applications",
         description="Contains old-style display app urls.",
         deprecated=False,  # TODO: Should this field be deprecated in favor of display_apps?
     )
     visualizations: List[Visualization] = Field(
-        [],
+        ...,
         title="Visualizations",
         description="The collection of visualizations that can be applied to this dataset.",
     )
@@ -2470,9 +2479,18 @@ class DeleteHDCAResult(Model):
     )
 
 
-AnyHDA = Union[HDASummary, HDADetailed, HDABeta]
+AnyHDA = Union[HDABeta, HDADetailed, HDASummary]
 AnyHDCA = Union[HDCABeta, HDCADetailed, HDCASummary]
-AnyHistoryContentItem = Union[AnyHDA, HDCASummary, HDCADetailed, HDCABeta]
+AnyHistoryContentItem = Union[
+    AnyHDA,
+    AnyHDCA,
+    Any,  # Allows custom keys to be specified in the serialization parameters
+]
+
+
+class HistoryContentItemList(BaseModel):
+    __root__: List[AnyHistoryContentItem]
+
 
 AnyJobStateSummary = Union[
     JobStateSummary,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -711,6 +711,17 @@ class UpdateHistoryContentsBatchPayload(HistoryBase):
         }
 
 
+class UpdateHistoryContentsPayload(HistoryBase):
+    """Contains arbitrary property values that will be updated for a particular history item."""
+    class Config:
+        schema_extra = {
+            "example": {
+                "visible": False,
+                "annotation": "Test",
+            }
+        }
+
+
 class HistorySummary(HistoryBase):
     """History summary information."""
     model_class: str = ModelClassField(HISTORY_MODEL_CLASS_NAME)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1,5 +1,6 @@
 """This module contains general pydantic models and common schema field annotations for them."""
 
+import json
 import re
 from datetime import datetime
 from enum import Enum
@@ -2542,6 +2543,7 @@ class HistoryContentsArchiveDryRunResult(BaseModel):
 
 
 class ContentsNearStats(BaseModel):
+    """Stats used by the `contents_near` endpoint."""
     matches: int
     matches_up: int
     matches_down: int
@@ -2550,11 +2552,24 @@ class ContentsNearStats(BaseModel):
     total_matches_down: int
     max_hid: Optional[int] = None
     min_hid: Optional[int] = None
-    history_size: str
+    history_size: int
     history_empty: bool
+
+    def to_headers(self) -> Dict[str, str]:
+        """Converts all field values to json strings.
+
+        The headers values need to be json strings or updating the response
+        headers will raise encoding errors."""
+        headers = {}
+        for key, val in self:
+            headers[key] = json.dumps(val)
+        return headers
 
 
 class HistoryContentsResult(Model):
+    """Collection of history content items.
+    Can contain different views and kinds of items.
+    """
     __root__: List[AnyHistoryContentItem]
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -361,8 +361,8 @@ class HistoryItemCommon(HistoryItemBase):
     class Config:
         extra = Extra.allow
 
-    type_id: str = Field(
-        ...,
+    type_id: Optional[str] = Field(
+        default=None,
         title="Type - ID",
         description="The type and the encoded ID of this item. Used for caching.",
         example="dataset-616e371b2cc6c62e",

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2540,6 +2540,29 @@ class HistoryContentsArchiveDryRunResult(BaseModel):
     Contains pairs of filepath/filename."""
     __root__: List[Tuple[str, str]]
 
+
+class ContentsNearStats(BaseModel):
+    matches: int
+    matches_up: int
+    matches_down: int
+    total_matches: int
+    total_matches_up: int
+    total_matches_down: int
+    max_hid: Optional[int] = None
+    min_hid: Optional[int] = None
+    history_size: str
+    history_empty: bool
+
+
+class HistoryContentsResult(Model):
+    __root__: List[AnyHistoryContentItem]
+
+
+class ContentsNearResult(BaseModel):
+    contents: HistoryContentsResult
+    stats: ContentsNearStats
+
+
 # Sharing -----------------------------------------------------------------
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2472,19 +2472,6 @@ class UpdateDatasetPermissionsPayload(Model):
     )
 
 
-class DeleteHDCAResult(Model):
-    id: EncodedDatabaseIdField = Field(
-        ...,
-        title="ID",
-        description="The encoded ID of the collection.",
-    )
-    deleted: bool = Field(
-        ...,
-        title="Deleted",
-        description="True if the collection was successfully deleted.",
-    )
-
-
 class CustomHistoryItem(Model):
     """Can contain any serializable property of the item.
 
@@ -2511,6 +2498,40 @@ AnyJobStateSummary = Union[
 ]
 
 HistoryArchiveExportResult = Union[JobExportHistoryArchiveModel, JobIdResponse]
+
+
+class DeleteHistoryContentPayload(BaseModel):
+    purge: bool = Field(
+        default=False,
+        title="Purge",
+        description="Whether to remove from disk the target HDA or child HDAs of the target HDCA.",
+    )
+    recursive: bool = Field(
+        default=False,
+        title="Recursive",
+        description="When deleting a dataset collection, whether to also delete containing datasets.",
+    )
+
+
+class DeleteHistoryContentResult(CustomHistoryItem):
+    """Contains minimum information about the deletion state of a history item.
+
+    Can also contain any other properties of the item."""
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="The encoded ID of the history item.",
+    )
+    deleted: bool = Field(
+        ...,
+        title="Deleted",
+        description="True if the item was successfully deleted.",
+    )
+    purged: Optional[bool] = Field(
+        default=None,
+        title="Purged",
+        description="True if the item was successfully removed from disk.",
+    )
 
 # Sharing -----------------------------------------------------------------
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -358,8 +358,11 @@ class HistoryItemBase(Model):
 
 class HistoryItemCommon(HistoryItemBase):
     """Common information provided by items contained in a History."""
-    type_id: Optional[str] = Field(
-        default=None,
+    class Config:
+        extra = Extra.allow
+
+    type_id: str = Field(
+        ...,
         title="Type - ID",
         description="The type and the encoded ID of this item. Used for caching.",
         example="dataset-616e371b2cc6c62e",
@@ -2479,17 +2482,23 @@ class DeleteHDCAResult(Model):
     )
 
 
+class CustomHistoryItem(Model):
+    """Can contain any serializable property of the item.
+
+    Allows arbitrary custom keys to be specified in the serialization
+    parameters without a particular view (predefined set of keys).
+    """
+    class Config:
+        extra = Extra.allow
+
+
 AnyHDA = Union[HDABeta, HDADetailed, HDASummary]
 AnyHDCA = Union[HDCABeta, HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Union[
     AnyHDA,
     AnyHDCA,
-    Any,  # Allows custom keys to be specified in the serialization parameters
+    CustomHistoryItem,
 ]
-
-
-class HistoryContentItemList(BaseModel):
-    __root__: List[AnyHistoryContentItem]
 
 
 AnyJobStateSummary = Union[

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2533,6 +2533,13 @@ class DeleteHistoryContentResult(CustomHistoryItem):
         description="True if the item was successfully removed from disk.",
     )
 
+
+class HistoryContentsArchiveDryRunResult(BaseModel):
+    """The structure of the archive for debugging.
+
+    Contains pairs of filepath/filename."""
+    __root__: List[Tuple[str, str]]
+
 # Sharing -----------------------------------------------------------------
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2536,9 +2536,14 @@ class DeleteHistoryContentResult(CustomHistoryItem):
 
 
 class HistoryContentsArchiveDryRunResult(BaseModel):
-    """The structure of the archive for debugging.
+    """
+    Contains a collection of filepath/filename entries that represent
+    the contents that would have been included in the archive.
+    This is returned when the `dry_run` flag is active when
+    creating an archive with the contents of the history.
 
-    Contains pairs of filepath/filename."""
+    This is used for debugging purposes.
+    """
     __root__: List[Tuple[str, str]]
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -31,7 +31,6 @@ from galaxy.model import (
 from galaxy.schema.fields import (
     EncodedDatabaseIdField,
     ModelClassField,
-    optional,
 )
 from galaxy.schema.types import RelativeUrl
 
@@ -570,12 +569,6 @@ class HDABeta(HDADetailed):  # TODO: change HDABeta name to a more appropriate o
     pass
 
 
-@optional
-class UpdateHDAPayload(HDABeta):
-    """Used for updating a particular HDA. All fields are optional."""
-    pass
-
-
 class DCSummary(Model):
     """Dataset Collection summary information."""
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
@@ -678,45 +671,44 @@ class HDCADetailed(HDCASummary):
     elements: List[DCESummary] = ElementsField
 
 
-@optional
-class UpdateHDCAPayload(HDCADetailed):
-    """Used for updating a particular HDCA. All fields are optional."""
-    pass
-
-
-class UpdateHistoryContentsBatchPayload(BaseModel):
-    class Config:
-        use_enum_values = True  # when using .dict()
-        allow_population_by_field_name = True
-        extra = Extra.allow  # Allow any additional field
-
-    items: List[Union[UpdateHDAPayload, UpdateHDCAPayload]] = Field(
-        ...,
-        title="Items",
-        description="A list of content items to update with the changes.",
-    )
-    deleted: Optional[bool] = Field(
-        default=False,
-        title="Deleted",
-        description=(
-            "This will check the uploading state if not deleting (i.e: deleted=False), "
-            "otherwise cannot delete uploading files, so it will raise an error."
-        ),
-    )
-    visible: Optional[bool] = Field(
-        default=False,
-        title="Visible",
-        description=(
-            "Show or hide history contents"
-        ),
-    )
-
-
 class HistoryBase(BaseModel):
     """Provides basic configuration for all the History models."""
     class Config:
         use_enum_values = True  # When using .dict()
         extra = Extra.allow  # Allow any other extra fields
+
+
+class UpdateContentItem(HistoryBase):
+    """Used for updating a particular HDA. All fields are optional."""
+    history_content_type: HistoryContentType = Field(
+        ...,
+        title="Content Type",
+        description="The type of this item.",
+    )
+    id: EncodedDatabaseIdField = EncodedEntityIdField
+
+
+class UpdateHistoryContentsBatchPayload(HistoryBase):
+    """Contains property values that will be updated for all the history`items` provided."""
+
+    items: List[UpdateContentItem] = Field(
+        ...,
+        title="Items",
+        description="A list of content items to update with the changes.",
+    )
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "items": [
+                    {
+                        "history_content_type": "dataset",
+                        "id": "string"
+                    }
+                ],
+                "visible": False,
+            }
+        }
 
 
 class HistorySummary(HistoryBase):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -690,7 +690,7 @@ class UpdateContentItem(HistoryBase):
 
 
 class UpdateHistoryContentsBatchPayload(HistoryBase):
-    """Contains property values that will be updated for all the history`items` provided."""
+    """Contains property values that will be updated for all the history `items` provided."""
 
     items: List[UpdateContentItem] = Field(
         ...,
@@ -2505,7 +2505,7 @@ class DeleteHistoryContentPayload(BaseModel):
     purge: bool = Field(
         default=False,
         title="Purge",
-        description="Whether to remove from disk the target HDA or child HDAs of the target HDCA.",
+        description="Whether to remove the dataset from storage. Datasets will only be removed from storage once all HDAs or LDDAs that refer to this datasets are deleted.",
     )
     recursive: bool = Field(
         default=False,

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2544,7 +2544,8 @@ class HistoryContentsArchiveDryRunResult(BaseModel):
 
     This is used for debugging purposes.
     """
-    __root__: List[Tuple[str, str]]
+    # TODO: Use Tuple again when https://github.com/tiangolo/fastapi/issues/3665 is fixed upstream
+    __root__: List[List[str]]  # List[Tuple[str, str]]
 
 
 class ContentsNearStats(BaseModel):

--- a/lib/galaxy/util/zipstream.py
+++ b/lib/galaxy/util/zipstream.py
@@ -22,6 +22,9 @@ class ZipstreamWrapper:
         else:
             yield iter(self.archive)
 
+    def get_iterator(self):
+        return iter(self.archive)
+
     def get_headers(self):
         headers = {}
         if self.archive_name:

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -16,6 +16,7 @@ from fastapi import (
     Form,
     Header,
     Query,
+    Request,
     Response,
 )
 from fastapi.params import Depends
@@ -27,7 +28,6 @@ try:
     from starlette_context import context as request_context
 except ImportError:
     request_context = None
-from starlette.requests import Request
 
 from galaxy import (
     app as galaxy_app,

--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -22,6 +22,7 @@ from fastapi.params import Depends
 from fastapi_utils.cbv import cbv
 from fastapi_utils.inferring_router import InferringRouter
 from pydantic.main import BaseModel
+from starlette.routing import NoMatchFound
 try:
     from starlette_context import context as request_context
 except ImportError:
@@ -31,6 +32,7 @@ from starlette.requests import Request
 from galaxy import (
     app as galaxy_app,
     model,
+    web,
 )
 from galaxy.exceptions import (
     AdminRequiredException,
@@ -147,9 +149,13 @@ class UrlBuilder:
 
     def __call__(self, name: str, **path_params):
         qualified = path_params.pop("qualified", False)
-        if qualified:
-            return self.request.url_for(name, **path_params)
-        return self.request.app.url_path_for(name, **path_params)
+        try:
+            if qualified:
+                return self.request.url_for(name, **path_params)
+            return self.request.app.url_path_for(name, **path_params)
+        except NoMatchFound:
+            # Fallback to legacy url_for
+            return web.url_for(name, **path_params)
 
 
 class GalaxyASGIRequest(GalaxyAbstractRequest):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -54,6 +54,7 @@ from galaxy.webapps.base.controller import (
 )
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
+    get_update_permission_payload,
     parse_serialization_params,
     query_serialization_params,
 )
@@ -314,20 +315,6 @@ def parse_content_filter_params(
         result.append([attr, op, val])
 
     return result
-
-
-def get_update_permission_payload(payload: Dict[str, Any]) -> UpdateDatasetPermissionsPayload:
-    """Coverts the generic payload dictionary into a UpdateDatasetPermissionsPayload model with custom parsing.
-
-    This is an attempt on supporting multiple aliases for the permissions params."""
-    # There are several allowed names for the same role list parameter, i.e.: `access`, `access_ids`, `access_ids[]`
-    # The `access_ids[]` name is not pydantic friendly, so this will be modelled as an alias but we can only set one alias
-    # TODO: Maybe we should choose only one way/naming and deprecate the others?
-    payload["access_ids"] = payload.get("access_ids[]") or payload.get("access")
-    payload["manage_ids"] = payload.get("manage_ids[]") or payload.get("manage")
-    payload["modify_ids"] = payload.get("modify_ids[]") or payload.get("modify")
-    update_payload = UpdateDatasetPermissionsPayload(**payload)
-    return update_payload
 
 
 @router.cbv

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -105,6 +105,7 @@ def get_index_query_params(
     ),
     dataset_details: Optional[str] = Query(
         default=None,
+        alias="details",
         title="Dataset Details",
         description=(
             "A comma-separated list of encoded dataset IDs that will return additional (full) details "
@@ -552,6 +553,8 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         """
         index_params = parse_index_query_params(**kwd)
         legacy_params = parse_legacy_index_query_params(**kwd)
+        # Sometimes the `v=dev` version is called with `details` or `dataset_details`
+        index_params.dataset_details = index_params.dataset_details or legacy_params.dataset_details
         serialization_params = parse_serialization_params(**kwd)
         filter_parameters = FilterQueryParams(**kwd)
         return self.service.index(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -45,7 +45,6 @@ from galaxy.schema.schema import (
 from galaxy.web import (
     expose_api,
     expose_api_anonymous,
-    expose_api_raw,
     expose_api_raw_anonymous,
 )
 from galaxy.webapps.base.controller import (
@@ -1147,7 +1146,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         delete_payload = DeleteHistoryContentPayload(purge=purge, recursive=recursive)
         return self.service.delete(trans, id, serialization_params, contents_type, delete_payload)
 
-    @expose_api_raw
+    @expose_api
     def archive(self, trans, history_id, filename='', format='zip', dry_run=True, **kwd):
         """
         archive( self, trans, history_id, filename='', format='zip', dry_run=True, **kwd )
@@ -1173,7 +1172,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
             return archive.response()
         return archive
 
-    @expose_api_raw_anonymous
+    @expose_api_anonymous
     def contents_near(self, trans, history_id, direction, hid, limit, **kwd):
         """
         Returns the following data:

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -48,12 +48,6 @@ log = logging.getLogger(__name__)
 
 
 class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, UsesTagsMixin):
-    hda_manager: hdas.HDAManager = depends(hdas.HDAManager)
-    history_manager: histories.HistoryManager = depends(histories.HistoryManager)
-    history_contents_manager: history_contents.HistoryContentsManager = depends(history_contents.HistoryContentsManager)
-    hda_serializer: hdas.HDASerializer = depends(hdas.HDASerializer)
-    hdca_serializer: hdcas.HDCASerializer = depends(hdcas.HDCASerializer)
-    history_contents_filters: history_contents.HistoryContentsFilters = depends(history_contents.HistoryContentsFilters)
 
     service: HistoriesContentsService = depends(HistoriesContentsService)
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -234,7 +234,7 @@ def get_index_jobs_summary_params(
         default=None,
         title="Types",
         description=(
-            "A comma-separated list of type of object represented by elements in the ids array - any of "
+            "A comma-separated list of type of object represented by elements in the `ids` array - any of "
             "`Job`, `ImplicitCollectionJob`, or `WorkflowInvocation`."
         ),
     ),
@@ -370,6 +370,30 @@ class FastAPIHistoryContents:
         efficient as possible.
         """
         return self.service.index_jobs_summary(trans, params)
+
+    @router.get(
+        '/api/histories/{history_id}/contents/{type}s/{id}/jobs_summary',
+        summary='Return detailed information about an `HDA` or `HDCAs` jobs.',
+    )
+    def show_jobs_summary(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        type: HistoryContentType = Path(
+            default=None,
+            title="Content Type",
+            description="The type of the history element to show.",
+            example=HistoryContentType.dataset,
+        ),
+    ) -> AnyJobStateSummary:
+        """Return detailed information about an `HDA` or `HDCAs` jobs.
+
+        **Warning**: We allow anyone to fetch job state information about any object they
+        can guess an encoded ID for - it isn't considered protected data. This keeps
+        polling IDs as part of state calculation for large histories and collections as
+        efficient as possible.
+        """
+        return self.service.show_jobs_summary(trans, id, contents_type=type)
 
 
 class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, UsesTagsMixin):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -220,8 +220,9 @@ def parse_legacy_index_query_params(
     else:
         content_types = [e.value for e in HistoryContentType]
 
+    id_list: Optional[List[EncodedDatabaseIdField]] = None
     if ids:
-        ids = util.listify(ids)
+        id_list = util.listify(ids)
         # If explicit ids given, always used detailed result.
         dataset_details = 'all'
     else:
@@ -229,7 +230,7 @@ def parse_legacy_index_query_params(
 
     return LegacyHistoryContentsIndexParams(
         types=content_types,
-        ids=ids,
+        ids=id_list,
         deleted=deleted,
         visible=visible,
         dataset_details=dataset_details,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -31,6 +31,7 @@ from galaxy.schema.schema import (
     DatasetAssociationRoles,
     DeleteHistoryContentPayload,
     DeleteHistoryContentResult,
+    HistoryContentsArchiveDryRunResult,
     HistoryContentType,
     UpdateDatasetPermissionsPayload,
     UpdateHistoryContentsBatchPayload,
@@ -1011,7 +1012,11 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         """
         dry_run = util.string_as_bool(dry_run)
         filter_parameters = FilterQueryParams(**kwd)
-        return self.service.archive(trans, history_id, filter_parameters, filename, dry_run)
+        archive = self.service.archive(trans, history_id, filter_parameters, filename, dry_run)
+        if not isinstance(archive, HistoryContentsArchiveDryRunResult):
+            trans.response.headers.update(archive.get_headers())
+            return archive.response
+        return archive
 
     @expose_api_raw_anonymous
     def contents_near(self, trans, history_id, direction, hid, limit, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -1087,9 +1087,15 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         hid = int(hid)
         limit = int(limit)
 
-        return self.service.contents_near(
+        result = self.service.contents_near(
             trans, history_id, serialization_params, filter_params, direction, hid, limit, since,
         )
+        if result is None:
+            trans.response.status = 204
+            return
+        # Put stats in http headers
+        trans.response.headers.update(result.stats.dict())
+        return result.contents
 
     # Parsing query string according to REST standards.
     def _parse_rest_params(self, qdict: Dict[str, Any]) -> HistoryContentsFilterList:

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -32,6 +32,7 @@ from galaxy.schema.schema import (
     HistoryContentType,
     UpdateDatasetPermissionsPayload,
     UpdateHistoryContentsBatchPayload,
+    UpdateHistoryContentsPayload,
 )
 from galaxy.web import (
     expose_api,
@@ -501,6 +502,22 @@ class FastAPIHistoryContents:
         will be made to the items.
         """
         return self.service.update_batch(trans, history_id, payload, serialization_params)
+
+    @router.put(
+        '/api/histories/{history_id}/contents/{id}',
+        summary='Updates the values for the history content item with the given ``ID``.',
+    )
+    def update(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+        type: HistoryContentType = ContentTypeQueryParam,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        payload: UpdateHistoryContentsPayload = Body(...),
+    ) -> AnyHistoryContentItem:
+        """Updates the values for the history content item with the given ``ID``."""
+        return self.service.update(trans, history_id, id, payload.dict(), serialization_params, contents_type=type)
 
 
 class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, UsesTagsMixin):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -652,6 +652,8 @@ class FastAPIHistoryContents:
         archive = self.service.archive(trans, history_id, filter_query_params, filename, dry_run)
         if isinstance(archive, HistoryContentsArchiveDryRunResult):
             return archive
+        if archive.upstream_mod_zip:
+            return StreamingResponse(archive.response(), headers=archive.get_headers())
         return StreamingResponse(archive.get_iterator(), headers=archive.get_headers(), media_type="application/zip")
 
     @router.get(
@@ -1148,7 +1150,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         archive = self.service.archive(trans, history_id, filter_parameters, filename, dry_run)
         if not isinstance(archive, HistoryContentsArchiveDryRunResult):
             trans.response.headers.update(archive.get_headers())
-            return archive.response
+            return archive.response()
         return archive
 
     @expose_api_raw_anonymous

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -392,11 +392,13 @@ class FastAPIHistoryContents:
         '/api/histories/{history_id}/contents/{type}s/{id}',
         name='history_content_typed',
         summary='Return detailed information about a specific HDA or HDCA with the given `ID` within a history.',
+        response_model_exclude_unset=True,
     )
     @router.get(
         '/api/histories/{history_id}/contents/{id}',
         name='history_content',
         summary='Return detailed information about an HDA within a history.',
+        response_model_exclude_unset=True,
         deprecated=True,
     )
     def show(
@@ -484,10 +486,12 @@ class FastAPIHistoryContents:
     @router.post(
         '/api/histories/{history_id}/contents/{type}s',
         summary='Create a new `HDA` or `HDCA` in the given History.',
+        response_model_exclude_unset=True,
     )
     @router.post(
         '/api/histories/{history_id}/contents',
         summary='Create a new `HDA` or `HDCA` in the given History.',
+        response_model_exclude_unset=True,
         deprecated=True,
     )
     def create(
@@ -561,10 +565,12 @@ class FastAPIHistoryContents:
     @router.put(
         '/api/histories/{history_id}/contents/{type}s/{id}',
         summary='Updates the values for the history content item with the given ``ID``.',
+        response_model_exclude_unset=True,
     )
     @router.put(
         '/api/histories/{history_id}/contents/{id}',
         summary='Updates the values for the history content item with the given ``ID``.',
+        response_model_exclude_unset=True,
         deprecated=True,
     )
     def update(

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -550,7 +550,9 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         :param id: encoded HistoryDatasetCollectionAssociation (HDCA) id
         :param history_id: encoded id string of the HDCA's History
         """
-        return self.service.download_dataset_collection(trans, id)
+        archive = self.service.get_dataset_collection_archive_for_download(trans, id)
+        trans.response.headers.update(archive.get_headers())
+        return archive.response()
 
     @expose_api_anonymous
     def create(self, trans, history_id, payload, **kwd):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -693,7 +693,7 @@ class FastAPIHistoryContents:
         """
         serialization_params.default_view = serialization_params.default_view or "betawebclient"
         # Needed to parse arbitrary query parameter names
-        filter_params = parse_content_filter_params(request.query_params)
+        filter_params = parse_content_filter_params(request.query_params._dict)
         result = self.service.contents_near(
             trans, history_id, serialization_params, filter_params, hid, limit, since,
         )

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -520,6 +520,19 @@ class FastAPIHistoryContents:
         """Updates the values for the history content item with the given ``ID``."""
         return self.service.update(trans, history_id, id, payload.dict(), serialization_params, contents_type=type)
 
+    @router.put(
+        '/api/histories/{history_id}/contents/{id}/validate',
+        summary='Validates the metadata associated with a dataset within a History.',
+    )
+    def validate(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        id: EncodedDatabaseIdField = HistoryItemIDPathParam,
+    ) -> dict:  # TODO: define a response?
+        """Validates the metadata associated with a dataset within a History."""
+        return self.service.validate(trans, history_id, id)
+
 
 class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, UsesTagsMixin):
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -487,6 +487,24 @@ class FastAPIHistoryContents:
         update_payload = get_update_permission_payload(payload)
         return self.service.update_permissions(trans, dataset_id, update_payload)
 
+    @router.put(
+        '/api/histories/{history_id}/contents',
+        summary='Batch update specific properties of a set items contained in the given History.',
+    )
+    def update_batch(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        history_id: EncodedDatabaseIdField = HistoryIDPathParam,
+        serialization_params: SerializationParams = Depends(query_serialization_params),
+        payload: UpdateHistoryContentsBatchPayload = Body(...),
+    ) -> List[AnyHistoryContentItem]:
+        """Batch update specific properties of a set items contained in the given History.
+
+        If you provide an invalid/unknown property key the request will not fail, but no changes
+        will be made to the items.
+        """
+        return self.service.update_batch(trans, history_id, payload, serialization_params)
+
 
 class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, UsesTagsMixin):
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -87,6 +87,13 @@ HistoryHDCAIDPathParam: EncodedDatabaseIdField = Path(
     description='The ID of the `HDCA` contained in the history.'
 )
 
+ContentTypeQueryParam = Query(
+    default=HistoryContentType.dataset,
+    title="Content Type",
+    description="The type of the history element to show.",
+    example=HistoryContentType.dataset,
+)
+
 
 def get_index_query_params(
     v: Optional[str] = Query(  # Should this be deprecated at some point and directly use the latest version by default?
@@ -335,12 +342,7 @@ class FastAPIHistoryContents:
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: EncodedDatabaseIdField = HistoryIDPathParam,
         id: EncodedDatabaseIdField = HistoryItemIDPathParam,
-        type: Optional[HistoryContentType] = Query(
-            default=None,
-            title="Content Type",
-            description="The type of the history element to show.",
-            example=HistoryContentType.dataset,
-        ),
+        type: HistoryContentType = ContentTypeQueryParam,
         fuzzy_count: Optional[int] = Query(
             default=None,
             title="Fuzzy Count",
@@ -403,12 +405,7 @@ class FastAPIHistoryContents:
         trans: ProvidesHistoryContext = DependsOnTrans,
         history_id: EncodedDatabaseIdField = HistoryIDPathParam,
         id: EncodedDatabaseIdField = HistoryItemIDPathParam,
-        type: HistoryContentType = Path(
-            default=None,
-            title="Content Type",
-            description="The type of the history element to show.",
-            example=HistoryContentType.dataset,
-        ),
+        type: HistoryContentType = ContentTypeQueryParam,
     ) -> AnyJobStateSummary:
         """Return detailed information about an `HDA` or `HDCAs` jobs.
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -463,11 +463,11 @@ class FastAPIHistoryContents:
         summary='Download the content of a dataset collection as a `zip` archive.',
         response_class=StreamingResponse,
     )
-    @router.get(  # TODO: Move to dataset_collections API?
+    @router.get(
         '/api/dataset_collection/{id}/download',
         summary='Download the content of a dataset collection as a `zip` archive.',
         response_class=StreamingResponse,
-        tags=["dataset_collections"],
+        tags=["dataset collections"],
     )
     def download_dataset_collection(
         self,
@@ -546,8 +546,13 @@ class FastAPIHistoryContents:
         return HistoryContentsResult.parse_obj(result)
 
     @router.put(
+        '/api/histories/{history_id}/contents/{type}s/{id}',
+        summary='Updates the values for the history content item with the given ``ID``.',
+    )
+    @router.put(
         '/api/histories/{history_id}/contents/{id}',
         summary='Updates the values for the history content item with the given ``ID``.',
+        deprecated=True,
     )
     def update(
         self,

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -334,6 +334,7 @@ class FastAPIHistoryContents:
 
     @router.get(
         '/api/histories/{history_id}/contents',
+        name='history_contents',
         summary='Returns the contents of the given history.',
     )
     @router.get(
@@ -369,11 +370,13 @@ class FastAPIHistoryContents:
 
     @router.get(
         '/api/histories/{history_id}/contents/{id}',
+        name='history_content',
         summary='Return detailed information about an HDA within a history.',
         deprecated=True,
     )
     @router.get(
         '/api/histories/{history_id}/contents/{type}s/{id}',
+        name='history_content_typed',
         summary='Return detailed information about a specific HDA or HDCA with the given `ID` within a history.',
     )
     def show(

--- a/lib/galaxy/webapps/galaxy/api/library_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/library_contents.py
@@ -263,7 +263,9 @@ class LibraryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
             create_params['parent'] = parent
             dataset_collection_manager = trans.app.dataset_collection_manager
             dataset_collection_instance = dataset_collection_manager.create(**create_params)
-            return [dictify_dataset_collection_instance(dataset_collection_instance, security=trans.security, parent=parent)]
+            return [dictify_dataset_collection_instance(
+                dataset_collection_instance, security=trans.security, url_builder=trans.url_builder, parent=parent
+            )]
         if status != 200:
             trans.response.status = status
             return output

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -672,13 +672,17 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         for output_name, collection_instance in vars.get('output_collections', []):
             history = target_history or trans.history
-            output_dict = dictify_dataset_collection_instance(collection_instance, security=trans.security, parent=history)
+            output_dict = dictify_dataset_collection_instance(
+                collection_instance, security=trans.security, url_builder=trans.url_builder, parent=history,
+            )
             output_dict['output_name'] = output_name
             rval['output_collections'].append(output_dict)
 
         for output_name, collection_instance in vars.get('implicit_collections', {}).items():
             history = target_history or trans.history
-            output_dict = dictify_dataset_collection_instance(collection_instance, security=trans.security, parent=history)
+            output_dict = dictify_dataset_collection_instance(
+                collection_instance, security=trans.security, url_builder=trans.url_builder, parent=history,
+            )
             output_dict['output_name'] = output_name
             rval['implicit_collections'].append(output_dict)
 

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -136,7 +136,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
 
         dataset_collection_instance = self.collection_manager.create(trans=trans, **create_params)
         rval = dictify_dataset_collection_instance(
-            dataset_collection_instance, security=trans.security, parent=create_params["parent"]
+            dataset_collection_instance, security=trans.security, url_builder=trans.url_builder, parent=create_params["parent"]
         )
         return rval
 
@@ -203,6 +203,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         rval = dictify_dataset_collection_instance(
             dataset_collection_instance,
             security=trans.security,
+            url_builder=trans.url_builder,
             parent=parent,
             view='element'
         )

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1035,8 +1035,13 @@ class HistoriesContentsService(ServiceBase):
         return rval
 
     def __collection_dict(self, trans, dataset_collection_instance, **kwds):
-        return dictify_dataset_collection_instance(dataset_collection_instance,
-            security=trans.security, parent=dataset_collection_instance.history, **kwds)
+        return dictify_dataset_collection_instance(
+            dataset_collection_instance,
+            security=trans.security,
+            url_builder=trans.url_builder,
+            parent=dataset_collection_instance.history,
+            **kwds
+        )
 
     def _get_history(self, trans, history_id: EncodedDatabaseIdField) -> History:
         """Retrieves the History with the given ID or raises an error if the current user cannot access it."""

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -107,6 +107,12 @@ class LegacyHistoryContentsIndexParams(Model):
     visible: Optional[bool]
 
 
+class HistoryContentsIndexJobsSummaryParams(Model):
+    """Query parameters exclusively used by the `index_jobs_summary` operation."""
+    ids: List[EncodedDatabaseIdField] = []
+    types: List[JobSourceType] = []
+
+
 class CreateHistoryContentPayloadBase(Model):
     type: Optional[HistoryContentType] = Field(
         HistoryContentType.dataset,
@@ -256,8 +262,7 @@ class HistoriesContentsService(ServiceBase):
 
     def index_jobs_summary(
         self, trans,
-        ids: List[EncodedDatabaseIdField],
-        types: List[JobSourceType],
+        params: HistoryContentsIndexJobsSummaryParams,
     ) -> List[AnyJobStateSummary]:
         """
         Return job state summary info for jobs, implicit groups jobs for collections or workflow invocations
@@ -266,14 +271,9 @@ class HistoriesContentsService(ServiceBase):
         can guess an encoded ID for - it isn't considered protected data. This keeps
         polling IDs as part of state calculation for large histories and collections as
         efficient as possible.
-
-        :param  ids:    the encoded ids of job summary objects to return - if ids
-                        is specified types must also be specified and have same length.
-        :param  types:  type of object represented by elements in the ids array - any of
-                        Job, ImplicitCollectionJob, or WorkflowInvocation.
-
-        :returns:   an array of job summary object dictionaries.
         """
+        ids = params.ids
+        types = params.types
         if len(ids) != len(types):
             raise exceptions.RequestParameterInvalidException(
                 f"The number of ids ({len(ids)}) and types ({len(types)}) must match."

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -281,7 +281,7 @@ class HistoriesContentsService(ServiceBase):
         trans,
         id: EncodedDatabaseIdField,
         serialization_params: SerializationParams,
-        contents_type: Optional[HistoryContentType],
+        contents_type: HistoryContentType,
         fuzzy_count: Optional[int] = None,
     ) -> AnyHistoryContentItem:
         """
@@ -314,7 +314,6 @@ class HistoriesContentsService(ServiceBase):
 
         :returns:   dictionary containing detailed HDA or HDCA information
         """
-        contents_type = contents_type or HistoryContentType.dataset
         if contents_type == HistoryContentType.dataset:
             return self.__show_dataset(trans, id, serialization_params)
         elif contents_type == HistoryContentType.dataset_collection:
@@ -348,7 +347,7 @@ class HistoriesContentsService(ServiceBase):
     def show_jobs_summary(
         self, trans,
         id: EncodedDatabaseIdField,
-        contents_type: HistoryContentType = HistoryContentType.dataset,
+        contents_type: HistoryContentType,
     ) -> AnyJobStateSummary:
         """
         Return detailed information about an HDA or HDCAs jobs
@@ -461,7 +460,7 @@ class HistoriesContentsService(ServiceBase):
         id: EncodedDatabaseIdField,
         payload: Dict[str, Any],
         serialization_params: SerializationParams,
-        contents_type: HistoryContentType = HistoryContentType.dataset,
+        contents_type: HistoryContentType,
     ):
         """
         Updates the values for the history content item with the given ``id``
@@ -558,7 +557,7 @@ class HistoriesContentsService(ServiceBase):
         self, trans,
         id,
         serialization_params: SerializationParams,
-        contents_type: HistoryContentType = HistoryContentType.dataset,
+        contents_type: HistoryContentType,
         purge: bool = False,
         recursive: bool = False,
     ) -> Union[AnyHDA, DeleteHDCAResult]:

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -486,7 +486,7 @@ class HistoriesContentsService(ServiceBase):
         history_id: EncodedDatabaseIdField,
         payload: UpdateHistoryContentsBatchPayload,
         serialization_params: SerializationParams,
-    ):
+    ) -> List[AnyHistoryContentItem]:
         """
         PUT /api/histories/{history_id}/contents
 

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -60,6 +60,7 @@ from galaxy.schema.schema import (
     AnyHDA,
     AnyHistoryContentItem,
     AnyJobStateSummary,
+    ColletionSourceType,
     DatasetAssociationRoles,
     DeleteHDCAResult,
     HistoryContentSource,
@@ -139,6 +140,52 @@ class CreateHistoryContentPayloadFromCopy(CreateHistoryContentPayloadBase):
     )
 
 
+class CollectionElementIdentifier(Model):
+    name: Optional[str] = Field(
+        None,
+        title="Name",
+        description="The name of the element.",
+    )
+    src: ColletionSourceType = Field(
+        ...,
+        title="Source",
+        description="The source of the element.",
+    )
+    id: EncodedDatabaseIdField = Field(
+        ...,
+        title="ID",
+        description="The encoded ID of the element.",
+    )
+    tags: List[str] = Field(
+        default=[],
+        title="Tags",
+        description="The list of tags associated with the element.",
+    )
+
+
+class CreateNewCollectionPayload(Model):
+    collection_type: Optional[str] = Field(
+        default=None,
+        title="Collection Type",
+        description="The type of the collection. For example, `list`, `paired`, `list:paired`.",
+    )
+    element_identifiers: Optional[List[CollectionElementIdentifier]] = Field(
+        default=None,
+        title="Element Identifiers",
+        description="List of elements that should be in the new collection.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        title="Name",
+        description="The name of the new collection.",
+    )
+    hide_source_items: Optional[bool] = Field(
+        default=False,
+        title="Hide Source Items",
+        description="Whether to mark the original HDAs as hidden.",
+    )
+
+
 class CreateHistoryContentPayloadFromCollection(CreateHistoryContentPayloadFromCopy):
     dbkey: Optional[str] = Field(
         default=None,
@@ -156,7 +203,7 @@ class CreateHistoryContentPayloadFromCollection(CreateHistoryContentPayloadFromC
     )
 
 
-class CreateHistoryContentPayload(CreateHistoryContentPayloadFromCollection):
+class CreateHistoryContentPayload(CreateHistoryContentPayloadFromCollection, CreateNewCollectionPayload):
     class Config:
         extra = Extra.allow
 

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -93,11 +93,13 @@ HistoryContentsFilterList = List[HistoryContentFilter]
 
 
 class HistoryContentsIndexParams(Model):
-    v: Optional[str]
+    """Query parameters exclusively used by the *new version* of `index` operation."""
+    v: Optional[Literal['dev']]
     dataset_details: Optional[DatasetDetailsType]
 
 
 class LegacyHistoryContentsIndexParams(Model):
+    """Query parameters exclusively used by the *legacy version* of `index` operation."""
     ids: Optional[List[EncodedDatabaseIdField]]
     types: List[HistoryContentType]
     dataset_details: Optional[DatasetDetailsType]

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -151,8 +151,8 @@ class CollectionElementIdentifier(Model):
         title="Source",
         description="The source of the element.",
     )
-    id: EncodedDatabaseIdField = Field(
-        ...,
+    id: Optional[EncodedDatabaseIdField] = Field(
+        None,
         title="ID",
         description="The encoded ID of the element.",
     )
@@ -161,6 +161,21 @@ class CollectionElementIdentifier(Model):
         title="Tags",
         description="The list of tags associated with the element.",
     )
+    element_identifiers: Optional[List['CollectionElementIdentifier']] = Field(
+        default=None,
+        title="Element Identifiers",
+        description="List of elements that should be in the new nested collection.",
+    )
+    collection_type: Optional[str] = Field(
+        default=None,
+        title="Collection Type",
+        description="The type of the nested collection. For example, `list`, `paired`, `list:paired`.",
+    )
+
+
+# Required for self-referencing models
+# See https://pydantic-docs.helpmanual.io/usage/postponed_annotations/#self-referencing-models
+CollectionElementIdentifier.update_forward_refs()
 
 
 class CreateNewCollectionPayload(Model):

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -534,7 +534,7 @@ class HistoriesContentsService(ServiceBase):
         history_content_id: EncodedDatabaseIdField
     ):
         """
-        Updates the values for the history content item with the given ``id``
+        Validates the metadata associated with a dataset within a History.
 
         :type   history_id: str
         :param  history_id: encoded id string of the items's History

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -1,5 +1,4 @@
 import datetime
-import json
 import logging
 import os
 import re

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -47,7 +47,7 @@ class DatasetsApiTestCase(ApiTestCase):
         }
         updated_hda = self._put(
             f"histories/{self.history_id}/contents/{hda_id}",
-            update_payload).json()
+            update_payload, json=True).json()
         assert 'cool:new_tag' in updated_hda['tags']
         assert 'cool:another_tag' in updated_hda['tags']
         payload = {'limit': 10, 'offset': 0, 'q': ['history_content_type', 'tag'], 'qv': ['dataset', 'cool:new_tag']}
@@ -169,19 +169,19 @@ class DatasetsApiTestCase(ApiTestCase):
 
         update_while_incomplete_response = self._put(  # try updating datatype while used as output of a running job
             f"histories/{self.history_id}/contents/{queued_id}",
-            {'datatype': 'tabular'})
+            data={'datatype': 'tabular'}, json=True)
         self._assert_status_code_is(update_while_incomplete_response, 400)
 
         self.dataset_populator.wait_for_history_jobs(self.history_id)  # now wait for upload to complete
 
         successful_updated_hda_response = self._put(
             f"histories/{self.history_id}/contents/{hda_id}",
-            {'datatype': 'tabular'}).json()
+            data={'datatype': 'tabular'}, json=True).json()
         assert successful_updated_hda_response['extension'] == 'tabular'
         assert successful_updated_hda_response['data_type'] == 'galaxy.datatypes.tabular.Tabular'
         assert 'scatterplot' in [viz['name'] for viz in successful_updated_hda_response['visualizations']]
 
         invalidly_updated_hda_response = self._put(  # try updating with invalid datatype
             f"histories/{self.history_id}/contents/{hda_id}",
-            {'datatype': 'invalid'})
+            data={'datatype': 'invalid'}, json=True)
         self._assert_status_code_is(invalidly_updated_hda_response, 400)

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -1,4 +1,3 @@
-import json
 import time
 import urllib
 from datetime import datetime
@@ -170,7 +169,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         )
         second_history_id = self.dataset_populator.new_history()
         assert self.__count_contents(second_history_id) == 0
-        create_response = self._post(f"histories/{second_history_id}/contents", create_data)
+        create_response = self._post(f"histories/{second_history_id}/contents", create_data, json=True)
         self._assert_status_code_is(create_response, 200)
         assert self.__count_contents(second_history_id) == 1
 
@@ -181,7 +180,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             content=ld["id"],
         )
         assert self.__count_contents(self.history_id) == 0
-        create_response = self._post(f"histories/{self.history_id}/contents", create_data)
+        create_response = self._post(f"histories/{self.history_id}/contents", create_data, json=True)
         self._assert_status_code_is(create_response, 200)
         assert self.__count_contents(self.history_id) == 1
 
@@ -342,18 +341,18 @@ class HistoryContentsApiTestCase(ApiTestCase):
             assert update_response['tags'] == ['existing:tag']
             creation_payload = {'collection_type': 'list',
                                 'history_id': history_id,
-                                'element_identifiers': json.dumps([{'id': hda_id,
-                                                                    'src': 'hda',
-                                                                    'name': 'element_id1',
-                                                                    'tags': ['my_new_tag']},
-                                                                   {'id': hda2_id,
-                                                                    'src': 'hda',
-                                                                    'name': 'element_id2',
-                                                                    'tags': ['another_new_tag']}
-                                                                   ]),
+                                'element_identifiers': [{'id': hda_id,
+                                                         'src': 'hda',
+                                                         'name': 'element_id1',
+                                                         'tags': ['my_new_tag']},
+                                                        {'id': hda2_id,
+                                                         'src': 'hda',
+                                                         'name': 'element_id2',
+                                                         'tags': ['another_new_tag']}
+                                                        ],
                                 'type': 'dataset_collection',
                                 'copy_elements': True}
-            r = self._post(f"histories/{self.history_id}/contents", creation_payload).json()
+            r = self._post(f"histories/{self.history_id}/contents", creation_payload, json=True).json()
             assert r['elements'][0]['object']['id'] != hda_id, "HDA has not been copied"
             assert len(r['elements'][0]['object']['tags']) == 1
             assert r['elements'][0]['object']['tags'][0] == 'my_new_tag'
@@ -489,7 +488,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             content=hdca_id,
         )
         assert len(self._get(f"histories/{second_history_id}/contents/dataset_collections").json()) == 0
-        create_response = self._post(f"histories/{second_history_id}/contents/dataset_collections", create_data)
+        create_response = self._post(f"histories/{second_history_id}/contents/dataset_collections", create_data, json=True)
         self.__check_create_collection_response(create_response)
         contents = self._get(f"histories/{second_history_id}/contents/dataset_collections").json()
         assert len(contents) == 1
@@ -503,7 +502,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert hdca["elements"][0]["object"]["metadata_dbkey"] == "?"
         assert hdca["elements"][0]["object"]["genome_build"] == "?"
         create_data = {'source': 'hdca', 'content': hdca_id, 'dbkey': 'hg19'}
-        create_response = self._post(f"histories/{self.history_id}/contents/dataset_collections", create_data)
+        create_response = self._post(f"histories/{self.history_id}/contents/dataset_collections", create_data, json=True)
         collection = self.__check_create_collection_response(create_response)
         new_forward = collection['elements'][0]['object']
         assert new_forward["metadata_dbkey"] == "hg19"
@@ -519,7 +518,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             copy_elements=True,
         )
         assert len(self._get(f"histories/{second_history_id}/contents/dataset_collections").json()) == 0
-        create_response = self._post(f"histories/{second_history_id}/contents/dataset_collections", create_data)
+        create_response = self._post(f"histories/{second_history_id}/contents/dataset_collections", create_data, json=True)
         self.__check_create_collection_response(create_response)
 
         contents = self._get(f"histories/{second_history_id}/contents/dataset_collections").json()

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -305,7 +305,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert str(self.__show(hda1).json()["deleted"]).lower() == "false"
         assert str(self.__show(hda1).json()["purged"]).lower() == "false"
         data = {'purge': True}
-        delete_response = self._delete(f"histories/{self.history_id}/contents/{hda1['id']}", data=data)
+        delete_response = self._delete(f"histories/{self.history_id}/contents/{hda1['id']}", data=data, json=True)
         assert delete_response.status_code < 300  # Something in the 200s :).
         assert str(self.__show(hda1).json()["deleted"]).lower() == "true"
         assert str(self.__show(hda1).json()["purged"]).lower() == "true"

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -676,7 +676,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             assert history_contents.status_code == 204
 
             # test parsing for other standard is08601 formats
-            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '20210826T155302Z', '2002-10-10T12:00:00-05:00']
+            sample_formats = ['2021-08-26T15:53:02+00:00', '2021-08-26T15:53:02Z', '2002-10-10T12:00:00-05:00']
             for date_str in sample_formats:
                 encoded_date = urllib.parse.quote_plus(date_str)  # handles pluses, minuses
                 history_contents = self._get(f"/api/histories/{history_id}/contents/near/100/100?since={encoded_date}")

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -547,7 +547,7 @@ steps:
         # We first copy the datasets, so that the update time is lower than the job creation time
         new_history_id = self.dataset_populator.new_history()
         copy_payload = {"content": dataset_id, "source": "hda", "type": "dataset"}
-        copy_response = self._post(f"histories/{new_history_id}/contents", data=copy_payload)
+        copy_response = self._post(f"histories/{new_history_id}/contents", data=copy_payload, json=True)
         self._assert_status_code_is(copy_response, 200)
         inputs = json.dumps({
             'input1': {'src': 'hda', 'id': dataset_id}
@@ -654,7 +654,7 @@ steps:
         # We test that a job can be found even if the collection has been copied to another history
         new_history_id = self.dataset_populator.new_history()
         copy_payload = {"content": list_id_a, "source": "hdca", "type": "dataset_collection"}
-        copy_response = self._post(f"histories/{new_history_id}/contents", data=copy_payload)
+        copy_response = self._post(f"histories/{new_history_id}/contents", data=copy_payload, json=True)
         self._assert_status_code_is(copy_response, 200)
         new_list_a = copy_response.json()['id']
         copied_inputs = json.dumps({

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -424,7 +424,7 @@ class LibrariesApiTestCase(ApiTestCase):
             'name': collection_name,
             'collection_type': 'list:paired',
             "type": "dataset_collection",
-            'element_identifiers': json.dumps([
+            'element_identifiers': [
                 {
                     'src': 'new_collection',
                     'name': 'pair1',
@@ -432,9 +432,9 @@ class LibrariesApiTestCase(ApiTestCase):
                     'element_identifiers': [{'name': 'forward', 'src': 'ldda', 'id': ld['id']},
                                             {'name': 'reverse', 'src': 'ldda', 'id': ld['id']}]
                 }
-            ])
+            ]
         }
-        new_collection = self._post(url, payload).json()
+        new_collection = self._post(url, payload, json=True).json()
         assert new_collection['name'] == collection_name
         pair = new_collection['elements'][0]
         assert pair['element_identifier'] == 'pair1'
@@ -453,14 +453,14 @@ class LibrariesApiTestCase(ApiTestCase):
             "history_id": history_id,
             "name": collection_name,
             "hide_source_items": not visible,
-            "element_identifiers": json.dumps([{
+            "element_identifiers": [{
                 "id": ld['id'],
                 "name": element_identifer,
-                "src": "ldda"}]),
+                "src": "ldda"}],
             "type": "dataset_collection",
             "elements": []
         }
-        new_collection = self._post(url, payload).json()
+        new_collection = self._post(url, payload, json=True).json()
         assert new_collection['name'] == collection_name
         assert new_collection['element_count'] == 1
         element = new_collection['elements'][0]

--- a/lib/galaxy_test/api/test_workflow_extraction.py
+++ b/lib/galaxy_test/api/test_workflow_extraction.py
@@ -454,14 +454,14 @@ test_data:
                 source="hda",
                 content=content["id"]
             )
-            response = self._post(f"histories/{history_id}/contents/datasets", payload)
+            response = self._post(f"histories/{history_id}/contents/datasets", payload, json=True)
 
         else:
             payload = dict(
                 source="hdca",
                 content=content["id"]
             )
-            response = self._post(f"histories/{history_id}/contents/dataset_collections", payload)
+            response = self._post(f"histories/{history_id}/contents/dataset_collections", payload, json=True)
         self._assert_status_code_is(response, 200)
         return response.json()
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2845,7 +2845,7 @@ steps:
             new_ds_map = json.loads(new_workflow_request['ds_map'])
             for key, input_values in invocation_1['inputs'].items():
                 copy_payload = {"content": input_values['id'], "source": "hda", "type": "dataset"}
-                copy_response = self._post(f"histories/{history_id_two}/contents", data=copy_payload).json()
+                copy_response = self._post(f"histories/{history_id_two}/contents", data=copy_payload, json=True).json()
                 new_ds_map[key]['id'] = copy_response['id']
             new_workflow_request['ds_map'] = json.dumps(new_ds_map, sort_keys=True)
             new_workflow_request['history'] = f"hist_id={history_id_two}"
@@ -2882,7 +2882,7 @@ outer_input:
             dataset_type = inputs['outer_input']['src']
             dataset_id = inputs['outer_input']['id']
             copy_payload = {"content": dataset_id, "source": dataset_type, "type": "dataset"}
-            copy_response = self._post(f"histories/{history_id_two}/contents", data=copy_payload)
+            copy_response = self._post(f"histories/{history_id_two}/contents", data=copy_payload, json=True)
             self._assert_status_code_is(copy_response, 200)
             new_dataset_id = copy_response.json()['id']
             inputs['outer_input']['id'] = new_dataset_id

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -576,7 +576,7 @@ class BaseDatasetPopulator(BasePopulator):
         delete_response.raise_for_status()
 
     def delete_dataset(self, history_id: str, content_id: str, purge: bool = False) -> Response:
-        delete_response = self._delete(f"histories/{history_id}/contents/{content_id}", {'purge': purge})
+        delete_response = self._delete(f"histories/{history_id}/contents/{content_id}", {'purge': purge}, json=True)
         return delete_response
 
     def create_tool_from_path(self, tool_path: str) -> Dict[str, Any]:


### PR DESCRIPTION
This is a follow up on #12231 and part of #10889

This PR includes the new `FastAPIHistoryContents` controller that replaces the old legacy routes for galaxy/api/history_contents.py and some additional refactorings, documentation, and types annotations.

## Additional comments / Issues
- I took the liberty of *temporarily* marking some routes and parameters as deprecated as some of them looked duplicated or legacy. This should only affect how they are displayed in the interactive documentation and can be reverted easily if they are incorrectly marked.

  ![Screenshot from 2021-10-11 20-19-06](https://user-images.githubusercontent.com/46503462/136836478-3ce5bf28-64d1-46b3-a07b-9571de1df1fc.png)

  ![Screenshot from 2021-10-11 20-22-29](https://user-images.githubusercontent.com/46503462/136836704-58eb741e-9b8b-433b-8132-a584416a1ede.png)

- I had to add in some cases several helper functions to use as FastAPI dependencies for retrieving the query parameters and parse them in a custom way. There was no way of directly using a pydantic model in those cases because the documentation was not rendered correctly.
- Temporarily adding [here the '/api/dataset_collection/{id}/download' route](https://github.com/galaxyproject/galaxy/pull/12578/commits/b7c5fc8e0dc3d8a8b3c06677e5a3c59a72fb7442#diff-d7789a8b5b8606bd040d59409203acc178c14fe4ec4d6b38e8955d87dc4ecea1R414-R419) as both endpoints were redirected to the same operation. It can be moved to the dataset_collections API and reuse this service later.
- I managed to make the `StreamingResponse` here work with minimal changes in ZipstreamWrapper in various endpoints, but I'm not sure if this is the best solution or we need to think of a different solution when the legacy controllers are removed. Not that I have a particular concern, just I don't know very well how to deal with files efficiently in the backend yet.
- I had to mark a bunch of API tests with `json=True`. It should be a temporal change until we can make JSON the default, see https://github.com/galaxyproject/galaxy/pull/12152#issuecomment-864134487.
- The `contents_near` endpoint was [exposed in *raw* mode](https://github.com/galaxyproject/galaxy/pull/12578/commits/1fff6648d7717d97ff369fc3374d761098cb5e19#diff-d7789a8b5b8606bd040d59409203acc178c14fe4ec4d6b38e8955d87dc4ecea1R1059). I changed it back to the normal JSON default, I don't know if there was a particular reason for the change. Also, this endpoint treats the filtering parameters in a different way, so instead of reusing the existing `FilterQueryParams` with *q*/*qv* pairs, it uses arbitrary query parameters. I managed to make it work in FastAPI mode by directly parsing the query parameters from the request, but unfortunately, this makes the filtering parameters not visible in the interactive documentation, although I guess this endpoint is quite for *internal use* so it may be ok.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to the interactive API documentation at http://127.0.0.1:8080/api/docs#/histories

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
