### PR TITLE
Replace hidden field input element with Vue

### DIFF
--- a/client/src/components/Form/Elements/FormHidden.test.js
+++ b/client/src/components/Form/Elements/FormHidden.test.js
@@ -1,0 +1,26 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import FormHidden from "./FormHidden";
+
+const localVue = getLocalVue();
+
+describe("FormHidden", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(FormHidden, {
+            propsData: {
+                value: false,
+                info: "info",
+            },
+            localVue,
+        });
+    });
+
+    it("check initial value and value change", async () => {
+        expect(wrapper.vm.value).toBe(false);
+        await wrapper.setProps({ value: true });
+        expect(wrapper.vm.value).toBe(true);
+        expect(wrapper.text()).toBe("info");
+    });
+});

--- a/client/src/components/Form/Elements/FormHidden.vue
+++ b/client/src/components/Form/Elements/FormHidden.vue
@@ -1,5 +1,7 @@
 <template>
-    <div />
+    <div>
+        {{ info }}
+    </div>
 </template>
 
 <script>
@@ -7,6 +9,10 @@ export default {
     props: {
         value: {
             required: true,
+        },
+        info: {
+            type: String,
+            default: null,
         },
     },
 };

--- a/client/src/components/Form/Elements/FormHidden.vue
+++ b/client/src/components/Form/Elements/FormHidden.vue
@@ -1,0 +1,13 @@
+<template>
+    <div />
+</template>
+
+<script>
+export default {
+    props: {
+        value: {
+            required: true,
+        },
+    },
+};
+</script>

--- a/client/src/components/Form/Elements/parameters.js
+++ b/client/src/components/Form/Elements/parameters.js
@@ -26,13 +26,9 @@ export default Backbone.View.extend({
         data_collection: "_fieldData",
         integer: "_fieldSlider",
         float: "_fieldSlider",
-        boolean: "_fieldBoolean",
         drill_down: "_fieldDrilldown",
         color: "_fieldColor",
         group_tag: "_fieldSelect",
-        hidden: "_fieldHidden",
-        hidden_data: "_fieldHidden",
-        baseurl: "_fieldHidden",
         library_data: "_fieldLibrary",
         ftpfile: "_fieldFtp",
         upload: "_fieldUpload",
@@ -185,22 +181,6 @@ export default Backbone.View.extend({
             is_workflow: input_def.is_workflow,
             min: input_def.min,
             max: input_def.max,
-            onchange: input_def.onchange,
-        });
-    },
-
-    /** Hidden field */
-    _fieldHidden: function (input_def) {
-        return new Ui.Hidden({
-            id: `field-${input_def.id}`,
-            info: input_def.info,
-        });
-    },
-
-    /** Boolean field */
-    _fieldBoolean: function (input_def) {
-        return new Ui.Switch({
-            id: `field-${input_def.id}`,
             onchange: input_def.onchange,
         });
     },

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -22,6 +22,7 @@
         </div>
         <div v-if="showField" class="ui-form-field" :data-label="title">
             <FormBoolean v-if="type == 'boolean'" v-model="currentValue" :id="id" />
+            <FormHidden v-else-if="type == 'hidden'" v-model="currentValue" :id="id" />
             <FormParameter
                 v-else-if="backbonejs"
                 v-model="currentValue"
@@ -42,12 +43,14 @@
 import _ from "underscore";
 import { getElementId } from "./utilities";
 import FormBoolean from "./Elements/FormBoolean";
+import FormHidden from "./Elements/FormHidden";
 import FormInput from "./Elements/FormInput";
 import FormParameter from "./Elements/FormParameter";
 
 export default {
     components: {
         FormBoolean,
+        FormHidden,
         FormInput,
         FormParameter,
     },

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -22,7 +22,12 @@
         </div>
         <div v-if="showField" class="ui-form-field" :data-label="title">
             <FormBoolean v-if="type == 'boolean'" v-model="currentValue" :id="id" />
-            <FormHidden v-else-if="type == 'hidden'" v-model="currentValue" :id="id" />
+            <FormHidden
+                v-else-if="['hidden', 'hidden_data', 'baseurl'].includes(type)"
+                v-model="currentValue"
+                :id="id"
+                :info="attrs['info']"
+            />
             <FormParameter
                 v-else-if="backbonejs"
                 v-model="currentValue"

--- a/client/src/mvc/ui/ui-misc.js
+++ b/client/src/mvc/ui/ui-misc.js
@@ -126,30 +126,6 @@ export var Input = Backbone.View.extend({
     },
 });
 
-/** Creates a hidden element input field used e.g. in the tool form */
-export var Hidden = Backbone.View.extend({
-    initialize: function (options) {
-        this.model = (options && options.model) || new Backbone.Model(options);
-        this.setElement(
-            $("<div/>")
-                .append((this.$info = $("<div/>")))
-                .append((this.$hidden = $("<div/>")))
-        );
-        this.listenTo(this.model, "change", this.render, this);
-        this.render();
-    },
-    value: function (new_val) {
-        new_val !== undefined && this.model.set("value", new_val);
-        return this.model.get("value");
-    },
-    render: function () {
-        this.$el.attr("id", this.model.id);
-        this.$hidden.val(this.model.get("value"));
-        this.model.get("info") ? this.$info.show().text(this.model.get("info")) : this.$info.hide();
-        return this;
-    },
-});
-
 export var NullableText = Backbone.View.extend({
     initialize: function (options) {
         this.model = (options && options.model) || new Backbone.Model().set(options);
@@ -316,7 +292,6 @@ export default {
     Select: Select,
     NullableText: NullableText,
     TextSelect: TextSelect,
-    Hidden: Hidden,
     Slider: Slider,
     Drilldown: Drilldown,
 };

--- a/client/tests/qunit/tests/ui_tests.js
+++ b/client/tests/qunit/tests/ui_tests.js
@@ -713,18 +713,6 @@ QUnit.test("message", function (assert) {
     assert.ok(message.$el.html() === "_new_message", "Correct new message.");
 });
 
-QUnit.test("hidden", function (assert) {
-    var hidden = new Ui.Hidden();
-    $("body").prepend(hidden.$el);
-    hidden.model.set("info", "_info");
-    assert.ok(hidden.$info.css("display", "block"), "Info shown.");
-    assert.ok(hidden.$info.html() === "_info", "Info text correct.");
-    hidden.model.set("info", "");
-    assert.ok(hidden.$info.css("display", "none"), "Info hidden.");
-    hidden.model.set("value", "_value");
-    assert.ok(hidden.$hidden.val() === "_value", "Correct value");
-});
-
 QUnit.test("select-content", function (assert) {
     var select = new SelectContent.View({});
     $("body").prepend(select.$el);


### PR DESCRIPTION
This PR replaces the Backbone-based hidden field input element in forms with a Vue component. Requires: #12820.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
