### PR TITLE
[21.09] Fix persisting pre-created dynamic outputs with metadata_strategy: extended

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -276,57 +276,17 @@ def set_metadata_portable():
                 set_meta(dataset, file_dict)
 
             if extended_metadata_collection:
+                collect_extra_files(object_store, dataset, ".")
                 meta = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id, dataset.dataset.uuid)
                 if meta:
                     context = ExpressionContext(meta, expression_context)
                 else:
                     context = expression_context
-
-                # Lazy and unattached
-                # if getattr(dataset, "hidden_beneath_collection_instance", None):
-                #    dataset.visible = False
-                dataset.blurb = 'done'
-                dataset.peek = 'no peek'
-                dataset.info = (dataset.info or '')
-                if context['stdout'].strip():
-                    # Ensure white space between entries
-                    dataset.info = f"{dataset.info.rstrip()}\n{context['stdout'].strip()}"
-                if context['stderr'].strip():
-                    # Ensure white space between entries
-                    dataset.info = f"{dataset.info.rstrip()}\n{context['stderr'].strip()}"
-                dataset.tool_version = version_string
-                dataset.set_size()
-                if 'uuid' in context:
-                    dataset.dataset.uuid = context['uuid']
-                if dataset_filename_override and dataset_filename_override != dataset.file_name:
-                    # This has to be a job with outputs_to_working_directory set.
-                    # We update the object store with the created output file.
-                    object_store.update_from_file(dataset.dataset, file_name=dataset_filename_override, create=True)
-                collect_extra_files(object_store, dataset, ".")
-                if Job.states.ERROR == final_job_state:
-                    dataset.blurb = "error"
-                    dataset.mark_unhidden()
-                else:
-                    # If the tool was expected to set the extension, attempt to retrieve it
-                    if dataset.ext == 'auto':
-                        dataset.extension = context.get('ext', 'data')
-                        dataset.init_meta(copy_from=dataset)
-
-                    # This has already been done:
-                    # else:
-                    #     self.external_output_metadata.load_metadata(dataset, output_name, self.sa_session, working_directory=self.working_directory, remote_metadata_directory=remote_metadata_directory)
-                    line_count = context.get('line_count', None)
-                    try:
-                        # Certain datatype's set_peek methods contain a line_count argument
-                        dataset.set_peek(line_count=line_count)
-                    except TypeError:
-                        # ... and others don't
-                        dataset.set_peek()
-
                 for context_key in TOOL_PROVIDED_JOB_METADATA_KEYS:
                     if context_key in context:
                         context_value = context[context_key]
                         setattr(dataset, context_key, context_value)
+                dataset.tool_version = version_string
                 # We never want to persist the external_filename.
                 dataset.dataset.external_filename = None
                 export_store.add_dataset(dataset)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from collections import defaultdict
 from json import (
     dump,
     dumps,
@@ -50,23 +51,20 @@ class ImportOptions:
 class SessionlessContext:
 
     def __init__(self):
-        self.objects = []
+        self.objects = defaultdict(dict)
 
     def flush(self):
         pass
 
     def add(self, obj):
-        self.objects.append(obj)
+        self.objects[obj.__class__][obj.id] = obj
 
     def query(self, model_class):
 
         def find(obj_id):
-            for obj in self.objects:
-                if isinstance(obj, model_class) and obj.id == obj_id:
-                    return obj
-            return None
+            return self.objects.get(model_class, {}).get(obj_id) or None
 
-        return Bunch(find=find)
+        return Bunch(find=find, get=find)
 
 
 class ModelImportStore(metaclass=abc.ABCMeta):

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -623,7 +623,8 @@ def persist_hdas(elements, model_persistence_context, final_job_state='ok'):
                 hda_id = discovered_file.match.object_id
                 primary_dataset = None
                 if hda_id:
-                    primary_dataset = model_persistence_context.sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
+                    sa_session = model_persistence_context.sa_session or model_persistence_context.import_store.sa_session
+                    primary_dataset = sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
 
                 sources = fields_match.sources
                 hashes = fields_match.hashes

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -58,14 +58,19 @@ class ExtendedMetadataIntegrationTestCase(integration_util.IntegrationTestCase):
             "elements": [element],
         }
         targets = json.dumps([target])
+        upload_content = 'abcdef'
         payload = {
             "history_id": history_id,
             "targets": targets,
-            "__files": {"files_0|file_data": 'abcdef'}
+            "__files": {"files_0|file_data": upload_content}
         }
         new_dataset = self.dataset_populator.fetch(payload, assert_ok=True).json()["outputs"][0]
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        return history_id, new_dataset
+        content = self.dataset_populator.get_history_dataset_content(
+            history_id=history_id,
+            dataset_id=new_dataset['id'],
+        )
+        assert content == upload_content
 
 
 class ExtendedMetadataIntegrationInstance(integration_util.IntegrationInstance):


### PR DESCRIPTION
This is currently failing with
```
ERROR    galaxy.jobs:__init__.py:1708 problem importing job outputs. stdout [] stderr [
CRITICAL:galaxy.objectstore:Error copying /private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpkj_tl1kx/tmpce19qa25/tmpuuo9uerh/database/objects/7/6/6/dataset_766b6b81-0fb5-4aa6-acaf-f67f79bab0fc.dat to /private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpkj_tl1kx/tmpce19qa25/tmpuuo9uerh/database/objects/7/6/6/dataset_766b6b81-0fb5-4aa6-acaf-f67f79bab0fc.dat: '/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpkj_tl1kx/tmpce19qa25/tmpuuo9uerh/database/objects/7/6/6/dataset_766b6b81-0fb5-4aa6-acaf-f67f79bab0fc.dat' and '/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpkj_tl1kx/tmpce19qa25/tmpuuo9uerh/database/objects/7/6/6/dataset_766b6b81-0fb5-4aa6-acaf-f67f79bab0fc.dat' are the same file
Traceback (most recent call last):
  File "/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpkj_tl1kx/tmpce19qa25/tmpuuo9uerh/database/job_working_directory_vqnmbzf6/000/1/metadata/set.py", line 1, in <module>
    from galaxy_ext.metadata.set_metadata import set_metadata; set_metadata()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/metadata/set_metadata.py", line 109, in set_metadata
    set_metadata_portable()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/metadata/set_metadata.py", line 356, in set_metadata_portable
    collect_dynamic_outputs(job_context, output_collections)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/job_execution/output_collect.py", line 128, in collect_dynamic_outputs
    persist_hdas(elements, job_context, final_job_state=job_context.final_job_state)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/store/discover.py", line 655, in persist_hdas
    collect_elements_for_history(elements)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/store/discover.py", line 626, in collect_elements_for_history
    primary_dataset = model_persistence_context.sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
AttributeError: 'NoneType' object has no attribute 'query'
]
Traceback (most recent call last):
  File "/Users/mvandenb/src/galaxy/lib/galaxy/jobs/__init__.py", line 1706, in finish
    import_model_store.perform_import(history=job.history)
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/store/__init__.py", line 171, in perform_import
    datasets_attrs = self.datasets_properties()
  File "/Users/mvandenb/src/galaxy/lib/galaxy/model/store/__init__.py", line 799, in datasets_properties
    datasets_attrs = load(open(datasets_attrs_file_name))
FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpkj_tl1kx/tmpce19qa25/tmpuuo9uerh/database/job_working_directory_vqnmbzf6/000/1/metadata/outputs_populated/datasets_attrs.txt'
```

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
