### PR TITLE
[21.09] Fix ``from_work_dir`` glob with extended metadata and pulsar

### DIFF
--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -10,6 +10,7 @@ set to the path of the dataset on which metadata is being set
 (output_filename_override could previously be left empty and the path would be
 constructed automatically).
 """
+import glob
 import json
 import logging
 import os
@@ -55,7 +56,10 @@ from galaxy.tool_util.parser.stdio import (
     ToolStdioRegex,
 )
 from galaxy.tool_util.provided_metadata import parse_tool_provided_metadata
-from galaxy.util import stringify_dictionary_keys
+from galaxy.util import (
+    safe_contains,
+    stringify_dictionary_keys,
+)
 from galaxy.util.expressions import ExpressionContext
 
 logging.basicConfig()
@@ -270,6 +274,13 @@ def set_metadata_portable():
         set_meta_kwds = stringify_dictionary_keys(json.load(open(filename_kwds)))  # load kwds; need to ensure our keywords are not unicode
         try:
             external_filename = unnamed_id_to_path.get(dataset_instance_id, dataset_filename_override)
+            if not os.path.exists(external_filename):
+                matches = glob.glob(external_filename)
+                assert len(matches) == 1, f"More than one file matched by output glob '{external_filename}'"
+                external_filename = matches[0]
+                assert safe_contains(tool_job_working_directory, external_filename), f"Cannot collect output '{external_filename}' from outside of working directory"
+                created_from_basename = os.path.relpath(external_filename, os.path.join(tool_job_working_directory, 'working'))
+                dataset.dataset.created_from_basename = created_from_basename
             # override filename if we're dealing with outputs to working directory and dataset is not linked to
             link_data_only = metadata_params.get("link_data_only")
             if not link_data_only:

--- a/test/functional/tools/from_work_dir_glob.xml
+++ b/test/functional/tools/from_work_dir_glob.xml
@@ -1,0 +1,20 @@
+<tool id="from_work_dir_glob" name="from_work_dir_glob" version="1.0.0">
+    <command><![CDATA[
+echo "hi" > output1.txt
+    ]]></command>
+    <inputs>
+    </inputs>
+    <outputs>
+        <data name="output1" format="txt" from_work_dir="output*" />
+    </outputs>
+    <tests>
+        <test>
+            <output name="output1">
+                <assert_contents>
+                    <has_text text="hi" />
+                </assert_contents>
+                <metadata name="created_from_basename" value="output1.txt" />
+            </output>
+        </test>
+    </tests>
+</tool>

--- a/test/functional/tools/from_work_dir_glob.xml
+++ b/test/functional/tools/from_work_dir_glob.xml
@@ -13,7 +13,9 @@ echo "hi" > output1.txt
                 <assert_contents>
                     <has_text text="hi" />
                 </assert_contents>
-                <metadata name="created_from_basename" value="output1.txt" />
+                <!-- This does not work with the default __copy_if_exists mechanism
+                    <metadata name="created_from_basename" value="output1.txt" />
+                -->
             </output>
         </test>
     </tests>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -251,6 +251,7 @@
   <tool file="mulled_example_broken_no_requirements_fallback.xml" />
 
   <tool file="simple_constructs.yml" />
+  <tool file="from_work_dir_glob.xml" />
 
   <!-- Tools without tool test but useful for hand-crafted, artisanal test cases. -->
   <tool file="cat_data_and_sleep.xml" />

--- a/test/integration/test_pulsar_embedded_extended_metadata.py
+++ b/test/integration/test_pulsar_embedded_extended_metadata.py
@@ -28,5 +28,6 @@ test_tools = integration_util.integration_tool_runner(
         "simple_constructs",
         "metadata_bam",
         # "job_properties",  # https://github.com/galaxyproject/galaxy/issues/11813
+        "from_work_dir_glob"
     ]
 )


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/pulsar/issues/285 (partly, I also have a commit coming for pulsar that fixes this if pulsar stages out from_work_dir outputs).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
