### PR TITLE
[21.09] Fix linter: Parameter validator needs no expression

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -19,16 +19,16 @@ FILTER_TYPES = [
 
 ATTRIB_VALIDATOR_COMPATIBILITY = {
     "check": ["metadata"],
-    "expression": ["regex", "substitute_value_in_message"],
+    "expression": ["substitute_value_in_message"],
     "table_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table"],
     "filename": ["dataset_metadata_in_file"],
     "metadata_name": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "dataset_metadata_in_file"],
-    "metadata_column": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_file options"],
+    "metadata_column": ["dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table", "value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_file"],
     "line_startswith": ["dataset_metadata_in_file"],
-    "min": ["in_range", "length"],
-    "max": ["in_range", "length"],
-    "exclude_min": ["in_range"],
-    "exclude_max": ["in_range"],
+    "min": ["in_range", "length", "dataset_metadata_in_range"],
+    "max": ["in_range", "length", "dataset_metadata_in_range"],
+    "exclude_min": ["in_range", "dataset_metadata_in_range"],
+    "exclude_max": ["in_range", "dataset_metadata_in_range"],
     "split": ["dataset_metadata_in_file"],
     "skip": ["metadata"]
 }
@@ -161,7 +161,7 @@ def lint_inputs(tool_xml, lint_ctx):
                     lint_ctx.error(f"Parameter [{param_name}]: attribute '{attrib}' is incompatible with validator of type '{vtype}'")
             if vtype == "expression" and validator.text is None:
                 lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
-            if vtype != "expression" and validator.text is not None:
+            if vtype not in ["expression", "regex"] and validator.text is not None:
                 lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')")
             if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib or "max" not in validator.attrib):
                 lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)")

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -163,7 +163,7 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
             if vtype not in ["expression", "regex"] and validator.text is not None:
                 lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')")
-            if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib or "max" not in validator.attrib):
+            if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib and "max" not in validator.attrib):
                 lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)")
             if vtype in ["metadata"] and ("check" not in validator.attrib and "skip" not in validator.attrib):
                 lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'check' or 'skip' attribute(s) {validator.attrib}")

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -163,8 +163,6 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
             if vtype != "expression" and validator.text is not None:
                 lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')")
-            if vtype == "regex" and "expression" not in validator.attrib:
-                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define an 'expression' attribute")
             if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib or "max" not in validator.attrib):
                 lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)")
             if vtype in ["metadata"] and ("check" not in validator.attrib or "skip" not in validator.attrib):

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -165,8 +165,8 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')")
             if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib or "max" not in validator.attrib):
                 lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)")
-            if vtype in ["metadata"] and ("check" not in validator.attrib or "skip" not in validator.attrib):
-                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'check' or 'skip' attribute(s)")
+            if vtype in ["metadata"] and ("check" not in validator.attrib and "skip" not in validator.attrib):
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'check' or 'skip' attribute(s) {validator.attrib}")
             if vtype in ["value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table"] and "table_name" not in validator.attrib:
                 lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'table_name' attribute")
 

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -132,7 +132,7 @@ def lint_inputs(tool_xml, lint_ctx):
             # lint statically defined options
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error(f"Select parameter [{param_name}] has option without value")
-            if len(set([option.text.strip() for option in select_options])) != len(select_options):
+            if len(set([option.text.strip() for option in select_options if option.text is not None])) != len(select_options):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same text content")
             if len(set([option.attrib.get("value") for option in select_options])) != len(select_options):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value")

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -41,7 +41,6 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
-    <command>$radio_select$radio_checkboxes</command>
     <inputs>
         <param name="radio_select" type="select" display="radio" optional="true" multiple="true">
             <option value="1">1</option>
@@ -59,7 +58,6 @@ SELECT_DUPLICATED_OPTIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
-    <command>$select</command>
     <inputs>
         <param name="select" type="select" optional="true" multiple="true">
             <option value="v">x</option>
@@ -73,7 +71,6 @@ SELECT_DEPRECATIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
-    <command>$select_do$select_ff$select_fp</command>
     <inputs>
         <param name="select_do" type="select" dynamic_options="blah()"/>
         <param name="select_ff" type="select">
@@ -90,7 +87,6 @@ SELECT_OPTION_DEFINITIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
-    <command>$select_noopt$select_noopts$select_fd_op$select_fd_fdt</command>
     <inputs>
         <param name="select_noopt" type="select"/>
         <param name="select_noopts" type="select">

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -41,6 +41,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
+    <command>$radio_select$radio_checkboxes</command>
     <inputs>
         <param name="radio_select" type="select" display="radio" optional="true" multiple="true">
             <option value="1">1</option>
@@ -58,6 +59,7 @@ SELECT_DUPLICATED_OPTIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
+    <command>$select</command>
     <inputs>
         <param name="select" type="select" optional="true" multiple="true">
             <option value="v">x</option>
