### PR TITLE
FastAPI: migrate Dataset Collections API

### DIFF
--- a/lib/galaxy/managers/collections.py
+++ b/lib/galaxy/managers/collections.py
@@ -645,8 +645,14 @@ class DatasetCollectionManager:
                 raise ItemAccessibilityException("LibraryDatasetCollectionAssociation is not accessible to the current user", type='error')
         return collection_instance
 
-    def get_collection_contents_qry(self, parent_id, limit=None, offset=None):
+    def get_collection_contents(self, trans, parent_id, limit=None, offset=None):
         """Find first level of collection contents by containing collection parent_id"""
+        contents_qry = self._get_collection_contents_qry(parent_id, limit=limit, offset=offset)
+        contents = contents_qry.with_session(trans.sa_session()).all()
+        return contents
+
+    def _get_collection_contents_qry(self, parent_id, limit=None, offset=None):
+        """Build query to find first level of collection contents by containing collection parent_id"""
         DCE = model.DatasetCollectionElement
         qry = Query(DCE).filter(DCE.dataset_collection_id == parent_id)
         qry = qry.order_by(DCE.element_index)

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -2455,6 +2455,7 @@ class DeleteHDCAResult(Model):
 
 
 AnyHDA = Union[HDASummary, HDADetailed, HDABeta]
