### PR TITLE
Show error codes when running mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ import-order-style = smarkets
 application-import-names = galaxy,galaxy_test,tool_shed
 
 [mypy]
+show_error_codes = True
 ignore_missing_imports = True
 check_untyped_defs = True
 exclude = lib/galaxy/tools/bundled|test/functional


### PR DESCRIPTION
E.g. this error:

```
lib/galaxy/tool_util/cwl/schema.py:38: error: "LoadingContext" has no attribute "relax_path_checks"
```

becomes

```
lib/galaxy/tool_util/cwl/schema.py:38: error: "LoadingContext" has no attribute "relax_path_checks"  [attr-defined]
```

making it easier to Google for solutions or to add a `# type: ignore[error-code]` comment.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Introduce a typing error
  2. Run `tox -e mypy`

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
