### PR TITLE
[21.09] Move node update requests to workflow component

### DIFF
--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -27,7 +27,6 @@
             </b-button>
         </template>
         <template v-slot:body>
-            <FormMessage :message="errorText" variant="danger" :persistent="true" />
             <FormElement
                 id="__label"
                 :value="node.label"
@@ -54,7 +53,6 @@ import FormDisplay from "components/Form/FormDisplay";
 import FormCard from "components/Form/FormCard";
 import FormElement from "components/Form/FormElement";
 import FormMessage from "components/Form/FormMessage";
-import { getModule } from "components/Workflow/Editor/modules/services";
 import { checkLabels } from "components/Workflow/Editor/modules/utilities";
 import WorkflowIcons from "components/Workflow/icons";
 
@@ -77,16 +75,6 @@ export default {
         getNode: {
             type: Function,
             required: true,
-        },
-    },
-    data() {
-        return {
-            errorText: null,
-        };
-    },
-    watch: {
-        id() {
-            this.errorText = null;
         },
     },
     computed: {
@@ -128,20 +116,12 @@ export default {
             ]);
         },
         onChange(values) {
-            getModule({
+            this.$emit("onSetData", this.node.id, {
                 id: this.node.id,
                 type: this.node.type,
                 content_id: this.node.content_id,
                 inputs: values,
-            }).then(
-                (data) => {
-                    this.errorText = null;
-                    this.$emit("onSetData", this.node.id, data);
-                },
-                () => {
-                    this.errorText = `Failed to handle node state.`;
-                }
-            );
+            });
         },
     },
 };

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -52,7 +52,6 @@
 import FormDisplay from "components/Form/FormDisplay";
 import FormCard from "components/Form/FormCard";
 import FormElement from "components/Form/FormElement";
-import FormMessage from "components/Form/FormMessage";
 import { checkLabels } from "components/Workflow/Editor/modules/utilities";
 import WorkflowIcons from "components/Workflow/icons";
 
@@ -61,7 +60,6 @@ export default {
         FormDisplay,
         FormCard,
         FormElement,
-        FormMessage,
     },
     props: {
         datatypes: {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -1,6 +1,7 @@
 <template>
     <CurrentUser v-slot="{ user }">
         <ToolCard
+            v-if="hasData"
             :id="node.config_form.id"
             :user="user"
             :version="node.config_form.version"
@@ -105,6 +106,9 @@ export default {
         },
         nodeId() {
             return this.node.id;
+        },
+        hasData() {
+            return !!this.node.config_form;
         },
         errorLabel() {
             return checkLabels(this.node.id, this.node.label, this.workflow.nodes);

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -55,7 +55,6 @@ import FormDisplay from "components/Form/FormDisplay";
 import ToolCard from "components/Tool/ToolCard";
 import FormSection from "./FormSection";
 import FormElement from "components/Form/FormElement";
-import { getModule } from "components/Workflow/Editor/modules/services";
 import { checkLabels } from "components/Workflow/Editor/modules/utilities";
 import Utils from "utils/utils";
 
@@ -85,9 +84,14 @@ export default {
         return {
             mainValues: {},
             sectionValues: {},
-            messageVariant: "",
             messageText: "",
+            messageVariant: "success",
         };
+    },
+    watch: {
+        nodeId() {
+            this.messageText = "";
+        },
     },
     computed: {
         node() {
@@ -98,6 +102,9 @@ export default {
         },
         id() {
             return `${this.node.id}:${this.node.config_form.id}`;
+        },
+        nodeId() {
+            return this.node.id;
         },
         errorLabel() {
             return checkLabels(this.node.id, this.node.label, this.workflow.nodes);
@@ -152,6 +159,7 @@ export default {
             this.postChanges();
         },
         onChangeVersion(newVersion) {
+            this.messageText = `Now you are using '${this.node.config_form.name}' version ${newVersion}.`;
             this.postChanges(newVersion);
         },
         onUpdateFavorites(user, newFavorites) {
@@ -159,18 +167,11 @@ export default {
         },
         postChanges(newVersion) {
             const options = this.node.config_form;
-            getModule({
+            this.$emit("onSetData", this.node.id, {
                 tool_id: options.id,
                 tool_version: newVersion || options.version,
                 type: "tool",
                 inputs: Object.assign({}, this.mainValues, this.sectionValues),
-            }).then((data) => {
-                this.$emit("onSetData", this.node.id, data);
-                if (newVersion) {
-                    const options = data.config_form;
-                    this.messageVariant = "success";
-                    this.messageText = `Now you are using '${options.name}' version ${options.version}, id '${options.id}'.`;
-                }
             });
         },
     },

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -326,7 +326,6 @@ export default {
         onActivate(node) {
             if (this.activeNode != node) {
                 this.onDeactivate();
-                document.activeElement.blur();
                 node.makeActive();
                 this.activeNode = node;
                 this.canvasManager.drawOverview();
@@ -471,7 +470,9 @@ export default {
         },
         onSetData(nodeId, newData) {
             const node = this.nodes[nodeId];
-            node.setData(newData);
+            getModule(newData).then((data) => {
+                node.setData(data);
+            });
         },
         onChangeOutputDatatype(nodeId, outputName, newDatatype) {
             const node = this.nodes[nodeId];


### PR DESCRIPTION
In certain cases, the workflow form tool update handle request might be still waiting for a response while the user switches to another node. This can lead to issues since the active node has changed. This PR fixes this by emitting an update request to the workflow component, instead of requesting new data within the form module. Note: The `document.activeElement.blur();` can be removed since this already happens in the `onDeactivate` call. Additionally this PR contains a data check for forms, this avoid console log errors when uninstalled tools are selected in the workflow editor.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
