### PR TITLE
Move the `titleonly` option to input element component

### DIFF
--- a/client/src/components/Form/Elements/parameters.js
+++ b/client/src/components/Form/Elements/parameters.js
@@ -38,7 +38,7 @@ export default Backbone.View.extend({
     /** Returns an input field for a given field type */
     create: function (input_def) {
         const Galaxy = getGalaxyInstance();
-        var fieldClass = this.types[input_def.titleonly ? "hidden" : input_def.type];
+        var fieldClass = this.types[input_def.type];
         this.field = typeof this[fieldClass] === "function" ? this[fieldClass].call(this, input_def) : null;
         if (!this.field) {
             this.field = input_def.options ? this._fieldSelect(input_def) : this._fieldText(input_def);

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -20,6 +20,10 @@ describe("FormElement", () => {
                 title: "title_text",
             },
             localVue,
+            stubs: {
+                FormInput: { template: "<div>form-input</div>" },
+                FormHidden: { template: "<div>form-hidden</div>" },
+            },
         });
     });
 
@@ -58,5 +62,12 @@ describe("FormElement", () => {
         await Vue.nextTick();
         expect(wrapper.findAll("span[title='Disable Collapsible']").length).toEqual(1);
         expect(wrapper.findAll("span[title='Enable Collapsible']").length).toEqual(0);
+    });
+
+    it("check type matching", async () => {
+        await wrapper.setProps({ type: "text" });
+        expect(wrapper.find("div[id='input'").text()).toEqual("form-input");
+        await wrapper.setProps({ attributes: { titleonly: true } });
+        expect(wrapper.find("div[id='input'").text()).toEqual("form-hidden");
     });
 });

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-show="!hidden" :id="elementId" :class="['ui-form-element section-row', cls]" :tour_id="id">
+    <div v-show="!isHidden" :id="elementId" :class="['ui-form-element section-row', cls]" :tour_id="id">
         <div v-if="hasError" class="ui-form-error">
             <span class="fa fa-exclamation mr-1" />
             <span class="ui-form-error-text" v-html="error" />
@@ -22,12 +22,7 @@
         </div>
         <div v-if="showField" class="ui-form-field" :data-label="title">
             <FormBoolean v-if="type == 'boolean'" v-model="currentValue" :id="id" />
-            <FormHidden
-                v-else-if="['hidden', 'hidden_data', 'baseurl'].includes(type)"
-                v-model="currentValue"
-                :id="id"
-                :info="attrs['info']"
-            />
+            <FormHidden v-else-if="isHiddenType" v-model="currentValue" :id="id" :info="attrs['info']" />
             <FormColor v-else-if="type == 'color'" v-model="currentValue" :id="id" />
             <FormParameter
                 v-else-if="backbonejs"
@@ -189,8 +184,14 @@ export default {
             }
             return help;
         },
-        hidden() {
+        isHidden() {
             return this.attrs["hidden"];
+        },
+        isHiddenType() {
+            return (
+                ["hidden", "hidden_data", "baseurl"].includes(this.type) ||
+                (this.attributes && this.attributes.titleonly)
+            );
         },
         previewText() {
             return _.escape(this.textValue).replace(/\n/g, "<br>");


### PR DESCRIPTION
This PR moves the `titleonly` option from the backbone-based parameters input element factory to the Vue input element component, otherwise the flag will be ignored since the `hidden` field is not available as backbone element anymore. As a consequence data inputs in the workflow editor are currently not displayed correctly.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
