### PR TITLE
Add test for invoking a workflow on a new autocreated history

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1762,6 +1762,16 @@ input_c:
         invocation_id = run_workflow_response.json()["id"]
         self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
 
+    def test_workflow_new_autocreated_history(self):
+        workflow = self.workflow_populator.load_workflow(name="test_for_new_autocreated_history")
+        workflow_request, history_id, workflow_id = self._setup_workflow_run(workflow)
+        del workflow_request['history']  # Not passing a history param means asking for a new history to be automatically created
+        run_workflow_dict = self.workflow_populator.invoke_workflow_raw(workflow_id, workflow_request, assert_ok=True).json()
+        new_history_id = run_workflow_dict["history_id"]
+        assert history_id != new_history_id
+        invocation_id = run_workflow_dict["id"]
+        self.wait_for_invocation_and_jobs(new_history_id, workflow_id, invocation_id)
+
     def test_workflow_output_dataset(self):
         with self.dataset_populator.test_history() as history_id:
             summary = self._run_workflow(WORKFLOW_SIMPLE, test_data={"input1": "hello world"}, history_id=history_id)


### PR DESCRIPTION
This fails without commit 397a3a0543e1a32fdb466649a00b1b57365ac3bf .

Opening against dev instead of release_20.09 because of the API testing changes introduced in #12516 .

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
