### PR TITLE
Remove `galaxy.util.getfullargspec`

### DIFF
--- a/lib/galaxy/jobs/mapper.py
+++ b/lib/galaxy/jobs/mapper.py
@@ -1,11 +1,11 @@
 import importlib
 import logging
+from inspect import getfullargspec
 from types import ModuleType
 
 import galaxy.jobs.rules
 from galaxy.jobs import stock_rules
 from galaxy.jobs.dynamic_tool_destination import map_tool_to_destination
-from galaxy.util.getargspec import getfullargspec
 from galaxy.util.submodules import import_submodules
 from .rule_helper import RuleHelper
 

--- a/lib/galaxy/jobs/splitters/multi.py
+++ b/lib/galaxy/jobs/splitters/multi.py
@@ -1,9 +1,9 @@
 import logging
 import os
 import shutil
+from inspect import getfullargspec
 
 from galaxy import model, util
-from galaxy.util.getargspec import getfullargspec
 
 
 log = logging.getLogger(__name__)

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -4,7 +4,6 @@ import inspect
 
 from galaxy.tool_util.parser import get_tool_source
 from galaxy.util import submodules
-from galaxy.util.getargspec import getfullargspec
 
 
 LEVEL_ALL = "all"
@@ -47,7 +46,7 @@ def lint_tool_source_with(lint_context, tool_source, extra_modules=None):
                 # Look at the first argument to the linter to decide
                 # if we should lint the XML description or the abstract
                 # tool parser object.
-                first_arg = getfullargspec(value).args[0]
+                first_arg = inspect.getfullargspec(value).args[0]
                 if first_arg == "tool_xml":
                     if tool_xml is None:
                         # XML linter and non-XML tool, skip for now

--- a/lib/galaxy/tool_util/verify/asserts/__init__.py
+++ b/lib/galaxy/tool_util/verify/asserts/__init__.py
@@ -1,8 +1,8 @@
 import logging
 import sys
+from inspect import getfullargspec
 
 from galaxy.util import unicodify
-from galaxy.util.getargspec import getfullargspec
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/util/getargspec.py
+++ b/lib/galaxy/util/getargspec.py
@@ -1,9 +1,0 @@
-import inspect
-
-
-def getfullargspec(func):
-    try:
-        return inspect.getfullargspec(func)
-    except AttributeError:
-        # on python 2
-        return inspect.getargspec(func)

--- a/lib/galaxy/util/pastescript/loadwsgi.py
+++ b/lib/galaxy/util/pastescript/loadwsgi.py
@@ -7,12 +7,12 @@ import inspect
 import os
 import re
 import sys
+from inspect import getfullargspec
 from typing import Callable, Dict, List, Optional, Union
 from urllib.parse import unquote
 
 import pkg_resources
 
-from galaxy.util.getargspec import getfullargspec
 from galaxy.util.properties import NicerConfigParser
 
 

--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -1,5 +1,6 @@
 import logging
 from functools import wraps
+from inspect import getfullargspec
 from json import loads
 from traceback import format_exc
 
@@ -17,7 +18,6 @@ from galaxy.util import (
     parse_non_hex_float,
     unicodify
 )
-from galaxy.util.getargspec import getfullargspec
 from galaxy.util.json import safe_dumps
 from galaxy.web.framework import url_for
 

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -1,3 +1,5 @@
+from inspect import getfullargspec
+
 import pytest
 
 from galaxy.tool_util.lint import LintContext
@@ -8,7 +10,6 @@ from galaxy.tool_util.linters import (
 )
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
-from galaxy.util.getargspec import getfullargspec
 
 WHITESPACE_IN_VERSIONS_AND_NAMES = """
 <tool name=" BWA Mapper " id="bwa tool" version=" 1.0.1 " is_multi_byte="true" display_interface="true" require_login="true" hidden="true">


### PR DESCRIPTION
seems not useful anymore since py2 is not supported anymore

btw. I just found `inspect.signature` which might be a convenient replacement (see in action here https://github.com/galaxyproject/galaxy/pull/12528)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
