### PR TITLE
Removing unusable Name field from Collections upload

### DIFF
--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -4,7 +4,6 @@
         <table class="upload-table ui-table-striped" v-show="!showHelper" ref="uploadTable">
             <thead>
                 <tr>
-                    <th>Name</th>
                     <th>Size</th>
                     <th>Status</th>
                     <th />
@@ -87,7 +86,7 @@
                 ref="btnCreate"
                 class="ui-button-default"
                 id="btn-new"
-                @click="_eventCreate"
+                @click="_eventCreate(false)"
                 :disabled="!enableSources"
             >
                 <span class="fa fa-edit"></span>{{ btnCreateTitle }}

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -80,7 +80,7 @@
                 ref="btnCreate"
                 class="ui-button-default"
                 id="btn-new"
-                @click="_eventCreate"
+                @click="_eventCreate(true)"
                 :disabled="!enableSources"
             >
                 <span class="fa fa-edit"></span>{{ btnCreateTitle }}

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -254,8 +254,12 @@ export default {
             }
         },
         /** Create a new file */
-        _eventCreate: function () {
-            this.uploadbox.add([{ name: "New File", size: 0, mode: "new" }]);
+        _eventCreate: function (withNewFile) {
+            if (withNewFile == true) {
+                this.uploadbox.add([{ name: "New File", size: 0, mode: "new" }]);
+            } else if (withNewFile == false) {
+                this.uploadbox.add([{ size: 0, mode: "new" }]);
+            }
         },
         /** Pause upload process */
         _eventStop: function () {


### PR DESCRIPTION
I updated the _eventCreate method to build a different view of the upload box for Collections, removing the name field. 
Issue #12535 
Screenshot of the fix:

![Screenshot from 2021-10-18 11-42-22](https://user-images.githubusercontent.com/26912553/137764879-4c081ad9-0bc0-46e6-ac15-e32782d2c54b.png)

## How to test the changes?
(Select all options that apply)
- [X] Instructions for manual testing are as follows:
  1. From the upload modal, navigate to the Collections tab
  2. Notice that there is no uneditable "New File" text anymore 
  3. Notice thta the Name field is no longer there

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
