### PR TITLE
consolidate and update help modal for Galaxy pages

### DIFF
--- a/client/src/components/Markdown/help.js
+++ b/client/src/components/Markdown/help.js
@@ -1,13 +1,12 @@
 export const markdownGeneralHelpHtml = `
 <p>
-    For an overview of standard Markdown visit the
-    <a href="https://commonmark.org/help/tutorial/">commonmark.org tutorial</a>.
+    For an overview of standard Markdown please visit the <a href="https://commonmark.org/help/tutorial/" target="_blank">tutorial</a>.
 </p>
 
 <p>
-    The Galaxy extensions to Markdown are represented as code blocks, these blocks start
-    with the line <tt>\`\`\`galaxy</tt> and end with the line <tt>\`\`\`</tt> and have a
-    command with arguments that reference parts of the workflow in the middle.
+    The Galaxy extensions to Markdown are represented as code blocks (using three backticks <code>\`\`\`</code>).
+    They start with the line <code>\`\`\`galaxy</code> and end with the line <code>\`\`\`</code> and have a
+    command with arguments that reference Galaxy objects in the middle.
 </p>`;
 
 export const datasetCommandsHtml = `

--- a/client/src/components/Markdown/markdownHelp.js
+++ b/client/src/components/Markdown/markdownHelp.js
@@ -1,79 +1,48 @@
-import { datasetCommandsHtml, markdownGeneralHelpHtml } from "components/Markdown/help";
+import { markdownGeneralHelpHtml } from "components/Markdown/help";
 
 const markdownHelp = `
-<div>
-<h3>Overview</h3>
-
 <p>
-    This document Markdown document will be used to generate your Galaxy Page.
-    This document should be Markdown with embedded command for extracting and
-    displaying Galaxy objects and their metadata. 
+This document is used to generate your Galaxy Page.
+It is written in Markdown with some specific features
+for extracting and displaying Galaxy objects and their metadata.
 </p>
 
 ${markdownGeneralHelpHtml}
-
-<h3>History Contents Commands</h3>
-
+<h3>Inserting Menu</h3>
+<p>You can embed Galaxy objects interactively by using the "Insert Objects" panel in the left
+sidebar. Clicking on an object type will bring up a wizard that will guide you through
+the parameter selection.</p>
+<h3>Examples</h3>
 <p>
-    These commands reference a dataset. For instance, the following examples would display
-    the dataset collection corresponding to a Galaxy dataset collection ID and display a
-    single dataset as an image corresponding to a Galaxy dataset ID.
-</p>
-
-<pre>
-\`\`\`galaxy
+Display the <strong>dataset collection</strong> corresponding to an ID of 33b43b4e7093c91f.<br>
+<pre>\`\`\`galaxy
 history_dataset_collection_display(history_dataset_collection_id=33b43b4e7093c91f)
-\`\`\`
-</pre>
-
-<pre>
-\`\`\`galaxy
+\`\`\`</pre>
+</p>
+<p>
+Display a <strong>single dataset</strong> as an image (the dataset should be an image).
+<pre>\`\`\`galaxy
 history_dataset_as_image(history_dataset_id=33b43b4e7093c91f)
-\`\`\`
-</pre>
-
-
-${datasetCommandsHtml}
-
-<h3>Workflow Commands</h3>
-
-<p>
-    These commands reference a workflow (currently only one). The following example would
-    display a representation of the workflow in the resulting Galaxy Page:
+\`\`\`</pre>
 </p>
-
-<pre>
-\`\`\`galaxy
+<p>
+Display a representation of a <strong>workflow</strong>.
+<pre>\`\`\`galaxy
 workflow_display(workflow_id=33b43b4e7093c91f>)
-\`\`\`
-</pre>
-
-<dl>
-<dt><tt>workflow_display</tt></dt>
-<dd>Embed a description of the workflow itself in the resulting document.</dd>
-</dl>
-
-<h3>Job Commands</h3>
-
-<p>
-    These commands reference a Galaxy job.For instance, the
-    following example would show the job parameters the job ID 33b43b4e7093c91f:
+\`\`\`</pre>
 </p>
-
-<pre>
-\`\`\`galaxy
+<p>
+Display the <strong>job parameters</strong> for the given job.
+<pre>\`\`\`galaxy
 job_parameters(job_id=33b43b4e7093c91f)
-\`\`\`
-</pre>
-
-<dt><tt>tool_stderr</tt></dt>
-<dd>Embed the tool standard error stream for this job in the resulting document.</dd>
-<dt><tt>tool_stdout</tt></dt>
-<dd>Embed the tool standard output stream for this job in the resulting document.</dd>
-<dt><tt>job_metrics</tt></dt>
-<dd>Embed the job metrics for this job in the resulting document (if Galaxy is configured and you have permission).</dd>
-<dt><tt>job_parameters</tt></dt>
-<dd>Embed the tool parameters for this job in the resulting document.</dd>
+\`\`\`</pre>
+</p>
+<p>
+Insert a custom <strong>visualization</strong> based on a dataset.
+<pre>\`\`\`galaxy
+visualization(visualization_id=nvd3_bar_stacked, history_dataset_id=d1dfd0042d880a92, x_axis_label="X-axis", x_axis_type|type="auto", y_axis_label="Y-axis", y_axis_type|type="auto", show_legend="true", groups_0|key="Data label")
+\`\`\`</pre>
+</p>
 `;
 
 import $ from "jquery";


### PR DESCRIPTION
I found the Pages help modal to be incomplete and slightly confusing. This is an attempt to clarify it.

Unless there is a pushback I will also adjust and update the help in the workflow report editor.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

![Galaxy](https://user-images.githubusercontent.com/1814954/137294770-dfe5d735-4531-476c-b707-570f20bb2b98.png)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
