### PR TITLE
Fix default value of `runners` in `job_conf_dict`

### DIFF
--- a/lib/galaxy/dependencies/__init__.py
+++ b/lib/galaxy/dependencies/__init__.py
@@ -43,9 +43,8 @@ class ConditionalDependencies:
     def parse_configs(self):
 
         def load_job_config_dict(job_conf_dict):
-            runners = job_conf_dict.get("runners", [])
-            for runner_id in runners:
-                runner = runners[runner_id]
+            runners = job_conf_dict.get("runners", {})
+            for runner in runners.values():
                 if "load" in runner:
                     self.job_runners.append(runner.get("load"))
                 if "rules_module" in runner:


### PR DESCRIPTION
Also optimise dict iteration in for loop.

Follow-up on https://github.com/galaxyproject/galaxy/pull/12893 , ping @cat-bro .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
