### PR TITLE
[21.09] Various fixes and enhancements for metadata_strategy: extended 

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -1,5 +1,13 @@
 name: API tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -1,5 +1,13 @@
 name: API (legacy paste) tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_USE_UVICORN: false

--- a/.github/workflows/converter_tests.yaml
+++ b/.github/workflows/converter_tests.yaml
@@ -1,5 +1,13 @@
 name: Converter tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 env:
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
 concurrency:

--- a/.github/workflows/db_indexes.yaml
+++ b/.github/workflows/db_indexes.yaml
@@ -1,5 +1,13 @@
 name: Database indexes
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 concurrency:
   group: database-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,5 +1,11 @@
 name: Build docs
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
 concurrency:
   group: docs-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/first_startup.yaml
+++ b/.github/workflows/first_startup.yaml
@@ -1,5 +1,11 @@
 name: first startup
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 env:
   YARN_INSTALL_OPTS: --frozen-lockfile
 concurrency:

--- a/.github/workflows/framework.yaml
+++ b/.github/workflows/framework.yaml
@@ -1,5 +1,13 @@
 name: Framework tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,5 +1,13 @@
 name: Integration
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 env:
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -1,5 +1,11 @@
 name: Integration Selenium
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 env:
   GALAXY_SKIP_CLIENT_BUILD: '0'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'

--- a/.github/workflows/jest.yaml
+++ b/.github/workflows/jest.yaml
@@ -1,5 +1,11 @@
 name: Client Unit Testing
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'client/**'
+  pull_request:
+    paths:
+      - 'client/**'
 concurrency:
   group: client-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,11 @@
 name: Python linting
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**.py'
+  pull_request:
+    paths:
+      - '**.py'
 concurrency:
   group: py-lint-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mulled.yaml
+++ b/.github/workflows/mulled.yaml
@@ -1,5 +1,13 @@
 name: Mulled Unit Tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 concurrency:
   group: mulled-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/osx_startup.yaml
+++ b/.github/workflows/osx_startup.yaml
@@ -1,5 +1,11 @@
 name: macOS startup
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 concurrency:
   group: osx-first-startup-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -1,5 +1,14 @@
 name: Performance tests
 on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
 concurrency:

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -1,5 +1,11 @@
 name: Selenium tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -1,5 +1,11 @@
 name: Selenium tests (beta history panel)
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1

--- a/.github/workflows/toolshed.yaml
+++ b/.github/workflows/toolshed.yaml
@@ -1,5 +1,11 @@
 name: Toolshed tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   TOOL_SHED_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/toolshed?client_encoding=utf8'

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,5 +1,13 @@
 name: Unit tests
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'client/**'
+      - 'doc/**'
 concurrency:
   group: py-unit-${{ github.ref }}
   cancel-in-progress: true

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -325,6 +325,9 @@ class JobContext(ModelPersistenceContext, BaseJobContext):
     def get_job_id(self):
         return self.job.id
 
+    def get_implicit_collection_jobs_association_id(self):
+        return self.job.implicit_collection_jobs_association_id
+
 
 class SessionlessJobContext(SessionlessModelPersistenceContext, BaseJobContext):
 
@@ -386,6 +389,9 @@ class SessionlessJobContext(SessionlessModelPersistenceContext, BaseJobContext):
 
     def get_job_id(self):
         return self.metadata_params["job_id_tag"]
+
+    def get_implicit_collection_jobs_association_id(self):
+        return self.metadata_params.get("implicit_collection_jobs_association_id")
 
 
 def collect_primary_datasets(job_context, output, input_ext):

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -326,7 +326,7 @@ class JobContext(ModelPersistenceContext, BaseJobContext):
         return self.job.id
 
     def get_implicit_collection_jobs_association_id(self):
