### PR TITLE
[21.05] Fix activation token sending for emails with characters that are escaped in html

### DIFF
--- a/lib/galaxy/managers/users.py
+++ b/lib/galaxy/managers/users.py
@@ -488,7 +488,7 @@ class UserManager(base.ModelManager, deletable.PurgableManagerMixin):
         """
         Send the verification email containing the activation link to the user's email.
         """
-        activation_token = self.__get_activation_token(trans, escape(email))
+        activation_token = self.__get_activation_token(trans, email)
         activation_link = url_for(controller='user', action='activate', activation_token=activation_token, email=escape(email), qualified=True)
         host = self.__get_host(trans)
         custom_message = ''


### PR DESCRIPTION
Discovered this will giving a training in France, where some users have an single quote in their email address.

The function body of escape is
```
def escape(s):
    """Replace the characters ``&``, ``<``, ``>``, ``'``, and ``"`` in
    the string with HTML-safe sequences. Use this if you need to display
    text that might contain such characters in HTML.

    If the object has an ``__html__`` method, it is called and the
    return value is assumed to already be safe for HTML.

    :param s: An object to be converted to a string and escaped.
    :return: A :class:`Markup` string with the escaped text.
    """
    if hasattr(s, "__html__"):
        return Markup(s.__html__())
    return Markup(
        text_type(s)
        .replace("&", "&amp;")
        .replace(">", "&gt;")
        .replace("<", "&lt;")
        .replace("'", "&#39;")
        .replace('"', "&#34;")
    )
```
It doesn't make sense to lookup the replaced values in the database,
and it breaks single-quotes in the email username portion, which is
valid https://en.wikipedia.org/wiki/Email_address#Syntax

Fixes
```
AttributeError: 'NoneType' object has no attribute 'activation_token'
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/recursive.py", line 85, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/middleware/statsd.py", line 35, in __call__
    req = self.application(environ, start_response)
  File "/cvmfs/main.galaxyproject.org/venv/lib/python3.6/site-packages/paste/httpexceptions.py", line 640, in __call__
    return self.application(environ, start_response)
  File "galaxy/web/framework/base.py", line 138, in __call__
    return self.handle_request(environ, start_response)
  File "galaxy/web/framework/base.py", line 217, in handle_request
    body = method(trans, **kwargs)
  File "galaxy/webapps/galaxy/controllers/user.py", line 183, in resend_verification
    message, status = self.resend_activation_email(trans, None, None)
  File "galaxy/webapps/galaxy/controllers/user.py", line 199, in resend_activation_email
    is_activation_sent = self.user_manager.send_activation_email(trans, email, username)
  File "galaxy/managers/users.py", line 479, in send_activation_email
    activation_token = self.__get_activation_token(trans, escape(email))
  File "galaxy/managers/users.py", line 524, in __get_activation_token
    activation_token = user.activation_token
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
