### PR TITLE
[21.09] Use default alert info instead of custom small info style

### DIFF
--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -581,7 +581,7 @@ DatasetListItemView.prototype.templates = (() => {
         resubmitted: BASE_MVC.wrapTemplate([
             // deleted not purged
             "<% if( model.resubmitted ){ %>",
-            '<div class="resubmitted-msg infomessagesmall">',
+            '<div class="resubmitted-msg alert alert-info">',
             _l("The job creating this dataset has been resubmitted"),
             "</div>",
             "<% } %>",

--- a/client/src/mvc/history/history-view.js
+++ b/client/src/mvc/history/history-view.js
@@ -523,7 +523,7 @@ HistoryView.prototype.templates = (() => {
         `<div>
             <div class="controls history-details"></div>
             <ul class="list-items"></ul>
-            <div class="empty-message infomessagesmall"></div>',
+            <div class="empty-message alert alert-info"></div>',
         </div>`;
 
     var controlsTemplate = BASE_MVC.wrapTemplate(

--- a/client/src/mvc/list/list-view.js
+++ b/client/src/mvc/list/list-view.js
@@ -859,7 +859,7 @@ ListPanel.prototype.templates = (() => {
         "<div>",
         '<div class="controls"></div>',
         '<div class="list-items"></div>',
-        '<div class="empty-message infomessagesmall"></div>',
+        '<div class="empty-message alert alert-info"></div>',
         "</div>",
     ]);
 


### PR DESCRIPTION
In three cases we are using `infomessagesmall` styles instead of the default `alert-info` class. This PR resolves this by replacing the first with the latter style class.

## How to test the changes?
  1. Create and empty history
  2. Notice how the alert shown in the history panel has a larger left than right padding.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