+AnyHDCA = Union[HDCABeta, HDCADetailed, HDCASummary]
 AnyHistoryContentItem = Union[AnyHDA, HDCASummary, HDCADetailed, HDCABeta]
 
 AnyJobStateSummary = Union[

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -585,6 +585,9 @@ class HDAObject(Model):
     hda_ldda: DatasetSourceType = HdaLddaField
     history_id: EncodedDatabaseIdField = HistoryIdField
 
+    class Config:
+        extra = Extra.allow  # Can contain more fields like metadata_*
+
 
 class DCObject(Model):
     """Dataset Collection Object"""

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -88,13 +88,11 @@ DatasetStateField: Dataset.states = Field(
 )
 
 CreateTimeField = Field(
-    ...,
     title="Create Time",
     description="The time and date this item was created.",
 )
 
 UpdateTimeField = Field(
-    ...,
     title="Update Time",
     description="The last time and date this item was updated.",
 )
@@ -137,7 +135,6 @@ ElementCountField: Optional[int] = Field(
 )
 
 PopulatedField: bool = Field(
-    ...,
     title="Populated",
     description="Whether the dataset collection elements (and any subcollections elements) were successfully populated.",
 )
@@ -167,7 +164,6 @@ GenomeBuildField: Optional[str] = Field(
 )
 
 ContentsUrlField = Field(
-    ...,
     title="Contents URL",
     description="The relative URL to access the contents of this History.",
 )
@@ -335,8 +331,7 @@ class Visualization(Model):  # TODO annotate this model
 class HistoryItemBase(Model):
     """Basic information provided by items contained in a History."""
     id: EncodedDatabaseIdField = EncodedEntityIdField
-    name: str = Field(
-        ...,
+    name: Optional[str] = Field(
         title="Name",
         description="The name of the item.",
     )
@@ -365,8 +360,8 @@ class HistoryItemBase(Model):
 
 class HistoryItemCommon(HistoryItemBase):
     """Common information provided by items contained in a History."""
-    type_id: str = Field(
-        ...,
+    type_id: Optional[str] = Field(
+        default=None,
         title="Type - ID",
         description="The type and the encoded ID of this item. Used for caching.",
         example="dataset-616e371b2cc6c62e",
@@ -376,8 +371,8 @@ class HistoryItemCommon(HistoryItemBase):
         title="Type",
         description="The type of this item.",
     )
-    create_time: datetime = CreateTimeField
-    update_time: datetime = UpdateTimeField
+    create_time: Optional[datetime] = CreateTimeField
+    update_time: Optional[datetime] = UpdateTimeField
     url: RelativeUrl = RelativeUrlField
     tags: TagCollection
 
@@ -596,7 +591,10 @@ class DCObject(Model):
     id: EncodedDatabaseIdField = EncodedEntityIdField
     model_class: str = ModelClassField(DC_MODEL_CLASS_NAME)
     collection_type: CollectionType = CollectionTypeField
-    contents_url: RelativeUrl = ContentsUrlField
+    populated: Optional[bool] = PopulatedField
+    element_count: Optional[int] = ElementCountField
+    contents_url: Optional[RelativeUrl] = ContentsUrlField
+    elements: List['DCESummary'] = ElementsField
 
 
 class DCESummary(Model):
@@ -618,11 +616,14 @@ class DCESummary(Model):
         title="Element Type",
         description="The type of the element. Used to interpret the `object` field.",
     )
-    object: Union[HDAObject, DCObject] = Field(
+    object: Union[HDAObject, HDADetailed, DCObject] = Field(
         ...,
         title="Object",
         description="The element's specific data depending on the value of `element_type`.",
     )
+
+
+DCObject.update_forward_refs()
 
 
 class DCDetailed(DCSummary):

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -243,6 +243,11 @@ class HistoryContentSource(str, Enum):
     new_collection = "new_collection"
 
 
+class DatasetCollectionInstanceType(str, Enum):
+    history = "history"
+    library = "library"
+
+
 class TagItem(ConstrainedStr):
     regex = re.compile(r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")
 
@@ -900,6 +905,83 @@ class CreateHistoryPayload(Model):
         default=None,
         title="Archive File",
         description="Uploaded file information when importing the history from a file.",
+    )
+
+
+class CollectionElementIdentifier(Model):
+    name: Optional[str] = Field(
+        None,
+        title="Name",
+        description="The name of the element.",
+    )
+    src: ColletionSourceType = Field(
+        ...,
+        title="Source",
+        description="The source of the element.",
+    )
+    id: Optional[EncodedDatabaseIdField] = Field(
+        default=None,
+        title="ID",
+        description="The encoded ID of the element.",
+    )
+    collection_type: Optional[str] = Field(
+        default=None,
+        title="Collection Type",
+        description="The type of the collection. For example, `list`, `paired`, `list:paired`.",
+    )
+    element_identifiers: Optional[List['CollectionElementIdentifier']] = Field(
+        default=None,
+        title="Element Identifiers",
+        description="List of elements that should be in the new sub-collection.",
+    )
+    tags: Optional[List[str]] = Field(
+        default=None,
+        title="Tags",
+        description="The list of tags associated with the element.",
+    )
+
+
+CollectionElementIdentifier.update_forward_refs()
+
+
+class CreateNewCollectionPayload(Model):
+    collection_type: str = Field(
+        ...,
+        title="Collection Type",
+        description="The type of the collection. For example, `list`, `paired`, `list:paired`.",
+    )
+    element_identifiers: List[CollectionElementIdentifier] = Field(
+        ...,
+        title="Element Identifiers",
+        description="List of elements that should be in the new collection.",
+    )
+    name: Optional[str] = Field(
+        default=None,
+        title="Name",
+        description="The name of the new collection.",
+    )
+    hide_source_items: Optional[bool] = Field(
+        default=False,
+        title="Hide Source Items",
+        description="Whether to mark the original HDAs as hidden.",
+    )
+    copy_elements: Optional[bool] = Field(
+        default=False,
+        title="Copy Elements",
+        description="Whether to create a copy of the source HDAs for the new collection.",
+    )
+    instance_type: Optional[DatasetCollectionInstanceType] = Field(
+        default=DatasetCollectionInstanceType.history,
+        title="Instance Type",
+        description="The type of the instance, either `history` (default) or `library`.",
+    )
+    history_id: Optional[EncodedDatabaseIdField] = Field(
+        default=None,
+        description="The ID of the history that will contain the collection. Required if `instance_type=history`.",
+    )
+    folder_id: Optional[EncodedDatabaseIdField] = Field(
+        default=None,
+        description="The ID of the history that will contain the collection. Required if `instance_type=library`.",
     )
 
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -87,13 +87,13 @@ DatasetStateField: Dataset.states = Field(
     description="The current state of this dataset.",
 )
 
-CreateTimeField: datetime = Field(
+CreateTimeField = Field(
     ...,
     title="Create Time",
     description="The time and date this item was created.",
 )
 
-UpdateTimeField: datetime = Field(
+UpdateTimeField = Field(
     ...,
     title="Update Time",
     description="The last time and date this item was updated.",
@@ -140,7 +140,7 @@ PopulatedField: bool = Field(
     description="Whether the dataset collection elements (and any subcollections elements) were successfully populated.",
 )
 
-ElementsField: List['DCESummary'] = Field(
+ElementsField = Field(
     [],
     title="Elements",
     description="The summary information of each of the elements inside the dataset collection.",

--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -480,11 +480,11 @@ class GalaxyInteractorApi:
     def _create_collection(self, history_id, collection_def):
         create_payload = dict(
             name=collection_def.name,
-            element_identifiers=dumps(self._element_identifiers(collection_def)),
+            element_identifiers=self._element_identifiers(collection_def),
             collection_type=collection_def.collection_type,
             history_id=history_id,
         )
-        return self._post("dataset_collections", data=create_payload).json()["id"]
+        return self._post("dataset_collections", data=create_payload, json=True).json()["id"]
 
     def _element_identifiers(self, collection_def):
         element_identifiers = []

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -6,6 +6,7 @@ from galaxy import exceptions
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
+    AnyHDCA,
     CreateNewCollectionPayload,
     DatasetCollectionInstanceType,
     HDCADetailed,
@@ -89,6 +90,18 @@ class FastAPIDatasetCollections:
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> SuitableConverters:
         return self.service.suitable_converters(trans, id, instance_type)
+
+    @router.get(
+        '/api/dataset_collections/{id}',
+        summary="Returns detailed information about the given collection.",
+    )
+    def show(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
+    ) -> AnyHDCA:
+        return self.service.show(trans, id, instance_type)
 
 
 class DatasetCollectionsController(BaseGalaxyAPIController):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -57,17 +57,17 @@ class FastAPIDatasetCollections:
     ) -> HDCADetailed:
         return self.service.create(trans, payload)
 
-    @router.put(
-        '/api/dataset_collections/{id}',
+    @router.post(
+        '/api/dataset_collections/{id}/copy',
         summary="Copy the given collection datasets to a new collection using a new `dbkey` attribute.",
     )
-    def update(
+    def copy(
         self,
         trans: ProvidesHistoryContext = DependsOnTrans,
         id: EncodedDatabaseIdField = Path(..., description="The ID of the dataset collection to copy."),
         payload: UpdateCollectionAttributePayload = Body(...),
     ):
-        self.service.update(trans, id, payload)
+        self.service.copy(trans, id, payload)
 
     @router.get(
         '/api/dataset_collections/{id}/attributes',
@@ -166,7 +166,7 @@ class DatasetCollectionsController(BaseGalaxyAPIController):
             create a new dataset collection instance.
         """
         update_payload = UpdateCollectionAttributePayload(**payload)
-        self.service.update(trans, id, update_payload)
+        self.service.copy(trans, id, update_payload)
 
     @expose_api
     def attributes(self, trans: ProvidesHistoryContext, id, instance_type='history'):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -1,9 +1,10 @@
 from logging import getLogger
 
-from fastapi import Body
+from fastapi import Body, Path
 
 from galaxy import exceptions
 from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.schema.fields import EncodedDatabaseIdField
 from galaxy.schema.schema import (
     CreateNewCollectionPayload,
     HDCADetailed,
@@ -39,6 +40,18 @@ class FastAPIDatasetCollections:
         payload: CreateNewCollectionPayload = Body(...),
     ) -> HDCADetailed:
         return self.service.create(trans, payload)
+
+    @router.put(
+        '/api/dataset_collections/{id}',
+        summary="Copy the given collection datasets to a new collection using a new `dbkey` attribute.",
+    )
+    def update(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = Path(..., description="The ID of the dataset collection to copy."),
+        payload: UpdateCollectionAttributePayload = Body(...),
+    ):
+        self.service.update(trans, id, payload)
 
 
 class DatasetCollectionsController(BaseGalaxyAPIController):
@@ -76,7 +89,7 @@ class DatasetCollectionsController(BaseGalaxyAPIController):
             create a new dataset collection instance.
         """
         update_payload = UpdateCollectionAttributePayload(**payload)
-        return self.service.update(trans, id, update_payload)
+        self.service.update(trans, id, update_payload)
 
     @expose_api
     def attributes(self, trans: ProvidesHistoryContext, id, instance_type='history'):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -4,7 +4,7 @@ from galaxy import exceptions
 from galaxy.managers.context import ProvidesHistoryContext
 from galaxy.schema.schema import CreateNewCollectionPayload
 from galaxy.web import expose_api
-from galaxy.webapps.galaxy.services.dataset_collections import DatasetCollectionsService
+from galaxy.webapps.galaxy.services.dataset_collections import DatasetCollectionsService, UpdateCollectionAttributePayload
 from . import BaseGalaxyAPIController, depends
 
 log = getLogger(__name__)
@@ -44,7 +44,8 @@ class DatasetCollectionsController(BaseGalaxyAPIController):
         * POST /api/dataset_collections/{hdca_id}/copy:
             create a new dataset collection instance.
         """
-        return self.service.update(trans, payload, id)
+        update_payload = UpdateCollectionAttributePayload(**payload)
+        return self.service.update(trans, id, update_payload)
 
     @expose_api
     def attributes(self, trans: ProvidesHistoryContext, id, instance_type='history'):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -2,6 +2,7 @@ from logging import getLogger
 
 from galaxy import exceptions
 from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.schema.schema import CreateNewCollectionPayload
 from galaxy.web import expose_api
 from galaxy.webapps.galaxy.services.dataset_collections import DatasetCollectionsService
 from . import BaseGalaxyAPIController, depends
@@ -31,7 +32,8 @@ class DatasetCollectionsController(BaseGalaxyAPIController):
         :rtype:     dict
         :returns:   element view of new dataset collection
         """
-        return self.service.create(trans, payload)
+        create_payload = CreateNewCollectionPayload(**payload)
+        return self.service.create(trans, create_payload)
 
     @expose_api
     def update(self, trans: ProvidesHistoryContext, payload: dict, id):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -1,13 +1,44 @@
 from logging import getLogger
 
+from fastapi import Body
+
 from galaxy import exceptions
 from galaxy.managers.context import ProvidesHistoryContext
-from galaxy.schema.schema import CreateNewCollectionPayload
+from galaxy.schema.schema import (
+    CreateNewCollectionPayload,
+    HDCADetailed,
+)
 from galaxy.web import expose_api
-from galaxy.webapps.galaxy.services.dataset_collections import DatasetCollectionsService, UpdateCollectionAttributePayload
-from . import BaseGalaxyAPIController, depends
+from galaxy.webapps.galaxy.services.dataset_collections import (
+    DatasetCollectionsService,
+    UpdateCollectionAttributePayload,
+)
+from . import (
+    BaseGalaxyAPIController,
+    depends,
+    DependsOnTrans,
+    Router
+)
 
 log = getLogger(__name__)
+
+router = Router(tags=['dataset collections'])
+
+
+@router.cbv
+class FastAPIDatasetCollections:
+    service: DatasetCollectionsService = depends(DatasetCollectionsService)
+
+    @router.post(
+        '/api/dataset_collections',
+        summary="Create a new dataset collection instance.",
+    )
+    def create(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        payload: CreateNewCollectionPayload = Body(...),
+    ) -> HDCADetailed:
+        return self.service.create(trans, payload)
 
 
 class DatasetCollectionsController(BaseGalaxyAPIController):

--- a/lib/galaxy/webapps/galaxy/api/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/api/dataset_collections.py
@@ -14,6 +14,7 @@ from galaxy.web import expose_api
 from galaxy.webapps.galaxy.services.dataset_collections import (
     DatasetCollectionAttributesResult,
     DatasetCollectionsService,
+    SuitableConverters,
     UpdateCollectionAttributePayload,
 )
 from . import (
@@ -76,6 +77,18 @@ class FastAPIDatasetCollections:
         instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
     ) -> DatasetCollectionAttributesResult:
         return self.service.attributes(trans, id, instance_type)
+
+    @router.get(
+        '/api/dataset_collections/{id}/suitable_converters',
+        summary="Returns a list of applicable converters for all datatypes in the given collection.",
+    )
+    def suitable_converters(
+        self,
+        trans: ProvidesHistoryContext = DependsOnTrans,
+        id: EncodedDatabaseIdField = DatasetCollectionIdPathParam,
+        instance_type: DatasetCollectionInstanceType = InstanceTypeQueryParam,
+    ) -> SuitableConverters:
+        return self.service.suitable_converters(trans, id, instance_type)
 
 
 class DatasetCollectionsController(BaseGalaxyAPIController):

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -284,6 +284,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         """
         serialization_params = parse_serialization_params(**kwd)
         create_payload = CreateHistoryContentPayload(**payload)
+        create_payload.type = kwd.get("type") or create_payload.type
         return self.service.create(trans, history_id, create_payload, serialization_params)
 
     @expose_api

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -136,7 +136,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         rval = dictify_dataset_collection_instance(
             dataset_collection_instance, security=trans.security, parent=create_params["parent"]
         )
-        return HDCADetailed.construct(**rval)
+        return rval
 
     def update(self, trans: ProvidesHistoryContext, id: EncodedDatabaseIdField, payload: UpdateCollectionAttributePayload):
         """

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from typing import List, Optional, Set
 
 import routes
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Extra, Field
 
 from galaxy import exceptions
 from galaxy.datatypes.registry import Registry
@@ -39,6 +39,9 @@ class UpdateCollectionAttributePayload(BaseModel):
         ...,
         description="TODO"
     )
+
+    class Config:
+        extra = Extra.forbid  # will cause validation to fail if extra attributes are included,
 
 
 class DatasetCollectionAttributesResult(BaseModel):

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -1,7 +1,6 @@
 from logging import getLogger
 from typing import List, Optional, Set
 
-import routes
 from pydantic import BaseModel, Extra, Field
 
 from galaxy import exceptions
@@ -250,7 +249,8 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         def serialize_element(dsc_element) -> DCESummary:
             result = dictify_element_reference(dsc_element, recursive=False, security=trans.security)
             if result["element_type"] == DCEType.dataset_collection:
-                result["object"]["contents_url"] = routes.url_for('contents_dataset_collection',
+                assert trans.url_builder
+                result["object"]["contents_url"] = trans.url_builder('contents_dataset_collection',
                     hdca_id=self.encode_id(hdca.id),
                     parent_id=self.encode_id(result["object"]["id"]))
             trans.security.encode_all_ids(result, recursive=True)

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -166,7 +166,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
             check_ownership=True
         )
         rval = dataset_collection_instance.to_dict(view="dbkeysandextensions")
-        return DatasetCollectionAttributesResult.construct(**rval)
+        return rval
 
     def suitable_converters(
         self,

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -140,7 +140,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         )
         return rval
 
-    def update(self, trans: ProvidesHistoryContext, id: EncodedDatabaseIdField, payload: UpdateCollectionAttributePayload):
+    def copy(self, trans: ProvidesHistoryContext, id: EncodedDatabaseIdField, payload: UpdateCollectionAttributePayload):
         """
         Iterate over all datasets of a collection and copy datasets with new attributes to a new collection.
         e.g attributes = {'dbkey': 'dm3'}

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -178,7 +178,7 @@ class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
         Returns suitable converters for all datatypes in collection
         """
         rval = self.collection_manager.get_converters_for_collection(trans, id, self.datatypes_registry, instance_type)
-        return SuitableConverters.parse_obj(rval)
+        return rval
 
     def show(
         self,

--- a/lib/galaxy/webapps/galaxy/services/dataset_collections.py
+++ b/lib/galaxy/webapps/galaxy/services/dataset_collections.py
@@ -1,0 +1,170 @@
+from logging import getLogger
+
+import routes
+
+from galaxy import exceptions
+from galaxy.datatypes.registry import Registry
+from galaxy.managers.collections import DatasetCollectionManager
+from galaxy.managers.collections_util import (
+    api_payload_to_create_params,
+    dictify_dataset_collection_instance,
+    dictify_element_reference,
+)
+from galaxy.managers.context import ProvidesHistoryContext
+from galaxy.managers.hdcas import HDCAManager
+from galaxy.managers.histories import HistoryManager
+from galaxy.security.idencoding import IdEncodingHelper
+from galaxy.webapps.base.controller import UsesLibraryMixinItems
+from galaxy.webapps.galaxy.services.base import ServiceBase
+
+
+log = getLogger(__name__)
+
+
+class DatasetCollectionsService(ServiceBase, UsesLibraryMixinItems):
+
+    def __init__(
+        self,
+        security: IdEncodingHelper,
+        history_manager: HistoryManager,
+        hdca_manager: HDCAManager,
+        collection_manager: DatasetCollectionManager,
+        datatypes_registry: Registry,
+    ):
+        super().__init__(security)
+        self.history_manager = history_manager
+        self.hdca_manager = hdca_manager
+        self.collection_manager = collection_manager
+        self.datatypes_registry = datatypes_registry
+
+    def create(self, trans: ProvidesHistoryContext, payload: dict):
+        """
+        Create a new dataset collection instance.
+
+        :type   payload: dict
+        :param  payload: (optional) dictionary structure containing:
+            * collection_type: dataset collection type to create.
+            * instance_type:   Instance type - 'history' or 'library'.
+            * name:            the new dataset collections's name
+            * datasets:        object describing datasets for collection
+        :rtype:     dict
+        :returns:   element view of new dataset collection
+        """
+        # TODO: Error handling...
+        create_params = api_payload_to_create_params(payload)
+        instance_type = payload.pop("instance_type", "history")
+        if instance_type == "history":
+            encoded_history_id = payload.get('history_id')
+            history_id = self.decode_id(encoded_history_id)
+            history = self.history_manager.get_owned(history_id, trans.user, current_history=trans.history)
+            create_params["parent"] = history
+            create_params["history"] = history
+        elif instance_type == "library":
+            folder_id = payload.get('folder_id')
+            library_folder = self.get_library_folder(trans, folder_id, check_accessible=True)
+            self.check_user_can_add_to_library_item(trans, library_folder, check_accessible=False)
+            create_params["parent"] = library_folder
+        else:
+            raise exceptions.RequestParameterInvalidException()
+
+        dataset_collection_instance = self.collection_manager.create(trans=trans, **create_params)
+        return dictify_dataset_collection_instance(dataset_collection_instance,
+                                                   security=trans.security, parent=create_params["parent"])
+
+    def update(self, trans: ProvidesHistoryContext, payload: dict, id):
+        """
+        Iterate over all datasets of a collection and copy datasets with new attributes to a new collection.
+        e.g attributes = {'dbkey': 'dm3'}
+        """
+
+        if len(payload) != 1:
+            raise exceptions.RequestParameterInvalidException("Update one attribute at a time.")
+        if 'dbkey' not in payload:
+            raise exceptions.RequestParameterInvalidException("This attribute cannot be modified.")
+
+        self.collection_manager.copy(trans, trans.history, "hdca", id, copy_elements=True, dataset_instance_attributes=payload)
+        trans.sa_session.flush()
+
+    def attributes(self, trans: ProvidesHistoryContext, id, instance_type='history'):
+        """
+        Returns dbkey/extension for collection elements
+        """
+        dataset_collection_instance = self.collection_manager.get_dataset_collection_instance(
+            trans,
+            id=id,
+            instance_type=instance_type,
+            check_ownership=True
+        )
+        return dataset_collection_instance.to_dict(view="dbkeysandextensions")
+
+    def suitable_converters(self, trans: ProvidesHistoryContext, id, instance_type='history'):
+        """
+        Returns suitable converters for all datatypes in collection
+        """
+        return self.collection_manager.get_converters_for_collection(trans, id, self.datatypes_registry, instance_type)
+
+    def show(self, trans: ProvidesHistoryContext, id, instance_type='history'):
+        """
+        Returns information about a particular dataset collection.
+        """
+        dataset_collection_instance = self.collection_manager.get_dataset_collection_instance(
+            trans,
+            id=id,
+            instance_type=instance_type,
+        )
+        if instance_type == 'history':
+            parent = dataset_collection_instance.history
+        elif instance_type == 'library':
+            parent = dataset_collection_instance.folder
+        else:
+            raise exceptions.RequestParameterInvalidException()
+
+        return dictify_dataset_collection_instance(
+            dataset_collection_instance,
+            security=trans.security,
+            parent=parent,
+            view='element'
+        )
+
+    def contents(self, trans: ProvidesHistoryContext, hdca_id, parent_id, instance_type='history', limit=None, offset=None):
+        """
+        Shows direct child contents of indicated dataset collection parent id
+
+        :type   string:     encoded string id
+        :param  id:         HDCA.id
+        :type   string:     encoded string id
+        :param  parent_id:  parent dataset_collection.id for the dataset contents to be viewed
+        :type   integer:    int
+        :param  limit:      pagination limit for returned dataset collection elements
+        :type   integer:    int
+        :param  offset:     pagination offset for returned dataset collection elements
+        :rtype:     list
+        :returns:   list of dataset collection elements and contents
+        """
+        # validate HDCA for current user, will throw error if not permitted
+        # TODO: refactor get_dataset_collection_instance
+        hdca = self.collection_manager.get_dataset_collection_instance(trans,
+            id=hdca_id, check_ownership=True,
+            instance_type=instance_type)
+
+        # check to make sure the dsc is part of the validated hdca
+        decoded_parent_id = self.decode_id(parent_id)
+        if parent_id != hdca_id and not hdca.contains_collection(decoded_parent_id):
+            errmsg = 'Requested dataset collection is not contained within indicated history content'
+            raise exceptions.ObjectNotFound(errmsg)
+
+        # retrieve contents
+        contents_qry = self.collection_manager.get_collection_contents_qry(decoded_parent_id, limit=limit, offset=offset)
+
+        # dictify and tack on a collection_url for drilling down into nested collections
+        def process_element(dsc_element):
+            result = dictify_element_reference(dsc_element, recursive=False, security=trans.security)
+            if result["element_type"] == "dataset_collection":
+                result["object"]["contents_url"] = routes.url_for('contents_dataset_collection',
+                    hdca_id=self.encode_id(hdca.id),
+                    parent_id=self.encode_id(result["object"]["id"]))
+            trans.security.encode_all_ids(result, recursive=True)
+            return result
+
+        results = contents_qry.with_session(trans.sa_session()).all()
+        return [process_element(el) for el in results]

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -61,7 +61,6 @@ from galaxy.schema.schema import (
     AnyHDA,
     AnyHistoryContentItem,
     AnyJobStateSummary,
-    ColletionSourceType,
     DatasetAssociationRoles,
     DeleteHDCAResult,
     HistoryContentSource,
@@ -183,52 +182,6 @@ class CreateHistoryContentPayloadFromCopy(CreateHistoryContentPayloadBase):
             "- The encoded id from the HDA\n"
             "- The encoded id from the HDCA\n"
         ),
-    )
-
-
-class CollectionElementIdentifier(Model):
-    name: Optional[str] = Field(
-        None,
-        title="Name",
-        description="The name of the element.",
-    )
-    src: ColletionSourceType = Field(
-        ...,
-        title="Source",
-        description="The source of the element.",
-    )
-    id: EncodedDatabaseIdField = Field(
-        ...,
-        title="ID",
-        description="The encoded ID of the element.",
-    )
-    tags: List[str] = Field(
-        default=[],
-        title="Tags",
-        description="The list of tags associated with the element.",
-    )
-
-
-class CreateNewCollectionPayload(Model):
-    collection_type: str = Field(
-        ...,
-        title="Collection Type",
-        description="The type of the collection. For example, `list`, `paired`, `list:paired`.",
-    )
-    element_identifiers: List[CollectionElementIdentifier] = Field(
-        ...,
-        title="Element Identifiers",
-        description="List of elements that should be in the new collection.",
-    )
-    name: Optional[str] = Field(
-        default=None,
-        title="Name",
-        description="The name of the new collection.",
-    )
-    hide_source_items: Optional[bool] = Field(
-        default=False,
-        title="Hide Source Items",
-        description="Whether to mark the original HDAs as hidden.",
     )
 
 

--- a/lib/galaxy_test/api/test_dataset_collections.py
+++ b/lib/galaxy_test/api/test_dataset_collections.py
@@ -22,7 +22,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
             self.history_id,
             instance_type="history",
         )
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         dataset_collection = self._check_create_response(create_response)
         returned_datasets = dataset_collection["elements"]
         assert len(returned_datasets) == 2, dataset_collection
@@ -33,11 +33,11 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         payload = dict(
             instance_type="history",
             history_id=self.history_id,
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
 
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         dataset_collection = self._check_create_response(create_response)
         returned_datasets = dataset_collection["elements"]
         assert len(returned_datasets) == 3, dataset_collection
@@ -47,7 +47,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
             self.history_id,
             instance_type="history",
         )
-        pair_create_response = self._post("dataset_collections", pair_payload)
+        pair_create_response = self._post("dataset_collections", pair_payload, json=True)
         dataset_collection = self._check_create_response(pair_create_response)
         hdca_id = dataset_collection["id"]
 
@@ -58,10 +58,10 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         payload = dict(
             instance_type="history",
             history_id=self.history_id,
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         dataset_collection = self._check_create_response(create_response)
         returned_collections = dataset_collection["elements"]
         assert len(returned_collections) == 1, dataset_collection
@@ -73,9 +73,9 @@ class DatasetCollectionApiTestCase(ApiTestCase):
             instance_type="history",
             history_id=self.history_id,
             name="a nested collection",
-            element_identifiers=json.dumps(identifiers),
+            element_identifiers=identifiers,
         )
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         dataset_collection = self._check_create_response(create_response)
         assert dataset_collection["collection_type"] == "list:paired"
         assert dataset_collection["name"] == "a nested collection"
@@ -169,10 +169,10 @@ class DatasetCollectionApiTestCase(ApiTestCase):
             payload = dict(
                 instance_type="history",
                 history_id=history_id,
-                element_identifiers=json.dumps(element_identifiers),
+                element_identifiers=element_identifiers,
                 collection_type="paired",
             )
-            create_response = self._post("dataset_collections", payload)
+            create_response = self._post("dataset_collections", payload, json=True)
             self._assert_status_code_is(create_response, 403)
 
     def test_enforces_unique_names(self):
@@ -181,11 +181,11 @@ class DatasetCollectionApiTestCase(ApiTestCase):
         payload = dict(
             instance_type="history",
             history_id=self.history_id,
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
 
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         self._assert_status_code_is(create_response, 400)
 
     def test_upload_collection(self):
@@ -488,7 +488,7 @@ class DatasetCollectionApiTestCase(ApiTestCase):
     def _create_collection_contents_pair(self):
         # Create a simple collection, return hdca and contents_url
         payload = self.dataset_collection_populator.create_pair_payload(self.history_id, instance_type="history")
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         hdca = self._check_create_response(create_response)
         root_contents_url = self._get_contents_url_for_hdca(hdca)
         return hdca, root_contents_url

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -348,7 +348,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         pre_dataset_count = self.__count_contents(type="dataset")
         pre_combined_count = self.__count_contents(type="dataset,dataset_collection")
 
-        dataset_collection_response = self._post(endpoint, payload)
+        dataset_collection_response = self._post(endpoint, payload, json=True)
 
         dataset_collection = self.__check_create_collection_response(dataset_collection_response)
 
@@ -418,7 +418,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
         )
 
         payload["hide_source_items"] = True
-        dataset_collection_response = self._post(f"histories/{self.history_id}/contents", payload)
+        dataset_collection_response = self._post(f"histories/{self.history_id}/contents", payload, json=True)
         self.__check_create_collection_response(dataset_collection_response)
 
         contents_response = self._get(f"histories/{self.history_id}/contents")
@@ -430,10 +430,10 @@ class HistoryContentsApiTestCase(ApiTestCase):
 
     def test_update_dataset_collection(self):
         hdca = self._create_pair_collection()
-        update_url = self._api_url(f"histories/{self.history_id}/contents/dataset_collections/{hdca['id']}", use_key=True)
-        # Awkward json.dumps required here because of https://trello.com/c/CQwmCeG6
-        body = json.dumps(dict(name="newnameforpair"))
-        update_response = put(update_url, data=body)
+        body = dict(name="newnameforpair")
+        update_response = self._put(
+            f"histories/{self.history_id}/contents/dataset_collections/{hdca['id']}", data=body, json=True
+        )
         self._assert_status_code_is(update_response, 200)
         show_response = self.__show(hdca)
         assert str(show_response.json()["name"]) == "newnameforpair"
@@ -457,7 +457,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
             self.history_id,
             type="dataset_collection"
         )
-        dataset_collection_response = self._post(f"histories/{self.history_id}/contents", payload)
+        dataset_collection_response = self._post(f"histories/{self.history_id}/contents", payload, json=True)
         self._assert_status_code_is(dataset_collection_response, 200)
         hdca = dataset_collection_response.json()
         return hdca
@@ -531,10 +531,10 @@ class HistoryContentsApiTestCase(ApiTestCase):
             history_id=history_id,
             type="dataset_collection",
             name="Test From Library",
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
-        create_response = self._post(f"histories/{history_id}/contents/dataset_collections", create_data)
+        create_response = self._post(f"histories/{history_id}/contents/dataset_collections", create_data, json=True)
         hdca = self.__check_create_collection_response(create_response)
         elements = hdca["elements"]
         assert len(elements) == 1
@@ -552,12 +552,12 @@ class HistoryContentsApiTestCase(ApiTestCase):
             history_id=self.history_id,
             type="dataset_collection",
             name="Test From Library",
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
         with self._different_user():
             second_history_id = self.dataset_populator.new_history()
-            create_response = self._post(f"histories/{second_history_id}/contents/dataset_collections", create_data)
+            create_response = self._post(f"histories/{second_history_id}/contents/dataset_collections", create_data, json=True)
             self._assert_status_code_is(create_response, 403)
 
     def __check_create_collection_response(self, response):

--- a/lib/galaxy_test/api/test_tools.py
+++ b/lib/galaxy_test/api/test_tools.py
@@ -1941,11 +1941,11 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         payload = dict(
             instance_type="history",
             history_id=history_id,
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
 
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         dataset_collection = create_response.json()
 
         inputs = {
@@ -1972,11 +1972,11 @@ class ToolsTestCase(ApiTestCase, TestsTools):
         payload = dict(
             instance_type="history",
             history_id=history_id,
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type="list",
         )
 
-        create_response = self._post("dataset_collections", payload)
+        create_response = self._post("dataset_collections", payload, json=True)
         dataset_collection = create_response.json()
 
         inputs = {

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1462,7 +1462,7 @@ class BaseDatasetCollectionPopulator:
         payload = dict(
             instance_type="history",
             history_id=history_id,
-            element_identifiers=json.dumps(element_identifiers),
+            element_identifiers=element_identifiers,
             collection_type=collection_type,
             name=name,
         )
@@ -1596,7 +1596,7 @@ class BaseDatasetCollectionPopulator:
             del kwds["contents"]
 
         if "element_identifiers" not in kwds:
-            kwds["element_identifiers"] = json.dumps(identifiers_func(history_id, contents=contents))
+            kwds["element_identifiers"] = identifiers_func(history_id, contents=contents)
 
         if "name" not in kwds:
             kwds["name"] = "Test Dataset Collection"
@@ -1674,7 +1674,7 @@ class DatasetCollectionPopulator(BaseDatasetCollectionPopulator):
         self.dataset_populator = DatasetPopulator(galaxy_interactor)
 
     def _create_collection(self, payload: dict) -> Response:
-        create_response = self.galaxy_interactor.post("dataset_collections", data=payload)
+        create_response = self.galaxy_interactor.post("dataset_collections", data=payload, json=True)
         return create_response
 
 
@@ -1863,7 +1863,7 @@ class GiDatasetCollectionPopulator(GiHttpMixin, BaseDatasetCollectionPopulator):
         self.dataset_collection_populator = GiDatasetCollectionPopulator(gi)
 
     def _create_collection(self, payload):
-        create_response = self._post("dataset_collections", data=payload)
+        create_response = self._post("dataset_collections", data=payload, json=True)
         return create_response
 
 

--- a/lib/galaxy_test/selenium/framework.py
+++ b/lib/galaxy_test/selenium/framework.py
@@ -644,7 +644,7 @@ class SeleniumSessionDatasetCollectionPopulator(SeleniumSessionGetPostMixin, pop
         self.dataset_populator = SeleniumSessionDatasetPopulator(selenium_context)
 
     def _create_collection(self, payload: dict) -> Response:
-        create_response = self._post("dataset_collections", data=payload)
+        create_response = self._post("dataset_collections", data=payload, json=True)
         return create_response
 
 


### PR DESCRIPTION
Part of the efforts for #10889 and necessary to be able to generate `contents_url` URLs for #12578

## Summary 
- [x] Move controller logic to the service layer
- [x] Create and update pydantic models with descriptions
- [x] Add type annotations
- [X] Refactor a bit the code and move database-related logic to the manager
- [x] Add FastAPI routes to replace old legacy routes

## Additional comments
- The **update** operation in `PUT /api/dataset_collections/{id}` endpoint looks like is actually making a copy of the collection changing the `dbkey` attribute of the datasets instead of updating the original collection, maybe the endpoint should be `POST /api/dataset_collections/{id}/copy` to better reflect the intention? Also, there is no return value, probably returning a summary view of the new collection will be useful or just 204.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to the interactive API documentation at http://127.0.0.1:8080/api/docs#/dataset%20collections and play with it

    ![Screenshot from 2021-10-27 16-59-04](https://user-images.githubusercontent.com/46503462/139092199-8e0619dc-39d9-498a-8600-0cb128adf775.png)


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
