### PR TITLE
Modify history contents/near endpoint to support new history scroller

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -252,12 +252,6 @@ class DatasetCollectionInstanceType(str, Enum):
     library = "library"
 
 
-class DirectionOptions(str, Enum):
-    near = "near"
-    before = "before"
-    after = "after"
-
-
 class TagItem(ConstrainedStr):
     regex = re.compile(r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")
 

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -252,6 +252,12 @@ class DatasetCollectionInstanceType(str, Enum):
     library = "library"
 
 
+class DirectionOptions(str, Enum):
+    near = "near"
+    before = "before"
+    after = "after"
+
+
 class TagItem(ConstrainedStr):
     regex = re.compile(r"^([^\s.:])+(.[^\s.:]+)*(:[^\s.:]+)?$")
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -518,7 +518,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
             trans, history_id, serialization_params, filter_params, hid, limit, since,
         )
 
-    @expose_api_raw_anonymous
+    @expose_api_anonymous
     def contents_after(self, trans, history_id, hid, limit, **kwd):
         """
         Return {limit} history items with hid > {hid}.

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -519,18 +519,18 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         )
 
     @expose_api_anonymous
-    def contents_after(self, trans, history_id, hid, limit, **kwd):
+    def contents_before(self, trans, history_id, hid, limit, **kwd):
         """
         Return {limit} history items with hid > {hid}.
 
-        GET /api/histories/{history_id}/contents/after/{hid}/{limit}
+        GET /api/histories/{history_id}/contents/before/{hid}/{limit}
         """
         serialization_params = parse_serialization_params(default_view='betawebclient', **kwd)
         filter_params = self._parse_rest_params(kwd)
         hid = int(hid)
         limit = int(limit)
 
-        return self.service.contents_after(
+        return self.service.contents_before(
             trans, history_id, serialization_params, filter_params, hid, limit
         )
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -518,6 +518,22 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
             trans, history_id, serialization_params, filter_params, hid, limit, since,
         )
 
+    @expose_api_raw_anonymous
+    def contents_after(self, trans, history_id, hid, limit, **kwd):
+        """
+        Return {limit} history items with hid > {hid}.
+
+        GET /api/histories/{history_id}/contents/after/{hid}/{limit}
+        """
+        serialization_params = parse_serialization_params(default_view='betawebclient', **kwd)
+        filter_params = self._parse_rest_params(kwd)
+        hid = int(hid)
+        limit = int(limit)
+
+        return self.service.contents_after(
+            trans, history_id, serialization_params, filter_params, hid, limit
+        )
+
     # Parsing query string according to REST standards.
     def _parse_rest_params(self, qdict: Dict[str, Any]) -> HistoryContentsFilterList:
         DEFAULT_OP = 'eq'

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -486,21 +486,17 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         return self.service.archive(trans, history_id, filter_parameters, filename, dry_run)
 
     @expose_api_raw_anonymous
-    def contents_near(self, trans, history_id, hid, limit, **kwd):
+    def contents_near(self, trans, history_id, direction, hid, limit, **kwd):
         """
-        This endpoint provides random access to a large history without having
-        to know exactly how many pages are in the final query. Pick a target HID
-        and filters, and the endpoint will get LIMIT counts above and below that
-        target regardless of how many gaps may exist in the HID due to
-        filtering.
+        Return {limit} history items "near" the {hid}. The {direction} determines what items
+        are selected:
+        - before: select items with hid < {hid}
+        - after:  select items with hid > {hid}
+        - near:   select items "around" {hid}, so that |before| <= limit // 2, |after| <= limit // 2 + 1
 
-        It does 2 queries, one up and one down from the target hid with a
-        result size of limit. Additional counts for total matches of both seeks
-        provided in the http headers.
+        Additional counts provided in the HTTP headers.
 
