### PR TITLE
Avoid console error when cloning newly created nodes

### DIFF
--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -399,6 +399,12 @@ export default {
                 _: "true",
             }).then((response) => {
                 const newData = Object.assign({}, response, node.step);
+                newData.workflow_outputs = newData.outputs.map((o) => {
+                    return {
+                        output_name: o.name,
+                        label: o.label,
+                    };
+                });
                 node.setNode(newData);
             });
         },

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -416,10 +416,10 @@ export default {
             const editUrl = `${getAppRoot()}workflow/editor?workflow_id=${contentId}`;
             this.onNavigate(editUrl);
         },
-        onClone(node) {
+        async onClone(node) {
             const newId = this.nodeIndex++;
             const stepCopy = JSON.parse(JSON.stringify(node.step));
-            Vue.set(this.steps, newId, {
+            await Vue.set(this.steps, newId, {
                 ...stepCopy,
                 id: newId,
                 uuid: null,
@@ -429,11 +429,9 @@ export default {
                 tool_state: JSON.parse(JSON.stringify(node.tool_state)),
                 post_job_actions: JSON.parse(JSON.stringify(node.postJobActions)),
             });
-            Vue.nextTick().then(() => {
-                this.canvasManager.drawOverview();
-                node = this.nodes[newId];
-                this.onActivate(node);
-            });
+            this.canvasManager.drawOverview();
+            node = this.nodes[newId];
+            this.onActivate(node);
         },
         onInsertTool(tool_id, tool_name) {
             this._insertStep(tool_id, tool_name, "tool");

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -580,7 +580,7 @@ export default {
                 type: type,
             });
         },
-        _loadEditorData(data) {
+        async _loadEditorData(data) {
             const report = data.report || {};
             const markdown = report.markdown || reportDefault;
             this.markdownText = markdown;
@@ -593,11 +593,10 @@ export default {
             getVersions(this.id).then((versions) => {
                 this.versions = versions;
             });
-            Vue.nextTick(() => {
-                this.canvasManager.drawOverview();
-                this.canvasManager.scrollToNodes();
-                this.hasChanges = has_changes;
-            });
+            await Vue.nextTick();
+            this.canvasManager.drawOverview();
+            this.canvasManager.scrollToNodes();
+            this.hasChanges = has_changes;
         },
         _loadCurrent(id, version) {
             this.onWorkflowMessage("Loading workflow...", "progress");

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -291,16 +291,7 @@ export default {
             return this;
         },
         setNode(data) {
-            data.workflow_outputs = data.outputs.map((o) => {
-                return {
-                    output_name: o.name,
-                    label: o.label,
-                };
-            });
             this.initData(data);
-
-            // emit change completion event
-            this.showLoading = false;
             this.$emit("onChange");
             this.$emit("onActivate", this);
         },

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -202,7 +202,7 @@ export default {
 
         // initialize node data
         this.$emit("onAdd", this);
-        if (this.step._complete) {
+        if (this.step.config_form) {
             this.initData(this.step);
         } else {
             this.$emit("onUpdate", this);

--- a/client/src/components/Workflow/Editor/modules/model.js
+++ b/client/src/components/Workflow/Editor/modules/model.js
@@ -1,7 +1,7 @@
 import Connector from "./connector";
 import Vue from "vue";
 
-export function fromSimple(workflow, data, appendData = false) {
+export async function fromSimple(workflow, data, appendData = false) {
     let offset = 0;
     if (appendData) {
         offset = workflow.nodeIndex;
@@ -15,57 +15,55 @@ export function fromSimple(workflow, data, appendData = false) {
             node.onRemove();
         });
     }
-    Vue.nextTick(() => {
-        workflow.version = data.version;
-        workflow.report = data.report || {};
-        Object.values(data.steps).forEach((step) => {
-            // If workflow being copied into another, wipe UUID and let
-            // Galaxy assign new ones.
-            if (appendData) {
-                step.uuid = null;
-            }
-            Vue.set(workflow.steps, workflow.nodeIndex++, {
-                ...step,
-                _complete: true,
-            });
+    await Vue.nextTick();
+    workflow.version = data.version;
+    workflow.report = data.report || {};
+    Object.values(data.steps).forEach((step) => {
+        // If workflow being copied into another, wipe UUID and let
+        // Galaxy assign new ones.
+        if (appendData) {
+            step.uuid = null;
+        }
+        Vue.set(workflow.steps, workflow.nodeIndex++, {
+            ...step,
+            _complete: true,
         });
-        Vue.nextTick(() => {
-            // Second pass, connections
-            let using_workflow_outputs = false;
-            Object.entries(data.steps).forEach(([id, step]) => {
-                if (step.workflow_outputs && step.workflow_outputs.length > 0) {
-                    using_workflow_outputs = true;
-                }
-            });
+    });
+    await Vue.nextTick();
+    // Second pass, connections
+    let using_workflow_outputs = false;
+    Object.entries(data.steps).forEach(([id, step]) => {
+        if (step.workflow_outputs && step.workflow_outputs.length > 0) {
+            using_workflow_outputs = true;
+        }
+    });
 
-            Object.entries(data.steps).forEach(([id, step]) => {
-                const nodeIndex = parseInt(id) + offset;
-                const node = workflow.nodes[nodeIndex];
-                Object.entries(step.input_connections).forEach(([k, v]) => {
-                    if (v) {
-                        if (!Array.isArray(v)) {
-                            v = [v];
-                        }
-                        v.forEach((x) => {
-                            const otherNodeIndex = parseInt(x.id) + offset;
-                            const otherNode = workflow.nodes[otherNodeIndex];
-                            const c = new Connector(workflow.canvasManager);
-                            c.connect(otherNode.outputTerminals[x.output_name], node.inputTerminals[k]);
-                            c.redraw();
-                        });
-                    }
+    Object.entries(data.steps).forEach(([id, step]) => {
+        const nodeIndex = parseInt(id) + offset;
+        const node = workflow.nodes[nodeIndex];
+        Object.entries(step.input_connections).forEach(([k, v]) => {
+            if (v) {
+                if (!Array.isArray(v)) {
+                    v = [v];
+                }
+                v.forEach((x) => {
+                    const otherNodeIndex = parseInt(x.id) + offset;
+                    const otherNode = workflow.nodes[otherNodeIndex];
+                    const c = new Connector(workflow.canvasManager);
+                    c.connect(otherNode.outputTerminals[x.output_name], node.inputTerminals[k]);
+                    c.redraw();
                 });
+            }
+        });
 
-                if (!using_workflow_outputs) {
-                    // Older workflows contain HideDatasetActions only, but no active outputs yet.
-                    Object.values(node.outputs).forEach((ot) => {
-                        if (!node.postJobActions[`HideDatasetAction${ot.name}`]) {
-                            node.activeOutputs.add(ot.name);
-                        }
-                    });
+        if (!using_workflow_outputs) {
+            // Older workflows contain HideDatasetActions only, but no active outputs yet.
+            Object.values(node.outputs).forEach((ot) => {
+                if (!node.postJobActions[`HideDatasetAction${ot.name}`]) {
+                    node.activeOutputs.add(ot.name);
                 }
             });
-        });
+        }
     });
 }
 

--- a/client/src/components/Workflow/Editor/modules/model.js
+++ b/client/src/components/Workflow/Editor/modules/model.js
@@ -26,7 +26,6 @@ export async function fromSimple(workflow, data, appendData = false) {
         }
         Vue.set(workflow.steps, workflow.nodeIndex++, {
             ...step,
-            _complete: true,
         });
     });
     await Vue.nextTick();


### PR DESCRIPTION
This PR prevents a console error when cloning, newly created workflow nodes. Additionally it applies `await` instead of parsing callbacks to promises to improve readibility. Finally it removes the not-well documented `_complete` flag and instead uses the `config_form` attribute to determine if a step's content is available for rendering.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Navigate to the Workflow Editor
  2. Insert a Tool node and immediately click on the clone-button
  3. Notice that a console error is triggered.

The reason for this console error is that the `_complete` flag was not set. With these changes this cryptic flag does not have to be set anymore. The state of the step data is determined by validating the existence of the `config_form` attribute instead.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
