### PR TITLE
[21.05] Fix file source restrictions

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -146,6 +146,8 @@ class ConfiguredFileSources:
     def plugins_to_dict(self, for_serialization=False, user_context=None):
         rval = []
         for file_source in self._file_sources:
+            if not file_source.user_has_access(user_context):
+                continue
             el = file_source.to_dict(for_serialization=for_serialization, user_context=user_context)
             rval.append(el)
         return rval

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -71,6 +71,8 @@ class BaseFilesSource(FilesSource):
         return self.writable
 
     def user_has_access(self, user_context) -> bool:
+        if user_context is None and self.user_context_required:
+            return False
         return (
             user_context is None
             or user_context.is_admin
@@ -79,6 +81,10 @@ class BaseFilesSource(FilesSource):
                 and self._user_has_required_groups(user_context)
             )
         )
+
+    @property
+    def user_context_required(self) -> bool:
+        return self.requires_roles is not None or self.requires_groups is not None
 
     def get_uri_root(self):
         prefix = self.get_prefix()
@@ -165,6 +171,8 @@ class BaseFilesSource(FilesSource):
 
     def _check_user_access(self, user_context):
         """Raises an exception if the given user doesn't have the rights to access this file source."""
+        if self.user_context_required and user_context is None:
+            raise ItemAccessibilityException("This action is restricted and requires a user context.")
         if user_context is not None and not self.user_has_access(user_context):
             raise ItemAccessibilityException(f"User {user_context.username} has no access to file source.")
 

--- a/lib/galaxy/files/sources/__init__.py
+++ b/lib/galaxy/files/sources/__init__.py
@@ -170,9 +170,11 @@ class BaseFilesSource(FilesSource):
         pass
 
     def _check_user_access(self, user_context):
-        """Raises an exception if the given user doesn't have the rights to access this file source."""
-        if self.user_context_required and user_context is None:
-            raise ItemAccessibilityException("This action is restricted and requires a user context.")
+        """Raises an exception if the given user doesn't have the rights to access this file source.
+
+        Warning: if the user_context is None, then the check is skipped. This is due to tool executions context
+        not having access to the user_context. The validation will be done when checking the tool parameters.
+        """
         if user_context is not None and not self.user_has_access(user_context):
             raise ItemAccessibilityException(f"User {user_context.username} has no access to file source.")
 

--- a/lib/galaxy/managers/remote_files.py
+++ b/lib/galaxy/managers/remote_files.py
@@ -9,8 +9,6 @@ from typing import (
     Optional,
 )
 
-from pydantic.tools import parse_obj_as
-
 from galaxy import exceptions
 from galaxy.app import MinimalManagerApp
 from galaxy.files import (
@@ -115,10 +113,11 @@ class RemoteFilesManager:
 
         return index
 
-    def get_files_source_plugins(self) -> FilesSourcePluginList:
+    def get_files_source_plugins(self, user_context: ProvidesUserContext) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
-        plugins = self._file_sources.plugins_to_dict()
-        return parse_obj_as(FilesSourcePluginList, plugins)
+        user_file_source_context = ProvidesUserFileSourcesUserContext(user_context)
+        plugins = self._file_sources.plugins_to_dict(user_context=user_file_source_context)
+        return FilesSourcePluginList.parse_obj(plugins)
 
     @property
     def _file_sources(self) -> ConfiguredFileSources:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2421,7 +2421,7 @@ class DirectoryUriToolParameter(SimpleTextToolParameter):
         user_context = ProvidesUserFileSourcesUserContext(trans)
         user_has_access = file_source.user_has_access(user_context)
         if not user_has_access:
-            raise ValueError(f"The user cannot access {value}.")
+            raise ParameterValueError(f"The user cannot access {value}.")
 
 
 class RulesListToolParameter(BaseJsonToolParameter):

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2421,7 +2421,7 @@ class DirectoryUriToolParameter(SimpleTextToolParameter):
         user_context = ProvidesUserFileSourcesUserContext(trans)
         user_has_access = file_source.user_has_access(user_context)
         if not user_has_access:
-            raise ParameterValueError(f"The user cannot access {value}.")
+            raise ParameterValueError(f"The user cannot access {value}.", self.name)
 
 
 class RulesListToolParameter(BaseJsonToolParameter):

--- a/lib/galaxy/webapps/galaxy/api/remote_files.py
+++ b/lib/galaxy/webapps/galaxy/api/remote_files.py
@@ -95,7 +95,7 @@ class FastAPIRemoteFiles:
         user_ctx: ProvidesUserContext = DependsOnTrans,
     ) -> FilesSourcePluginList:
         """Display plugin information for each of the gxfiles:// URI targets available."""
