### PR TITLE
[21.09] Don't change panel view after installing repositories, clean up provider

### DIFF
--- a/client/src/components/Panels/ProviderAwareToolBox.vue
+++ b/client/src/components/Panels/ProviderAwareToolBox.vue
@@ -2,7 +2,7 @@
     <ConfigProvider class="d-flex flex-column" v-slot="{ config }">
         <ToolPanelViewProvider
             v-slot="{ currentPanel, currentPanelView }"
-            :site-default-panel-view="config.default_panel_view"
+            :panel-view="config.default_panel_view"
             v-if="config.default_panel_view"
         >
             <ToolBox

--- a/client/src/components/Panels/ProviderAwareToolBoxWorkflow.vue
+++ b/client/src/components/Panels/ProviderAwareToolBoxWorkflow.vue
@@ -2,7 +2,7 @@
     <ConfigProvider class="d-flex flex-column" v-slot="{ config }">
         <ToolPanelViewProvider
             v-slot="{ currentPanel, currentPanelView }"
-            :site-default-panel-view="config.default_panel_view"
+            :panel-view="config.default_panel_view"
             v-if="config.default_panel_view"
         >
             <ToolBoxWorkflow

--- a/client/src/components/Toolshed/RepositoryDetails/Index.vue
+++ b/client/src/components/Toolshed/RepositoryDetails/Index.vue
@@ -37,11 +37,7 @@
                         </template>
                     </b-table>
                     <ConfigProvider v-slot="{ config }">
-                        <ToolPanelViewProvider
-                            v-slot="{ currentPanel }"
-                            site-default-panel-view="default"
-                            :set-default-panel-view="true"
-                        >
+                        <ToolPanelViewProvider v-slot="{ currentPanel }" :panel-view="`default`" :set-default="false">
                             <InstallationSettings
                                 v-if="showSettings"
                                 :repo="repo"

--- a/client/src/components/providers/ToolPanelViewProvider.js
+++ b/client/src/components/providers/ToolPanelViewProvider.js
@@ -2,32 +2,39 @@ import { mapGetters, mapActions } from "vuex";
 
 export default {
     props: {
-        siteDefaultPanelView: {
+        panelView: {
             type: String,
             required: true,
         },
-        setDefaultPanelView: {
+        setDefault: {
             type: Boolean,
-            default: false,
+            required: false,
+            default: true,
         },
     },
     computed: {
-        ...mapGetters("panels", ["currentPanel", "currentPanelView"]),
+        ...mapGetters("panels", ["currentPanel", "currentPanelView", "panel"]),
+        localPanelView() {
+            return this.setDefault ? this.currentPanelView : this.panelView;
+        },
+        localPanel() {
+            return this.setDefault ? this.currentPanel : this.panel(this.panelView);
+        },
     },
     methods: {
-        ...mapActions("panels", ["initCurrentPanelView", "setCurrentPanelView"]),
+        ...mapActions("panels", ["initCurrentPanelView", "fetchPanel"]),
     },
     created() {
-        if (this.setDefaultPanelView) {
-            this.setCurrentPanelView(this.siteDefaultPanelView);
+        if (this.setDefault) {
+            this.initCurrentPanelView(this.panelView);
         } else {
-            this.initCurrentPanelView(this.siteDefaultPanelView);
+            this.fetchPanel(this.panelView);
         }
     },
     render() {
         return this.$scopedSlots.default({
-            currentPanel: this.currentPanel,
-            currentPanelView: this.currentPanelView,
+            currentPanel: this.localPanel,
+            currentPanelView: this.localPanelView,
         });
     },
 };

--- a/client/src/store/panelStore.js
+++ b/client/src/store/panelStore.js
@@ -42,6 +42,10 @@ const actions = {
         const { data } = await axios.get(`${getAppRoot()}api/tools?in_panel=true&view=${panelView}`);
         commit("savePanelView", { panelView, panel: data });
     },
+    fetchPanel: async ({ commit }, panelView) => {
+        const { data } = await axios.get(`${getAppRoot()}api/tools?in_panel=true&view=${panelView}`);
+        commit("savePanelView", { panelView, panel: data });
+    },
 };
 
 const mutations = {


### PR DESCRIPTION
Rename site-default-panel-view to panel-view, fetch from store without setting default if set-default is false

Minor follow-up to #12655 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
