### PR TITLE
[21.09] Downgrade bowtie requirement for CONVERTER_fasta_to_bowtie_color_index

### DIFF
--- a/lib/galaxy/datatypes/converters/fasta_to_bowtie_color_index_converter.xml
+++ b/lib/galaxy/datatypes/converters/fasta_to_bowtie_color_index_converter.xml
@@ -1,8 +1,9 @@
-<tool id="CONVERTER_fasta_to_bowtie_color_index" name="Convert FASTA to Bowtie color space Index" version="1.3.1">
+<tool id="CONVERTER_fasta_to_bowtie_color_index" name="Convert FASTA to Bowtie color space Index" version="1.2.3">
     <!-- <description>__NOT_USED_CURRENTLY_FOR_CONVERTERS__</description> -->
     <!-- Used on the metadata edit page. -->
     <requirements>
-        <requirement type="package" version="1.3.1">bowtie</requirement>
+        <!-- Bowtie >= 1.3.0 removed support for colorspace -->
+        <requirement type="package" version="1.2.3">bowtie</requirement>
     </requirements>
     <command>
 <![CDATA[


### PR DESCRIPTION
I think it's also fairly safe to downgrade the tool version and keep it in sync with the requirement since this is not a TS tool, the broken version was [committed just yesterday](https://github.com/galaxyproject/galaxy/pull/12844), and nobody should be really using this format any more.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
