### PR TITLE
Removing last character of pair name for Paired List Collections if it's a . or _

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -724,8 +724,8 @@ export default {
                     revName = revName.replace(extension, "");
                 }
             }
-            if (lcs.substring(lcs.length-1) == "." || lcs.substring(lcs.length-1) == "_") {
-                lcs = lcs.substring(0,lcs.length-1)
+            if (lcs.substring(lcs.length - 1) == "." || lcs.substring(lcs.length - 1) == "_") {
+                lcs = lcs.substring(0, lcs.length - 1);
             }
             return lcs || `${fwdName} & ${revName}`;
         },

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -724,6 +724,9 @@ export default {
                     revName = revName.replace(extension, "");
                 }
             }
+            if (lcs.substring(lcs.length-1) == "." || lcs.substring(lcs.length-1) == "_") {
+                lcs = lcs.substring(0,lcs.length-1)
+            }
             return lcs || `${fwdName} & ${revName}`;
         },
         clickAutopair: function () {

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -724,7 +724,7 @@ export default {
                     revName = revName.replace(extension, "");
                 }
             }
-            if (lcs.substring(lcs.length - 1) == "." || lcs.substring(lcs.length - 1) == "_") {
+            if (lcs.endsWith(".") || lcs.endsWith("_")) {
                 lcs = lcs.substring(0, lcs.length - 1);
             }
             return lcs || `${fwdName} & ${revName}`;


### PR DESCRIPTION
Issue #11781 
@jmchilton believed that this could still be an issue for some users who are not sure how to use the filters appropriately. 

Screenshot of changes: 
![Screenshot from 2021-10-18 14-08-32](https://user-images.githubusercontent.com/26912553/137784206-ac487142-a0a7-41bd-85e0-9a297b840eb5.png)

## How to test the changes?
(Select all options that apply)
- [] Instructions for manual testing are as follows:
  1. Add datasets that have . or _ in their names, near the end (ex. UII_moo_1.1.fastq & UII_moo_1.2.fastq)
  2. Do not use appropriate filters; instead, clear filters, and manually pair datasets.
  3. The pair name will not end in a . or _

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
