### PR TITLE
Add a few charts artifacts to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,8 @@ config/plugins/**/static/dist
 config/plugins/**/static/script.js
 config/plugins/**/static/main.css
 config/plugins/**/static/plugin_build_hash.txt
+config/plugins/**/static/*.map
+
+# viz-specific build artifacts to ignore (until these are removed from codebase)
+config/plugins/visualizations/annotate_image/static/jquery.contextMenu.css
+config/plugins/visualizations/nvd3/nvd3_bar/static/nvd3.js


### PR DESCRIPTION
@assuntad23 noticed these pop up on build in dev.  They're from #12890.  Most charts artifacts are ignored with the existing globs, but some of the charts we just swapped to autobuild had a couple extra bits to handle.



## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
