### PR TITLE
Fix job runner shutdown

### DIFF
--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -576,8 +576,13 @@ def uvicorn_serve(app, port, host=None):
     server = Server(config=config)
 
     def run_in_loop(loop):
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(server.serve())
+        try:
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(server.serve())
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+            log.info("Event loop for uvicorn closed")
 
     loop = asyncio.new_event_loop()
     t = threading.Thread(target=run_in_loop, args=(loop,))

--- a/lib/galaxy_test/driver/driver_util.py
+++ b/lib/galaxy_test/driver/driver_util.py
@@ -736,6 +736,8 @@ class EmbeddedServerWrapper(ServerWrapper):
         return self._app
 
     def stop(self):
+        log.info(f"{threading.active_count()} threads were active before stopping embedded server")
+
         if self._server is not None and hasattr(self._server, "server_close"):
             log.info(f"Shutting down embedded {self.name} Paste server")
             self._server.server_close()
@@ -755,6 +757,8 @@ class EmbeddedServerWrapper(ServerWrapper):
             log.info(f"Stopping application {self.name}")
             self._app.shutdown()
             log.info(f"Application {self.name} stopped.")
+
+        log.info(f"{threading.active_count()} active after stopping embedded server")
 
 
 class UwsgiServerWrapper(ServerWrapper):

--- a/test/integration/conftest.py
+++ b/test/integration/conftest.py
@@ -5,9 +5,9 @@ import pytest
 from galaxy_test.api.conftest import pytest_configure  # noqa: F401
 
 
-def pytest_unconfigure(config):
+def pytest_collection_finish(session):
     try:
-        # This needs to be run if no test were run.
+        # This needs to be run after test collection
         from .test_config_defaults import DRIVER
         DRIVER.tear_down()
         print("Galaxy test driver shutdown successful")


### PR DESCRIPTION
It seems putting the stop signal onto the queue is not enough (does a queue ever grab more than 1 signal ??).
This eventually lets the thread count go to 1 (so only the main thread is left) after a few tests.
We have another "bug" which is that we start an instance during test discovery that doesn't get cleaned up until we hit an integration test that doesn't start a server. That's fixed with https://github.com/galaxyproject/galaxy/pull/12744/commits/05e308d2cff96dd1e8b82f8efd91aec71d8909a7

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