-        return self.job.implicit_collection_jobs_association_id
+        return self.job.implicit_collection_jobs_association and self.job.implicit_collection_jobs_association.id
 
 
 class SessionlessJobContext(SessionlessModelPersistenceContext, BaseJobContext):

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -118,6 +118,7 @@ def collect_dynamic_outputs(
                 collection_type_description = COLLECTION_TYPE_DESCRIPTION_FACTORY.for_collection_type(collection_type)
                 structure = UninitializedTree(collection_type_description)
                 hdca = job_context.create_hdca(name, structure)
+                output_collections[name] = hdca
                 job_context.add_dataset_collection(hdca)
             error_message = unnamed_output_dict.get("error_message")
             if error_message:

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -103,9 +103,10 @@ def collect_dynamic_outputs(
         # "hdca" (place discovered files in a history dataset collection), and "hdas" (place discovered files in a history
         # as stand-alone datasets).
         if destination_type == "library_folder":
-            # populate a library folder (needs to be already have been created)
+            # populate a library folder (needs to have already been created)
             library_folder = job_context.get_library_folder(destination)
             persist_elements_to_folder(job_context, elements, library_folder)
+            job_context.persist_library_folder(library_folder)
         elif destination_type == "hdca":
             # create or populate a dataset collection in the history
             assert "collection_type" in unnamed_output_dict

--- a/lib/galaxy/job_execution/output_collect.py
+++ b/lib/galaxy/job_execution/output_collect.py
@@ -118,6 +118,7 @@ def collect_dynamic_outputs(
                 collection_type_description = COLLECTION_TYPE_DESCRIPTION_FACTORY.for_collection_type(collection_type)
                 structure = UninitializedTree(collection_type_description)
                 hdca = job_context.create_hdca(name, structure)
+                job_context.add_dataset_collection(hdca)
             error_message = unnamed_output_dict.get("error_message")
             if error_message:
                 hdca.collection.handle_population_failed(error_message)

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1702,7 +1702,7 @@ class JobWrapper(HasResourceParameters):
         if extended_metadata:
             try:
                 import_options = store.ImportOptions(allow_dataset_object_edit=True, allow_edit=True)
-                import_model_store = store.get_import_model_store_for_directory(os.path.join(self.working_directory, 'metadata', 'outputs_populated'), app=self.app, import_options=import_options)
+                import_model_store = store.get_import_model_store_for_directory(os.path.join(self.working_directory, 'metadata', 'outputs_populated'), app=self.app, import_options=import_options, user=job.user)
                 import_model_store.perform_import(history=job.history)
             except Exception:
                 log.exception(f"problem importing job outputs. stdout [{job.stdout}] stderr [{job.stderr}]")

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2152,6 +2152,7 @@ class JobWrapper(HasResourceParameters):
                                                                         job=job,
                                                                         max_metadata_value_size=self.app.config.max_metadata_value_size,
                                                                         validate_outputs=self.validate_outputs,
+                                                                        link_data_only=self.__link_file_check(),
                                                                         **kwds)
         if resolve_metadata_dependencies:
             metadata_tool = self.app.toolbox.get_tool("__SET_METADATA__")

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1732,17 +1732,17 @@ class JobWrapper(HasResourceParameters):
                     self._finish_dataset(
                         output_name, dataset, job, context, final_job_state, remote_metadata_directory
                     )
+                if not final_job_state == job.states.ERROR:
+                    dataset_assoc.dataset.dataset.state = model.Dataset.states.OK
 
-        for dataset_assoc in output_dataset_associations:
-            if job.states.ERROR == final_job_state:
+        if job.states.ERROR == final_job_state:
+            for dataset_assoc in output_dataset_associations:
                 log.debug("(%s) setting dataset %s state to ERROR", job.id, dataset_assoc.dataset.dataset.id)
                 # TODO: This is where the state is being set to error. Change it!
                 dataset_assoc.dataset.dataset.state = model.Dataset.states.ERROR
                 # Pause any dependent jobs (and those jobs' outputs)
                 for dep_job_assoc in dataset_assoc.dataset.dependent_jobs:
                     self.pause(dep_job_assoc.job, "Execution of this dataset's job is paused because its input datasets are in an error state.")
-            else:
-                dataset_assoc.dataset.dataset.state = model.Dataset.states.OK
 
         # If any of the rest of the finish method below raises an
         # exception, the fail method will run and set the datasets to

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1660,7 +1660,7 @@ class JobWrapper(HasResourceParameters):
             # the tasks failed. So include the stderr, stdout, and exit code:
             return fail()
 
-        extended_metadata = self.external_output_metadata.extended
+        extended_metadata = self.external_output_metadata.extended and not self.tool.tool_type == 'interactive'
 
         # We collect the stderr from tools that write their stderr to galaxy.json
         tool_provided_metadata = self.get_tool_provided_job_metadata()

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1709,7 +1709,7 @@ class JobWrapper(HasResourceParameters):
                     user=job.user,
                     tag_handler=self.app.tag_handler.create_tag_handler_session(),
                 )
-                import_model_store.perform_import(history=job.history)
+                import_model_store.perform_import(history=job.history, job=job)
             except Exception:
                 log.exception(f"problem importing job outputs. stdout [{job.stdout}] stderr [{job.stderr}]")
                 raise

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1719,20 +1719,15 @@ class JobWrapper(HasResourceParameters):
                 self.version_string = collect_shrinked_content_from_path(version_filename)
 
         output_dataset_associations = job.output_datasets + job.output_library_datasets
-        for dataset_assoc in output_dataset_associations:
-            context = self.get_dataset_finish_context(job_context, dataset_assoc)
-            # should this also be checking library associations? - can a library item be added from a history before the job has ended? -
-            # lets not allow this to occur
-            # need to update all associated output hdas, i.e. history was shared with job running
-            for dataset in dataset_assoc.dataset.dataset.history_associations + dataset_assoc.dataset.dataset.library_associations:
-                output_name = dataset_assoc.name
-                standard_job_finish = not extended_metadata
-                if extended_metadata:
-                    if job.states.ERROR == final_job_state:
-                        dataset.blurb = "error"
-                        dataset.mark_unhidden()
+        if not extended_metadata:
+            for dataset_assoc in output_dataset_associations:
+                context = self.get_dataset_finish_context(job_context, dataset_assoc)
+                # should this also be checking library associations? - can a library item be added from a history before the job has ended? -
+                # lets not allow this to occur
+                # need to update all associated output hdas, i.e. history was shared with job running
+                for dataset in dataset_assoc.dataset.dataset.history_associations + dataset_assoc.dataset.dataset.library_associations:
+                    output_name = dataset_assoc.name
 
-                if standard_job_finish:
                     # Handles retry internally on error for instance...
                     self._finish_dataset(
                         output_name, dataset, job, context, final_job_state, remote_metadata_directory

--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1702,7 +1702,13 @@ class JobWrapper(HasResourceParameters):
         if extended_metadata:
             try:
                 import_options = store.ImportOptions(allow_dataset_object_edit=True, allow_edit=True)
-                import_model_store = store.get_import_model_store_for_directory(os.path.join(self.working_directory, 'metadata', 'outputs_populated'), app=self.app, import_options=import_options, user=job.user)
+                import_model_store = store.get_import_model_store_for_directory(
+                    os.path.join(self.working_directory, 'metadata', 'outputs_populated'),
+                    app=self.app,
+                    import_options=import_options,
+                    user=job.user,
+                    tag_handler=self.app.tag_handler.create_tag_handler_session(),
+                )
                 import_model_store.perform_import(history=job.history)
             except Exception:
                 log.exception(f"problem importing job outputs. stdout [{job.stdout}] stderr [{job.stderr}]")

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -754,7 +754,6 @@ class PulsarJobRunner(AsynchronousJobRunner):
         return job_state
 
     def __client_outputs(self, client, job_wrapper):
-        work_dir_outputs = self.get_work_dir_outputs(job_wrapper)
         metadata_directory = os.path.join(job_wrapper.working_directory, "metadata")
         metadata_strategy = job_wrapper.get_destination_configuration('metadata_strategy', None)
         tool = job_wrapper.tool
@@ -767,6 +766,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
             # we only need to recover the final model store.
             dynamic_outputs = EXTENDED_METADATA_DYNAMIC_COLLECTION_PATTERN
             output_files = []
+            work_dir_outputs = []
         else:
             # otherwise collect everything we might need
             dynamic_outputs = DEFAULT_DYNAMIC_COLLECTION_PATTERN[:]
@@ -775,6 +775,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
             # grab tool provided metadata (galaxy.json) also...
             dynamic_outputs.append(re.escape(tool_provided_metadata_file_path))
             output_files = self.get_output_files(job_wrapper)
+            work_dir_outputs = self.get_work_dir_outputs(job_wrapper)
         dynamic_file_sources = [
             {"path": tool_provided_metadata_file_path, "type": "galaxy" if tool_provided_metadata_style == "default" else "legacy_galaxy"}
         ]

--- a/lib/galaxy/jobs/runners/pulsar.py
+++ b/lib/galaxy/jobs/runners/pulsar.py
@@ -755,7 +755,6 @@ class PulsarJobRunner(AsynchronousJobRunner):
 
     def __client_outputs(self, client, job_wrapper):
         work_dir_outputs = self.get_work_dir_outputs(job_wrapper)
-        output_files = self.get_output_files(job_wrapper)
         metadata_directory = os.path.join(job_wrapper.working_directory, "metadata")
         metadata_strategy = job_wrapper.get_destination_configuration('metadata_strategy', None)
         tool = job_wrapper.tool
@@ -767,6 +766,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
             # if Pulsar is doing remote metadata and the remote metadata is extended,
             # we only need to recover the final model store.
             dynamic_outputs = EXTENDED_METADATA_DYNAMIC_COLLECTION_PATTERN
+            output_files = []
         else:
             # otherwise collect everything we might need
             dynamic_outputs = DEFAULT_DYNAMIC_COLLECTION_PATTERN[:]
@@ -774,6 +774,7 @@ class PulsarJobRunner(AsynchronousJobRunner):
             dynamic_outputs.extend(job_wrapper.tool.output_discover_patterns)
             # grab tool provided metadata (galaxy.json) also...
             dynamic_outputs.append(re.escape(tool_provided_metadata_file_path))
+            output_files = self.get_output_files(job_wrapper)
         dynamic_file_sources = [
             {"path": tool_provided_metadata_file_path, "type": "galaxy" if tool_provided_metadata_style == "default" else "legacy_galaxy"}
         ]

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -165,6 +165,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
                 export_store.add_dataset_collection(dataset_collection)
                 output_collections[name] = {
                     'id': dataset_collection.id,
+                    'model_class': dataset_collection.__class__.__name__
                 }
 
         if self.write_object_store_conf:

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -108,7 +108,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
                                 job_metadata=None, provided_metadata_style=None, compute_tmp_dir=None,
                                 include_command=True, max_metadata_value_size=0,
                                 validate_outputs=False,
-                                object_store_conf=None, tool=None, job=None,
+                                object_store_conf=None, tool=None, job=None, link_data_only=False,
                                 kwds=None):
         assert job_metadata, "setup_external_metadata must be supplied with job_metadata path"
         kwds = kwds or {}
@@ -181,6 +181,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
 
             # setup the rest
             metadata_params["tool"] = tool_as_dict
+            metadata_params["link_data_only"] = link_data_only
             metadata_params["tool_path"] = tool.config_file
             metadata_params["job_id_tag"] = job.get_id_tag()
             metadata_params["implicit_collection_jobs_association_id"] = job.implicit_collection_jobs_association and job.implicit_collection_jobs_association.id

--- a/lib/galaxy/metadata/__init__.py
+++ b/lib/galaxy/metadata/__init__.py
@@ -183,6 +183,7 @@ class PortableDirectoryMetadataGenerator(MetadataCollectionStrategy):
             metadata_params["tool"] = tool_as_dict
             metadata_params["tool_path"] = tool.config_file
             metadata_params["job_id_tag"] = job.get_id_tag()
+            metadata_params["implicit_collection_jobs_association_id"] = job.implicit_collection_jobs_association and job.implicit_collection_jobs_association.id
             metadata_params["job_params"] = job.raw_param_dict()
             metadata_params["output_collections"] = output_collections
 

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -28,7 +28,6 @@ from galaxy.datatypes import sniff
 from galaxy.datatypes.data import validate
 from galaxy.job_execution.output_collect import (
     collect_dynamic_outputs,
-    collect_extra_files,
     collect_primary_datasets,
     collect_shrinked_content_from_path,
     default_exit_code_file,
@@ -280,7 +279,6 @@ def set_metadata_portable():
                     # outputs to working directory, and not already pushed by pulsar + extended metadata,
                     # move output to final destination.
                     object_store.update_from_file(dataset.dataset, file_name=external_filename, create=True)
-                collect_extra_files(object_store, dataset, ".")
                 # TODO: merge expression_context into tool_provided_metadata so we don't have to special case this (here and in _finish_dataset)
                 meta = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id, dataset.dataset.uuid)
                 if meta:
@@ -313,6 +311,7 @@ def set_metadata_portable():
                         setattr(dataset, context_key, context_value)
                 # We never want to persist the external_filename.
                 dataset.dataset.external_filename = None
+                dataset.dataset.extra_files_path = None
                 export_store.add_dataset(dataset)
             else:
                 dataset.metadata.to_JSON_dict(filename_out)  # write out results of set_meta

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -226,8 +226,9 @@ def set_metadata_portable():
         if destination_type == 'hdas':
             for element in elements:
                 filename = element.get('filename')
-                if filename:
-                    unnamed_id_to_path[element['object_id']] = os.path.join(job_context.job_working_directory, filename)
+                object_id = element.get('object_id')
+                if filename and object_id:
+                    unnamed_id_to_path[object_id] = os.path.join(job_context.job_working_directory, filename)
 
     for output_name, output_dict in outputs.items():
         dataset_instance_id = output_dict["id"]

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -28,6 +28,7 @@ from galaxy.datatypes import sniff
 from galaxy.datatypes.data import validate
 from galaxy.job_execution.output_collect import (
     collect_dynamic_outputs,
+    collect_extra_files,
     collect_primary_datasets,
     collect_shrinked_content_from_path,
     default_exit_code_file,
@@ -273,6 +274,8 @@ def set_metadata_portable():
                 # We're going to run through set_metadata in collect_dynamic_outputs with more contextual metadata,
                 # so skip set_meta here.
                 set_meta(dataset, file_dict)
+                if extended_metadata_collection:
+                    collect_extra_files(object_store, dataset, ".")
 
             if extended_metadata_collection:
                 if external_filename.startswith(tool_job_working_directory) and os.path.getsize(external_filename):

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -39,7 +39,6 @@ from galaxy.job_execution.setup import TOOL_PROVIDED_JOB_METADATA_KEYS
 from galaxy.model import (
     Dataset,
     HistoryDatasetAssociation,
-    HistoryDatasetCollectionAssociation,
     Job,
     store,
 )
@@ -306,7 +305,10 @@ def set_metadata_portable():
         # discover extra outputs...
         output_collections = {}
         for name, output_collection in metadata_params["output_collections"].items():
-            output_collections[name] = import_model_store.sa_session.query(HistoryDatasetCollectionAssociation).find(output_collection["id"])
+            # TODO: remove HistoryDatasetCollectionAssociation fallback on 22.01, model_class used to not be serialized prior to 21.09
+            model_class = output_collection.get('model_class', 'HistoryDatasetCollectionAssociation')
+            collection = import_model_store.sa_session.query(getattr(galaxy.model, model_class)).find(output_collection["id"])
+            output_collections[name] = collection
         outputs = {}
         for name, output in metadata_params["outputs"].items():
             klass = getattr(galaxy.model, output.get('model_class', 'HistoryDatasetAssociation'))

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -276,6 +276,7 @@ def set_metadata_portable():
                 set_meta(dataset, file_dict)
                 if extended_metadata_collection:
                     collect_extra_files(object_store, dataset, ".")
+                    dataset.dataset.state = final_job_state
 
             if extended_metadata_collection:
                 if external_filename.startswith(tool_job_working_directory) and os.path.getsize(external_filename):

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -276,57 +276,17 @@ def set_metadata_portable():
                 set_meta(dataset, file_dict)
 
             if extended_metadata_collection:
+                collect_extra_files(object_store, dataset, ".")
                 meta = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id, dataset.dataset.uuid)
                 if meta:
                     context = ExpressionContext(meta, expression_context)
                 else:
                     context = expression_context
-
-                # Lazy and unattached
-                # if getattr(dataset, "hidden_beneath_collection_instance", None):
-                #    dataset.visible = False
-                dataset.blurb = 'done'
-                dataset.peek = 'no peek'
-                dataset.info = (dataset.info or '')
-                if context['stdout'].strip():
-                    # Ensure white space between entries
-                    dataset.info = f"{dataset.info.rstrip()}\n{context['stdout'].strip()}"
-                if context['stderr'].strip():
-                    # Ensure white space between entries
-                    dataset.info = f"{dataset.info.rstrip()}\n{context['stderr'].strip()}"
-                dataset.tool_version = version_string
-                dataset.set_size()
-                if 'uuid' in context:
-                    dataset.dataset.uuid = context['uuid']
-                if dataset_filename_override and dataset_filename_override != dataset.file_name:
-                    # This has to be a job with outputs_to_working_directory set.
-                    # We update the object store with the created output file.
-                    object_store.update_from_file(dataset.dataset, file_name=dataset_filename_override, create=True)
-                collect_extra_files(object_store, dataset, ".")
-                if Job.states.ERROR == final_job_state:
-                    dataset.blurb = "error"
-                    dataset.mark_unhidden()
-                else:
-                    # If the tool was expected to set the extension, attempt to retrieve it
-                    if dataset.ext == 'auto':
-                        dataset.extension = context.get('ext', 'data')
-                        dataset.init_meta(copy_from=dataset)
-
-                    # This has already been done:
-                    # else:
-                    #     self.external_output_metadata.load_metadata(dataset, output_name, self.sa_session, working_directory=self.working_directory, remote_metadata_directory=remote_metadata_directory)
-                    line_count = context.get('line_count', None)
-                    try:
-                        # Certain datatype's set_peek methods contain a line_count argument
-                        dataset.set_peek(line_count=line_count)
-                    except TypeError:
-                        # ... and others don't
-                        dataset.set_peek()
-
                 for context_key in TOOL_PROVIDED_JOB_METADATA_KEYS:
                     if context_key in context:
                         context_value = context[context_key]
                         setattr(dataset, context_key, context_value)
+                dataset.tool_version = version_string
                 # We never want to persist the external_filename.
                 dataset.dataset.external_filename = None
                 export_store.add_dataset(dataset)

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -312,7 +312,7 @@ def set_metadata_portable():
             klass = getattr(galaxy.model, output.get('model_class', 'HistoryDatasetAssociation'))
             outputs[name] = import_model_store.sa_session.query(klass).find(output["id"])
 
-        input_ext = json.loads(metadata_params["job_params"].get("__input_ext", '"data"'))
+        input_ext = json.loads(metadata_params["job_params"].get("__input_ext") or '"data"')
         collect_primary_datasets(
             job_context,
             outputs,

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sys
 import traceback
+from pathlib import Path
 
 try:
     from pulsar.client.staging import COMMAND_VERSION_FILENAME
@@ -176,6 +177,20 @@ def set_metadata_portable():
 
             with open(os.path.join(outputs_directory, "stderr"), "rb") as f:
                 tool_stderr = f.read()
+        elif os.path.exists(os.path.join(tool_job_working_directory, 'task_0')):
+            # We have a task splitting job
+            tool_stdout = b''
+            tool_stderr = b''
+            paths = Path(tool_job_working_directory).glob('task_*')
+            for path in paths:
+                with open(path / 'outputs' / 'tool_stdout', 'rb') as f:
+                    task_stdout = f.read()
+                    if task_stdout:
+                        tool_stdout = b"%s[%s stdout]\n%s\n" % (tool_stdout, path.name.encode(), task_stdout)
+                with open(path / 'outputs' / 'tool_stderr', 'rb') as f:
+                    task_stderr = f.read()
+                    if task_stderr:
+                        tool_stderr = b"%s[%s stdout]\n%s\n" % (tool_stderr, path.name.encode(), task_stderr)
         else:
             wdc = os.listdir(tool_job_working_directory)
             odc = os.listdir(outputs_directory)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3976,6 +3976,8 @@ class DatasetInstance:
             deleted=self.deleted,
             visible=self.visible,
             dataset_uuid=(lambda uuid: str(uuid) if uuid else None)(self.dataset.uuid),
+            validated_state=self.validated_state,
+            validated_state_message=self.validated_state_message,
         )
 
         serialization_options.attach_identifier(id_encoder, self, rval)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -4563,6 +4563,7 @@ class LibraryFolder(Base, Dictifiable, HasName, RepresentById):
     def serialize(self, id_encoder, serialization_options):
         rval = dict_for(
             self,
+            id=self.id,  # FIXME: serialize only in sessionless export mode
             name=self.name,
             description=self.description,
             genome_build=self.genome_build,
@@ -4697,7 +4698,7 @@ class LibraryDataset(Base, RepresentById):
                     name=ldda.name,
                     file_name=ldda.file_name,
                     created_from_basename=ldda.created_from_basename,
-                    uploaded_by=ldda.user.email,
+                    uploaded_by=ldda.user and ldda.user.email,
                     message=ldda.message,
                     date_uploaded=ldda.create_time.isoformat(),
                     update_time=ldda.update_time.isoformat(),

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -5412,6 +5412,7 @@ class DatasetCollection(Base, Dictifiable, UsesAnnotations, RepresentById):
             self,
             type=self.collection_type,
             populated_state=self.populated_state,
+            populated_state_message=self.populated_state_message,
             elements=list(map(lambda e: e.serialize(id_encoder, serialization_options), self.elements))
         )
         serialization_options.attach_identifier(id_encoder, self, rval)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -468,8 +468,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                         dce.child_collection = import_collection(element_attrs['child_collection'])
                     else:
                         raise Exception("Unknown collection element type encountered.")
-
-                    self._session_add(dce)
+                dc.element_count = len(elements_attrs)
 
             if "id" in collection_attrs and self.import_options.allow_edit and not self.sessionless:
                 dc = self.sa_session.query(model.DatasetCollection).get(collection_attrs["id"])
@@ -489,7 +488,6 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 dc.populated_state = collection_attrs["populated_state"]
                 dc.populated_state_message = collection_attrs.get('populated_state_message')
                 self._attach_raw_id_if_editing(dc, collection_attrs)
-                # TODO: element_count...
                 materialize_elements(dc)
 
             self._session_add(dc)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -231,6 +231,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     "visible",
                     "metadata",
                     "tool_version",
+                    "validated_state",
+                    "validated_state_message",
                 ]
                 for attribute in attributes:
                     if attribute in dataset_attrs:

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -621,6 +621,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
             history.add_pending_items()
 
     def _import_jobs(self, object_import_tracker, history):
