### PR TITLE
[21.05] Fix id encoding in datasets API `show` method

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -158,7 +158,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
                                                              view=kwd.get('view', 'detailed'), user=trans.user, trans=trans)
             else:
                 dataset_dict = dataset.to_dict()
-                rval = self.encode_all_ids(dataset_dict)
+                rval = self.encode_all_ids(trans, dataset_dict)
         return rval
 
     @web.expose_api_anonymous

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -1,6 +1,9 @@
 import json
 import unittest
 
+import pytest
+import requests
+
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,
@@ -90,15 +93,26 @@ class LibrariesApiTestCase(ApiTestCase):
     def test_show_private_dataset_permissions(self):
         library, library_dataset = self.library_populator.new_library_dataset_in_private_library("ForCreateDatasets", wait=True)
         with self._different_user():
-            response = self.library_populator.show_ldda(library["id"], library_dataset["id"])
+            with pytest.raises(requests.exceptions.HTTPError) as exc_info:
+                self.library_populator.show_ld(library["id"], library_dataset["id"])
             # TODO: this should really be 403 and a proper JSON exception.
-            self._assert_status_code_is(response, 400)
+            self._assert_status_code_is(exc_info.value.response, 400)
 
     def test_create_dataset(self):
         library, library_dataset = self.library_populator.new_library_dataset_in_private_library("ForCreateDatasets", wait=True)
         self._assert_has_keys(library_dataset, "peek", "data_type")
         assert library_dataset["peek"].find("create_test") >= 0
         assert library_dataset["file_ext"] == "txt", library_dataset["file_ext"]
+        # Get library dataset (same as library_dataset)
+        library_dataset_from_show = self.library_populator.show_ld(library["id"], library_dataset["id"])
+        assert library_dataset_from_show["id"] == library_dataset["id"]
+        assert library_dataset_from_show["parent_library_id"] == library["id"]
+        assert library_dataset_from_show["folder_id"] == library["root_folder_id"]
+        # Get library dataset dataset association
+        ldda = self.library_populator.show_ldda(library_dataset_from_show["ldda_id"])
+        assert ldda["library_dataset_id"] == library_dataset["id"]
+        assert ldda["parent_library_id"] == library["id"]
+        assert ldda["file_ext"] == "txt"
 
     def test_fetch_upload_to_folder(self):
         history_id, library, destination = self._setup_fetch_to_folder("flat_zip")
@@ -287,7 +301,7 @@ class LibrariesApiTestCase(ApiTestCase):
         self._assert_status_code_is(create_response, 200)
         ld = create_response.json()
         library_id = ld['parent_library_id']
-        return self.library_populator.wait_on_library_dataset(library={'id': library_id}, dataset=ld)
+        return self.library_populator.wait_on_library_dataset(library_id, ld["id"])
 
     def test_update_dataset_in_folder(self):
         ld = self._create_dataset_in_folder_in_library("ForUpdateDataset", content=">seq\nATGC", wait=True).json()

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1279,11 +1279,11 @@ class LibraryPopulator:
         library = self.new_private_library(name)
         payload, files = self.create_dataset_request(library, **create_dataset_kwds)
         dataset = self.raw_library_contents_create(library["id"], payload, files=files).json()[0]
-        return self.wait_on_library_dataset(library, dataset)
+        return self.wait_on_library_dataset(library["id"], dataset["id"])
 
-    def wait_on_library_dataset(self, library, dataset):
+    def wait_on_library_dataset(self, library_id, dataset_id):
         def show():
-            return self.galaxy_interactor.get("libraries/{}/contents/{}".format(library["id"], dataset["id"]))
+            return self.galaxy_interactor.get(f"libraries/{library_id}/contents/{dataset_id}")
 
         wait_on_state(show, assert_ok=True, timeout=DEFAULT_TIMEOUT)
         return show().json()
@@ -1295,8 +1295,15 @@ class LibraryPopulator:
         url_rel = "libraries/%s/contents" % library_id
         return self.galaxy_interactor.post(url_rel, payload, files=files)
 
-    def show_ldda(self, library_id, library_dataset_id):
-        return self.galaxy_interactor.get(f"libraries/{library_id}/contents/{library_dataset_id}")
+    def show_ld(self, library_id, library_dataset_id):
+        response = self.galaxy_interactor.get(f"libraries/{library_id}/contents/{library_dataset_id}")
+        response.raise_for_status()
+        return response.json()
+
+    def show_ldda(self, ldda_id):
+        response = self.galaxy_interactor.get(f"datasets/{ldda_id}?hda_ldda=ldda")
+        response.raise_for_status()
+        return response.json()
 
     def new_library_dataset_in_private_library(self, library_name="private_dataset", wait=True):
         library = self.new_private_library(library_name)
@@ -1307,11 +1314,7 @@ class LibraryPopulator:
         assert len(library_datasets) == 1
         library_dataset = library_datasets[0]
         if wait:
-            def show():
-                return self.show_ldda(library["id"], library_dataset["id"])
-
-            wait_on_state(show, assert_ok=True)
-            library_dataset = show().json()
+            library_dataset = self.wait_on_library_dataset(library["id"], library_dataset["id"])
 
         return library, library_dataset
 

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -215,8 +215,8 @@ class AdminsCanPasteFilePathsTestCase(BaseUploadContentConfigurationTestCase):
         payload, files = self.library_populator.create_dataset_request(library, upload_option="upload_paths", paths=path, link_data=True)
         response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
         assert response.status_code == 200
-        assert os.path.exists(path)
-        self.library_populator.wait_on_library_dataset(library, response.json()[0])
+        dataset = response.json()[0]
+        self.library_populator.wait_on_library_dataset(library["id"], dataset["id"])
         # We should probably verify the linking, but this was enough for now to exhibit
         # https://github.com/galaxyproject/galaxy/issues/8756
 
@@ -693,7 +693,7 @@ class ServerDirectoryValidUsageTestCase(BaseUploadContentConfigurationTestCase):
 
         assert library_dataset["file_size"] == 12, library_dataset
 
-    def link_data_only(self):
+    def test_link_data_only(self):
         content = "hello world\n"
         dir_path = os.path.join(self.server_dir(), "lib1")
         file_path = self._write_file(dir_path, content)
@@ -703,7 +703,7 @@ class ServerDirectoryValidUsageTestCase(BaseUploadContentConfigurationTestCase):
         response = self.library_populator.raw_library_contents_create(library["id"], payload, files=files)
         assert response.status_code == 200, response.json()
         dataset = response.json()[0]
-        ok_dataset = self.library_populator.wait_on_library_dataset(library, dataset)
+        ok_dataset = self.library_populator.wait_on_library_dataset(library["id"], dataset["id"])
         assert ok_dataset["file_size"] == 12, ok_dataset
         assert ok_dataset["file_name"] == file_path, ok_dataset
 


### PR DESCRIPTION
Follow-up on https://github.com/galaxyproject/galaxy/pull/12616
Fix https://github.com/galaxyproject/galaxy/issues/12610

Also:
- Add API test
- Some refactoring in `LibraryPopulator`
- Add `test_` to `ServerDirectoryValidUsageTestCase.link_data_only()` method name so it actually gets tested

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
