### PR TITLE
Force strict channel priority when building images with mulled

### DIFF
--- a/lib/galaxy/tool_util/deps/mulled/invfile.lua
+++ b/lib/galaxy/tool_util/deps/mulled/invfile.lua
@@ -90,7 +90,7 @@ inv.task('build')
             .. 'conda install '
             .. channel_args .. ' '
             .. target_args
-            .. ' -p /usr/local --copy --yes '
+            .. ' --strict-channel-priority -p /usr/local --copy --yes '
             .. verbose
             .. postinstall)
     .wrap('build/dist')


### PR DESCRIPTION
This is best practice as described here: https://github.com/bioconda/bioconda-recipes/issues/13774

The following command:
conda install -c conda-forge -c bioconda 'changeo=0.4.4' 'biopython=1.72' 'python=3.7.1' 'r-data.table=1.11.4' 'bash=4.4.18' 'xlrd=1.2.0' 'r-reshape2=1.4.3' 'r-seqinr=3.4_5' 'r-scales=0.5.0' 'tar=1.34' 'file=5.39' 'r-ggplot2=3.0.0' 'unzip=6.0' -p /usr/local --copy --yes --strict-channel-priority

Finishes in 10-15 seconds with strict channel priority. Never finishes (at least not within 3 hours) without it.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
