### PR TITLE
Beta history menu reorg, display fixes.

### DIFF
--- a/client/src/components/History/ContentOperations.vue
+++ b/client/src/components/History/ContentOperations.vue
@@ -59,8 +59,6 @@
                         :disabled="!hasSelection"
                     >
                         <span v-localize>Permanently Delete</span>
-                        <span v-if="numSelected">{{ numSelected }} items</span>
-                        <span v-else>(Disabled)</span>
                     </b-dropdown-item>
 
                     <b-dropdown-item

--- a/client/src/components/History/ContentOperations.vue
+++ b/client/src/components/History/ContentOperations.vue
@@ -31,6 +31,7 @@
                     size="sm"
                     text="Selection"
                     :disabled="!hasSelection"
+                    data-description="selected content menu"
                 >
                     <b-dropdown-text id="history-op-selected-content">
                         <span v-localize v-if="hasSelection">With {{ numSelected }} selected items...</span>
@@ -99,6 +100,7 @@
                     size="sm"
                     text="History"
                     :disabled="!totalMatches"
+                    data-description="history action menu"
                 >
                     <b-dropdown-text id="history-op-all-content">
                         <span v-localize>With entire history...</span>

--- a/client/src/components/History/ContentOperations.vue
+++ b/client/src/components/History/ContentOperations.vue
@@ -62,54 +62,6 @@
                         <span v-if="numSelected">{{ numSelected }} items</span>
                         <span v-else>(Disabled)</span>
                     </b-dropdown-item>
-                </b-dropdown>
-
-                <b-dropdown
-                    class="history-contents-list-action-menu-btn"
-                    size="sm"
-                    text="History"
-                    :disabled="!totalMatches"
-                >
-                    <b-dropdown-text id="history-op-all-content">
-                        <span v-localize>With entire history...</span>
-                    </b-dropdown-text>
-
-                    <b-dropdown-item v-b-modal:show-all-hidden-content aria-describedby="history-op-all-content">
-                        <span v-localize>Unhide All Hidden Content</span>
-                    </b-dropdown-item>
-
-                    <b-dropdown-item v-b-modal:delete-all-hidden-content aria-describedby="history-op-all-content">
-                        <span v-localize>Delete All Hidden Content</span>
-                    </b-dropdown-item>
-
-                    <b-dropdown-item v-b-modal:purge-all-deleted-content aria-describedby="history-op-all-content">
-                        <span v-localize>Purge All Hidden Content</span>
-                    </b-dropdown-item>
-                </b-dropdown>
-
-                <b-dropdown
-                    class="history-contents-list-action-menu-btn"
-                    size="sm"
-                    text="Create New Content"
-                    :disabled="!totalMatches"
-                    data-description="new content menu"
-                >
-                    <template v-slot:button-content>
-                        <Icon icon="plus" />
-                        <span class="sr-only" v-localize>Create New Content</span>
-                    </template>
-
-                    <b-dropdown-text id="history-op-new-content">
-                        <span>Create new content</span>
-                    </b-dropdown-text>
-
-                    <b-dropdown-item
-                        aria-describedby="history-op-new-content"
-                        @click="iframeRedirect('/dataset/copy_datasets')"
-                        data-description="copy datasets"
-                    >
-                        <span v-localize>Copy Datasets</span>
-                    </b-dropdown-item>
 
                     <b-dropdown-item
                         aria-describedby="history-op-new-content"
@@ -141,6 +93,37 @@
                         data-description="build collection from rules"
                     >
                         <span v-localize>Build Collection from Rules</span>
