### PR TITLE
[21.09] Fix remote object store datasets not purged

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -300,10 +300,9 @@ def set_metadata_portable():
                     dataset.state = dataset.dataset.state = final_job_state
 
             if extended_metadata_collection:
-                outputs_to_working = external_filename.startswith(tool_job_working_directory) and os.path.getsize(external_filename)
-                if not link_data_only and outputs_to_working:
-                    # outputs to working directory, and not already pushed by pulsar + extended metadata,
-                    # move output to final destination.
+                if not link_data_only and os.path.getsize(external_filename):
+                    # Here we might be updating a disk based objectstore when outputs_to_working_directory is used,
+                    # or a remote object store from its cache path.
                     object_store.update_from_file(dataset.dataset, file_name=external_filename, create=True)
                 # TODO: merge expression_context into tool_provided_metadata so we don't have to special case this (here and in _finish_dataset)
                 meta = tool_provided_metadata.get_dataset_meta(output_name, dataset.dataset.id, dataset.dataset.uuid)

--- a/lib/galaxy/objectstore/__init__.py
+++ b/lib/galaxy/objectstore/__init__.py
@@ -625,6 +625,10 @@ class DiskObjectStore(ConcreteObjectStore):
                     path = self._get_filename(obj, **kwargs)
                     shutil.copy(file_name, path)
                     umask_fix_perms(path, self.config.umask, 0o666)
+            except shutil.SameFileError:
+                # That's ok, we need to ignore this so that remote object stores can update
+                # the remote object from the cache file path
+                pass
             except OSError as ex:
                 log.critical(f'Error copying {file_name} to {self.__get_filename(obj, **kwargs)}: {ex}')
                 raise ex

--- a/lib/galaxy/objectstore/azure_blob.py
+++ b/lib/galaxy/objectstore/azure_blob.py
@@ -23,7 +23,8 @@ from galaxy.exceptions import (
 )
 from galaxy.util import (
     directory_hash_id,
-    umask_fix_perms
+    umask_fix_perms,
+    unlink,
 )
 from galaxy.util.path import safe_relpath
 from galaxy.util.sleeper import Sleeper
@@ -428,7 +429,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual blob in Azure and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path))
+                shutil.rmtree(self._get_cache_path(rel_path), ignore_errors=True)
                 blobs = self.service.list_blobs(self.container_name, prefix=rel_path)
                 for blob in blobs:
                     log.debug("Deleting from Azure: %s", blob)
@@ -436,7 +437,7 @@ class AzureBlobObjectStore(ConcreteObjectStore):
                 return True
             else:
                 # Delete from cache first
-                os.unlink(self._get_cache_path(rel_path))
+                unlink(self._get_cache_path(rel_path), ignore_errors=True)
                 # Delete from S3 as well
                 if self._in_azure(rel_path):
                     log.debug("Deleting from Azure: %s", rel_path)

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -17,6 +17,7 @@ from galaxy.util import (
     directory_hash_id,
     safe_relpath,
     umask_fix_perms,
+    unlink,
 )
 from galaxy.util.sleeper import Sleeper
 from .s3 import parse_config_xml
@@ -608,7 +609,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in S3 and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path))
+                shutil.rmtree(self._get_cache_path(rel_path), ignore_errors=True)
                 results = self.bucket.objects.list(prefix=rel_path)
                 for key in results:
                     log.debug("Deleting key %s", key.name)
@@ -616,7 +617,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
                 return True
             else:
                 # Delete from cache first
-                os.unlink(self._get_cache_path(rel_path))
+                unlink(self._get_cache_path(rel_path), ignore_errors=True)
                 # Delete from S3 as well
                 if self._key_exists(rel_path):
                     key = self.bucket.objects.get(rel_path)

--- a/lib/galaxy/objectstore/s3.py
+++ b/lib/galaxy/objectstore/s3.py
@@ -24,6 +24,7 @@ from galaxy.util import (
     directory_hash_id,
     string_as_bool,
     umask_fix_perms,
+    unlink,
     which,
 )
 from galaxy.util.path import safe_relpath
@@ -492,6 +493,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
                           rel_path, source_file)
         except S3ResponseError:
             log.exception("Trouble pushing S3 key '%s' from file '%s'", rel_path, source_file)
