### PR TITLE
Tweak tool form building performance

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5316,7 +5316,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, RepresentById):
     def dataset_instances(self):
         db_session = object_session(self)
         if db_session and self.id:
-            return self._get_nested_collection_attributes(return_entities=(HistoryDatasetAssociation,)).all()
+            return self._get_nested_collection_attributes(return_entities=(HistoryDatasetAssociation,))
         else:
             # Sessionless context
             instances = []

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5218,7 +5218,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, RepresentById):
             )
             extensions = set()
             states = set()
-            for extension, state in q:
+            for extension, state in q.all():
                 states.add(state)
                 extensions.add(extension)
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1812,6 +1812,7 @@ class BaseDataToolParameter(ToolParameter):
                     validator.validate(v, trans)
 
         dataset_count = 0
+        collection = None
         if value:
             if self.multiple:
                 if not isinstance(value, list):
@@ -1821,13 +1822,16 @@ class BaseDataToolParameter(ToolParameter):
 
             for v in value:
                 if isinstance(v, galaxy.model.HistoryDatasetCollectionAssociation):
-                    for dataset_instance in v.collection.dataset_instances:
-                        dataset_count += 1
-                        do_validate(dataset_instance)
+                    collection = v.collection
                 elif isinstance(v, galaxy.model.DatasetCollectionElement):
-                    for dataset_instance in v.child_collection.dataset_instances:
-                        dataset_count += 1
-                        do_validate(dataset_instance)
+                    collection = v.child_collection
+                if collection:
+                    if self.validators:
+                        for dataset_instance in collection.dataset_instances:
+                            dataset_count += 1
+                            do_validate(dataset_instance)
+                    elif self.min or self.max:
+                        dataset_count += collection.dataset_instances.count()
                 else:
                     dataset_count += 1
                     do_validate(v)

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -403,13 +403,13 @@ class MappingTests(BaseModelTestCase):
         q = c2._get_nested_collection_attributes(return_entities=(model.HistoryDatasetAssociation, model.Dataset))
         assert q.all() == [(d1, d1.dataset), (d2, d2.dataset)]
         # Assert properties that use _get_nested_collection_attributes return correct content
-        assert c2.dataset_instances == [d1, d2]
+        assert c2.dataset_instances.all() == [d1, d2]
         assert c2.dataset_elements == [dce1, dce2]
         assert c2.dataset_action_tuples == []
         assert c2.populated_optimized
         assert c2.dataset_states_and_extensions_summary == ({'new'}, {'txt', 'bam'})
         assert c2.element_identifiers_extensions_paths_and_metadata_files == [[('inner_list', 'forward'), 'bam', 'mock_dataset_14.dat', [('bai', 'mock_dataset_14.dat'), ('bam.csi', 'mock_dataset_14.dat')]], [('inner_list', 'reverse'), 'txt', 'mock_dataset_14.dat', []]]
-        assert c3.dataset_instances == []
+        assert c3.dataset_instances.all() == []
         assert c3.dataset_elements == []
         assert c3.dataset_states_and_extensions_summary == (set(), set())
         q = c4._get_nested_collection_attributes(element_attributes=('element_identifier',))

--- a/test/unit/jobs/test_job_context.py
+++ b/test/unit/jobs/test_job_context.py
@@ -83,5 +83,5 @@ def test_job_context_discover_outputs_flushes_once(mocker):
     collection_builder.populate()
     assert spy.call_count == 0
     sa_session.flush()
-    assert len(collection.dataset_instances) == 10
+    assert collection.dataset_instances.count() == 10
     assert collection.dataset_instances[0].dataset.file_size == 1

--- a/test/unit/managers/test_CollectionManager.py
+++ b/test/unit/managers/test_CollectionManager.py
@@ -53,7 +53,7 @@ class DatasetCollectionManagerTestCase(BaseTestCase, CreatesCollectionsMixin):
         collection = hdca.collection
         self.assertEqual(collection.collection_type, 'list')
         self.assertEqual(collection.state, 'ok')
-        self.assertEqual(len(collection.dataset_instances), 3)
+        self.assertEqual(collection.dataset_instances.count(), 3)
         self.assertEqual(len(collection.elements), 3)
 
         self.log("and that collection should have three well-formed Elements")

