### PR TITLE
Allow trailing semicolon in last column of gff3

### DIFF
--- a/lib/galaxy/datatypes/util/gff_util.py
+++ b/lib/galaxy/datatypes/util/gff_util.py
@@ -369,7 +369,10 @@ def parse_gff3_attributes(attr_str):
     attributes_list = attr_str.split(";")
     attributes = {}
     for tag_value_pair in attributes_list:
-        pair = tag_value_pair.strip().split("=")
+        tag_value_pair = tag_value_pair.strip()
+        if tag_value_pair == '':
+            continue
+        pair = tag_value_pair.split("=")
         if len(pair) == 1:
             raise Exception("Attribute '%s' does not contain a '='" % tag_value_pair)
         if pair == '':


### PR DESCRIPTION
example: https://github.com/galaxyproject/tools-iuc/blob/7998bbefd9bfd03bc0e92a922297b503832c0419/tools/aegean/test-data/TAIR10_GFF3_genes.gff#L7

note: clearly the example is gff2 but its used by the tool as gff3

- [ ] wondering if this function should also be called in the Gff sniffer
- [ ] also wondering if we should switch the order of the sniffers, currently gff runs before gff3, or?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
