### PR TITLE
Align alert and state colors

### DIFF
--- a/client/src/style/scss/theme/blue.scss
+++ b/client/src/style/scss/theme/blue.scss
@@ -57,7 +57,7 @@ $theme-colors: map-merge(
 $theme-color-interval: 5% !default;
 
 // Alerts and states
-$alert-bg-level: -12 !default;
+$alert-bg-level: -16 !default;
 $alert-border-level: -6 !default;
 $alert-color-level: 16 !default;
 
@@ -145,8 +145,8 @@ $table-border-color: transparent;
 // Additional state colors
 $state-default-bg: $gray-200;
 $state-default-border: $border-color;
-$state-paused-bg: lighten($brand-info, 50%);
-$state-running-bg: lighten($brand-warning, 40%);
+$state-paused-bg: $state-info-bg;
+$state-running-bg: $state-warning-bg;
 $state-running-border: $border-color;
 
 // Workflow editor

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -478,18 +478,19 @@ $ui-margin-horizontal-large: $margin-v * 2;
 .ui-dragover {
     @extend .p-1;
     border-radius: $border-radius-base;
-    border: 2px solid $state-warning-bg;
-    background: lighten($state-warning-bg, 10%);
+    border: $border-default;
+    border-color: $state-warning-border;
+    background: $state-warning-bg;
 }
 
 .ui-dragover-danger {
     @extend .ui-dragover;
-    border: 2px solid $state-danger-bg;
-    background: lighten($state-danger-bg, 10%);
+    border-color: $state-danger-border;
+    background: $state-danger-bg;
 }
 
 .ui-dragover-success {
     @extend .ui-dragover;
-    border: 2px solid $state-success-bg;
-    background: lighten($state-success-bg, 10%);
+    border-color: $state-success-border;
+    background: $state-success-bg;
 }

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -437,6 +437,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
             @extend .ui-input;
             background-image: none;
             background: transparent;
+            border: $border-default;
             -webkit-appearance: none;
             -moz-border-radius: $border-radius-base;
             line-height: 1.5rem;


### PR DESCRIPTION
Related to #12611. Our color theme has a discrepancy between alert and history dataset state colors. This PR unifies those colors. This PR will probably end up targeting 22.01.

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/2105447/135679745-cf96ef0c-3a1e-4460-8808-bc2bc5159288.png">

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
