### PR TITLE
Consider a history not new once there are any items in it

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -526,11 +526,10 @@ class HistorySerializer(sharable.SharableModelSerializer, deletable.PurgableSeri
         # TODO: history_state and state_counts are classically calc'd at the same time
         #   so this is rel. ineff. - if we keep this...
         hda_state_counts = self.serialize_state_counts(history, 'counts', exclude_deleted=True, **context)
-        num_hdas = sum(hda_state_counts.values())
-        if num_hdas == 0:
+        if history.empty:
             state = states.NEW
-
         else:
+            num_hdas = sum(hda_state_counts.values())
             if (hda_state_counts[states.RUNNING] > 0
                     or hda_state_counts[states.SETTING_METADATA] > 0
                     or hda_state_counts[states.UPLOAD] > 0):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2427,7 +2427,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, Serializable
 
     @property
     def empty(self):
-        return self.hid_counter == 1
+        return self.hid_counter is None or self.hid_counter == 1
 
     def add_pending_items(self, set_output_hid=True):
         # These are assumed to be either copies of existing datasets or new, empty datasets,

--- a/test/integration/test_upload_configuration_options.py
+++ b/test/integration/test_upload_configuration_options.py
@@ -434,8 +434,7 @@ class SimpleFtpUploadConfigurationTestCase(BaseFtpUploadConfigurationTestCase):
             "collection_type": "list",
             "name": "cool collection",
         }
-        response = self.fetch_target(target)
-        self._assert_status_code_is(response, 200)
+        response = self.fetch_target(target, assert_ok=True, wait=True)
         response_object = response.json()
         assert "output_collections" in response_object
         output_collections = response_object["output_collections"]

--- a/test/unit/app/managers/test_HistoryManager.py
+++ b/test/unit/app/managers/test_HistoryManager.py
@@ -569,7 +569,7 @@ class HistorySerializerTestCase(BaseTestCase):
         self.assertIsInstance(serialized['hdas'], list)
 
         self.log('a history with contents should be properly reflected in empty, etc.')
-        hda1 = self.hda_manager.create(history=history1, hid=1)
+        hda1 = self.hda_manager.create(history=history1)
         self.hda_manager.update(hda1, dict(state='ok'))
 
         serialized = self.history_serializer.serialize(history1, keys)


### PR DESCRIPTION
Fixes waiting for history state to become OK if the history contains
only empty collections. This is needed for CWL conformance testing,
but it is also a minor annoyance in tests that time out when dataset discovery in collections fails.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
