### PR TITLE
[21.09] Show loading error in tool form

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -3,6 +3,7 @@
         <CurrentUser v-slot="{ user }">
             <UserHistories v-if="user" :user="user" v-slot="{ currentHistoryId }">
                 <div v-if="currentHistoryId">
+                    <b-alert :show="messageShow" :variant="messageVariant" v-html="messageText" />
                     <LoadingSpan v-if="showLoading" message="Loading Tool" />
                     <div v-if="showEntryPoints">
                         <ToolEntryPoints v-for="job in entryPoints" :job-id="job.id" :key="job.id" />
@@ -152,6 +153,7 @@ export default {
             remapAllowed: false,
             errorTitle: null,
             errorContent: null,
+            messageShow: false,
             messageVariant: "",
             messageText: "",
             useCachedJobs: false,
@@ -250,15 +252,20 @@ export default {
                 .then((data) => {
                     this.formConfig = data;
                     this.remapAllowed = this.job_id && data.job_remap;
-                    this.showLoading = false;
                     this.showForm = true;
                     if (newVersion) {
                         this.messageVariant = "success";
                         this.messageText = `Now you are using '${data.name}' version ${data.version}, id '${data.id}'.`;
                     }
                 })
+                .catch((error) => {
+                    this.messageVariant = "danger";
+                    this.messageText = `Loading tool ${this.id} failed: ${error}`;
+                    this.messageShow = true;
+                })
                 .finally(() => {
                     this.disabled = false;
+                    this.showLoading = false;
                 });
         },
         onExecute(config, historyId) {

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -253,6 +253,7 @@ export default {
                     this.formConfig = data;
                     this.remapAllowed = this.job_id && data.job_remap;
                     this.showForm = true;
+                    this.messageShow = false;
                     if (newVersion) {
                         this.messageVariant = "success";
                         this.messageText = `Now you are using '${data.name}' version ${data.version}, id '${data.id}'.`;


### PR DESCRIPTION
Otherwise if the tool form fails to load it's not clear what went wrong and worse it looks like it is still loading. Not sure about the additional b-alert, but we can't use the error handling in the child components ... in the future they should probably emit warnings and errors to the parent component ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Raise an an exception on the tool build endpoint

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
