### PR TITLE
Fix gff and scidx parsing

### DIFF
--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1519,7 +1519,7 @@ class ScIdx(Tabular):
                 # just check one data line
                 break
         # at least the comment and header are required
-        if count >= 2:
+        if count >= 1:
             return True
         return False
 

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -824,8 +824,8 @@ class Gff(Tabular, _RemoteCallMixin):
                 if not hdr or hdr == ['']:
                     continue
                 hdr0_parts = hdr[0].split()
-                if hdr0_parts[0] == '##gff-version' and not hdr0_parts[1].startswith('2'):
-                    return False
+                if hdr0_parts[0] == '##gff-version':
+                    return hdr0_parts[1].startswith('2')
                 # The gff-version header comment may have been stripped, so inspect the data
                 if hdr[0].startswith('#'):
                     continue
@@ -1507,7 +1507,7 @@ class ScIdx(Tabular):
                 else:
                     return False
             # Skip first line.
-            if count > 1:
+            if count >= 1:
                 items = line.split('\t')
                 if len(items) != 5:
                     return False

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1468,13 +1468,13 @@ class ScIdx(Tabular):
     peak count values.
 
     >>> from galaxy.datatypes.sniff import get_test_fname
-    >>> fname = get_test_fname( 'cntrl_hg19.scidx' )
-    >>> ScIdx().sniff( fname )
+    >>> fname = get_test_fname('cntrl_hg19.scidx')
+    >>> ScIdx().sniff(fname)
     True
-    >>> Bed().sniff( fname )
+    >>> Bed().sniff(fname)
     False
-    >>> fname = get_test_fname( 'empty.txt' )
-    >>> ScIdx().sniff( fname )
+    >>> fname = get_test_fname('empty.txt')
+    >>> ScIdx().sniff(fname)
     False
     """
     file_ext = "scidx"
@@ -1516,8 +1516,7 @@ class ScIdx(Tabular):
                     return False
                 if int(line[2]) + int(line[3]) != int(line[4]):
                     return False
-            # just check one data line
-            if count > 2:
+                # just check one data line
                 break
         # at least the comment and header are required
         if count >= 2:

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1496,8 +1496,7 @@ class ScIdx(Tabular):
         Checks for 'scidx-ness.'
         """
         count = 0
-        for count, line in enumerate(file_prefix.line_iterator()):
-            line = line.strip().split()
+        for count, line in enumerate(iter_headers(file_prefix, '\t')):
             # The first line is always a comment like this:
             # 2015-11-23 20:18:56.51;input.bam;READ1
             if count == 0:

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -1519,7 +1519,8 @@ class ScIdx(Tabular):
             # just check one data line
             if count > 2:
                 break
-        if count == 3:
+        # at least the comment and header are required
+        if count >= 2:
             return True
         return False
 

--- a/lib/galaxy/datatypes/test/cntrl_hg19.scidx
+++ b/lib/galaxy/datatypes/test/cntrl_hg19.scidx
@@ -1,0 +1,20 @@
+#2016-11-04 08:39:36.449;localbam.bam;READ1
+chrom	index	forward	reverse	value
+chr1	13038	1	0	1
+chr1	16604	0	1	1
+chr1	19215	1	0	1
+chr1	20151	0	1	1
+chr1	48908	1	0	1
+chr1	49489	1	0	1
+chr1	55105	1	0	1
+chr1	57499	0	1	1
+chr1	66636	1	0	1
+chr1	67393	0	1	1
+chr1	72875	0	1	1
+chr1	73954	0	1	1
+chr1	82146	1	0	1
+chr1	85089	0	1	1
+chr1	101405	1	0	1
+chr1	106851	0	1	1
+chr1	108358	0	1	1
+chr1	113877	0	1	1


### PR DESCRIPTION
- gff: if there is a `##gff-version` line then respect it
  - it now is analogous to the Gff3 sniffer
  - follow up to https://github.com/galaxyproject/galaxy/pull/12676
- scidx: do not skip the 2nd line

this is fall out of https://github.com/galaxyproject/galaxy/pull/12073 .. found while fixing IUC tools

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
