### PR TITLE
Drop legacy uploadpost

### DIFF
--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -121,6 +121,7 @@ import _ from "underscore";
 import { getGalaxyInstance } from "app";
 import UploadRow from "mvc/upload/collection/collection-row";
 import UploadBoxMixin from "./UploadBoxMixin";
+import { uploadModelsToPayload } from "./helpers";
 import { BButton } from "bootstrap-vue";
 
 export default {
@@ -178,7 +179,7 @@ export default {
                 this._eventAnnounce(index, file);
             },
             initialize: (index) => {
-                return this.app.toData([this.collection.get(index)], this.history_id);
+                return uploadModelsToPayload([this.collection.get(index)], this.history_id);
             },
             progress: (index, percentage) => {
                 this._eventProgress(index, percentage);

--- a/client/src/components/Upload/Collection.vue
+++ b/client/src/components/Upload/Collection.vue
@@ -216,14 +216,6 @@ export default {
         appModel() {
             return this.app.model;
         },
-        history_id() {
-            const storeId = this.$store?.getters["betaHistory/currentHistoryId"];
-            if (storeId) {
-                return storeId;
-            }
-            const legacyId = this.app.currentHistory();
-            return legacyId;
-        },
     },
     watch: {
         extension: function (value) {
@@ -269,28 +261,6 @@ export default {
             this._updateStateForCounters();
             this._eventReset();
             this.$emit("dismiss");
-        },
-
-        /** Start upload process */
-        _eventStart: function () {
-            if (this.counterAnnounce == 0 || this.counterRunning > 0) {
-                return;
-            }
-            this.uploadSize = 0;
-            this.uploadCompleted = 0;
-            this.collection.each((model) => {
-                if (model.get("status") == "init") {
-                    model.set("status", "queued");
-                    this.uploadSize += model.get("file_size");
-                }
-            });
-            this.appModel.set({ percentage: 0, status: "success" });
-            this.counterRunning = this.counterAnnounce;
-
-            // package ftp files separately, and remove them from queue
-            this._uploadFtp();
-            this.uploadbox.start();
-            this._updateStateForCounters();
         },
 
         /** Remove all */

--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -61,6 +61,7 @@ import $ from "jquery";
 import { getGalaxyInstance } from "app";
 import UploadRow from "mvc/upload/composite/composite-row";
 import UploadBoxMixin from "./UploadBoxMixin";
+import { uploadModelsToPayload } from "./helpers";
 
 export default {
     mixins: [UploadBoxMixin],
@@ -139,9 +140,9 @@ export default {
                     extension: this.extension,
                 });
             });
-            $.uploadpost({
+            $.uploadchunk({
                 url: this.app.uploadPath,
-                data: this.app.toFileUploadData(this.collection.filter()),
+                data: uploadModelsToPayload(this.collection.filter(), this.history_id, true),
                 success: (message) => {
                     this._eventSuccess(message);
                 },

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -213,13 +213,6 @@ export default {
         appModel() {
             return this.app.model;
         },
-        history_id() {
-            const storeId = this.$store?.getters["betaHistory/currentHistoryId"];
-            if (storeId) {
-                return storeId;
-            }
-            return this.app.currentHistoryId;
-        },
     },
     watch: {
         extension: function (value) {
@@ -260,31 +253,6 @@ export default {
             var it = this.collection.get(index);
             it.set({ percentage: 100, status: "success", hids: hids });
             this._updateStateForSuccess(it);
-        },
-
-        /** Start upload process */
-        _eventStart: function () {
-            if (this.counterAnnounce !== 0 && this.counterRunning === 0) {
-                // prepare upload process
-                this.uploadSize = 0;
-                this.uploadCompleted = 0;
-                this.collection.each((model) => {
-                    if (model.get("status") == "init") {
-                        model.set("status", "queued");
-                        this.uploadSize += model.get("file_size");
-                    }
-                });
-
-                this.appModel.set({ percentage: 0, status: "success" });
-                this.counterRunning = this.counterAnnounce;
-
-                // package ftp files separately, and remove them from queue
-                this._uploadFtp();
-
-                // queue remaining files
-                this.uploadbox.start();
-                this._updateStateForCounters();
-            }
         },
 
         /** Remove all */

--- a/client/src/components/Upload/Default.vue
+++ b/client/src/components/Upload/Default.vue
@@ -114,6 +114,7 @@ import _l from "utils/localization";
 import _ from "underscore";
 import UploadRow from "mvc/upload/default/default-row";
 import UploadBoxMixin from "./UploadBoxMixin";
+import { uploadModelsToPayload } from "./helpers";
 import { BButton } from "bootstrap-vue";
 
 export default {
@@ -175,7 +176,7 @@ export default {
                 this._eventAnnounce(index, file);
             },
             initialize: (index) => {
-                return this.app.toData([this.collection.get(index)], this.history_id);
+                return uploadModelsToPayload([this.collection.get(index)], this.history_id);
             },
             progress: (index, percentage) => {
                 this._eventProgress(index, percentage);

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -5,6 +5,7 @@ import Popover from "mvc/ui/ui-popover";
 import UploadExtension from "mvc/upload/upload-extension";
 import UploadModel from "mvc/upload/upload-model";
 import UploadWrapper from "./UploadWrapper";
+import { defaultNewFileName, uploadModelsToPayload } from "./helpers";
 import { getGalaxyInstance } from "app";
 import UploadFtp from "mvc/upload/upload-ftp";
 import LazyLimited from "mvc/lazy/lazy-limited";
@@ -14,7 +15,6 @@ import { getAppRoot } from "onload";
 import axios from "axios";
 
 const localize = _l;
-export const defaultNewFileName = "New File";
 
 export default {
     components: {
@@ -118,7 +118,7 @@ export default {
                 }
             });
             if (list.length > 0) {
-                const data = this.app.toFetchData(list, this.history_id);
+                const data = uploadModelsToPayload(list, this.history_id);
                 axios
                     .post(`${getAppRoot()}api/tools/fetch`, data)
                     .then((message) => {

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -14,6 +14,7 @@ import { getAppRoot } from "onload";
 import axios from "axios";
 
 const localize = _l;
+export const defaultNewFileName = "New File";
 
 export default {
     components: {
@@ -53,6 +54,14 @@ export default {
         btnCloseTitle() {
             return this.hasCallback ? "Cancel" : "Close";
         },
+        history_id() {
+            const storeId = this.$store?.getters["betaHistory/currentHistoryId"];
+            if (storeId) {
+                return storeId;
+            }
+            const legacyId = this.app.currentHistory();
+            return legacyId;
+        },
     },
     methods: {
         $uploadBox() {
@@ -76,6 +85,29 @@ export default {
         uploadSelect: function () {
             this.uploadbox.select();
         },
+
+        /** Start upload process */
+        _eventStart: function () {
+            if (this.counterAnnounce == 0 || this.counterRunning > 0) {
+                return;
+            }
+            this.uploadSize = 0;
+            this.uploadCompleted = 0;
+            this.collection.each((model) => {
+                if (model.get("status") == "init") {
+                    model.set("status", "queued");
+                    this.uploadSize += model.get("file_size");
+                }
+            });
+            this.appModel.set({ percentage: 0, status: "success" });
+            this.counterRunning = this.counterAnnounce;
+
+            // package ftp files separately, and remove them from queue
+            this._uploadFtp();
+            this.uploadbox.start();
+            this._updateStateForCounters();
+        },
+
         /** Package and upload ftp files in a single request */
         _uploadFtp: function () {
             const list = [];
@@ -256,7 +288,7 @@ export default {
         /** Create a new file */
         _eventCreate: function (withNewFile) {
             if (withNewFile == true) {
-                this.uploadbox.add([{ name: "New File", size: 0, mode: "new" }]);
+                this.uploadbox.add([{ name: defaultNewFileName, size: 0, mode: "new" }]);
             } else if (withNewFile == false) {
                 this.uploadbox.add([{ size: 0, mode: "new" }]);
             }
@@ -346,9 +378,7 @@ export default {
             return models;
         },
         getRequestUrl: function (items, history_id) {
-            var data = this.app.toData(items, history_id);
-            const appRoot = getAppRoot();
-            return data.fetchRequest ? `${appRoot}api/tools/fetch` : this.app.uploadPath;
+            return `${getAppRoot()}api/tools/fetch`;
         },
     },
 };

--- a/client/src/components/Upload/UploadModalContent.vue
+++ b/client/src/components/Upload/UploadModalContent.vue
@@ -34,6 +34,7 @@ import Collection from "./Collection";
 import Default from "./Default";
 import RulesInput from "./RulesInput";
 import LoadingSpan from "components/LoadingSpan";
+import { uploadModelsToPayload } from "./helpers";
 import { BTabs, BTab } from "bootstrap-vue";
 import { commonProps } from "./helpers";
 
@@ -60,7 +61,6 @@ export default {
             extensionsSet: false,
             datatypesMapper: null,
             datatypesMapperReady: true,
-            URI_PREFIXES: ["http", "https", "ftp", "file", "gxfiles", "gximport", "gxuserimport", "gxftp"],
         };
     },
     created() {
@@ -174,143 +174,12 @@ export default {
         currentFtp: function () {
             return this.currentUserId && this.ftpUploadSite;
         },
-        toData: function (items, history_id) {
-            const data = {
-                fetchRequest: null,
-                uploadRequest: null,
-            };
-            if (items && items.length > 0) {
-                const split = this.preprocess(items);
-                if (split.urls.length > 0) {
-                    data.fetchRequest = this.toFetchData(split.urls, history_id);
-                } else {
-                    data.uploadRequest = this.toFileUploadData(split.files, history_id);
-                }
-            }
-            return data;
-        },
-        preprocess: function (items) {
-            const data = {
-                urls: [],
-                files: [],
-            };
-            for (var index in items) {
-                var it = items[index];
-                if (it.get("file_mode") != "new" || !this.itemIsURL(it)) {
-                    data.files.push(it);
-                } else {
-                    data.urls.push(it);
-                }
-            }
-            return data;
-        },
-        itemIsURL: function (item) {
-            return this.URI_PREFIXES.some((prefix) => item.get("url_paste").startsWith(prefix));
-        },
         /**
-         * Package API data from array of models
+         * Package API data from array of backbone models
          * @param{Array} items - Upload items/rows filtered from a collection
          */
-        toFileUploadData: function (items, history_id) {
-            // create dictionary for data submission
-            var data = {
-                payload: {
-                    tool_id: "upload1",
-                    history_id: history_id || this.currentHistoryId,
-                    inputs: {},
-                },
-                files: [],
-                error_message: null,
-            };
-            // add upload tools input data
-            if (items && items.length > 0) {
-                var inputs = {
-                    file_count: items.length,
-                    dbkey: items[0].get("genome", "?"),
-                    // sometimes extension set to "" in automated testing after first upload of
-                    // a session. https://github.com/galaxyproject/galaxy/issues/5169
-                    file_type: items[0].get("extension") || "auto",
-                };
-                for (var index in items) {
-                    var it = items[index];
-                    it.set("status", "running");
-                    if (it.get("file_size") > 0) {
-                        var prefix = `files_${index}|`;
-                        inputs[`${prefix}type`] = "upload_dataset";
-                        if (it.get("file_name") != "New File") {
-                            inputs[`${prefix}NAME`] = it.get("file_name");
-                        }
-                        inputs[`${prefix}space_to_tab`] = (it.get("space_to_tab") && "Yes") || null;
-                        inputs[`${prefix}to_posix_lines`] = (it.get("to_posix_lines") && "Yes") || null;
-                        inputs[`${prefix}dbkey`] = it.get("genome", null);
-                        inputs[`${prefix}file_type`] = it.get("extension", null);
-                        let uri;
-                        let how;
-                        switch (it.get("file_mode")) {
-                            case "new":
-                                inputs[`${prefix}url_paste`] = it.get("url_paste");
-                                break;
-                            case "ftp":
-                                uri = it.get("file_path");
-                                how = "ftp_files";
-                                if (uri.indexOf("://") >= 0) {
-                                    how = "url_paste";
-                                }
-                                inputs[`${prefix}${how}`] = uri;
-                                break;
-                            case "local":
-                                data.files.push({
-                                    name: `${prefix}file_data`,
-                                    file: it.get("file_data"),
-                                });
-                        }
-                    } else if (it.get("optional")) {
-                        continue;
-                    } else {
-                        data.error_message = "Upload content incomplete.";
-                        it.set("status", "error");
-                        it.set("info", data.error_message);
-                        break;
-                    }
-                }
-                data.payload.inputs = JSON.stringify(inputs);
-            }
-            return data;
-        },
-        toFetchData: function (items, history_id) {
-            var data = {
-                history_id: history_id,
-                space_to_tab: items[0].get("space_to_tab"),
-                to_posix_lines: items[0].get("to_posix_lines"),
-                targets: [
-                    {
-                        destination: { type: "hdas" },
-                        elements: [],
-                        name: "",
-                    },
-                ],
-                auto_decompress: true,
-            };
-
-            items.forEach((item) => {
-                let urls;
-                if (item.get("file_mode") == "ftp") {
-                    urls = [item.get("file_uri") || item.get("file_path")];
-                } else {
-                    urls = item.get("url_paste").split("\n");
-                }
-                urls.forEach((url) => {
-                    if (url != "") {
-                        data.targets[0].elements.push({
-                            url: url.trim(),
-                            src: "url",
-                            dbkey: item.get("genome", "?"),
-                            ext: item.get("extension", "auto"),
-                        });
-                    }
-                });
-            });
-            return data;
+        toData: function (items, history_id, composite = false) {
+            return uploadModelsToPayload(items, history_id, composite);
         },
     },
 };

--- a/client/src/utils/data.js
+++ b/client/src/utils/data.js
@@ -5,6 +5,7 @@ import DataDialog from "components/DataDialog/DataDialog.vue";
 import { FilesDialog } from "components/FilesDialog";
 import DatasetCollectionDialog from "components/SelectionDialog/DatasetCollectionDialog.vue";
 import { mountUploadModal } from "components/Upload";
+import { uploadModelsToPayload } from "components/Upload/helpers";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
 
@@ -92,8 +93,8 @@ export function create(options) {
         return options.history_id;
     }
     getHistory().then((history_id) => {
-        $.uploadpost({
-            url: `${getAppRoot()}api/tools`,
+        $.uploadchunk({
+            url: `${getAppRoot()}api/tools/fetch`,
             success: (response) => {
                 if (history_panel) {
                     history_panel.refreshContents();
@@ -104,19 +105,7 @@ export function create(options) {
             },
             error: options.error,
             data: {
-                payload: {
-                    tool_id: "upload1",
-                    history_id: history_id,
-                    inputs: JSON.stringify({
-                        "files_0|type": "upload_dataset",
-                        "files_0|NAME": options.file_name,
-                        "files_0|space_to_tab": options.space_to_tab ? "Yes" : null,
-                        "files_0|to_posix_lines": options.to_posix_lines ? "Yes" : null,
-                        "files_0|dbkey": options.genome || "?",
-                        "files_0|file_type": options.extension || "auto",
-                        "files_0|url_paste": options.url_paste,
-                    }),
-                },
+                payload: uploadModelsToPayload([options], history_id),
             },
         });
     });

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -295,7 +295,7 @@ def _fetch_target(upload_config, target):
                 # Groom the dataset content if necessary
                 datatype.groom_dataset_content(path)
 
-        rval = {"name": name, "filename": path, "dbkey": dbkey, "ext": ext, "link_data_only": link_data_only, "sources": sources, "hashes": hashes}
+        rval = {"name": name, "filename": path, "dbkey": dbkey, "ext": ext, "link_data_only": link_data_only, "sources": sources, "hashes": hashes, "info": f"uploaded {ext} file"}
         if staged_extra_files:
             rval["extra_files"] = os.path.abspath(staged_extra_files)
         return _copy_and_validate_simple_attributes(item, rval)

--- a/lib/galaxy_test/selenium/test_history_dataset_state.py
+++ b/lib/galaxy_test/selenium/test_history_dataset_state.py
@@ -12,7 +12,7 @@ BUTTON_TOOLTIPS = {
     "info": 'View details',
     "rerun": 'Run this job again',
 }
-EXPECTED_TOOLHELP_TITLE_TEXT = 'Tool help for Upload File'
+EXPECTED_TOOLHELP_TITLE_TEXT = 'Tool help for Data Fetch'
 TEST_DBKEY_TEXT = 'Honeybee (Apis mellifera): apiMel3 (apiMel3)'
 FIRST_HID = 1
 


### PR DESCRIPTION
Everything should work via fetch data, meaning all file data uploads use the tus protocol.
Overall this is cleaner and should make it easier (or at least not harder) to decouple upload from jQuery and sanitizing the upload modal architecture.
Also fixes https://github.com/galaxyproject/galaxy/issues/12746 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
