### PR TITLE
Fix linter for select inputs

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -137,15 +137,17 @@ def lint_inputs(tool_xml, lint_ctx):
             if len(set([option.attrib.get("value") for option in select_options])) != len(select_options):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value")
 
+            multiple = string_as_bool(param_attrib.get("multiple", "false"))
+            optional = string_as_bool(param_attrib.get("optional", param_attrib.get("multiple", "false")))
             if param_attrib.get("display") == "checkboxes":
-                if not string_as_bool(param_attrib.get("multiple", "false")):
+                if not multiple:
                     lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute')
-                if not string_as_bool(param_attrib.get("optional", "false")):
+                if not optional:
                     lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute')
             if param_attrib.get("display") == "radio":
-                if string_as_bool(param_attrib.get("multiple", "false")):
+                if multiple:
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with multiple="true"')
-                if string_as_bool(param_attrib.get("optional", "false")):
+                if optional:
                     lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with optional="true"')
         # TODO: Validate type, much more...
 

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -138,7 +138,7 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value")
 
             multiple = string_as_bool(param_attrib.get("multiple", "false"))
-            optional = string_as_bool(param_attrib.get("optional", param_attrib.get("multiple", "false")))
+            optional = string_as_bool(param_attrib.get("optional", multiple))
             if param_attrib.get("display") == "checkboxes":
                 if not multiple:
                     lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute')

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -68,15 +68,18 @@ NO_WHEN_IN_CONDITIONAL_XML = """
 """
 
 RADIO_SELECT_INCOMPATIBILITIES = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <inputs>
         <param name="radio_select" type="select" display="radio" optional="true" multiple="true">
             <option value="1">1</option>
             <option value="2">2</option>
         </param>
-        <param name="radio_checkboxes" type="select" display="checkboxes" optional="false" multiple="false">
+        <param name="checkboxes_select" type="select" display="checkboxes" optional="false" multiple="false">
+            <option value="1">1</option>
+            <option value="2">2</option>
+        </param>
+        <!-- this must not raise any warning/error since multiple=true implies true as default for optional -->
+        <param name="checkboxes_select_correct" type="select" display="checkboxes" multiple="true">
             <option value="1">1</option>
             <option value="2">2</option>
         </param>
@@ -254,8 +257,8 @@ TESTS = [
         lambda x:
             'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages
             and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages
-            and 'Select [radio_checkboxes] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute' in x.error_messages
-            and 'Select [radio_checkboxes] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute' in x.error_messages
+            and 'Select [checkboxes_select] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute' in x.error_messages
+            and 'Select [checkboxes_select] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute' in x.error_messages
             and len(x.warn_messages) == 0 and len(x.error_messages) == 4
     ),
     (


### PR DESCRIPTION
from the docs: `select parameters with multiple="true" are optional by default`

xref https://github.com/galaxyproject/tools-iuc/pull/4164#issuecomment-967600351

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
