### PR TITLE
[21.09] Ensure that tool installations use the default tool panel

### DIFF
--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -41,6 +41,7 @@
                             v-if="config.default_panel_view"
                             v-slot="{ currentPanel }"
                             :site-default-panel-view="config.default_panel_view"
+                            :select-default-panel-view="true"
                         >
                             <InstallationSettings
                                 v-if="showSettings"

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -41,7 +41,7 @@
                             v-if="config.default_panel_view"
                             v-slot="{ currentPanel }"
                             :site-default-panel-view="config.default_panel_view"
-                            :select-default-panel-view="true"
+                            :set-default-panel-view="true"
                         >
                             <InstallationSettings
                                 v-if="showSettings"

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -38,9 +38,8 @@
                     </b-table>
                     <ConfigProvider v-slot="{ config }">
                         <ToolPanelViewProvider
-                            v-if="config.default_panel_view"
                             v-slot="{ currentPanel }"
-                            :site-default-panel-view="config.default_panel_view"
+                            site-default-panel-view="default"
                             :set-default-panel-view="true"
                         >
                             <InstallationSettings

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -36,15 +36,25 @@
                             />
                         </template>
                     </b-table>
-                    <InstallationSettings
-                        v-if="showSettings"
-                        :repo="repo"
-                        :toolshed-url="toolshedUrl"
-                        :changeset-revision="selectedChangeset"
-                        :requires-panel="selectedRequiresPanel"
-                        @hide="onHide"
-                        @ok="onOk"
-                    />
+                    <ConfigProvider v-slot="{ config }">
+                        <ToolPanelViewProvider
+                            v-if="config.default_panel_view"
+                            v-slot="{ currentPanel }"
+                            :site-default-panel-view="config.default_panel_view"
+                        >
+                            <InstallationSettings
+                                v-if="showSettings"
+                                :repo="repo"
+                                :toolshed-url="toolshedUrl"
+                                :changeset-revision="selectedChangeset"
+                                :requires-panel="selectedRequiresPanel"
+                                :current-panel="currentPanel"
+                                :tool-dynamic-configs="config.tool_dynamic_configs"
+                                @hide="onHide"
+                                @ok="onOk"
+                            />
+                        </ToolPanelViewProvider>
+                    </ConfigProvider>
                 </div>
             </div>
         </div>
@@ -54,6 +64,8 @@
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import { Services } from "../services";
+import ConfigProvider from "components/providers/ConfigProvider";
+import ToolPanelViewProvider from "components/providers/ToolPanelViewProvider";
 import InstallationSettings from "./InstallationSettings.vue";
 import InstallationButton from "./InstallationButton.vue";
 import RepositoryTools from "./RepositoryTools.vue";
