### PR TITLE
[21.09] Allow users to retry tool job submissions if an error occurs

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -263,21 +263,23 @@ export default {
             console.debug("toolForm::onExecute()", jobDef);
             submitJob(jobDef).then(
                 (jobResponse) => {
+                    this.showExecuting = false;
                     if (Galaxy.currHistoryPanel) {
                         Galaxy.currHistoryPanel.refreshContents();
                     }
-                    this.showForm = false;
                     if (jobResponse.produces_entry_points) {
                         this.showEntryPoints = true;
                         this.entryPoints = jobResponse.jobs;
                     }
                     const nJobs = jobResponse && jobResponse.jobs ? jobResponse.jobs.length : 0;
                     if (nJobs > 0) {
+                        this.showForm = false;
                         this.showSuccess = true;
                         this.jobDef = jobDef;
                         this.jobResponse = jobResponse;
                     } else {
                         this.showError = true;
+                        this.showForm = true;
                         this.errorTitle = "Invalid success response. No jobs found.";
                         this.errorContent = jobResponse;
                     }
@@ -299,7 +301,6 @@ export default {
                     }
                     if (genericError) {
                         this.showError = true;
-                        this.showForm = false;
                         this.errorTitle = "Job submission failed";
                         this.errorContent = this.jobDef;
                     }

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -14,14 +14,16 @@
                         :tool-name="toolName"
                     />
                     <Webhook v-if="showSuccess" type="tool" :tool-id="jobDef.tool_id" />
-                    <b-alert v-if="showError" show variant="danger">
-                        <h4>{{ errorTitle | l }}</h4>
-                        <p>
-                            The server could not complete the request. Please contact the Galaxy Team if this error
-                            persists.
-                        </p>
-                        <pre>{{ errorContentPretty }}</pre>
-                    </b-alert>
+                    <b-modal v-model="showError" size="sm" :title="errorTitle | l" scrollable ok-only>
+                        <b-alert show variant="danger">
+                            The server could not complete this request. Please verify your parameter settings, retry
+                            submission and contact the Galaxy Team if this error persists. A transcript of the submitted
+                            data is shown below.
+                        </b-alert>
+                        <small class="text-muted">
+                            <pre>{{ errorContentPretty }}</pre>
+                        </small>
+                    </b-modal>
                     <ToolRecommendation v-if="showRecommendation" :tool-id="formConfig.id" />
                     <ToolCard
                         v-if="showForm"
@@ -280,7 +282,7 @@ export default {
                     } else {
                         this.showError = true;
                         this.showForm = true;
-                        this.errorTitle = "Invalid success response. No jobs found.";
+                        this.errorTitle = "Job submission rejected.";
                         this.errorContent = jobResponse;
                     }
                     if ([true, "true"].includes(config.enable_tool_recommendations)) {
@@ -301,7 +303,7 @@ export default {
                     }
                     if (genericError) {
                         this.showError = true;
-                        this.errorTitle = "Job submission failed";
+                        this.errorTitle = "Job submission failed.";
                         this.errorContent = this.jobDef;
                     }
                 }


### PR DESCRIPTION
A job submission error can occur when the internet connection is lost or an invalid collection is parsed. This PR restores the users ability to read the error notification and return to the regular tool form in order to retry the job submission. This change only affects the regular tool form.

<img width="1334" alt="image" src="https://user-images.githubusercontent.com/2105447/135694851-11ff7fb7-2465-4ad4-b07b-0f83adea3295.png">


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