+            raise
         return False
 
     def file_ready(self, obj, **kwargs):
@@ -612,7 +614,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
             # with all the files in it. This is easy for the local file system,
             # but requires iterating through each individual key in S3 and deleing it.
             if entire_dir and extra_dir:
-                shutil.rmtree(self._get_cache_path(rel_path))
+                shutil.rmtree(self._get_cache_path(rel_path), ignore_errors=True)
                 results = self._bucket.get_all_keys(prefix=rel_path)
                 for key in results:
                     log.debug("Deleting key %s", key.name)
@@ -620,7 +622,7 @@ class S3ObjectStore(ConcreteObjectStore, CloudConfigMixin):
                 return True
             else:
                 # Delete from cache first
-                os.unlink(self._get_cache_path(rel_path))
+                unlink(self._get_cache_path(rel_path), ignore_errors=True)
                 # Delete from S3 as well
                 if self._key_exists(rel_path):
                     key = Key(self._bucket, rel_path)

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -1503,6 +1503,17 @@ def force_symlink(source, link_name):
             raise e
 
 
+def unlink(path_or_fd, ignore_errors=False):
+    """Calls os.unlink on `path_or_fd`, and ignore FileNoteFoundError if ignore_errors is True."""
+    try:
+        os.unlink(path_or_fd)
+    except FileNotFoundError:
+        if ignore_errors:
+            pass
+        else:
+            raise
+
+
 def move_merge(source, target):
     # when using shutil and moving a directory, if the target exists,
     # then the directory is placed inside of it

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -337,8 +337,8 @@ class BaseDatasetPopulator(BasePopulator):
         delete_response = self._delete(f"histories/{history_id}")
         delete_response.raise_for_status()
 
-    def delete_dataset(self, history_id: str, content_id: str) -> Response:
-        delete_response = self._delete(f"histories/{history_id}/contents/{content_id}")
+    def delete_dataset(self, history_id: str, content_id: str, purge: bool = False) -> Response:
+        delete_response = self._delete(f"histories/{history_id}/contents/{content_id}", {'purge': purge})
         return delete_response
 
     def create_tool_from_path(self, tool_path: str) -> Response:

--- a/test/integration/objectstore/_base.py
+++ b/test/integration/objectstore/_base.py
@@ -1,10 +1,52 @@
 import os
 import re
+import string
+import subprocess
 
 from galaxy_test.base.populators import (
     DatasetPopulator,
 )
 from galaxy_test.driver import integration_util
+
+
+OBJECT_STORE_HOST = os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_HOST', '127.0.0.1')
+OBJECT_STORE_PORT = int(os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_PORT', 9000))
+OBJECT_STORE_ACCESS_KEY = os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY', 'minioadmin')
+OBJECT_STORE_SECRET_KEY = os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY', 'minioadmin')
+OBJECT_STORE_CONFIG = string.Template("""
+<object_store type="hierarchical" id="primary">
+    <backends>
+        <object_store id="swifty" type="swift" weight="1" order="0">
+            <auth access_key="${access_key}" secret_key="${secret_key}" />
+            <bucket name="galaxy" use_reduced_redundancy="False" max_chunk_size="250"/>
+            <connection host="${host}" port="${port}" is_secure="False" conn_path="" multipart="True"/>
+            <cache path="${temp_directory}/object_store_cache" size="1000" />
+            <extra_dir type="job_work" path="${temp_directory}/job_working_directory_swift"/>
+            <extra_dir type="temp" path="${temp_directory}/tmp_swift"/>
+        </object_store>
+    </backends>
+</object_store>
+""")
+
+
+def start_minio(container_name):
+    minio_start_args = [
+        'docker',
+        'run',
+        '-p',
+        f'{OBJECT_STORE_PORT}:9000',
+        '-d',
+        '--name',
+        container_name,
+        '--rm',
+        'minio/minio:latest',
+        'server',
+        '/tmp/data']
+    subprocess.check_call(minio_start_args)
+
+
+def stop_minio(container_name):
+    subprocess.check_call(['docker', 'rm', '-f', container_name])
 
 
 class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
@@ -34,3 +76,46 @@ class BaseObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
 
 def files_count(directory):
     return sum(len(files) for _, _, files in os.walk(directory))
+
+
+@integration_util.skip_unless_docker()
+class BaseSwiftObjectStoreIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.container_name = "%s_container" % cls.__name__
+        start_minio(cls.container_name)
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_minio(cls.container_name)
+        super().tearDownClass()
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        temp_directory = cls._test_driver.mkdtemp()
+        cls.object_stores_parent = temp_directory
+        cls.object_store_cache_path = f"{temp_directory}/object_store_cache"
+        config_path = os.path.join(temp_directory, "object_store_conf.xml")
+        config["object_store_store_by"] = "uuid"
+        config["metadata_strategy"] = "extended"
+        config["outpus_to_working_dir"] = True
+        config["retry_metadata_internally"] = False
+        with open(config_path, "w") as f:
+            f.write(
+                OBJECT_STORE_CONFIG.safe_substitute(
+                    {
+                        "temp_directory": temp_directory,
+                        "host": OBJECT_STORE_HOST,
+                        "port": OBJECT_STORE_PORT,
+                        "access_key": OBJECT_STORE_ACCESS_KEY,
+                        "secret_key": OBJECT_STORE_SECRET_KEY,
+                    }
+                )
+            )
+        config["object_store_config_file"] = config_path
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)

