### PR TITLE
Pass destination env vars and tags when resubmitting jobs

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -281,9 +281,12 @@ class JobHandlerQueue(Monitors):
     def __recover_job_wrapper(self, job):
         # Already dispatched and running
         job_wrapper = self.job_wrapper(job)
+        destination = job_wrapper.job_destination or {}
+        envs = destination.get("env", [])
+        tags = destination.get("tags", [])
         # Use the persisted destination as its params may differ from
         # what's in the job_conf xml
-        job_destination = JobDestination(id=job.destination_id, runner=job.job_runner_name, params=job.destination_params)
+        job_destination = JobDestination(id=job.destination_id, tags=tags, runner=job.job_runner_name, params=job.destination_params, env=envs)
         # resubmits are not persisted (it's a good thing) so they
         # should be added back to the in-memory destination on startup
         try:

--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -281,12 +281,9 @@ class JobHandlerQueue(Monitors):
     def __recover_job_wrapper(self, job):
         # Already dispatched and running
         job_wrapper = self.job_wrapper(job)
-        destination = job_wrapper.job_destination or {}
-        envs = destination.get("env", [])
-        tags = destination.get("tags", [])
         # Use the persisted destination as its params may differ from
         # what's in the job_conf xml
-        job_destination = JobDestination(id=job.destination_id, tags=tags, runner=job.job_runner_name, params=job.destination_params, env=envs)
+        job_destination = JobDestination(id=job.destination_id, runner=job.job_runner_name, params=job.destination_params)
         # resubmits are not persisted (it's a good thing) so they
         # should be added back to the in-memory destination on startup
         try:

--- a/test/functional/tools/exit_code_from_env.xml
+++ b/test/functional/tools/exit_code_from_env.xml
@@ -2,7 +2,7 @@
     <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
     <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
 echo 'Hello' > '$out_file1' &&
-: \${GX_TARGET_EXIT_CODE:-0} &&
+: \${GX_TARGET_EXIT_CODE:=0} &&
 exit \${GX_TARGET_EXIT_CODE}
     ]]></command>
     <inputs>

--- a/test/functional/tools/exit_code_from_env_default_fail.xml
+++ b/test/functional/tools/exit_code_from_env_default_fail.xml
@@ -1,0 +1,26 @@
+<tool id="exit_code_from_env_default_fail" name="exit_code_from_env_default_fail" version="1.0.0">
+    <!-- tool errors out with identified OOM error if less than 10MB are allocated. -->
+    <command detect_errors="exit_code" oom_exit_code="42"><![CDATA[
+echo 'Hello' > '$out_file1' &&
+: \${GX_TARGET_EXIT_CODE:=2} &&
+exit \${GX_TARGET_EXIT_CODE}
+    ]]></command>
+    <inputs>
+        <param name="input" type="integer" label="Dummy" value="6" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="5" />
+            <output name="out_file1">
+                <assert_contents>
+                    <has_line line="Hello" />
+                </assert_contents>
+            </output>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -94,6 +94,7 @@
   <tool file="exit_code_oom.xml" />
   <tool file="exit_code_from_file.xml" />
   <tool file="exit_code_from_env.xml" />
+  <tool file="exit_code_from_env_default_fail.xml" />
   <tool file="gzipped_inputs.xml" />
   <tool file="options_from_metadata_file.xml" />
   <tool file="output_order.xml" />

--- a/test/integration/resubmission_tool_detected_resubmit_twice_job_conf.xml
+++ b/test/integration/resubmission_tool_detected_resubmit_twice_job_conf.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<job_conf>
+    <plugins>
+        <plugin id="local" type="runner" load="galaxy.jobs.runners.local:LocalJobRunner" workers="2"/>
+    </plugins>
+
+    <handlers>
+        <handler id="main"/>
+    </handlers>
+
+    <destinations default="local_resubmit">
+        <destination id="local_resubmit" runner="local">
+            <env id="GX_TARGET_EXIT_CODE">4</env>
+            <resubmit condition="tool_detected_failure" destination="local_not_yet_good" />
+        </destination>
+
+        <destination id="local_not_yet_good" runner="local">
+            <env id="GX_TARGET_EXIT_CODE">4</env>
+            <resubmit condition="tool_detected_failure" destination="local_good" />
+        </destination>
+
+        <destination id="local_good" runner="local">
+            <env id="GX_TARGET_EXIT_CODE">0</env>
+        </destination>
+    </destinations>
+
+</job_conf>

--- a/test/integration/test_job_resubmission.py
+++ b/test/integration/test_job_resubmission.py
@@ -12,6 +12,7 @@ JOB_RESUBMISSION_SMALL_MEMORY_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "
 JOB_RESUBMISSION_SMALL_MEMORY_RESUBMISSION_TO_LARGE_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_small_memory_resubmission_to_large_job_conf.xml")
 JOB_RESUBMISSION_TOOL_DETECTED_ALWAYS_ERROR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_tool_detected_always_error_job_conf.xml")
 JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_tool_detected_resubmit_job_conf.xml")
+JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_TWICE_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_tool_detected_resubmit_twice_job_conf.xml")
 JOB_RESUBMISSION_JOB_RESOURCES_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_job_resource_parameters_conf.xml")
 JOB_RESUBMISSION_PULSAR_JOB_CONFIG_FILE = os.path.join(SCRIPT_DIRECTORY, "resubmission_pulsar_job_conf.xml")
 
@@ -180,7 +181,19 @@ class JobResubmissionToolDetectedErrorResubmitsIntegrationTestCase(_BaseResubmis
         config["job_config_file"] = JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_JOB_CONFIG_FILE
 
     def test_dynamic_resubmission(self):
-        self._assert_job_passes(tool_id="exit_code_from_env")
+        self._assert_job_passes(tool_id="exit_code_from_env_default_fail")
+
+
+# Verify the test tool will resubmit on failure tested above and will then pass in
+# an environment without a tool indicated error.
+class JobResubmissionToolDetectedErrorResubmitsTwiceIntegrationTestCase(_BaseResubmissionIntegerationTestCase):
+
+    @classmethod
+    def handle_galaxy_config_kwds(cls, config):
+        config["job_config_file"] = JOB_RESUBMISSION_TOOL_DETECTED_RESUBMIT_TWICE_JOB_CONFIG_FILE
+
+    def test_dynamic_resubmission(self):
+        self._assert_job_passes(tool_id="exit_code_from_env_default_fail")
 
 
 # Verify that a failure to connect to pulsar can trigger a resubmit


### PR DESCRIPTION
While playing with the sorting hat, I've noticed that some env vars I had set for specific tools where not passed when jobs were resubmitted.
This PR fixes this problem by copying the env and tags from the first destination to the resubmission one.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Configure a destination with env vars + tags, configure resubmission too, and notice that on resubmission the env + tags disappear from the new JobDestination

I've attempted at writing a test case in https://github.com/galaxyproject/galaxy/blob/dev/test/integration/resubmission_job_conf.yml but I haven't managed, and I don't have much more time to spend on this for now

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
