### PR TITLE
[21.05] Fix ``user_library_import_symlink_allowlist`` option

### DIFF
--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -147,7 +147,7 @@ def safe_walk(path, allowlist=None):
     """
     for i, elems in enumerate(walk(path, followlinks=bool(allowlist)), start=1):
         dirpath, dirnames, filenames = elems
-        _check = _SafeContainsDirectoryChecker(dirpath, path, allowlist=None).check
+        _check = _SafeContainsDirectoryChecker(dirpath, path, allowlist=allowlist).check
 
         if allowlist and i % WALK_MAX_DIRS == 0:
             raise RuntimeError(


### PR DESCRIPTION
Fix the problem where the `user_library_import_symlink_allowlist` was not respected and symlinked files where not presented in the data library 'add datasets from User Directory'; related to #8478

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
