### PR TITLE
Split integration tests more evenly

### DIFF
--- a/.ci/minikube-test-setup/start_services.sh
+++ b/.ci/minikube-test-setup/start_services.sh
@@ -7,6 +7,6 @@ kubectl expose deployment testing --type=LoadBalancer --name=testing-service
 
 CLUSTER_IP=$(kubectl get service testing-service -o jsonpath='{.spec.clusterIP}')
 GALAXY_TEST_DBURI="postgresql://postgres:postgres@${CLUSTER_IP}:5432/galaxy?client_encoding=utf-8"
-GALAXY_TEST_AMQP_URL="amqp://${CLUSTER_IP}:5672)//"
+GALAXY_TEST_AMQP_URL="amqp://${CLUSTER_IP}:5672//"
 export GALAXY_TEST_DBURI
 export GALAXY_TEST_AMQP_URL

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7']
-        subset: ['upload_datatype', 'extended_metadata', 'kubernetes', 'not (upload_datatype or extended_metadata or kubernetes)']
+        chunk: ['1', '2', '3', '4']
     services:
       postgres:
         image: postgres:13
@@ -32,19 +32,15 @@ jobs:
       - name: Prune unused docker image, volumes and containers
         run: docker system prune -a -f
       - name: Clean dotnet folder for space
-        if: matrix.subset == 'kubernetes'
         run: rm -Rf /usr/share/dotnet
       - name: Setup Minikube
-        if: matrix.subset == 'kubernetes'
         id: minikube
         uses: CodingNagger/minikube-setup-action@v1.0.3
         with:
           minikube-version: "1.9.0-0_amd64"
       - name: Launch Minikube
-        if: matrix.subset == 'kubernetes'
         run: eval ${{ steps.minikube.outputs.launcher }}
       - name: Check pods
-        if: matrix.subset == 'kubernetes'
         run: |
           kubectl get pods
       - uses: actions/checkout@v2
@@ -70,19 +66,13 @@ jobs:
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration
       - name: Install ffmpeg
         run: sudo apt-get update && sudo apt-get -y install ffmpeg
-        if: matrix.subset == 'upload_datatype'
       - name: Run tests
-        if: matrix.subset != 'kubernetes'
-        run: './run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"'
-        working-directory: 'galaxy root'
-      - name: Run tests
-        if: matrix.subset == 'kubernetes'
         run: |
           . .ci/minikube-test-setup/start_services.sh
-          ./run_tests.sh -integration test/integration -- -k "${{ matrix.subset }}"
+          ./run_tests.sh -integration test/integration -- --num-shards=4 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: Integration test results (${{ matrix.python-version }}, ${{ matrix.subset }})
+          name: Integration test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
           path: 'galaxy root/run_integration_tests.html'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7']
-        chunk: ['1', '2', '3', '4']
+        chunk: ['0', '1', '2', '3']
     services:
       postgres:
         image: postgres:13

--- a/test/integration/test_resolvers.py
+++ b/test/integration/test_resolvers.py
@@ -45,11 +45,15 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()
         self._assert_dependency_type(response)
+        # Verify GET request
+        create_response = self._get("dependency_resolvers/dependency", data=data, admin=True)
+        self._assert_status_code_is(create_response, 200)
+        response = create_response.json()
+        self._assert_dependency_type(response)
 
     def test_dependency_install_not_exact(self):
         """
         Test installation of gnuplot with a version that does not exist.
-        Sh
         """
         data = GNUPLOT.copy()
         data['version'] = '4.9999'
@@ -57,17 +61,11 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()
         self._assert_dependency_type(response, exact=False)
-
-    def test_dependency_status_installed_exact(self):
-        """
-        GET request to dependency_resolvers/dependency with GNUPLOT dependency.
-        Should be installed through conda (response['dependency_type'] == 'conda').
-        """
-        data = GNUPLOT
+        # Verify GET request
         create_response = self._get("dependency_resolvers/dependency", data=data, admin=True)
         self._assert_status_code_is(create_response, 200)
         response = create_response.json()
-        self._assert_dependency_type(response)
+        self._assert_dependency_type(response, exact=False)
 
     def test_legacy_r_mapping(self):
         """
@@ -87,19 +85,6 @@ class CondaResolutionIntegrationTestCase(integration_util.IntegrationTestCase):
         create_response = self._post("tools", data=payload)
         self._assert_status_code_is(create_response, 200)
         dataset_populator.wait_for_history(history_id, assert_ok=True)
-
-    def test_dependency_status_installed_not_exact(self):
-        """
-        GET request to dependency_resolvers/dependency with GNUPLOT dependency.
-        Should be installed through conda (response['dependency_type'] == 'conda'),
-        but version 4.9999 does not exist.
-        """
-        data = GNUPLOT.copy()
-        data['version'] = '4.9999'
-        create_response = self._get("dependency_resolvers/dependency", data=data, admin=True)
-        self._assert_status_code_is(create_response, 200)
-        response = create_response.json()
-        self._assert_dependency_type(response, exact=False)
 
     def test_conda_install_through_tools_api(self):
         tool_id = 'mulled_example_multi_1'


### PR DESCRIPTION
The downside is that we setup minikube and ffmpeg for all tests, but the upside should be more even execution time.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
