### PR TITLE
[21.09] Fix a small bug in Error summary Vue template.

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/Summary/Error.vue
+++ b/client/src/components/History/ContentItem/Dataset/Summary/Error.vue
@@ -3,7 +3,7 @@
         <div v-if="!props.dataset.purged && props.dataset.misc_info">
             <span>{{ props.dataset.misc_info }}</span>
         </div>
-        <span class="help-text" v-localize>An error occurred with this props.dataset</span>
+        <span class="help-text" v-localize>An error occurred with this dataset</span>
         <div v-if="props.dataset.misc_info" class="job-error-text">
             <span>{{ props.dataset.misc_info }}</span>
         </div>


### PR DESCRIPTION
I was digging around in this file and this looked around.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Probably just open a errored dataset in the beta history?

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