-        I've also abandoned the wierd q/qv syntax.
-
-        * GET /api/histories/{history_id}/contents/near/{hid}/{limit}
+        GET /api/histories/{history_id}/contents/{direction}/{hid}/{limit}
         """
         serialization_params = parse_serialization_params(default_view='betawebclient', **kwd)
 
@@ -515,23 +511,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         limit = int(limit)
 
         return self.service.contents_near(
-            trans, history_id, serialization_params, filter_params, hid, limit, since,
-        )
-
-    @expose_api_anonymous
-    def contents_before(self, trans, history_id, hid, limit, **kwd):
-        """
-        Return {limit} history items with hid > {hid}.
-
-        GET /api/histories/{history_id}/contents/before/{hid}/{limit}
-        """
-        serialization_params = parse_serialization_params(default_view='betawebclient', **kwd)
-        filter_params = self._parse_rest_params(kwd)
-        hid = int(hid)
-        limit = int(limit)
-
-        return self.service.contents_before(
-            trans, history_id, serialization_params, filter_params, hid, limit
+            trans, history_id, serialization_params, filter_params, direction, hid, limit, since,
         )
 
     # Parsing query string according to REST standards.

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -317,8 +317,8 @@ def populate_api_routes(webapp, app):
                           action="contents_near",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/after/{hid}/{limit}",
-                          action="contents_after",
+    webapp.mapper.connect("/api/histories/{history_id}/contents/before/{hid}/{limit}",
+                          action="contents_before",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
     webapp.mapper.resource('user',

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -313,7 +313,15 @@ def populate_api_routes(webapp, app):
                           controller="datasets",
                           action="get_metadata_file",
                           conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/{direction}/{hid}/{limit}",
+    webapp.mapper.connect("/api/histories/{history_id}/contents/near/{hid}/{limit}",
+                          action="contents_near",
+                          controller='history_contents',
+                          conditions=dict(method=["GET"]))
+    webapp.mapper.connect("/api/histories/{history_id}/contents/after/{hid}/{limit}",
+                          action="contents_near",
+                          controller='history_contents',
+                          conditions=dict(method=["GET"]))
+    webapp.mapper.connect("/api/histories/{history_id}/contents/before/{hid}/{limit}",
                           action="contents_near",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -318,11 +318,11 @@ def populate_api_routes(webapp, app):
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
     webapp.mapper.connect("/api/histories/{history_id}/contents/after/{hid}/{limit}",
-                          action="contents_near",
+                          action="contents_after",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
     webapp.mapper.connect("/api/histories/{history_id}/contents/before/{hid}/{limit}",
-                          action="contents_near",
+                          action="contents_before",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
     webapp.mapper.resource('user',

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -317,6 +317,10 @@ def populate_api_routes(webapp, app):
                           action="contents_near",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
+    webapp.mapper.connect("/api/histories/{history_id}/contents/after/{hid}/{limit}",
+                          action="contents_after",
+                          controller='history_contents',
+                          conditions=dict(method=["GET"]))
     webapp.mapper.resource('user',
                            'users',
                            controller='group_users',

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -313,12 +313,8 @@ def populate_api_routes(webapp, app):
                           controller="datasets",
                           action="get_metadata_file",
                           conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/near/{hid}/{limit}",
+    webapp.mapper.connect("/api/histories/{history_id}/contents/{direction}/{hid}/{limit}",
                           action="contents_near",
-                          controller='history_contents',
-                          conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/before/{hid}/{limit}",
-                          action="contents_before",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
     webapp.mapper.resource('user',

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -788,7 +788,7 @@ class HistoriesContentsService(ServiceBase):
         trans.response.headers['history_size'] = str(history.disk_size)
         trans.response.headers['history_empty'] = json.dumps(history.empty)  # convert to proper bool
 
-        return json.dumps(contents)
+        return contents
 
     def _hid_greater_than(self, hid: int) -> HistoryContentsFilterList:
         return [["hid", "gt", hid]]

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -63,6 +63,7 @@ from galaxy.schema.schema import (
     AnyJobStateSummary,
     DatasetAssociationRoles,
     DeleteHDCAResult,
+    DirectionOptions,
     HistoryContentSource,
     HistoryContentType,
     JobSourceType,
@@ -693,23 +694,26 @@ class HistoriesContentsService(ServiceBase):
         history_id: EncodedDatabaseIdField,
         serialization_params: SerializationParams,
         filter_params: HistoryContentsFilterList,
+        direction: DirectionOptions,
         hid: int,
         limit: int,
         since: Optional[datetime.datetime] = None,
     ):
         """
-        This endpoint provides random access to a large history without having
-        to know exactly how many pages are in the final query. Pick a target HID
-        and filters, and the endpoint will get LIMIT counts above and below that
-        target regardless of how many gaps may exist in the HID due to
-        filtering.
+        Return {limit} history items "near" the {hid}. The {direction} determines what items
+        are selected:
+        - before: select items with hid < {hid}
+        - after:  select items with hid > {hid}
+        - near:   select items "around" {hid}, so that |before| <= limit // 2, |after| <= limit // 2 + 1
 
