### PR TITLE
[Need Help] Override model serializer callback for generating URLs in ASGI context

### DIFF
--- a/lib/galaxy/web/framework/__init__.py
+++ b/lib/galaxy/web/framework/__init__.py
@@ -7,7 +7,7 @@ from . import base
 DEPRECATED_URL_ATTRIBUTE_MESSAGE = "*deprecated attribute, URL not filled in by server*"
 
 
-def handle_url_for(*args, **kwargs) -> str:
+def handle_uwsgi_url_for(*args, **kwargs) -> str:
     """Tries to resolve the URL using the `routes` module.
 
     This only works in a WSGI app so a deprecation message is returned
@@ -19,4 +19,4 @@ def handle_url_for(*args, **kwargs) -> str:
         return DEPRECATED_URL_ATTRIBUTE_MESSAGE
 
 
-url_for = handle_url_for
+url_for = handle_uwsgi_url_for

--- a/lib/galaxy/webapps/base/api.py
+++ b/lib/galaxy/webapps/base/api.py
@@ -1,19 +1,27 @@
-from fastapi import FastAPI, Request
+import logging
+
+from fastapi import Depends, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from starlette.responses import Response
+from starlette.routing import NoMatchFound
+
+from galaxy.exceptions import MessageException
+from galaxy.managers.base import ModelSerializer
+from galaxy.web.framework import handle_uwsgi_url_for
 try:
     from starlette_context.middleware import RawContextMiddleware
     from starlette_context.plugins import RequestIdPlugin
 except ImportError:
     pass
-
-from galaxy.exceptions import MessageException
 from galaxy.web.framework.base import walk_controller_modules
 from galaxy.web.framework.decorators import (
     api_error_message,
     validation_error_to_message_exception
 )
+from galaxy.webapps.galaxy.api import UrlBuilder
+
+log = logging.getLogger(__name__)
 
 
 def add_exception_handler(
@@ -47,3 +55,34 @@ def include_all_package_routers(app: FastAPI, package_name: str):
         router = getattr(module, "router", None)
         if router:
             app.include_router(router)
+
+
+def get_url_builder(request: Request):
+    return UrlBuilder(request)
+
+
+def setup_reverse_url_lookup(app):
+    """Makes all model serializers to use the ASGI URL builder by default.
+    And fallback to UWSGI URL handling if the route is not registered.
+    """
+
+    def uses_dependency_injection(func):
+        return app.magic_partial(func)
+
+    @uses_dependency_injection
+    def handle_asgi_url_for(*args, url_builder: UrlBuilder = Depends(get_url_builder), **kwargs) -> str:
+        """Use the injected ASGI UrlBuilder to try and generate the URL.
+
+        The name of the route must be registered correctly in the FastAPI route endpoint, otherwise it will
+        fallback to the legacy UWSGI URL handling mechanism which in most cases will not work in ASGI context.
+        """
+        if url_builder:
+            try:
+                return url_builder(*args, **kwargs)
+            except NoMatchFound:
+                log.debug(f"No matching for route name: '{args[0]}'.")
+                pass
+        # Fallback to legacy url_for handling
+        return handle_uwsgi_url_for(*args, **kwargs)
+
+    ModelSerializer.url_for = handle_asgi_url_for

--- a/lib/galaxy/webapps/galaxy/fast_app.py
+++ b/lib/galaxy/webapps/galaxy/fast_app.py
@@ -13,6 +13,7 @@ from galaxy.webapps.base.api import (
     add_exception_handler,
     add_request_id_middleware,
     include_all_package_routers,
+    setup_reverse_url_lookup,
 )
 from galaxy.webapps.base.webapp import config_allows_origin
 
@@ -131,4 +132,5 @@ def initialize_fast_app(gx_wsgi_webapp, gx_app):
     include_all_package_routers(app, 'galaxy.webapps.galaxy.api')
     wsgi_handler = WSGIMiddleware(gx_wsgi_webapp)
     app.mount('/', wsgi_handler)
+    setup_reverse_url_lookup(gx_app)
     return app


### PR DESCRIPTION
This is a (currently failed) attempt to support URL generation for some fields in the API response models, so it will upset a considerable amount of API tests if not all of them...

In the last Backend-WG meeting, we decided to finally deprecate this functionality going forward, but @nsoranzo expressed in this https://github.com/galaxyproject/galaxy/pull/12578#issuecomment-941306905 his concern about this, so I decided to give it a last try.
Unfortunately, the dependency injection is not working in this case, probably I'm overlooking something obvious, or I'm doing something fundamentally wrong or I just don't have yet the required Python Wizardry level to cast this spell. Maybe someone more experienced can give me a hand here?

The alternative to this could be just going and try to manually pass the `UrlBuilder` instance to every call to `url_for` which is less than ideal and I think is not possible in all situations because we don't always have access to the Request instance.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
