### PR TITLE
[21.05] Fix possible None in TokenContainedEvaluator

### DIFF
--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -4,6 +4,7 @@ from collections import (
     defaultdict,
     namedtuple,
 )
+from typing import Set
 
 from galaxy import exceptions
 from galaxy.util import (
@@ -246,15 +247,19 @@ class ProvidesUserFileSourcesUserContext:
         return user and user.extra_preferences or defaultdict(lambda: None)
 
     @property
-    def role_names(self):
+    def role_names(self) -> Set[str]:
         """The set of role names of this user."""
         user = self.trans.user
+        if user is None:
+            return set()
         return user and set([ura.role.name for ura in user.roles])
 
     @property
-    def group_names(self):
+    def group_names(self) -> Set[str]:
         """The set of group names to which this user belongs."""
         user = self.trans.user
+        if user is None:
+            return set()
         return user and set([ugr.group.name for ugr in user.groups])
 
     @property

--- a/lib/galaxy/files/__init__.py
+++ b/lib/galaxy/files/__init__.py
@@ -250,17 +250,13 @@ class ProvidesUserFileSourcesUserContext:
     def role_names(self) -> Set[str]:
         """The set of role names of this user."""
         user = self.trans.user
-        if user is None:
-            return set()
-        return user and set([ura.role.name for ura in user.roles])
+        return set(ura.role.name for ura in user.roles) if user else set()
 
     @property
     def group_names(self) -> Set[str]:
         """The set of group names to which this user belongs."""
         user = self.trans.user
-        if user is None:
-            return set()
-        return user and set([ugr.group.name for ugr in user.groups])
+        return set(ugr.group.name for ugr in user.groups) if user else set()
 
     @property
     def is_admin(self):

--- a/lib/galaxy/util/bool_expressions.py
+++ b/lib/galaxy/util/bool_expressions.py
@@ -172,7 +172,7 @@ class TokenContainedEvaluator(TokenEvaluator):
         :param tokens: The list of tokens that should be evaluated to True.
         :type tokens: List[str]
         """
-        self.tokens = tokens
+        self.tokens = tokens or set()
 
     def evaluate(self, token: str) -> bool:
         return token in self.tokens


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12667

The evaluator was expecting a set of tokens but retrieving roles or groups for an anonymous user was actually returning None instead of an empty set.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Add a `required_roles` or `required_groups` to any file source plugin configuration like [here](https://github.com/galaxyproject/usegalaxy-playbook/blob/b6382605018a9e61186c3cb8e6d72f75cd789575/env/common/templates/galaxy/config/file_sources_conf.yml.j2#L51)
  - Try to upload any file to Galaxy with an anonymous user.
  - Check there is no exception in the logs like in https://github.com/galaxyproject/galaxy/issues/12667#issue-1021032113

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
