### PR TITLE
[21.09] Prefer model class when it exists in grid sorting

### DIFF
--- a/lib/galaxy/web/framework/helpers/grids.py
+++ b/lib/galaxy/web/framework/helpers/grids.py
@@ -76,9 +76,9 @@ class GridColumn:
         """Sort query using this column."""
         if column_name is None:
             column_name = self.key
-        column = self.model_class.table.c.get(column_name)
+        column = getattr(self.model_class, column_name)
         if column is None:
-            column = getattr(self.model_class, column_name)
+            column = self.model_class.table.c.get(column_name)
         if ascending:
             query = query.order_by(column.asc())
         else:


### PR DESCRIPTION
This fixes history update time sort to work correctly in grids. (Fixes #12753)

The query that was getting generated by the previous ordering (preferring explicit table column) was this:

```
SELECT history.update_time AS history_update_time, (SELECT max(history_audit.update_time) AS max_1
FROM history_audit
WHERE history_audit.history_id = history.id) AS anon_1, history.id AS history_id, history.create_time AS history_create_time, history.user_id AS history_user_id, history.name AS history_name, history.hid_counter AS history_hid_counter, history.deleted AS history_deleted, history.purged AS history_purged, history.importing AS history_importing, history.genome_build AS history_genome_build, history.importable AS history_importable, history.slug AS history_slug, history.published AS history_published, (SELECT count(history_user_share_association.id) AS count_1
FROM history_user_share_association
WHERE history.id = history_user_share_association.history_id) AS anon_2
FROM history
WHERE %(param_1)s = history.user_id AND history.importing = false AND history.deleted = false ORDER BY history.update_time DESC
```

Note the sort is by the column, not by the anon_1 computed, as here, after the fix:
```
SELECT history.update_time AS history_update_time, (SELECT max(history_audit.update_time) AS max_1 
FROM history_audit 
WHERE history_audit.history_id = history.id) AS anon_1, history.id AS history_id, history.create_time AS history_create_time, history.user_id AS history_user_id, history.name AS history_name, history.hid_counter AS history_hid_counter, history.deleted AS history_deleted, history.purged AS history_purged, history.importing AS history_importing, history.genome_build AS history_genome_build, history.importable AS history_importable, history.slug AS history_slug, history.published AS history_published, (SELECT count(history_user_share_association.id) AS count_1 
FROM history_user_share_association 
WHERE history.id = history_user_share_association.history_id) AS anon_2 
FROM history 
WHERE %(param_1)s = history.user_id AND history.importing = false AND history.deleted = false ORDER BY anon_1 ASC
```


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