+        self._flush()
         object_key = self.object_key
 
         def _find_hda(input_key):

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -217,6 +217,8 @@ class ModelImportStore(metaclass=abc.ABCMeta):
 
                     if 'id' in dataset_attrs["dataset"] and self.import_options.allow_edit:
                         dataset_instance.dataset.id = dataset_attrs["dataset"]['id']
+                    if job:
+                        dataset_instance.dataset.job_id = job.id
 
             if 'id' in dataset_attrs and self.import_options.allow_edit and not self.sessionless:
                 dataset_instance = self.sa_session.query(getattr(model, dataset_attrs['model_class'])).get(dataset_attrs["id"])

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from collections import defaultdict
 from json import (
     dump,
     dumps,
@@ -50,23 +51,20 @@ class ImportOptions:
 class SessionlessContext:
 
     def __init__(self):
-        self.objects = []
+        self.objects = defaultdict(dict)
 
     def flush(self):
         pass
 
     def add(self, obj):
-        self.objects.append(obj)
+        self.objects[obj.__class__][obj.id] = obj
 
     def query(self, model_class):
 
         def find(obj_id):
-            for obj in self.objects:
-                if isinstance(obj, model_class) and obj.id == obj_id:
-                    return obj
-            return None
+            return self.objects.get(model_class, {}).get(obj_id) or None
 
-        return Bunch(find=find)
+        return Bunch(find=find, get=find)
 
 
 class ModelImportStore(metaclass=abc.ABCMeta):

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -468,16 +468,18 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                 attributes = [
                     "collection_type",
                     "populated_state",
+                    "populated_state_message",
                     "element_count",
                 ]
                 for attribute in attributes:
                     if attribute in collection_attrs:
-                        setattr(dc, attribute, collection_attrs[attribute])
+                        setattr(dc, attribute, collection_attrs.get(attribute))
                 materialize_elements(dc)
             else:
                 # create collection
                 dc = model.DatasetCollection(collection_type=collection_attrs['type'])
                 dc.populated_state = collection_attrs["populated_state"]
+                dc.populated_state_message = collection_attrs.get('populated_state_message')
                 self._attach_raw_id_if_editing(dc, collection_attrs)
                 # TODO: element_count...
                 materialize_elements(dc)

--- a/lib/galaxy/model/store/__init__.py
+++ b/lib/galaxy/model/store/__init__.py
@@ -69,7 +69,7 @@ class SessionlessContext:
 
 class ModelImportStore(metaclass=abc.ABCMeta):
 
-    def __init__(self, import_options=None, app=None, user=None, object_store=None):
+    def __init__(self, import_options=None, app=None, user=None, object_store=None, tag_handler=None):
         if object_store is None:
             if app is not None:
                 object_store = app.object_store
@@ -84,6 +84,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
         self.user = user
         self.import_options = import_options or ImportOptions()
         self.dataset_state_serialized = True
+        self.tag_handler = tag_handler
 
     @abc.abstractmethod
     def defines_new_history(self):
@@ -353,8 +354,7 @@ class ModelImportStore(metaclass=abc.ABCMeta):
                     add_item_annotation(self.sa_session, self.user, dataset_instance, dataset_attrs['annotation'])
                     tag_list = dataset_attrs.get('tags')
                     if tag_list:
-                        tag_handler = model.tags.GalaxyTagHandler(sa_session=self.sa_session)
-                        tag_handler.set_tags_from_list(user=self.user, item=dataset_instance, new_tags_list=tag_list)
+                        self.tag_handler.set_tags_from_list(user=self.user, item=dataset_instance, new_tags_list=tag_list, flush=False)
 
                 if self.app:
                     self.app.datatypes_registry.set_external_metadata_tool.regenerate_imported_metadata_if_needed(

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -349,6 +349,9 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
     def persist_object(self, obj):
         """Add the target to the persistence layer."""
 
+    def persist_library_folder(self, library_folder):
+        """Add library folder to sessionless export. Noop for session export."""
+
     def flush(self):
         """If database bound, flush the persisted objects to ensure IDs."""
 
@@ -433,7 +436,9 @@ class SessionlessModelPersistenceContext(ModelPersistenceContext):
         library_folder.item_count += 1
 
     def get_library_folder(self, destination):
-        raise NotImplementedError()
+        folder = galaxy.model.LibraryFolder()
+        folder.id = destination.get("library_folder_id")
+        return folder
 
     def get_hdca(self, object_id):
         raise NotImplementedError()
@@ -447,6 +452,9 @@ class SessionlessModelPersistenceContext(ModelPersistenceContext):
         parent_folder.item_count += 1
         parent_folder.folders.append(nested_folder)
         return nested_folder
+
+    def persist_library_folder(self, library_folder):
+        self.export_store.export_library(library_folder)
 
     def add_datasets_to_history(self, datasets, for_output_dataset=None):
         # Consider copying these datasets to for_output_dataset copied histories

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -617,7 +617,8 @@ def persist_hdas(elements, model_persistence_context, final_job_state='ok'):
                 hda_id = discovered_file.match.object_id
                 primary_dataset = None
                 if hda_id:
-                    primary_dataset = model_persistence_context.sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
+                    sa_session = model_persistence_context.sa_session or model_persistence_context.import_store.sa_session
+                    primary_dataset = sa_session.query(galaxy.model.HistoryDatasetAssociation).get(hda_id)
 
                 sources = fields_match.sources
                 hashes = fields_match.hashes

--- a/lib/galaxy/model/store/discover.py
+++ b/lib/galaxy/model/store/discover.py
@@ -116,6 +116,8 @@ class ModelPersistenceContext(metaclass=abc.ABCMeta):
                 self.add_library_dataset_to_folder(library_folder, ld)
                 primary_data = ldda
         primary_data.raw_set_dataset_state(final_job_state)
+        if final_job_state == galaxy.model.Job.states.ERROR and not self.get_implicit_collection_jobs_association_id():
+            primary_data.visible = True
 
         for source_dict in sources:
             source = galaxy.model.DatasetSource()
@@ -474,6 +476,9 @@ class SessionlessModelPersistenceContext(ModelPersistenceContext):
 
     def add_output_dataset_association(self, name, dataset):
         """No-op, no job context to persist this association for."""
+
+    def get_implicit_collection_jobs_association_id(self):
+        """No-op, no job context."""
 
 
 def persist_extra_files(object_store, src_extra_files_path, primary_data):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -403,6 +403,17 @@ class GalaxyTagHandlerSession(GalaxyTagHandler):
         return tag
 
 
+class GalaxySessionlessTagHandler(GalaxyTagHandlerSession):
+
+    def _get_tag(self, tag_name):
+        """Get tag from cache or database."""
+        # Short-circuit session access
+        return self.created_tags.get(tag_name)
+
+    def get_tag_by_name(self, tag_name):
+        self.created_tags.get(tag_name)
+
+
 class CommunityTagHandler(TagHandler):
     def __init__(self, sa_session):
         TagHandler.__init__(self, sa_session)

--- a/lib/galaxy/tool_util/parser/output_collection_def.py
+++ b/lib/galaxy/tool_util/parser/output_collection_def.py
@@ -92,6 +92,7 @@ class DatasetCollectionDescription:
             'assign_primary_output': self.assign_primary_output,
             'directory': self.directory,
             'recurse': self.recurse,
+            'match_relative_path': self.match_relative_path,
         }
 
     @property

--- a/lib/galaxy/tool_util/parser/output_collection_def.py
+++ b/lib/galaxy/tool_util/parser/output_collection_def.py
@@ -117,7 +117,7 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
         if pattern in NAMED_PATTERNS:
             pattern = NAMED_PATTERNS.get(pattern)
         self.pattern = pattern
-        sort_by = kwargs.get("sort_by", DEFAULT_SORT_BY)
+        self.sort_by = sort_by = kwargs.get("sort_by", DEFAULT_SORT_BY)
         if sort_by.startswith("reverse_"):
             self.sort_reverse = True
             sort_by = sort_by[len("reverse_"):]
@@ -144,6 +144,7 @@ class FilePatternDatasetCollectionDescription(DatasetCollectionDescription):
             "sort_comp": self.sort_comp,
             "pattern": self.pattern,
             "recurse": self.recurse,
+            "sort_by": self.sort_by,
         })
         return as_dict
 

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -558,7 +558,9 @@ class BaseDatasetPopulator(BasePopulator):
                 if history_content_id is None:
                     raise Exception(f"Could not find content with HID [{hid}] in [{history_contents}]")
             else:
