### PR TITLE
Add framework test using unuploadable test data

### DIFF
--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -202,7 +202,7 @@
   <tool file="model_attributes.xml" />
   <tool file="python_environment_problem.xml" />
   <tool file="config_vars.xml" />
-
+  <tool file="test_with_unuploadable_dataset.xml"/>
   <tool file="multiple_versions_v01.xml" />
   <tool file="multiple_versions_v01galaxy6.xml" />
   <tool file="multiple_versions_v02.xml" />

--- a/test/functional/tools/test_with_unuploadable_dataset.xml
+++ b/test/functional/tools/test_with_unuploadable_dataset.xml
@@ -1,0 +1,17 @@
+<tool id="test_with_unuploadable_dataset" name="test with unuploadable dataset" version="1.0.0">
+    <command>
+        cat '$input' > '$output'
+    </command>
+    <inputs>
+        <param name="input" type="data" format="iqtree" />
+    </inputs>
+    <outputs>
+        <data name="output" format="iqtree" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="1.txt" ftype="iqtree" />
+            <output name="output" value="1.txt" ftype="iqtree" />
+        </test>
+    </tests>
+</tool>

--- a/tools/data_source/upload.xml
+++ b/tools/data_source/upload.xml
@@ -8,7 +8,7 @@
   <configfiles>
     <file_sources filename="file_sources.json" />
   </configfiles>
-  <command>
+  <command><![CDATA[
     python '$__tool_directory__/upload.py' '$GALAXY_ROOT_DIR' '$GALAXY_DATATYPES_CONF_FILE' '$paramfile'
     #set $outnum = 0
     #while $varExists('output%i' % $outnum):
@@ -21,16 +21,17 @@
         #end if
         '${output.dataset.dataset.id}:${output.files_path}:${file_name}'
     #end while
-  </command>
+  ]]></command>
   <inputs nginx_upload="true">
-    <param name="file_type" type="select" label="File Format" help="Which format? See help below">
+    <!-- <param name="file_type" type="select" label="File Format" help="Which format? See help below">
       <options from_parameter="tool.app.datatypes_registry.upload_file_formats" transform_lines="[ &quot;%s%s%s&quot; % ( line, self.separator, line ) for line in obj ]">
         <column name="value" index="1"/>
         <column name="name" index="0"/>
         <filter type="sort_by" column="0"/>
         <filter type="add_value" name="Auto-detect" value="auto" index="0"/>
       </options>
-    </param>
+    </param> -->
+    <param name="file_type" type="text" label="File Format" help="Which format? See help below"/>
     <param name="file_count" type="hidden" value="auto" />
     <upload_dataset name="files" title="Specify Files for Dataset" file_type_name="file_type" metadata_ref="files_metadata">
         <param name="file_data" type="file" label="File" ajax-upload="true" help="TIP: Due to browser limitations, uploading files larger than 2GB is guaranteed to fail.  To upload large files, use the URL method (below) or FTP (if enabled by the site administrator).">


### PR DESCRIPTION
Datatypes can be either visible in uploads or not (`display_in_upload="true|false"`). There are good reasons to to keep this distinction:

- some datatypes exist "only" to ensure that correct inputs are used
- do not clutter the upload form with such data sets

But there are also reasons against it: 

- sharing of datasets across Galaxys (but there is the slightly inconvenient detour via `Edit dataset attributes`)

The problem is that its currently impossible to test tools (with planemo) that have inputs with datatypes that have `display_in_upload="false"`. 

- [x] add test to show problem
- [ ] fix

This becomes really important if https://github.com/galaxyproject/galaxy/pull/12073 would be merged. Because it will forbid to give arbitrary dataypes to data parameters (which allowed to specify/use a datatype which is an uploadable superclass ). 


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
