### PR TITLE
[21.09] Allow sessionless access to some datasets API endpoints

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -124,7 +124,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         )
         return [self.serializer_by_type[content.history_content_type].serialize_to_view(content, user=trans.user, trans=trans, view=view) for content in contents]
 
-    @web.expose_api_anonymous
+    @web.expose_api_anonymous_and_sessionless
     def show(self, trans, id, hda_ldda='hda', data_type=None, provider=None, **kwd):
         """
         GET /api/datasets/{encoded_dataset_id}
@@ -420,7 +420,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
 
         return data
 
-    @web.expose_api_anonymous
+    @web.expose_api_anonymous_and_sessionless
     def extra_files(self, trans, history_content_id, history_id, **kwd):
         """
         GET /api/histories/{encoded_history_id}/contents/{encoded_content_id}/extra_files
@@ -495,7 +495,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
             "item_url": item_url,
         }
 
-    @web.expose_api_raw_anonymous
+    @web.expose_api_raw_anonymous_and_sessionless
     def get_metadata_file(self, trans, history_content_id, history_id, metadata_file=None, **kwd):
         """
         GET /api/histories/{history_id}/contents/{history_content_id}/metadata_file


### PR DESCRIPTION
Commit c92fcb91d7f455d5c3d11febe3f5d028741e178f broke a BioBlend test where a public dataset is accessed anonymously via the API:

https://github.com/galaxyproject/bioblend/blob/main/bioblend/_tests/TestGalaxyDatasets.py#L181-L190

See the GitHub workflow failed jobs:

https://github.com/galaxyproject/bioblend/runs/4074342140?check_suite_focus=true

N.B.: in terms of access control, `legacy_expose_api_anonymous` is equivalent to `expose_api_anonymous_and_sessionless` (not `expose_api_anonymous`).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
