### PR TITLE
[21.09] Add property to disable tool form

### DIFF
--- a/client/src/components/Tool/ToolCard.test.js
+++ b/client/src/components/Tool/ToolCard.test.js
@@ -30,6 +30,7 @@ describe("ToolCard", () => {
                 },
                 messageText: "messageText",
                 messageVariant: "warning",
+                disabled: false,
             },
             localVue,
         });
@@ -46,5 +47,8 @@ describe("ToolCard", () => {
         expect(dropdownHeader.attributes("title")).toBe("Options");
         const dropdownItems = wrapper.findAll(".dropdown-item");
         expect(dropdownItems.length).toBe(4);
+        await wrapper.setProps({ disabled: true });
+        const iconSpinner = wrapper.find(".portlet-title-icon");
+        expect(iconSpinner.classes()).toContain("fa-spin");
     });
 });

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -91,6 +91,7 @@
                 <FormMessage :message="errorText" variant="danger" :persistent="true" />
                 <FormMessage :message="messageText" :variant="messageVariant" />
                 <slot name="body" />
+                <div v-if="disabled" class="portlet-backdrop" />
             </div>
         </div>
         <slot name="buttons" />
@@ -154,6 +155,10 @@ export default {
         messageVariant: {
             type: String,
             default: "info",
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
         },
     },
     data() {
@@ -273,3 +278,8 @@ export default {
     },
 };
 </script>
+<style scoped>
+.portlet-backdrop {
+    display: block;
+}
+</style>

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -80,8 +80,8 @@
                     </b-button>
                 </div>
                 <div class="portlet-title">
-                    <font-awesome-icon v-if="disabled" icon="spinner" class="fa-fw mr-1" spin />
-                    <font-awesome-icon v-else icon="wrench" class="fa-fw mr-1" />
+                    <font-awesome-icon v-if="disabled" icon="spinner" class="portlet-title-icon fa-fw mr-1" spin />
+                    <font-awesome-icon v-else icon="wrench" class="portlet-title-icon fa-fw mr-1" />
                     <span class="portlet-title-text">
                         <b itemprop="name">{{ title }}</b> <span itemprop="description">{{ description }}</span> (Galaxy
                         Version {{ version }})

--- a/client/src/components/Tool/ToolCard.vue
+++ b/client/src/components/Tool/ToolCard.vue
@@ -80,7 +80,8 @@
                     </b-button>
                 </div>
                 <div class="portlet-title">
-                    <i class="portlet-title-icon fa mr-1 fa-wrench" style="display: inline"></i>
+                    <font-awesome-icon v-if="disabled" icon="spinner" class="fa-fw mr-1" spin />
+                    <font-awesome-icon v-else icon="wrench" class="fa-fw mr-1" />
                     <span class="portlet-title-text">
                         <b itemprop="name">{{ title }}</b> <span itemprop="description">{{ description }}</span> (Galaxy
                         Version {{ version }})
@@ -116,9 +117,16 @@ import ToolFooter from "components/Tool/ToolFooter";
 import ToolHelp from "components/Tool/ToolHelp";
 import Webhooks from "mvc/webhooks";
 import { addFavorite, removeFavorite } from "components/Tool/services";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faSpinner, faWrench } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faSpinner);
+library.add(faWrench);
 
 export default {
     components: {
+        FontAwesomeIcon,
         FormMessage,
         ToolFooter,
         ToolHelp,

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -229,10 +229,13 @@ export default {
         },
         onUpdate() {
             this.disabled = true;
-            updateToolFormData(this.formConfig.id, this.currentVersion, this.history_id, this.formData).then((data) => {
-                this.formConfig = data;
-                this.disabled = false;
-            });
+            updateToolFormData(this.formConfig.id, this.currentVersion, this.history_id, this.formData)
+                .then((data) => {
+                    this.formConfig = data;
+                })
+                .finally(() => {
+                    this.disabled = false;
+                });
         },
         onChangeVersion(newVersion) {
             this.requestTool(newVersion);
@@ -243,17 +246,20 @@ export default {
         requestTool(newVersion) {
             this.currentVersion = newVersion || this.currentVersion;
             this.disabled = true;
-            return getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id).then((data) => {
-                this.formConfig = data;
-                this.remapAllowed = this.job_id && data.job_remap;
-                this.showLoading = false;
-                this.showForm = true;
-                this.disabled = false;
-                if (newVersion) {
-                    this.messageVariant = "success";
-                    this.messageText = `Now you are using '${data.name}' version ${data.version}, id '${data.id}'.`;
-                }
-            });
+            return getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id)
+                .then((data) => {
+                    this.formConfig = data;
+                    this.remapAllowed = this.job_id && data.job_remap;
+                    this.showLoading = false;
+                    this.showForm = true;
+                    if (newVersion) {
+                        this.messageVariant = "success";
+                        this.messageText = `Now you are using '${data.name}' version ${data.version}, id '${data.id}'.`;
+                    }
+                })
+                .finally(() => {
+                    this.disabled = false;
+                });
         },
         onExecute(config, historyId) {
             if (this.validationInternal) {

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -35,6 +35,7 @@
                         :options="formConfig"
                         :message-text="messageText"
                         :message-variant="messageVariant"
+                        :disabled="disabled || showExecuting"
                         @onChangeVersion="onChangeVersion"
                         @onUpdateFavorites="onUpdateFavorites"
                         itemscope="itemscope"
@@ -137,6 +138,7 @@ export default {
     },
     data() {
         return {
+            disabled: false,
             showLoading: true,
             showForm: false,
             showEntryPoints: false,
@@ -226,8 +228,10 @@ export default {
             }
         },
         onUpdate() {
+            this.disabled = true;
             updateToolFormData(this.formConfig.id, this.currentVersion, this.history_id, this.formData).then((data) => {
                 this.formConfig = data;
+                this.disabled = false;
             });
         },
         onChangeVersion(newVersion) {
@@ -238,11 +242,13 @@ export default {
         },
         requestTool(newVersion) {
             this.currentVersion = newVersion || this.currentVersion;
+            this.disabled = true;
             return getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id).then((data) => {
                 this.formConfig = data;
                 this.remapAllowed = this.job_id && data.job_remap;
                 this.showLoading = false;
                 this.showForm = true;
+                this.disabled = false;
                 if (newVersion) {
                     this.messageVariant = "success";
                     this.messageText = `Now you are using '${data.name}' version ${data.version}, id '${data.id}'.`;

--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -231,7 +231,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
         top: 0px;
         width: 100%;
         height: 100%;
-        opacity: 0.2;
+        opacity: 0.15;
         background: $white;
         cursor: not-allowed;
     }


### PR DESCRIPTION
This resolves #12576. The reason for this issue is that the tool form is waiting for the completion of a server response. The server response contains the new values. If the input element is selected before the server has responded the old value is still displayed in the parameter field.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/2105447/136109164-a4c4940a-a7de-41b7-8acd-57350425ac5c.png">


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
