### PR TITLE
[21.09] Remove Interactive Environments from Visualizations

### DIFF
--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -90,25 +90,16 @@ export function fetchMenu(options = {}) {
     // Visualization tab.
     //
     if (Galaxy.config.visualizations_visible) {
-        menu.push({
-            id: "visualization",
-            title: _l("Visualize"),
-            url: "javascript:void(0)",
-            tooltip: _l("Visualize datasets"),
-            disabled: !Galaxy.user.id,
-            menu: [
-                {
-                    title: _l("Create Visualization"),
-                    url: "visualizations",
-                    target: "__use_router__",
-                },
-                {
-                    title: _l("Interactive Environments"),
-                    url: "visualization/gie_list",
-                    target: "galaxy_main",
-                },
-            ],
-        });
+        if (Galaxy.config.visualizations_visible) {
+            menu.push({
+                id: "visualization",
+                title: _l("Visualize"),
+                tooltip: _l("Visualize datasets"),
+                disabled: !Galaxy.user.id,
+                url: "visualizations",
+                target: "__use_router__",
+            });
+        }
     }
 
     //


### PR DESCRIPTION
Suggested in #12587.

## How to test the changes?
1. Load the Analysis panel
2. Click on `Visualize` in the masthead
3. Verify that a list of visualizations plugins is displayed

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
