### PR TITLE
[21.09] Set wait instead of not-allowed cursor to indicate tool form loading

### DIFF
--- a/client/src/style/scss/ui.scss
+++ b/client/src/style/scss/ui.scss
@@ -233,7 +233,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
         height: 100%;
         opacity: 0.15;
         background: $white;
-        cursor: not-allowed;
+        cursor: wait;
     }
 }
 


### PR DESCRIPTION
This PR fixes a minor issue regarding the mouse cursor during a tool form update. Currently the cursor indicates that operations are not permitted. This PR displays an hourglass instead.

## How to test the changes?
  1. Select data in a tool form
  2. Notice how the mouse cursor displays an hour glass

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
