### PR TITLE
[21.09] Sync reset mapping with Node component map-over state

### DIFF
--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -251,9 +251,6 @@ export default {
             this.onRedraw();
         },
         onAddOutput(output, terminal) {
-            if (this.mapOver) {
-                terminal.setMapOver(this.mapOver);
-            }
             this.outputTerminals[output.name] = terminal;
             this.onRedraw();
         },

--- a/client/src/components/Workflow/Editor/NodeInput.vue
+++ b/client/src/components/Workflow/Editor/NodeInput.vue
@@ -103,7 +103,7 @@ export default {
             return terminal;
         },
         onChange() {
-            this.isMultiple = this.terminal.mapOver && this.terminal.mapOver.isCollection;
+            this.isMultiple = this.terminal.isMappedOver();
             this.$emit("onChange");
         },
         onRemove() {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -54,9 +54,6 @@ export default {
             const activeLabel = this.output.activeLabel || this.output.label || this.output.name;
             return `${activeLabel} (${extensions})`;
         },
-        node() {
-            return this.getNode();
-        },
         activeClass() {
             return this.output.activeOutput && "mark-terminal-active";
         },
@@ -136,9 +133,7 @@ export default {
                 terminal: this.terminal,
             });
             this.terminal.on("change", this.onChange.bind(this));
