### PR TITLE
[WIP] Fixes and enhancements for test_history_dataset_state.py.

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -8,7 +8,7 @@
                 :disabled="dataset.purged || isIn(STATES.UPLOAD, STATES.NEW)"
                 @click.stop="viewData"
                 variant="link"
-                class="px-1"
+                class="px-1 display-btn"
             />
             <IconButton
                 v-if="writable && notIn(STATES.DISCARDED)"
@@ -17,7 +17,7 @@
                 :disabled="dataset.deleted || isIn(STATES.UPLOAD, STATES.NEW)"
                 @click.stop="backboneRoute('datasets/edit', { dataset_id: dataset.id })"
                 variant="link"
-                class="px-1"
+                class="px-1 edit-btn"
             />
             <IconButton
                 v-if="writable && dataset.accessible"
@@ -26,7 +26,7 @@
                 :disabled="dataset.purged"
                 v-b-modal="bsId('delete-modal')"
                 variant="link"
-                class="px-1"
+                class="px-1 delete-btn"
                 @click.stop
             />
 
@@ -36,7 +36,7 @@
                 variant="link"
                 :text="'Dataset Operations' | l"
                 toggle-class="p-1 pl-2"
-                class="flex-grow-0"
+                class="flex-grow-0 dataset-operations-dropdown"
                 v-if="expanded"
                 boundary="window"
             >
@@ -87,6 +87,7 @@
                     title="Download"
                     :href="prependPath(dataset.getUrl('download'))"
                     target="_blank"
+                    class="download-btn"
                     download
                 >
                     <Icon icon="download" class="mr-1" />
@@ -129,6 +130,7 @@
                     v-if="notIn(STATES.NOT_VIEWABLE)"
                     key="dataset-details"
                     title="View Dataset Details"
+                    class="params-btn"
                     @click.stop.prevent="showDetails"
                 >
                     <Icon icon="info-circle" class="mr-1" />

--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -60,23 +60,12 @@
                 </b-dropdown-item>
 
                 <b-dropdown-item
-                    v-if="!dataset.purged && dataset.getUrl('download')"
+                    v-if="showDownloads && dataset.getUrl('download')"
                     title="Copy Link"
                     @click.stop="$emit('copy-link')"
                 >
                     <Icon icon="link" class="mr-1" />
                     <span v-localize>Copy Link</span>
-                </b-dropdown-item>
-
-                <b-dropdown-item
-                    v-if="!(showDownloads && dataset.hasMetaData)"
-                    title="Download"
-                    :href="prependPath(dataset.getUrl('download'))"
-                    target="_blank"
-                    download
-                >
-                    <Icon icon="download" class="mr-1" />
-                    <span v-localize>Download</span>
                 </b-dropdown-item>
 
                 <b-dropdown-group v-if="showDownloads && dataset.hasMetaData">
@@ -92,6 +81,17 @@
                         <span v-localize>{{ "Download " + mf.file_type }}</span>
                     </b-dropdown-item>
                 </b-dropdown-group>
+
+                <b-dropdown-item
+                    v-else-if="showDownloads"
+                    title="Download"
+                    :href="prependPath(dataset.getUrl('download'))"
+                    target="_blank"
+                    download
+                >
+                    <Icon icon="download" class="mr-1" />
+                    <span v-localize>Download</span>
+                </b-dropdown-item>
 
                 <b-dropdown-item
                     v-if="dataset.rerunnable && dataset.creating_job && notIn(STATES.UPLOAD, STATES.NOT_VIEWABLE)"

--- a/client/src/components/History/ContentItem/Dataset/Summary/Ok.vue
+++ b/client/src/components/History/ContentItem/Dataset/Summary/Ok.vue
@@ -11,8 +11,8 @@
             <label class="prompt" v-localize>database</label>
             <span class="value">{{ props.dataset.metadata_dbkey }}</span>
         </div>
-        <div v-if="props.dataset.misc_info">
-            <span>{{ props.dataset.misc_info }}</span>
+        <div v-if="props.dataset.misc_info" class="info">
+            <span class="value">{{ props.dataset.misc_info }}</span>
         </div>
     </div>
 </template>

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1461,6 +1461,17 @@ class NavigatesGalaxy(HasDriver):
         dataset_selector = next_level_element_selector.descendant(".dataset")
         self.wait_for_and_click(dataset_selector)
 
+    def history_panel_item_view_dataset_details(self, hid):
+        if not self.is_beta_history():
+            self.history_panel_ensure_showing_item_details(hid)
+            self.hda_click_details(hid)
+            self.components.dataset_details._.wait_for_visible()
+        else:
+            item = self.history_panel_item_component(hid=hid)
+            item.dataset_operations_dropdown.wait_for_and_click()
+            item.info_button.wait_for_and_click()
+            self.components.dataset_details._.wait_for_visible()
+
     def history_panel_item_click_visualization_menu(self, hid):
         viz_button_selector = f"{self.history_panel_item_selector(hid)} .visualizations-dropdown"
         self.wait_for_and_click_selector(viz_button_selector)

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -127,9 +127,6 @@ history_panel:
       hid: '${_} .hid'
       name: '${_} .name'
       details: '${_} .details'
