### PR TITLE
Fix menu overflow in right panel

### DIFF
--- a/client/src/mvc/list/list-view.js
+++ b/client/src/mvc/list/list-view.js
@@ -298,7 +298,9 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
             }
             var $newMenu = $(
                 `<div class="list-action-menu btn-group dropdown">
-                    <button class="${this.actionButtonClass} btn btn-secondary dropdown-toggle" data-boundary="viewport" data-toggle="dropdown">
+                    <button class="${
+                        this.actionButtonClass
+                    } btn btn-secondary dropdown-toggle" data-boundary="viewport" data-toggle="dropdown">
                         ${_l("For all selected")}...
                     </button>
                     <div class="dropdown-menu" role="menu"/>

--- a/client/src/mvc/list/list-view.js
+++ b/client/src/mvc/list/list-view.js
@@ -297,8 +297,8 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
                 return $menu.empty();
             }
             var $newMenu = $(
-                `<div class="list-action-menu btn-group">
-                    <button class="${this.actionButtonClass} btn btn-secondary dropdown-toggle" data-toggle="dropdown">
+                `<div class="list-action-menu btn-group dropdown">
+                    <button class="${this.actionButtonClass} btn btn-secondary dropdown-toggle" data-boundary="viewport" data-toggle="dropdown">
                         ${_l("For all selected")}...
                     </button>
                     <div class="dropdown-menu" role="menu"/>

--- a/client/src/mvc/list/list-view.js
+++ b/client/src/mvc/list/list-view.js
@@ -301,7 +301,7 @@ var ListPanel = Backbone.View.extend(BASE_MVC.LoggableMixin).extend(
                     <button class="${this.actionButtonClass} btn btn-secondary dropdown-toggle" data-toggle="dropdown">
                         ${_l("For all selected")}...
                     </button>
-                    <div class="dropdown-menu float-right" role="menu"/>
+                    <div class="dropdown-menu" role="menu"/>
                 </div>`
             );
             var $actions = actions.map((action) => {

--- a/client/src/nls/es/locale.js
+++ b/client/src/nls/es/locale.js
@@ -222,7 +222,7 @@ define({
 
     None: "Ninguna",
 
-    "For all selected": "Para todos los seleccionados",
+    "For all selected": "Para los seleccionados",
 
     // ---- history-view-edit
 

--- a/client/src/style/scss/base.scss
+++ b/client/src/style/scss/base.scss
@@ -160,7 +160,7 @@ body {
     @extend .unified-panel;
     right: 0px;
     width: $panel-width;
-    overflow: unset;
+    overflow: unset !important;
 }
 #right > .unified-panel-footer {
     .drag {


### PR DESCRIPTION
This should fix the panel overflow/overlap issue in #12822

![image](https://user-images.githubusercontent.com/155398/141320717-9b90f926-355e-4972-99b4-7c67c941a656.png)

I tried to trim up the button text, too, per the suggestion in that thread but will have to tinker here.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
