### PR TITLE
[21.09] Fix new user welcome plugin build status storage/detection

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -10,7 +10,7 @@ const glob = require("glob");
  * un-built visualizations in the repository; for performance and
  * simplicity just add them one at a time until we upgrade older viz's.
  */
-const PLUGIN_BUILD_IDS = [
+const STATIC_PLUGIN_BUILD_IDS = [
     "annotate_image",
     "chiraviz",
     "editor",
@@ -23,8 +23,11 @@ const PLUGIN_BUILD_IDS = [
     "openseadragon",
     "pv",
     "nora",
-    "new_user",
 ];
+
+const DIST_PLUGIN_BUILD_IDS = ["new_user"];
+
+const PLUGIN_BUILD_IDS = Array.prototype.concat(DIST_PLUGIN_BUILD_IDS, STATIC_PLUGIN_BUILD_IDS);
 
 const paths = {
     node_modules: "./node_modules",
@@ -32,7 +35,9 @@ const paths = {
         "../config/plugins/{visualizations,interactive_environments,welcome_page}/*/static/**/*",
         "../config/plugins/{visualizations,interactive_environments,welcome_page}/*/*/static/**/*",
     ],
-    plugin_build_modules: [`../config/plugins/{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/package.json`],
+    plugin_build_modules: [
+        `../config/plugins/{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/package.json`,
+    ],
     lib_locs: {
         // This is a stepping stone towards having all this staged
         // automatically.  Eventually, this dictionary and staging step will
@@ -87,7 +92,11 @@ function buildPlugins(callback) {
                 let skip_build = false;
                 const f = path.join(process.cwd(), file).slice(0, -12);
                 const plugin_name = path.dirname(file).split(path.sep).pop();
-                const hash_file_path = path.join(f, "static", "plugin_build_hash.txt");
+                const hash_file_path = path.join(
+                    f,
+                    DIST_PLUGIN_BUILD_IDS.indexOf(plugin_name) > -1 ? "dist" : "static",
+                    "plugin_build_hash.txt"
+                );
 
                 if (fs.existsSync(hash_file_path)) {
                     skip_build =
@@ -130,7 +139,9 @@ const client = parallel(fonts, stageLibs);
 const plugins = series(buildPlugins, cleanPlugins, stagePlugins);
 
 function watchPlugins() {
-    const BUILD_PLUGIN_WATCH_GLOB = [`../config/plugins/{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/**/*`];
+    const BUILD_PLUGIN_WATCH_GLOB = [
+        `../config/plugins/{visualizations,welcome_page}/{${PLUGIN_BUILD_IDS.join(",")}}/**/*`,
+    ];
     watch(BUILD_PLUGIN_WATCH_GLOB, { queue: false }, plugins);
 }
 


### PR DESCRIPTION
Without this, you'll notice the new user welcome rebuilds every time.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. `yarn run gulp plugins` from the client directory to test just the plugin build repeatedly.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
