### PR TITLE
Make directory path editable in remote files

### DIFF
--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -87,6 +87,7 @@ export default {
             filter: null,
             items: [],
             modalShow: true,
+            url: undefined,
             optionsShow: false,
             undoShow: false,
             hasValue: false,

--- a/client/src/components/DataDialog/DataDialog.vue
+++ b/client/src/components/DataDialog/DataDialog.vue
@@ -87,7 +87,6 @@ export default {
             filter: null,
             items: [],
             modalShow: true,
-            url: undefined,
             optionsShow: false,
             undoShow: false,
             hasValue: false,

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.test.js
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.test.js
@@ -1,0 +1,134 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import DirectoryPathEditableBreadcrumb from "./DirectoryPathEditableBreadcrumb";
+import FilesDialog from "./FilesDialog";
+
+import flushPromises from "flush-promises";
+import MockAdapter from "axios-mock-adapter";
+import axios from "axios";
+import { rootResponse } from "./testingData";
+const localVue = getLocalVue();
+jest.mock("app");
+
+describe("DirectoryPathEditableBreadcrumb", () => {
+    let wrapper;
+    let spyOnUrlSet;
+    let spyOnAddPath;
+    let spyOnUpdateURL;
+
+    const testingData = {
+        url: "gxfiles://directory/subdirectory",
+        protocol: "gxfiles:",
+        expectedNumberOfPaths: 4,
+        pathChunks: [{ pathChunk: "directory" }, { pathChunk: "subdirectory" }],
+    };
+    const validPath = "validpath";
+    const invalidPath = "./];";
+
+    const saveNewChunk = async (path) => {
+        // enter a new path chunk
+        const input = wrapper.find("#path-input-breadcrumb");
+        await input.setValue(path);
+        expect(input.element.value).toBe(path);
+
+        input.trigger("keyup.enter");
+        return input;
+    };
+    const init = async () => {
+        // the file dialog modal should exist
+        const filesDialogComponent = wrapper.findComponent(FilesDialog);
+        expect(filesDialogComponent.exists()).toBe(true);
+        filesDialogComponent.vm.callback({ url: testingData.url });
+        // HACK to avoid https://github.com/facebook/jest/issues/2549 (URL implementation is not the same as global node)
+        wrapper.vm.pathChunks = testingData.pathChunks;
+        await flushPromises();
+    };
+
+    beforeEach(async () => {
+        const axiosMock = new MockAdapter(axios);
+        spyOnUrlSet = jest.spyOn(DirectoryPathEditableBreadcrumb.methods, "setUrl");
+        spyOnAddPath = jest.spyOn(DirectoryPathEditableBreadcrumb.methods, "addPath");
+        spyOnUpdateURL = jest.spyOn(DirectoryPathEditableBreadcrumb.methods, "updateURL");
+
+        // register axios paths
+        axiosMock.onGet("/api/remote_files/plugins").reply(200, rootResponse);
+
+        wrapper = mount(DirectoryPathEditableBreadcrumb, {
+            propsData: {
+                callback: () => {},
+            },
+            localVue: localVue,
+        });
+        await flushPromises();
+        await init();
+    });
+    afterEach(async () => {
+        if (wrapper) {
+            wrapper.destroy();
+        }
+        wrapper = undefined;
+    });
+
+    it("should render Breadcrumb", async () => {
+        // after initial folder is chosen, setUrl() should be called and modal disappear
+        expect(spyOnUrlSet).toHaveBeenCalled();
+        expect(wrapper.findComponent(FilesDialog).exists()).toBe(false);
+        expect(wrapper.find("ol.breadcrumb").exists()).toBe(true);
+
+        await flushPromises();
+
+        // check breadcrumb items
+        const breadcrumbPaths = wrapper.findAll("li.breadcrumb-item");
+        expect(breadcrumbPaths.length).toBe(testingData.expectedNumberOfPaths);
+        expect(wrapper.find(".pathname").text()).toBe(testingData.protocol);
+        const regularPathElements = wrapper.findAll("li.breadcrumb-item button[disabled='disabled']");
+
+        expect(regularPathElements.length).toBe(testingData.pathChunks.length);
+
+        const chunks = testingData.pathChunks.map((e) => e.pathChunk);
+        // every item should be rendered
+        for (let i = 0; i < regularPathElements.length; i++) {
+            const text = regularPathElements.at(i).text();
+            expect(chunks.includes(text)).toBe(true);
+        }
+    });
+
+    it("should prevent invalid Paths", async () => {
+        // enter a new path chunk
+        const input = await saveNewChunk(invalidPath);
+        await flushPromises();
+        // after new entry is entered the value of input should be an empty string
+        expect(input.element.value).toBe(invalidPath);
+        // should be the same name plus additional item
+        expect(wrapper.findAll("li.breadcrumb-item").length).toBe(testingData.expectedNumberOfPaths);
+    });
+
+    it("should save and remove new Paths", async () => {
+        // enter a new path chunk
+        const input = await saveNewChunk(validPath);
+
+        await flushPromises();
+        expect(spyOnAddPath).toHaveBeenCalled();
+        // after new entry is entered the value of input should be an empty string
+        expect(input.element.value).toBe("");
+
+        // should be the same name plus additional item
+        expect(wrapper.findAll("li.breadcrumb-item").length).toBe(testingData.expectedNumberOfPaths + 1);
+        // find newly added chunk
+        const addedChunk = wrapper.findAll("li.breadcrumb-item button").wrappers.find((e) => e.text() === validPath);
+        // remove chunk from the path
+        await addedChunk.trigger("click");
+        await flushPromises();
+        // number of elements should be the same again
+        expect(wrapper.findAll("li.breadcrumb-item").length).toBe(testingData.expectedNumberOfPaths);
+    });
+
+    it("should update new path", async () => {
+        // enter a new path chunk
+        expect(spyOnUpdateURL).toHaveBeenCalled();
+        await saveNewChunk(validPath);
+        await flushPromises();
+
+        expect(spyOnUpdateURL).toHaveBeenCalled();
+    });
+});

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -22,7 +22,6 @@
                     @keyup.enter="addPath"
                     @keydown.191.capture.prevent.stop="addPath"
                     @keydown.8.capture.prevent.stop="removeLastPath"
-                    @keyup="debug"
                     v-model="currentDirectoryName"
                     placeholder="enter directory name"
                     trim

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -21,6 +21,8 @@
                     :state="isValidName"
                     @keyup.enter="addPath"
                     @keydown.191.capture.prevent.stop="addPath"
+                    @keydown.8.capture.prevent.stop="removeLastPath"
+                    @keyup="debug"
                     v-model="currentDirectoryName"
                     placeholder="enter directory name"
                     trim
@@ -77,13 +79,18 @@ export default {
             Object.keys(data).forEach((k) => (this[k] = data[k]));
             this.redrawModal();
             console.debug("reset");
-            this.updateURL(true)
-
+            this.updateURL(true);
         },
         // forcing modal to be redrawn
         // https://michaelnthiessen.com/force-re-render/
         redrawModal() {
             this.modalKey += 1;
+        },
+        removeLastPath() {
+            // check whether the last item is editable
+            if (this.pathChunks.length > 0 && this.pathChunks.at(-1).editable) {
+                this.pathChunks.pop();
+            }
         },
         setUrl({ url }) {
             this.url = new URL(url);

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -6,7 +6,7 @@
         </div>
         <b-breadcrumb v-if="url">
             <b-breadcrumb-item title="Select another folder" @click="reset" class="align-items-center">
-                <b-button class="pathname" pill variant="primary">
+                <b-button class="pathname" variant="primary">
                     <font-awesome-icon icon="folder-open" /> {{ url.protocol }}</b-button
                 >
             </b-breadcrumb-item>
@@ -15,13 +15,7 @@
                 :key="index"
                 class="existent-url-path align-items-center"
             >
-                <b-button
-                    class="regular-path-chunk"
-                    @click="removePath(index)"
-                    pill
-                    :disabled="!editable"
-                    variant="dark"
-                >
+                <b-button class="regular-path-chunk" @click="removePath(index)" :disabled="!editable" variant="dark">
                     {{ pathChunk }}</b-button
                 >
             </b-breadcrumb-item>

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -1,0 +1,73 @@
+<template>
+    <b-breadcrumb>
+        <b-breadcrumb-item>
+            <b-dropdown class="justify-content-md-center">
+                <template v-slot:button-content>
+                    <font-awesome-icon icon="plug" />
+                    {{ currentSource ? currentSource.doc : "Choose your remote" }}
+                </template>
+                <b-dropdown-item
+                    @click="currentSource = fileSource"
+                    v-for="(fileSource, index) in remoteFileSources"
+                    :key="index"
+                    >{{ fileSource.doc }}</b-dropdown-item
+                >
+            </b-dropdown>
+        </b-breadcrumb-item>
+        <b-breadcrumb-item class="d-flex align-items-center"> TEXT </b-breadcrumb-item>
+        <b-breadcrumb-item class="directory-input-field">
+            <b-form-input v-on:keyup.enter="addPath" v-model="directoryName" placeholder="Name your directory..." />
+        </b-breadcrumb-item>
+    </b-breadcrumb>
+</template>
+
+<script>
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { faPlug } from "@fortawesome/free-solid-svg-icons";
+import { Services } from "./services";
+
+library.add(faPlug);
+
+export default {
+    components: {
+        FontAwesomeIcon,
+    },
+    data() {
+        return {
+            remoteFileSources: [],
+            currentSource: undefined,
+            directoryName: "",
+        };
+    },
+    created() {
+        new Services().getFileSources().then((items) => {
+            this.remoteFileSources = items;
+        });
+    },
+    props: {
+        callback: {
+            type: Function,
+            default: () => {},
+        },
+        title: {
+            type: String,
+            default: "copy to clipboard",
+            required: false,
+        },
+    },methods:{
+      addPath(){
+        this.remoteFileSources.push(this.currentSource)
+      }
+  }
+};
+</script>
+
+<style scoped>
+.breadcrumb-item::before {
+    font-size: 1.5rem;
+}
+.directory-input-field a {
+    text-decoration: none;
+}
+</style>

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -1,24 +1,27 @@
 <template>
     <div>
         <div v-if="!url">
-            <b-button @click="reset"> <font-awesome-icon icon="folder-open" /> Select folder </b-button>
+            <b-button id="select-btn" @click="reset"> <font-awesome-icon icon="folder-open" /> Select folder </b-button>
             <FilesDialog :key="modalKey" mode="directory" :callback="setUrl" :require-writable="true" />
         </div>
         <b-breadcrumb v-if="url">
             <b-breadcrumb-item title="Select another folder" @click="reset" class="align-items-center">
-                <b-button pill variant="primary"> <font-awesome-icon icon="folder-open" /> {{ url.protocol }}</b-button>
+                <b-button class="pathname" pill variant="primary">
+                    <font-awesome-icon icon="folder-open" /> {{ url.protocol }}</b-button
+                >
             </b-breadcrumb-item>
             <b-breadcrumb-item
                 v-for="({ pathChunk, editable }, index) in pathChunks"
                 :key="index"
                 class="existent-url-path align-items-center"
             >
-                <b-button @click="removePath(index)" pill :disabled="!editable" variant="dark">
+                <b-button class="regular-path-chunk" @click="removePath(index)" pill :disabled="!editable" variant="dark">
                     {{ pathChunk }}</b-button
                 >
             </b-breadcrumb-item>
             <b-breadcrumb-item class="directory-input-field align-items-center">
                 <b-input
+                    id="path-input-breadcrumb"
                     aria-describedby="input-live-help input-live-feedback"
                     :state="isValidName"
                     @keyup.enter="addPath"

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -14,9 +14,23 @@
                 >
             </b-dropdown>
         </b-breadcrumb-item>
-        <b-breadcrumb-item class="d-flex align-items-center"> TEXT </b-breadcrumb-item>
+        <b-breadcrumb-item v-for="(chunk, index) in pathChunks" :key="index" class="d-flex align-items-center">
+            {{ chunk }}
+        </b-breadcrumb-item>
         <b-breadcrumb-item class="directory-input-field">
-            <b-form-input v-on:keyup.enter="addPath" v-model="directoryName" placeholder="Name your directory..." />
+            <b-input
+                aria-describedby="input-live-help input-live-feedback"
+                :state="isValidName"
+                @keyup.enter="addPath"
+                @keydown.191.capture.prevent.stop="addPath"
+                v-model="directoryName"
+                placeholder="Name your directory..."
+                trim
+            />
+            <b-form-invalid-feedback id="input-live-feedback">
+                Your directory name contains invalid characters
+            </b-form-invalid-feedback>
+            <b-form-text id="input-live-help"> Please enter directory name and press enter or "/" </b-form-text>
         </b-breadcrumb-item>
     </b-breadcrumb>
 </template>
@@ -36,6 +50,7 @@ export default {
     data() {
         return {
             remoteFileSources: [],
+            pathChunks: [],
             currentSource: undefined,
             directoryName: "",
         };
@@ -55,11 +70,24 @@ export default {
             default: "copy to clipboard",
             required: false,
         },
-    },methods:{
-      addPath(){
-        this.remoteFileSources.push(this.currentSource)
-      }
-  }
+    },
+    computed: {
+        isValidName() {
+            if (!this.directoryName) {
+                return null;
+            }
+            const regex = new RegExp("^(\\w+\\.?)*\\w+$", "g");
+            return regex.test(this.directoryName);
+        },
+    },
+    methods: {
+        addPath({ key }) {
+            if (key === "Enter" || (key === "/" && this.isValidName)) {
+                this.pathChunks.push(this.directoryName.replaceAll("/", ""));
+                this.directoryName = "";
+            }
+        },
+    },
 };
 </script>
 

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -15,7 +15,13 @@
                 :key="index"
                 class="existent-url-path align-items-center"
             >
-                <b-button class="regular-path-chunk" @click="removePath(index)" pill :disabled="!editable" variant="dark">
+                <b-button
+                    class="regular-path-chunk"
+                    @click="removePath(index)"
+                    pill
+                    :disabled="!editable"
+                    variant="dark"
+                >
                     {{ pathChunk }}</b-button
                 >
             </b-breadcrumb-item>

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -52,10 +52,6 @@ export default {
     },
     data() {
         return { ...getDefaultValues(), modalKey: 0 };
-        // return {
-        // pathChunks: new URL("gxfiles://pdb-gzip/directory1").pathname.split("/").filter((path) => path),
-        // url: new URL("gxfiles://pdb-gzip/directory1"),
-        // };
     },
     props: {
         callback: {
@@ -80,7 +76,9 @@ export default {
             const data = getDefaultValues();
             Object.keys(data).forEach((k) => (this[k] = data[k]));
             this.redrawModal();
-            console.log("reset");
+            console.debug("reset");
+            this.updateURL(true)
+
         },
         // forcing modal to be redrawn
         // https://michaelnthiessen.com/force-re-render/
@@ -88,14 +86,13 @@ export default {
             this.modalKey += 1;
         },
         setUrl({ url }) {
-            console.log("!!!!!!!!!");
-            console.log(url);
             this.url = new URL(url);
             // split path and keep only valid entries
             this.pathChunks = this.url.pathname
                 .split("/")
                 .filter((path) => path)
                 .map((x) => ({ name: x, editable: false }));
+            this.updateURL();
         },
         addPath({ key }) {
             if (key === "Enter" || (key === "/" && this.isValidName)) {
@@ -105,8 +102,11 @@ export default {
                 this.updateURL();
             }
         },
-        updateURL() {
-            const url = `${this.url.protocol}//${this.pathChunks.map(({name}) => name).join("/")}`;
+        updateURL(isReset = false) {
+            let url = undefined;
+            if (!isReset) {
+                url = `${this.url.protocol}//${this.pathChunks.map(({ name }) => name).join("/")}`;
+            }
             this.callback(url);
         },
     },

--- a/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
+++ b/client/src/components/FilesDialog/DirectoryPathEditableBreadcrumb.vue
@@ -106,7 +106,7 @@ export default {
             }
         },
         updateURL() {
-            const url = `${this.url.protocol}//${this.pathChunks.map((name) => name).join("/")}`;
+            const url = `${this.url.protocol}//${this.pathChunks.map(({name}) => name).join("/")}`;
             this.callback(url);
         },
     },

--- a/client/src/mvc/ui/ui-file-source.js
+++ b/client/src/mvc/ui/ui-file-source.js
@@ -8,21 +8,21 @@ var View = Backbone.View.extend({
     initialize: function (options) {
         this.model = new Backbone.Model();
         this.target = options.target;
-        const props = {
-            mode: "directory",
-            requireWritable: true,
-        };
-        // create insert edit button
-        this.browse_button = new Ui.Button({
-            title: _l("Select"),
-            icon: "fa fa-edit",
-            tooltip: _l("Select URI"),
-            onclick: () => {
-                filesDialog((uri) => {
-                    this._handleRemoteFilesUri(uri);
-                }, props);
-            },
-        });
+        // const props = {
+        //     mode: "directory",
+        //     requireWritable: true,
+        // };
+        // // create insert edit button
+        // this.browse_button = new Ui.Button({
+        //     title: _l("Select"),
+        //     icon: "fa fa-edit",
+        //     tooltip: _l("Select URI"),
+        //     onclick: () => {
+        //         filesDialog((uri) => {
+        //             this._handleRemoteFilesUri(uri);
+        //         }, props);
+        //     },
+        // });
 
         // add change event. fires on trigger
         this.on("change", () => {
@@ -34,7 +34,7 @@ var View = Backbone.View.extend({
         // create elements
         this.setElement(this._template(options));
         this.$text = this.$(".ui-uri-preview");
-        this.$(".ui-file-select-button").append(this.browse_button.$el);
+        // this.$(".ui-file-select-button").append(this.browse_button.$el);
         this.listenTo(this.model, "change", this.render, this);
         this.render();
     },
@@ -44,23 +44,21 @@ var View = Backbone.View.extend({
     },
 
     render: function () {
-        const value = this._value;
-        if (value) {
-            if (typeof value == "string") {
-                this.$text.text(value);
-            } else if (value.url !== this.$text.text()) {
-                this.$text.text(value.url);
-            }
-        } else {
-            breadcrump(
-                ".ui-uri-preview",
-                (uri) => {
-                    this._handleRemoteFilesUri(uri);
-                },
-
-                { test_props: true }
-            );
+        let value = this._value;
+        if (value && typeof value != "string") {
+            value = value.url;
         }
+        if (!value) {
+            value = "";
+        }
+        breadcrump(
+            ".ui-uri-preview",
+            (uri) => {
+                this._handleRemoteFilesUri(uri);
+            },
+
+            { url: value }
+        );
     },
 
     /** Main Template */
@@ -89,7 +87,7 @@ var View = Backbone.View.extend({
 
     /** Returns current value */
     _getValue: function () {
-        return this._value?.url;
+        return this._value;
     },
 
     /** Sets current value */

--- a/client/src/mvc/ui/ui-file-source.js
+++ b/client/src/mvc/ui/ui-file-source.js
@@ -1,5 +1,6 @@
 import Backbone from "backbone";
 import { filesDialog } from "utils/data";
+import { breadcrump } from "utils/mountBreadcrump";
 import _l from "utils/localization";
 import Ui from "mvc/ui/ui-misc";
 
@@ -51,7 +52,14 @@ var View = Backbone.View.extend({
                 this.$text.text(value.url);
             }
         } else {
-            this.$text.text("select...");
+            breadcrump(
+                ".ui-uri-preview",
+                (uri) => {
+                    this._handleRemoteFilesUri(uri);
+                },
+
+                { test_props: true }
+            );
         }
     },
 

--- a/client/src/mvc/ui/ui-file-source.js
+++ b/client/src/mvc/ui/ui-file-source.js
@@ -1,28 +1,10 @@
 import Backbone from "backbone";
-import { filesDialog } from "utils/data";
 import { breadcrump } from "utils/mountBreadcrump";
-import _l from "utils/localization";
-import Ui from "mvc/ui/ui-misc";
 
 var View = Backbone.View.extend({
     initialize: function (options) {
         this.model = new Backbone.Model();
         this.target = options.target;
-        // const props = {
-        //     mode: "directory",
-        //     requireWritable: true,
-        // };
-        // // create insert edit button
-        // this.browse_button = new Ui.Button({
-        //     title: _l("Select"),
-        //     icon: "fa fa-edit",
-        //     tooltip: _l("Select URI"),
-        //     onclick: () => {
-        //         filesDialog((uri) => {
-        //             this._handleRemoteFilesUri(uri);
-        //         }, props);
-        //     },
-        // });
 
         // add change event. fires on trigger
         this.on("change", () => {
@@ -33,8 +15,6 @@ var View = Backbone.View.extend({
 
         // create elements
         this.setElement(this._template(options));
-        this.$text = this.$(".ui-uri-preview");
-        // this.$(".ui-file-select-button").append(this.browse_button.$el);
         this.listenTo(this.model, "change", this.render, this);
         this.render();
     },
@@ -92,23 +72,10 @@ var View = Backbone.View.extend({
 
     /** Sets current value */
     _setValue: function (new_value) {
-        if (new_value) {
-            if (typeof new_value == "string") {
-                let parsed_value;
-                // if new_value is not a JSON, set it as String
-                try {
-                    parsed_value = JSON.parse(new_value);
-                } catch (e) {
-                    parsed_value = new_value;
-                } finally {
-                    new_value = parsed_value;
-                }
-            }
-            this._value = new_value;
-            this.model.trigger("error", null);
-            this.model.trigger("change");
-            this.trigger("change");
-        }
+        this._value = new_value;
+        this.model.trigger("error", null);
+        this.model.trigger("change");
+        this.trigger("change");
     },
 });
 

--- a/client/src/mvc/ui/ui-file-source.js
+++ b/client/src/mvc/ui/ui-file-source.js
@@ -13,32 +13,20 @@ var View = Backbone.View.extend({
             }
         });
 
-        // create elements
-        this.setElement(this._template(options));
-        this.listenTo(this.model, "change", this.render, this);
-        this.render();
-    },
-
-    _handleRemoteFilesUri: function (uri) {
-        this._setValue(uri);
-    },
-
-    render: function () {
-        let value = this._value;
-        if (value && typeof value != "string") {
-            value = value.url;
-        }
-        if (!value) {
-            value = "";
-        }
         breadcrump(
             ".ui-uri-preview",
             (uri) => {
                 this._handleRemoteFilesUri(uri);
             },
 
-            { url: value }
+            { url: this._value }
         );
+        // create elements
+        this.setElement(this._template(options));
+    },
+
+    _handleRemoteFilesUri: function (uri) {
+        this._setValue(uri);
     },
 
     /** Main Template */
@@ -46,14 +34,13 @@ var View = Backbone.View.extend({
         return `
             <div class="ui-rules-edit clearfix">
                 <span class="ui-uri-preview" />
-                <span class="ui-file-select-button float-left" />
             </div>
         `;
     },
 
     /** Return/Set current value */
     value: function (new_value) {
-        if (new_value !== undefined) {
+        if (new_value) {
             this._setValue(new_value);
         } else {
             return this._getValue();
@@ -72,10 +59,12 @@ var View = Backbone.View.extend({
 
     /** Sets current value */
     _setValue: function (new_value) {
-        this._value = new_value;
-        this.model.trigger("error", null);
-        this.model.trigger("change");
-        this.trigger("change");
+        if (this._value !== new_value) {
+            this._value = new_value;
+            this.model.trigger("error", null);
+            this.model.trigger("change");
+            this.trigger("change");
+        }
     },
 });
 

--- a/client/src/utils/mountBreadcrump.js
+++ b/client/src/utils/mountBreadcrump.js
@@ -1,0 +1,14 @@
+import DirectoryPathEditableBreadcrumb from "components/FilesDialog/DirectoryPathEditableBreadcrumb";
+import { waitForElementToBePresent } from "utils/utils";
+
+import { mountVueComponent } from "utils/mountVueComponent";
+
+export function breadcrump(selector, callback, options = {}) {
+    waitForElementToBePresent(selector).then((selector) => {
+        Object.assign(options, {
+            callback: callback,
+        });
+
+        mountVueComponent(DirectoryPathEditableBreadcrumb)(options, selector);
+    });
+}

--- a/client/src/utils/utils.js
+++ b/client/src/utils/utils.js
@@ -362,6 +362,18 @@ export function hashFnv32a(str) {
     return hval >>> 0;
 }
 
+/**
+ * Return a promise, resolve it when element appears
+ * @param selector
+ * @returns {Promise<*>}
+ */
+export async function waitForElementToBePresent(selector) {
+    while (document.querySelector(selector) === null) {
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+    }
+    return document.querySelector(selector);
+}
+
 export default {
     cssLoadFile: cssLoadFile,
     cssGetAttribute: cssGetAttribute,
@@ -382,4 +394,5 @@ export default {
     appendScriptStyle: appendScriptStyle,
     getQueryString: getQueryString,
     setWindowTitle: setWindowTitle,
+    waitForElementToBePresent: waitForElementToBePresent,
 };


### PR DESCRIPTION
xref: https://github.com/galaxyproject/galaxy/issues/12346

Long Story short:
it's now possible to create folders with "enter" and "/" keys and delete with backspace (similar to github) 

![finalfinal](https://user-images.githubusercontent.com/15801412/138493759-9460ec61-6a8c-4f03-a634-ddb378adad89.gif)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
