### PR TITLE
[21.09] Fix startup with edam

### DIFF
--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -71,8 +71,8 @@ class EdamToolPanelView(ToolPanelView):
                     for path in self.edam[term]['path']:
                         if len(path) == 1:
                             t = term
-       	       	       	elif len(path) == 0:
-      	      	       	    continue
+                        elif len(path) == 0:
+                            continue
                         else:
                             t = path[0]
 

--- a/lib/galaxy/tool_util/toolbox/views/edam.py
+++ b/lib/galaxy/tool_util/toolbox/views/edam.py
@@ -71,6 +71,8 @@ class EdamToolPanelView(ToolPanelView):
                     for path in self.edam[term]['path']:
                         if len(path) == 1:
                             t = term
+       	       	       	elif len(path) == 0:
+      	      	       	    continue
                         else:
                             t = path[0]
 


### PR DESCRIPTION
A quick fix for #12859, maybe there's a better way

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. try to startup with the tool `toolshed.g2.bx.psu.edu/repos/iuc/instrain_compare/instrain_compare/1.5.3+galaxy0` installed

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
