### PR TITLE
[21.09] Fix wrong dataset details link

### DIFF
--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -9,7 +9,6 @@ import BASE_MVC from "mvc/base-mvc";
 import _l from "utils/localization";
 import { mountNametags } from "components/Nametags";
 import { Toast } from "ui/toast";
-import { getAppRoot } from "onload/loadConfig";
 
 var logNamespace = "dataset";
 /*==============================================================================
@@ -273,8 +272,6 @@ export var DatasetListItemView = _super.extend(
          *  @returns {jQuery} rendered DOM
          */
         _renderShowParamsButton: function () {
-            const url = `datasets/${this.model.get("id")}/details`;
-
             return faIconButton({
                 title: _l("View details"),
                 classes: "params-btn",
@@ -286,12 +283,12 @@ export var DatasetListItemView = _super.extend(
                     if (Galaxy.frame && Galaxy.frame.active) {
                         ev.preventDefault();
                         Galaxy.frame.add({
-                            url: `${getAppRoot()}${url}`,
+                            url: this.model.urls.show_params,
                             title: `Dataset Details of ${this.model.get("name")}`,
                         });
                     } else if (Galaxy.router) {
                         ev.preventDefault();
-                        Galaxy.router.push(url);
+                        Galaxy.router.push(this.model.urls.show_params);
                         Galaxy.trigger("activate-hda", this.model.get("id"));
                     }
                 },

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -215,6 +215,11 @@ class ProvidesUserContext(ProvidesAppContext):
         return self.app.config.is_admin_user(self.user)
 
     @property
+    def user_is_bootstrap_admin(self) -> bool:
+        """Master key provided so there is no real user"""
+        return not self.anonymous and self.user.bootstrap_admin_user
+
+    @property
     def user_can_do_run_as(self) -> bool:
         return self.app.user_manager.user_can_do_run_as(self.user)
 

--- a/lib/galaxy/managers/genomes.py
+++ b/lib/galaxy/managers/genomes.py
@@ -67,8 +67,8 @@ class GenomesManager:
             paths = [x[-1] for x in tbl_entries if id in x]
             file_name = paths.pop()
         except TypeError:
-            raise ReferenceDataError('Data tables not found for {index_type}')
+            raise ReferenceDataError(f'Data tables not found for {index_type}')
         except IndexError:
-            raise ReferenceDataError('Data tables not found for {index_type} for {id}')
+            raise ReferenceDataError(f'Data tables not found for {index_type} for {id}')
         else:
             return f"{file_name}{ext}"

--- a/lib/galaxy/webapps/galaxy/api/genomes.py
+++ b/lib/galaxy/webapps/galaxy/api/genomes.py
@@ -12,8 +12,8 @@ from fastapi.responses import Response
 from galaxy.managers.context import ProvidesUserContext
 from galaxy.managers.genomes import GenomesManager
 from galaxy.web import (
-    expose_api_anonymous,
-    expose_api_raw_anonymous,
+    expose_api_anonymous_and_sessionless,
+    expose_api_raw_anonymous_and_sessionless,
 )
 from galaxy.web.framework.helpers import is_true
 from . import (
@@ -163,7 +163,7 @@ class GenomesController(BaseGalaxyAPIController):
     """
     manager: GenomesManager = depends(GenomesManager)
 
-    @expose_api_anonymous
+    @expose_api_anonymous_and_sessionless
     def index(self, trans, **kwd):
         """
         GET /api/genomes: returns a list of installed genomes
@@ -171,7 +171,7 @@ class GenomesController(BaseGalaxyAPIController):
         chrom_info = kwd.get('chrom_info')
         return self.manager.get_dbkeys(trans.user, chrom_info)
 
-    @expose_api_anonymous
+    @expose_api_anonymous_and_sessionless
     def show(self, trans, id, num=None, chrom=None, low=None, high=None, **kwd):
         """
         GET /api/genomes/{id}
@@ -182,7 +182,7 @@ class GenomesController(BaseGalaxyAPIController):
         reference = is_true(kwd.get('reference', False))
         return self.manager.get_genome(trans, id, num, chrom, low, high, reference)
 
-    @expose_api_raw_anonymous
+    @expose_api_raw_anonymous_and_sessionless
     def indexes(self, trans, id, **kwd):
         """
         GET /api/genomes/{id}/indexes?type={table name}
@@ -194,7 +194,7 @@ class GenomesController(BaseGalaxyAPIController):
         index_type = kwd.get('type')
         return self.manager.get_indexes(id, index_type)
 
-    @expose_api_raw_anonymous
+    @expose_api_raw_anonymous_and_sessionless
     def sequences(self, trans, id, chrom=None, low=None, high=None, **kwd):
         """
         GET /api/genomes/{id}/sequences

--- a/lib/galaxy/webapps/galaxy/api/tools.py
+++ b/lib/galaxy/webapps/galaxy/api/tools.py
@@ -553,6 +553,8 @@ class ToolsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         return self._create(trans, payload, **kwd)
 
     def _create(self, trans: GalaxyWebTransaction, payload, **kwd):
+        if trans.user_is_bootstrap_admin:
+            raise exceptions.RealUserRequiredException("Only real users can execute tools or run jobs.")
         action = payload.get('action')
         if action == 'rerun':
             raise Exception("'rerun' action has been deprecated")

--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -325,6 +325,9 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
             'workflow',
         }
 
+        if trans.user_is_bootstrap_admin:
+            raise exceptions.RealUserRequiredException("Only real users can create or run workflows.")
+
         if payload is None or len(ways_to_create.intersection(payload)) == 0:
             message = f"One parameter among - {', '.join(ways_to_create)} - must be specified"
             raise exceptions.RequestParameterMissingException(message)

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -350,6 +350,18 @@ steps:
                                  timeout=DEFAULT_SOCKET_TIMEOUT)
         assert response.status_code == 200, response.text
 
+    @skip_without_tool('detect_errors_aggressive')
+    def test_report_error_bootstrap_admin(self):
+        with self.dataset_populator.test_history() as history_id:
+            payload = self.dataset_populator.run_tool_payload(
+                tool_id='detect_errors_aggressive',
+                inputs={'error_bool': 'true'},
+                history_id=history_id,
+            )
+            run_response = self._post("tools", data=payload, key=self.master_api_key)
+            self._assert_status_code_is(run_response, 400)
+
+    @skip_without_tool("create_2")
     @uses_test_history(require_new=True)
     def test_deleting_output_keep_running_until_all_deleted(self, history_id):
         job_state, outputs = self._setup_running_two_output_job(history_id, 120)

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2942,6 +2942,12 @@ outer_input:
         run_workflow_response = self._post("workflows", data=workflow_request)
         self._assert_status_code_is(run_workflow_response, 403)
 
+    def test_cannot_run_bootstrap_admin_workflow(self):
+        workflow = self.workflow_populator.load_workflow(name="test_bootstrap_admin_cannot_run")
+        workflow_request, _ = self._setup_workflow_run(workflow)
+        run_workflow_response = self._post("workflows", data=workflow_request, key=self.master_api_key, json=True)
+        self._assert_status_code_is(run_workflow_response, 400)
+
     @skip_without_tool("cat")
     @skip_without_tool("cat_list")
     def test_workflow_run_with_matching_lists(self):


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12804.
This is not the ideal fix, the client should ideally contruct the link
... but it's the old history, it's an easy fix and it's consistent with
what the new history does (for now).

There is some backbone manipulation of the model id (which is not
HistoryDatasetAssociation, but a DatasetCollectionElement in
a collection context)  which is supposed to set the id to the
HistoryDatasetAssociation id. I guess it may not have run on time ?
I also don't know where it is and how to find it, might have been
deleted ? I think it was related to https://github.com/galaxyproject/galaxy/blob/dev/client/src/mvc/collection/collection-model.js#L86

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Follow https://github.com/galaxyproject/galaxy/issues/12804, and note that the link you see if you hover over the info icon is the same as what you'll see in the address bar.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