-        return self.manager.get_files_source_plugins()
+        return self.manager.get_files_source_plugins(user_ctx)
 
 
 class RemoteFilesAPIController(BaseGalaxyAPIController):
@@ -136,4 +136,4 @@ class RemoteFilesAPIController(BaseGalaxyAPIController):
         :returns:   list of configured plugins
         :rtype:     list
         """
-        return self.manager.get_files_source_plugins()
+        return self.manager.get_files_source_plugins(trans)

--- a/test/integration/test_remote_files_posix.py
+++ b/test/integration/test_remote_files_posix.py
@@ -19,7 +19,13 @@ class PosixFileSourceIntegrationTestCase(PosixFileSourceSetup, integration_util.
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
 
     def test_plugin_config(self):
+        # Default user has required role but not required group, so cannot see plugin
         plugin_config_response = self.galaxy_interactor.get("remote_files/plugins")
+        api_asserts.assert_status_code_is_ok(plugin_config_response)
+        plugins = plugin_config_response.json()
+        assert len(plugins) == 0
+        # Admins can see plugins
+        plugin_config_response = self.galaxy_interactor.get("remote_files/plugins", admin=True)
         api_asserts.assert_status_code_is_ok(plugin_config_response)
         plugins = plugin_config_response.json()
         assert len(plugins) == 1

--- a/test/unit/files/test_posix.py
+++ b/test/unit/files/test_posix.py
@@ -264,9 +264,6 @@ def test_posix_user_access_requires_role():
     }
     file_sources = _configured_file_sources(writable=True, plugin_extra_config=plugin_extra_config)
 
-    user_context = None  # user_context is required when there are restrictions
-    _assert_user_access_prohibited(file_sources, user_context)
-
     user_context = user_context_fixture()
     _assert_user_access_prohibited(file_sources, user_context)
 
@@ -280,9 +277,6 @@ def test_posix_user_access_requires_group():
         "requires_groups": allowed_group_name,
     }
     file_sources = _configured_file_sources(writable=True, plugin_extra_config=plugin_extra_config)
-
-    user_context = None  # user_context is required when there are restrictions
-    _assert_user_access_prohibited(file_sources, user_context)
 
     user_context = user_context_fixture()
     _assert_user_access_prohibited(file_sources, user_context)

--- a/test/unit/files/test_posix.py
+++ b/test/unit/files/test_posix.py
@@ -264,6 +264,9 @@ def test_posix_user_access_requires_role():
     }
     file_sources = _configured_file_sources(writable=True, plugin_extra_config=plugin_extra_config)
 
+    user_context = None  # user_context is required when there are restrictions
+    _assert_user_access_prohibited(file_sources, user_context)
+
     user_context = user_context_fixture()
     _assert_user_access_prohibited(file_sources, user_context)
 
@@ -277,6 +280,9 @@ def test_posix_user_access_requires_group():
         "requires_groups": allowed_group_name,
     }
     file_sources = _configured_file_sources(writable=True, plugin_extra_config=plugin_extra_config)
+
+    user_context = None  # user_context is required when there are restrictions
+    _assert_user_access_prohibited(file_sources, user_context)
 
     user_context = user_context_fixture()
     _assert_user_access_prohibited(file_sources, user_context)


### PR DESCRIPTION
https://github.com/galaxyproject/galaxy/pull/11769 was introduced to support additional restrictions to particular remote file sources but, for this to work, the user context is required when trying to read or write to these sources. This was not the case, for example, when trying to export a History to a remote file, since the export was done in the context of a tool execution that cannot access the user context, also the API was not passing in the user context when retrieving the list of available sources resulting in the whole list displayed to the user.

This PR tries to fix this by preventing passing the user context in the API calls and adds validation to check user access for the `DirectoryUriToolParameter` to forbid tool execution when the user has no access to a particular source.

Many thanks to @wm75 for discovering this!

### Additional comments
I don't know if there is an easy/viable way of passing the user context down to the tool execution so we can force the user context to be required, but that will make me happier :sweat_smile: 

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
    Try to export a History to a remote file:
      - If you have the required roles or groups you should see restricted file sources and be able to export
      - if you don't have access you won't be able to export
  

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
