### PR TITLE
Lint for todos everywhere in tool xml

### DIFF
--- a/lib/galaxy/tool_util/linters/help.py
+++ b/lib/galaxy/tool_util/linters/help.py
@@ -25,9 +25,6 @@ def lint_help(tool_xml, lint_ctx):
     lint_ctx.valid("Tool contains help section.")
     invalid_rst = rst_invalid(help)
 
-    if "TODO" in help:
-        lint_ctx.warn("Help contains TODO text.")
-
     if invalid_rst:
         lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].")
     else:

--- a/lib/galaxy/tool_util/linters/todo.py
+++ b/lib/galaxy/tool_util/linters/todo.py
@@ -6,7 +6,8 @@ import re
 def _has_todo(txt):
     """
     check if text contains a TODO
-    the todo needs to be delimited by whitespaces or be at the begin/end
+    the todo needs to be delimited by a non-alphanumerical character (whitespaces, #, ...)
+    or be at the begin/end of txt
     """
     return re.search(r"(^|\W)(todo|TODO)(\W|$)", txt) is not None
 

--- a/lib/galaxy/tool_util/linters/todo.py
+++ b/lib/galaxy/tool_util/linters/todo.py
@@ -1,0 +1,23 @@
+"""This module contains a linting functions checking for TODO in attributes and text"""
+
+import re
+
+
+def _has_todo(txt):
+    """
+    check if text contains a TODO
+    the todo needs to be delimited by whitespaces or be at the begin/end
+    """
+    return re.search(r"(^|\W)(todo|TODO)(\W|$)", txt) is not None
+
+
+def lint_todo(tool_xml, lint_ctx):
+    """
+    check if any attribute / text contains a TODO
+    """
+    for el in tool_xml.iter():
+        for a in el.attrib:
+            if _has_todo(el.attrib[a]):
+                lint_ctx.warn(f'{el.tag} attribute "{a}" contains a "TODO"')
+        if _has_todo(el.text):
+            lint_ctx.warn(f'{el.tag} text contains a "TODO"')

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -8,6 +8,7 @@ from galaxy.tool_util.linters import (
     inputs,
     outputs,
     tests,
+    todo
 )
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
@@ -46,6 +47,27 @@ REQUIREMENT_WO_VERSION = """
     </inputs>
 </tool>
 """
+
+TOOL_WITH_TODOS = """
+<tool name="mastodon" id="masTODOn" version="TODO">
+    <description>TODO</description>
+    <command><![CDATA[
+    ##TODO
+    ]]>
+    </command>
+    <inputs>
+        <param name="label_select" type="select" label="Points to label" help="TODO">
+            <option value="none" selected="True">todo</option>
+            <option value="none" selected="True">mastodon</option>
+        </param>
+    </inputs>
+    <help><![CDATA[
+    TODO
+    ]]>
+    </help>
+</tool>
+"""
+
 
 NO_SECTIONS_XML = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
@@ -282,6 +304,17 @@ TESTS_EXPECT_FAILURE_OUTPUT = """
 
 TESTS = [
     (
+        TOOL_WITH_TODOS, todo.lint_todo,
+        lambda x:
+            'tool attribute "version" contains a "TODO"' in x.warn_messages
+            and 'description text contains a "TODO"' in x.warn_messages
+            and 'command text contains a "TODO"' in x.warn_messages
+            and 'param attribute "help" contains a "TODO"' in x.warn_messages
+            and 'option text contains a "TODO"' in x.warn_messages
+            and 'help text contains a "TODO"' in x.warn_messages
+            and len(x.warn_messages) == 6 and len(x.error_messages) == 0
+    ),
+    (
         WHITESPACE_IN_VERSIONS_AND_NAMES, general.lint_general,
         lambda x:
             "Tool version contains whitespace, this may cause errors: [ 1.0.1 ]." in x.warn_messages
@@ -400,6 +433,7 @@ TESTS = [
 ]
 
 TEST_IDS = [
+    'lint for todos',
     'hazardous whitespace',
     'requirement without version',
     'lint no sections',


### PR DESCRIPTION
- all attributes
- and text

fixes https://github.com/galaxyproject/galaxy/issues/12628

Not sure if this is (now) a good idea?


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