-      title_button_area: '${_} .primary-actions'
-      primary_action_buttons: '${_} .actions .left'
-      secondary_action_buttons: '${_} .actions .right'
       summary: '${_} .summary'
       blurb: '${_} .blurb .value'
       dbkey: '${_} .dbkey .value'
@@ -138,15 +135,14 @@ history_panel:
       toolhelp_title: '${_} .toolhelp strong'
 
       # Title buttons...
-      display_button: '${_} .icon-btn.display-btn'
-      edit_button: '${_} .icon-btn.edit-btn'
-      delete_button: '${_} .icon-btn.delete-btn'
+      display_button: '${_} .display-btn'
+      edit_button: '${_} .edit-btn'
+      delete_button: '${_} .delete-btn'
 
       # Action buttons...
       download_button: '${_} .icon-btn.download-btn'
       info_button: '${_} .icon-btn.params-btn'
       dbkey_button: '${_} .fa.fa-question'
-      rerun_button: '${_} .icon-btn.rerun-btn'
       nametags: '${_} .nametags .badge-tags'
 
   # beta content item
@@ -160,9 +156,6 @@ history_panel:
 
       hid: '${_} .hid'
       name: '${_} .name'
-      title_button_area: '${_} .primary-actions'
-      primary_action_buttons: '${_} .actions .left'
-      secondary_action_buttons: '${_} .actions .right'
       blurb: '${_} .blurb .value'
       dbkey: '${_} .dbkey .value'
       info: '${_} .info .value'
@@ -170,16 +163,17 @@ history_panel:
       toolhelp_title: '${_} .toolhelp strong'
 
       # Title buttons...
-      display_button: '${_} .icon-btn.display-btn'
-      edit_button: '${_} .icon-btn.edit-btn'
-      delete_button: '${_} .icon-btn.delete-btn'
+      display_button: '${_} .display-btn'
+      edit_button: '${_} .edit-btn'
+      delete_button: '${_} .delete-btn'
 
       # Action buttons...
-      download_button: '${_} .icon-btn.download-btn'
-      info_button: '${_} .icon-btn.params-btn'
+      download_button: '${_} .download-btn'
+      info_button: '${_} .params-btn'
       dbkey_button: '${_} .fa.fa-question'
-      rerun_button: '${_} .icon-btn.rerun-btn'
       nametags: '${_} .nametags .badge-tags'
+
+      dataset_operations_dropdown: '${_}  .dataset-operations-dropdown'
 
   # re-usable history editor, scoped for use in different layout scenarios (multi, etc.)
   editor:

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -14,54 +14,67 @@ BUTTON_TOOLTIPS = {
 }
 EXPECTED_TOOLHELP_TITLE_TEXT = 'Tool help for Upload File'
 TEST_DBKEY_TEXT = 'Honeybee (Apis mellifera): apiMel3 (apiMel3)'
+FIRST_HID = 1
 
 
 class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
-    hid = 1
+    ensure_registered = True
 
     @selenium_test
-    def test_dataset_state(self, hid=hid):
-        item = self._prepare_dataset(self.hid)
-        self.history_panel_item_body_component(hid, wait=True)
+    def test_dataset_state(self):
+        item = self._prepare_dataset()
+        self.history_panel_item_body_component(FIRST_HID, wait=True)
 
-        self.assert_item_summary_includes(hid, "1 sequence")
-        self.assert_item_dbkey_displayed_as(hid, "?")
-        self.assert_item_info_includes(hid, 'uploaded fasta file')
-        self.assert_item_peek_includes(hid, ">hg17")
+        self.assert_item_summary_includes(FIRST_HID, "1 sequence")
+        if not self.is_beta_history():
+            # it doesn't seem like we display the dbkey in the beta history panel?
+            self.assert_item_dbkey_displayed_as(FIRST_HID, "?")
+        self.assert_item_info_includes(FIRST_HID, 'uploaded fasta file')
+        self.assert_item_peek_includes(FIRST_HID, ">hg17")
 
-        item.dbkey_button.wait_for_and_click()
-        toolhelp_title_text = item.toolhelp_title.wait_for_visible().text
-        # assert tool helptext
-        assert EXPECTED_TOOLHELP_TITLE_TEXT == toolhelp_title_text, "Toolhelp title [{}] was not expected text [{}].".format(
-            EXPECTED_TOOLHELP_TITLE_TEXT, toolhelp_title_text)
+        self.screenshot("history_panel_dataset_before_click_dbkey")
+
+        if not self.is_beta_history():
+            # is this a problem???
+            item.dbkey_button.wait_for_and_click()
+
+        if not self.is_beta_history():
+            # need to redo tooltip stuff for beta history panel...
+            toolhelp_title_text = item.toolhelp_title.wait_for_visible().text
+            # assert tool helptext
+            assert EXPECTED_TOOLHELP_TITLE_TEXT == toolhelp_title_text, "Toolhelp title [{}] was not expected text [{}].".format(
+                EXPECTED_TOOLHELP_TITLE_TEXT, toolhelp_title_text)
 
         self.screenshot("history_panel_dataset_expanded")
 
