### PR TITLE
[21.05] Fix bad merge

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -19,7 +19,10 @@ from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.util import (
     validation
 )
-from .hdas import HDAManager
+from .hdas import (
+    HDAManager,
+    HistoryDatasetAssociationNoHistoryException,
+)
 from .histories import HistoryManager
 from .lddas import LDDAManager
 
@@ -266,7 +269,7 @@ class DatasetCollectionManager:
             for dataset in dataset_collection_instance.collection.dataset_instances:
                 try:
                     self.hda_manager.error_unless_owner(dataset, user=trans.get_user(), current_history=trans.history)
-                except hdas.HistoryDatasetAssociationNoHistoryException:
+                except HistoryDatasetAssociationNoHistoryException:
                     log.info("Cannot delete HistoryDatasetAssociation {}, HistoryDatasetAssociation has no associated History, cannot verify owner".format(dataset.id))
                     continue
                 if not dataset.deleted:


### PR DESCRIPTION
we've changed the import, so merging https://github.com/galaxyproject/galaxy/pull/12722 into 21.05 failed.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
