### PR TITLE
[21.05] Fix `directory_uri` tool parameter validation error

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2417,6 +2417,8 @@ class DirectoryUriToolParameter(SimpleTextToolParameter):
 
     def validate(self, value, trans=None):
         super().validate(value, trans=trans)
+        if not value:
+            return  # value is not set yet, do not validate
         file_source = trans.app.file_sources.get_file_source_path(value).file_source
         user_context = ProvidesUserFileSourcesUserContext(trans)
         user_has_access = file_source.user_has_access(user_context)


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/12607

Some tools don't have a directory URI set by default so the validation must be done only when the parameter is set, otherwise, the tool will error before render.


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Get this tool https://github.com/usegalaxy-eu/temporary-tools/tree/master/test/export and add it to your `tool_conf.xml`
  2. Go to https://<your_galaxy>/root?tool_id=directory_uri
  3. Instead of the `Invalid uri []` error you should see the tool rendering correctly.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
