### PR TITLE
Ignore dbkey option filter if dbkey is unset for dataset

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -70,6 +70,10 @@ List of behavior changes associated with profile versions:
 - Do not use Galaxy python environment for `data_source_async` tools.
 - Drop request parameters received by data source tools that are not declared in `<request_param_translation>` section.
 
+### 22.09
+
+- Dynamic options metadata filters of data parameters now allow any metadata if the referred data set does not define the metadata.
+
 ### Examples
 
 A normal tool:

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2261,7 +2261,7 @@ class DataToolParameter(BaseDataToolParameter):
         # this behavior needs to be entirely reworked (in a backwards compatible manner)
         options_filter_attribute = self.options_filter_attribute
         if options_filter_attribute is None:
-            if value.metadata.element_is_set('dbkey'):
+            if value.metadata is not None and value.metadata.element_is_set('dbkey'):
                 return value.get_dbkey()
             else:
                 return None

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2261,10 +2261,7 @@ class DataToolParameter(BaseDataToolParameter):
         # this behavior needs to be entirely reworked (in a backwards compatible manner)
         options_filter_attribute = self.options_filter_attribute
         if options_filter_attribute is None:
-            if value.metadata is not None and value.metadata.element_is_set('dbkey'):
-                return value.get_dbkey()
-            else:
-                return None
+            return value.get_dbkey()
         if options_filter_attribute.endswith("()"):
             call_attribute = True
             options_filter_attribute = options_filter_attribute[:-2]

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2261,7 +2261,10 @@ class DataToolParameter(BaseDataToolParameter):
         # this behavior needs to be entirely reworked (in a backwards compatible manner)
         options_filter_attribute = self.options_filter_attribute
         if options_filter_attribute is None:
-            return value.get_dbkey()
+            if value.metadata.element_is_set('dbkey'):
+                return value.get_dbkey()
+            else:
+                return None
         if options_filter_attribute.endswith("()"):
             call_attribute = True
             options_filter_attribute = options_filter_attribute[:-2]

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -155,7 +155,7 @@ class DatasetMatcher:
         applicable).
         """
         param = self.param
-        return param.options and param.get_options_filter_attribute(hda) not in self.filter_values
+        return param.options and param.get_options_filter_attribute(hda) not in self.filter_values and len(self.filter_values) > 0
 
 
 class HdaDirectMatch:

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -155,7 +155,8 @@ class DatasetMatcher:
         applicable).
         """
         param = self.param
-        return param.options and param.get_options_filter_attribute(hda) not in self.filter_values
+        options_filter_attribute = param.get_options_filter_attribute(hda)
+        return param.options and options_filter_attribute and options_filter_attribute not in self.filter_values
 
 
 class HdaDirectMatch:

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -169,8 +169,7 @@ class DatasetMatcher:
         for select parameters).
         """
         param = self.param
-
-        if param.tool.profile < 22.09:
+        if param.tool and param.tool.profile < 22.09:
             return param.options and param.get_options_filter_attribute(hda) not in self.filter_values
         else:
             return (

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -155,8 +155,7 @@ class DatasetMatcher:
         applicable).
         """
         param = self.param
-        options_filter_attribute = param.get_options_filter_attribute(hda)
-        return param.options and options_filter_attribute and options_filter_attribute not in self.filter_values
+        return param.options and param.get_options_filter_attribute(hda) not in self.filter_values
 
 
 class HdaDirectMatch:

--- a/lib/galaxy/tools/parameters/dataset_matcher.py
+++ b/lib/galaxy/tools/parameters/dataset_matcher.py
@@ -151,11 +151,33 @@ class DatasetMatcher:
             return self.valid_hda_match(hda, check_implicit_conversions=check_implicit_conversions)
 
     def filter(self, hda):
