### PR TITLE
Typing fixes for various unit tests.

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -27,6 +27,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Type,
     TYPE_CHECKING,
     Union,
 )
@@ -144,6 +145,7 @@ AUTO_PROPAGATED_TAGS = ["name"]
 if TYPE_CHECKING:
     class _HasTable:
         table: Table
+        __table__: Table
 else:
     _HasTable = object
 
@@ -5126,7 +5128,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, Serializable):
         hda_attributes: Optional[Iterable[str]] = None,
         dataset_attributes: Optional[Iterable[str]] = None,
         dataset_permission_attributes: Optional[Iterable[str]] = None,
-        return_entities: Optional[Iterable[Union[HistoryDatasetAssociation, Dataset, DatasetPermissions, 'DatasetCollectionElement']]] = None,
+        return_entities: Optional[Iterable[Union[Type[HistoryDatasetAssociation], Type[Dataset], Type[DatasetPermissions], Type['DatasetCollection'], Type['DatasetCollectionElement']]]] = None,
         inner_filter: Optional[InnerCollectionFilter] = None
     ):
         collection_attributes = collection_attributes or ()

--- a/lib/galaxy/tool_util/output_checker.py
+++ b/lib/galaxy/tool_util/output_checker.py
@@ -1,17 +1,18 @@
 import re
+from enum import Enum
 from logging import getLogger
 
 from galaxy.tool_util.parser.stdio import StdioErrorLevel
 from galaxy.util import unicodify
-from galaxy.util.bunch import Bunch
 
 log = getLogger(__name__)
 
-DETECTED_JOB_STATE = Bunch(
-    OK='ok',
-    OUT_OF_MEMORY_ERROR='oom_error',
-    GENERIC_ERROR='generic_error',
-)
+
+class DETECTED_JOB_STATE(str, Enum):
+    OK = 'ok'
+    OUT_OF_MEMORY_ERROR = 'oom_error'
+    GENERIC_ERROR = 'generic_error'
+
 
 ERROR_PEEK_SIZE = 2000
 

