### PR TITLE
Avoid using `at` function to access session id in upload url

### DIFF
--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -123,8 +123,9 @@ import * as tus from "tus-js-client";
                 );
 
                 const toolInputs = JSON.parse(data.payload.inputs);
+                const sessionId = upload.url.substr(upload.url.lastIndexOf("/") + 1);
                 toolInputs["files_0|file_data"] = {
-                    session_id: upload.url.split("/").at(-1),
+                    session_id: sessionId,
                     name: file.name,
                 };
                 data.payload.inputs = JSON.stringify(toolInputs);


### PR DESCRIPTION
Safari does not support the `at` function for arrays which leads to an upload error. Since we are rewriting the `uploadbox` this PR makes only a minimal adjustment. We should probably also raise an error if the `url` does not contain a `session_id`. 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