@@ -71,6 +73,7 @@ SELECT_DEPRECATIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
+    <command>$select_do$select_ff$select_fp</command>
     <inputs>
         <param name="select_do" type="select" dynamic_options="blah()"/>
         <param name="select_ff" type="select">
@@ -87,6 +90,7 @@ SELECT_OPTION_DEFINITIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
+    <command>$select_noopt$select_noopts$select_fd_op$select_fd_fdt</command>
     <inputs>
         <param name="select_noopt" type="select"/>
         <param name="select_noopts" type="select">
@@ -129,6 +133,51 @@ VALIDATOR_INCOMPATIBILITIES = """
         <param name="param_name" type="text">
             <validator type="in_range">TEXT</validator>
             <validator type="regex" filename="blah"/>
+        </param>
+    </inputs>
+</tool>
+"""
+
+VALIDATOR_CORRECT = """
+<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+    <description>The BWA Mapper</description>
+    <version_command interpreter="python">bwa.py --version</version_command>
+    <inputs>
+        <param name="data_param" type="data" format="data">
+            <validator type="metadata" check="md1,md2" skip="md3,md4" message="cutom validation message" negate="true"/>
+            <validator type="unspecified_build" message="cutom validation message" negate="true"/>
+            <validator type="dataset_ok_validator" message="cutom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="cutom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="cutom validation message" negate="true"/>
+            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message" negate="true"/>
+        </param>
+        <param name="collection_param" type="collection">
+            <validator type="metadata" check="md1,md2" skip="md3,md4" message="cutom validation message"/>
+            <validator type="unspecified_build" message="cutom validation message"/>
+            <validator type="dataset_ok_validator" message="cutom validation message"/>
+            <validator type="dataset_metadata_in_range" min="0" max="100" exclude_min="true" exclude_max="true" message="cutom validation message"/>
+            <validator type="dataset_metadata_in_file" filename="file.tsv" metadata_column="3" split=","  message="cutom validation message"/>
+            <validator type="dataset_metadata_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message"/>
+        </param>
+        <param name="text_param" type="text">
+            <validator type="regex">reg.xp</validator>
+            <validator type="length" min="0" max="100" message="cutom validation message"/>
+            <validator type="empty_field" message="cutom validation message"/>
+            <validator type="value_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message"/>
+            <validator type="expression" message="cutom validation message">somepythonexpression</validator>
+        </param>
+        <param name="select_param" type="select">
+            <options from_data_table="bowtie2_indexes"/>
+            <validator type="no_options" negate="true"/>
+            <validator type="regex" negate="true">reg.xp</validator>
+            <validator type="length" min="0" max="100" message="cutom validation message" negate="true"/>
+            <validator type="empty_field" message="cutom validation message" negate="true"/>
+            <validator type="value_in_data_table" table_name="datatable_name" metadata_column="3" message="cutom validation message" negate="true"/>
+            <validator type="expression" message="cutom validation message" negate="true">somepythonexpression</validator>
+        </param>
+        <param name="int_param" type="integer">
+            <validator type="in_range" min="0" max="100" exclude_min="true" exclude_max="true" negate="true"/>
+            <validator type="expression" message="cutom validation message">somepythonexpression</validator>
         </param>
     </inputs>
 </tool>
@@ -226,8 +275,11 @@ TESTS = [
             and "Parameter [param_name]: validator with an incompatible type 'in_range'" in x.error_messages
             and "Parameter [param_name]: 'in_range' validators need to define the 'min' or 'max' attribute(s)" in x.error_messages
             and "Parameter [param_name]: attribute 'filename' is incompatible with validator of type 'regex'" in x.error_messages
-            and "Parameter [param_name]: 'regex' validators need to define an 'expression' attribute" in x.error_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 4
+            and len(x.warn_messages) == 1 and len(x.error_messages) == 3
+    ),
+    (
+        VALIDATOR_CORRECT, inputs.lint_inputs,
+        lambda x: len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
         OUTPUTS_COLLECTION_FORMAT_SOURCE, outputs.lint_output,
@@ -251,6 +303,7 @@ TEST_IDS = [
     'select option definitions',
     'hazardous whitespace',
     'validator imcompatibilities',
+    'validator all correct',
     'outputs collection static elements with format_source',
     'outputs discover datatsets with tool provided metadata'
 ]


### PR DESCRIPTION
Fixes some problems added here https://github.com/galaxyproject/galaxy/pull/12262

- there is no expression attribute for regex validators:  probably mixed this up with the output assert.
- also regex needs text
- dataset_metadata_in_range also has min, max, ...

I ran this on the IUC repo and found several cases of `no_options` for `data` and one case for `text` parameters. The linter complains about this .. but I think this is correct. Seems to me that this also did not work before https://github.com/galaxyproject/galaxy/pull/11043.

Furthermore a small fix for option tags without text which is `None`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

I also ran `planemo lint` over the complete IUC repo.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