--- a/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
+++ b/test/unit/data/datatypes/dataproviders/test_base_dataproviders.py
@@ -354,7 +354,7 @@ class Test_MultiSourceDataProvider(BaseTestCase):
             """
         ]
         contents = [clean_multiline_string(c) for c in contents]
-        source_list = [open(self.tmpfiles.create_tmpfile(c)) for c in contents]
+        source_list_f = [open(self.tmpfiles.create_tmpfile(c)) for c in contents]
 
         def no_Fs(string):
             return None if string.startswith('F') else string
@@ -363,9 +363,9 @@ class Test_MultiSourceDataProvider(BaseTestCase):
             return None if ('youtu.be' in string) else string
 
         source_list = [
-            base.LimitedOffsetDataProvider(source_list[0], filter_fn=no_Fs, limit=2, offset=1),
-            base.LimitedOffsetDataProvider(source_list[1], limit=1, offset=3),
-            base.FilteredDataProvider(source_list[2], filter_fn=no_youtube),
+            base.LimitedOffsetDataProvider(source_list_f[0], filter_fn=no_Fs, limit=2, offset=1),
+            base.LimitedOffsetDataProvider(source_list_f[1], limit=1, offset=3),
+            base.FilteredDataProvider(source_list_f[2], filter_fn=no_youtube),
         ]
         provider = self.provider_class(source_list)
         log.debug('provider: %s', provider)

--- a/test/unit/data/datatypes/util.py
+++ b/test/unit/data/datatypes/util.py
@@ -2,21 +2,33 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
+from typing import Optional
 
 from galaxy.datatypes.sniff import get_test_fname
-from galaxy.util.bunch import Bunch
 from galaxy.util.hash_util import md5_hash_file
+
+
+class MockMetadata:
+    file_name: Optional[str] = None
+
+
+class MockDataset:
+    file_name: Optional[str] = None
+
+    def __init__(self, id):
+        self.id = id
+        self.metadata = MockMetadata()
+
+    def has_data(self):
+        return True
 
 
 @contextmanager
 def get_dataset(filename, index_attr='bam_index', dataset_id=1, has_data=True):
-    dataset = Bunch()
-    dataset.has_data = lambda: True
-    dataset.id = dataset_id
-    dataset.metadata = Bunch()
+    dataset = MockDataset(dataset_id)
     with get_input_files(filename) as input_files, get_tmp_path() as index_path:
         dataset.file_name = input_files[0]
-        index = Bunch()
+        index = MockMetadata()
         index.file_name = index_path
         setattr(dataset.metadata, index_attr, index)
         yield dataset

--- a/test/unit/data/model/test_model_store.py
+++ b/test/unit/data/model/test_model_store.py
@@ -494,7 +494,7 @@ def _mock_app(store_by="id"):
     app = GalaxyDataTestApp()
     test_object_store_config = TestConfig(store_by=store_by)
     app.object_store = test_object_store_config.object_store
-    app.model.Dataset.object_store = app.object_store
+    app.model.Dataset.object_store = app.object_store  # type: ignore
     return app
 
 

--- a/test/unit/data/model/test_test_mapping.py
+++ b/test/unit/data/model/test_test_mapping.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import registry, Session
 
+from galaxy.model import _HasTable
 from . test_mapping import (
     are_same_entity_collections,
     dbcleanup,
@@ -187,14 +188,14 @@ mapper_registry = registry()
 
 
 @mapper_registry.mapped
-class Foo:
+class Foo(_HasTable):
     __tablename__ = 'foo'
     id = Column(Integer, primary_key=True)
     field1 = Column(Integer)
 
 
 @mapper_registry.mapped
-class Bar:
+class Bar(_HasTable):
     __tablename__ = 'bar'
     id = Column(Integer, primary_key=True)
     field1 = Column(Integer)

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -4,6 +4,7 @@ import random
 import unittest
 import uuid
 from tempfile import NamedTemporaryFile
+from typing import List
 
 import pytest
 from sqlalchemy import inspect, select
@@ -11,6 +12,7 @@ from sqlalchemy import inspect, select
 import galaxy.datatypes.registry
 import galaxy.model
 import galaxy.model.mapping as mapping
+from galaxy import model
 from galaxy.model.database_utils import create_database
 from galaxy.model.metadata import MetadataTempFile
 from galaxy.model.security import GalaxyRBACAgent
@@ -29,6 +31,7 @@ skip_if_not_postgres_base = pytest.mark.skipif(
 
 
 class BaseModelTestCase(unittest.TestCase):
+    model: mapping.GalaxyModelMapping
 
     @classmethod
     def _db_uri(cls):
@@ -69,8 +72,6 @@ class BaseModelTestCase(unittest.TestCase):
 class MappingTests(BaseModelTestCase):
 
     def test_annotations(self):
-        model = self.model
-
         u = model.User(email="annotator@example.com", password="password")
         self.persist(u)
 
@@ -104,7 +105,7 @@ class MappingTests(BaseModelTestCase):
         self.persist(h)
         persist_and_check_annotation(model.HistoryAnnotationAssociation, history=h)
 
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(d1)
         persist_and_check_annotation(model.HistoryDatasetAssociationAnnotationAssociation, hda=d1)
 
@@ -128,8 +129,6 @@ class MappingTests(BaseModelTestCase):
         persist_and_check_annotation(model.LibraryDatasetCollectionAnnotationAssociation, library_dataset_collection=library_dataset_collection)
 
     def test_ratings(self):
-        model = self.model
-
         user_email = "rater@example.com"
         u = model.User(email=user_email, password="password")
         self.persist(u)
@@ -152,7 +151,7 @@ class MappingTests(BaseModelTestCase):
         self.persist(h)
         persist_and_check_rating(model.HistoryRatingAssociation, h)
 
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(d1)
         persist_and_check_rating(model.HistoryDatasetAssociationRatingAssociation, d1)
 
@@ -181,22 +180,22 @@ class MappingTests(BaseModelTestCase):
             assert isinstance(item.get_display_name(), str)
             assert item.get_display_name() == name
 
-        ldda = self.model.LibraryDatasetDatasetAssociation(name='ldda_name')
+        ldda = model.LibraryDatasetDatasetAssociation(name='ldda_name')
         assert_display_name_converts_to_unicode(ldda, 'ldda_name')
 
-        hda = self.model.HistoryDatasetAssociation(name='hda_name')
+        hda = model.HistoryDatasetAssociation(name='hda_name')
         assert_display_name_converts_to_unicode(hda, 'hda_name')
 
-        history = self.model.History(name='history_name')
+        history = model.History(name='history_name')
         assert_display_name_converts_to_unicode(history, 'history_name')
 
-        library = self.model.Library(name='library_name')
+        library = model.Library(name='library_name')
         assert_display_name_converts_to_unicode(library, 'library_name')
 
-        library_folder = self.model.LibraryFolder(name='library_folder')
+        library_folder = model.LibraryFolder(name='library_folder')
         assert_display_name_converts_to_unicode(library_folder, 'library_folder')
 
-        history = self.model.History(
+        history = model.History(
             name='Hello₩◎ґʟⅾ'
         )
 
@@ -205,11 +204,11 @@ class MappingTests(BaseModelTestCase):
         assert history.get_display_name() == 'Hello₩◎ґʟⅾ'
 
     def test_hda_to_library_dataset_dataset_association(self):
-        u = self.model.User(email="mary@example.com", password="password")
-        hda = self.model.HistoryDatasetAssociation(name='hda_name')
+        u = model.User(email="mary@example.com", password="password")
+        hda = model.HistoryDatasetAssociation(name='hda_name')
         self.persist(hda)
         trans = collections.namedtuple('trans', 'user')
-        target_folder = self.model.LibraryFolder(name='library_folder')
+        target_folder = model.LibraryFolder(name='library_folder')
         ldda = hda.to_library_dataset_dataset_association(
             trans=trans(user=u),
             target_folder=target_folder,
@@ -235,7 +234,6 @@ class MappingTests(BaseModelTestCase):
         assert target_folder.item_count == 1
 
     def test_tags(self):
-        model = self.model
         TAG_NAME = 'Test Tag'
         my_tag = model.Tag(name=TAG_NAME)
         u = model.User(email="tagger@example.com", password="password")
@@ -244,14 +242,14 @@ class MappingTests(BaseModelTestCase):
         def tag_and_test(taggable_object, tag_association_class):
             q = select(tag_association_class).join(model.Tag).where(model.Tag.name == TAG_NAME)
 
-            assert len(model.session.execute(q).all()) == 0
+            assert len(self.model.session.execute(q).all()) == 0
 
             tag_association = tag_association_class()
             tag_association.tag = my_tag
             taggable_object.tags = [tag_association]
             self.persist(tag_association, taggable_object)
 
-            assert len(model.session.execute(q).all()) == 1
+            assert len(self.model.session.execute(q).all()) == 1
 
         sw = model.StoredWorkflow(user=u)
         tag_and_test(sw, model.StoredWorkflowTagAssociation)
@@ -259,7 +257,7 @@ class MappingTests(BaseModelTestCase):
         h = model.History(name="History for Tagging", user=u)
         tag_and_test(h, model.HistoryTagAssociation)
 
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         tag_and_test(d1, model.HistoryDatasetAssociationTagAssociation)
 
         page = model.Page(user=u)
@@ -276,61 +274,57 @@ class MappingTests(BaseModelTestCase):
         tag_and_test(library_dataset_collection, model.LibraryDatasetCollectionTagAssociation)
 
     def test_collection_get_interface(self):
-        model = self.model
         u = model.User(email="mary@example.com", password="password")
         h1 = model.History(name="History 1", user=u)
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=self.model.session)
         c1 = model.DatasetCollection(collection_type="list")
         elements = 100
         dces = [model.DatasetCollectionElement(collection=c1, element=d1, element_identifier=f"{i}", element_index=i) for i in range(elements)]
         self.persist(u, h1, d1, c1, *dces, flush=False, expunge=False)
-        model.session.flush()
+        self.model.session.flush()
         for i in range(elements):
             assert c1[i] == dces[i]
 
     def test_dataset_instance_order(self):
-        model = self.model
         u = model.User(email="mary@example.com", password="password")
         h1 = model.History(name="History 1", user=u)
         elements = []
         list_pair = model.DatasetCollection(collection_type="list:paired")
         for i in range(20):
             pair = model.DatasetCollection(collection_type="pair")
-            forward = model.HistoryDatasetAssociation(extension="txt", history=h1, name=f"forward_{i}", create_dataset=True, sa_session=model.session)
-            reverse = model.HistoryDatasetAssociation(extension="bam", history=h1, name=f"reverse_{i}", create_dataset=True, sa_session=model.session)
+            forward = model.HistoryDatasetAssociation(extension="txt", history=h1, name=f"forward_{i}", create_dataset=True, sa_session=self.model.session)
+            reverse = model.HistoryDatasetAssociation(extension="bam", history=h1, name=f"reverse_{i}", create_dataset=True, sa_session=self.model.session)
             dce1 = model.DatasetCollectionElement(collection=pair, element=forward, element_identifier=f"forward_{i}", element_index=1)
             dce2 = model.DatasetCollectionElement(collection=pair, element=reverse, element_identifier=f"reverse_{i}", element_index=2)
             to_persist = [(forward, reverse), (dce1, dce2)]
             self.persist(pair)
-            for item in to_persist:
+            for pair_item in to_persist:
                 if i % 2:
-                    self.persist(item[0])
-                    self.persist(item[1])
+                    self.persist(pair_item[0])
+                    self.persist(pair_item[1])
                 else:
-                    self.persist(item[1])
-                    self.persist(item[0])
+                    self.persist(pair_item[1])
+                    self.persist(pair_item[0])
             elements.append(model.DatasetCollectionElement(collection=list_pair, element=pair, element_index=i, element_identifier=str(i)))
         self.persist(list_pair)
         random.shuffle(elements)
         for item in elements:
             self.persist(item)
-        forward = []
-        reverse = []
+        forward_hdas: List[model.HistoryDatasetAssociation] = []
+        reverse_hdas: List[model.HistoryDatasetAssociation] = []
         for i, dataset_instance in enumerate(list_pair.dataset_instances):
             if i % 2:
-                reverse.append(dataset_instance)
+                reverse_hdas.append(dataset_instance)
             else:
-                forward.append(dataset_instance)
-        assert all(d.name == f"forward_{i}" for i, d in enumerate(forward))
-        assert all(d.name == f"reverse_{i}" for i, d in enumerate(reverse))
+                forward_hdas.append(dataset_instance)
+        assert all(d.name == f"forward_{i}" for i, d in enumerate(forward_hdas))
+        assert all(d.name == f"reverse_{i}" for i, d in enumerate(reverse_hdas))
 
     def test_collections_in_histories(self):
-        model = self.model
-
         u = model.User(email="mary@example.com", password="password")
         h1 = model.History(name="History 1", user=u)
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
-        d2 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=self.model.session)
+        d2 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=self.model.session)
 
         c1 = model.DatasetCollection(collection_type="pair")
         hc1 = model.HistoryDatasetCollectionAssociation(history=h1, collection=c1, name="HistoryCollectionTest1")
@@ -347,8 +341,6 @@ class MappingTests(BaseModelTestCase):
         assert loaded_dataset_collection["right"] == dce2
 
     def test_collections_in_library_folders(self):
-        model = self.model
-
         u = model.User(email="mary2@example.com", password="password")
         lf = model.LibraryFolder(name="RootFolder")
         library = model.Library(name="Library1", root_folder=lf)
@@ -369,10 +361,9 @@ class MappingTests(BaseModelTestCase):
         # assert loaded_dataset_collection.collection_type == "pair"
 
     def test_nested_collection_attributes(self):
-        model = self.model
         u = model.User(email="mary2@example.com", password="password")
         h1 = model.History(name="History 1", user=u)
-        d1 = model.HistoryDatasetAssociation(extension="bam", history=h1, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="bam", history=h1, create_dataset=True, sa_session=self.model.session)
         index = NamedTemporaryFile("w")
         index.write("cool bam index")
         index2 = NamedTemporaryFile("w")
@@ -383,7 +374,7 @@ class MappingTests(BaseModelTestCase):
         assert d1.metadata.bam_csi_index
         assert isinstance(d1.metadata.bam_index, model.MetadataFile)
         assert isinstance(d1.metadata.bam_csi_index, model.MetadataFile)
-        d2 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
+        d2 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=self.model.session)
         c1 = model.DatasetCollection(collection_type='paired')
         dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
         dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
@@ -392,12 +383,12 @@ class MappingTests(BaseModelTestCase):
         c3 = model.DatasetCollection(collection_type="list:list")
         c4 = model.DatasetCollection(collection_type="list:list:paired")
         dce4 = model.DatasetCollectionElement(collection=c4, element=c2, element_identifier="outer_list", element_index=0)
-        model.session.add_all([d1, d2, c1, dce1, dce2, c2, dce3, c3, c4, dce4])
-        model.session.flush()
+        self.model.session.add_all([d1, d2, c1, dce1, dce2, c2, dce3, c3, c4, dce4])
+        self.model.session.flush()
         q = c2._get_nested_collection_attributes(element_attributes=('element_identifier',), hda_attributes=('extension',), dataset_attributes=('state',))
         assert [(r.keys()) for r in q] == [['element_identifier_0', 'element_identifier_1', 'extension', 'state'], ['element_identifier_0', 'element_identifier_1', 'extension', 'state']]
         assert q.all() == [('inner_list', 'forward', 'bam', 'new'), ('inner_list', 'reverse', 'txt', 'new')]
-        q = c2._get_nested_collection_attributes(return_entities=(model.HistoryDatasetAssociation,))
+        q = c2._get_nested_collection_attributes(return_entities=(model.HistoryDatasetAssociation, ))
         assert q.all() == [d1, d2]
         q = c2._get_nested_collection_attributes(return_entities=(model.HistoryDatasetAssociation, model.Dataset))
         assert q.all() == [(d1, d1.dataset), (d2, d2.dataset)]
@@ -417,74 +408,66 @@ class MappingTests(BaseModelTestCase):
         assert c4.element_identifiers_extensions_and_paths == [(('outer_list', 'inner_list', 'forward'), 'bam', 'mock_dataset_14.dat'), (('outer_list', 'inner_list', 'reverse'), 'txt', 'mock_dataset_14.dat')]
 
     def test_dataset_dbkeys_and_extensions_summary(self):
-        model = self.model
         u = model.User(email="mary2@example.com", password="password")
         h1 = model.History(name="History 1", user=u)
-        d1 = model.HistoryDatasetAssociation(extension="bam", dbkey="hg19", history=h1, create_dataset=True, sa_session=model.session)
-        d2 = model.HistoryDatasetAssociation(extension="txt", dbkey="hg19", history=h1, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="bam", dbkey="hg19", history=h1, create_dataset=True, sa_session=self.model.session)
+        d2 = model.HistoryDatasetAssociation(extension="txt", dbkey="hg19", history=h1, create_dataset=True, sa_session=self.model.session)
         c1 = model.DatasetCollection(collection_type='paired')
         dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
         dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
         hdca = model.HistoryDatasetCollectionAssociation(collection=c1, history=h1)
-        model.session.add_all([d1, d2, c1, dce1, dce2, hdca])
-        model.session.flush()
+        self.model.session.add_all([d1, d2, c1, dce1, dce2, hdca])
+        self.model.session.flush()
         assert hdca.dataset_dbkeys_and_extensions_summary[0] == {"hg19"}
         assert hdca.dataset_dbkeys_and_extensions_summary[1] == {"bam", "txt"}
 
     def test_populated_optimized_ok(self):
-        model = self.model
         u = model.User(email="mary2@example.com", password="password")
         h1 = model.History(name="History 1", user=u)
-        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
-        d2 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=self.model.session)
+        d2 = model.HistoryDatasetAssociation(extension="txt", history=h1, create_dataset=True, sa_session=self.model.session)
         c1 = model.DatasetCollection(collection_type='paired')
         dce1 = model.DatasetCollectionElement(collection=c1, element=d1, element_identifier="forward", element_index=0)
         dce2 = model.DatasetCollectionElement(collection=c1, element=d2, element_identifier="reverse", element_index=1)
-        model.session.add_all([d1, d2, c1, dce1, dce2])
-        model.session.flush()
+        self.model.session.add_all([d1, d2, c1, dce1, dce2])
+        self.model.session.flush()
         assert c1.populated
         assert c1.populated_optimized
 
     def test_populated_optimized_empty_list_list_ok(self):
-        model = self.model
         c1 = model.DatasetCollection(collection_type='list')
         c2 = model.DatasetCollection(collection_type='list:list')
         dce1 = model.DatasetCollectionElement(collection=c2, element=c1, element_identifier="empty_list", element_index=0)
-        model.session.add_all([c1, c2, dce1])
-        model.session.flush()
+        self.model.session.add_all([c1, c2, dce1])
+        self.model.session.flush()
         assert c1.populated
         assert c1.populated_optimized
         assert c2.populated
         assert c2.populated_optimized
 
     def test_populated_optimized_list_list_not_populated(self):
-        model = self.model
         c1 = model.DatasetCollection(collection_type='list')
         c1.populated_state = False
         c2 = model.DatasetCollection(collection_type='list:list')
         dce1 = model.DatasetCollectionElement(collection=c2, element=c1, element_identifier="empty_list", element_index=0)
-        model.session.add_all([c1, c2, dce1])
-        model.session.flush()
+        self.model.session.add_all([c1, c2, dce1])
+        self.model.session.flush()
         assert not c1.populated
         assert not c1.populated_optimized
         assert not c2.populated
         assert not c2.populated_optimized
 
     def test_default_disk_usage(self):
-        model = self.model
-
         u = model.User(email="disk_default@test.com", password="password")
         self.persist(u)
         u.adjust_total_disk_usage(1)
         u_id = u.id
         self.expunge()
-        user_reload = model.session.query(model.User).get(u_id)
+        user_reload = self.model.session.query(model.User).get(u_id)
         assert user_reload.disk_usage == 1
 
     def test_basic(self):
-        model = self.model
-
-        original_user_count = len(model.session.query(model.User).all())
+        original_user_count = len(self.model.session.query(model.User).all())
 
         # Make some changes and commit them
         u = model.User(email="james@foo.bar.baz", password="password")
@@ -496,20 +479,20 @@ class MappingTests(BaseModelTestCase):
         self.persist(u, h1, h2)
         # q1 = model.Query( "h2->q1" )
         metadata = dict(chromCol=1, startCol=2, endCol=3)
-        d1 = model.HistoryDatasetAssociation(extension="interval", metadata=metadata, history=h2, create_dataset=True, sa_session=model.session)
+        d1 = model.HistoryDatasetAssociation(extension="interval", metadata=metadata, history=h2, create_dataset=True, sa_session=self.model.session)
         # h2.queries.append( q1 )
         # h2.queries.append( model.Query( "h2->q2" ) )
         self.persist(d1)
 
         # Check
-        users = model.session.query(model.User).all()
+        users = self.model.session.query(model.User).all()
         assert len(users) == original_user_count + 1
         user = [user for user in users if user.email == "james@foo.bar.baz"][0]
         assert user.email == "james@foo.bar.baz"
         assert user.password == "password"
         assert len(user.histories) == 1
         assert user.histories[0].name == "History 1"
-        hists = model.session.query(model.History).all()
+        hists = self.model.session.query(model.History).all()
         hist0 = [history for history in hists if history.name == "History 1"][0]
         hist1 = [history for history in hists if history.name == "H" * 255][0]
         assert hist0.name == "History 1"
@@ -523,7 +506,7 @@ class MappingTests(BaseModelTestCase):
         # Do an update and check
         hist1.name = "History 2b"
         self.expunge()
-        hists = model.session.query(model.History).all()
+        hists = self.model.session.query(model.History).all()
         hist0 = [history for history in hists if history.name == "History 1"][0]
         hist1 = [history for history in hists if history.name == "History 2b"][0]
         assert hist0.name == "History 1"
@@ -532,22 +515,20 @@ class MappingTests(BaseModelTestCase):
 
     def test_metadata_spec(self):
         metadata = dict(chromCol=1, startCol=2, endCol=3)
-        d = self.model.HistoryDatasetAssociation(extension="interval", metadata=metadata, sa_session=self.model.session)
+        d = model.HistoryDatasetAssociation(extension="interval", metadata=metadata, sa_session=self.model.session)
         assert d.metadata.chromCol == 1
         assert d.metadata.anyAttribute is None
         assert 'items' not in d.metadata
 
     def test_dataset_job_relationship(self):
-        model = self.model
         dataset = model.Dataset()
         job = model.Job()
         dataset.job = job
         self.persist(job, dataset)
-        loaded_dataset = model.session.query(model.Dataset).filter(model.Dataset.id == dataset.id).one()
+        loaded_dataset = self.model.session.query(model.Dataset).filter(model.Dataset.id == dataset.id).one()
         assert loaded_dataset.job_id == job.id
 
     def test_jobs(self):
-        model = self.model
         u = model.User(email="jobtest@foo.bar.baz", password="password")
         job = model.Job()
         job.user = u
@@ -555,11 +536,10 @@ class MappingTests(BaseModelTestCase):
 
         self.persist(u, job)
 
-        loaded_job = model.session.query(model.Job).filter(model.Job.user == u).first()
+        loaded_job = self.model.session.query(model.Job).filter(model.Job.user == u).first()
         assert loaded_job.tool_id == "cat1"
 
     def test_job_metrics(self):
-        model = self.model
         u = model.User(email="jobtest@foo.bar.baz", password="password")
         job = model.Job()
         job.user = u
@@ -581,18 +561,16 @@ class MappingTests(BaseModelTestCase):
         assert len(task.text_metrics[1].metric_value) <= 1023
 
     def test_tasks(self):
-        model = self.model
         u = model.User(email="jobtest@foo.bar.baz", password="password")
         job = model.Job()
         task = model.Task(job=job, working_directory="/tmp", prepare_files_cmd="split.sh")
         job.user = u
         self.persist(u, job, task)
 
-        loaded_task = model.session.query(model.Task).filter(model.Task.job == job).first()
+        loaded_task = self.model.session.query(model.Task).filter(model.Task.job == job).first()
         assert loaded_task.prepare_input_files_cmd == "split.sh"
 
     def test_history_contents(self):
-        model = self.model
         u = model.User(email="contents@foo.bar.baz", password="password")
         # gs = model.GalaxySession()
         h1 = model.History(name="HistoryContentsHistory1", user=u)
@@ -607,7 +585,7 @@ class MappingTests(BaseModelTestCase):
         self.session().flush()
 
         def contents_iter_names(**kwds):
-            history = model.context.query(model.History).filter(
+            history = self.model.context.query(model.History).filter(
                 model.History.name == "HistoryContentsHistory1"
             ).first()
             return list(map(lambda hda: hda.name, history.contents_iter(**kwds)))
@@ -624,7 +602,6 @@ class MappingTests(BaseModelTestCase):
         assert contents_iter_names(ids=[d1.id, d3.id]) == ["1", "3"]
 
     def test_history_audit(self):
-        model = self.model
         u = model.User(email="contents@foo.bar.baz", password="password")
         h1 = model.History(name="HistoryAuditHistory", user=u)
         h2 = model.History(name="HistoryAuditHistory", user=u)
@@ -664,7 +641,6 @@ class MappingTests(BaseModelTestCase):
         assert h2_audits[0] == h2_latest
 
     def _non_empty_flush(self):
-        model = self.model
         lf = model.LibraryFolder(name="RootFolder")
         session = self.session()
         session.add(lf)
@@ -745,7 +721,6 @@ class MappingTests(BaseModelTestCase):
         assert 'id' not in inspect(galaxy_model_object_new).unloaded
 
     def test_workflows(self):
-        model = self.model
         user = model.User(
             email="testworkflows@bx.psu.edu",
             password="password"
@@ -847,13 +822,13 @@ class MappingTests(BaseModelTestCase):
         security_agent = GalaxyRBACAgent(self.model)
 
         def check_private_role(private_role, email):
-            assert private_role.type == self.model.Role.types.PRIVATE
+            assert private_role.type == model.Role.types.PRIVATE
             assert len(private_role.users) == 1
             assert private_role.name == email
             assert private_role.description == "Private Role for " + email
 
         email = "rule_user_1@example.com"
-        u = self.model.User(email=email, password="password")
+        u = model.User(email=email, password="password")
         self.persist(u)
 
         role = security_agent.get_private_user_role(u)
@@ -863,7 +838,7 @@ class MappingTests(BaseModelTestCase):
         check_private_role(role, email)
 
         email = "rule_user_2@example.com"
-        u = self.model.User(email=email, password="password")
+        u = model.User(email=email, password="password")
         self.persist(u)
         role = security_agent.get_private_user_role(u)
         assert role is None
@@ -881,8 +856,8 @@ class MappingTests(BaseModelTestCase):
 
         u_from, u_to, u_other = self._three_users("private_share_role")
 
-        h = self.model.History(name="History for Annotation", user=u_from)
-        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        h = model.History(name="History for Annotation", user=u_from)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(h, d1)
 
         security_agent.privately_share_dataset(d1.dataset, [u_to])
@@ -893,8 +868,8 @@ class MappingTests(BaseModelTestCase):
         security_agent = GalaxyRBACAgent(self.model)
         u_from, u_to, u_other = self._three_users("make_dataset_public")
 
-        h = self.model.History(name="History for Annotation", user=u_from)
-        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        h = model.History(name="History for Annotation", user=u_from)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(h, d1)
 
         security_agent.privately_share_dataset(d1.dataset, [u_to])
@@ -907,8 +882,8 @@ class MappingTests(BaseModelTestCase):
         security_agent = GalaxyRBACAgent(self.model)
         u_from, _, u_other = self._three_users("set_all_perms")
 
-        h = self.model.History(name="History for Annotation", user=u_from)
-        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        h = model.History(name="History for Annotation", user=u_from)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(h, d1)
 
         role = security_agent.get_private_user_role(u_from, auto_create=True)
@@ -924,8 +899,8 @@ class MappingTests(BaseModelTestCase):
         security_agent = GalaxyRBACAgent(self.model)
         u_from, u_to, u_other = self._three_users("can_manage_dataset")
 
-        h = self.model.History(name="History for Prevent Sharing", user=u_from)
-        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        h = model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(h, d1)
 
         self._make_owned(security_agent, u_from, d1)
@@ -937,8 +912,8 @@ class MappingTests(BaseModelTestCase):
         security_agent = GalaxyRBACAgent(self.model)
         u_from, _, u_other = self._three_users("can_manage_dataset_ps")
 
-        h = self.model.History(name="History for Prevent Sharing", user=u_from)
-        d1 = self.model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
+        h = model.History(name="History for Prevent Sharing", user=u_from)
+        d1 = model.HistoryDatasetAssociation(extension="txt", history=h, create_dataset=True, sa_session=self.model.session)
         self.persist(h, d1)
 
         self._make_private(security_agent, u_from, d1)
@@ -950,9 +925,9 @@ class MappingTests(BaseModelTestCase):
         email_to = f"user_{suffix}e2@example.com"
         email_other = f"user_{suffix}e3@example.com"
 
-        u_from = self.model.User(email=email_from, password="password")
-        u_to = self.model.User(email=email_to, password="password")
-        u_other = self.model.User(email=email_other, password="password")
+        u_from = model.User(email=email_from, password="password")
+        u_to = model.User(email=email_to, password="password")
+        u_other = model.User(email=email_other, password="password")
         self.persist(u_from, u_to, u_other)
         return u_from, u_to, u_other
 
@@ -970,7 +945,7 @@ class MappingTests(BaseModelTestCase):
         security_agent.set_all_dataset_permissions(hda.dataset, permissions)
 
     def new_hda(self, history, **kwds):
-        return history.add_dataset(self.model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds))
+        return history.add_dataset(model.HistoryDatasetAssociation(create_dataset=True, sa_session=self.model.session, **kwds))
 
 
 @skip_if_not_postgres_base
@@ -980,6 +955,7 @@ class PostgresMappingTests(MappingTests):
     def _db_uri(cls):
         base = os.environ.get("GALAXY_TEST_UNIT_MAPPING_URI_POSTGRES_BASE")
         dbname = "gxtest" + str(uuid.uuid4())
+        assert base
         postgres_url = base + dbname
         create_database(postgres_url)
         return postgres_url

--- a/test/unit/data/test_model_copy.py
+++ b/test/unit/data/test_model_copy.py
@@ -5,6 +5,11 @@ import threading
 import galaxy.datatypes.registry
 import galaxy.model
 import galaxy.model.mapping as mapping
+from galaxy.model import (
+    History,
+    HistoryDatasetAssociation,
+    User,
+)
 from galaxy.model.metadata import MetadataTempFile
 from galaxy.objectstore.unittest_utils import (
     Config as TestConfig,
@@ -104,15 +109,15 @@ def _setup_mapping_and_user():
         # Start the database and connect the mapping
         model = mapping.init("/tmp", "sqlite:///:memory:", create_tables=True, object_store=object_store, slow_query_log_threshold=SLOW_QUERY_LOG_THRESHOLD, thread_local_log=THREAD_LOCAL_LOG)
 
-        u = model.User(email="historycopy@example.com", password="password")
-        h1 = model.History(name="HistoryCopyHistory1", user=u)
+        u = User(email="historycopy@example.com", password="password")
+        h1 = History(name="HistoryCopyHistory1", user=u)
         model.context.add_all([u, h1])
         model.context.flush()
         yield test_config, object_store, model, h1
 
 
 def _create_hda(model, object_store, history, path, visible=True, include_metadata_file=False):
-    hda = model.HistoryDatasetAssociation(extension="bam", create_dataset=True, sa_session=model.context)
+    hda = HistoryDatasetAssociation(extension="bam", create_dataset=True, sa_session=model.context)
     hda.visible = visible
     model.context.add(hda)
     model.context.flush([hda])

--- a/test/unit/files/test_posix.py
+++ b/test/unit/files/test_posix.py
@@ -380,7 +380,14 @@ def _assert_user_access_granted(file_sources, user_context):
     assert_realizes_as(file_sources, "gxfiles://test1/a", "a\n", user_context=user_context)
 
 
-def _configured_file_sources(include_allowlist=False, plugin_extra_config=None, per_user=False, writable=None, allow_subdir_creation=True):
+class TestConfiguredFileSources(ConfiguredFileSources):
+
+    def __init__(self, file_sources_config: ConfiguredFileSourcesConfig, conf_dict: dict, test_root: str):
+        super().__init__(file_sources_config, conf_dict=conf_dict)
+        self.test_root = test_root
+
+
+def _configured_file_sources(include_allowlist=False, plugin_extra_config=None, per_user=False, writable=None, allow_subdir_creation=True) -> TestConfiguredFileSources:
     tmp, root = _setup_root()
     config_kwd = {}
     if include_allowlist:
@@ -400,8 +407,7 @@ def _configured_file_sources(include_allowlist=False, plugin_extra_config=None, 
         plugin['root'] = root
     plugin.update(plugin_extra_config or {})
     _write_file_fixtures(tmp, root)
-    file_sources = ConfiguredFileSources(file_sources_config, conf_dict={"test1": plugin})
-    file_sources.test_root = root
+    file_sources = TestConfiguredFileSources(file_sources_config, conf_dict={"test1": plugin}, test_root=root)
     return file_sources
 
 

--- a/test/unit/jobs/dynamic_tool_destination/mockGalaxy.py
+++ b/test/unit/jobs/dynamic_tool_destination/mockGalaxy.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from typing import NamedTuple
 
 
 # Job mock and helpers=======================================
@@ -70,20 +70,25 @@ class ToolDependency:
 
 # App mock=======================================================
 class App:
-    def __init__(self, tool_id, params):
+    def __init__(self, tool_id: str, params: str):
         self.job_config = JobConfig(tool_id, params)
+
+
+class Info(NamedTuple):
+    id: str
+    nativeSpec: str
+    runner: str
 
 
 class JobConfig:
     def __init__(self, tool_id, params):
-        self.info = namedtuple('info', ['id', 'nativeSpec', 'runner'])
         self.tool_id = tool_id
         self.nativeSpec = params
         self.default_id = "cluster_default"
         self.defNativeSpec = "-q test.q"
         self.defRunner = "drmaa"
-        self.keys = {tool_id: self.info(self.tool_id, self.nativeSpec, self.defRunner),
-                     "cluster_default": self.info(self.default_id, self.defNativeSpec, self.defRunner), }
+        self.keys = {tool_id: Info(self.tool_id, self.nativeSpec, self.defRunner),
+                     "cluster_default": Info(self.default_id, self.defNativeSpec, self.defRunner), }
 
     def get_destination(self, tool_id):
         invalid_destinations = ["cluster-kow", "destinationf", "thig",
@@ -103,7 +108,8 @@ class JobMappingException(Exception):
 
 
 class JobDestination:
-    def __init__(self, **kwd):
+    def __init__(self, params=None, **kwd):
+        params = params or {}
         self.id = kwd.get('id')
-        self.nativeSpec = kwd.get('params')['nativeSpecification']
+        self.nativeSpec = params['nativeSpecification']
         self.runner = kwd.get('runner')

--- a/test/unit/jobs/test_command_factory.py
+++ b/test/unit/jobs/test_command_factory.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from os import getcwd
 from tempfile import mkdtemp
+from typing import List, Tuple
 from unittest import TestCase
 
 from galaxy.jobs.command_factory import (
@@ -21,7 +22,7 @@ class TestCommandFactory(TestCase):
     def setUp(self):
         self.job_dir = mkdtemp()
         self.job_wrapper = MockJobWrapper(self.job_dir)
-        self.workdir_outputs = []
+        self.workdir_outputs: List[Tuple[str, str]] = []
 
         def workdir_outputs(job_wrapper, **kwds):
             assert job_wrapper == self.job_wrapper

--- a/test/unit/queue_worker/test_database_heartbeat.py
+++ b/test/unit/queue_worker/test_database_heartbeat.py
@@ -67,4 +67,5 @@ def wait_for_assertion(assert_f):
             assertion_error = e
         time.sleep(.2)
 
-    raise assertion_error
+    if assertion_error:
+        raise assertion_error

--- a/test/unit/shed_unit/test_shed_index.py
+++ b/test/unit/shed_unit/test_shed_index.py
@@ -36,8 +36,8 @@ def community_file_dir():
 
 @pytest.fixture()
 def community_file_structure(community_file_dir):
-    cf = namedtuple('community', 'file_path hgweb_config_dir dburi')
-    return cf(
+    community = namedtuple('community', 'file_path hgweb_config_dir dburi')
+    return community(
         file_path=os.path.join(community_file_dir, 'database', 'community_files'),
         hgweb_config_dir=community_file_dir,
         dburi="sqlite:///%s" % os.path.join(community_file_dir, 'database', 'community.sqlite')

--- a/test/unit/shed_unit/test_td_common_util.py
+++ b/test/unit/shed_unit/test_td_common_util.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 from os.path import join
+from typing import Any, Dict
 
 from galaxy.tool_shed.galaxy_install.tool_dependencies.env_manager import EnvManager
 from galaxy.tool_shed.galaxy_install.tool_dependencies.recipe.env_file_builder import EnvFileBuilder
@@ -49,7 +50,7 @@ def test_get_env_shell_file_paths_from_setup_environment_elem():
     action_elem = parse_xml_string(xml)
     required_for_install_env_sh = '/path/to/existing.sh'
     all_env_paths = [required_for_install_env_sh]
-    action_dict = {}
+    action_dict: Dict[str, Any] = {}
     env_manager = EnvManager(mock_app)
 
     r_env_sh = '/path/to/go/env.sh'

--- a/test/unit/test_galaxy_transactions.py
+++ b/test/unit/test_galaxy_transactions.py
@@ -29,6 +29,10 @@ class Transaction(context.ProvidesAppContext):
     def app(self):
         return self._app
 
+    @property
+    def url_builder(self):
+        return None
+
 
 @pytest.fixture
 def transaction():

--- a/test/unit/tool_util/biotools/test_edam_parsing.py
+++ b/test/unit/tool_util/biotools/test_edam_parsing.py
@@ -7,6 +7,7 @@ from ._util import content_dir
 def test_edam_parse_bwa():
     metadata_source = GitContentBiotoolsMetadataSource(content_dir)
     biotools_entry = metadata_source.get_biotools_metadata("bwa")
+    assert biotools_entry
     parsed_edam_info = biotools_entry.edam_info
     assert len(parsed_edam_info.edam_operations) == 4
     assert "operation_3198" in parsed_edam_info.edam_operations

--- a/test/unit/tool_util/test_output_checker.py
+++ b/test/unit/tool_util/test_output_checker.py
@@ -1,17 +1,18 @@
 from unittest import TestCase
+from unittest.mock import Mock
+
 
 from galaxy.tool_util.output_checker import check_output, DETECTED_JOB_STATE
 from galaxy.tool_util.parser.stdio import (
     StdioErrorLevel,
     ToolStdioRegex,
 )
-from galaxy.util.bunch import Bunch
 
 
 class OutputCheckerTestCase(TestCase):
 
     def setUp(self):
-        self.tool = Bunch(
+        self.tool = Mock(
             stdio_regexes=[],
             stdio_exit_codes=[],
         )
@@ -27,26 +28,26 @@ class OutputCheckerTestCase(TestCase):
         self.__assertNotSuccessful()
 
     def test_exit_code_error(self):
-        mock_exit_code = Bunch(range_start=1, range_end=1, error_level=StdioErrorLevel.FATAL, desc=None)
+        mock_exit_code = Mock(range_start=1, range_end=1, error_level=StdioErrorLevel.FATAL, desc=None)
         self.tool.stdio_exit_codes.append(mock_exit_code)
         self.tool_exit_code = 1
         self.__assertNotSuccessful()
 
     def test_exit_code_success(self):
-        mock_exit_code = Bunch(range_start=1, range_end=1, error_level=StdioErrorLevel.FATAL, desc=None)
+        mock_exit_code = Mock(range_start=1, range_end=1, error_level=StdioErrorLevel.FATAL, desc=None)
         self.tool.stdio_exit_codes.append(mock_exit_code)
         self.tool_exit_code = 0
         self.__assertSuccessful()
 
     def test_problematic_strings_matching(self):
         problematic_str = '\x80abc'
-        self.__add_regex(Bunch(match=r'.abc', stdout_match=False, stderr_match=True, error_level=StdioErrorLevel.FATAL, desc=None))
+        self.__add_regex(Mock(match=r'.abc', stdout_match=False, stderr_match=True, error_level=StdioErrorLevel.FATAL, desc=None))
         self.stderr = problematic_str
         self.__assertNotSuccessful()
 
     def test_problematic_strings_not_matching(self):
         problematic_str = '\x80abc'
-        self.__add_regex(Bunch(match=r'.abcd', stdout_match=False, stderr_match=True, error_level=StdioErrorLevel.FATAL, desc=None))
+        self.__add_regex(Mock(match=r'.abcd', stdout_match=False, stderr_match=True, error_level=StdioErrorLevel.FATAL, desc=None))
         self.stderr = problematic_str
         self.__assertSuccessful()
 

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from math import isinf
+from typing import Optional
 
 from galaxy.tool_util.parser.factory import get_tool_source
 from galaxy.util import galaxy_directory
@@ -194,6 +195,8 @@ outputs:
 
 
 class BaseLoaderTestCase(unittest.TestCase):
+    source_file_name: Optional[str] = None
+    source_contents: Optional[str] = None
 
     def setUp(self):
         self.temp_directory = tempfile.mkdtemp()

--- a/test/unit/tool_util/test_util.py
+++ b/test/unit/tool_util/test_util.py
@@ -1,4 +1,5 @@
 from os import environ
+from typing import Dict
 
 import pytest
 
@@ -63,7 +64,7 @@ def test_modify_environ__update_and_restore(load_keyval):
 def test_modify_environ__remove_and_restore(load_keyval):
     key1, val1 = load_keyval()
     key2, val2 = load_keyval('key to remove', 'value to remove')
-    to_update = {}
+    to_update: Dict[str, str] = {}
     to_remove = [key2]
 
     with modify_environ(to_update, to_remove):
@@ -77,7 +78,7 @@ def test_modify_environ__remove_nonexistant_key(load_keyval):
     # Test that removing wrong key does not raise an error
     key1, val1 = load_keyval()
     key_nonexistant = 'no such key'
-    to_update = {}
+    to_update: Dict[str, str] = {}
     to_remove = [key_nonexistant]
 
     assert key_nonexistant not in environ  # ensure key to remove does not exist

--- a/test/unit/tool_util/test_verify.py
+++ b/test/unit/tool_util/test_verify.py
@@ -1,6 +1,7 @@
 import collections
 import gzip
 import tempfile
+from typing import Any, Dict, List, Optional, Tuple, Type
 
 import pytest
 
@@ -20,6 +21,8 @@ F4 = b"A\r\nB\nC"
 MULTILINE_MATCH = b".*"
 TestFile = collections.namedtuple('TestFile', 'value path')
 
+TestDef = Tuple[bytes, bytes, Optional[Dict[str, Any]], Optional[Type[AssertionError]]]
+
 
 def test_file_list():
     files = []
@@ -34,6 +37,7 @@ def test_file_list():
 
 def generate_tests(multiline=False):
     f1, f2, f3, f4, multiline_match, f5 = test_file_list()
+    tests: List[TestDef]
     if multiline:
         tests = [(multiline_match, f1, {'lines_diff': 0, 'sort': True}, None)]
     else:
@@ -50,9 +54,11 @@ def generate_tests(multiline=False):
 def generate_tests_sim_size():
     f1, f2, f3, f4, multiline_match, f5 = test_file_list()
     # tests for equal files
-    tests = [(f1, f1, None, None),  # pass default values
-             (f1, f1, {'delta': 0}, None),  # pass for values that should always pass
-             (f1, f1, {'delta_frac': 0.0}, None)]
+    tests: List[TestDef] = [
+        (f1, f1, None, None),  # pass default values
+        (f1, f1, {'delta': 0}, None),  # pass for values that should always pass
+        (f1, f1, {'delta_frac': 0.0}, None),
+    ]
     # tests for two different file (diff is 422 lines, 0.011709602)
     tests += [(f1, f2, None, None),  # pass default values
              (f1, f2, {'delta': 422}, None),  # test around the actual difference of two different

--- a/test/unit/tool_util/toolbox/test_toolbox_filters.py
+++ b/test/unit/tool_util/toolbox/test_toolbox_filters.py
@@ -50,9 +50,9 @@ def filter_factory(config_dict=None):
             tool_section_filters=["filtermod:filter_section"],
             tool_label_filters=["filtermod:filter_label_1", "filtermod:filter_label_2"],
         )
-    config = Bunch(**config_dict)
     parent_module_name = '.'.join(__name__.split('.')[:-1])
-    config.toolbox_filter_base_modules = f"galaxy.tool_util.toolbox.filters,{parent_module_name}.filter_modules"
+    config_dict["toolbox_filter_base_modules"] = f"galaxy.tool_util.toolbox.filters,{parent_module_name}.filter_modules"
+    config = Bunch(**config_dict)
     app = Bunch(config=config)
     toolbox = Bunch(app=app)
     return FilterFactory(toolbox)

--- a/test/unit/util/test_checkers.py
+++ b/test/unit/util/test_checkers.py
@@ -13,7 +13,7 @@ def test_check_html():
         tmp.flush()
         assert check_html(tmp.name)
     # Test a non-UTF8 binary file
-    with tempfile.NamedTemporaryFile(mode='wb') as tmp:
-        tmp.write(b'\x1f\x8b')
-        tmp.flush()
-        assert not check_html(tmp.name)
+    with tempfile.NamedTemporaryFile(mode='wb') as tmpb:
+        tmpb.write(b'\x1f\x8b')
+        tmpb.flush()
+        assert not check_html(tmpb.name)

--- a/test/unit/util/test_compression_util.py
+++ b/test/unit/util/test_compression_util.py
@@ -45,6 +45,7 @@ class CompressionUtilTestCase(unittest.TestCase):
             shutil.rmtree(temp_dir, ignore_errors=True)
 
     def assert_format_detected(self, path, expected_fmt, allowed_fmts=None):
+        expected_type: type
         for mode in ['r', 'rb', 'rt', 'U']:
             if 'b' in mode:
                 expected_type = bytes

--- a/test/unit/util/test_utils.py
+++ b/test/unit/util/test_utils.py
@@ -1,5 +1,6 @@
 import errno
 import tempfile
+from typing import Dict
 
 import pytest
 
@@ -82,7 +83,7 @@ def test_clean_multiline_string():
 
 
 def test_safe_loads():
-    d = {}
+    d: Dict[str, str] = {}
     rval = safe_loads(d)
     assert rval == d
     assert rval is not d

--- a/test/unit/workflows/test_extract_summary.py
+++ b/test/unit/workflows/test_extract_summary.py
@@ -109,6 +109,7 @@ class TestWorkflowExtractSummary(unittest.TestCase):
 
 
 class MockJobToOutputDatasetAssociation:
+    job = None
 
     def __init__(self, name, dataset):
         self.name = name


### PR DESCRIPTION
My idea for #12637 sort of hit blocker on the fact that unit tests have different paths/package names between root Galaxy and packaged Galaxy but the two versions of the Galaxy codebase share a setup.cfg. So I guess we want to just fix all the unit test typing errors (or at least minimize them) before moving ahead with #12637.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
