### PR TITLE
[21.05] Fix output step name in docker image build

### DIFF
--- a/.github/workflows/build_container_image.yaml
+++ b/.github/workflows/build_container_image.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       # https://stackoverflow.com/questions/59810838/how-to-get-the-short-sha-for-the-github-workflow
       - name: Set outputs
-        id: vars
+        id: commit
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Set branch name
         id: branch


### PR DESCRIPTION
An incorrect step id is causing another build failure.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
