### PR TITLE
[21.09] Add missing tool_ids to workflow invocation failure message

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -838,8 +838,9 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
             raise exceptions.RequestParameterInvalidException("Must specify 'batch' to use batch parameters.")
 
         tool_ids = self.workflow_contents_manager.get_all_tool_ids(workflow)
-        if not all([self.app.toolbox.has_tool(tool_id) for tool_id in tool_ids]):
-            raise exceptions.MessageException("Workflow was not invoked; some required tools are not installed.")
+        missing_tool_ids = [tool_id for tool_id in tool_ids if not self.app.toolbox.has_tool(tool_id)]
+        if missing_tool_ids:
+            raise exceptions.MessageException(f"Workflow was not invoked; the following required tools are not installed: {', '.join(missing_tool_ids)}")
 
         invocations = []
         for run_config in run_configs:

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -939,7 +939,7 @@ steps:
 """)
             invocation_response = self.__invoke_workflow(history_id, workflow_id, assert_ok=False)
             self._assert_status_code_is(invocation_response, 400)
-            self.assertEqual(invocation_response.json().get('err_msg'), "Workflow was not invoked; some required tools are not installed.")
+            self.assertEqual(invocation_response.json().get('err_msg'), "Workflow was not invoked; the following required tools are not installed: nonexistent_tool")
 
     @skip_without_tool("collection_creates_pair")
     def test_workflow_run_output_collections(self):


### PR DESCRIPTION
Small emendation to #11844 to list the missing tool_ids in the error message which is thrown when a workflow is invoked and some of the required tools are missing.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