-        """Filter out this value based on other values for job (if
-        applicable).
+        """Filter out this value based on other values for job
+
+        Returns True iff it should be filtered
+
+        If the parameter does not define a options element False will be returned in any case.
+        It is checked if the metadata of the hda (by default dbkey) is in the set of allowed
+        metadata (defined by the key attribute of options-filter element) if the referred
+        parameter (defined by the ref attribute of the options-filter element).
+
+        If another metadata element of the hda should be used this can only be specified with
+        the (deprecated options_filter_attribute of the options element) Which metadata
+
+        For profile < 22.09 the function returns always False if the metadata element
+        of the referred dataset was not set. For later profiles the function returns true
+        in any case (which makes it analoguous to the behaviour of the dynamic options filter
+        for select parameters).
         """
         param = self.param
-        return param.options and param.get_options_filter_attribute(hda) not in self.filter_values and len(self.filter_values) > 0
+
+        if param.tool.profile < 22.09:
+            return param.options and param.get_options_filter_attribute(hda) not in self.filter_values
+        else:
+            return (
+                param.options
+                and param.get_options_filter_attribute(hda) not in self.filter_values
+                and len(self.filter_values) > 0
+            )
 
 
 class HdaDirectMatch:

--- a/test/functional/tools/dbkey_data_filter_input.xml
+++ b/test/functional/tools/dbkey_data_filter_input.xml
@@ -1,0 +1,59 @@
+<tool id="dbkey_data_filter_input" name="dbkey_data_filter_input" version="0.1.0" profile="22.9">
+    <description>Filter (single) data input on a dbkey</description>
+    <command><![CDATA[
+       cat '$inputs' > '$output' &&
+       echo $inputs.metadata.dbkey
+       echo $other.metadata.dbkey
+    ]]></command>
+    <inputs>
+        <param name="inputs" type="data" format="txt" label="Inputs" help="" />
+        <param name="other" type="data" format="txt" label="Other">
+            <options>
+                <filter type="data_meta" key="dbkey" ref="inputs"/>
+            </options>
+            <validator type="no_options" message="No reference genome is available for the build associated with the selected input dataset" />
+        </param>
+    </inputs>
+
+    <outputs>
+        <data name="output" format="txt" />
+    </outputs>
+
+    <tests>
+        <!-- can choose a dbkey if it matches input -->
+        <test>
+            <param name="inputs" value="simple_line.txt" dbkey="hg19" />
+            <param name="other" value="simple_line_x2.txt" dbkey="hg19"/>
+            <output name="output" file="simple_line.txt" />
+            <assert_stdout>
+                <has_text text="hg19" n="2"/>
+            </assert_stdout>
+        </test>
+        <!-- choose any dbkey if not specified in reference -->
+        <test>
+            <param name="inputs" value="simple_line.txt" />
+            <param name="other" value="simple_line_x2.txt" dbkey="hg19"/>
+            <output name="output" file="simple_line.txt" />
+            <assert_stdout>
+                <has_text text="hg19" n="1"/>
+            </assert_stdout>
+        </test>
+        <!-- cant choose a dkkey different from reference
+             this test should actually fail (ie it should have:
+             expect_failure="true" and output assertions removed)
+             it doesnt because for testing currently no restrictions are
+             applied to datasets (like dbkey filters)
+             https://github.com/galaxyproject/galaxy/pull/12073
+        -->
+        <test>
+            <param name="inputs" value="simple_line.txt" dbkey="hg18" />
+            <param name="other" value="simple_line_x2.txt" dbkey="hg19"/>
+            <assert_stdout>
+                <has_text text="hg18" n="1"/>
+                <has_text text="hg19" n="1"/>
+            </assert_stdout>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/sample_tool_conf.xml
+++ b/test/functional/tools/sample_tool_conf.xml
@@ -64,6 +64,7 @@
   <tool file="dbkey_filter_multi_input.xml" />
   <tool file="dbkey_filter_collection.xml" />
   <tool file="dbkey_output_action.xml" />
+  <tool file="dbkey_data_filter_input.xml" />
   <tool file="composite_output.xml" />
   <tool file="composite_output_tests.xml" />
   <tool file="unicode_stream.xml" />

--- a/test/unit/app/tools/test_dataset_matcher.py
+++ b/test/unit/app/tools/test_dataset_matcher.py
@@ -10,14 +10,7 @@ from galaxy.util import (
 )
 from galaxy.util.unittest import TestCase
 from .test_data_parameters import MockHistoryDatasetAssociation
-
-
-class MockTool:
-    def __init__(self, app):
-        self.app = app
-        self.tool_type = "default"
-        self.valid_input_states = model.Dataset.valid_input_states
-
+from .util import MockTool
 
 class TestDatasetMatcher(TestCase, UsesApp):
     def test_hda_mismatches(self):

--- a/test/unit/app/tools/test_dataset_matcher.py
+++ b/test/unit/app/tools/test_dataset_matcher.py
@@ -12,6 +12,7 @@ from galaxy.util.unittest import TestCase
 from .test_data_parameters import MockHistoryDatasetAssociation
 from .util import MockTool
 
+
 class TestDatasetMatcher(TestCase, UsesApp):
     def test_hda_mismatches(self):
         # Datasets not visible are not "valid" for param.

--- a/test/unit/app/tools/test_dataset_matcher.py
+++ b/test/unit/app/tools/test_dataset_matcher.py
@@ -91,6 +91,37 @@ class TestDatasetMatcher(TestCase, UsesApp):
         hda_match = self.test_context.hda_match(self.mock_hda)
         assert not hda_match
 
+    def test_filtered_hda_unset_key(self):
+        """
+        test (for the default profile 16.04) that hda is filtered
+        if the referred dataset does not set a dbkey
+        """
+        self.filtered_param = True
+        data1_val = model.HistoryDatasetAssociation()
+        data1_val.dbkey = "?"
+        self.other_values = {"data1": data1_val}
+        assert self.test_context.filter_values == set()
+
+        # mock_hda is hg19, other is ? so should not be "valid hda"
+        hda_match = self.test_context.hda_match(self.mock_hda)
+        assert not hda_match
+
+    def test_filtered_hda_unset_key_profile(self):
+        """
+        test (for the profile version 22.09 that the hda is NOT
+        filtered if the referred data set does not set a dbkey
+        """
+        self.tool.profile = 22.09
+        self.filtered_param = True
+        data1_val = model.HistoryDatasetAssociation()
+        data1_val.dbkey = "?"
+        self.other_values = {"data1": data1_val}
+        assert self.test_context.filter_values == set()
+
+        # mock_hda is hg19, other is hg18 so should not be "valid hda"
+        hda_match = self.test_context.hda_match(self.mock_hda)
+        assert hda_match
+
     def test_filtered_hda_unmatched_key(self):
         self.filtered_param = True
         data1_val = model.HistoryDatasetAssociation()

--- a/test/unit/app/tools/util.py
+++ b/test/unit/app/tools/util.py
@@ -1,11 +1,9 @@
 from galaxy import model
 from galaxy.app_unittest_utils.tools_support import UsesApp
 from galaxy.tools.parameters import basic
-from galaxy.util import (
-    bunch,
-    XML,
-)
+from galaxy.util import XML
 from galaxy.util.unittest import TestCase
+
 
 class MockTool:
     def __init__(self, app):

--- a/test/unit/app/tools/util.py
+++ b/test/unit/app/tools/util.py
@@ -7,16 +7,18 @@ from galaxy.util import (
 )
 from galaxy.util.unittest import TestCase
 
+class MockTool:
+    def __init__(self, app):
+        self.app = app
+        self.tool_type = "default"
+        self.valid_input_states = model.Dataset.valid_input_states
+        self.profile = 23.0
+
 
 class BaseParameterTestCase(TestCase, UsesApp):
     def setUp(self):
         self.setup_app()
-        self.mock_tool = bunch.Bunch(
-            app=self.app,
-            tool_type="default",
-            valid_input_states=model.Dataset.valid_input_states,
-            profile=23.0,
-        )
+        self.mock_tool = MockTool(self.app)
 
     def _parameter_for(self, **kwds):
         content = kwds["xml"]


### PR DESCRIPTION
Like in the filter for selects with dynamic options.
Note actually in the select case we check if the referred dataset has the dbkey set while we do this here for the dataset itself. I guess this could be changed but I could not find a good way to do this.

Discovered while fixing https://github.com/galaxyproject/tools-iuc/pull/4023 for https://github.com/galaxyproject/galaxy/pull/12073 where this leads to a bug because filtered datasets are not matching:
https://github.com/galaxyproject/galaxy/blob/5ea4d7e647d09dde957e824a083b1bd6acaa6f17/lib/galaxy/tools/parameters/dataset_matcher.py#L132

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
