### PR TITLE
Add Tag validation in API requests

### DIFF
--- a/lib/galaxy/managers/tags.py
+++ b/lib/galaxy/managers/tags.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from typing import (
-    List,
     Optional,
 )
 
@@ -13,6 +12,7 @@ from galaxy.managers.context import ProvidesUserContext
 from galaxy.model import ItemTagAssociation
 from galaxy.model.tags import GalaxyTagHandlerSession
 from galaxy.schema.fields import EncodedDatabaseIdField
+from galaxy.schema.schema import TagCollection
 
 taggable_item_names = {item: item for item in ItemTagAssociation.associated_item_names}
 # This Enum is generated dynamically and mypy can not statically infer it's real type
@@ -31,7 +31,7 @@ class ItemTagsPayload(BaseModel):
         title="Item class",
         description="The name of the class of the item that will be tagged.",
     )
-    item_tags: Optional[List[str]] = Field(
+    item_tags: Optional[TagCollection] = Field(
         default=None,
         title="Item tags",
         description="The list of tags that will replace the current tags associated with the item.",
@@ -48,8 +48,8 @@ class TagsManager:
         """Apply a new set of tags to an item; previous tags are deleted."""
         tag_handler = GalaxyTagHandlerSession(trans.sa_session)
         new_tags: Optional[str] = None
-        if payload.item_tags and len(payload.item_tags) > 0:
-            new_tags = ",".join(payload.item_tags)
+        if payload.item_tags and len(payload.item_tags.__root__) > 0:
+            new_tags = ",".join(payload.item_tags.__root__)
         item = self._get_item(trans, payload)
         user = trans.user
         tag_handler.delete_item_tags(user, item)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -1,5 +1,6 @@
 """This module contains general pydantic models and common schema field annotations for them."""
 
+import re
 from datetime import datetime
 from enum import Enum
 from typing import (
@@ -15,7 +16,6 @@ from pydantic import (
     AnyHttpUrl,
     AnyUrl,
     BaseModel,
-    constr,
     ConstrainedStr,
     Extra,
     Field,
@@ -243,7 +243,8 @@ class HistoryContentSource(str, Enum):
     new_collection = "new_collection"
 
 
-TagItem: ConstrainedStr = constr(regex=r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")
+class TagItem(ConstrainedStr):
+    regex = re.compile(r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")
 
 
 class TagCollection(Model):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -15,6 +15,8 @@ from pydantic import (
     AnyHttpUrl,
     AnyUrl,
     BaseModel,
+    constr,
+    ConstrainedStr,
     Extra,
     Field,
     FilePath,
@@ -241,9 +243,12 @@ class HistoryContentSource(str, Enum):
     new_collection = "new_collection"
 
 
+TagItem: ConstrainedStr = constr(regex=r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")
+
+
 class TagCollection(Model):
     """Represents the collection of tags associated with an item."""
-    __root__: List[str] = Field(
+    __root__: List[TagItem] = Field(
         default=...,
         title="Tags",
         description="The collection of tags associated with an item.",


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/issues/12568#issuecomment-938479609

Tags are now validated in every request that uses the `TagCollection` or `TagItem` pydantic models.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to http://127.0.0.1:8080/api/docs#/tags/update_api_tags_put
  - Modify the **Request Body** with something like:
    ```json
    {
      "item_id": "put_any_history_ID_here",
      "item_class": "History",
      "item_tags": [
        "name:cool_tag", "valid", "...invalid"
      ]
    }
    ```
  - You should get a Bad Request (400) because of the tag `"...invalid"`
  - Remove this tag and try again, this time you should get a 204 and the new tags should be in the history.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
