### PR TITLE
Enable workflow output options for subworkflows

### DIFF
--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -59,7 +59,7 @@ export default {
         },
         showCallout() {
             const node = this.getNode();
-            return node.type == "tool";
+            return ["tool", "subworkflow"].includes(node.type);
         },
         terminalClass() {
             const cls = "terminal output-terminal";


### PR DESCRIPTION
Currently only tool node outputs can be enabled/disabled in the workflow editor. Subworkflow outputs are always shown and not hidden. This PR enables the checkboxes next to subworkflow outputs such that users can decide to show or hide the output in the history. Follow-up to #10478.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