@@ -62,6 +74,8 @@ Vue.use(BootstrapVue);
 
 export default {
     components: {
+        ConfigProvider,
+        ToolPanelViewProvider,
         InstallationSettings,
         InstallationButton,
         RepositoryTools,

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationButton.vue
@@ -22,7 +22,7 @@ export default {
     props: {
         status: {
             type: String,
-            required: true,
+            default: null,
         },
     },
     data() {

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-modal id="repo-install-settings" v-model="modalShow" @ok="onOk" @hide="onHide">
+    <b-modal id="repo-install-settings" :static="modalStatic" v-model="modalShow" @ok="onOk" @hide="onHide">
         <template v-slot:modal-header>
             <h4 class="title m-0">
                 {{ modalTitle }}
@@ -78,6 +78,10 @@ export default {
         toolDynamicConfigs: {
             type: Array,
             default: null,
+        },
+        modalStatic: {
+            type: Boolean,
+            default: false,
         },
     },
     data() {

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -16,7 +16,7 @@
         >
             <b-form-input list="sectionSelect" v-model="toolSection" />
             <datalist id="sectionSelect">
-                <option v-for="section in toolSections" :key="section.name">
+                <option v-for="section in toolSections" :key="section.id">
                     {{ section.name }}
                 </option>
             </datalist>
@@ -72,6 +72,14 @@ export default {
             type: String,
             required: true,
         },
+        currentPanel: {
+            type: Array,
+            default: null,
+        },
+        toolDynamicConfigs: {
+            type: Array,
+            default: null,
+        },
     },
     data() {
         return {
@@ -80,9 +88,7 @@ export default {
             installToolDependencies: true,
             installRepositoryDependencies: true,
             installResolverDependencies: true,
-            toolConfigs: [],
             toolConfig: null,
-            toolSections: [],
             toolSection: null,
         };
     },
@@ -96,9 +102,22 @@ export default {
         showConfig() {
             return this.toolConfigs.length > 1;
         },
+        toolSections() {
+            const panel = this.currentPanel;
+            if (panel) {
+                return panel.filter((x) => x.elems);
+            } else {
+                return [];
+            }
+        },
+        toolConfigs() {
+            return this.toolDynamicConfigs || [];
+        },
     },
     created() {
-        this.load();
+        if (this.toolConfigs.length > 0) {
+            this.toolConfig = this.toolConfigs[0];
+        }
     },
     methods: {
         findSection: function (name) {
@@ -114,17 +133,6 @@ export default {
                 }
             }
             return result;
-        },
-        load: function () {
-            const galaxy = getGalaxyInstance();
-            const sections = galaxy.config.toolbox;
-            if (sections) {
-                this.toolSections = sections.filter((x) => x.elems);
-            }
-            this.toolConfigs = galaxy.config.tool_dynamic_configs || [];
-            if (this.toolConfigs.length > 0) {
-                this.toolConfig = this.toolConfigs[0];
-            }
         },
         onAdvanced: function () {
             this.advancedShow = !this.advancedShow;

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -50,7 +50,6 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
-import { getGalaxyInstance } from "app";
 
 Vue.use(BootstrapVue);
 

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -48,11 +48,6 @@
     </b-modal>
 </template>
 <script>
-import Vue from "vue";
-import BootstrapVue from "bootstrap-vue";
-
-Vue.use(BootstrapVue);
-
 export default {
     props: {
         repo: {

--- a/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/InstallationSettings.vue
@@ -1,5 +1,5 @@
 <template>
-    <b-modal id="repo-install-settings" :static="modalStatic" v-model="modalShow" @ok="onOk" @hide="onHide">
+    <b-modal id="repo-install-settings" v-model="modalShow" @ok="onOk" @hide="onHide">
         <template v-slot:modal-header>
             <h4 class="title m-0">
                 {{ modalTitle }}
@@ -70,10 +70,6 @@ export default {
         },
         toolshedUrl: {
             type: String,
-            required: true,
-        },
-        modalStatic: {
-            type: Boolean,
             required: true,
         },
     },

--- a/client/src/components/Toolshed/SearchList/Index.vue
+++ b/client/src/components/Toolshed/SearchList/Index.vue
@@ -37,7 +37,7 @@ export default {
     props: {
         query: {
             type: String,
-            required: true,
+            default: null,
         },
         scrolled: {
             type: Boolean,

--- a/client/src/components/providers/ToolPanelViewProvider.js
+++ b/client/src/components/providers/ToolPanelViewProvider.js
@@ -6,15 +6,23 @@ export default {
             type: String,
             required: true,
         },
+        selectDefaultPanelView: {
+            type: Boolean,
+            default: false,
+        },
     },
     computed: {
         ...mapGetters("panels", ["currentPanel", "currentPanelView"]),
     },
     methods: {
-        ...mapActions("panels", ["initCurrentPanelView"]),
+        ...mapActions("panels", ["initCurrentPanelView", "setCurrentPanelView"]),
     },
     created() {
-        this.initCurrentPanelView(this.siteDefaultPanelView);
+        if (this.selectDefaultPanelView) {
+            this.setCurrentPanelView(this.siteDefaultPanelView);
+        } else {
+            this.initCurrentPanelView(this.siteDefaultPanelView);
+        }
     },
     render() {
         return this.$scopedSlots.default({

--- a/client/src/components/providers/ToolPanelViewProvider.js
+++ b/client/src/components/providers/ToolPanelViewProvider.js
@@ -6,7 +6,7 @@ export default {
             type: String,
             required: true,
         },
-        selectDefaultPanelView: {
+        setDefaultPanelView: {
             type: Boolean,
             default: false,
         },
@@ -18,7 +18,7 @@ export default {
         ...mapActions("panels", ["initCurrentPanelView", "setCurrentPanelView"]),
     },
     created() {
-        if (this.selectDefaultPanelView) {
+        if (this.setDefaultPanelView) {
             this.setCurrentPanelView(this.siteDefaultPanelView);
         } else {
             this.initCurrentPanelView(this.siteDefaultPanelView);

--- a/tool-data/all_fasta.loc.sample
+++ b/tool-data/all_fasta.loc.sample
@@ -4,13 +4,13 @@
 #all_fasta.loc. This file has the format (white space characters are
 #TAB characters):
 #
-#<unique_build_id>	<dbkey>	<display_name>	<file_path>
+#<unique_build_id>	<dbkey>		<display_name>	<file_path>
 #
 #So, all_fasta.loc could look something like this:
 #
-#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3	/path/to/genome/apiMel3/apiMel3.fa
-#hg19canon	hg19	Human (Homo sapiens): hg19 Canonical	/path/to/genome/hg19/hg19canon.fa
-#hg19full	hg19	Human (Homo sapiens): hg19 Full	/path/to/genome/hg19/hg19full.fa
+#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3		/path/to/genome/apiMel3/apiMel3.fa
+#hg19canon	hg19		Human (Homo sapiens): hg19 Canonical		/path/to/genome/hg19/hg19canon.fa
+#hg19full	hg19		Human (Homo sapiens): hg19 Full			/path/to/genome/hg19/hg19full.fa
 #
 #Your all_fasta.loc file should contain an entry for each individual
 #fasta file. So there will be multiple fasta files for each build,

--- a/tool-data/all_fasta.loc.sample
+++ b/tool-data/all_fasta.loc.sample
@@ -4,13 +4,13 @@
 #all_fasta.loc. This file has the format (white space characters are
 #TAB characters):
 #
-#<unique_build_id>	<dbkey>		<display_name>	<file_path>
+#<unique_build_id>	<dbkey>	<display_name>	<file_path>
 #
 #So, all_fasta.loc could look something like this:
 #
-#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3		/path/to/genome/apiMel3/apiMel3.fa
-#hg19canon	hg19		Human (Homo sapiens): hg19 Canonical		/path/to/genome/hg19/hg19canon.fa
-#hg19full	hg19		Human (Homo sapiens): hg19 Full			/path/to/genome/hg19/hg19full.fa
+#apiMel3	apiMel3	Honeybee (Apis mellifera): apiMel3	/path/to/genome/apiMel3/apiMel3.fa
+#hg19canon	hg19	Human (Homo sapiens): hg19 Canonical	/path/to/genome/hg19/hg19canon.fa
+#hg19full	hg19	Human (Homo sapiens): hg19 Full	/path/to/genome/hg19/hg19full.fa
 #
 #Your all_fasta.loc file should contain an entry for each individual
 #fasta file. So there will be multiple fasta files for each build,


### PR DESCRIPTION
This PR adjust the tool installation modal which is accessible in the admin panel. Tool installations require a target tool panel and allow users to select tool sections. Since Galaxy now allows a variety of tool panels, the installation panel needs to select the `default` tool panel first before submitting tool installation requests.

## How to test the changes?
  1. Navigate to the toolshed installation page in the admin panel
  2. Select a tool to install and verify that the tool section panel options of the default panel are populated.
  3. Install the tool and verify that it was placed into the correct section, regardless of which tool panel was initially displayed in the Analysis view.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
