### PR TITLE
[21.09] 'to to' typos (minor)

### DIFF
--- a/client/src/components/HistoryExport/ToLink.vue
+++ b/client/src/components/HistoryExport/ToLink.vue
@@ -35,7 +35,7 @@
             <p>
                 <b
                     ><a class="export-link" href="#" @click.prevent="regenerateExport"
-                        >Click here to to generate a new archive for this history.</a
+                        >Click here to generate a new archive for this history.</a
                     ></b
                 >
             </p>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -5520,7 +5520,7 @@ Examples are included in the test tools directory including:
       <xs:extension base="xs:string">
         <xs:attribute name="interpreter" type="xs:string">
           <xs:annotation>
-            <xs:documentation xml:lang="en"><![CDATA[*Deprecated*. This will prefix the version command with the value of this attribute (e.g. ``python`` or ``perl``) and the tool directory, in order to to run an executable file shipped with the tool. It is recommended to instead use ``<interpreter> '$__tool_directory__/<executable_name>'`` in the tag content. If this attribute is not specified, the tag should contain a Bash command calling executable(s) available in the ``$PATH``, as modified after loading the requirements.]]></xs:documentation>
+            <xs:documentation xml:lang="en"><![CDATA[*Deprecated*. This will prefix the version command with the value of this attribute (e.g. ``python`` or ``perl``) and the tool directory, in order to run an executable file shipped with the tool. It is recommended to instead use ``<interpreter> '$__tool_directory__/<executable_name>'`` in the tag content. If this attribute is not specified, the tag should contain a Bash command calling executable(s) available in the ``$PATH``, as modified after loading the requirements.]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
       </xs:extension>

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -456,8 +456,8 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
                 # We'll end up creating a new galaxy_session
                 session_key = None
         # If remote user is in use it can invalidate the session and in some
-        # cases won't have a cookie set above, so we need to to check some
-        # things now.
+        # cases won't have a cookie set above, so we need to check some things
+        # now.
         if self.app.config.use_remote_user:
             remote_user_email = self.environ.get(self.app.config.remote_user_header, None)
             if galaxy_session:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -298,7 +298,7 @@ function perform_stable_merge() {
         log_exec git merge -m "Merge branch 'release_${RELEASE_CURR}' into '${STABLE_BRANCH}'" "__release_${RELEASE_CURR}"
         PUSH_BRANCHES+=("__stable:${STABLE_BRANCH}")
     else
-        log "Release '${RELEASE_CURR}' < stable branch release '${stable}', skipping merge to to '${STABLE_BRANCH}'"
+        log "Release '${RELEASE_CURR}' < stable branch release '${stable}', skipping merge to '${STABLE_BRANCH}'"
     fi
     git checkout "$branch_curr"
 }


### PR DESCRIPTION
The one in HistoryExport was noticed by @jennaj in https://github.com/galaxyproject/galaxy/issues/12761, and I grepped when fixing it for more.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
