### PR TITLE
Fix OpenAPI docs not rendering

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -8,7 +8,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -2042,7 +2041,8 @@ class RoleListModel(BaseModel):
 
 # The tuple should probably be another proper model instead?
 # Keeping it as a Tuple for now for backward compatibility
-RoleNameIdTuple = Tuple[str, EncodedDatabaseIdField]
+# TODO: Use Tuple again when https://github.com/tiangolo/fastapi/issues/3665 is fixed upstream
+RoleNameIdTuple = List[str]  # Tuple[str, EncodedDatabaseIdField]
 
 # Group_Roles -----------------------------------------------------------------
 


### PR DESCRIPTION
There is a regression bug in FastAPI/Pydantic (see https://github.com/tiangolo/fastapi/issues/3665) that prevents the OpenAPI interactive documentation to render when we have models using `Tuple`.


![Screenshot from 2021-11-15 14-56-11](https://user-images.githubusercontent.com/46503462/141807450-1b117312-4e12-453e-a2a9-d701dee9d0de.png)

```
uvicorn.error ERROR 2021-11-15 14:57:31,928 [pN:main,p:38696,tN:MainThread] Exception in ASGI application
Traceback (most recent call last):
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/uvicorn/protocols/http/h11_impl.py", line 373, in run_asgi
    result = await app(self.scope, self.receive, self.send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/uvicorn/middleware/proxy_headers.py", line 75, in __call__
    return await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/fastapi/applications.py", line 208, in __call__
    await super().__call__(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/errors.py", line 181, in __call__
    raise exc from None
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/errors.py", line 159, in __call__
    await self.app(scope, receive, _send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette_context/middleware/raw_middleware.py", line 96, in __call__
    await self.app(scope, receive, send_wrapper)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/base.py", line 25, in __call__
    response = await self.dispatch_func(request, self.call_next)
  File "/home/davelopez/dev/galaxy/lib/galaxy/webapps/galaxy/fast_app.py", line 92, in add_send_file_header
    response = await call_next(request)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/base.py", line 45, in call_next
    task.result()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/base.py", line 25, in __call__
    response = await self.dispatch_func(request, self.call_next)
  File "/home/davelopez/dev/galaxy/lib/galaxy/webapps/galaxy/fast_app.py", line 77, in add_x_frame_options
    response = await call_next(request)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/base.py", line 45, in call_next
    task.result()
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/middleware/base.py", line 38, in coro
    await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/exceptions.py", line 82, in __call__
    raise exc from None
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/exceptions.py", line 71, in __call__
    await self.app(scope, receive, sender)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py", line 580, in __call__
    await route.handle(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py", line 241, in handle
    await self.app(scope, receive, send)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/starlette/routing.py", line 52, in app
    response = await func(request)
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/fastapi/applications.py", line 161, in openapi
    return JSONResponse(self.openapi())
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/fastapi/applications.py", line 136, in openapi
    self.openapi_schema = get_openapi(
  File "/home/davelopez/dev/galaxy/.venv/lib/python3.9/site-packages/fastapi/openapi/utils.py", line 410, in get_openapi
    return jsonable_encoder(OpenAPI(**output), by_alias=True, exclude_none=True)  # type: ignore
  File "pydantic/main.py", line 406, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 9 validation errors for OpenAPI
components -> schemas -> LibraryCurrentPermissions -> properties -> access_library_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryCurrentPermissions -> properties -> modify_library_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryCurrentPermissions -> properties -> manage_library_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryCurrentPermissions -> properties -> add_library_item_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryCurrentPermissions -> $ref
  field required (type=value_error.missing)
components -> schemas -> LibraryFolderCurrentPermissions -> properties -> modify_folder_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryFolderCurrentPermissions -> properties -> manage_folder_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryFolderCurrentPermissions -> properties -> add_library_item_role_list -> items -> items
  value is not a valid dict (type=type_error.dict)
components -> schemas -> LibraryFolderCurrentPermissions -> $ref
  field required (type=value_error.missing)
```


Since Tuple is currently used just in one place, we can temporarily replace it with a simple List, we will lose a bit of validation but still is not worth reverting back to a previous version of FastAPI because of this.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
