### PR TITLE
Fix how beta history panel decides when downloads are available.

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -60,23 +60,12 @@
                 </b-dropdown-item>
 
                 <b-dropdown-item
-                    v-if="!dataset.purged && dataset.getUrl('download')"
+                    v-if="showDownloads && dataset.getUrl('download')"
                     title="Copy Link"
                     @click.stop="$emit('copy-link')"
                 >
                     <Icon icon="link" class="mr-1" />
                     <span v-localize>Copy Link</span>
-                </b-dropdown-item>
-
-                <b-dropdown-item
-                    v-if="!(showDownloads && dataset.hasMetaData)"
-                    title="Download"
-                    :href="prependPath(dataset.getUrl('download'))"
-                    target="_blank"
-                    download
-                >
-                    <Icon icon="download" class="mr-1" />
-                    <span v-localize>Download</span>
                 </b-dropdown-item>
 
                 <b-dropdown-group v-if="showDownloads && dataset.hasMetaData">
@@ -92,6 +81,17 @@
                         <span v-localize>{{ "Download " + mf.file_type }}</span>
                     </b-dropdown-item>
                 </b-dropdown-group>
+
+                <b-dropdown-item
+                    v-else-if="showDownloads"
+                    title="Download"
+                    :href="prependPath(dataset.getUrl('download'))"
+                    target="_blank"
+                    download
+                >
+                    <Icon icon="download" class="mr-1" />
+                    <span v-localize>Download</span>
+                </b-dropdown-item>
 
                 <b-dropdown-item
                     v-if="dataset.rerunnable && dataset.creating_job && notIn(STATES.UPLOAD, STATES.NOT_VIEWABLE)"


### PR DESCRIPTION
I think respects what I would assume the intention of ``showDownloads`` is more clearly?

Before this fix, I'm pretty sure a purged dataset or a discarded dataset would have a download link and after this commit - I think that link appropriately goes away.

This is the basis for some tests and such around ensuring discarded and deferred datasets do not have a download dataset button in #12533.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Do that manual test around discarded or purged datasets as I described above.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
