### PR TITLE
[21.09] Add client-side validation to tag editor widget

### DIFF
--- a/client/src/components/Tags/StatelessTags.vue
+++ b/client/src/components/Tags/StatelessTags.vue
@@ -163,11 +163,23 @@ export default {
         .ti-input {
             padding: 0;
             border: none;
-            .error {
-                background: url("../../assets/images/error_icon.svg");
-                background-repeat: no-repeat;
-                background-size: contain;
-                background-position: right;
+
+            .ti-new-tag-input {
+                &.error:focus {
+                    //TODO: These relative URLs are unfortunate.
+                    background: url("../../../node_modules/@fortawesome/fontawesome-free/svgs/solid/times.svg");
+                    padding-right: 1.5rem;
+                    background-repeat: no-repeat;
+                    background-size: contain;
+                    background-position: right;
+                }
+                &:not(.error):focus {
+                    background: url("../../../node_modules/@fortawesome/fontawesome-free/svgs/solid/check.svg");
+                    padding-right: 1.5rem;
+                    background-repeat: no-repeat;
+                    background-size: contain;
+                    background-position: right;
+                }
             }
         }
         .ti-tag {

--- a/client/src/components/Tags/StatelessTags.vue
+++ b/client/src/components/Tags/StatelessTags.vue
@@ -22,6 +22,7 @@ upstream component or environment that is accessed through props and events -->
             :disabled="disabled"
             placeholder="Add Tags"
             :add-on-key="triggerKeys"
+            :validation="validation"
             @before-adding-tag="beforeAddingTag"
             @before-deleting-tag="beforeDeletingTag"
             @tags-changed="tagsChanged"
@@ -35,7 +36,7 @@ upstream component or environment that is accessed through props and events -->
 
 <script>
 import VueTagsInput from "@johmun/vue-tags-input";
-import { createTag } from "./model";
+import { createTag, VALID_TAG_RE } from "./model";
 
 export default {
     components: {
@@ -56,6 +57,12 @@ export default {
             tagText: "",
             tagToggle: !isClosed,
             triggerKeys: [13, " "],
+            validation: [
+                {
+                    classes: "error",
+                    rule: VALID_TAG_RE,
+                },
+            ],
         };
     },
     computed: {

--- a/client/src/components/Tags/StatelessTags.vue
+++ b/client/src/components/Tags/StatelessTags.vue
@@ -163,6 +163,12 @@ export default {
         .ti-input {
             padding: 0;
             border: none;
+            .error {
+                background: url("../../assets/images/error_icon.svg");
+                background-repeat: no-repeat;
+                background-size: contain;
+                background-position: right;
+            }
         }
         .ti-tag {
             border-radius: 4px;

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -5,6 +5,8 @@
 
 import { keyedColorScheme } from "utils/color";
 
+// VALID TAG REGEX
+const VALID_TAG_RE = /([a-zA-Z0-9])+(.[a-zA-Z0-9]+)?(:[a-zA-Z0-9]+)?/;
 function TagModel(props = {}) {
     this.text = "";
 
@@ -44,10 +46,6 @@ function TagModel(props = {}) {
             return this.text.startsWith("name:") ? this.text.replace("name:", "#") : this.text;
         },
     });
-
-    // VALID TAG REGEX
-    // TODO: Not quite right
-    const VALID_TAG_RE = /([a-zA-Z0-9.])+(:[a-zA-Z0-9]+)?/;
 
     // valid flag
     Object.defineProperty(this, "valid", {

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -6,7 +6,8 @@
 import { keyedColorScheme } from "utils/color";
 
 // VALID TAG REGEX
-export const VALID_TAG_RE = /([a-zA-Z0-9])+(.[a-zA-Z0-9]+)?(:[a-zA-Z0-9]+)?/;
+export const VALID_TAG_RE = /([^\s.:])+(.[^\s.:]+)?(:[^\s.:]+)?/;
+
 function TagModel(props = {}) {
     this.text = "";
 

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -6,7 +6,7 @@
 import { keyedColorScheme } from "utils/color";
 
 // VALID TAG REGEX
-export const VALID_TAG_RE = /([^\s.:])+(.[^\s.:]+)?(:[^\s.:]+)?/;
+export const VALID_TAG_RE = /^([^\s.:])+(.[^\s.:]+)?(:[^\s.:]+)?$/;
 
 function TagModel(props = {}) {
     this.text = "";

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -45,6 +45,10 @@ function TagModel(props = {}) {
         },
     });
 
+    // VALID TAG REGEX
+    // TODO: Not quite right
+    const VALID_TAG_RE = /([a-zA-Z0-9.])+(:[a-zA-Z0-9]+)?/
+    
     // valid flag
     Object.defineProperty(this, "valid", {
         enumerable: false,
@@ -52,7 +56,7 @@ function TagModel(props = {}) {
             if (!this.text.length) {
                 return false;
             }
-            return this.text != "name:";
+            return VALID_TAG_RE.test(this.text);
         },
     });
 }

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -47,15 +47,12 @@ function TagModel(props = {}) {
 
     // VALID TAG REGEX
     // TODO: Not quite right
-    const VALID_TAG_RE = /([a-zA-Z0-9.])+(:[a-zA-Z0-9]+)?/
-    
+    const VALID_TAG_RE = /([a-zA-Z0-9.])+(:[a-zA-Z0-9]+)?/;
+
     // valid flag
     Object.defineProperty(this, "valid", {
         enumerable: false,
         get: function () {
-            if (!this.text.length) {
-                return false;
-            }
             return VALID_TAG_RE.test(this.text);
         },
     });

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -6,7 +6,7 @@
 import { keyedColorScheme } from "utils/color";
 
 // VALID TAG REGEX
-export const VALID_TAG_RE = /^([^\s.:])+(.[^\s.:]+)?(:[^\s.:]+)?$/;
+export const VALID_TAG_RE = /^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$/;
 
 function TagModel(props = {}) {
     this.text = "";

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -6,7 +6,7 @@
 import { keyedColorScheme } from "utils/color";
 
 // VALID TAG REGEX
-const VALID_TAG_RE = /([a-zA-Z0-9])+(.[a-zA-Z0-9]+)?(:[a-zA-Z0-9]+)?/;
+export const VALID_TAG_RE = /([a-zA-Z0-9])+(.[a-zA-Z0-9]+)?(:[a-zA-Z0-9]+)?/;
 function TagModel(props = {}) {
     this.text = "";
 

--- a/client/src/components/Tags/model.js
+++ b/client/src/components/Tags/model.js
@@ -5,7 +5,8 @@
 
 import { keyedColorScheme } from "utils/color";
 
-// VALID TAG REGEX
+// Valid tag regex. The basic format here is a tag name with optional subtags
+// separated by a period, and then an optional value after a colon.
 export const VALID_TAG_RE = /^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$/;
 
 function TagModel(props = {}) {

--- a/client/src/components/Tags/model.test.js
+++ b/client/src/components/Tags/model.test.js
@@ -64,13 +64,12 @@ describe("Tags/model.js", () => {
 
     describe("Tag matching regular expression tests", () => {
         it("Should match a simple tag", () => {
-            const validTags = ["abc", "def", "ghi"];
+            const validTags = ["abc", "def", "ghi", "tag1", "🌌", "name:🌌", "🌌.🌌"];
             const invalidTags = [".", "", " "];
             for (const tag of validTags) {
                 expect(VALID_TAG_RE.test(tag)).toBeTruthy();
             }
             for (const tag of invalidTags) {
-                console.log(`${tag}`);
                 expect(VALID_TAG_RE.test(tag)).toBeFalsy();
             }
         });

--- a/client/src/components/Tags/model.test.js
+++ b/client/src/components/Tags/model.test.js
@@ -63,12 +63,14 @@ describe("Tags/model.js", () => {
     });
 
     describe("Tag matching regular expression tests", () => {
-        it("Should match a simple tag", () => {
-            const validTags = ["abc", "def", "ghi", "tag1", "🌌", "name:🌌", "🌌.🌌"];
-            const invalidTags = [".", "", " "];
+        it("Should allow valid tags", () => {
+            const validTags = ["tag1", "tag.subtag", "tag.subtag:value", "🌌", "name:🌌", "🌌.🌌"];
             for (const tag of validTags) {
                 expect(VALID_TAG_RE.test(tag)).toBeTruthy();
             }
+        });
+        it("Should not allow invalid tags", () => {
+            const invalidTags = ["", " ", ".", "..", "...", ":", ":value", "tag:", "tag.", ".tag"];
             for (const tag of invalidTags) {
                 expect(VALID_TAG_RE.test(tag)).toBeFalsy();
             }

--- a/client/src/components/Tags/model.test.js
+++ b/client/src/components/Tags/model.test.js
@@ -1,4 +1,4 @@
-import { createTag, diffTags } from "./model";
+import { createTag, diffTags, VALID_TAG_RE } from "./model";
 
 describe("Tags/model.js", () => {
     // Basic props
@@ -59,6 +59,20 @@ describe("Tags/model.js", () => {
             expect(model == expectedLabel).toBeTruthy();
             expect(model.text).toEqual(expectedLabel);
             expect(model.toString()).toEqual(expectedLabel);
+        });
+    });
+
+    describe("Tag matching regular expression tests", () => {
+        it("Should match a simple tag", () => {
+            const validTags = ["abc", "def", "ghi"];
+            const invalidTags = [".", "", " "];
+            for (const tag of validTags) {
+                expect(VALID_TAG_RE.test(tag)).toBeTruthy();
+            }
+            for (const tag of invalidTags) {
+                console.log(`${tag}`);
+                expect(VALID_TAG_RE.test(tag)).toBeFalsy();
+            }
         });
     });
 });

--- a/client/src/components/Tags/model.test.js
+++ b/client/src/components/Tags/model.test.js
@@ -64,7 +64,7 @@ describe("Tags/model.js", () => {
 
     describe("Tag matching regular expression tests", () => {
         it("Should allow valid tags", () => {
-            const validTags = ["tag1", "tag.subtag", "tag.subtag:value", "🌌", "name:🌌", "🌌.🌌"];
+            const validTags = ["tag1", "tag.subtag", "tag.subtag.subtag", "tag.subtag:value", "🌌", "name:🌌", "🌌.🌌"];
             for (const tag of validTags) {
                 expect(VALID_TAG_RE.test(tag)).toBeTruthy();
             }


### PR DESCRIPTION
Adds client-side validation to the tag editor widget.  Regex defined in tag model validates input, allows full unicode, but makes sure tag is structurally correct.

![image](https://user-images.githubusercontent.com/155398/136220164-6fbf8dc0-0b18-4345-a751-e5a7924dc743.png)


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
