### PR TITLE
[21.09] Add error state to dataset provider, show error in dataset details page

### DIFF
--- a/client/src/components/Details/DatasetDetails.vue
+++ b/client/src/components/Details/DatasetDetails.vue
@@ -1,34 +1,45 @@
 <template>
     <ConfigProvider v-slot="{ config }">
-        <DatasetProvider :id="datasetId" v-slot="{ item: dataset, loading: isDatasetLoading }">
-            <CurrentUser v-slot="{ user }">
-                <JobDetailsProvider
-                    v-if="!isDatasetLoading"
-                    :jobid="dataset.creating_job"
-                    v-slot="{ result: job, loading: isJobLoading }"
-                    :use-cache="false"
-                >
-                    <div v-if="!isJobLoading">
-                        <dataset-information class="detail" :hda_id="datasetId" />
-                        <job-parameters class="detail" dataset_type="hda" :dataset-id="datasetId" />
-                        <job-information class="detail" :job_id="dataset.creating_job" />
-                        <dataset-storage class="detail" :dataset-id="datasetId" />
-                        <inheritance-chain class="detail" :dataset-id="datasetId" :dataset-name="dataset.name" />
-                        <job-metrics
-                            class="detail"
-                            v-if="config"
-                            :aws_estimate="config.aws_estimate"
-                            :dataset-id="datasetId"
-                        />
-                        <job-destination-params class="detail" v-if="user.is_admin" :job-id="dataset.creating_job" />
-                        <job-dependencies class="detail" :dependencies="job.dependencies"></job-dependencies>
-                        <div class="detail" v-if="dataset.peek">
-                            <h3>Dataset Peek:</h3>
-                            <div v-html="dataset.peek" />
+        <DatasetProvider
+            :id="datasetId"
+            v-slot="{ item: dataset, loading: isDatasetLoading, error: datasetLoadingError }"
+        >
+            <div>
+                <LoadingSpan v-if="isDatasetLoading" />
+                <Alert v-else-if="datasetLoadingError" :message="datasetLoadingError" variant="error" />
+                <CurrentUser v-else v-slot="{ user }">
+                    <JobDetailsProvider
+                        v-if="!isDatasetLoading"
+                        :jobid="dataset.creating_job"
+                        v-slot="{ result: job, loading: isJobLoading }"
+                        :use-cache="false"
+                    >
+                        <div v-if="!isJobLoading">
+                            <dataset-information class="detail" :hda_id="datasetId" />
+                            <job-parameters class="detail" dataset_type="hda" :dataset-id="datasetId" />
+                            <job-information class="detail" :job_id="dataset.creating_job" />
+                            <dataset-storage class="detail" :dataset-id="datasetId" />
+                            <inheritance-chain class="detail" :dataset-id="datasetId" :dataset-name="dataset.name" />
+                            <job-metrics
+                                class="detail"
+                                v-if="config"
+                                :aws_estimate="config.aws_estimate"
+                                :dataset-id="datasetId"
+                            />
+                            <job-destination-params
+                                class="detail"
+                                v-if="user.is_admin"
+                                :job-id="dataset.creating_job"
+                            />
+                            <job-dependencies class="detail" :dependencies="job.dependencies"></job-dependencies>
+                            <div class="detail" v-if="dataset.peek">
+                                <h3>Dataset Peek:</h3>
+                                <div v-html="dataset.peek" />
+                            </div>
                         </div>
-                    </div>
-                </JobDetailsProvider>
-            </CurrentUser>
+                    </JobDetailsProvider>
+                </CurrentUser>
+            </div>
         </DatasetProvider>
     </ConfigProvider>
 </template>
@@ -37,6 +48,7 @@
 import DatasetInformation from "components/DatasetInformation/DatasetInformation";
 import JobInformation from "components/JobInformation/JobInformation";
 import JobDestinationParams from "components/JobDestinationParams/JobDestinationParams";
+import LoadingSpan from "components/LoadingSpan";
 import DatasetStorage from "components/Dataset/DatasetStorage/DatasetStorage";
 import InheritanceChain from "../InheritanceChain/InheritanceChain";
 import JobParameters from "components/JobParameters/JobParameters";
@@ -46,12 +58,15 @@ import { DatasetProvider } from "components/providers";
 import { JobDetailsProvider } from "components/providers/JobProvider";
 import ConfigProvider from "components/providers/ConfigProvider";
 import CurrentUser from "components/providers/CurrentUser";
+import Alert from "components/Alert";
 
 export default {
     components: {
+        Alert,
         CurrentUser,
         JobParameters,
         InheritanceChain,
+        LoadingSpan,
         DatasetStorage,
         DatasetInformation,
         JobInformation,

--- a/client/src/components/providers/rxProviders.js
+++ b/client/src/components/providers/rxProviders.js
@@ -5,11 +5,12 @@ export default {
     data() {
         return {
             item: undefined,
+            error: undefined,
         };
     },
     computed: {
         loading() {
-            return this.item === undefined;
+            return this.item === undefined && this.error === undefined;
         },
     },
     methods: {
@@ -24,8 +25,10 @@ export default {
         this.listenTo(monitor$, {
             next: (ds) => {
                 this.item = ds;
+                this.error = undefined;
             },
             error: (err) => {
+                this.error = err.response.err_msg;
                 console.warn("error in content monitor", err);
             },
             complete: () => {
@@ -37,6 +40,7 @@ export default {
         return this.$scopedSlots.default({
             loading: this.loading,
             item: this.item,
+            error: this.error,
         });
     },
 };


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12794

adds these 2 states:
<img width="713" alt="Screenshot 2021-10-27 at 19 06 17" src="https://user-images.githubusercontent.com/6804901/139113572-00783a69-1cee-4e68-afd7-3b2fff337ceb.png">
<img width="695" alt="Screenshot 2021-10-27 at 19 06 05" src="https://user-images.githubusercontent.com/6804901/139113575-0dd2590f-ddf3-48ae-b968-2c9f5d5dd2f4.png">

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
Make a private dataset, then click show info button. Take URL and open in private mode, you should see the Alert component.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