-        self._assert_action_buttons(hid)
+        self._assert_action_buttons(FIRST_HID)
+        self._assert_downloadable(FIRST_HID)
+        self.history_panel_item_view_dataset_details(FIRST_HID)
+        self.screenshot("dataset_details_ok")
 
     @selenium_test
-    def test_dataset_change_dbkey(self, hid=hid):
-        item = self._prepare_dataset(hid)
-        self.assert_item_dbkey_displayed_as(hid, "?")
+    def test_dataset_change_dbkey(self):
+        item = self._prepare_dataset()
+        self.assert_item_dbkey_displayed_as(FIRST_HID, "?")
         item.dbkey.wait_for_and_click()
         self.components.edit_dataset_attributes.database_build_dropdown.wait_for_and_click()
         # choose database option from 'Database/Build' dropdown, that equals to dbkey_text
         self.components.edit_dataset_attributes.dbkey_dropdown_results.dbkey_dropdown_option(
             dbkey_text=TEST_DBKEY_TEXT).wait_for_and_click()
         self.components.edit_dataset_attributes.save_btn.wait_for_and_click()
-        self.history_panel_wait_for_hid_ok(hid)
-        self.assert_item_dbkey_displayed_as(hid, "apiMel3")
+        self.history_panel_wait_for_hid_ok(FIRST_HID)
+        self.assert_item_dbkey_displayed_as(FIRST_HID, "apiMel3")
 
-    def _prepare_dataset(self, hid):
-        self.register()
+    def _prepare_dataset(self):
+        self.history_panel_create_new()
         self.perform_upload(self.get_filename("1.fasta"))
-        self.history_panel_wait_for_hid_ok(hid)
-        self.assert_item_name(hid, "1.fasta")
-        self.assert_item_hid_text(hid)
-        self._assert_title_buttons(hid)
+        self.history_panel_wait_for_hid_ok(FIRST_HID)
+        self.assert_item_name(FIRST_HID, "1.fasta")
+        self.assert_item_hid_text(FIRST_HID)
+        self._assert_title_buttons(FIRST_HID)
 
         # Expand HDA and wait for details to show up.
-        return self.history_panel_click_item_title(hid=hid, wait=True)
+        return self.history_panel_click_item_title(hid=FIRST_HID, wait=True)
 
     def _assert_title_buttons(self, hid, expected_buttons=None):
         if expected_buttons is None:
@@ -73,6 +86,26 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
             expected_buttons = ["info", "download"]
         self._assert_buttons(hid, expected_buttons)
 
+    def _assert_downloadable(self, hid, is_downloadable=True):
+        if not self.is_beta_history():
+            item = self.history_panel_item_component(hid=hid)
+            if is_downloadable:
+                assert item.download_button.is_displayed
+            else:
+                item.download_button.assert_absent_or_hidden()
+        else:
+            item = self.history_panel_item_component(hid=hid)
+            item.dataset_operations_dropdown.wait_for_and_click()
+            item.info_button.wait_for_visible()
+            if is_downloadable:
+                assert item.download_button.is_displayed
+            else:
+                item.download_button.assert_absent_or_hidden()
+
+            # close menu...
+            item.dataset_operations_dropdown.wait_for_and_click()
+            self.sleep_for(self.wait_types.UX_RENDER)
+
     def _assert_buttons(self, hid, expected_buttons):
         item_button = self.history_panel_item_component(hid=hid)
         for i, expected_button in enumerate(expected_buttons):
@@ -80,10 +113,12 @@ class HistoryDatasetStateTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
             # ensure old tooltip expired,
             # no tooltip appeared before the 1st element
             if i > 0:
-                previous_button = item_button[f"{expected_buttons[i - 1]}_button"].wait_for_visible()
-                if previous_button.get_attribute("aria-describedby") is not None:
-                    # wait for tooltip to disappear
-                    self.components._.tooltip_balloon.wait_for_absent()
+                if not self.is_beta_history():
+                    previous_button = item_button[f"{expected_buttons[i - 1]}_button"].wait_for_visible()
+                    if previous_button.get_attribute("aria-describedby") is not None:
+                        # wait for tooltip to disappear
+                        self.components._.tooltip_balloon.wait_for_absent()
 
             button = item_button[f"{expected_button}_button"]
-            self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_button])
+            if not self.is_beta_history():
+                self.assert_tooltip_text(button.wait_for_visible(), BUTTON_TOOLTIPS[expected_button])


### PR DESCRIPTION
A big problem is this wasn't actually testing against the beta history panel in the beta history panel mode because of the registering a new user for each test method. I've reduced the number of user registrations required and I've started to fix up things toward getting it to work with the beta history panel. Not everything is working with the new beta history panel so there are some conditionals just skipping test assertions - but overall we are better with some beta history panel tests than none.

In light of down stream work on the dataset details component and newer dataset states, I've also added some more test assertion hooks to do some basic testing of the dataset details component within this context. These newer screenshots work for both history panels.

Builds on bug fix #12642

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
