### PR TITLE
Create new history for anonymous API users via history/current_histor…

### DIFF
--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -292,7 +292,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
 
     def test_delete_anon(self):
         with self._different_user(anon=True):
-            history_id = self.dataset_populator.new_history()
+            history_id = self._get(f"{self.url}/history/current_history_json").json()['id']
             hda1 = self.dataset_populator.new_dataset(history_id)
             self.dataset_populator.wait_for_history(history_id)
             assert str(self.__show(hda1).json()["deleted"]).lower() == "false"

--- a/lib/galaxy_test/api/test_jobs.py
+++ b/lib/galaxy_test/api/test_jobs.py
@@ -324,7 +324,7 @@ steps:
     @skip_without_tool('detect_errors_aggressive')
     def test_report_error_anon(self):
         with self._different_user(anon=True):
-            history_id = self.dataset_populator.new_history()
+            history_id = self._get(f"{self.url}/history/current_history_json").json()['id']
             self._run_error_report(history_id)
 
     def _run_error_report(self, history_id):


### PR DESCRIPTION
…y_json

We require API authentication to create new histories now (which makes sense IMO), so in order for these 2 tests to pass I am creating a new history via /history/current_history_json.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
