### PR TITLE
Modify logic in history_contents/near to accommodate scroller

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -502,7 +502,7 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         - total matches:      total matches-up + total matches-down + 1 (+1 for hid == {hid})
         - displayed matches-up:   hid <= {hid} (hid == {hid} is included)
         - displayed matches-down: hid > {hid}
-        - displayed matches:      displayed matches-up + displayed matches-down 
+        - displayed matches:      displayed matches-up + displayed matches-down
 
         b) {limit} history items:
         - if direction == before: hid <= {hid}

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -494,11 +494,24 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
     @expose_api_raw_anonymous
     def contents_near(self, trans, history_id, direction, hid, limit, **kwd):
         """
-        Supports scroller functionality.
-        Return {limit} history items "near" {hid}, so that |before| <= limit // 2, |after| <= limit // 2 + 1.
-        Additional counts provided in the HTTP headers.
+        Returns the following data:
 
-        GET /api/histories/{history_id}/contents/near/{hid}/{limit}
+        a) item counts:
+        - total matches-up:   hid < {hid}
+        - total matches-down: hid > {hid}
+        - total matches:      total matches-up + total matches-down + 1 (+1 for hid == {hid})
+        - displayed matches-up:   hid <= {hid} (hid == {hid} is included)
+        - displayed matches-down: hid > {hid}
+        - displayed matches:      displayed matches-up + displayed matches-down 
+
+        b) {limit} history items:
+        - if direction == before: hid <= {hid}
+        - if direction == after:  hid > {hid}
+        - if direction == near:   "near" {hid}, so that |before| <= limit // 2, |after| <= limit // 2 + 1.
+
+        Intended purpose: supports scroller functionality.
+
+        GET /api/histories/{history_id}/contents/{direction:near|before|after}/{hid}/{limit}
         """
         serialization_params = parse_serialization_params(default_view='betawebclient', **kwd)
 

