### PR TITLE
[21.05] Fix: encode all ids when returning a `ldda` in datasets API `show` operation

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -158,7 +158,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
                                                              view=kwd.get('view', 'detailed'), user=trans.user, trans=trans)
             else:
                 dataset_dict = dataset.to_dict()
-                rval = trans.security.encode_all_ids(dataset_dict)
+                rval = self.encode_all_ids(dataset_dict)
         return rval
 
     @web.expose_api_anonymous

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -157,7 +157,8 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
                 return self.hda_serializer.serialize_to_view(dataset,
                                                              view=kwd.get('view', 'detailed'), user=trans.user, trans=trans)
             else:
-                rval = dataset.to_dict()
+                dataset_dict = dataset.to_dict()
+                rval = trans.security.encode_all_ids(dataset_dict)
         return rval
 
     @web.expose_api_anonymous


### PR DESCRIPTION
This should fix #12610

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  Follow the same instructions as in #12610 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
