### PR TITLE
Allow workflows to automatically filter inputs by tag

### DIFF
--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -433,19 +433,15 @@ const View = Backbone.View.extend({
                 self._patchValue(item);
                 console.log(item)
                 const current_src = item.src || src;
+                let addOption = false;
                 if (this.model.attributes.tag) {
                     if(item.tags.includes(this.model.attributes.tag)) {
-                        select_options[current_src].push({
-                            hid: item.hid,
-                            keep: item.keep,
-                            label: `${item.hid || "Selected"}: ${item.name}`,
-                            value: item.id,
-                            origin: item.origin,
-                            tags: item.tags,
-                        });
+                        addOption = true
                     };
+                } else {
+                    addOption = true;
                 }
-                else {
+                if (addOption) {
                     select_options[current_src].push({
                     hid: item.hid,
                     keep: item.keep,

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -433,14 +433,7 @@ const View = Backbone.View.extend({
                 self._patchValue(item);
                 console.log(item)
                 const current_src = item.src || src;
-                let addOption = false;
-                if (this.model.attributes.tag) {
-                    if(item.tags.includes(this.model.attributes.tag)) {
-                        addOption = true
-                    };
-                } else {
-                    addOption = true;
-                }
+                const addOption = !this.model.attributes.tag || item.tags.includes(this.model.attributes.tag);
                 if (addOption) {
                     select_options[current_src].push({
                     hid: item.hid,

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -125,6 +125,9 @@ const Configurations = {
 /** View for hda and dce content selector ui elements */
 const View = Backbone.View.extend({
     initialize: function (options) {
+        console.log('Workflow info');
+        console.log(options);
+        console.log(options.tag);
         const self = this;
         this.model =
             (options && options.model) ||
@@ -321,6 +324,9 @@ const View = Backbone.View.extend({
                 icon: c.icon,
                 tooltip: c.tooltip,
             });
+            console.log("Test location");
+            console.log(self.model);
+            console.log(self.model.attributes.tag);
             self.fields.push(
                 new Select.View({
                     optional: self.model.get("optional"),
@@ -425,15 +431,30 @@ const View = Backbone.View.extend({
         _.each(options, (items, src) => {
             _.each(items, (item) => {
                 self._patchValue(item);
+                console.log(item)
                 const current_src = item.src || src;
-                select_options[current_src].push({
+                if (this.model.attributes.tag) {
+                    if(item.tags.includes(this.model.attributes.tag)) {
+                        select_options[current_src].push({
+                            hid: item.hid,
+                            keep: item.keep,
+                            label: `${item.hid || "Selected"}: ${item.name}`,
+                            value: item.id,
+                            origin: item.origin,
+                            tags: item.tags,
+                        });
+                    };
+                }
+                else {
+                    select_options[current_src].push({
                     hid: item.hid,
                     keep: item.keep,
                     label: `${item.hid || "Selected"}: ${item.name}`,
                     value: item.id,
                     origin: item.origin,
                     tags: item.tags,
-                });
+                   });
+                }
                 self.cache[`${item.id}_${current_src}`] = item;
             });
         });

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -125,9 +125,6 @@ const Configurations = {
 /** View for hda and dce content selector ui elements */
 const View = Backbone.View.extend({
     initialize: function (options) {
-        console.log('Workflow info');
-        console.log(options);
-        console.log(options.tag);
         const self = this;
         this.model =
             (options && options.model) ||
@@ -324,9 +321,6 @@ const View = Backbone.View.extend({
                 icon: c.icon,
                 tooltip: c.tooltip,
             });
-            console.log("Test location");
-            console.log(self.model);
-            console.log(self.model.attributes.tag);
             self.fields.push(
                 new Select.View({
                     optional: self.model.get("optional"),
@@ -431,7 +425,6 @@ const View = Backbone.View.extend({
         _.each(options, (items, src) => {
             _.each(items, (item) => {
                 self._patchValue(item);
-                console.log(item)
                 const current_src = item.src || src;
                 if (this.model.attributes.tag) {
                     if(item.tags.includes(this.model.attributes.tag)) {
@@ -443,7 +436,7 @@ const View = Backbone.View.extend({
                             origin: item.origin,
                             tags: item.tags,
                         });
-                    };
+                    }
                 }
                 else {
                     select_options[current_src].push({

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -429,13 +429,13 @@ const View = Backbone.View.extend({
                 const addOption = !this.model.attributes.tag || item.tags.includes(this.model.attributes.tag);
                 if (addOption) {
                     select_options[current_src].push({
-                    hid: item.hid,
-                    keep: item.keep,
-                    label: `${item.hid || "Selected"}: ${item.name}`,
-                    value: item.id,
-                    origin: item.origin,
-                    tags: item.tags,
-                   });
+                        hid: item.hid,
+                        keep: item.keep,
+                        label: `${item.hid || "Selected"}: ${item.name}`,
+                        value: item.id,
+                        origin: item.origin,
+                        tags: item.tags,
+                    });
                 }
                 self.cache[`${item.id}_${current_src}`] = item;
             });

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -1864,11 +1864,13 @@ class DataToolParameter(BaseDataToolParameter):
         if not input_source.get_bool('no_validation', False):
             self.validators.append(validation.MetadataValidator())
         self._parse_formats(trans, input_source)
+        tag = input_source.get("tag")
         self.multiple = input_source.get_bool('multiple', False)
         if not self.multiple and (self.min is not None):
             raise ParameterValueError("cannot specify 'min' property on single data parameter. Set multiple=\"true\" to enable this option", self.name)
         if not self.multiple and (self.max is not None):
             raise ParameterValueError("cannot specify 'max' property on single data parameter. Set multiple=\"true\" to enable this option", self.name)
+        self.tag = tag
         self.is_dynamic = True
         self._parse_options(input_source)
         # Load conversions required for the dataset input
@@ -2047,6 +2049,7 @@ class DataToolParameter(BaseDataToolParameter):
             d['min'] = self.min
             d['max'] = self.max
         d['options'] = {'hda': [], 'hdca': []}
+        d['tag'] = self.tag
 
         # return dictionary without options if context is unavailable
         history = trans.history
@@ -2134,9 +2137,11 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         super().__init__(tool, input_source, trans)
         self._parse_formats(trans, input_source)
         collection_types = input_source.get("collection_type", None)
+        tag = input_source.get("tag")
         if collection_types:
             collection_types = [t.strip() for t in collection_types.split(",")]
         self._collection_types = collection_types
+        self.tag = tag
         self.multiple = False  # Accessed on DataToolParameter a lot, may want in future
         self.is_dynamic = True
         self._parse_options(input_source)  # TODO: Review and test.
@@ -2228,6 +2233,7 @@ class DataCollectionToolParameter(BaseDataToolParameter):
         d['extensions'] = self.extensions
         d['multiple'] = self.multiple
         d['options'] = {'hda': [], 'hdca': [], 'dce': []}
+        d['tag'] = self.tag
 
         # return dictionary without options if context is unavailable
         history = trans.history

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -618,6 +618,7 @@ def format_param(trans, formats):
 class InputModuleState(TypedDict, total=False):
     optional: bool
     format: List[str]
+    tag: str
 
 
 class InputModule(WorkflowModule):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -680,6 +680,12 @@ class InputModule(WorkflowModule):
             formats = None
         if formats:
             rval["format"] = formats
+        if "tag" in inputs:
+            tag = inputs["tag"]
+        else:
+            tag = None
+        rval["tag"] = tag
+        print(rval)
         return rval
 
     def step_state_to_tool_state(self, state):
@@ -725,22 +731,27 @@ class InputDataModule(InputModule):
     def get_runtime_inputs(self, connections=None):
         parameter_def = self._parse_state_into_dict()
         optional = parameter_def["optional"]
+        tag = parameter_def["tag"]
         formats = parameter_def.get("format")
         if not formats:
             formats = self.get_filter_set(connections)
         else:
             formats = ",".join(listify(formats))
-        data_src = dict(name="input", label=self.label, multiple=False, type="data", format=formats, optional=optional)
+        data_src = dict(name="input", label=self.label, multiple=False, type="data", format=formats, tag=tag, optional=optional)
         input_param = DataToolParameter(None, data_src, self.trans)
         return dict(input=input_param)
 
 
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
+        tag = parameter_def["tag"]
         optional = parameter_def["optional"]
+        tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
+        input_tag = TextToolParameter(None, tag_source)
         inputs = {}
         inputs["optional"] = optional_param(optional)
         inputs["format"] = format_param(self.trans, parameter_def.get("format"))
+        inputs["tag"] = input_tag
         return inputs
 
 
@@ -775,8 +786,9 @@ class InputDataCollectionModule(InputModule):
         parameter_def = self._parse_state_into_dict()
         collection_type = parameter_def["collection_type"]
         optional = parameter_def["optional"]
+        tag = parameter_def["tag"]
         formats = parameter_def.get("format")
-        collection_param_source = dict(name="input", label=self.label, type="data_collection", collection_type=collection_type, optional=optional)
+        collection_param_source = dict(name="input", label=self.label, type="data_collection", collection_type=collection_type, tag=tag, optional=optional)
         if formats:
             collection_param_source["format"] = ",".join(listify(formats))
         input_param = DataCollectionToolParameter(None, collection_param_source, self.trans)

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -685,7 +685,6 @@ class InputModule(WorkflowModule):
         else:
             tag = None
         rval["tag"] = tag
-        print(rval)
         return rval
 
     def step_state_to_tool_state(self, state):

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -742,15 +742,14 @@ class InputDataModule(InputModule):
 
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
-        if parameter_def["tag"]:
-            tag = parameter_def["tag"]
-            tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
-            input_tag = TextToolParameter(None, tag_source)
-            inputs["tag"] = input_tag
+        tag = parameter_def["tag"]
+        tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
+        input_tag = TextToolParameter(None, tag_source)
         optional = parameter_def["optional"]
         inputs = {}
         inputs["optional"] = optional_param(optional)
         inputs["format"] = format_param(self.trans, parameter_def.get("format"))
+        inputs["tag"] = input_tag
         return inputs
 
 
@@ -819,11 +818,6 @@ class InputDataCollectionModule(InputModule):
         else:
             collection_type = self.default_collection_type
         state_as_dict["collection_type"] = collection_type
-        if "tag" in inputs:
-            tag = inputs["tag"]
-        else:
-            tag = None
-        state_as_dict["tag"] = tag
         return state_as_dict
 
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -740,7 +740,6 @@ class InputDataModule(InputModule):
         input_param = DataToolParameter(None, data_src, self.trans)
         return dict(input=input_param)
 
-
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
         tag = parameter_def["tag"]

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -742,14 +742,15 @@ class InputDataModule(InputModule):
 
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
-        tag = parameter_def["tag"]
+        if parameter_def["tag"]:
+            tag = parameter_def["tag"]
+            tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
+            input_tag = TextToolParameter(None, tag_source)
+            inputs["tag"] = input_tag
         optional = parameter_def["optional"]
-        tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
-        input_tag = TextToolParameter(None, tag_source)
         inputs = {}
         inputs["optional"] = optional_param(optional)
         inputs["format"] = format_param(self.trans, parameter_def.get("format"))
-        inputs["tag"] = input_tag
         return inputs
 
 

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -734,6 +734,7 @@ class InputDataModule(InputModule):
         input_param = DataToolParameter(None, data_src, self.trans)
         return dict(input=input_param)
 
+
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
         optional = parameter_def["optional"]
@@ -752,6 +753,7 @@ class InputDataCollectionModule(InputModule):
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
         collection_type = parameter_def["collection_type"]
+        tag = parameter_def["tag"]
         optional = parameter_def["optional"]
         collection_type_source = dict(name="collection_type", label="Collection type", type="text", value=collection_type)
         collection_type_source["options"] = [
@@ -760,10 +762,13 @@ class InputDataCollectionModule(InputModule):
             {"value": "list:paired", "label": "List of Dataset Pairs"},
         ]
         input_collection_type = TextToolParameter(None, collection_type_source)
+        tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
+        input_tag = TextToolParameter(None, tag_source)
         inputs = {}
         inputs["collection_type"] = input_collection_type
         inputs["optional"] = optional_param(optional)
         inputs["format"] = format_param(self.trans, parameter_def.get("format"))
+        inputs["tag"] = input_tag
         return inputs
 
     def get_runtime_inputs(self, **kwds):
@@ -803,6 +808,11 @@ class InputDataCollectionModule(InputModule):
         else:
             collection_type = self.default_collection_type
         state_as_dict["collection_type"] = collection_type
+        if "tag" in inputs:
+            tag = inputs["tag"]
+        else:
+            tag = None
+        state_as_dict["tag"] = tag
         return state_as_dict
 
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -1280,6 +1280,19 @@ steps:
             invocation_id = self.__invoke_workflow(workflow_id, inputs=inputs, history_id=history_id)
             self.wait_for_invocation_and_jobs(history_id, workflow_id, invocation_id)
 
+    @skip_without_tool("cat1")
+    @skip_without_tool("__FLATTEN__")
+    def test_workflow_input_tags(self):
+        workflow = self.workflow_populator.load_workflow_from_resource(name="test_workflow_with_input_tags")
+        workflow_id = self.workflow_populator.create_workflow(workflow)
+        downloaded_workflow = self._download_workflow(workflow_id)
+        count = 0
+        tag_test = ["tag1", "tag2"]
+        for step in downloaded_workflow["steps"]:
+            current = json.loads(downloaded_workflow["steps"][step]["tool_state"])
+            assert current["tag"] == tag_test[count]
+            count += 1
+
     @skip_without_tool('column_param')
     def test_empty_file_data_column_specified(self):
         # Regression test for https://github.com/galaxyproject/galaxy/pull/10981

--- a/lib/galaxy_test/base/data/test_workflow_with_input_tags.ga
+++ b/lib/galaxy_test/base/data/test_workflow_with_input_tags.ga
@@ -1,0 +1,70 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "simple workflow",
+    "format-version": "0.1",
+    "name": "TestWorkflow1",
+    "steps": {
+        "0": {
+            "annotation": "input1 description",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "input1 description",
+                    "name": "WorkflowInput1"
+                }
+            ],
+            "label": "WorkflowInput1",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 370.65625,
+                "height": 61,
+                "left": 613.546875,
+                "right": 813.546875,
+                "top": 309.65625,
+                "width": 200,
+                "x": 613.546875,
+                "y": 309.65625
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"tag1\"}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "5262f9f9-28d7-486f-9cf8-f7c01da4f31c",
+            "workflow_outputs": []
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [],
+            "label": null,
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "bottom": 472.5,
+                "height": 81,
+                "left": 616,
+                "right": 816,
+                "top": 391.5,
+                "width": 200,
+                "x": 616,
+                "y": 391.5
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"tag\": \"tag2\", \"collection_type\": \"list\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "f6ee8140-92cf-4bbd-8683-dc9076fd72fa",
+            "workflow_outputs": []
+        }
+    },
+    "tags": [],
+    "uuid": "6e6d28b0-cf38-47d3-937c-18738da04306",
+    "version": 4
+}


### PR DESCRIPTION
Allows for large projects with many outputs to easily pre-select inputs when using multiple workflows

Thank you @guerler for the help on this one!

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
