### PR TITLE
[21.05] Update docker autobuilds to use correct repos

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -21,8 +21,10 @@ jobs:
       - name: Set branch name
         id: branch
         run: echo "::set-output name=name::$(BRANCH_NAME=${GITHUB_REF##*/}; echo ${BRANCH_NAME/release_/})"
-      - run: docker build . --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} -t galaxy/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
-      - run: docker tag galaxy/galaxy-min:${{ steps.branch.outputs.name }} quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }}
+      - name: Build container image
+        run: docker build . --build-arg GIT_COMMIT=$(git rev-parse HEAD) --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') --build-arg IMAGE_TAG=${{ steps.branch.outputs.name }} -t galaxyproject/galaxy-min:${{ steps.branch.outputs.name }} -t quay.io/galaxyproject/galaxy-min:${{ steps.branch.outputs.name }} -f .k8s_ci.Dockerfile
+      - name: Create auto-expiring one for per-commit auto repository
+        run: echo "FROM galaxyproject/galaxy-min:${{ steps.branch.outputs.name }}" | docker build --label "quay.expires-after"="90d" -t "quay.io/galaxyproject/galaxy-k8s-auto:${{ steps.commit.outputs.sha_short }}" -
       - name: Login to quay.io
         uses: actions-hub/docker/login@master
         env:
@@ -32,4 +34,17 @@ jobs:
       - name: Push to quay.io with branch name
         uses: actions-hub/docker@master
         with:
-          args: push quay.io/galaxy-min/galaxy:${{ steps.branch.outputs.name }}
+          args: push quay.io/galaxyproject/galaxy-min:${{ steps.branch.outputs.name }}
+      - name: Push to quay.io with commit hash
+        uses: actions-hub/docker@master
+        with:
+          args: push quay.io/galaxyproject/galaxy-k8s-auto:${{ steps.commit.outputs.sha_short }}
+      - name: Login to DockerHub
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Push to DockerHub with branch name
+        uses: actions-hub/docker@master
+        with:
+          args: push galaxyproject/galaxy-min:${{ steps.branch.outputs.name }}


### PR DESCRIPTION
This PR fixes the repository names and makes them uniform for autobuilds created in: https://github.com/galaxyproject/galaxy/pull/12837

The repos are as follows:
1. galaxyproject/galaxy-min - autobuilt images tagged by branch name
2. quay.io/galaxyproject/galaxy-min - corresponding mirror on quay.io
3. quay.io/galaxyproject/galaxy-k8s-auto  - autobuilt images tagged by commit sha for chatops

A bot user has been created in the "galaxyproject" account for these autobuilds.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
