### PR TITLE
[21.05] Fixes for docker galaxy-min ci build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .k8s_ci.Dockerfile
 .venv
 database
+node_modules

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -21,18 +21,14 @@ jobs:
       - name: Set branch name
         id: branch
         run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/}-auto)"
-      - run: docker build . -t galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} -f .k8s_ci.Dockerfile
-      - run: docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }} && docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-min/galaxy:${{ steps.vars.outputs.sha_short }}
+      - run: docker build . -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
+      - run: docker tag galaxy/galaxy-min:${{ steps.branch.outputs.name }} quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }}
       - name: Login to quay.io
         uses: actions-hub/docker/login@master
         env:
           DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
           DOCKER_REGISTRY_URL: quay.io
-      - name: Push to quay.io with commit ID
-        uses: actions-hub/docker@master
-        with:
-          args: push quay.io/galaxy-min/galaxy:${{ steps.vars.outputs.sha_short }}
       - name: Push to quay.io with branch name
         uses: actions-hub/docker@master
         with:

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set branch name
         id: branch
         run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/})"
-      - run: docker build . -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
+      - run: docker build . --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
       - run: docker tag galaxy/galaxy-min:${{ steps.branch.outputs.name }} quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }}
       - name: Login to quay.io
         uses: actions-hub/docker/login@master

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -22,7 +22,7 @@ jobs:
         id: branch
         run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/}-auto)"
       - run: docker build . -t galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} -f .k8s_ci.Dockerfile
-      - run: docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-k8s/galaxy:${{ steps.branch.outputs.name }} && docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-k8s/galaxy:${{ steps.vars.outputs.sha_short }}
+      - run: docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }} && docker tag galaxy/galaxy-min:${{ steps.vars.outputs.sha_short }} quay.io/galaxy-min/galaxy:${{ steps.vars.outputs.sha_short }}
       - name: Login to quay.io
         uses: actions-hub/docker/login@master
         env:
@@ -32,8 +32,8 @@ jobs:
       - name: Push to quay.io with commit ID
         uses: actions-hub/docker@master
         with:
-          args: push quay.io/galaxy-k8s/galaxy:${{ steps.vars.outputs.sha_short }}
+          args: push quay.io/galaxy-min/galaxy:${{ steps.vars.outputs.sha_short }}
       - name: Push to quay.io with branch name
         uses: actions-hub/docker@master
         with:
-          args: push quay.io/galaxy-k8s/galaxy:${{ steps.branch.outputs.name }}
+          args: push quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }}

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -20,7 +20,7 @@ jobs:
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Set branch name
         id: branch
-        run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/}-auto)"
+        run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/})"
       - run: docker build . -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
       - run: docker tag galaxy/galaxy-min:${{ steps.branch.outputs.name }} quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }}
       - name: Login to quay.io

--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - 'release*'
-      - anvil
+      - dev
 concurrency:
   group: docker-build-${{ github.ref }}
   cancel-in-progress: true

--- a/.k8s_ci.Dockerfile
+++ b/.k8s_ci.Dockerfile
@@ -27,6 +27,10 @@ ARG FINAL_STAGE_BASE=$STAGE1_BASE
 ARG GALAXY_USER=galaxy
 ARG GALAXY_PLAYBOOK_REPO=https://github.com/galaxyproject/galaxy-docker-k8s
 
+ARG GIT_COMMIT=unspecified
+ARG BUILD_DATE=unspecified
+ARG IMAGE_TAG=unspecified
+
 #======================================================
 # Stage 1 - Setup common requirements for build
 #======================================================
@@ -123,6 +127,22 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG ROOT_DIR
 ARG SERVER_DIR
 ARG GALAXY_USER
+
+ARG GIT_COMMIT
+ARG BUILD_DATE
+ARG IMAGE_TAG
+
+LABEL org.opencontainers.image.title="Galaxy Minimal Image" \
+      org.opencontainers.image.description="A size optimized image for Galaxy targeting k8s and ci applications" \
+      org.opencontainers.image.authors="galaxyproject.org" \
+      org.opencontainers.image.vendor="Galaxy Project" \
+      org.opencontainers.image.documentation="https://github.com/galaxyproject/galaxy-docker-k8s" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="$IMAGE_TAG" \
+      org.opencontainers.image.url="https://github.com/galaxyproject/galaxy-docker-k8s" \
+      org.opencontainers.image.source="https://github.com/galaxyproject/galaxy.git" \
+      org.opencontainers.image.revision=$GIT_COMMIT \
+      org.opencontainers.image.created=$BUILD_DATE
 
 # Init Env
 ENV LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Fixes issue with builds on quay.io and reduces number of image tags.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
