### PR TITLE
FastAPI: migrate datasets API

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -107,7 +107,7 @@ def get_filter_query_params(
 
 
 def get_update_permission_payload(payload: Dict[str, Any]) -> UpdateDatasetPermissionsPayload:
-    """Coverts the generic payload dictionary into a UpdateDatasetPermissionsPayload model with custom parsing.
+    """Converts the generic payload dictionary into a UpdateDatasetPermissionsPayload model with custom parsing.
     This is an attempt on supporting multiple aliases for the permissions params."""
     # There are several allowed names for the same role list parameter, i.e.: `access`, `access_ids`, `access_ids[]`
     # The `access_ids[]` name is not pydantic friendly, so this will be modelled as an alias but we can only set one alias

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -1,9 +1,17 @@
 """This module contains utility functions shared across the api package."""
-from typing import Any, Dict, Optional
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 
 from fastapi import Query
 
-from galaxy.schema import SerializationParams
+from galaxy.schema import (
+    FilterQueryParams,
+    SerializationParams,
+)
 from galaxy.schema.schema import UpdateDatasetPermissionsPayload
 
 SerializationViewQueryParam: Optional[str] = Query(
@@ -43,6 +51,55 @@ def query_serialization_params(
     default_view: Optional[str] = SerializationDefaultViewQueryParam,
 ) -> SerializationParams:
     return parse_serialization_params(view=view, keys=keys, default_view=default_view)
+
+
+def get_filter_query_params(
+    q: Optional[List[str]] = Query(
+        default=None,
+        title="Filter Query",
+        description="Generally a property name to filter by followed by an (often optional) hyphen and operator string.",
+        example="create_time-gt",
+    ),
+    qv: Optional[List[str]] = Query(
+        default=None,
+        title="Filter Value",
+        description="The value to filter by.",
+        example="2015-01-29",
+    ),
+    offset: Optional[int] = Query(
+        default=0,
+        ge=0,
+        title="Offset",
+        description="Starts at the beginning skip the first ( offset - 1 ) items and begin returning at the Nth item",
+    ),
+    limit: Optional[int] = Query(
+        default=None,
+        ge=1,
+        title="Limit",
+        description="The maximum number of items to return.",
+    ),
+    order: Optional[str] = Query(
+        default=None,
+        title="Order",
+        description=(
+            "String containing one of the valid ordering attributes followed (optionally) "
+            "by '-asc' or '-dsc' for ascending and descending order respectively. "
+            "Orders can be stacked as a comma-separated list of values."
+        ),
+        example="name-dsc,create_time",
+    ),
+) -> FilterQueryParams:
+    """
+    This function is meant to be used as a Dependency.
+    See https://fastapi.tiangolo.com/tutorial/dependencies/#first-steps
+    """
+    return FilterQueryParams(
+        q=q,
+        qv=qv,
+        offset=offset,
+        limit=limit,
+        order=order,
+    )
 
 
 def get_update_permission_payload(payload: Dict[str, Any]) -> UpdateDatasetPermissionsPayload:

--- a/lib/galaxy/webapps/galaxy/api/common.py
+++ b/lib/galaxy/webapps/galaxy/api/common.py
@@ -4,9 +4,13 @@ from typing import (
     Dict,
     List,
     Optional,
+    Set,
 )
 
-from fastapi import Query
+from fastapi import (
+    Query,
+    Request,
+)
 
 from galaxy.schema import (
     FilterQueryParams,
@@ -113,3 +117,16 @@ def get_update_permission_payload(payload: Dict[str, Any]) -> UpdateDatasetPermi
     payload["modify_ids"] = payload.get("modify_ids[]") or payload.get("modify")
     update_payload = UpdateDatasetPermissionsPayload(**payload)
     return update_payload
+
+
+def get_query_parameters_from_request_excluding(request: Request, exclude: Set[str]) -> dict:
+    """Gets all the request query parameters excluding the given parameters names in `exclude` set.
+
+    This is useful when an endpoint uses arbitrary or dynamic query parameters that
+    cannot be anticipated or documented beforehand. The `exclude` set can be used to avoid
+    including those parameters that are already handled by the endpoint.
+    """
+    extra_params = request.query_params._dict
+    for param_name in exclude:
+        extra_params.pop(param_name, None)
+    return extra_params

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -208,6 +208,7 @@ class FastAPIDatasets:
 
     @router.get(
         '/api/histories/{history_id}/contents/{history_content_id}/display',
+        name="history_contents_display",
         summary='Displays dataset (preview) content.',
         tags=["histories"],
         response_class=StreamingResponse,
@@ -220,7 +221,10 @@ class FastAPIDatasets:
         history_content_id: EncodedDatabaseIdField = DatasetIDPathParam,
         preview: bool = Query(
             default=False,
-            description="TODO",
+            description=(
+                "Whether to get preview contents to be directly displayed on the web. "
+                "If preview is False (default) the contents will be downloaded instead."
+            ),
         ),
         filename: Optional[str] = Query(
             default=None,
@@ -228,7 +232,10 @@ class FastAPIDatasets:
         ),
         to_ext: Optional[str] = Query(
             default=None,
-            description="TODO",
+            description=(
+                "The file extension when downloading the display data. Use the value `data` to "
+                "let the server infer it from the data type."
+            )
         ),
         raw: bool = Query(
             default=False,
@@ -241,8 +248,8 @@ class FastAPIDatasets:
     ):
         """Streams the preview contents of a dataset to be displayed in a browser."""
         extra_params = get_query_parameters_from_request_excluding(request, {"preview", "filename", "to_ext", "raw"})
-        display_content = self.service.display(trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params)
-        return StreamingResponse(display_content)
+        display_data, headers = self.service.display(trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params)
+        return StreamingResponse(display_data, headers=headers)
 
     @router.get(
         '/api/histories/{history_id}/contents/{history_content_id}/metadata_file',

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -7,8 +7,12 @@ from galaxy import (
     util,
     web
 )
-from galaxy.schema import FilterQueryParams
-from galaxy.webapps.base.controller import UsesVisualizationMixin
+from galaxy.schema import (
+    FilterQueryParams,
+)
+from galaxy.schema.schema import (
+    DatasetSourceType,
+)
 from galaxy.webapps.galaxy.api.common import (
     get_update_permission_payload,
     parse_serialization_params,
@@ -81,8 +85,10 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         """
         serialization_params = parse_serialization_params(**kwd)
         filter_parameters = FilterQueryParams(**kwd)
+        filter_parameters.limit = filter_parameters.limit or limit
+        filter_parameters.offset = filter_parameters.offset or offset
         return self.service.index(
-            trans, limit, offset, history_id, serialization_params, filter_parameters
+            trans, history_id, serialization_params, filter_parameters
         )
 
     @web.expose_api_anonymous_and_sessionless
@@ -131,7 +137,7 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         :rtype:     dict
         :returns:   dictionary containing new permissions
         """
-        hda_ldda = kwd.pop('hda_ldda', 'hda')
+        hda_ldda = kwd.pop('hda_ldda', DatasetSourceType.hda)
         if payload:
             kwd.update(payload)
         update_payload = get_update_permission_payload(kwd)
@@ -173,7 +179,10 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         """
         GET /api/histories/{history_id}/contents/{history_content_id}/metadata_file
         """
-        metadata_file, headers = self.service.get_metadata_file(trans, history_content_id, metadata_file)
+        # TODO: remove open_file parameter when deleting this legacy endpoint
+        metadata_file, headers = self.service.get_metadata_file(
+            trans, history_content_id, metadata_file, open_file=True
+        )
         trans.response.headers.update(headers)
         return metadata_file
 

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -17,7 +17,10 @@ from fastapi import (
     Query,
     Request,
 )
-from starlette.responses import FileResponse
+from starlette.responses import (
+    FileResponse,
+    StreamingResponse,
+)
 
 from galaxy import (
     util,
@@ -181,6 +184,7 @@ class FastAPIDatasets:
         '/api/histories/{history_id}/contents/{history_content_id}/display',
         summary='Displays history content (dataset).',
         tags=["histories"],
+        response_class=StreamingResponse,
     )
     def display(
         self,
@@ -210,7 +214,8 @@ class FastAPIDatasets:
         ),
     ):
         extra_params = get_query_parameters_from_request_excluding(request, {"preview", "filename", "to_ext", "raw"})
-        return self.service.display(trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params)
+        display_content = self.service.display(trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params)
+        return StreamingResponse(display_content)
 
     @router.get(
         '/api/histories/{history_id}/contents/{history_content_id}/metadata_file',

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -36,6 +36,7 @@ from galaxy.schema.schema import (
 )
 from galaxy.webapps.galaxy.api.common import (
     get_filter_query_params,
+    get_query_parameters_from_request_excluding,
     get_update_permission_payload,
     parse_serialization_params,
     query_serialization_params,
@@ -208,10 +209,7 @@ class FastAPIDatasets:
             ),
         ),
     ):
-        exclude_params = set(["preview", "filename", "to_ext", "raw"])
-        extra_params = request.query_params._dict
-        for p in exclude_params:
-            extra_params.pop(p, None)
+        extra_params = get_query_parameters_from_request_excluding(request, {"preview", "filename", "to_ext", "raw"})
         return self.service.display(trans, history_content_id, history_id, preview, filename, to_ext, raw, **extra_params)
 
     @router.get(

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -398,10 +398,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                     file_path = hda.file_name
                 rval = open(file_path, 'rb')
             else:
-                display_kwd = kwd.copy()
-                if 'key' in display_kwd:
-                    del display_kwd["key"]
-                rval, headers = hda.datatype.display_data(trans, hda, preview, filename, to_ext, **display_kwd)
+                rval, headers = hda.datatype.display_data(trans, hda, preview, filename, to_ext, **kwd)
         except galaxy_exceptions.MessageException:
             raise
         except Exception as e:

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -421,7 +421,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         trans: ProvidesHistoryContext,
         dataset_id: EncodedDatabaseIdField,
     ) -> DatasetTextContentDetails:
-        """ Returns item content as Text. """
+        """ Returns dataset content as Text. """
         user = self.get_authenticated_user(trans)
         decoded_id = self.decode_id(dataset_id)
         hda = self.hda_manager.get_accessible(decoded_id, user)

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -436,6 +436,9 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
     ):
         """
         Gets the associated metadata file.
+
+        The `open_file` parameter determines if we return the path of the file or the opened file handle.
+        TODO: Remove the `open_file` parameter when removing the associated legacy endpoint.
         """
         decoded_content_id = self.decode_id(history_content_id)
         hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)


### PR DESCRIPTION
This builds on top of https://github.com/galaxyproject/galaxy/pull/12847 and is part of #10889

This PR includes the new FastAPIDatasets controller that replaces the old legacy routes for galaxy/api/datasets.py and some additional refactorings, documentation, and types annotations.

For more details see each commit.

## Comments
- The `show` endpoint can take a `data_type` query parameter that can **wildly** change the behavior of this operation, accepting and returning completely different parameters and responses. This makes this endpoint hard to document and it is clearly not SRP friendly. For backward compatibility reasons it can be left like that, but probably, in the future, would be interesting to extract a different endpoint with each of those `data_type` (in the route path) so we can document each route accordingly and mark this endpoint as deprecated.
- The `converted` action was also doing completely different things depending on the `ext` path parameter so I decided to extract it into two different operations and routes, so they could be better documented.
- This new controller also contributes some *history contents* routes (see screenshot below). Although they have the `histories` tag, since they are under the same parent `datasets` tag, they will display in both sections.

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Go to the interactive API documentation at http://127.0.0.1:8080/api/docs#/datasets
  ![Screenshot from 2021-11-26 14-48-55](https://user-images.githubusercontent.com/46503462/143590735-7ad5bd72-3ea3-435f-8b3e-27ee5f7ea29c.png)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