--- a/test/unit/managers/test_HistoryContentsManager.py
+++ b/test/unit/managers/test_HistoryContentsManager.py
@@ -80,10 +80,10 @@ class HistoryAsContainerTestCase(HistoryAsContainerBaseTestCase):
         history = self.history_manager.create(name='history', user=user2)
         hdas = [self.add_hda_to_history(history, name=('hda-' + str(x))) for x in range(3)]
         hdca = self.add_list_collection_to_history(history, hdas)
-        self.assertEqual(hdas, hdca.dataset_instances)
+        self.assertEqual(hdas, hdca.dataset_instances.all())
 
         hdca = self.add_list_collection_to_history(history, hdas, copy_elements=True)
-        self.assertNotEqual(hdas, hdca.dataset_instances)
+        self.assertNotEqual(hdas, hdca.dataset_instances.all())
 
     def test_subcontainers(self):
         user2 = self.user_manager.create(**user2_data)

--- a/test/unit/test_model_discovery.py
+++ b/test/unit/test_model_discovery.py
@@ -182,7 +182,7 @@ def test_persist_target_hdca():
 
     import_hdca = import_history.dataset_collections[0]
     datasets = import_hdca.dataset_instances
-    assert len(datasets) == 2
+    assert datasets.count() == 2
     dataset0 = datasets[0]
     dataset1 = datasets[1]
 


### PR DESCRIPTION
Some performance tweaking to deal with very slow form building of the apply_rules tool on main.
This is based on those 2 stack frames (these are pretty much exclusively what I could capture) I was able to dump while building the apply_rules tool:
```
Thread 25647 (idle): "uWSGIWorker8Core3"
    __init__ (sqlalchemy/engine/cursor.py:1024)
    _setup_result_proxy (sqlalchemy/engine/default.py:1411)
    _execute_context (sqlalchemy/engine/base.py:1786)
    _execute_clauseelement (sqlalchemy/engine/base.py:1461)
    _execute_on_connection (sqlalchemy/sql/elements.py:324)
    _execute_20 (sqlalchemy/engine/base.py:1582)
    execute (sqlalchemy/orm/session.py:1689)
    _iter (sqlalchemy/orm/query.py:2847)
    __iter__ (sqlalchemy/orm/query.py:2837)
    dataset_states_and_extensions_summary (__init__.py:5221)
    hdca_match (dataset_matcher.py:214)
    match_collections (basic.py:2154)
    to_dict (basic.py:2252)
    populate_model (__init__.py:2342)
    to_json (__init__.py:2272)
    build (tools.py:136)
    decorator (decorators.py:312)
    handle_request (base.py:217)
    __call__ (base.py:138)
    __call__ (httpexceptions.py:640)
    __call__ (statsd.py:35)
    __call__ (recursive.py:85)
    __call__ (sentry_sdk/integrations/wsgi.py:136)
    __call__ (error.py:154)
    __call__ (translogger.py:69)
    __call__ (xforwardedhost.py:23)
    __call__ (request_id.py:15)
    __call__ (batch.py:85)
```
and
```
Thread 25647 (idle): "uWSGIWorker8Core3"
    __init__ (sqlalchemy/engine/cursor.py:1024)
    _setup_result_proxy (sqlalchemy/engine/default.py:1411)
    _execute_context (sqlalchemy/engine/base.py:1786)
    _execute_clauseelement (sqlalchemy/engine/base.py:1461)
    _execute_on_connection (sqlalchemy/sql/elements.py:324)
    _execute_20 (sqlalchemy/engine/base.py:1582)
    execute (sqlalchemy/orm/session.py:1689)
    _iter (sqlalchemy/orm/query.py:2847)
    all (sqlalchemy/orm/query.py:2709)
    dataset_instances (__init__.py:5319)
    validate (basic.py:1824)
    check_param (__init__.py:194)
    _populate_state_legacy (__init__.py:459)
    populate_state (__init__.py:348)
    to_json (__init__.py:2267)
    build (tools.py:136)
    decorator (decorators.py:312)
    handle_request (base.py:217)
    __call__ (base.py:138)
    __call__ (httpexceptions.py:640)
    __call__ (statsd.py:35)
    __call__ (recursive.py:85)
    __call__ (sentry_sdk/integrations/wsgi.py:136)
    __call__ (error.py:154)
    __call__ (translogger.py:69)
    __call__ (xforwardedhost.py:23)
    __call__ (request_id.py:15)
    __call__ (batch.py:85)
```

I will try to do some local profiling as well to confirm that this really helps.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
