### PR TITLE
Avoid double '/' when generating fully qualified API URLs in API tests

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -734,8 +734,8 @@ class GalaxyInteractorApi:
     def get_api_url(self, path: str) -> str:
         if path.startswith("http"):
             return path
-        elif path.startswith("/api"):
-            path = path[len("/api"):]
+        elif path.startswith("/api/"):
+            path = path[len("/api/"):]
         return f"{self.api_url}/{path}"
 
     def _prepare_request_params(self, data=None, files=None, as_json: bool = False, params: dict = None, headers: dict = None):


### PR DESCRIPTION
Because the slash was not included here, in line 739, a new slash was inserted resulting in URLs like:
`/api/dataset_collections/adb5f5c93f827949` -> `http://127.0.0.1:9567/api//dataset_collections/adb5f5c93f827949` (*notice the double slash after api*)

Apparently, the WSGI controllers ignore this double slash but the FastAPI routes couldn't match the URL so they were falling back to the legacy controllers. It took me a while to figure out this was the reason I could hit the FastAPI routes with a regular request but in the API tests they were using the old legacy route... fortunately, this only affects the #12781 which are still WIP as the other API tests that may be affected are not using FastAPI yet.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
