### PR TITLE
Provide 2 types of scoped_session in DI (initially "type of session parameter should be scoped_session")

### DIFF
--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -35,8 +35,8 @@ from galaxy.model.base import SharedModelMapping
 from galaxy.model.database_heartbeat import DatabaseHeartbeat
 from galaxy.model.mapping import GalaxyModelMapping
 from galaxy.model.scoped_session import (
-    gxy_scoped_session,
-    tsi_scoped_session,
+    galaxy_scoped_session,
+    install_model_scoped_session,
 )
 from galaxy.model.tags import GalaxyTagHandler
 from galaxy.queue_worker import (
@@ -132,8 +132,8 @@ class MinimalGalaxyApplication(BasicApp, config.ConfiguresGalaxyMixin, HaltableC
         self._register_singleton(IdEncodingHelper, self.security)
         self._register_singleton(SharedModelMapping, self.model)
         self._register_singleton(GalaxyModelMapping, self.model)
-        self._register_singleton(gxy_scoped_session, self.model.context)
-        self._register_singleton(tsi_scoped_session, self.install_model.context)
+        self._register_singleton(galaxy_scoped_session, self.model.context)
+        self._register_singleton(install_model_scoped_session, self.install_model.context)
 
     def configure_fluent_log(self):
         if self.config.fluent_log:

--- a/lib/galaxy/app.py
+++ b/lib/galaxy/app.py
@@ -4,10 +4,6 @@ import sys
 import time
 from typing import Any, Callable, List, Tuple
 
-from sqlalchemy.orm.scoping import (
-    scoped_session,
-)
-
 import galaxy.model
 import galaxy.model.security
 import galaxy.queues
@@ -38,6 +34,10 @@ from galaxy.managers.workflows import (
 from galaxy.model.base import SharedModelMapping
 from galaxy.model.database_heartbeat import DatabaseHeartbeat
 from galaxy.model.mapping import GalaxyModelMapping
+from galaxy.model.scoped_session import (
+    gxy_scoped_session,
+    tsi_scoped_session,
+)
 from galaxy.model.tags import GalaxyTagHandler
 from galaxy.queue_worker import (
     GalaxyQueueWorker,
@@ -132,7 +132,8 @@ class MinimalGalaxyApplication(BasicApp, config.ConfiguresGalaxyMixin, HaltableC
         self._register_singleton(IdEncodingHelper, self.security)
         self._register_singleton(SharedModelMapping, self.model)
         self._register_singleton(GalaxyModelMapping, self.model)
-        self._register_singleton(scoped_session, self.model.context)
+        self._register_singleton(gxy_scoped_session, self.model.context)
+        self._register_singleton(tsi_scoped_session, self.install_model.context)
 
     def configure_fluent_log(self):
         if self.config.fluent_log:

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -6,8 +6,6 @@ import shutil
 import tempfile
 from typing import Any
 
-from sqlalchemy.orm.scoping import scoped_session
-
 from galaxy import (
     di,
     quota,
@@ -19,6 +17,7 @@ from galaxy.managers.users import UserManager
 from galaxy.model import tags
 from galaxy.model.base import SharedModelMapping
 from galaxy.model.mapping import GalaxyModelMapping
+from galaxy.model.scoped_session import gxy_scoped_session
 from galaxy.model.unittest_utils import GalaxyDataTestApp, GalaxyDataTestConfig
 from galaxy.security import idencoding
 from galaxy.structured_app import BasicApp, MinimalManagerApp, StructuredApp
@@ -73,7 +72,7 @@ class MockApp(di.Container, GalaxyDataTestApp):
         self.name = kwargs.get('name', 'galaxy')
         self[SharedModelMapping] = self.model
         self[GalaxyModelMapping] = self.model
-        self[scoped_session] = self.model.context
+        self[gxy_scoped_session] = self.model.context
         self.visualizations_registry = MockVisualizationsRegistry()
         self.tag_handler = tags.GalaxyTagHandler(self.model.context)
         self[tags.GalaxyTagHandler] = self.tag_handler

--- a/lib/galaxy/app_unittest_utils/galaxy_mock.py
+++ b/lib/galaxy/app_unittest_utils/galaxy_mock.py
@@ -17,7 +17,7 @@ from galaxy.managers.users import UserManager
 from galaxy.model import tags
 from galaxy.model.base import SharedModelMapping
 from galaxy.model.mapping import GalaxyModelMapping
-from galaxy.model.scoped_session import gxy_scoped_session
+from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.model.unittest_utils import GalaxyDataTestApp, GalaxyDataTestConfig
 from galaxy.security import idencoding
 from galaxy.structured_app import BasicApp, MinimalManagerApp, StructuredApp
@@ -72,7 +72,7 @@ class MockApp(di.Container, GalaxyDataTestApp):
         self.name = kwargs.get('name', 'galaxy')
         self[SharedModelMapping] = self.model
         self[GalaxyModelMapping] = self.model
-        self[gxy_scoped_session] = self.model.context
+        self[galaxy_scoped_session] = self.model.context
         self.visualizations_registry = MockVisualizationsRegistry()
         self.tag_handler = tags.GalaxyTagHandler(self.model.context)
         self[tags.GalaxyTagHandler] = self.tag_handler

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -3,15 +3,13 @@ from functools import wraps
 from celery import shared_task
 from kombu import serialization
 from lagom import magic_bind_to_container
-from sqlalchemy.orm.scoping import (
-    scoped_session,
-)
 
 from galaxy import model
 from galaxy.app import MinimalManagerApp
 from galaxy.jobs.manager import JobManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
+from galaxy.model.scoped_session import gxy_scoped_session
 from galaxy.util import ExecutionTimer
 from galaxy.util.custom_logging import get_logger
 from . import get_galaxy_app
@@ -53,7 +51,7 @@ def galaxy_task(*args, **celery_task_kwd):
 
 
 @galaxy_task(ignore_result=True)
-def recalculate_user_disk_usage(session: scoped_session, user_id=None):
+def recalculate_user_disk_usage(session: gxy_scoped_session, user_id=None):
     if user_id:
         user = session.query(model.User).get(user_id)
         if user:
@@ -83,7 +81,7 @@ def set_metadata(hda_manager: HDAManager, ldda_manager: LDDAManager, dataset_id,
 @galaxy_task(ignore_result=True)
 def export_history(
         app: MinimalManagerApp,
-        sa_session: scoped_session,
+        sa_session: gxy_scoped_session,
         job_manager: JobManager,
         store_directory,
         history_id,
@@ -100,7 +98,7 @@ def export_history(
 
 
 @galaxy_task
-def prune_history_audit_table(sa_session: scoped_session):
+def prune_history_audit_table(sa_session: gxy_scoped_session):
     """Prune ever growing history_audit table."""
     timer = ExecutionTimer()
     model.HistoryAudit.prune(sa_session)

--- a/lib/galaxy/celery/tasks.py
+++ b/lib/galaxy/celery/tasks.py
@@ -9,7 +9,7 @@ from galaxy.app import MinimalManagerApp
 from galaxy.jobs.manager import JobManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
-from galaxy.model.scoped_session import gxy_scoped_session
+from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.util import ExecutionTimer
 from galaxy.util.custom_logging import get_logger
 from . import get_galaxy_app
@@ -51,7 +51,7 @@ def galaxy_task(*args, **celery_task_kwd):
 
 
 @galaxy_task(ignore_result=True)
-def recalculate_user_disk_usage(session: gxy_scoped_session, user_id=None):
+def recalculate_user_disk_usage(session: galaxy_scoped_session, user_id=None):
     if user_id:
         user = session.query(model.User).get(user_id)
         if user:
@@ -81,7 +81,7 @@ def set_metadata(hda_manager: HDAManager, ldda_manager: LDDAManager, dataset_id,
 @galaxy_task(ignore_result=True)
 def export_history(
         app: MinimalManagerApp,
-        sa_session: gxy_scoped_session,
+        sa_session: galaxy_scoped_session,
         job_manager: JobManager,
         store_directory,
         history_id,
@@ -98,7 +98,7 @@ def export_history(
 
 
 @galaxy_task
-def prune_history_audit_table(sa_session: gxy_scoped_session):
+def prune_history_audit_table(sa_session: galaxy_scoped_session):
     """Prune ever growing history_audit table."""
     timer = ExecutionTimer()
     model.HistoryAudit.prune(sa_session)

--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -5,8 +5,7 @@ Mixins for Annotatable model managers and serializers.
 import logging
 from typing import Dict
 
-from sqlalchemy.orm.scoping import scoped_session
-
+from galaxy.model.scoped_session import gxy_scoped_session
 from .base import (
     Deserializer,
     FunctionFilterParsersType,
@@ -33,7 +32,7 @@ class AnnotatableManagerMixin:
     #: class of AnnotationAssociation (e.g. HistoryAnnotationAssociation)
     annotation_assoc: type
 
-    def session(self) -> scoped_session:
+    def session(self) -> gxy_scoped_session:
         ...
 
     def annotation(self, item):

--- a/lib/galaxy/managers/annotatable.py
+++ b/lib/galaxy/managers/annotatable.py
@@ -5,7 +5,7 @@ Mixins for Annotatable model managers and serializers.
 import logging
 from typing import Dict
 
-from galaxy.model.scoped_session import gxy_scoped_session
+from galaxy.model.scoped_session import galaxy_scoped_session
 from .base import (
     Deserializer,
     FunctionFilterParsersType,
@@ -32,7 +32,7 @@ class AnnotatableManagerMixin:
     #: class of AnnotationAssociation (e.g. HistoryAnnotationAssociation)
     annotation_assoc: type
 
-    def session(self) -> gxy_scoped_session:
+    def session(self) -> galaxy_scoped_session:
         ...
 
     def annotation(self, item):

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -39,8 +39,6 @@ import string
 from json import dumps
 from typing import Callable, List, Optional
 
-from sqlalchemy.orm.scoping import scoped_session
-
 from galaxy.exceptions import UserActivationRequiredException
 from galaxy.model import (
     Dataset,
@@ -49,6 +47,7 @@ from galaxy.model import (
     Role,
 )
 from galaxy.model.base import ModelMapping
+from galaxy.model.scoped_session import gxy_scoped_session
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import bunch
@@ -136,10 +135,10 @@ class ProvidesAppContext:
             self.sa_session.flush()
 
     @property
-    def sa_session(self) -> scoped_session:
+    def sa_session(self) -> gxy_scoped_session:
         """Provide access to Galaxy's SQLAlchemy session.
 
-        :rtype: sqlalchemy.orm.scoping.scoped_session
+        :rtype: galaxy.model.scoped_session.gxy_scoped_session
         """
         return self.app.model.session
 

--- a/lib/galaxy/managers/context.py
+++ b/lib/galaxy/managers/context.py
@@ -47,7 +47,7 @@ from galaxy.model import (
     Role,
 )
 from galaxy.model.base import ModelMapping
-from galaxy.model.scoped_session import gxy_scoped_session
+from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import MinimalManagerApp
 from galaxy.util import bunch
@@ -135,10 +135,10 @@ class ProvidesAppContext:
             self.sa_session.flush()
 
     @property
-    def sa_session(self) -> gxy_scoped_session:
+    def sa_session(self) -> galaxy_scoped_session:
         """Provide access to Galaxy's SQLAlchemy session.
 
-        :rtype: galaxy.model.scoped_session.gxy_scoped_session
+        :rtype: galaxy.model.scoped_session.galaxy_scoped_session
         """
         return self.app.model.session
 

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -9,7 +9,6 @@ from pydantic import (
 )
 from sqlalchemy import and_, false, func, or_
 from sqlalchemy.orm import aliased
-from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.sql import select
 
 from galaxy import model
@@ -22,6 +21,7 @@ from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
+from galaxy.model.scoped_session import gxy_scoped_session
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.util import (
@@ -98,7 +98,7 @@ class JobSearch:
     """Search for jobs using tool inputs or other jobs"""
     def __init__(
         self,
-        sa_session: scoped_session,
+        sa_session: gxy_scoped_session,
         hda_manager: HDAManager,
         dataset_collection_manager: DatasetCollectionManager,
         ldda_manager: LDDAManager,

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -21,7 +21,7 @@ from galaxy.managers.collections import DatasetCollectionManager
 from galaxy.managers.datasets import DatasetManager
 from galaxy.managers.hdas import HDAManager
 from galaxy.managers.lddas import LDDAManager
-from galaxy.model.scoped_session import gxy_scoped_session
+from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.security.idencoding import IdEncodingHelper
 from galaxy.structured_app import StructuredApp
 from galaxy.util import (
@@ -98,7 +98,7 @@ class JobSearch:
     """Search for jobs using tool inputs or other jobs"""
     def __init__(
         self,
-        sa_session: gxy_scoped_session,
+        sa_session: galaxy_scoped_session,
         hda_manager: HDAManager,
         dataset_collection_manager: DatasetCollectionManager,
         ldda_manager: LDDAManager,

--- a/lib/galaxy/model/base.py
+++ b/lib/galaxy/model/base.py
@@ -39,7 +39,6 @@ class ModelMapping(Bunch):
         # For backward compatibility with "context.current"
         # deprecated?
         context.current = context
-        self._SessionLocal = SessionLocal
         self.session = context
         self.scoped_registry = context.registry
 

--- a/lib/galaxy/model/scoped_session.py
+++ b/lib/galaxy/model/scoped_session.py
@@ -7,9 +7,9 @@ scoped_session objects that produce sessions that may have different binds
 from sqlalchemy.orm import scoped_session
 
 
-class gxy_scoped_session(scoped_session):
+class galaxy_scoped_session(scoped_session):
     """scoped_session used for galaxy model."""
 
 
-class tsi_scoped_session(scoped_session):
+class install_model_scoped_session(scoped_session):
     """scoped_session used for tool_shed_install model."""

--- a/lib/galaxy/model/scoped_session.py
+++ b/lib/galaxy/model/scoped_session.py
@@ -1,0 +1,15 @@
+"""
+These classes are used for registering different scoped_session objects with
+the DI framework. This type distinction is necessary because we need to store
+scoped_session objects that produce sessions that may have different binds
+(i.e., if the tool_shed_install model uses a different database).
+"""
+from sqlalchemy.orm import scoped_session
+
+
+class gxy_scoped_session(scoped_session):
+    """scoped_session used for galaxy model."""
+
+
+class tsi_scoped_session(scoped_session):
+    """scoped_session used for tool_shed_install model."""

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -2,11 +2,11 @@ import logging
 import re
 from typing import Dict, List, Optional, Tuple
 
-from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import func
 
 import galaxy.model
+from galaxy.model.scoped_session import gxy_scoped_session
 from galaxy.util import (
     strip_control_characters,
     unicodify,
@@ -28,7 +28,7 @@ class TagHandler:
     Manages CRUD operations related to tagging objects.
     """
 
-    def __init__(self, sa_session: scoped_session) -> None:
+    def __init__(self, sa_session: gxy_scoped_session) -> None:
         self.sa_session = sa_session
         # Minimum tag length.
         self.min_tag_len = 1
@@ -355,7 +355,7 @@ class TagHandler:
 
 
 class GalaxyTagHandler(TagHandler):
-    def __init__(self, sa_session: scoped_session):
+    def __init__(self, sa_session: gxy_scoped_session):
         from galaxy import model
         TagHandler.__init__(self, sa_session)
         self.item_tag_assoc_info["History"] = ItemTagAssocInfo(model.History,

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -6,7 +6,7 @@ from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import func
 
 import galaxy.model
-from galaxy.model.scoped_session import gxy_scoped_session
+from galaxy.model.scoped_session import galaxy_scoped_session
 from galaxy.util import (
     strip_control_characters,
     unicodify,
@@ -28,7 +28,7 @@ class TagHandler:
     Manages CRUD operations related to tagging objects.
     """
 
-    def __init__(self, sa_session: gxy_scoped_session) -> None:
+    def __init__(self, sa_session: galaxy_scoped_session) -> None:
         self.sa_session = sa_session
         # Minimum tag length.
         self.min_tag_len = 1
@@ -355,7 +355,7 @@ class TagHandler:
 
 
 class GalaxyTagHandler(TagHandler):
-    def __init__(self, sa_session: gxy_scoped_session):
+    def __init__(self, sa_session: galaxy_scoped_session):
         from galaxy import model
         TagHandler.__init__(self, sa_session)
         self.item_tag_assoc_info["History"] = ItemTagAssocInfo(model.History,

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import (
     defer,
     joinedload,
 )
-from sqlalchemy.orm.session import sessionmaker
+from sqlalchemy.orm import scoped_session
 from sqlitedict import SqliteDict
 
 from galaxy.model.tool_shed_install import ToolShedRepository
@@ -286,7 +286,7 @@ class ToolShedRepositoryCache:
     repositories: List[ToolShedRepository]
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
-    def __init__(self, session: sessionmaker):
+    def __init__(self, session: scoped_session):
         self.session = session()
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -13,9 +13,9 @@ from sqlalchemy.orm import (
     defer,
     joinedload,
 )
-from sqlalchemy.orm import scoped_session
 from sqlitedict import SqliteDict
 
+from galaxy.model.scoped_session import tsi_scoped_session
 from galaxy.model.tool_shed_install import ToolShedRepository
 from galaxy.tool_util.toolbox.base import ToolConfRepository
 from galaxy.util import unicodify
@@ -286,7 +286,7 @@ class ToolShedRepositoryCache:
     repositories: List[ToolShedRepository]
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
-    def __init__(self, session: scoped_session):
+    def __init__(self, session: tsi_scoped_session):
         self.session = session()
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import (
 )
 from sqlitedict import SqliteDict
 
-from galaxy.model.scoped_session import tsi_scoped_session
+from galaxy.model.scoped_session import install_model_scoped_session
 from galaxy.model.tool_shed_install import ToolShedRepository
 from galaxy.tool_util.toolbox.base import ToolConfRepository
 from galaxy.util import unicodify
@@ -286,7 +286,7 @@ class ToolShedRepositoryCache:
     repositories: List[ToolShedRepository]
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
-    def __init__(self, session: tsi_scoped_session):
+    def __init__(self, session: install_model_scoped_session):
         self.session = session()
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []


### PR DESCRIPTION
**UPDATE:** Initially, this was fixing one bug, as a step towards migrating to SQLAlchemy 2.0. However, [as described in this comment](https://github.com/galaxyproject/galaxy/pull/12931#issuecomment-971726107), the bug fix exposed a deeper issue. Since one cannot be fixed without the other, this PR contains both fixes.

**Summary of problem being solved:**
The dependency injection system stores only one scoped_session. We need 2: one for the main model, the other one for the tool_shed_install model. ([see comment below for details](https://github.com/galaxyproject/galaxy/pull/12931#issuecomment-971726107))

**Implementation summary:**
I've added 2 empty classes that extend `sqlalchemy.orm.scoped_session`. I use these types as keys in the DI to store `galaxy.model.context` and `galaxy.install_model.context` - which are scoped_session objects, each bound to the appropriate engine. Thus, we simply specify one or the other in a constructor - and the right scoped_session will be injected.
(at first, I used these in model.base to instantiate one or the other - but then realized this was completely unnecessary!)

I tried placing these class definitions in `model.base.py`, as well as `model.__init__.py` (which caused a circular dependency and raised an error) and `model.mapping.py`. In the end I created a separate module, and this felt like the cleanest/most intuitive location. But this is completely subjective. 

Naming: I wanted something succinct, and using `gxy_` and `tsi_` prefixes (for galaxy and tool_shed_install) felt right (all the alternatives I came up with seemed long and awkward). I'm also using these all over the new migrations code (#12869), so these will be consistent. But again, very subjective.

I haven't looked too deeply into Lagom - so maybe there is a more elegant way to address such a situation (the need for storing 2 *different* objects of the *same* type - I think we considered the possibility of such a case when we first discussed adding DI).

---------------------
**INITIAL DESCRIPTION:**
(this is a step towards #12541)

The type of the `session` parameter should be scoped_session, not sessonmaker. With the former, the injector locates the instance of scoped_session that has been [bound to an engine here](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/model/base.py#L55) and [registered here](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/app.py#L135). With the latter, DI cannot find an instance of `sessionmaker`, so it creates a new instance (that uses default parameters).

**Why this is a problem (besides being incorrect)**
The session we get on the next line is a session object that has been constructed using default arguments. Most importantly, it does not have a bind that we set in `model/base`. This error went unnoticed because we also [bind the model's `MetaData` property to the same engine](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/model/tool_shed_install/mapping.py#L15). Given this bind, having no bind on the session object is inconsequential: the query will still execute. 
However, this will change as soon as we remove the bind from the metadata, which we have to do because bound metadata is [no longer supported in SQLAlchemy 2.0](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed).


```
# this is the correct/fixed version (note the session properties):
(Pdb) session
<sqlalchemy.orm.scoping.scoped_session object at 0x7f01d00cff40>
(Pdb) pp session.__dict__
{'current': <sqlalchemy.orm.scoping.scoped_session object at 0x7f01d00cff40>,
 'registry': <sqlalchemy.util._collections.ScopedRegistry object at 0x7f01d00cf9a0>,
 'session_factory': sessionmaker(class_='Session', 
bind=Engine(sqlite:////home/sergey/0dev/galaxy/_galaxy/dev/database/universe.sqlite?isolation_level=IMMEDIATE), autoflush=False, autocommit=True, expire_on_commit=True

# this is the incorrect version (note the session properties)
(Pdb) session
sessionmaker(class_='Session', bind=None, autoflush=True, autocommit=False, expire_on_commit=True)
(Pdb) pp session.__dict__
{'class_': <class 'sqlalchemy.orm.session.Session'>,
 'kw': {'autocommit': False,
        'autoflush': True,
        'bind': None,
        'expire_on_commit': True}}
```



## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