--- a/test/integration/objectstore/test_remote_objectstore_cache_operations.py
+++ b/test/integration/objectstore/test_remote_objectstore_cache_operations.py
@@ -1,0 +1,48 @@
+import os
+import shutil
+
+import pytest
+
+from ._base import (
+    BaseSwiftObjectStoreIntegrationTestCase,
+    files_count,
+)
+
+
+class CacheOperationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
+
+    def tearDown(self):
+        shutil.rmtree(self.object_store_cache_path)
+        os.mkdir(self.object_store_cache_path)
+        return super().tearDown()
+
+    def upload_dataset(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id, content='123', wait=True)
+        return hda
+
+    def test_cache_populated(self):
+        self.upload_dataset()
+        assert files_count(self.object_store_cache_path) == 1
+
+    def test_cache_repopulated(self):
+        hda = self.upload_dataset()
+        assert files_count(self.object_store_cache_path) == 1
+        shutil.rmtree(self.object_store_cache_path)
+        os.mkdir(self.object_store_cache_path)
+        assert files_count(self.object_store_cache_path) == 0
+        content = self.dataset_populator.get_history_dataset_content(hda['history_id'], content_id=hda['id'])
+        assert content == '123\n'
+        assert files_count(self.object_store_cache_path) == 1
+
+    def test_delete_item_not_in_cache(self):
+        hda = self.upload_dataset()
+        assert files_count(self.object_store_cache_path) == 1
+        shutil.rmtree(self.object_store_cache_path)
+        os.mkdir(self.object_store_cache_path)
+        assert files_count(self.object_store_cache_path) == 0
+        self.dataset_populator.delete_dataset(hda['history_id'], hda['id'], purge=True)
+        # Don't wait for dataset, this uses the history state, which is new if there is no dataset ...
+        with pytest.raises(AssertionError) as excinfo:
+            self.dataset_populator.get_history_dataset_content(hda['history_id'], content_id=hda['id'], wait=False, assert_ok=False)
+            assert "File Not Found" in str(excinfo.value)

--- a/test/integration/objectstore/test_swift_objectstore.py
+++ b/test/integration/objectstore/test_swift_objectstore.py
@@ -1,27 +1,6 @@
-import os
-import string
-import subprocess
-
 from galaxy_test.driver import integration_util
+from ._base import BaseSwiftObjectStoreIntegrationTestCase
 
