### PR TITLE
GxITs: don't always add trailing slash to entry point url

### DIFF
--- a/lib/galaxy/managers/interactivetool.py
+++ b/lib/galaxy/managers/interactivetool.py
@@ -260,9 +260,7 @@ class InteractiveToolManager:
                     rval = '{}/{}'.format(rval.rstrip('/'), entry_point.entry_url.lstrip('/'))
             else:
                 rval = self.get_entry_point_path(trans, entry_point)
-            # Add trailing slash to the URL
-            if rval[-1] != "/":
-                rval = f'{rval}/'
+
             return rval
 
     def get_entry_point_subdomain(self, trans, entry_point):


### PR DESCRIPTION
Starting with 21.05, all GxIT entry point urls gets added a trailing slash. While it can be harmless for some of these tools, for others like AskOmics, the url is just not working anymore.

Fix for #12662 

It would be nice to backport this to 21.05 and 21.09

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Run the AskOmics interactive tool
  2. When it's ready, open it
  3. Without this patch, you get an error instead of the AskOmics UI

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
