### PR TITLE
[21.09] Avoid uncaught exceptions when trying to set invalid tag names

### DIFF
--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -7,7 +7,6 @@ from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import func
 
 import galaxy.model
-from galaxy.exceptions import MessageException
 from galaxy.util import (
     strip_control_characters,
     unicodify,
@@ -158,7 +157,7 @@ class TagHandler:
     def apply_item_tag(self, user, item, name, value=None, flush=True):
         # Use lowercase name for searching/creating tag.
         if name is None:
-            raise MessageException("The tag name is empty or contains invalid characters.")
+            return
         lc_name = name.lower()
         # Get or create item-tag association.
         item_tag_assoc = self._get_item_tag_assoc(user, item, lc_name)

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import func
 
 import galaxy.model
+from galaxy.exceptions import MessageException
 from galaxy.util import (
     strip_control_characters,
     unicodify,
@@ -156,6 +157,8 @@ class TagHandler:
 
     def apply_item_tag(self, user, item, name, value=None, flush=True):
         # Use lowercase name for searching/creating tag.
+        if name is None:
+            raise MessageException("The tag name is empty or contains invalid characters.")
         lc_name = name.lower()
         # Get or create item-tag association.
         item_tag_assoc = self._get_item_tag_assoc(user, item, lc_name)


### PR DESCRIPTION
xref https://github.com/galaxyproject/galaxy/issues/12568
After tag sanitization, the tag name can be None if there are no valid characters at all. 
This change will raise a proper MessageException and turn the 500 error code into a bad request (400).

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow instructions in https://github.com/galaxyproject/galaxy/issues/12568
  - Check that no exception is logged and instead a `400 Bad Request` is returned. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
