### PR TITLE
[21.09] Two fixes for linting

### DIFF
--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -1,6 +1,7 @@
 """This module contains a linting functions for tool outputs."""
 from galaxy.util import string_as_bool
 from ._util import is_valid_cheetah_placeholder
+from ..parser.output_collection_def import NAMED_PATTERNS
 
 
 def lint_output(tool_xml, lint_ctx):
@@ -84,9 +85,7 @@ def __check_pattern(node):
         return True
     if "pattern" not in node.attrib:
         return False
-    if node.attrib["pattern"] == "__default__":
-        return True
-    if node.attrib["pattern"] in ["__name_and_ext__", "__designation_and_ext__"]:
-        return True
-    if "(?P<ext>" in node.attrib["pattern"]:
+    pattern = node.attrib["pattern"]
+    regex_pattern = NAMED_PATTERNS.get(pattern, pattern)
+    if "(?P<ext>" in regex_pattern:
         return True

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -86,5 +86,7 @@ def __check_pattern(node):
         return False
     if node.attrib["pattern"] == "__default__":
         return True
-    if "ext" in node.attrib["pattern"] and node.attrib["pattern"].startswith("__") and node.attrib["pattern"].endswith("__"):
+    if node.attrib["pattern"] in ["__name_and_ext__", "__designation_and_ext__"]:
+        return True
+    if "(?P<ext>" in node.attrib["pattern"]:
         return True

--- a/lib/galaxy/tool_util/linters/xml_order.py
+++ b/lib/galaxy/tool_util/linters/xml_order.py
@@ -8,6 +8,9 @@ https://github.com/galaxy-iuc/standards.
 TAG_ORDER = [
     'description',
     'macros',
+    'edam_topics',
+    'edam_operations',
+    'xrefs',
     'parallelism',
     'requirements',
     'code',


### PR DESCRIPTION
- allow for `pattern="...(?<ext>...)..."` in discovered datasets
-  allow for xref, edam_topics, edam_operations. So far the linter produced confusing info, e.g. `Unknown tag [xref] encountered, this may result in a warning in the future.` Alternatively we can drop the test at all since this should be covered by the check against xsd

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
