### PR TITLE
Lint for option without text or value

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -74,6 +74,7 @@ def lint_inputs(tool_xml, lint_ctx):
             options = param.findall("./options")
             filters = param.findall("./options/filter")
             select_options = param.findall('./option')
+            select_options_text = [option.text.strip() if option.text is not None else option.attrib.get("value", "").capitalize() for option in select_options]
 
             if dynamic_options is not None:
                 lint_ctx.warn(f"Select parameter [{param_name}] uses deprecated 'dynamic_options' attribute.")
@@ -131,7 +132,9 @@ def lint_inputs(tool_xml, lint_ctx):
             # lint statically defined options
             if any(['value' not in option.attrib for option in select_options]):
                 lint_ctx.error(f"Select parameter [{param_name}] has option without value")
-            if len({option.text.strip() for option in select_options if option.text is not None}) != len(select_options):
+            if any([option.text is None for option in select_options]):
+                lint_ctx.warn(f"Select parameter [{param_name}] has option without text")
+            if len(set(select_options_text)) != len(select_options_text):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same text content")
             if len({option.attrib.get("value") for option in select_options}) != len(select_options):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value")

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -85,9 +85,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 """
 
 SELECT_DUPLICATED_OPTIONS = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <inputs>
         <param name="select" type="select" optional="true" multiple="true">
             <option value="v">x</option>
@@ -114,9 +112,7 @@ SELECT_DEPRECATIONS = """
 """
 
 SELECT_OPTION_DEFINITIONS = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <inputs>
         <param name="select_noopt" type="select"/>
         <param name="select_noopts" type="select">
@@ -129,6 +125,10 @@ SELECT_OPTION_DEFINITIONS = """
         </param>
         <param name="select_fd_fdt" type="select">
             <options from_dataset="xyz" from_data_table="xyz"/>
+        </param>
+        <param name="select_noval_notext" type="select">
+            <option>option wo value</option>
+            <option value="value"/>
         </param>
     </inputs>
 </tool>
@@ -283,7 +283,9 @@ TESTS = [
             and "Select parameter [select_fd_op] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute." in x.error_messages
             and "Select parameter [select_fd_op] contains multiple options elements" in x.error_messages
             and "Select parameter [select_fd_fdt] options uses 'from_dataset' and 'from_data_table' attribute." in x.error_messages
-            and len(x.warn_messages) == 0 and len(x.error_messages) == 5
+            and "Select parameter [select_noval_notext] has option without value" in x.error_messages
+            and "Select parameter [select_noval_notext] has option without text" in x.warn_messages
+            and len(x.warn_messages) == 1 and len(x.error_messages) == 6
     ),
     (
         VALIDATOR_INCOMPATIBILITIES, inputs.lint_inputs,


### PR DESCRIPTION
add a linter warning if text is missing from option

fixes https://github.com/galaxyproject/galaxy/issues/12865

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