-                # No hid specified - just grab most recent element.
+                # No hid specified - just grab most recent element of correct content type
+                if kwds.get('history_content_type'):
+                    history_contents = [c for c in history_contents if c['history_content_type'] == kwds['history_content_type']]
                 history_content_id = history_contents[-1]["id"]
         return history_content_id
 

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -5,6 +5,9 @@
     <datatype extension="txt" type="galaxy.datatypes.data:Text" display_in_upload="true"/>
     <datatype extension="tabular" type="galaxy.datatypes.tabular:Tabular" display_in_upload="true"/>
     <datatype extension="csv" type="galaxy.datatypes.tabular:CSV" display_in_upload="true" />
+    <datatype extension="tsv" type="galaxy.datatypes.tabular:TSV" display_in_upload="true">
+      <converter file="tabular_to_csv.xml" target_datatype="csv"/>
+    </datatype>
     <datatype extension="interval" type="galaxy.datatypes.interval:Interval" display_in_upload="true" description="File must start with definition line in the following format (columns may be in any order)." >
     </datatype>
     <datatype extension="fasta" type="galaxy.datatypes.sequence:Fasta" auto_compressed_types="gz" display_in_upload="true">

--- a/test/integration/embedded_pulsar_docker_job_conf.yml
+++ b/test/integration/embedded_pulsar_docker_job_conf.yml
@@ -19,6 +19,7 @@ execution:
       docker_sudo: false
       docker_required: true
       container_monitor_result: callback
