### PR TITLE
[21.01] Disable text input for unselected inputs

### DIFF
--- a/templates/webapps/galaxy/workflow/build_from_current_history.mako
+++ b/templates/webapps/galaxy/workflow/build_from_current_history.mako
@@ -33,10 +33,12 @@
     $(function() {
         $("#checkall").click( function() {
             $("input[type=checkbox]").attr( 'checked', true );
+            $(".as-named-input").prop( 'disabled', false );
             return false;
         }).show();
         $("#uncheckall").click( function() {
             $("input[type=checkbox]").attr( 'checked', false );
+            $(".as-named-input").prop( 'disabled', true );
             return false;
         }).show();
     });
@@ -62,7 +64,8 @@
                     </div>
                     %if disabled:
                         <input type="checkbox" id="as-input-${ encoded_id }" class="as-input"
-                               name="${data.history_content_type}_ids" value="${data.hid}" checked="true" />
+                               name="${data.history_content_type}_ids" value="${data.hid}" checked="true"
+                               onclick="document.getElementById('as-named-input-${ encoded_id }').disabled = !document.getElementById('as-input-${ encoded_id }').checked" />
                         <label for="as-input-${ encoded_id }" >${_('Treat as input dataset')}</label>
                         <input type="text" id="as-named-input-${ encoded_id }" class="as-named-input"
                                name="${data.history_content_type}_names" value="${data.display_name() | h}" />


### PR DESCRIPTION
This means they won't be included in the submitted form.
Since we just pick the index of a selected dataset name in `extract_steps`, this would lead to the wrong input dataset label in the workflow editor. Fixes the first issue in https://github.com/galaxyproject/galaxy/issues/12590

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Follow #12590

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
