### PR TITLE
Sync Selenium GitHub workflows

### DIFF
--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.7']
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           path: 'galaxy root'
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full Python version
@@ -45,8 +45,7 @@ jobs:
         shell: bash
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
       - name: Cache pip dir
-        uses: actions/cache@v1
-        id: pip-cache
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
@@ -54,13 +53,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-selenium
+          key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-integration-selenium
       - uses: mvdbeek/gha-yarn-cache@master
         with:
           yarn-lock-file: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@master
       - name: Run tests
-        run: './run_tests.sh -integration test/integration_selenium'
+        run: ./run_tests.sh -integration test/integration_selenium
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -10,7 +10,7 @@ env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1
-  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 'true'
+  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
 concurrency:
   group: selenium-${{ github.ref }}
@@ -49,14 +49,14 @@ jobs:
         with:
           path: ~/.cache/pip
           key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
-      - uses: mvdbeek/gha-yarn-cache@master
-        with:
-          yarn-lock-file: 'galaxy root/client/yarn.lock'
       - name: Cache galaxy venv
         uses: actions/cache@v2
         with:
           path: .venv
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-selenium
+      - uses: mvdbeek/gha-yarn-cache@master
+        with:
+          yarn-lock-file: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@master
       - name: Run tests
         run: ./run_tests.sh -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
@@ -65,4 +65,9 @@ jobs:
         if: failure()
         with:
           name: Selenium test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
+          path: 'galaxy root/run_selenium_tests.html'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Selenium debug info (${{ matrix.python-version }}, ${{ matrix.chunk }})
           path: 'galaxy root/database/test_errors'

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -8,11 +8,14 @@ on:
       - 'doc/**'
 env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
-  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
+  GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1
   GALAXY_TEST_SELENIUM_BETA_HISTORY: 1
+  GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
-  GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+concurrency:
+  group: selenium-beta-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test
@@ -52,15 +55,20 @@ jobs:
         with:
           path: .venv
           key: gxy-venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-selenium-beta
+      - uses: mvdbeek/gha-yarn-cache@master
+        with:
+          yarn-lock-file: 'galaxy root/client/yarn.lock'
       - uses: nanasess/setup-chromedriver@master
       - name: Run tests
         run: ./run_tests.sh -selenium lib/galaxy_test/selenium -- --num-shards=3 --shard-id=${{ matrix.chunk }}
         working-directory: 'galaxy root'
       - uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: Selenium beta history panel test results (${{ matrix.python-version }}, ${{ matrix.chunk }})
-          path: 'galaxy root/database/test_errors'
-      - uses: actions/upload-artifact@v2
-        with:
-          name: Selenium beta history panel test results (${{ matrix.python-version }})
           path: 'galaxy root/run_selenium_tests.html'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: Selenium beta history panel debug info (${{ matrix.python-version }}, ${{ matrix.chunk }})
+          path: 'galaxy root/database/test_errors'


### PR DESCRIPTION
In particular:
- Cancel in-progress concurrent builds for selenium_beta workflow
- Caching of `yarn.lock` for selenium_beta
- Upload run_selenium_tests.html in case of failure for selenium workflow

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
