### PR TITLE
Refactor galaxy.app to be a package.

### DIFF
--- a/lib/galaxy/app/__init__.py
+++ b/lib/galaxy/app/__init__.py
@@ -71,8 +71,8 @@ from galaxy.web.proxy import ProxyManager
 from galaxy.web_stack import application_stack_instance, ApplicationStack
 from galaxy.webhooks import WebhooksRegistry
 from galaxy.workflow.trs_proxy import TrsProxy
-from .di import Container
-from .structured_app import BasicApp, MinimalManagerApp, StructuredApp
+from ..di import Container
+from ..structured_app import BasicApp, MinimalManagerApp, StructuredApp
 
 log = logging.getLogger(__name__)
 app = None

--- a/packages/app/galaxy/app
+++ b/packages/app/galaxy/app
@@ -1,0 +1,1 @@
+../../../lib/galaxy/app/

--- a/packages/app/galaxy/app.py
+++ b/packages/app/galaxy/app.py
@@ -1,1 +1,0 @@
-../../../lib/galaxy/app.py

--- a/packages/app/setup.py
+++ b/packages/app/setup.py
@@ -32,6 +32,7 @@ TEST_DIR = 'tests'
 PACKAGES = [
     'galaxy',
     'galaxy.actions',
+    'galaxy.app',
     'galaxy.config',
     'galaxy.files',
     'galaxy.files.sources',


### PR DESCRIPTION
This allows for storing more galaxy-app related functionality in a structured place for it - see conversation on https://github.com/galaxyproject/galaxy/pull/12553.

Makes me nervous but testing this was recommended by @nsoranzo.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
