### PR TITLE
Assert datatype file ext

### DIFF
--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -237,7 +237,6 @@ class Registry:
                                             self.imported_modules.append(imported_module)
                                         if hasattr(imported_module, datatype_class_name):
                                             datatype_class = getattr(imported_module, datatype_class_name)
-                                            assert 'file_ext' in datatype_class.__dict__, f"file_ext undefined for {datatype_class}"
                                     except Exception as e:
                                         full_path = os.path.join(proprietary_path, proprietary_datatype_module)
                                         self.log.debug("Exception importing proprietary code file %s: %s", full_path, galaxy.util.unicodify(e))

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -237,6 +237,7 @@ class Registry:
                                             self.imported_modules.append(imported_module)
                                         if hasattr(imported_module, datatype_class_name):
                                             datatype_class = getattr(imported_module, datatype_class_name)
+                                            assert 'file_ext' in datatype_class.__dict__, f"file_ext undefined for {datatype_class}"
                                     except Exception as e:
                                         full_path = os.path.join(proprietary_path, proprietary_datatype_module)
                                         self.log.debug("Exception importing proprietary code file %s: %s", full_path, galaxy.util.unicodify(e))
@@ -250,6 +251,7 @@ class Registry:
                                         for mod in fields:
                                             module = getattr(module, mod)
                                         datatype_class = getattr(module, datatype_class_name)
+                                        assert 'file_ext' in datatype_class.__dict__, f"file_ext undefined for {datatype_class}"
                                         self.log.debug(f'Retrieved datatype module {str(datatype_module)}:{datatype_class_name} from the datatype registry for extension {extension}.')
                                     except Exception:
                                         self.log.exception('Error importing datatype module %s', str(datatype_module))
@@ -257,6 +259,7 @@ class Registry:
                         elif type_extension is not None:
                             try:
                                 datatype_class = self.datatypes_by_extension[type_extension].__class__
+                                assert 'file_ext' in datatype_class.__dict__, f"file_ext undefined for {datatype_class}"
                                 self.log.debug(f'Retrieved datatype module {str(datatype_class.__name__)} from type_extension {type_extension} for extension {extension}.')
                             except Exception:
                                 self.log.exception('Error determining datatype_class for type_extension %s', str(type_extension))
@@ -902,7 +905,6 @@ class Registry:
         else:
             ext = dataset_or_ext
             dataset = None
-
         if self.get_datatype_by_extension(ext) is not None and self.get_datatype_by_extension(ext).matches_any(accepted_formats):
             return True, None, None
 


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/12713

If a datatype does not define `file_ext` sniffing does not work, so maybe its a good idea to assert. Not sure if this will be noticed. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
