### PR TITLE
Fix deprecation warnings from the `threading` module

### DIFF
--- a/lib/galaxy/model/database_heartbeat.py
+++ b/lib/galaxy/model/database_heartbeat.py
@@ -96,6 +96,6 @@ class DatabaseHeartbeat:
 
     def send_database_heartbeat(self):
         if self.active:
-            while not self.exit.isSet():
+            while not self.exit.is_set():
                 self.update_watcher_designation()
                 self.exit.wait(self.heartbeat_interval)

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -792,7 +792,7 @@ class DistributedObjectStore(NestedObjectStore):
         if fsmon and (self.global_max_percent_full or [_ for _ in self.max_percent_full.values() if _ != 0.0]):
             self.sleeper = Sleeper()
             self.filesystem_monitor_thread = threading.Thread(target=self.__filesystem_monitor)
-            self.filesystem_monitor_thread.setDaemon(True)
+            self.filesystem_monitor_thread.daemon = True
             self.filesystem_monitor_thread.start()
             log.info("Filesystem space monitor started")
 

--- a/lib/galaxy/tool_util/toolbox/watcher.py
+++ b/lib/galaxy/tool_util/toolbox/watcher.py
@@ -101,7 +101,7 @@ class ToolConfWatcher:
         hashes = {}
         if self.cache:
             self.cache.assert_hashes_initialized()
-        while self._active and not self.exit.isSet():
+        while self._active and not self.exit.is_set():
             do_reload = False
             drop_on_next_loop = set()
             drop_now = set()

--- a/lib/galaxy/util/monitors.py
+++ b/lib/galaxy/util/monitors.py
@@ -23,7 +23,7 @@ class Monitors:
             monitor_func = getattr(self, target_name)
         self.sleeper = Sleeper()
         self.monitor_thread = threading.Thread(name=name, target=monitor_func)
-        self.monitor_thread.setDaemon(True)
+        self.monitor_thread.daemon = True
         self._start = start
         self.start_monitoring()
 

--- a/lib/galaxy/util/task.py
+++ b/lib/galaxy/util/task.py
@@ -40,7 +40,7 @@ class IntervalTask:
     def run(self):
         if self.immediate_start:
             self._exec()
-        while not self.event.isSet():
+        while not self.event.is_set():
             self.event.wait(self.interval)
             if self.running:
                 self._exec()


### PR DESCRIPTION
Fix the following deprecation warnings in Python 3.10:

- `DeprecationWarning: isSet() is deprecated, use is_set() instead`
- `DeprecationWarning: setDaemon() is deprecated, set the daemon attribute instead`

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
