### PR TITLE
Hack to fix converter tests failing recently in CI

### DIFF
--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Move test data
       run: rsync -av --remove-source-files --exclude .git galaxy-test-data/ 'galaxy root/test-data/'
     - name: Install planemo
-      run: pip install planemo
+      run: pip install planemo 'click==8.0.1'
     - name: Install jq
       run: sudo apt-get install jq
     - name: Determine converters to check


### PR DESCRIPTION
It would be nice to keep these things unpinned in dev but pin the whole stack for releases, but that is a longer term task.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
