### PR TITLE
[21.09] Improve error handling in DirectoryUriToolParameter validation

### DIFF
--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -2419,7 +2419,10 @@ class DirectoryUriToolParameter(SimpleTextToolParameter):
         super().validate(value, trans=trans)
         if not value:
             return  # value is not set yet, do not validate
-        file_source = trans.app.file_sources.get_file_source_path(value).file_source
+        file_source_path = trans.app.file_sources.get_file_source_path(value)
+        file_source = file_source_path.file_source
+        if file_source is None:
+            raise ParameterValueError(f"'{value}' is not a valid file source uri.", self.name)
         user_context = ProvidesUserFileSourcesUserContext(trans)
         user_has_access = file_source.user_has_access(user_context)
         if not user_has_access:


### PR DESCRIPTION
Avoids 500 status code if the parameter has a wrong value and the file source plugin or the path is not valid.
Detected on https://github.com/galaxyproject/galaxy/pull/12759, thanks @OlegZharkov!

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Find the tool `Export datasets`.
  - Provide an invalid `d_uri` parameter.
  - Instead of a 500 status code error you will get a 400 bad request with the message: `'{value}' is not a valid file source uri.`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
