### PR TITLE
Tool linter: simple test for test params absent from inputs

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -30,7 +30,7 @@ def lint_tsts(tool_xml, lint_ctx):
         for param in test.findall("param"):
             name = param.attrib.get("name", None)
             if not name:
-                lint_ctx.warn("Found test param tag without a name defined.")
+                lint_ctx.error("Found test param tag without a name defined.")
                 continue
             name = name.split("|")[-1]
             xpaths = [f"@name='{name}'",

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -26,6 +26,30 @@ def lint_tsts(tool_xml, lint_ctx):
                 has_test = True
                 break
 
+        # really simple test that test parameters are also present in the inputs
+        for param in test.findall("param"):
+            name = param.attrib.get("name", None)
+            if not name:
+                lint_ctx.warn("Found test param tag without a name defined.")
+                continue
+            name = name.split("|")[-1]
+            xpaths = [f"@name='{name}'",
+                      f"@argument='{name}'",
+                      f"@argument='-{name}'",
+                      f"@argument='--{name}'"]
+            if "_" in name:
+                xpaths += [f"@argument='-{name.replace('_', '-')}'",
+                           f"@argument='--{name.replace('_', '-')}'"]
+            found = False
+            for xp in xpaths:
+                inxpath = f".//inputs//param[{xp}]"
+                inparam = tool_xml.findall(inxpath)
+                if len(inparam) > 0:
+                    found = True
+                    break
+            if not found:
+                lint_ctx.error(f"Test param {name} not found in the inputs")
+
         output_data_names, output_collection_names = _collect_output_names(tool_xml)
         found_output_test = False
         for output in test.findall("output"):

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -188,7 +188,7 @@ TESTS_WO_EXPECTATIONS = """
 TESTS_PARAM = """
 <tool>
     <inputs>
-        <param name="existent_test_name"/>
+        <param argument="--existent-test-name"/>
         <conditional>
             <when>
                 <param name="another_existent_test_name"/>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -5,7 +5,7 @@ from galaxy.tool_util.linters import (
     general,
     inputs,
     outputs,
-    tests
+    tests,
 )
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
@@ -319,7 +319,7 @@ TEST_IDS = [
     'outputs collection static elements with format_source',
     'outputs discover datatsets with tool provided metadata',
     'test without expectations',
-    'test param missing from inputs'
+    'test param missing from inputs',
 ]
 
 


### PR DESCRIPTION
The IUC tools directory contains approx. 54 such cases. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
