### PR TITLE
[21.09] Drop legacy_expose_api from api/datasets

### DIFF
--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -101,6 +101,14 @@ class DatasetsApiTestCase(ApiTestCase):
         self._assert_status_code_is(show_response, 200)
         self.__assert_matches_hda(hda1, show_response.json())
 
+    def test_show_permission_denied(self):
+        hda = self.dataset_populator.new_dataset(self.history_id)
+        self.dataset_populator.make_private(history_id=self.history_id, dataset_id=hda['id'])
+        with self._different_user():
+            show_response = self._get(f"datasets/{hda['id']}")
+            self._assert_status_code_is(show_response, 400)
+            assert show_response.json()['err_msg'] == 'You are not allowed to access this dataset'
+
     def __assert_matches_hda(self, input_hda, query_hda):
         self._assert_has_keys(query_hda, "id", "name")
         assert input_hda["name"] == query_hda["name"]


### PR DESCRIPTION
We raise `MessageException`s inside the security checks, and these are not
handled in legacy_expose_api.
Fixes
```
MessageException: You are not allowed to access this dataset
  File "galaxy/web/framework/decorators.py", line 184, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "galaxy/webapps/galaxy/api/datasets.py", line 134, in show
    dataset = self.get_hda_or_ldda(trans, hda_ldda=hda_ldda, dataset_id=id)
  File "galaxy/webapps/base/controller.py", line 987, in get_hda_or_ldda
    return self.get_hda(trans, dataset_id, check_ownership=False, check_accessible=True)
  File "galaxy/webapps/base/controller.py", line 1023, in get_hda
    error("You are not allowed to access this dataset")
  File "galaxy/web/framework/decorators.py", line 32, in error
    raise MessageException(message, type='error')
```
(https://sentry.galaxyproject.org/organizations/galaxy/issues/6012/?project=3&query=is%3Aunresolved).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