-        It does 2 queries, one up and one down from the target hid with a
-        result size of limit. Additional counts for total matches of both seeks
-        provided in the http headers.
-
-        I've also abandoned the wierd q/qv syntax.
+        Additional counts provided in the HTTP headers.
         """
+        def get_contents_data(hid_params, order, limit):
+            params = filter_params + hid_params
+            matches, total_count = self._seek(history, params, order, limit, serialization_params)
+            expanded = self._expand_contents(trans, matches, serialization_params)
+            return len(matches), total_count, expanded
+
         history: History = self.history_manager.get_accessible(
             self.decode_id(history_id), trans.user, current_history=trans.history
         )
@@ -725,69 +729,61 @@ class HistoriesContentsService(ServiceBase):
                 trans.response.status = 204
                 return
 
-        # SEEK UP, contents > hid
-        up_params = filter_params + self._hid_greater_than(hid)
-        up_order = 'hid-asc'
-        contents_up, up_count = self._seek(history, up_params, up_order, limit, serialization_params)
-
-        # SEEK DOWN, contents <= hid
-        down_params = filter_params + self._hid_less_or_equal_than(hid)
-        down_order = 'hid-dsc'
-        contents_down, down_count = self._seek(history, down_params, down_order, limit, serialization_params)
-
-        # min/max hid values
         min_hid, max_hid = self._get_filtered_extrema(history, filter_params)
+        order_asc, order_dsc = 'hid-asc', 'hid-dsc'
 
-        # results
-        up = self._expand_contents(trans, contents_up, serialization_params)
-        up.reverse()
-        down = self._expand_contents(trans, contents_down, serialization_params)
-        contents = up + down
+        if direction == DirectionOptions.after:  # seek up: contents > hid (newer)
+            hid_params = self._hid_greater_than(hid)
+            match_count, total_count, expanded = get_contents_data(hid_params, order_asc, limit)
+            item_counts = self._set_item_counts(matches_up=match_count, total_matches_up=total_count)
+            expanded.reverse()
 
-        # Put stats in http headers
-        trans.response.headers['matches_up'] = len(contents_up)
-        trans.response.headers['matches_down'] = len(contents_down)
-        trans.response.headers['total_matches_up'] = up_count
-        trans.response.headers['total_matches_down'] = down_count
+        elif direction == DirectionOptions.before:  # seek down: contents <= hid (older)
+            hid_params = self._hid_less_than(hid)
+            match_count, total_count, expanded = get_contents_data(hid_params, order_dsc, limit)
+            item_counts = self._set_item_counts(matches_down=match_count, total_matches_down=total_count)
+
+        elif direction == DirectionOptions.near:  # seek up, down; then reverse up, and combine
+            up_limit, down_limit = self._get_limits(limit)
+
+            hid_params = self._hid_greater_than(hid)
+            up_match_count, up_total_count, up_expanded = get_contents_data(hid_params, order_asc, up_limit)
+
+            hid_params = self._hid_less_or_equal_than(hid)
+            down_match_count, down_total_count, down_expanded = get_contents_data(hid_params, order_dsc, down_limit)
+
+            item_counts = self._set_item_counts(matches_up=up_match_count, total_matches_up=up_total_count,
+                matches_down=down_match_count, total_matches_down=down_total_count)
+
+            up_expanded.reverse()
+            expanded = up_expanded + down_expanded
+
+        trans.response.headers['matches'] = item_counts['matches']
+        trans.response.headers['matches_up'] = item_counts['matches_up']
+        trans.response.headers['matches_down'] = item_counts['matches_down']
+        trans.response.headers['total_matches'] = item_counts['total_matches']
+        trans.response.headers['total_matches_up'] = item_counts['total_matches_up']
+        trans.response.headers['total_matches_down'] = item_counts['total_matches_down']
         trans.response.headers['max_hid'] = max_hid
         trans.response.headers['min_hid'] = min_hid
         trans.response.headers['history_size'] = str(history.disk_size)
         trans.response.headers['history_empty'] = json.dumps(history.empty)  # convert to proper bool
 
-        return json.dumps(contents)
+        return json.dumps(expanded)
 
-    def contents_before(
-        self, trans,
-        history_id: EncodedDatabaseIdField,
-        serialization_params: SerializationParams,
-        filter_params: HistoryContentsFilterList,
-        hid: int,
-        limit: int,
-        since: Optional[datetime.datetime] = None,
-    ):
-        """
-        Return {limit} history items with hid > {hid}.
-        """
-        history: History = self.history_manager.get_accessible(
-            self.decode_id(history_id), trans.user, current_history=trans.history
-        )
-        params = filter_params + self._hid_less_than(hid)
-        order = 'hid-dsc'
-        contents, count = self._seek(history, params, order, limit, serialization_params)
+    def _get_limits(self, limit):
+        q, r = divmod(limit, 2)
+        return q, q + r
 
-        min_hid, max_hid = self._get_filtered_extrema(history, filter_params)
-
-        contents = self._expand_contents(trans, contents, serialization_params)
-
-        # Put stats in http headers
-        trans.response.headers['matches_down'] = len(contents)
-        trans.response.headers['total_matches_down'] = count
-        trans.response.headers['max_hid'] = max_hid
-        trans.response.headers['min_hid'] = min_hid
-        trans.response.headers['history_size'] = str(history.disk_size)
-        trans.response.headers['history_empty'] = json.dumps(history.empty)  # convert to proper bool
-
-        return contents
+    def _set_item_counts(self, *, matches_up=0, total_matches_up=0, matches_down=0, total_matches_down=0):
+        counts = {}
+        counts['matches'] = matches_up + matches_down
+        counts['matches_up'] = matches_up
+        counts['matches_down'] = matches_down
+        counts['total_matches'] = total_matches_up + total_matches_down
+        counts['total_matches_up'] = total_matches_up
+        counts['total_matches_down'] = total_matches_down
+        return counts
 
     def _hid_greater_than(self, hid: int) -> HistoryContentsFilterList:
         return [["hid", "gt", hid]]

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import re
+from enum import Enum
 from typing import (
     Any,
     Dict,
@@ -63,7 +64,6 @@ from galaxy.schema.schema import (
     AnyJobStateSummary,
     DatasetAssociationRoles,
     DeleteHDCAResult,
-    DirectionOptions,
     HistoryContentSource,
     HistoryContentType,
     JobSourceType,
@@ -81,6 +81,12 @@ from galaxy.webapps.galaxy.services.base import ServiceBase
 log = logging.getLogger(__name__)
 
 DatasetDetailsType = Union[Set[EncodedDatabaseIdField], Literal['all']]
+
+
+class DirectionOptions(str, Enum):
+    near = "near"
+    before = "before"
+    after = "after"
 
 
 class HistoryContentsFilterQueryParams(FilterQueryParams):

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from requests import delete, put
 
-from galaxy.schema.schema import DirectionOptions
+from galaxy.webapps.galaxy.services.history_contents import DirectionOptions
 from galaxy_test.base.populators import (
     DatasetCollectionPopulator,
     DatasetPopulator,

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -799,10 +799,10 @@ class HistoryContentsApiNearTestCase(ApiTestCase):
             self._create_list_in_history(history_id)
             result = self._get_content(history_id, self.NEAR, hid=5, limit=4)
             assert len(result) == 4
-            assert result[0]['hid'] == 7  # hid + 1
-            assert result[1]['hid'] == 6  # hid
-            assert result[2]['hid'] == 5  # hid - 1
-            assert result[3]['hid'] == 4  # hid - 2
+            assert result[0]['hid'] == 7  # hid + 2
+            assert result[1]['hid'] == 6  # hid + 1
+            assert result[2]['hid'] == 5  # hid
+            assert result[3]['hid'] == 4  # hid - 1
 
     def test_near_less_than_before_limit(self):  # n before < limit // 2
         with self.dataset_populator.test_history() as history_id:

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -750,13 +750,18 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert len(contents_response) == expected_num_collections
 
 
-class HistoryContentsApiNearTestCase(HistoryContentsApiTestCase):
+class HistoryContentsApiNearTestCase(ApiTestCase):
     """
     Test the /api/histories/{history_id}/contents/{direction}/{hid}/{limit} endpoint.
     """
     NEAR = DirectionOptions.near
     BEFORE = DirectionOptions.before
     AFTER = DirectionOptions.after
+
+    def setUp(self):
+        super().setUp()
+        self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
+        self.dataset_collection_populator = DatasetCollectionPopulator(self.galaxy_interactor)
 
     def _create_list_in_history(self, history_id, n=2):
         # Creates list of size n*4 (n collections with 3 items each)

--- a/test/unit/webapps/services/test_history_contents.py
+++ b/test/unit/webapps/services/test_history_contents.py
@@ -1,0 +1,43 @@
+import pytest
+
+from galaxy.webapps.galaxy.services.history_contents import HistoriesContentsService
+
+
+@pytest.fixture
+def mock_init(monkeypatch):
+    monkeypatch.setattr(HistoriesContentsService, '__init__', lambda _: None)
+
+
+class TestSetItemCounts:
+
+    def test_set_item_counts_before(self, mock_init):
+        service = HistoriesContentsService()
+        down = 10
+        total_down = 100
+        counts = service._set_item_counts(matches_down=down, total_matches_down=total_down)
+        self._verify_counts(counts, down=down, total_down=total_down)
+
+    def test_set_item_counts_after(self, mock_init):
+        service = HistoriesContentsService()
+        up = 10
+        total_up = 100
+        counts = service._set_item_counts(matches_up=up, total_matches_up=total_up)
+        self._verify_counts(counts, up=up, total_up=total_up)
+
+    def test_set_item_counts_near(self, mock_init):
+        service = HistoriesContentsService()
+        up = 10
+        total_up = 100
+        down = 5
+        total_down = 50
+        counts = service._set_item_counts(matches_up=up, total_matches_up=total_up,
+            matches_down=down, total_matches_down=total_down)
+        self._verify_counts(counts, up=up, total_up=total_up, down=down, total_down=total_down)
+
+    def _verify_counts(self, counts, up=0, total_up=0, down=0, total_down=0):
+        assert counts['matches'] == up + down
+        assert counts['matches_up'] == up
+        assert counts['matches_down'] == down
+        assert counts['total_matches'] == total_up + total_down
+        assert counts['total_matches_up'] == total_up
+        assert counts['total_matches_down'] == total_down

--- a/test/unit/webapps/services/test_history_contents.py
+++ b/test/unit/webapps/services/test_history_contents.py
@@ -11,21 +11,21 @@ def mock_init(monkeypatch):
 class TestSetItemCounts:
 
     def test_set_item_counts_before(self, mock_init):
-        service = HistoriesContentsService()
+        service = HistoriesContentsService()  # type: ignore
         down = 10
         total_down = 100
         counts = service._set_item_counts(matches_down=down, total_matches_down=total_down)
         self._verify_counts(counts, down=down, total_down=total_down)
 
     def test_set_item_counts_after(self, mock_init):
-        service = HistoriesContentsService()
+        service = HistoriesContentsService()  # type: ignore
         up = 10
         total_up = 100
         counts = service._set_item_counts(matches_up=up, total_matches_up=total_up)
         self._verify_counts(counts, up=up, total_up=total_up)
 
     def test_set_item_counts_near(self, mock_init):
-        service = HistoriesContentsService()
+        service = HistoriesContentsService()  # type: ignore
         up = 10
         total_up = 100
         down = 5


### PR DESCRIPTION
UPDATE: as per discussion here and on gitter, I've implemented this as one endpoint:
`/api/histories/{history-id}/contents/{direction}/{hid}/{limit}`

Direction can be `near|after|before`.

The limit is now the same regardless of direction. If `direction=near`, the up and down boundaries are calculated as follows:
`up = limit // 2 + 1 if limit //2 == 1 else limit // 2`
`down = limit // 2`
The "up" selection excludes the provided `hid`, the "down" selection includes it, so the total number is always `<= limit`. If one of the boundaries is greater than the available items in that direction, we do not shift the middle - i.e., if we have 10 items total (hids 1 through 10), `hid=9`, `limit=5`, then the result will be hids 7,8,9,10 - i.e., we will not move the selection window one hid down to accommodate the maximum limit of 5 (i.e., we will not select 6,7,8,9,10 instead). I think this would be the expected behavior in such a case. But this can be changed.

If `direction=after|before`, the provided `hid` is not included.

I've added API and unit tests. The unit tests verify assignment of total counts. The API tests check the results under several scenarios (even/odd limits; near/after/before directions with total counts being less than and greater than limits). I've verified this manually as well (although I don't know if it'll work for the scroller).



~~This is a new endpoint that's needed for the new history scroller.~~
~~No tests. It's a near-duplicate of the `contents/near` endpoint which has test coverage.~~ 
~~I excluded the `since` parameter because I suspect it's not needed here, but ***I'm not at all sure***.~~
I'm not adding a FastAPI controller (or more tests, for that matter) for the sake of getting this out ASAP so that this doesn't delay work on the new history.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Try to access `{your galaxy host}/api/histories/{history id}/contents/{direction}/{hid}/{limit}
If direction=near, hid=10 and limit=3, the data will contain hid=11, hid=12, hid=13.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
