### PR TITLE
[21.09] Fix job detail caching

### DIFF
--- a/client/src/components/Details/DatasetDetails.vue
+++ b/client/src/components/Details/DatasetDetails.vue
@@ -6,6 +6,7 @@
                     v-if="!isDatasetLoading"
                     :jobid="dataset.creating_job"
                     v-slot="{ result: job, loading: isJobLoading }"
+                    :use-cache="false"
                 >
                     <div v-if="!isJobLoading">
                         <dataset-information class="detail" :hda_id="datasetId" />


### PR DESCRIPTION
Fixes #12585 

Disable singlequeryprovider cache for jobdetails in this context -- cache savings minimal here for a 1-off and these do update.

TODO for dev: support initial use from cache also allow firing an update when mounted?  This would be the best of both worlds here, I think.


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Submit a brand new job, quickly view job details.
  2. Wait for job to run and look at job details again, note they are different.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
