### PR TITLE
Discourage the use of true/falsevalue for boolean test parameters

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1443,8 +1443,8 @@ Values for these parameters are simply given by the desired value.
 #### ``boolean``
 
 The value of the test parameter should be set to `true` or `false` corresponding
-to the cases that the parameter is checked or not. Alternatively the value
-specified as `truevalue` or `falsevalue` can be given.
+to the cases that the parameter is checked or not. It is also possible, but
+discouraged, to use the value specified as `truevalue` or `falsevalue`.
 
 #### ``data``
 


### PR DESCRIPTION
xref https://github.com/galaxyproject/tools-iuc/pull/4053#issuecomment-942217779

Because it gives a stronger test.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
