### PR TITLE
[21.09] Fix parsing of yml job conf file in galaxy.dependencies

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -42,15 +42,13 @@ class ConditionalDependencies:
     def parse_configs(self):
 
         def load_job_config_dict(job_conf_dict):
-            for runner in job_conf_dict.get("runners"):
+            runners = job_conf_dict.get("runners", [])
+            for runner_id in runners:
+                runner = runners[runner_id]
                 if "load" in runner:
                     self.job_runners.append(runner.get("load"))
                 if "rules_module" in runner:
-                    self.job_rule_modules.append(plugin.text)
-                if "params" in runner:
-                    runner_params = runner["params"]
-                    if "rules_module" in runner_params:
-                        self.job_rule_modules.append(plugin.text)
+                    self.job_rule_modules.append(runner.get("rules_module"))
 
         if "job_config" in self.config:
             load_job_config_dict(self.config.get("job_config"))
@@ -75,7 +73,7 @@ class ConditionalDependencies:
                     pass
             else:
                 try:
-                    with open("job_conf_path") as f:
+                    with open(job_conf_path) as f:
                         job_conf_dict = yaml.safe_load(f)
                     load_job_config_dict(job_conf_dict)
                 except OSError:

--- a/test/unit/app/dependencies/test_deps.py
+++ b/test/unit/app/dependencies/test_deps.py
@@ -24,6 +24,11 @@ FILES_SOURCES_DROPBOX = """
 - type: webdav
 - type: dropbox
 """
+JOB_CONF_YAML = """
+runners:
+  runner1:
+    load: job_runner_A
+"""
 
 
 def test_default_objectstore():
@@ -78,6 +83,16 @@ def test_fs_configured():
         cds = cc.get_cond_deps(config=config)
         assert cds.check_fs_dropboxfs()
         assert cds.check_fs_webdavfs()
+
+
+def test_yaml_jobconf_runners():
+    with _config_context() as cc:
+        job_conf_file = cc.write_config("job_conf.yml", JOB_CONF_YAML)
+        config = {
+            "job_config_file": job_conf_file,
+        }
+        cds = cc.get_cond_deps(config=config)
+        assert 'job_runner_A' in cds.job_runners
 
 
 @contextmanager


### PR DESCRIPTION
A .yml job conf file is not parsed correctly in this file, so conditional dependencies are not detected.

## How to test the changes?
(Select all options that apply)
- [X] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
