### PR TITLE
[21.09] Restore overwritten styles

### DIFF
--- a/client/src/components/Markdown/Elements/HistoryDatasetCollection/CollectionDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetCollection/CollectionDisplay.vue
@@ -131,5 +131,6 @@ export default {
 <style scoped>
 .content-height {
     max-height: 15rem;
+    overflow-y: auto;
 }
 </style>

--- a/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
+++ b/client/src/components/Markdown/Elements/HistoryDatasetDisplay.vue
@@ -177,5 +177,6 @@ export default {
 <style scoped>
 .content-height {
     max-height: 20rem;
+    overflow-y: auto;
 }
 </style>

--- a/client/src/components/Markdown/Elements/ToolStd.vue
+++ b/client/src/components/Markdown/Elements/ToolStd.vue
@@ -33,5 +33,6 @@ export default {
 <style scoped>
 .content-height {
     max-height: 15rem;
+    overflow-y: auto;
 }
 </style>

--- a/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
+++ b/client/src/components/Markdown/Elements/Workflow/WorkflowDisplay.vue
@@ -109,5 +109,6 @@ export default {
 <style scoped>
 .content-height {
     max-height: 15rem;
+    overflow-y: auto;
 }
 </style>

--- a/client/src/components/NewUserWelcome/NewUserWelcome.vue
+++ b/client/src/components/NewUserWelcome/NewUserWelcome.vue
@@ -85,7 +85,7 @@ export default {
 };
 </script>
 
-<style type="text/css">
+<style scoped type="text/css">
 .card {
     border: 0px;
 }


### PR DESCRIPTION
Fixes #12592. Partially related to #11085. Recently we introduced components with hard-coded styles and colors. Some of these settings overwrite the bootstrap defaults. This PR moves these styles into `scope` for now but they need to be removed to resolve this issue and avoid conflicts with the theming options. These issues are difficult to track down since styles can be changed globally anywhere in the client-code. We should entirely avoid hard-coded colors and customizations.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
