### PR TITLE
[21.09] Dispose previously mounted Vue-components in Analysis router

### DIFF
--- a/client/src/components/HistoryExport/ExportLink.vue
+++ b/client/src/components/HistoryExport/ExportLink.vue
@@ -14,7 +14,7 @@
         <i
             title="Information about when the history export was generated is included in the job details. Additionally, if there are issues with export, the job details may help figure out the underlying problem or communicate issues to your Galaxy administrator."
         >
-            (<a class="show-job-link" href="#" @click="showDetails">view job details</a>)
+            (<b-link class="show-job-link" href="#" @click="showDetails">view job details</b-link>)
         </i>
         <b-modal v-model="details" modal-class="job-information-modal" scrollable ok-only hide-header>
             <job-information :job_id="historyExport.job_id" :include-times="true" />

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -165,12 +165,22 @@ export default {
         };
     },
     created() {
-        this.requestTool();
+        this.requestTool().then(() => {
+            const Galaxy = getGalaxyInstance();
+            if (Galaxy && Galaxy.currHistoryPanel) {
+                console.debug("ToolForm::created - Listening to history changes.");
+                Galaxy.currHistoryPanel.collection.on("change", () => {
+                    this.onUpdate();
+                    console.debug("ToolForm::created - Loading history changes.");
+                });
+            }
+        });
+    },
+    beforeDestroy() {
         const Galaxy = getGalaxyInstance();
         if (Galaxy && Galaxy.currHistoryPanel) {
-            Galaxy.currHistoryPanel.collection.on("change", () => {
-                this.onUpdate();
-            });
+            Galaxy.currHistoryPanel.collection.off("change");
+            console.debug("ToolForm::beforeDestroy - Stopped listening to history changes.");
         }
     },
     computed: {
@@ -227,7 +237,7 @@ export default {
         },
         requestTool(newVersion) {
             this.currentVersion = newVersion || this.currentVersion;
-            getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id).then((data) => {
+            return getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id).then((data) => {
                 this.formConfig = data;
                 this.remapAllowed = this.job_id && data.job_remap;
                 this.showLoading = false;

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -168,19 +168,16 @@ export default {
         this.requestTool().then(() => {
             const Galaxy = getGalaxyInstance();
             if (Galaxy && Galaxy.currHistoryPanel) {
-                console.debug("ToolForm::created - Listening to history changes.");
-                Galaxy.currHistoryPanel.collection.on("change", () => {
-                    this.onUpdate();
-                    console.debug("ToolForm::created - Loading history changes.");
-                });
+                console.debug(`ToolForm::created - Started listening to history changes. [${this.id}]`);
+                Galaxy.currHistoryPanel.collection.on("change", this.onHistoryChange, this);
             }
         });
     },
     beforeDestroy() {
         const Galaxy = getGalaxyInstance();
         if (Galaxy && Galaxy.currHistoryPanel) {
-            Galaxy.currHistoryPanel.collection.off("change");
-            console.debug("ToolForm::beforeDestroy - Stopped listening to history changes.");
+            Galaxy.currHistoryPanel.collection.off("change", this.onHistoryChange, this);
+            console.debug(`ToolForm::beforeDestroy - Stopped listening to history changes. [${this.id}]`);
         }
     },
     computed: {
@@ -214,6 +211,10 @@ export default {
         },
         reuseAllowed(user) {
             return allowCachedJobs(user.preferences);
+        },
+        onHistoryChange() {
+            console.debug(`ToolForm::created - Loading history changes. [${this.id}]`);
+            this.onUpdate();
         },
         onValidation(validationInternal) {
             this.validationInternal = validationInternal;

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -125,7 +125,11 @@ export const getAnalysisRouter = (Galaxy) => {
             }
             this.page.display(container, noPadding);
             const mountFn = mountVueComponent(component);
-            return mountFn(propsData, container);
+            if (this.currentComponent && this.currentComponent.$destroy) {
+                this.currentComponent.$destroy();
+            }
+            this.currentComponent = mountFn(propsData, container);
+            return this.currentComponent;
         },
 
         show_tours: function (tour_id) {


### PR DESCRIPTION
This PR fixes #12464. It is not a new issue but it turns out that the analysis router's helper mounts new Vue-components without properly disposing previously mounted components. Normally a component's `$destroy` would be induced by a `v-if` statement. Currently the router manually mounts individual Vue-components and attempts to destroy them by removing the `dom` element using `$.empty()`. This however does not trigger `beforeDestroy` and `destroyed` which prevents Vue-components from being properly disposed. This PR fixes that and additionally unbinds history backbone model listeners in the tool form. This issue underlines that we need to modernize the Analysis router.

#12464 can be reproduced as follows:
  1. Load the Analysis panel
  2. Select a tool containing a `conditional` parameter
  3. Select several other tools from the tool panel
  4. Upload a file. This will trigger the described exception.

The reason is that the upload triggers a refresh of all previously selected tool form components. However, the input parameters of most tools have been removed by the `$.empty()` call. The refresh request to the server triggers an exception because conditional parameters are always required. With this PR only the currently mounted tool will be refreshed when the history changes.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