+                    </b-dropdown-item>
+                </b-dropdown>
+
+                <b-dropdown
+                    class="history-contents-list-action-menu-btn"
+                    size="sm"
+                    text="History"
+                    :disabled="!totalMatches"
+                >
+                    <b-dropdown-text id="history-op-all-content">
+                        <span v-localize>With entire history...</span>
+                    </b-dropdown-text>
+
+                    <b-dropdown-item
+                        aria-describedby="history-op-new-content"
+                        @click="iframeRedirect('/dataset/copy_datasets')"
+                        data-description="copy datasets"
+                    >
+                        <span v-localize>Copy Datasets</span>
+                    </b-dropdown-item>
+
+                    <b-dropdown-item v-b-modal:show-all-hidden-content aria-describedby="history-op-all-content">
+                        <span v-localize>Unhide All Hidden Content</span>
+                    </b-dropdown-item>
+
+                    <b-dropdown-item v-b-modal:delete-all-hidden-content aria-describedby="history-op-all-content">
+                        <span v-localize>Delete All Hidden Content</span>
+                    </b-dropdown-item>
+
+                    <b-dropdown-item v-b-modal:purge-all-deleted-content aria-describedby="history-op-all-content">
+                        <span v-localize>Purge All Hidden Content</span>
                     </b-dropdown-item>
                 </b-dropdown>
             </b-button-group>

--- a/client/src/components/History/ContentOperations.vue
+++ b/client/src/components/History/ContentOperations.vue
@@ -63,7 +63,7 @@
                     </b-dropdown-item>
 
                     <b-dropdown-item
-                        aria-describedby="history-op-new-content"
+                        aria-describedby="history-op-selected-content"
                         @click="buildDatasetList"
                         data-description="build list"
                     >
@@ -71,7 +71,7 @@
                     </b-dropdown-item>
 
                     <b-dropdown-item
-                        aria-describedby="history-op-new-content"
+                        aria-describedby="history-op-selected-content"
                         @click="buildDatasetPair"
                         data-description="build pair"
                     >
@@ -79,7 +79,7 @@
                     </b-dropdown-item>
 
                     <b-dropdown-item
-                        aria-describedby="history-op-new-content"
+                        aria-describedby="history-op-selected-content"
                         @click="buildListOfPairs"
                         data-description="build list of pairs"
                     >
@@ -87,7 +87,7 @@
                     </b-dropdown-item>
 
                     <b-dropdown-item
-                        aria-describedby="history-op-new-content"
+                        aria-describedby="history-op-selected-content"
                         @click="buildCollectionFromRules"
                         data-description="build collection from rules"
                     >
@@ -107,7 +107,7 @@
                     </b-dropdown-text>
 
                     <b-dropdown-item
-                        aria-describedby="history-op-new-content"
+                        aria-describedby="history-op-all-content"
                         @click="iframeRedirect('/dataset/copy_datasets')"
                         data-description="copy datasets"
                     >

--- a/client/src/components/History/CurrentHistoryPanel.vue
+++ b/client/src/components/History/CurrentHistoryPanel.vue
@@ -7,7 +7,7 @@
                         v-on="handlers"
                         :histories="histories"
                         :current-history="currentHistory"
-                        title="Current History"
+                        title="Histories"
                     />
                 </template>
             </HistoryPanel>
@@ -32,10 +32,5 @@ export default {
         HistoryPanel,
         HistoriesMenu,
     },
-    // data() {
-    //     return {
-    //         showModal: false,
-    //     };
-    // },
 };
 </script>

--- a/client/src/components/History/HistoriesMenu.vue
+++ b/client/src/components/History/HistoriesMenu.vue
@@ -8,7 +8,6 @@
             variant="link"
             :text="title | l"
             toggle-class="text-decoration-none"
-            no-caret
             class="histories-operation-menu"
             data-description="histories operation menu"
         >

--- a/client/src/components/History/HistoriesMenu.vue
+++ b/client/src/components/History/HistoriesMenu.vue
@@ -24,7 +24,7 @@
 
             <b-dropdown-item v-b-modal.history-selector-modal>
                 <Icon fixed-width class="mr-1" icon="exchange-alt" />
-                <span v-localize>Change the Current History</span>
+                <span v-localize>Change History</span>
             </b-dropdown-item>
 
             <b-dropdown-item data-description="create new history" @click="$emit('createNewHistory')">

--- a/client/src/components/History/HistoriesMenu.vue
+++ b/client/src/components/History/HistoriesMenu.vue
@@ -12,7 +12,7 @@
             data-description="histories operation menu"
         >
             <template v-slot:button-content>
