### PR TITLE
[21.09] Modernize sorter (sort1) tool

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -222,6 +222,7 @@ WORKFLOW_SAFE_TOOL_VERSION_UPDATES = {
     'Grep1': safe_update(packaging.version.parse("1.0.1"), packaging.version.parse("1.0.3")),
     'Show beginning1': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
     'Show tail1': safe_update(packaging.version.parse("1.0.0"), packaging.version.parse("1.0.1")),
+    'sort1': safe_update(packaging.version.parse("1.1.0"), packaging.version.parse("1.2.0")),
 }
 
 

--- a/tools/filters/sorter.py
+++ b/tools/filters/sorter.py
@@ -1,19 +1,12 @@
 """
     Sorts tabular data on one or more columns. All comments of the file are collected
     and placed at the beginning of the sorted output file.
-
-    usage: sorter.py [options]
-    -i, --input: Tabular file to be sorted
-    -o, --output: Sorted output file
-    -k, --key: Key (see manual for bash/sort)
-
-    usage: sorter.py input output [key ...]
 """
 # 03/05/2013 guerler
 
+import argparse
 import subprocess
 import sys
-from optparse import OptionParser
 
 
 def stop_err(msg):
@@ -22,40 +15,48 @@ def stop_err(msg):
 
 def main():
     # define options
-    parser = OptionParser()
-    parser.add_option("-i", "--input")
-    parser.add_option("-o", "--output")
-    parser.add_option("-k", "--key", action="append")
-    parser.add_option("-H", "--header_lines", type='int')
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-i", "--input", type=argparse.FileType("r"), help="Tabular file to be sorted")
+    parser.add_argument("-o", "--output", type=argparse.FileType("w"), help="Sorted output file")
+    parser.add_argument("-k", "--key", action="append", help="Key (see manual for bash/sort)")
+    parser.add_argument("-H", "--header_lines", type=int, help="Number of header lines to ignore")
 
     # parse
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
     try:
         # retrieve options
-        input = options.input
-        output = options.output
-        header_lines = options.header_lines
-        key = [" -k" + k for k in options.key]
+        input_fh = args.input
+        output_fh = args.output
+        header_lines = args.header_lines
+        key_args = []
+        for k in args.key:
+            key_args.extend(['-k', k])
 
-        with open(output, 'w') as out:
-            # sed header
-            if header_lines > 0:
-                sed_header = ['sed', '-n', "1,%dp" % header_lines, input]
-                subprocess.check_call(sed_header, stdout=out)
+        # sed header
+        if header_lines > 0:
+            sed_header = ['sed', '-n', f"1,{header_lines:d}p"]
+            subprocess.check_call(sed_header, stdin=input_fh, stdout=output_fh)
+            input_fh.seek(0)
 
-            # grep comments
-            grep_comments = ['grep', '^#', input]
-            exit_code = subprocess.call(grep_comments, stdout=out)
-            if exit_code not in [0, 1]:
-                stop_err('Searching for comment lines failed')
+        # grep comments
+        grep_comments = ['grep', '^#']
+        exit_code = subprocess.call(grep_comments, stdout=output_fh)
+        if exit_code not in [0, 1]:
+            stop_err('Searching for comment lines failed')
 
-            # grep and sort columns
-            sed_header_restore = ""
-            if header_lines > 0:
-                sed_header_restore = "sed '1,%dd' | " % (header_lines)
-            sort_columns = "(cat %s | %s grep '^[^#]' | sort -f -t '\t' %s)" % (input, sed_header_restore, ' '.join(key))
-            subprocess.check_call(sort_columns, stdout=out, shell=True)
+        # grep and sort columns
+        if header_lines > 0:
+            sed_cmd = ['sed', f'1,{header_lines:d}d']
+            sed_header_restore = subprocess.Popen(sed_cmd, stdin=input_fh, stdout=subprocess.PIPE)
+            pipe_stdin = sed_header_restore.stdout
+        else:
+            pipe_stdin = input_fh
+        grep = subprocess.Popen(['grep', '^[^#]'], stdin=pipe_stdin, stdout=subprocess.PIPE)
+        sort = subprocess.Popen(['sort', '-f', '-t', '\t'] + key_args, stdin=grep.stdout, stdout=output_fh)
+        # wait for commands to complete
+        sort.communicate()
+        assert sort.returncode == 0, f"sort pipeline exited with non-zero exit code: {sort.returncode:d}"
 
     except Exception as ex:
         stop_err('Error running sorter.py\n' + str(ex))

--- a/tools/filters/sorter.xml
+++ b/tools/filters/sorter.xml
@@ -1,9 +1,10 @@
-<tool id="sort1" name="Sort" version="1.1.0">
+<tool id="sort1" name="Sort" version="1.2.0">
     <description>data in ascending or descending order</description>
     <requirements>
-        <requirement type="package" version="2.7.13">python</requirement>
+        <requirement type="package" version="3.8">python</requirement>
         <requirement type="package" version="2.14">grep</requirement>
         <requirement type="package" version="4.4">sed</requirement>
+        <requirement type="package" version="8.31">coreutils</requirement>
     </requirements>
     <command detect_errors="exit_code">
 python '$__tool_directory__/sorter.py'


### PR DESCRIPTION
- Don't use shell, pipe with `subprocess.PIPE` instead
- Switch `optparse` for `argparse`
- Add missing coreutils requirement for `sort` command
- Change Python requirement from 2.7 to 3.8

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
