### PR TITLE
FastAPI: Add response wrapper for `SessionRequestContext`

### DIFF
--- a/lib/galaxy/work/context.py
+++ b/lib/galaxy/work/context.py
@@ -71,21 +71,43 @@ class GalaxyAbstractRequest:
         """The host address."""
 
 
+class GalaxyAbstractResponse:
+    """Abstract interface to provide access to some response utilities."""
+
+    @abc.abstractproperty
+    def headers(self) -> dict:
+        """The response headers."""
+
+    def set_content_type(self, content_type: str):
+        """
+        Sets the Content-Type header
+        """
+        self.headers["content-type"] = content_type
+
+    def get_content_type(self):
+        return self.headers.get("content-type", None)
+
+
 class SessionRequestContext(WorkRequestContext):
     """Like WorkRequestContext, but provides access to galaxy session and request."""
 
     def __init__(self, **kwargs):
         self.galaxy_session = kwargs.pop('galaxy_session', None)
-        self._request: GalaxyAbstractRequest = kwargs.pop("request")
+        self.__request: GalaxyAbstractRequest = kwargs.pop("request")
+        self.__response: GalaxyAbstractResponse = kwargs.pop("response")
         super().__init__(**kwargs)
 
     @property
     def host(self):
-        return self._request.host
+        return self.__request.host
 
     @property
     def request(self) -> GalaxyAbstractRequest:
-        return self._request
+        return self.__request
+
+    @property
+    def response(self) -> GalaxyAbstractResponse:
+        return self.__response
 
     def get_galaxy_session(self):
         return self.galaxy_session

--- a/test/unit/webapps/test_response_wrapper.py
+++ b/test/unit/webapps/test_response_wrapper.py
@@ -29,8 +29,15 @@ async def change_headers(trans=Depends(get_trans)):
 
 
 @app.get("/test/change_content_type")
-async def change_content_type(trans=Depends(get_trans)):
+async def change_content_type(response: Response, trans=Depends(get_trans)):
+    trans.response.__response = response
     trans.response.set_content_type("test-content-type")
+
+
+@app.get("/test/change_content_type_custom_response")
+async def change_content_type_custom_response(trans=Depends(get_trans)):
+    trans.response.set_content_type("test-content-type")
+    return Response(headers=trans.response.headers)
 
 
 def test_change_headers():
@@ -47,3 +54,13 @@ def test_change_content_type():
     assert response.status_code == 200
     assert "content-type" in response.headers
     assert "test-content-type" in response.headers["content-type"]
+    assert response.headers["content-type"] == "test-content-type"
+
+
+def test_change_content_type_custom_response():
+    response = client.get("/test/change_content_type_custom_response")
+
+    assert response.status_code == 200
+    assert "content-type" in response.headers
+    assert "test-content-type" in response.headers["content-type"]
+    assert response.headers["content-type"] == "test-content-type"

--- a/test/unit/webapps/test_response_wrapper.py
+++ b/test/unit/webapps/test_response_wrapper.py
@@ -54,7 +54,11 @@ def test_change_content_type():
     assert response.status_code == 200
     assert "content-type" in response.headers
     assert "test-content-type" in response.headers["content-type"]
-    assert response.headers["content-type"] == "test-content-type"
+    # Since we are not explicitly returning a response in `/test/change_content_type`
+    # the default response will be JSONResponse, hence we will end up with both content types.
+    # If we don't want this behavior we must explicitly return a response
+    # like in `/test/change_content_type_custom_response`.
+    assert response.headers["content-type"] == "application/json, test-content-type"
 
 
 def test_change_content_type_custom_response():

--- a/test/unit/webapps/test_response_wrapper.py
+++ b/test/unit/webapps/test_response_wrapper.py
@@ -1,0 +1,43 @@
+from fastapi.applications import FastAPI
+from fastapi.testclient import TestClient
+
+from galaxy.webapps.galaxy.api import DependsOnTrans  # TODO mock most of the dependencies?
+
+app = FastAPI()
+
+client = TestClient(app)
+
+OK_RESPONSE = {"msg": "OK"}
+
+
+@app.get("/test/change_headers")
+async def change_headers(trans=DependsOnTrans):
+    trans.response.headers["test-header"] = "test-value"
+    return OK_RESPONSE
+
+
+@app.get("/test/change_content_type")
+async def change_content_type(trans=DependsOnTrans):
+    trans.response.set_content_type("test-content-type")
+    return OK_RESPONSE
+
+
+def test_change_headers():
+    response = client.get("/test/change_headers")
+
+    _assert_response_ok(response)
+    assert "test-header" in response.headers
+    assert response.headers["test-header"] == "test-value"
+
+
+def test_change_content_type():
+    response = client.get("/test/change_content_type")
+
+    _assert_response_ok(response)
+    assert "content-type" in response.headers
+    assert response.headers["content-type"] == "test-content-type"
+
+
+def _assert_response_ok(response):
+    assert response.status_code == 200
+    assert response.json() == OK_RESPONSE


### PR DESCRIPTION
Similar to https://github.com/galaxyproject/galaxy/pull/12531 but in this case for the response object.

This is necessary for migrating `/api/histories/{encoded_history_id}/contents/{encoded_content_id}/display` in https://github.com/galaxyproject/galaxy/pull/12924 because deep down the [display_data](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/datatypes/data.py#L371) function, and it's children overrides, use the response object through `trans.response` to set or read the headers depending on multiple conditions.

Ideally, we want to completely avoid using `trans.response` in the datatypes module so I will try to explore removing them in a future PR.

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
