### PR TITLE
[21.09] Restore ToolEntryPoints component

### DIFF
--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -102,6 +102,7 @@ import ConfigProvider from "components/providers/ConfigProvider";
 import LoadingSpan from "components/LoadingSpan";
 import FormDisplay from "components/Form/FormDisplay";
 import FormElement from "components/Form/FormElement";
+import ToolEntryPoints from "components/ToolEntryPoints/ToolEntryPoints";
 import ToolSuccess from "./ToolSuccess";
 import UserHistories from "components/History/providers/UserHistories";
 import Webhook from "components/Common/Webhook";
@@ -115,6 +116,7 @@ export default {
         FormDisplay,
         ToolCard,
         FormElement,
+        ToolEntryPoints,
         ToolSuccess,
         UserHistories,
         Webhook,


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12692

This got lost while vue-ifying the tool form.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Launch an interactive tool and see 

![Screenshot 2021-10-30 at 09 37 49](https://user-images.githubusercontent.com/6804901/139524665-3bd7f667-97d7-447a-8e58-0f94bb197b41.png)

I'm working on making the out of the box setup for ITs simpler, when that's done I'll add a Selenium test for this.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
