### PR TITLE
Framework support for integration tests requiring celery.

### DIFF
--- a/lib/galaxy/dependencies/dev-requirements.txt
+++ b/lib/galaxy/dependencies/dev-requirements.txt
@@ -169,6 +169,7 @@ pyreadline==2.1; python_version >= "3.6" and python_full_version < "3.0.0" and p
 pyrsistent==0.17.3; python_version >= "3.5"
 pysam==0.16.0.1
 pytest-asyncio==0.15.1; python_version >= "3.6"
+pytest-celery==0.0.0
 pytest-cov==2.11.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 pytest-html==3.1.1; python_version >= "3.6"
 pytest-json-report==1.2.4

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -636,7 +636,8 @@ def build_galaxy_app(simple_kwargs):
     )
     # Build the Universe Application
     app = GalaxyUniverseApplication(**simple_kwargs)
-    rebind_container_to_task(app)
+    if not simple_kwargs.get("enable_celery_tasks"):
+        rebind_container_to_task(app)
 
     log.info("Embedded Galaxy application started")
 

--- a/lib/galaxy_test/driver/integration_util.py
+++ b/lib/galaxy_test/driver/integration_util.py
@@ -169,6 +169,18 @@ class IntegrationInstance(UsesApiTestCaseMixin):
         return os.path.realpath(os.path.join(cls._test_driver.galaxy_test_tmp_dir, name))
 
 
+class UsesCeleryTasks:
+    enable_celery_tasks = True
+
+    @pytest.fixture(autouse=True)
+    def _request_celery_app(self, celery_app):
+        self._celery_app = celery_app
+
+    @pytest.fixture(autouse=True)
+    def _request_celery_worker(self, celery_worker):
+        self._celery_worker = celery_worker
+
+
 class IntegrationTestCase(IntegrationInstance, TestCase):
     """Unit TestCase with utilities for spinning up Galaxy."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ NoseHTML = "*"
 pygithub = ">=1.54.1"  # prevent downgrade (depends on pyjwt(<2.0); pyjwt auto-upgrade to 2.0.1 causes pygithub downgrade to 1.53)
 pytest = "*"
 pytest-asyncio = "*"
+pytest-celery = "*"
 pytest-cov = "*"
 pytest-html = "*"
 python-irodsclient = "*"

--- a/test/integration/test_celery_tasks.py
+++ b/test/integration/test_celery_tasks.py
@@ -1,0 +1,43 @@
+from celery import shared_task
+
+from galaxy.celery.tasks import purge_hda
+from galaxy.model import HistoryDatasetAssociation
+from galaxy_test.base.populators import DatasetPopulator, wait_on
+from galaxy_test.driver.integration_util import IntegrationTestCase, UsesCeleryTasks
+
+
+@shared_task
+def mul(x, y):
+    return x * y
+
+
+class CeleryTasksIntegrationTestCase(IntegrationTestCase, UsesCeleryTasks):
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+
+    def test_random_simple_task_to_verify_framework_for_testing(self):
+        assert mul.delay(4, 4).get(timeout=10) == 16
+
+    def test_galaxy_task(self):
+        history_id = self.dataset_populator.new_history()
+        dataset = self.dataset_populator.new_dataset(history_id, wait=True)
+        hda = self._latest_hda
+        assert hda
+
+        def hda_purged():
+            latest_details = self.dataset_populator.get_history_dataset_details(history_id, dataset=dataset, assert_ok=False, wait=False)
+            return True if latest_details["purged"] else None
+
+        assert not hda_purged()
+
+        purge_hda.delay(hda_id=hda.id).get(timeout=10)
+
+        wait_on(hda_purged, "dataset to become purged")
+        assert hda_purged()
+
+    @property
+    def _latest_hda(self):
+        latest_hda = self._app.model.session.query(HistoryDatasetAssociation).order_by(HistoryDatasetAssociation.table.c.id.desc()).first()
+        return latest_hda


### PR DESCRIPTION
Rework task decorators to be less verbose and so we don't need hacky delay-ed import of the task functions and so there are no circular dependencies between galaxy.celery.__init__ and galaxy.celery.tasks. Not to say the get_galaxy_app() in there isn't its own kind of hacky, but I think on balance this is a lot cleaner.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Install included dependency changes.
  2. ``pytest -s test/integration/test_celery_tasks.py``

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
