### PR TITLE
[21.09] Adjust appearance of new user welcome page

### DIFF
--- a/client/src/components/NewUserWelcome/NewUserWelcome.vue
+++ b/client/src/components/NewUserWelcome/NewUserWelcome.vue
@@ -87,18 +87,6 @@ export default {
 
 <style scoped type="scss">
 .new-user-welcome::v-deep {
-    .card {
-        border: 0px;
-    }
-    .card-img {
-        height: 12rem;
-    }
-    .card-header,
-    .card-footer {
-        border-bottom: 0px;
-        border-top: 0px;
-        background-color: #ffffff;
-    }
     .carousel-fig {
         padding-bottom: 10;
     }

--- a/client/src/components/NewUserWelcome/components/Subtopics.vue
+++ b/client/src/components/NewUserWelcome/components/Subtopics.vue
@@ -14,7 +14,7 @@
                         :alt="subject.alt"
                     ></b-card-img>
                     <b-card-text class="font-weight-light">{{ subject.intro | localize }}</b-card-text>
-                    <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{
+                    <b-button class="mt-auto" variant="info" @click="$emit('select', idx)">{{
                         subject.title | localize
                     }}</b-button>
                 </b-card>

--- a/client/src/components/NewUserWelcome/components/Subtopics.vue
+++ b/client/src/components/NewUserWelcome/components/Subtopics.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <header class="main-header alert">
+        <header class="main-header">
             <h1 class="text-center my-3">{{ title | localize }}</h1>
-            <span>{{ intro | localize }}</span>
+            <h4 class="text-center my-3">{{ intro | localize }}</h4>
         </header>
         <b-row class="justify-content-md-center mb-3">
             <b-card-group v-for="(subject, idx) in topics" :key="idx">

--- a/client/src/components/NewUserWelcome/components/Subtopics.vue
+++ b/client/src/components/NewUserWelcome/components/Subtopics.vue
@@ -13,7 +13,7 @@
                         :src="imgUrl(subject.image)"
                         :alt="subject.alt"
                     ></b-card-img>
-                    <b-card-text>{{ subject.intro | localize }}</b-card-text>
+                    <b-card-text class="font-weight-light">{{ subject.intro | localize }}</b-card-text>
                     <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{
                         subject.title | localize
                     }}</b-button>

--- a/client/src/components/NewUserWelcome/components/Subtopics.vue
+++ b/client/src/components/NewUserWelcome/components/Subtopics.vue
@@ -6,7 +6,7 @@
         </header>
         <b-row class="justify-content-md-center mb-3">
             <b-card-group v-for="(subject, idx) in topics" :key="idx">
-                <b-card class="text-center m-2" body-class="d-flex flex-column">
+                <b-card class="text-center m-2 border-0" body-class="d-flex flex-column">
                     <b-card-img
                         class="section-header mb-3"
                         height="50h"

--- a/client/src/components/NewUserWelcome/components/Subtopics.vue
+++ b/client/src/components/NewUserWelcome/components/Subtopics.vue
@@ -1,35 +1,29 @@
 <template>
     <div>
-        <b-card class="text-center">
-            <b-card-header>
-                <h1>{{ title | localize }}</h1>
-                <h4>
-                    {{ intro | localize }}
-                </h4>
-            </b-card-header>
-            <b-row class="justify-content-md-center">
-                <b-card-group style="d-flex flex-column" v-for="(subject, idx) in topics" :key="idx">
-                    <b-card class="text-center" body-class="d-flex flex-column" style="width: 15rem">
-                        <b-card-header style="height: 6rem; text-align: center; align-v: bottom">
-                            <h4>
-                                {{ subject.title | localize }}
-                            </h4>
-                        </b-card-header>
-                        <b-card-img
-                            class="section-header"
-                            height="200vh"
-                            :src="imgUrl(subject.image)"
-                            :alt="subject.alt"
-                        ></b-card-img>
-                        <b-card-text>{{ subject.intro | localize }}</b-card-text>
-                        <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">Learn more</b-button>
-                    </b-card>
-                </b-card-group>
-            </b-row>
-            <b-card-footer>
-                <b-button class="mt-auto" variant="primary" @click="$emit('back')">Return</b-button>
-            </b-card-footer>
-        </b-card>
+        <header class="main-header alert">
+            <h1 class="text-center my-3">{{ title | localize }}</h1>
+            <span>{{ intro | localize }}</span>
+        </header>
+        <b-row class="justify-content-md-center mb-3">
+            <b-card-group v-for="(subject, idx) in topics" :key="idx">
+                <b-card class="text-center m-2" body-class="d-flex flex-column">
+                    <b-card-img
+                        class="section-header mb-3"
+                        height="50h"
+                        :src="imgUrl(subject.image)"
+                        :alt="subject.alt"
+                    ></b-card-img>
+                    <b-card-text>{{ subject.intro | localize }}</b-card-text>
+                    <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{
+                        subject.title | localize
+                    }}</b-button>
+                </b-card>
+            </b-card-group>
+        </b-row>
+        <b-button class="mt-auto" variant="primary" role="link" @click="$emit('back')">
+            <span class="fa fa-caret-left mr-1" />
+            <span>Return</span>
+        </b-button>
     </div>
 </template>
 <script>
@@ -52,3 +46,8 @@ export default {
     },
 };
 </script>
