### PR TITLE
[21.09] Allow empty `truevalue` for conditional test parameters

### DIFF
--- a/client/src/components/Form/utilities.js
+++ b/client/src/components/Form/utilities.js
@@ -4,7 +4,7 @@ import _ from "underscore";
  * @param{dict}   inputs    - Nested dictionary of input elements
  * @param{dict}   callback  - Called with the mapped dictionary object and corresponding model node
  */
-export var visitInputs = (inputs, callback, prefix, context) => {
+export function visitInputs(inputs, callback, prefix, context) {
     context = Object.assign({}, context);
     _.each(inputs, (input) => {
         if (input && input.type && input.name) {
@@ -41,24 +41,32 @@ export var visitInputs = (inputs, callback, prefix, context) => {
                 callback(node, name, context);
         }
     }
-};
+}
 
 /** Match conditional values to selected cases
  * @param{dict}   input     - Definition of conditional input parameter
  * @param{dict}   value     - Current value
  */
-export var matchCase = (input, value) => {
+export function matchCase(input, value) {
     if (input.test_param.type == "boolean") {
-        if (value == "true") {
-            value = input.test_param.truevalue || "true";
+        if (["true", true].includes(value)) {
+            if (input.test_param.truevalue !== undefined) {
+                value = input.test_param.truevalue;
+            } else {
+                value = "true";
+            }
         } else {
-            value = input.test_param.falsevalue || "false";
+            if (input.test_param.falsevalue !== undefined) {
+                value = input.test_param.falsevalue;
+            } else {
+                value = "false";
+            }
         }
     }
-    for (var i in input.cases) {
+    for (let i = 0; i < input.cases.length; i++) {
         if (input.cases[i].value == value) {
             return i;
         }
     }
     return -1;
-};
+}

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -83,5 +83,6 @@ describe("form component utilities", () => {
         input.test_param.type = "select";
         expect(matchCase(input, "")).toEqual(0);
         expect(matchCase(input, "unavailable")).toEqual(-1);
+        expect(matchCase(input, "falsevalue")).toEqual(1);
     });
 });

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -66,6 +66,9 @@ describe("form component utilities", () => {
         expect(matchCase(input, "false")).toEqual(1);
 
         // test (empty) truevalue
+        input.test_param.truevalue = undefined;
+        input.cases[0].value = "true";
+        expect(matchCase(input, "true")).toEqual(0);
         input.test_param.truevalue = "";
         expect(matchCase(input, "true")).toEqual(-1);
         input.cases[0].value = "";

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -22,24 +22,22 @@ describe("form component utilities", () => {
             },
             cases: [
                 {
-                    name: "c",
                     value: "true",
+                    inputs: [
+                        {
+                            name: "c",
+                            type: "text",
+                            value: "cvalue",
+                        },
+                    ],
+                },
+                {
+                    value: "false",
                     inputs: [
                         {
                             name: "d",
                             type: "text",
                             value: "dvalue",
-                        },
-                    ],
-                },
-                {
-                    name: "e",
-                    value: "false",
-                    inputs: [
-                        {
-                            name: "f",
-                            type: "text",
-                            value: "fvalue",
                         },
                     ],
                 },
@@ -75,9 +73,9 @@ describe("form component utilities", () => {
         expect(matchCase(input, "true")).toEqual(0);
 
         // test visit inputs
-        expect(visitInputsString([input])).toEqual("a|b=true;a|d=dvalue;");
+        expect(visitInputsString([input])).toEqual("a|b=true;a|c=cvalue;");
         input.test_param.value = "false";
-        expect(visitInputsString([input])).toEqual("a|b=false;a|f=fvalue;");
+        expect(visitInputsString([input])).toEqual("a|b=false;a|d=dvalue;");
 
         // switch test parameter to other type than boolean e.g. select
         input.test_param.type = "select";

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -3,7 +3,7 @@ import { matchCase, visitInputs } from "./utilities";
 function visitInputsString(inputs) {
     let results = "";
     visitInputs(inputs, (input, identifier) => {
-        results += `${identifier}-${input.name}&`;
+        results += `${identifier}=${input.value};`;
     });
     return results;
 }
@@ -28,7 +28,7 @@ describe("form component utilities", () => {
                         {
                             name: "d",
                             type: "text",
-                            value: "d",
+                            value: "dvalue",
                         },
                     ],
                 },
@@ -39,7 +39,7 @@ describe("form component utilities", () => {
                         {
                             name: "f",
                             type: "text",
-                            value: "f",
+                            value: "fvalue",
                         },
                     ],
                 },
@@ -75,9 +75,9 @@ describe("form component utilities", () => {
         expect(matchCase(input, "true")).toEqual(0);
 
         // test visit inputs
-        expect(visitInputsString([input])).toEqual("a|b-b&a|d-d&");
+        expect(visitInputsString([input])).toEqual("a|b=true;a|d=dvalue;");
         input.test_param.value = "false";
-        expect(visitInputsString([input])).toEqual("a|b-b&a|f-f&");
+        expect(visitInputsString([input])).toEqual("a|b=false;a|f=fvalue;");
 
         // switch test parameter to other type than boolean e.g. select
         input.test_param.type = "select";

--- a/client/src/components/Form/utilities.test.js
+++ b/client/src/components/Form/utilities.test.js
@@ -1,0 +1,84 @@
+import { matchCase, visitInputs } from "./utilities";
+
+function visitInputsString(inputs) {
+    let results = "";
+    visitInputs(inputs, (input, identifier) => {
+        results += `${identifier}-${input.name}&`;
+    });
+    return results;
+}
+
+describe("form component utilities", () => {
+    it("conditional case matching", () => {
+        const input = {
+            name: "a",
+            type: "conditional",
+            test_param: {
+                name: "b",
+                type: "boolean",
+                value: "true",
+                truevalue: undefined,
+                falsevalue: undefined,
+            },
+            cases: [
+                {
+                    name: "c",
+                    value: "true",
+                    inputs: [
+                        {
+                            name: "d",
+                            type: "text",
+                            value: "d",
+                        },
+                    ],
+                },
+                {
+                    name: "e",
+                    value: "false",
+                    inputs: [
+                        {
+                            name: "f",
+                            type: "text",
+                            value: "f",
+                        },
+                    ],
+                },
+            ],
+        };
+
+        // test simple case matching
+        expect(matchCase(input, "true")).toEqual(0);
+        expect(matchCase(input, true)).toEqual(0);
+        expect(matchCase(input, "false")).toEqual(1);
+        expect(matchCase(input, false)).toEqual(1);
+
+        // test truevalue
+        input.test_param.truevalue = "truevalue";
+        expect(matchCase(input, "true")).toEqual(-1);
+        input.cases[0].value = "truevalue";
+        expect(matchCase(input, "true")).toEqual(0);
+
+        // test falsevalue
+        input.test_param.falsevalue = "falsevalue";
+        expect(matchCase(input, "true")).toEqual(0);
+        expect(matchCase(input, "false")).toEqual(-1);
+        input.cases[1].value = "falsevalue";
+        expect(matchCase(input, "false")).toEqual(1);
+
+        // test (empty) truevalue
+        input.test_param.truevalue = "";
+        expect(matchCase(input, "true")).toEqual(-1);
+        input.cases[0].value = "";
+        expect(matchCase(input, "true")).toEqual(0);
+
+        // test visit inputs
+        expect(visitInputsString([input])).toEqual("a|b-b&a|d-d&");
+        input.test_param.value = "false";
+        expect(visitInputsString([input])).toEqual("a|b-b&a|f-f&");
+
+        // switch test parameter to other type than boolean e.g. select
+        input.test_param.type = "select";
+        expect(matchCase(input, "")).toEqual(0);
+        expect(matchCase(input, "unavailable")).toEqual(-1);
+    });
+});

--- a/client/src/mvc/form/form-data.js
+++ b/client/src/mvc/form/form-data.js
@@ -125,10 +125,9 @@ export var Manager = Backbone.Model.extend({
     /** Matches a new tool model to the current input elements e.g. used to update dynamic options
      */
     matchModel: function (inputs, callback) {
-        var self = this;
         visitInputs(inputs, (input, name) => {
-            if (self.flat_dict[name]) {
-                callback(input, self.flat_dict[name]);
+            if (this.flat_dict[name]) {
+                callback(input, this.flat_dict[name]);
             }
         });
     },


### PR DESCRIPTION
Tools can define `conditionals` with a `boolean` test parameter and set the `truevalue` attribute to an empty string or `0`. In this case the `matchCase` client helper might be unable to identify the correct case. This PR fixes this issue and adds jest tests in addition to the existing, more comprehensive qunit form tests. The `matchCase` helper detects string or boolean test parameter values, and returns a number.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
