### PR TITLE
[21.05] If datatype is unknown display warning when trying to connect nodes

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.js
+++ b/client/src/components/Workflow/Editor/modules/terminals.js
@@ -340,6 +340,11 @@ class BaseInputTerminal extends Terminal {
                     this._isSubType(cat_outputs[other_datatype_i], thisDatatype)
                 ) {
                     return new ConnectionAcceptable(true, null);
+                } else if (!this.datatypesMapper.datatypes.includes(other_datatype)) {
+                    return new ConnectionAcceptable(
+                        false,
+                        `Effective output data type [${other_datatype}] unknown. This tool cannot be executed on this Galaxy Server at this moment, please contact the Administrator.`
+                    );
                 }
             }
         }


### PR DESCRIPTION
<img width="552" alt="Screenshot 2021-10-29 at 14 21 41" src="https://user-images.githubusercontent.com/6804901/139434141-d783c74e-4edf-4968-b788-06b279d12736.png">
That should prevent confusion as in #12526

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
