### PR TITLE
Remove unused visualization props from markdown page component to avoid warnings

### DIFF
--- a/client/src/components/Markdown/MarkdownVisualization.vue
+++ b/client/src/components/Markdown/MarkdownVisualization.vue
@@ -2,10 +2,8 @@
     <span>
         <MarkdownSelector
             v-if="labelShow"
-            :initial-value="argumentType"
             :argument-name="argumentName"
             :labels="labels"
-            :label-title="selectedLabelTitle"
             @onOk="onLabel"
             @onCancel="onCancel"
         />


### PR DESCRIPTION
This PR removes two unused Vue props from the Visualization Markdown wrapper in Pages/Reports to avoid console warnings.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Run all client jest tests e.g. with `yarn run jest-watch`.
  2. Notice that previously appearing console warnings are resolved.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
