### PR TITLE
Update localization directive to trim whitepsace around text content.

### DIFF
--- a/client/src/components/History/ContentItem/DatasetCollection/DscMenu.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscMenu.vue
@@ -27,7 +27,7 @@
                 </template>
 
                 <b-dropdown-item @click.stop="$emit('delete')">
-                    <span v-localize>Delete Collection Only </span>
+                    <span v-localize>Delete Collection Only</span>
                 </b-dropdown-item>
 
                 <b-dropdown-item @click.stop="$emit('delete', { recursive: true })">

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -51,7 +51,7 @@
                             <span class="fa fa-cubes" />
                         </template>
                         <b-dropdown-item v-for="v of availableVersions" :key="v" @click="$emit('onChangeVersion', v)">
-                            <span class="fa fa-cube" /><span v-localize>Switch to </span>{{ v }}</b-dropdown-item
+                            <span class="fa fa-cube" /><span v-localize>Switch to</span> {{ v }}</b-dropdown-item
                         >
                     </b-dropdown>
                     <b-button

--- a/client/src/components/plugins/localization.js
+++ b/client/src/components/plugins/localization.js
@@ -8,11 +8,11 @@ const newlineMatch = /\r?\n|\r/g;
 const doublespaces = /\s\s+/g;
 
 const localizeDirective = {
+    // TODO consider using a different hook if we need dynamic updates in content translation
     bind(el, binding, vnode) {
         el.childNodes.forEach((node) => {
-            const oneline = node.textContent.replace(newlineMatch, " ");
-            const singleSpaces = oneline.replace(doublespaces, " ");
-            node.textContent = _l(singleSpaces);
+            const standardizedContent = node.textContent.replace(newlineMatch, " ").replace(doublespaces, " ").trim();
+            node.textContent = _l(standardizedContent);
         });
     },
 };


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12475

This is only necessary in the directive, since spacing around the text content can be difficult to work with.  Direct consumers of `_l` will continue to specify exact strings.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Set localization to ES, look at 'tools' become Herramientas.
  2. Go to toolbox.vue, add extra space around the 'Tools' text.
  3. Notice that it still translates.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