-            if (this.node.mapOver) {
-                this.terminal.setMapOver(this.node.mapOver);
-            }
+            this.terminal.emit("change");
             this.$emit("onAdd", this.output, this.terminal);
         },
         onChange() {

--- a/client/src/components/Workflow/Editor/modules/terminals.js
+++ b/client/src/components/Workflow/Editor/modules/terminals.js
@@ -169,6 +169,7 @@ class Terminal extends EventEmitter {
     }
     resetMapping() {
         this.mapOver = NULL_COLLECTION_TYPE_DESCRIPTION;
+        this.node.mapOver = undefined;
         this.emit("change");
     }
     resetCollectionTypeSource() {

--- a/client/src/components/Workflow/Editor/modules/terminals.js
+++ b/client/src/components/Workflow/Editor/modules/terminals.js
@@ -591,6 +591,9 @@ class BaseOutputTerminal extends Terminal {
         super(attr);
         this.datatypes = attr.datatypes;
         this.optional = attr.optional;
+        if (this.node.mapOver) {
+            this.setMapOver(this.node.mapOver);
+        }
     }
     get force_datatype() {
         const changeOutputDatatype = this.node.postJobActions["ChangeDatatypeAction" + this.name];

--- a/client/tests/qunit/tests/workflow_editor_tests.js
+++ b/client/tests/qunit/tests/workflow_editor_tests.js
@@ -326,6 +326,7 @@ QUnit.test("Collection output can connect to same collection input type", functi
     const outputTerminal = new Terminals.OutputCollectionTerminal({
         datatypes: "txt",
         collection_type: "list",
+        node: {},
     });
     outputTerminal.node = {postJobActions: {}};
     assert.ok(
@@ -340,6 +341,7 @@ QUnit.test("Optional collection output can not connect to required collection in
         datatypes: "txt",
         collection_type: "list",
         optional: true,
+        node: {},
     });
     outputTerminal.node = {};
     assert.ok(!inputTerminal.canAccept(outputTerminal).canAccept);
@@ -350,6 +352,7 @@ QUnit.test("Collection output cannot connect to different collection input type"
     const outputTerminal = new Terminals.OutputCollectionTerminal({
         datatypes: "txt",
         collection_type: "paired",
+        node: {},
     });
     outputTerminal.node = {};
     assert.ok(!inputTerminal.canAccept(outputTerminal).canAccept);
@@ -542,6 +545,7 @@ QUnit.module("Node view", {
                 datatypes: [outputType],
                 mapOver: Terminals.NULL_COLLECTION_TYPE_DESCRIPTION,
                 element: inputEl,
+                node: {},
             });
             outputTerminal.node = {
                 markChanged: function () {},
@@ -572,6 +576,7 @@ QUnit.module("Node view", {
                 datatypes: ["txt"],
                 mapOver: new Terminals.CollectionTypeDescription("list"),
                 element: inputEl,
+                node: {},
             });
             outputTerminal.node = {
                 markChanged: function () {},
@@ -598,6 +603,7 @@ QUnit.module("Node view", {
                 datatypes: ["txt"],
                 mapOver: new Terminals.CollectionTypeDescription("list"),
                 element: inputEl,
+                node: {},
             });
             outputTerminal.node = {
                 markChanged: function () {},
@@ -832,7 +838,10 @@ QUnit.test("equal", function (assert) {
 });
 
 QUnit.test("default constructor", function (assert) {
-    const terminal = new Terminals.InputTerminal({ input: {} });
+    const terminal = new Terminals.InputTerminal({
+        input: {},
+        node: {},
+    });
     assert.ok(terminal.mapOver === Terminals.NULL_COLLECTION_TYPE_DESCRIPTION);
 });
 
@@ -902,7 +911,11 @@ QUnit.module("terminal mapping logic", {
             output["extensions"] = ["data"];
         }
         const outputEl = $("<div>")[0];
-        const outputTerminal = new Terminals.OutputTerminal({ element: outputEl, datatypes: output.extensions });
+        const outputTerminal = new Terminals.OutputTerminal({
+            element: outputEl,
+            datatypes: output.extensions,
+            node: {},
+        });
         outputTerminal.node = node;
         if (mapOver) {
             outputTerminal.setMapOver(new Terminals.CollectionTypeDescription(mapOver));
@@ -921,6 +934,7 @@ QUnit.module("terminal mapping logic", {
             element: outputEl,
             datatypes: output.extensions,
             collection_type: collectionType,
+            node: {},
         });
         outputTerminal.node = node;
         if (mapOver) {

--- a/client/tests/qunit/tests/workflow_editor_tests.js
+++ b/client/tests/qunit/tests/workflow_editor_tests.js
@@ -1280,7 +1280,6 @@ QUnit.test("simple mapping over collection outputs works correctly", function (a
     this.verifyNotAttachable(assert, testTerminal1, connectedOutput);
 });
 
-
 QUnit.test("node mapping state over collection outputs works correctly", function (assert) {
     const inputTerminal1 = this.newInputTerminal();
     const outputCollectionTerminal1 = this.newOutputCollectionTerminal("list");

--- a/client/tests/qunit/tests/workflow_editor_tests.js
+++ b/client/tests/qunit/tests/workflow_editor_tests.js
@@ -1279,3 +1279,15 @@ QUnit.test("simple mapping over collection outputs works correctly", function (a
     const testTerminal1 = this.newInputTerminal("list:list:list");
     this.verifyNotAttachable(assert, testTerminal1, connectedOutput);
 });
+
+
+QUnit.test("node mapping state over collection outputs works correctly", function (assert) {
+    const inputTerminal1 = this.newInputTerminal();
+    const outputCollectionTerminal1 = this.newOutputCollectionTerminal("list");
+    assert.ok(!inputTerminal1.node.mapOver);
+    const connector = new Connector({}, outputCollectionTerminal1, inputTerminal1);
+    outputCollectionTerminal1.connect(connector);
+    assert.ok(inputTerminal1.node.mapOver);
+    inputTerminal1.disconnect(connector);
+    assert.ok(!inputTerminal1.node.mapOver);
+});


### PR DESCRIPTION
Fixes: #12032. New outputs rely on a predefined `node.mapOver` state defined in the `setMapOver` helper. When resetting the `mapOver` state the `node.mapOver` state is not updated. Hence newly created terminals run into an outdated state which in some cases leads to issues. The handling of the `node.mapOver` state has been moved to the `terminal` module since it is only used there.