### PR TITLE
[21.09] Fix branch for release notes

### DIFF
--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -33,7 +33,7 @@ function addNewsIframe() {
         currentGalaxyVersion = "21.09";
     }
 
-    const releaseNotes = `https://docs.galaxyproject.org/en/master/releases/${currentGalaxyVersion}_announce_user.html`;
+    const releaseNotes = `https://docs.galaxyproject.org/en/latest/releases/${currentGalaxyVersion}_announce_user.html`;
     const lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
     // Check that they've seen the current version's release notes.
     if (lastSeenVersion != currentGalaxyVersion) {


### PR DESCRIPTION
Fixes linking to non-existent docs on master branch

![image](https://user-images.githubusercontent.com/458683/135620859-495a0cee-ef5d-40e6-9e5f-8a2ba24fbc55.png)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. start galaxy
  2. view release notes
  3. are they correct?

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