+      remote_metadata: true
 
 tools:
 - id: upload1

--- a/test/integration/embedded_pulsar_job_conf.xml
+++ b/test/integration/embedded_pulsar_job_conf.xml
@@ -10,6 +10,7 @@
         <destination id="local" runner="local">
         </destination>
         <destination id="pulsar_embed" runner="pulsar_embed">
+            <param id="remote_metadata">true</param>
         </destination>
     </destinations>
     <tools>

--- a/test/integration/test_config_defaults.py
+++ b/test/integration/test_config_defaults.py
@@ -272,6 +272,8 @@ def get_config_data():
     for key, data in DRIVER.app.config.schema.app_schema.items():
         if key in DO_NOT_TEST:
             continue
+        elif f"GALAXY_CONFIG_OVERRIDE_{str(key).upper()}" in os.environ:
+            continue
         expected_value = get_expected(key, data, parent_dirs)
         loaded_value = getattr(DRIVER.app.config, key)
         data = OptionData(key=key, expected=expected_value, loaded=loaded_value)  # passed to test

--- a/test/integration/test_extended_metadata.py
+++ b/test/integration/test_extended_metadata.py
@@ -58,14 +58,19 @@ class ExtendedMetadataIntegrationTestCase(integration_util.IntegrationTestCase):
             "elements": [element],
         }
         targets = json.dumps([target])