--- a/lib/galaxy/webapps/galaxy/api/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/api/history_contents.py
@@ -37,7 +37,6 @@ from galaxy.webapps.base.controller import (
 from galaxy.webapps.galaxy.api.common import parse_serialization_params
 from galaxy.webapps.galaxy.services.history_contents import (
     CreateHistoryContentPayload,
-    DirectionOptions,
     HistoriesContentsService,
     HistoryContentsFilterList,
     HistoryContentsFilterQueryParams,
@@ -493,36 +492,14 @@ class HistoryContentsController(BaseGalaxyAPIController, UsesLibraryMixinItems, 
         return self.service.archive(trans, history_id, filter_parameters, filename, dry_run)
 
     @expose_api_raw_anonymous
-    def contents_near(self, trans, history_id, hid, limit, **kwd):
+    def contents_near(self, trans, history_id, direction, hid, limit, **kwd):
         """
+        Supports scroller functionality.
         Return {limit} history items "near" {hid}, so that |before| <= limit // 2, |after| <= limit // 2 + 1.
         Additional counts provided in the HTTP headers.
 
         GET /api/histories/{history_id}/contents/near/{hid}/{limit}
         """
-        return self._handle_direction(trans, history_id, DirectionOptions.near, hid, limit, **kwd)
-
-    @expose_api_raw_anonymous
-    def contents_after(self, trans, history_id, hid, limit, **kwd):
-        """
-        Return {limit} history items with hid > {hid}.
-        Additional counts provided in the HTTP headers.
-
-        GET /api/histories/{history_id}/contents/after/{hid}/{limit}
-        """
-        return self._handle_direction(trans, history_id, DirectionOptions.after, hid, limit, **kwd)
-
-    @expose_api_raw_anonymous
-    def contents_before(self, trans, history_id, hid, limit, **kwd):
-        """
-        Return {limit} history items with hid < {hid}.
-        Additional counts provided in the HTTP headers.
-
-        GET /api/histories/{history_id}/contents/before/{hid}/{limit}
-        """
-        return self._handle_direction(trans, history_id, DirectionOptions.before, hid, limit, **kwd)
-
-    def _handle_direction(self, trans, history_id, direction, hid, limit, **kwd):
         serialization_params = parse_serialization_params(default_view='betawebclient', **kwd)
 
         since_str = kwd.pop('since', None)

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -313,16 +313,8 @@ def populate_api_routes(webapp, app):
                           controller="datasets",
                           action="get_metadata_file",
                           conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/near/{hid}/{limit}",
+    webapp.mapper.connect("/api/histories/{history_id}/contents/{direction:near|before|after}/{hid}/{limit}",
                           action="contents_near",
-                          controller='history_contents',
-                          conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/after/{hid}/{limit}",
-                          action="contents_after",
-                          controller='history_contents',
-                          conditions=dict(method=["GET"]))
-    webapp.mapper.connect("/api/histories/{history_id}/contents/before/{hid}/{limit}",
-                          action="contents_before",
                           controller='history_contents',
                           conditions=dict(method=["GET"]))
     webapp.mapper.resource('user',

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -739,13 +739,15 @@ class HistoriesContentsService(ServiceBase):
             matches = self._get_matches(history, filter_params, _hid_params, order_by_asc, limit, serialization_params)
             expanded = self._expand_contents(trans, matches, serialization_params)
             expanded.reverse()
-            item_counts = self._set_item_counts(matches_up=len(matches), total_matches_up=up_total_count, total_matches_down=down_total_count)
+            item_counts = self._set_item_counts(
+                matches_up=len(matches), total_matches_up=up_total_count, total_matches_down=down_total_count)
 
         elif direction == DirectionOptions.before:  # seek down: contents <= hid (older)
             _hid_params = self._hid_less_than(hid)
             matches = self._get_matches(history, filter_params, _hid_params, order_by_dsc, limit, serialization_params)
             expanded = self._expand_contents(trans, matches, serialization_params)
-            item_counts = self._set_item_counts(matches_down=len(matches), total_matches_up=up_total_count, total_matches_down=down_total_count)
+            item_counts = self._set_item_counts(
+                matches_down=len(matches), total_matches_up=up_total_count, total_matches_down=down_total_count)
 
         elif direction == DirectionOptions.near:  # seek up, down; then reverse up, and combine
             up_limit, down_limit = self._get_limits(limit)
@@ -760,7 +762,9 @@ class HistoriesContentsService(ServiceBase):
             down_expanded = self._expand_contents(trans, down_matches, serialization_params)
 
             expanded = up_expanded + down_expanded
-            item_counts = self._set_item_counts(matches_up=len(up_matches), matches_down=len(down_matches), total_matches_up=up_total_count, total_matches_down=down_total_count)
+            item_counts = self._set_item_counts(
+                matches_up=len(up_matches), matches_down=len(down_matches), total_matches_up=up_total_count,
+                total_matches_down=down_total_count)
 
         trans.response.headers['matches'] = item_counts['matches']
         trans.response.headers['matches_up'] = item_counts['matches_up']

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -788,7 +788,7 @@ class HistoriesContentsService(ServiceBase):
         counts['matches'] = matches_up + matches_down
         counts['matches_up'] = matches_up
         counts['matches_down'] = matches_down
-        counts['total_matches'] = total_matches_up + total_matches_down
+        counts['total_matches'] = total_matches_up + total_matches_down + 1  # + 1 for hid == {hid}
         counts['total_matches_up'] = total_matches_up
         counts['total_matches_down'] = total_matches_down
         return counts

--- a/test/unit/webapps/services/test_history_contents.py
+++ b/test/unit/webapps/services/test_history_contents.py
@@ -9,35 +9,45 @@ def mock_init(monkeypatch):
 
 
 class TestSetItemCounts:
+    """
+    up:         number of displayed items with hid > {hid}
+    down:       number of displayed items with hid < {hid}
+    total_up:   total number of items with hid > {hid}
+    total_down: total number of items with hid < {hid}
+    """
 
     def test_set_item_counts_before(self, mock_init):
         service = HistoriesContentsService()  # type: ignore
         down = 10
+        total_up = 90
         total_down = 100
-        counts = service._set_item_counts(matches_down=down, total_matches_down=total_down)
-        self._verify_counts(counts, down=down, total_down=total_down)
+        counts = service._set_item_counts(matches_down=down, total_matches_up=total_up, total_matches_down=total_down)
+        self._verify_counts(counts, down=down, total_up=total_up, total_down=total_down)
 
     def test_set_item_counts_after(self, mock_init):
         service = HistoriesContentsService()  # type: ignore
-        up = 10
-        total_up = 100
-        counts = service._set_item_counts(matches_up=up, total_matches_up=total_up)
-        self._verify_counts(counts, up=up, total_up=total_up)
+        up = 9
+        total_up = 90
+        total_down = 100
+        counts = service._set_item_counts(matches_up=up, total_matches_up=total_up, total_matches_down=total_down)
+        self._verify_counts(counts, up=up, total_up=total_up, total_down=total_down)
 
     def test_set_item_counts_near(self, mock_init):
         service = HistoriesContentsService()  # type: ignore
-        up = 10
-        total_up = 100
-        down = 5
-        total_down = 50
-        counts = service._set_item_counts(matches_up=up, total_matches_up=total_up,
-            matches_down=down, total_matches_down=total_down)
-        self._verify_counts(counts, up=up, total_up=total_up, down=down, total_down=total_down)
+        up = 9
+        down = 10
+        total_up = 90
+        total_down = 100
+        counts = service._set_item_counts(matches_up=up, matches_down=down, total_matches_up=total_up,
+            total_matches_down=total_down)
+        self._verify_counts(counts, up=up, down=down, total_up=total_up, total_down=total_down)
 
     def _verify_counts(self, counts, up=0, total_up=0, down=0, total_down=0):
+        # counts of displayed items
         assert counts['matches'] == up + down
         assert counts['matches_up'] == up
         assert counts['matches_down'] == down
+        # total counts of matching items
         assert counts['total_matches'] == total_up + total_down
         assert counts['total_matches_up'] == total_up
         assert counts['total_matches_down'] == total_down

--- a/test/unit/webapps/services/test_history_contents.py
+++ b/test/unit/webapps/services/test_history_contents.py
@@ -48,6 +48,6 @@ class TestSetItemCounts:
         assert counts['matches_up'] == up
         assert counts['matches_down'] == down
         # total counts of matching items
-        assert counts['total_matches'] == total_up + total_down
+        assert counts['total_matches'] == total_up + total_down + 1
         assert counts['total_matches_up'] == total_up
         assert counts['total_matches_down'] == total_down


### PR DESCRIPTION
To support the scroller, the endpoint needs to fetch total counts of items above AND below the provided `hid` *regardless* of direction.

A few notes:
- The primary change is that total counts are calculated in all cases; this led to some minor refactoring.
- The after/before/near endpoints have been combined following [this approach](https://github.com/galaxyproject/galaxy/pull/12892#issuecomment-966957702) (thank you @davelopez).
- I've updated the endpoint description to clarify its behavior, noting its primary purpose as scroller support (to prevent it from being mistaken for a simple one-query before/after kind of thing).

For more context, see #12892.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  see #12892.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
