### PR TITLE
Fix bookmarking workflow twice

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/workflows.py
+++ b/lib/galaxy/webapps/galaxy/api/workflows.py
@@ -539,9 +539,11 @@ class WorkflowsAPIController(BaseGalaxyAPIController, UsesStoredWorkflowMixin, U
 
             if 'menu_entry' in workflow_dict or 'show_in_tool_panel' in workflow_dict:
                 if workflow_dict.get('menu_entry') or workflow_dict.get('show_in_tool_panel'):
-                    menuEntry = model.StoredWorkflowMenuEntry()
-                    menuEntry.stored_workflow = stored_workflow
-                    trans.user.stored_workflow_menu_entries.append(menuEntry)
+                    workflow_ids = [wf.stored_workflow_id for wf in trans.user.stored_workflow_menu_entries]
+                    if trans.security.decode_id(id) not in workflow_ids:
+                        menuEntry = model.StoredWorkflowMenuEntry()
+                        menuEntry.stored_workflow = stored_workflow
+                        trans.user.stored_workflow_menu_entries.append(menuEntry)
                 else:
                     # remove if in list
                     entries = {x.stored_workflow_id: x for x in trans.user.stored_workflow_menu_entries}


### PR DESCRIPTION
If we send `bookmark a workflow` request twice, it adds this workflow twice to `stored_workflow_menu_entries` array. 
This check prevents this behavior. noticed this bug while working on https://github.com/galaxyproject/galaxy/pull/12810

Thanks to a lot to @davelopez for helping out!


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Send bookmark workflow request twice (curl, postman or hardcode UI code)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