+        upload_content = 'abcdef'
         payload = {
             "history_id": history_id,
             "targets": targets,
-            "__files": {"files_0|file_data": 'abcdef'}
+            "__files": {"files_0|file_data": upload_content}
         }
         new_dataset = self.dataset_populator.fetch(payload, assert_ok=True).json()["outputs"][0]
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
-        return history_id, new_dataset
+        content = self.dataset_populator.get_history_dataset_content(
+            history_id=history_id,
+            dataset_id=new_dataset['id'],
+        )
+        assert content == upload_content
 
 
 class ExtendedMetadataIntegrationInstance(integration_util.IntegrationInstance):

--- a/test/integration/test_pulsar_embedded_mq.py
+++ b/test/integration/test_pulsar_embedded_mq.py
@@ -36,6 +36,8 @@ execution:
       dependency_resolution: none
       default_file_action: remote_transfer
       jobs_directory: ${jobs_directory}
+      remote_metadata: true
+      remote_property_galaxy_home: ${galaxy_home}
     local_environment:
       runner: local
 tools:
@@ -65,6 +67,7 @@ class EmbeddedMessageQueuePulsarIntegrationInstance(integration_util.Integration
         job_conf_str = job_conf_template.substitute(
             amqp_url=AMQP_URL,
             jobs_directory=jobs_directory,
+            galaxy_home=os.path.join(SCRIPT_DIRECTORY, os.pardir)
         )
         with tempfile.NamedTemporaryFile(suffix="_mq_job_conf.yml", mode="w", delete=False) as job_conf:
             job_conf.write(job_conf_str)

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -56,7 +56,7 @@ class BaseUploadContentConfigurationInstance(integration_util.IntegrationInstanc
         self.library_populator = LibraryPopulator(self.galaxy_interactor)
         self.history_id = self.dataset_populator.new_history()
 
-    def fetch_target(self, target, assert_ok=False, attach_test_file=False):
+    def fetch_target(self, target, assert_ok=False, attach_test_file=False, wait=False):
         payload = {
             "history_id": self.history_id,
             "targets": json.dumps([target]),
@@ -64,7 +64,7 @@ class BaseUploadContentConfigurationInstance(integration_util.IntegrationInstanc
         if attach_test_file:
             payload["__files"] = {"files_0|file_data": open(self.test_data_resolver.get_filename("4.bed"))}
 
-        response = self.dataset_populator.fetch(payload, assert_ok=assert_ok)
+        response = self.dataset_populator.fetch(payload, assert_ok=assert_ok, wait=wait)
         return response
 
     def _write_file(self, dir_path, content, filename="test"):
@@ -530,8 +530,8 @@ class AdvancedFtpUploadFetchTestCase(BaseFtpUploadConfigurationTestCase):
             "elements": elements,
             "collection_type": "list:list",
         }
-        self.fetch_target(target, assert_ok=True)
-        hdca = self.dataset_populator.get_history_collection_details(self.history_id)
+        self.fetch_target(target, assert_ok=True, wait=True)
+        hdca = self.dataset_populator.get_history_collection_details(self.history_id, history_content_type='dataset_collection')
         assert len(hdca["elements"]) == 2, hdca
         element0 = hdca["elements"][0]
         assert element0["element_identifier"] == "subdirel1"

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -531,7 +531,7 @@ class AdvancedFtpUploadFetchTestCase(BaseFtpUploadConfigurationTestCase):
             "collection_type": "list:list",
         }
         self.fetch_target(target, assert_ok=True)
-        hdca = self.dataset_populator.get_history_collection_details(self.history_id, hid=1)
+        hdca = self.dataset_populator.get_history_collection_details(self.history_id)
         assert len(hdca["elements"]) == 2, hdca
         element0 = hdca["elements"][0]
         assert element0["element_identifier"] == "subdirel1"


### PR DESCRIPTION
This fixes all sorts of things that didn't work when metadata_strategy is set to extended and/or outputs_to_working_directory is set to true.
There are still a few corner cases that don't work when using pulsar with metadata_strategy:extended and outputs_to_working_directory, but that isn't a very useful combination anyway, since pulsar already isolates the outputs. I'll try to fix those in a followup so that we could eventually use the PulsarEmbeddedJobRunner as the default job runner in Galaxy and unify Galaxy and Pulsar job runners.

This doesn't technically come with tests, but I'll work on testing this via scheduled tests. These commits are taken from https://github.com/galaxyproject/galaxy/pull/12751, so you can see this works there. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