-                <Icon class="mr-1" icon="folder" />
+                <Icon fixed-width class="mr-1" icon="folder" />
                 <span class="text-nowrap">{{ title | l }}</span>
             </template>
 
@@ -23,17 +23,17 @@
             <b-dropdown-divider></b-dropdown-divider>
 
             <b-dropdown-item v-b-modal.history-selector-modal>
-                <Icon class="mr-1" icon="exchange-alt" />
+                <Icon fixed-width class="mr-1" icon="exchange-alt" />
                 <span v-localize>Change the Current History</span>
             </b-dropdown-item>
 
             <b-dropdown-item data-description="create new history" @click="$emit('createNewHistory')">
-                <Icon class="mr-1" icon="plus" />
+                <Icon fixed-width class="mr-1" icon="plus" />
                 <span v-localize>Create a New History</span>
             </b-dropdown-item>
 
             <b-dropdown-item @click="backboneRoute('/histories/list')">
-                <Icon class="mr-1" icon="list" />
+                <Icon fixed-width class="mr-1" icon="list" />
                 <span v-localize>View Saved Histories</span>
             </b-dropdown-item>
 
@@ -41,14 +41,14 @@
                 data-description="switch to multi history view"
                 @click="redirect('/history/view_multiple')"
             >
-                <Icon class="mr-1" icon="columns" />
+                <Icon fixed-width class="mr-1" icon="columns" />
                 <span v-localize>Show Histories Side-by-Side</span>
             </b-dropdown-item>
 
             <b-dropdown-divider></b-dropdown-divider>
 
             <b-dropdown-item data-description="switch to legacy history view" @click="switchToLegacyHistoryPanel">
-                <Icon class="mr-1" icon="arrow-up" />
+                <Icon fixed-width class="mr-1" icon="arrow-up" />
                 <span v-localize>Return to legacy panel</span>
             </b-dropdown-item>
         </b-dropdown>

--- a/client/src/components/History/HistoryMenu.vue
+++ b/client/src/components/History/HistoryMenu.vue
@@ -8,68 +8,68 @@
             data-description="history menu"
         >
             <template v-slot:button-content>
-                <Icon icon="cog" />
+                <Icon fixed-width icon="cog" />
                 <span class="sr-only">Operations on the current history</span>
             </template>
 
             <b-dropdown-item v-b-modal:copy-history-modal>
-                <Icon icon="copy" class="mr-1" />
+                <Icon fixed-width icon="copy" class="mr-1" />
                 <span v-localize>Copy this History</span>
             </b-dropdown-item>
 
             <b-dropdown-item v-b-modal:delete-history-modal>
-                <Icon icon="trash" class="mr-1" />
+                <Icon fixed-width icon="trash" class="mr-1" />
                 <span v-localize>Delete this History</span>
             </b-dropdown-item>
 
             <b-dropdown-item v-b-modal:purge-history-modal>
-                <Icon icon="burn" class="mr-1" />
+                <Icon fixed-width icon="burn" class="mr-1" />
                 <span v-localize>Purge this History</span>
             </b-dropdown-item>
 
             <b-dropdown-divider></b-dropdown-divider>
 
             <b-dropdown-item @click="iframeRedirect('/history/resume_paused_jobs?current=True')">
-                <Icon icon="play" class="mr-1" />
+                <Icon fixed-width icon="play" class="mr-1" />
                 <span v-localize>Resume Paused Jobs</span>
             </b-dropdown-item>
 
             <b-dropdown-item @click="iframeRedirect('/workflow/build_from_current_history')">
-                <Icon icon="file-export" class="mr-1" />
+                <Icon fixed-width icon="file-export" class="mr-1" />
                 <span v-localize>Extract Workflow</span>
             </b-dropdown-item>
 
             <b-dropdown-item @click="backboneRoute('/histories/show_structure')" data-description="show structure">
-                <Icon icon="code-branch" class="mr-1" />
+                <Icon fixed-width icon="code-branch" class="mr-1" />
                 <span v-localize>Show Structure</span>
             </b-dropdown-item>
 
             <b-dropdown-divider></b-dropdown-divider>
 
             <b-dropdown-item @click="backboneRoute('/histories/sharing', { id: history.id })">
