### PR TITLE
[21.09] Fix ambiguity in remote file upload

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.test.js
+++ b/client/src/components/FilesDialog/FilesDialog.test.js
@@ -5,10 +5,8 @@ import { shallowMount, createLocalVue } from "@vue/test-utils";
 import flushPromises from "flush-promises";
 import { BButton } from "bootstrap-vue";
 import MockAdapter from "axios-mock-adapter";
-import Vue from "vue";
 import axios from "axios";
 import BootstrapVue from "bootstrap-vue";
-import SelectionDialogMixin from "components/SelectionDialog/SelectionDialogMixin";
 
 import {
     rootId,
@@ -117,7 +115,7 @@ describe("FilesDialog, file mode", () => {
         // assert that OK button is active
         expect(wrapper.vm.hasValue).toBe(true);
 
-        //    unselect each file
+        // unselect each file
         applyForEachFile((file) => utils.clickOn(file));
 
         // assert that OK button is disabled
@@ -219,11 +217,9 @@ describe("FilesDialog, directory mode", () => {
     });
 
     it("should select folders", async () => {
-        // console.log(wrapper.html());
         const btn = wrapper.find("#ok-btn");
 
         expect(btn.attributes().disabled).toBe("disabled");
-        // const okBtn = buttons.find((btn) => btn.getAttribute("id") === "ok-btn");
         await utils.open_root_folder(false);
         const folder = utils.getRenderedDirectory(directoryId);
         await utils.getTable().$emit("open", folder);

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -36,7 +36,7 @@
                 class="float-right ml-1 file-dialog-modal-ok"
                 variant="primary"
                 @click="finalize"
-                :disabled="!hasValue"
+                :disabled="!hasValue || isBusy"
             >
                 Ok
             </b-btn>

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -34,7 +34,8 @@
                 size="sm"
                 class="float-right ml-1 file-dialog-modal-ok"
                 variant="primary"
-                @click="fileMode ? finalize : selectDirectory(currentDirectory)"
+                id="ok-btn"
+                @click="fileMode ? finalize : selectLeaf(currentDirectory)"
                 :disabled="(fileMode && !hasValue) || isBusy || (!fileMode && urlTracker.atRoot())"
             >
                 {{ fileMode ? "Ok" : "Select this folder" }}
@@ -54,6 +55,7 @@ import { Model } from "./model";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretLeft } from "@fortawesome/free-solid-svg-icons";
+
 
 library.add(faCaretLeft);
 export default {
@@ -141,7 +143,7 @@ export default {
             }
             if (record.isLeaf) {
                 // record is file
-                this.selectFile(record);
+                this.selectLeaf(record);
             } else {
                 // record is directory
                 // you cannot select entire root directory
@@ -173,7 +175,7 @@ export default {
                 this.model.unselectUnderPath(path);
             }
         },
-        selectFile(file, selectOnly = false) {
+        selectLeaf(file, selectOnly = false) {
             const selected = this.model.exists(file.id);
             if (selected) {
                 this.unselectPath(file.url, true);
@@ -208,7 +210,7 @@ export default {
                         const sub_record = this.parseItemFileMode(item);
                         if (sub_record.isLeaf) {
                             // select file under this path
-                            this.selectFile(sub_record, true);
+                            this.selectLeaf(sub_record, true);
                         } else {
                             // select subdirectory
                             this.selectedDirectories.push(sub_record);

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -18,7 +18,6 @@
                 :show-select-icon="undoShow && multiple"
                 :show-details="showDetails"
                 :show-time="showTime"
-                :show-navigate="showNavigate"
                 :is-busy="isBusy"
                 @clicked="clicked"
                 @open="open"
@@ -90,7 +89,6 @@ export default {
             hasValue: false,
             showTime: true,
             showDetails: true,
-            showNavigate: true,
             isBusy: false,
             currentDirectory: undefined,
             selectAllIcon: selectionStates.unselected,

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -30,14 +30,14 @@
                 Back
             </b-btn>
             <b-btn
-                v-if="multiple"
+                v-if="multiple || !fileMode"
                 size="sm"
                 class="float-right ml-1 file-dialog-modal-ok"
                 variant="primary"
-                @click="finalize"
-                :disabled="!hasValue || isBusy"
+                @click="fileMode ? finalize : selectDirectory(currentDirectory)"
+                :disabled="(fileMode && !hasValue) || isBusy || (!fileMode && urlTracker.atRoot())"
             >
-                Ok
+                {{ fileMode ? "Ok" : "Select this folder" }}
             </b-btn>
         </template>
     </selection-dialog>
@@ -135,7 +135,11 @@ export default {
         },
         /** Collects selected datasets in value array **/
         clicked: function (record) {
-            if (record.isLeaf || !this.fileMode) {
+            // ignore the click during directory mode
+            if (!this.fileMode) {
+                return;
+            }
+            if (record.isLeaf) {
                 // record is file
                 this.selectFile(record);
             } else {
@@ -222,7 +226,12 @@ export default {
         },
         /** Called when selection is complete, values are formatted and parsed to external callback **/
         finalize: function () {
-            const results = this.model.finalize();
+            let results;
+            if (this.fileMode) {
+                results = this.model.finalize();
+            } else {
+                results = this.currentDirectory.url;
+            }
             this.modalShow = false;
             this.callback(results);
         },

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -35,7 +35,7 @@
                 class="float-right ml-1 file-dialog-modal-ok"
                 variant="primary"
                 id="ok-btn"
-                @click="fileMode ? finalize : selectLeaf(currentDirectory)"
+                @click="fileMode ? finalize() : selectLeaf(currentDirectory)"
                 :disabled="(fileMode && !hasValue) || isBusy || (!fileMode && urlTracker.atRoot())"
             >
                 {{ fileMode ? "Ok" : "Select this folder" }}
@@ -227,12 +227,7 @@ export default {
         },
         /** Called when selection is complete, values are formatted and parsed to external callback **/
         finalize: function () {
-            let results;
-            if (this.fileMode) {
-                results = this.model.finalize();
-            } else {
-                results = this.currentDirectory.url;
-            }
+            const results = this.model.finalize();
             this.modalShow = false;
             this.callback(results);
         },

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -56,7 +56,6 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faCaretLeft } from "@fortawesome/free-solid-svg-icons";
 
-
 library.add(faCaretLeft);
 export default {
     mixins: [SelectionDialogMixin],

--- a/client/src/components/SelectionDialog/DataDialogTable.vue
+++ b/client/src/components/SelectionDialog/DataDialogTable.vue
@@ -36,7 +36,9 @@
                         </div>
                         <div @click.stop="open(data.item)" v-else>
                             <font-awesome-icon icon="folder" />
-                            <b-link :title="`label-${data.item.labelTitle}`">{{ data.value ? data.value : "-" }}</b-link>
+                            <b-link :title="`label-${data.item.labelTitle}`">{{
+                                data.value ? data.value : "-"
+                            }}</b-link>
                         </div>
                     </span>
                 </div>
@@ -68,19 +70,18 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
-import { faCheckSquare, faSquare, faCaretSquareRight, faMinusSquare } from "@fortawesome/free-regular-svg-icons";
+import { faCheckSquare, faSquare, faMinusSquare } from "@fortawesome/free-regular-svg-icons";
 import { faFolder } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { selectionStates } from "components/SelectionDialog/selectionStates";
 
 Vue.use(BootstrapVue);
-library.add(faCheckSquare, faSquare, faFolder, faCaretSquareRight, faMinusSquare);
+library.add(faCheckSquare, faSquare, faFolder, faMinusSquare);
 
 const LABEL_FIELD = { key: "label", sortable: true };
 const DETAILS_FIELD = { key: "details", sortable: true };
 const TIME_FIELD = { key: "time", sortable: true };
-const NAVIGATE_FIELD = { key: "navigate", label: "", sortable: false };
 const SELECT_ICON_FIELD = { key: "select_icon", label: "", sortable: false };
 
 export default {

--- a/client/src/components/SelectionDialog/DataDialogTable.vue
+++ b/client/src/components/SelectionDialog/DataDialogTable.vue
@@ -27,17 +27,22 @@
                 <div style="cursor: pointer">
                     <pre
                         v-if="isEncoded"
-                        :title="data.item.labelTitle"
+                        :title="`label-${data.item.labelTitle}`"
                     ><code>{{ data.value ? data.value : "-" }}</code></pre>
                     <span v-else>
-                        <i v-if="data.item.isLeaf" :class="leafIcon" />
-                        <font-awesome-icon v-else icon="folder" />
-                        <span :title="data.item.labelTitle">{{ data.value ? data.value : "-" }}</span>
+                        <div v-if="data.item.isLeaf">
+                            <i :class="leafIcon" />
+                            <span :title="`label-${data.item.labelTitle}`">{{ data.value ? data.value : "-" }}</span>
+                        </div>
+                        <div @click.stop="open(data.item)" v-else>
+                            <font-awesome-icon icon="folder" />
+                            <b-link :title="`label-${data.item.labelTitle}`">{{ data.value ? data.value : "-" }}</b-link>
+                        </div>
                     </span>
                 </div>
             </template>
             <template v-slot:cell(details)="data">
-                {{ data.value ? data.value : "-" }}
+                <span :title="`details-${data.item.labelTitle}`">{{ data.value ? data.value : "-" }}</span>
             </template>
             <template v-slot:cell(time)="data">
                 {{ data.value ? data.value : "-" }}
@@ -55,7 +60,13 @@
             </div>
             <div v-else>No entries.</div>
         </div>
-        <b-pagination v-if="nItems > perPage" v-model="currentPage" :per-page="perPage" :total-rows="nItems" />
+        <b-pagination
+            class="justify-content-md-center"
+            v-if="nItems > perPage"
+            v-model="currentPage"
+            :per-page="perPage"
+            :total-rows="nItems"
+        />
     </div>
 </template>
 

--- a/client/src/components/SelectionDialog/DataDialogTable.vue
+++ b/client/src/components/SelectionDialog/DataDialogTable.vue
@@ -47,11 +47,6 @@
             <template v-slot:cell(time)="data">
                 {{ data.value ? data.value : "-" }}
             </template>
-            <template v-slot:cell(navigate)="data">
-                <b-button variant="light" size="sm" v-if="!data.item.isLeaf" @click.stop="open(data.item)">
-                    <font-awesome-icon :icon="['far', 'caret-square-right']" />
-                </b-button>
-            </template>
         </b-table>
         <div v-if="nItems === 0">
             <div v-if="filter">
@@ -121,10 +116,6 @@ export default {
             type: Boolean,
             default: true,
         },
-        showNavigate: {
-            type: Boolean,
-            default: false,
-        },
         showSelectIcon: {
             type: Boolean,
             default: false,
@@ -165,9 +156,6 @@ export default {
             }
             if (this.showTime) {
                 fields.push(TIME_FIELD);
-            }
-            if (this.showNavigate) {
-                fields.push(NAVIGATE_FIELD);
             }
 
             return fields;

--- a/client/src/components/SelectionDialog/DataDialogTable.vue
+++ b/client/src/components/SelectionDialog/DataDialogTable.vue
@@ -50,6 +50,11 @@
                 {{ data.value ? data.value : "-" }}
             </template>
         </b-table>
+        <div class="text-center" v-if="isBusy">
+            <b-spinner small type="grow"></b-spinner>
+            <b-spinner small type="grow"></b-spinner>
+            <b-spinner small type="grow"></b-spinner>
+        </div>
         <div v-if="nItems === 0">
             <div v-if="filter">
                 No search results found for: <b>{{ this.filter }}</b

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -407,8 +407,10 @@ histories:
 
 files_dialog:
   selectors:
-    ftp_row: 'span[title="gxftp://"]'
-    row: 'span[title="${uri}"]'
+    ftp_label: 'a[title="label-gxftp://"]'
+    ftp_details: 'span[title="details-gxftp://"]'
+    row: 'span[title="label-${uri}"]'
+    back_btn: '#back-btn'
 
 history_export:
   selectors:

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -46,7 +46,6 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
         files_dialog.back_btn.wait_for_and_click()
         files_dialog.ftp_details.wait_for_and_click()
 
-
         history_export.name_input.wait_for_and_send_keys("my_export.tar.gz")
         history_export.export_button.wait_for_and_click()
 

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -39,7 +39,14 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
         history_export.tab_export_to_file.wait_for_and_click()
         history_export.export_link.wait_for_absent_or_hidden()
         history_export.directory_input.wait_for_and_click()
-        files_dialog.ftp_row.wait_for_and_click()
+
+        # test opening folder by clicking on its name
+        files_dialog.ftp_label.wait_for_and_click()
+        # navigate back
+        files_dialog.back_btn.wait_for_and_click()
+        files_dialog.ftp_details.wait_for_and_click()
+
+
         history_export.name_input.wait_for_and_send_keys("my_export.tar.gz")
         history_export.export_button.wait_for_and_click()
 
@@ -51,7 +58,7 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
         gx_selenium_context.components.histories.import_button.wait_for_and_click()
         history_import = gx_selenium_context.components.history_import
         history_import.radio_button_remote_files.wait_for_and_click()
-        files_dialog.ftp_row.wait_for_and_click()
+        files_dialog.ftp_label.wait_for_and_click()
         files_dialog.row(uri="gxftp://my_export.tar.gz").wait_for_and_click()
 
         history_import.import_button.wait_for_and_click()

--- a/test/integration_selenium/test_history_import_export_ftp.py
+++ b/test/integration_selenium/test_history_import_export_ftp.py
@@ -40,11 +40,9 @@ class HistoryImportExportFtpSeleniumIntegrationTestCase(SeleniumIntegrationTestC
         history_export.export_link.wait_for_absent_or_hidden()
         history_export.directory_input.wait_for_and_click()
 
-        # test opening folder by clicking on its name
+        # open directory by clicking on its name
         files_dialog.ftp_label.wait_for_and_click()
-        # navigate back
-        files_dialog.back_btn.wait_for_and_click()
-        files_dialog.ftp_details.wait_for_and_click()
+        self.components.upload.file_dialog_ok.wait_for_and_click()
 
         history_export.name_input.wait_for_and_send_keys("my_export.tar.gz")
         history_export.export_button.wait_for_and_click()


### PR DESCRIPTION
 https://github.com/galaxyproject/galaxy/issues/12635

improvements:
Open the folder on title click
Add a spinner on table busy state
Removed the _open folder_ button
Add "select this folder" btn when "directory" mode is set
Add test for opening folder with a name 


![data-dialog](https://user-images.githubusercontent.com/15801412/136049793-6b3a156b-eb19-4794-b918-37f8d5c33a4a.gif)
## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
