### PR TITLE
[21.09] Use correct path for cgroup metrics when running within containers

### DIFF
--- a/lib/galaxy/job_metrics/instrumenters/cgroup.py
+++ b/lib/galaxy/job_metrics/instrumenters/cgroup.py
@@ -28,6 +28,9 @@ CONVERSION = {
 CPU_USAGE_TEMPLATE = r"""
 if [ -e "/proc/$$/cgroup" -a -d "{cgroup_mount}" ]; then
     cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '($2=="cpuacct,cpu") || ($2=="cpu,cpuacct") {{print $3}}');
+    if [ ! -e "{cgroup_mount}/cpu$cgroup_path/cpuacct.usage" ]; then
+        cgroup_path="";
+    fi;
     for f in {cgroup_mount}/{{cpu\,cpuacct,cpuacct\,cpu}}$cgroup_path/{{cpu,cpuacct}}.*; do
         if [ -f "$f" ]; then
             echo "__$(basename $f)__" >> {metrics}; cat "$f" >> {metrics} 2>/dev/null;
@@ -38,6 +41,9 @@ fi
 MEMORY_USAGE_TEMPLATE = """
 if [ -e "/proc/$$/cgroup" -a -d "{cgroup_mount}" ]; then
     cgroup_path=$(cat "/proc/$$/cgroup" | awk -F':' '$2=="memory"{{print $3}}');
+    if [ ! -e "{cgroup_mount}/memory$cgroup_path/memory.max_usage_in_bytes" ]; then
+        cgroup_path="";
+    fi;
     for f in {cgroup_mount}/memory$cgroup_path/memory.*; do
         echo "__$(basename $f)__" >> {metrics}; cat "$f" >> {metrics} 2>/dev/null;
     done;


### PR DESCRIPTION
Closes: https://github.com/galaxyproject/galaxy/issues/12366

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
