### PR TITLE
[20.05] Continue deleting dataset collection if member HDA has no history

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -255,7 +255,11 @@ class DatasetCollectionManager(object):
 
         if recursive:
             for dataset in dataset_collection_instance.collection.dataset_instances:
-                self.hda_manager.error_unless_owner(dataset, user=trans.get_user(), current_history=trans.history)
+                try:
+                    self.hda_manager.error_unless_owner(dataset, user=trans.get_user(), current_history=trans.history)
+                except hdas.HistoryDatasetAssociationNoHistoryException:
+                    log.info("Cannot delete HistoryDatasetAssociation {}, HistoryDatasetAssociation has no associated History, cannot verify owner".format(dataset.id))
+                    continue
                 if not dataset.deleted:
                     dataset.deleted = True
 

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -24,6 +24,10 @@ from galaxy.managers import (
 log = logging.getLogger(__name__)
 
 
+class HistoryDatasetAssociationNoHistoryException(Exception):
+    pass
+
+
 class HDAManager(datasets.DatasetAssociationManager,
                  secured.OwnableManagerMixin,
                  taggable.TaggableManagerMixin,
@@ -69,9 +73,11 @@ class HDAManager(datasets.DatasetAssociationManager,
         """
         Use history to see if current user owns HDA.
         """
-        history = hda.history
         if self.user_manager.is_admin(user, trans=kwargs.get("trans", None)):
             return True
+        history = hda.history
+        if history is None:
+            raise HistoryDatasetAssociationNoHistoryException
         # allow anonymous user to access current history
         # TODO: some dup here with historyManager.is_owner but prevents circ import
         # TODO: awkward kwarg (which is my new band name); this may not belong here - move to controller?


### PR DESCRIPTION
These can be cleaned up with pgcleanup.

Fixes https://github.com/galaxyproject/galaxy/issues/12716

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Create a dataset collection, and then set the history_id column of one the dataset instances in the dataset collection to `NULL`. Try deleting the collection, it should work.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
