### PR TITLE
Change logged-in-as to use username

### DIFF
--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -267,7 +267,9 @@ export function fetchMenu(options = {}) {
             tooltip: _l("Account and saved data"),
             menu: [
                 {
-                    title: `${_l("Logged in as")} ${Galaxy.user.get("username") ? Galaxy.user.get("username") : Galaxy.user.get("email") }`,
+                    title: `${_l("Logged in as")} ${
+                        Galaxy.user.get("username") ? Galaxy.user.get("username") : Galaxy.user.get("email")
+                    }`,
                     disabled: true,
                 },
                 {

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -267,7 +267,7 @@ export function fetchMenu(options = {}) {
             tooltip: _l("Account and saved data"),
             menu: [
                 {
-                    title: `${_l("Logged in as")} ${Galaxy.user.get("username")}`,
+                    title: `${_l("Logged in as")} ${Galaxy.user.get("username") ? Galaxy.user.get("username") : Galaxy.user.get("email") }`,
                     disabled: true,
                 },
                 {

--- a/client/src/layout/menu.js
+++ b/client/src/layout/menu.js
@@ -267,7 +267,7 @@ export function fetchMenu(options = {}) {
             tooltip: _l("Account and saved data"),
             menu: [
                 {
-                    title: `${_l("Logged in as")} ${Galaxy.user.get("email")}`,
+                    title: `${_l("Logged in as")} ${Galaxy.user.get("username")}`,
                     disabled: true,
                 },
                 {

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -576,15 +576,15 @@ class NavigatesGalaxy(HasDriver):
             # Make sure the user menu was dropped down
             user_menu = self.components.masthead.user_menu.wait_for_visible()
             try:
-                user_email_element = self.components.masthead.user_email.wait_for_visible()
+                username_element = self.components.masthead.user_email.wait_for_visible()
             except self.TimeoutException as e:
                 menu_items = user_menu.find_elements_by_css_selector("li a")
                 menu_text = [mi.text for mi in menu_items]
                 message = f"Failed to find logged in message in menu items {', '.join(menu_text)}"
                 raise self.prepend_timeout_message(e, message)
 
-            text = user_email_element.text
-            assert email in text
+            text = username_element.text
+            assert username in text
             assert self.get_logged_in_user()["email"] == email
 
             # clicking away no longer closes menu post Masthead -> VueJS

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -576,7 +576,7 @@ class NavigatesGalaxy(HasDriver):
             # Make sure the user menu was dropped down
             user_menu = self.components.masthead.user_menu.wait_for_visible()
             try:
-                username_element = self.components.masthead.user_email.wait_for_visible()
+                username_element = self.components.masthead.username.wait_for_visible()
             except self.TimeoutException as e:
                 menu_items = user_menu.find_elements_by_css_selector("li a")
                 menu_text = [mi.text for mi in menu_items]

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -39,7 +39,7 @@ masthead:
     user_menu: '#user .dropdown-menu a'
     workflow: '#workflow .nav-link'
 
-    user_email:
+    username:
       type: xpath
       selector: '//a[contains(text(), "Logged in as")]'
 

--- a/lib/galaxy_test/selenium/test_registration.py
+++ b/lib/galaxy_test/selenium/test_registration.py
@@ -26,7 +26,7 @@ class RegistrationTestCase(SeleniumTestCase):
         self.logout_if_needed()
         assert not self.is_logged_in()
         self.home()
-        self.components.masthead.user_email.assert_absent_or_hidden()
+        self.components.masthead.username.assert_absent_or_hidden()
 
     @selenium_test
     def test_reregister_email_fails(self):


### PR DESCRIPTION
We get support requests with emails often, this will decrease how often
users leak their email accidentally in public chat rooms, and will give
us easier instructions for where to find the username.

Also it helps re-inforce the notion of the public username/user profile
which I think more accurately reflects most other modern services. My
username is much more important than my email (which is a largely
private/internal/'implementation detail')

![screenshot of login dropdown highlighting "logged in as helena-rasche"](https://user-images.githubusercontent.com/458683/136193636-5c92b3c6-a017-4cc9-8808-a34e9a232d4b.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Login
  2. Check dropdown

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