+<style scoped>
+.card {
+    width: 15rem;
+}
+</style>

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -13,7 +13,7 @@
                         :src="imgUrl(subject.image)"
                         :alt="subject.alt"
                     ></b-card-img>
-                    <b-card-text>{{ subject.blurb | localize }}</b-card-text>
+                    <b-card-text class="font-weight-light">{{ subject.blurb | localize }}</b-card-text>
                     <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{
                         subject.title | localize
                     }}</b-button>

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -1,17 +1,10 @@
 <template>
-    <div class="user-welcome-topics">
+    <div>
         <header class="main-header alert alert-info">
-            <h1 class="text-center my-3">{{ "Welcome to Galaxy" | localize }}</h1>
-            <span>
-                {{
-                    "Galaxy is web-based platform for reproducible computational analysis. Research in Galaxy \
-                is supported by 3 pillars: data, tools, and workflows. For an introduction to each, visit the \
-                below pages, or begin your analysis by selting a tool from the toolbar to the left."
-                        | localize
-                }}
-            </span>
+            <h1 class="text-center my-3">{{ title | localize }}</h1>
+            <span>{{ intro | localize }}</span>
         </header>
-        <b-row class="justify-content-md-center">
+        <b-row class="justify-content-md-center mb-3">
             <b-card-group v-for="(subject, idx) in topics" :key="idx">
                 <b-card class="text-center m-2" body-class="d-flex flex-column">
                     <b-card-img
@@ -33,8 +26,26 @@
 import { getAppRoot } from "onload/loadConfig";
 export default {
     props: {
-        topics: { type: Array, required: true },
-        imageLoc: { type: String, required: false, default: "plugins/welcome_page/new_user/dist/static/topics/" },
+        topics: {
+            type: Array,
+            required: true,
+        },
+        imageLoc: {
+            type: String,
+            required: false,
+            default: "plugins/welcome_page/new_user/dist/static/topics/",
+        },
+        title: {
+            type: String,
+            default: "Welcome to Galaxy",
+        },
+        intro: {
+            type: String,
+            default:
+                "Galaxy is web-based platform for reproducible computational analysis. Research in Galaxy \
+                is supported by 3 pillars: data, tools, and workflows. For an introduction to each, visit the \
+                below pages, or begin your analysis by selting a tool from the toolbar to the left.",
+        },
     },
     methods: {
         imgUrl(src) {

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -6,7 +6,7 @@
         </header>
         <b-row class="justify-content-md-center mb-3">
             <b-card-group v-for="(subject, idx) in topics" :key="idx">
-                <b-card class="text-center m-2" body-class="d-flex flex-column">
+                <b-card class="text-center m-2 border-0" body-class="d-flex flex-column">
                     <b-card-img
                         class="section-header mb-3"
                         height="50h"

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -13,7 +13,7 @@
         </header>
         <b-row class="justify-content-md-center">
             <b-card-group v-for="(subject, idx) in topics" :key="idx">
-                <b-card class="text-center border-0" body-class="d-flex flex-column">
+                <b-card class="text-center m-2" body-class="d-flex flex-column">
                     <b-card-img
                         class="section-header mb-3"
                         height="50h"
@@ -43,3 +43,8 @@ export default {
     },
 };
 </script>
+<style scoped>
+    .card {
+        width: 15rem;
+    }
+</style>

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <header class="main-header alert alert-info">
+        <header class="main-header">
             <h1 class="text-center my-3">{{ title | localize }}</h1>
-            <span>{{ intro | localize }}</span>
+            <h4 class="text-center my-3">{{ intro | localize }}</h4>
         </header>
         <b-row class="justify-content-md-center mb-3">
             <b-card-group v-for="(subject, idx) in topics" :key="idx">

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -21,7 +21,9 @@
                         :alt="subject.alt"
                     ></b-card-img>
                     <b-card-text>{{ subject.blurb | localize }}</b-card-text>
-                    <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{ subject.title | localize }}</b-button>
+                    <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{
+                        subject.title | localize
+                    }}</b-button>
                 </b-card>
             </b-card-group>
         </b-row>
