### PR TITLE
[21.09] Add file_ext property to Pretext and others datatypes

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -51,6 +51,7 @@ pysam.set_verbosity(0)
 class Binary(data.Data):
     """Binary data"""
     edam_format = "format_2333"
+    file_ext = "binary"
 
     @staticmethod
     def register_sniffable_binary_format(data_type, ext, type_class):

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -3152,6 +3152,7 @@ class Pretext(Binary):
     >>> Pretext().sniff(fname)
     True
     """
+    file_ext = "pretext"
 
     def sniff_prefix(self, sniff_prefix):
         # The first 4 bytes of any pretext file is 'pstm', and the rest of the

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -452,6 +452,7 @@ class SraManifest(Tabular):
 
 class Taxonomy(Tabular):
     file_ext = "taxonomy"
+
     def __init__(self, **kwd):
         """Initialize taxonomy datatype"""
         super().__init__(**kwd)

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -264,6 +264,7 @@ class TabularData(data.Text):
 @dataproviders.decorators.has_dataproviders
 class Tabular(TabularData):
     """Tab delimited data"""
+    file_ext = "tabular"
 
     def get_column_names(self, first_line=None):
         return None
@@ -438,7 +439,7 @@ class Tabular(TabularData):
 
 class SraManifest(Tabular):
     """A manifest received from the sra_source tool."""
-    ext = 'sra_manifest.tabular'
+    file_ext = 'sra_manifest.tabular'
     data_line_offset = 1
 
     def set_meta(self, dataset, **kwds):
@@ -450,6 +451,7 @@ class SraManifest(Tabular):
 
 
 class Taxonomy(Tabular):
+    file_ext = "taxonomy"
     def __init__(self, **kwd):
         """Initialize taxonomy datatype"""
         super().__init__(**kwd)


### PR DESCRIPTION
otherwise sniffing does not work

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