-                <Icon icon="share-alt" class="mr-1" />
+                <Icon fixed-width icon="share-alt" class="mr-1" />
                 <span v-localize>Share or Publish</span>
             </b-dropdown-item>
 
             <b-dropdown-item @click="backboneRoute('/histories/permissions', { id: history.id })">
-                <Icon icon="user-lock" class="mr-1" />
+                <Icon fixed-width icon="user-lock" class="mr-1" />
                 <span v-localize>Set Permissions</span>
             </b-dropdown-item>
 
             <b-dropdown-item v-b-modal:history-privacy-modal>
-                <Icon icon="lock" class="mr-1" />
+                <Icon fixed-width icon="lock" class="mr-1" />
                 <span v-localize>Make Private</span>
             </b-dropdown-item>
 
             <b-dropdown-divider></b-dropdown-divider>
 
             <b-dropdown-item @click="backboneRoute('/histories/citations', { id: history.id })">
-                <Icon icon="stream" class="mr-1" />
+                <Icon fixed-width icon="stream" class="mr-1" />
                 <span v-localize>Export Tool Citations</span>
             </b-dropdown-item>
 
             <b-dropdown-item @click="backboneRoute(history.exportLink)" data-description="export to file">
-                <Icon icon="file-archive" class="mr-1" />
+                <Icon fixed-width icon="file-archive" class="mr-1" />
                 <span v-localize>Export History to File</span>
             </b-dropdown-item>
         </b-dropdown>

--- a/client/src/components/History/HistoryMenu.vue
+++ b/client/src/components/History/HistoryMenu.vue
@@ -8,7 +8,7 @@
             data-description="history menu"
         >
             <template v-slot:button-content>
-                <Icon icon="wrench" />
+                <Icon icon="cog" />
                 <span class="sr-only">Operations on the current history</span>
             </template>
 

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1339,7 +1339,7 @@ class NavigatesGalaxy(HasDriver):
 
     def history_panel_click_copy_elements(self):
         if self.is_beta_history():
-            self.use_bootstrap_dropdown(option="copy datasets", menu="new content menu")
+            self.use_bootstrap_dropdown(option="copy datasets", menu="history action menu")
         else:
             self.click_history_option("Copy Datasets")
 

--- a/lib/galaxy_test/selenium/test_collection_builders.py
+++ b/lib/galaxy_test/selenium/test_collection_builders.py
@@ -165,7 +165,7 @@ class CollectionBuildersTestCase(SeleniumTestCase):
             self.history_panel_wait_for_hid_visible(hid, allowed_force_refreshes=1)
 
     def _collection_dropdown(self, option_description):
-        return self.use_bootstrap_dropdown(option=option_description, menu="new content menu")
+        return self.use_bootstrap_dropdown(option=option_description, menu="selected content menu")
 
     def _wait_for_and_select(self, hids):
         """

--- a/lib/galaxy_test/selenium/test_collection_edit.py
+++ b/lib/galaxy_test/selenium/test_collection_edit.py
@@ -66,7 +66,7 @@ class CollectionEditTestCase(SeleniumTestCase):
             row.send_keys(" ")
 
     def _collection_dropdown(self, option_description):
-        return self.use_bootstrap_dropdown(option=option_description, menu="new content menu")
+        return self.use_bootstrap_dropdown(option=option_description, menu="selected content menu")
 
     def _wait_for_hid_visible(self, hid, state="ok"):
         timeout = self.wait_length(self.wait_types.JOB_COMPLETION)


### PR DESCRIPTION
Reorganized as discussed in UI/UX meeting this week.

Also fixed styling and made icons align correctly.

Renamed "Current History" menu to simply "Histories", which is a more appropriate context there, and added a dropdown caret since it was pointed out that it's not an obvious button.

Swapped wrench to Cog to match what we use everywhere else.

I am torn about the location of "Copy Datasets"; even though we said it should be in that History menu in the meeting I'm leaning towards kicking it up to the cog.

WIP/Forthcoming: Optimizing histories fetch to not pull the summaries of all user histories in order to load the menu at the top.  I also need to update the selenium tests to account for moved options.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