-OBJECT_STORE_HOST = os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_HOST', '127.0.0.1')
-OBJECT_STORE_PORT = int(os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_PORT', 9000))
-OBJECT_STORE_ACCESS_KEY = os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_ACCESS_KEY', 'minioadmin')
-OBJECT_STORE_SECRET_KEY = os.environ.get('GALAXY_INTEGRATION_OBJECT_STORE_SECRET_KEY', 'minioadmin')
-OBJECT_STORE_CONFIG = string.Template("""
-<object_store type="hierarchical" id="primary">
-    <backends>
-        <object_store id="swifty" type="swift" weight="1" order="0">
-            <auth access_key="${access_key}" secret_key="${secret_key}" />
-            <bucket name="galaxy" use_reduced_redundancy="False" max_chunk_size="250"/>
-            <connection host="${host}" port="${port}" is_secure="False" conn_path="" multipart="True"/>
-            <cache path="${temp_directory}/object_store_cache" size="1000" />
-            <extra_dir type="job_work" path="${temp_directory}/job_working_directory_swift"/>
-            <extra_dir type="temp" path="${temp_directory}/tmp_swift"/>
-        </object_store>
-    </backends>
-</object_store>
-""")
 TEST_TOOL_IDS = [
     "multi_output",
     "multi_output_configured",
@@ -48,64 +27,9 @@ TEST_TOOL_IDS = [
 ]
 
 
-def start_minio(container_name):
-    minio_start_args = [
-        'docker',
-        'run',
-        '-p',
-        f'{OBJECT_STORE_PORT}:9000',
-        '-d',
-        '--name',
-        container_name,
-        # '--rm',
-        'minio/minio:latest',
-        'server',
-        '/tmp/data']
-    subprocess.check_call(minio_start_args)
-
-
-def stop_minio(container_name):
-    subprocess.check_call(['docker', 'rm', '-f', container_name])
-
-
-@integration_util.skip_unless_docker()
-class SwiftObjectStoreIntegrationTestCase(integration_util.IntegrationTestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.container_name = "%s_container" % cls.__name__
-        start_minio(cls.container_name)
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        stop_minio(cls.container_name)
-        super().tearDownClass()
-
-    @classmethod
-    def handle_galaxy_config_kwds(cls, config):
-        temp_directory = cls._test_driver.mkdtemp()
-        cls.object_stores_parent = temp_directory
-        config_path = os.path.join(temp_directory, "object_store_conf.xml")
-        config["object_store_store_by"] = "uuid"
-        config["metadata_strategy"] = "extended"
-        config["outpus_to_working_dir"] = True
-        config["retry_metadata_internally"] = False
-        with open(config_path, "w") as f:
-            f.write(
-                OBJECT_STORE_CONFIG.safe_substitute(
-                    {
-                        "temp_directory": temp_directory,
-                        "host": OBJECT_STORE_HOST,
-                        "port": OBJECT_STORE_PORT,
-                        "access_key": OBJECT_STORE_ACCESS_KEY,
-                        "secret_key": OBJECT_STORE_SECRET_KEY,
-                    }
-                )
-            )
-        config["object_store_config_file"] = config_path
+class SwiftObjectStoreIntegrationTestCase(BaseSwiftObjectStoreIntegrationTestCase):
+    pass
 
 
 instance = integration_util.integration_module_instance(SwiftObjectStoreIntegrationTestCase)
-
 test_tools = integration_util.integration_tool_runner(TEST_TOOL_IDS)

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -1,18 +1,37 @@
 import os
-from tempfile import mkdtemp
+from tempfile import (
+    mkdtemp,
+    mkstemp,
+)
 from uuid import uuid4
+
+import pytest
 
 from galaxy.exceptions import ObjectInvalid
 from galaxy.objectstore.azure_blob import AzureBlobObjectStore
 from galaxy.objectstore.cloud import Cloud
 from galaxy.objectstore.pithos import PithosObjectStore
 from galaxy.objectstore.s3 import S3ObjectStore
-from galaxy.util import directory_hash_id
+from galaxy.util import (
+    directory_hash_id,
+    unlink,
+)
 from ..unittest_utils.objectstore_helpers import (
     Config as TestConfig,
     DISK_TEST_CONFIG,
     DISK_TEST_CONFIG_YAML,
 )
+
+
+def test_unlink_path():
+    with pytest.raises(FileNotFoundError):
+        unlink(uuid4().hex)
+    unlink(uuid4().hex, ignore_errors=True)
+    fd, path = mkstemp()
+    os.close(fd)
+    assert os.path.exists(path)
+    unlink(path)
+    assert not os.path.exists(path)
 
 
 def test_disk_store():


### PR DESCRIPTION
Fixes #11940 and contains another fix for pushing outputs to a remote object store in extended metadata mode (https://github.com/galaxyproject/galaxy/commit/5d51af51eaa5d19307e2f7b5e8dc05efd128cf2e), which broke in https://github.com/galaxyproject/galaxy/pull/12785 and which made the new integration test fail.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
