### PR TITLE
Fix for PairedListCreator errant autopairing

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -480,7 +480,7 @@ export default {
             filters: this.DEFAULT_FILTERS,
             automaticallyPair: true,
             initialPairsPossible: true,
-            matchPercentage: 0.9,
+            matchPercentage: 0.99,
             twoPassAutoPairing: true,
             removeExtensions: true,
             workingElements: [],


### PR DESCRIPTION
I increased the matchPercentage used for autopairing. This prevents the mismatched pairs found in #12593 

Both screenshots use the same datasets as #12593, and in both I've omitted ERR5949460_2.fastqsanger.gz

Screenshot from dev/21.09:

![Screenshot from 2021-10-15 17-43-04](https://user-images.githubusercontent.com/26912553/137556771-138c2087-3295-43bf-835a-ba2759023a98.png)

Screenshot with matchPercentage increase:

![Screenshot from 2021-10-15 17-42-00](https://user-images.githubusercontent.com/26912553/137556781-6970b77a-4cc0-4f14-b752-0f98f3e8f926.png)

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Try to create a list of dataset pairs, but do not select one of the reverse pairs.
  2. You'll see that the forward pair (who is missing it's partner) will remain in the unpaired section
  3. PairedListCollectionCreator tests pass, Tutorial on Creating Paired Lists works, too. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