@@ -44,7 +46,7 @@ export default {
 };
 </script>
 <style scoped>
-    .card {
-        width: 15rem;
-    }
+.card {
+    width: 15rem;
+}
 </style>

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -1,7 +1,7 @@
 <template>
-    <div>
-        <header class="main-header text-center">
-            <h1>{{ "Welcome to Galaxy" | localize }}</h1>
+    <div class="user-welcome-topics">
+        <header class="main-header alert alert-info">
+            <h1 class="text-center my-3">{{ "Welcome to Galaxy" | localize }}</h1>
             <span>
                 {{
                     "Galaxy is web-based platform for reproducible computational analysis. Research in Galaxy \
@@ -11,30 +11,20 @@
                 }}
             </span>
         </header>
-        <b-card class="text-center">
-            <b-card-header>
-                <h1>{{ "Get to Know Galaxy" | localize }}</h1>
-            </b-card-header>
-            <b-row class="justify-content-md-center">
-                <b-card-group v-for="(subject, idx) in topics" :key="idx">
-                    <b-card class="text-center" body-class="d-flex flex-column" style="width: 18rem">
-                        <b-card-header class="text-center">
-                            <h3>
-                                {{ subject.title | localize }}
-                            </h3>
-                        </b-card-header>
-                        <b-card-img
-                            class="section-header"
-                            height="200vh"
-                            :src="imgUrl(subject.image)"
-                            :alt="subject.alt"
-                        ></b-card-img>
-                        <b-card-text>{{ subject.blurb | localize }}</b-card-text>
-                        <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">Learn more</b-button>
-                    </b-card>
-                </b-card-group>
-            </b-row>
-        </b-card>
+        <b-row class="justify-content-md-center">
+            <b-card-group v-for="(subject, idx) in topics" :key="idx">
+                <b-card class="text-center border-0" body-class="d-flex flex-column">
+                    <b-card-img
+                        class="section-header mb-3"
+                        height="50h"
+                        :src="imgUrl(subject.image)"
+                        :alt="subject.alt"
+                    ></b-card-img>
+                    <b-card-text>{{ subject.blurb | localize }}</b-card-text>
+                    <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{ subject.title | localize }}</b-button>
+                </b-card>
+            </b-card-group>
+        </b-row>
     </div>
 </template>
 <script>

--- a/client/src/components/NewUserWelcome/components/Topics.vue
+++ b/client/src/components/NewUserWelcome/components/Topics.vue
@@ -14,7 +14,7 @@
                         :alt="subject.alt"
                     ></b-card-img>
                     <b-card-text class="font-weight-light">{{ subject.blurb | localize }}</b-card-text>
-                    <b-button class="mt-auto" variant="primary" @click="$emit('select', idx)">{{
+                    <b-button class="mt-auto" variant="info" @click="$emit('select', idx)">{{
                         subject.title | localize
                     }}</b-button>
                 </b-card>


### PR DESCRIPTION
The new user welcome page helps new users to get started with Galaxy. The welcome page is configurable as plugin and can be easily populated with new content, thanks to @astrovsky01. This PR makes adjusts the rendering components of the welcome page by aligning the appearance to the existing Galaxy theming. It also consolidates the `topics` and `subtopics` component which are essential equivalent.

<img width="1515" alt="image" src="https://user-images.githubusercontent.com/2105447/136587346-8142acc1-e6ef-4a61-b535-ee9b50b2bd1e.png">


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
