### PR TITLE
Fix gff-version header sniffing

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -823,7 +823,8 @@ class Gff(Tabular, _RemoteCallMixin):
             for hdr in iter_headers(file_prefix, '\t'):
                 if not hdr or hdr == ['']:
                     continue
-                if hdr[0].startswith('##gff-version') and hdr[0].find('2') < 0:
+                hdr0_parts = hdr[0].split()
+                if hdr0_parts[0] == '##gff-version' and not hdr0_parts[1].startswith('2'):
                     return False
                 # The gff-version header comment may have been stripped, so inspect the data
                 if hdr[0].startswith('#'):
@@ -963,10 +964,9 @@ class Gff3(Gff):
             for hdr in iter_headers(file_prefix, '\t'):
                 if not hdr or hdr == ['']:
                     continue
-                if hdr[0].startswith('##gff-version') and hdr[0].find('3') >= 0:
-                    return True
-                elif hdr[0].startswith('##gff-version') and hdr[0].find('3') < 0:
-                    return False
+                hdr0_parts = hdr[0].split()
+                if hdr0_parts[0] == '##gff-version':
+                    return hdr0_parts[1].startswith('3')
                 # The gff-version header comment may have been stripped, so inspect the data
                 if hdr[0].startswith('#'):
                     continue
@@ -1045,7 +1045,8 @@ class Gtf(Gff):
             for hdr in iter_headers(file_prefix, '\t'):
                 if not hdr or hdr == ['']:
                     continue
-                if hdr[0].startswith('##gff-version') and hdr[0].find('2') < 0:
+                hdr0_parts = hdr[0].split()
+                if hdr0_parts[0] == '##gff-version' and not hdr0_parts[1].startswith('2'):
                     return False
                 # The gff-version header comment may have been stripped, so inspect the data
                 if hdr[0].startswith('#'):


### PR DESCRIPTION
In GFF3 major revision and minor revision numbers are allowed. From
https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md :

    The GFF version follows the format of 3.#.# in this spec. This directive
    must be present, must be the topmost line of the file. The version
    number always begins with 3, the second and third numbers are optional
    and indicate a major revision and a minor revision respectively.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
