### PR TITLE
Allow labeling of subworkflow outputs in parent workflow

### DIFF
--- a/client/src/components/Form/Elements/FormInput.test.js
+++ b/client/src/components/Form/Elements/FormInput.test.js
@@ -2,8 +2,6 @@ import { mount } from "@vue/test-utils";
 import { getLocalVue } from "jest/helpers";
 import FormInput from "./FormInput";
 
-jest.mock("app");
-
 const localVue = getLocalVue();
 
 describe("FormInput", () => {

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.test.js
@@ -1,0 +1,52 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import FormDefault from "./FormDefault";
+import { ActiveOutputs } from "components/Workflow/Editor/modules/outputs";
+
+const localVue = getLocalVue();
+
+describe("FormDefault", () => {
+    let wrapper;
+    const activeOutputs = new ActiveOutputs();
+    const outputs = [
+        { name: "output-name", label: "output-label" },
+        { name: "other-name", label: "other-label" },
+    ];
+
+    beforeEach(() => {
+        activeOutputs.initialize(outputs);
+        wrapper = mount(FormDefault, {
+            propsData: {
+                datatypes: [],
+                getManager: () => {
+                    return {
+                        nodes: [],
+                    };
+                },
+                getNode: () => {
+                    return {
+                        name: "node-title",
+                        type: "subworkflow",
+                        outputs: outputs,
+                        activeOutputs: activeOutputs,
+                        config_form: {
+                            inputs: [],
+                        },
+                    };
+                },
+            },
+            localVue,
+        });
+    });
+
+    it("check initial value and value change", async () => {
+        const title = wrapper.find(".portlet-title-text").text();
+        expect(title).toBe("node-title");
+        const inputCount = wrapper.findAll("input").length;
+        expect(inputCount).toBe(3);
+        const outputLabelCount = wrapper.findAll("div[tour_id='__label__output-name']").length;
+        expect(outputLabelCount).toBe(1);
+        const otherLabelCount = wrapper.findAll("div[tour_id='__label__other-name']").length;
+        expect(otherLabelCount).toBe(1);
+    });
+});

--- a/client/src/components/Workflow/Editor/Forms/FormDefault.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormDefault.vue
@@ -43,16 +43,14 @@
                 help="Add an annotation or notes to this step. Annotations are available when a workflow is viewed."
                 @input="onAnnotation"
             />
-            <FormDisplay v-if="!isSubworkflow" :id="id" :inputs="inputs" @onChange="onChange" />
-            <div v-else>
+            <FormDisplay :id="id" :inputs="inputs" @onChange="onChange" />
+            <div v-if="isSubworkflow">
                 <FormOutputLabel
-                    v-for="(output, index) in outputs"
+                    v-for="(output, index) in node.outputs"
                     :key="index"
                     :name="output.name"
-                    :label="getOutputLabel(output)"
-                    :error="outputLabelError"
+                    :active-outputs="node.activeOutputs"
                     :show-details="true"
-                    @onLabel="onOutputLabel"
                 />
             </div>
         </template>
@@ -64,8 +62,8 @@ import FormDisplay from "components/Form/FormDisplay";
 import FormCard from "components/Form/FormCard";
 import FormElement from "components/Form/FormElement";
 import FormOutputLabel from "./FormOutputLabel";
-import WorkflowIcons from "components/Workflow/icons";
 import { checkLabels } from "components/Workflow/Editor/modules/utilities";
+import WorkflowIcons from "components/Workflow/icons";
 
 export default {
     components: {
@@ -87,11 +85,6 @@ export default {
             type: Function,
             required: true,
         },
-    },
-    data() {
-        return {
-            outputLabelError: null,
-        };
     },
     computed: {
         node() {
@@ -115,18 +108,8 @@ export default {
         errorLabel() {
             return checkLabels(this.node.id, this.node.label, this.workflow.nodes);
         },
-        activeOutputs() {
-            return this.node.activeOutputs;
-        },
-        outputs() {
-            return this.node.outputs;
-        },
     },
     methods: {
-        getOutputLabel(output) {
-            const activeOutput = this.activeOutputs.get(output.name);
-            return activeOutput && activeOutput.label;
-        },
         onAnnotation(newAnnotation) {
             this.$emit("onAnnotation", this.node.id, newAnnotation);
         },
@@ -148,13 +131,6 @@ export default {
                 content_id: this.node.content_id,
                 inputs: values,
             });
-        },
-        onOutputLabel(pjaKey, outputName, newLabel) {
-            if (this.node.labelOutput(outputName, newLabel)) {
-                this.outputLabelError = null;
-            } else {
-                this.outputLabelError = `Duplicate output label '${newLabel}' will be ignored.`;
-            }
         },
     },
 };

--- a/client/src/components/Workflow/Editor/Forms/FormOutput.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutput.vue
@@ -1,12 +1,7 @@
 <template>
     <FormCard :title="outputTitle" collapsible :expanded.sync="expanded">
         <template v-slot:body>
-            <FormOutputLabel
-                :name="outputName"
-                :label="outputLabel"
-                :error="outputLabelError"
-                @onLabel="onLabel"
-            />
+            <FormOutputLabel :name="outputName" :label="outputLabel" :error="outputLabelError" @onLabel="onLabel" />
             <FormElement
                 :id="actionNames.RenameDatasetAction__newname"
                 :value="formData[actionNames.RenameDatasetAction__newname]"

--- a/client/src/components/Workflow/Editor/Forms/FormOutput.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutput.vue
@@ -1,14 +1,11 @@
 <template>
     <FormCard :title="outputTitle" collapsible :expanded.sync="expanded">
         <template v-slot:body>
-            <FormElement
-                :id="outputLabelId"
-                :value="outputLabel"
+            <FormOutputLabel
+                :name="outputName"
+                :label="outputLabel"
                 :error="outputLabelError"
-                title="Label"
-                type="text"
-                help="This will provide a short name to describe the output - this must be unique across workflows."
-                @input="onLabel"
+                @onLabel="onLabel"
             />
             <FormElement
                 :id="actionNames.RenameDatasetAction__newname"
@@ -100,6 +97,7 @@
 <script>
 import FormCard from "components/Form/FormCard";
 import FormElement from "components/Form/FormElement";
+import FormOutputLabel from "./FormOutputLabel";
 
 const actions = [
     "RenameDatasetAction__newname",
@@ -120,6 +118,7 @@ export default {
     components: {
         FormCard,
         FormElement,
+        FormOutputLabel,
     },
     props: {
         outputName: {
@@ -161,9 +160,6 @@ export default {
         outputTitle() {
             const title = this.outputLabel || this.outputName;
             return `Configure Output: '${title}'`;
-        },
-        outputLabelId() {
-            return `__label__${this.outputName}`;
         },
         actionNames() {
             const index = {};
@@ -225,8 +221,8 @@ export default {
         onInput(value, pjaKey) {
             this.$emit("onInput", value, pjaKey);
         },
-        onLabel(newLabel) {
-            this.$emit("onLabel", this.outputLabelId, this.outputName, newLabel);
+        onLabel(id, name, label) {
+            this.$emit("onLabel", id, name, label);
         },
         onDatatype(newDatatype) {
             this.$emit("onDatatype", this.actionNames.ChangeDatatypeAction__newtype, this.outputName, newDatatype);

--- a/client/src/components/Workflow/Editor/Forms/FormOutput.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutput.vue
@@ -1,7 +1,7 @@
 <template>
     <FormCard :title="outputTitle" collapsible :expanded.sync="expanded">
         <template v-slot:body>
-            <FormOutputLabel :name="outputName" :label="outputLabel" :error="outputLabelError" @onLabel="onLabel" />
+            <FormOutputLabel :name="outputName" :active-outputs="activeOutputs" />
             <FormElement
                 :id="actionNames.RenameDatasetAction__newname"
                 :value="formData[actionNames.RenameDatasetAction__newname]"
@@ -140,6 +140,10 @@ export default {
             type: Object,
             required: true,
         },
+        activeOutputs: {
+            type: Object,
+            required: true,
+        },
     },
     data() {
         return {
@@ -215,9 +219,6 @@ export default {
         },
         onInput(value, pjaKey) {
             this.$emit("onInput", value, pjaKey);
-        },
-        onLabel(id, name, label) {
-            this.$emit("onLabel", id, name, label);
         },
         onDatatype(newDatatype) {
             this.$emit("onDatatype", this.actionNames.ChangeDatatypeAction__newtype, this.outputName, newDatatype);

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.test.js
@@ -1,0 +1,50 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import FormOutputLabel from "./FormOutputLabel";
+import { ActiveOutputs } from "components/Workflow/Editor/modules/outputs";
+
+const localVue = getLocalVue();
+
+describe("FormOutputLabel", () => {
+    let wrapper;
+    let wrapperOther;
+    const activeOutputs = new ActiveOutputs();
+    const outputs = [
+        { name: "output-name", label: "output-label" },
+        { name: "other-name", label: "other-label" },
+    ];
+
+    beforeEach(() => {
+        activeOutputs.initialize(outputs);
+        wrapper = mount(FormOutputLabel, {
+            propsData: {
+                name: "output-name",
+                activeOutputs: activeOutputs,
+            },
+            localVue,
+        });
+        wrapperOther = mount(FormOutputLabel, {
+            propsData: {
+                name: "other-name",
+                activeOutputs: activeOutputs,
+            },
+            localVue,
+        });
+    });
+
+    it("check initial value and value change", async () => {
+        const title = wrapper.find(".ui-form-title-text");
+        expect(title.text()).toBe("Label");
+        await wrapper.setProps({ showDetails: true });
+        expect(title.text()).toBe("Label for: 'output-name'");
+        const input = wrapper.find("input");
+        const inputOther = wrapperOther.find("input");
+        await input.setValue("new-label");
+        expect(wrapper.vm.error).toBe(null);
+        expect(activeOutputs.get("output-name").label).toBe("new-label");
+        await inputOther.setValue("other-label");
+        await input.setValue("other-label");
+        expect(wrapper.vm.error).toBe("Duplicate output label 'other-label' will be ignored.");
+        expect(activeOutputs.get("output-name").label).toBe("new-label");
+    });
+});

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -1,11 +1,10 @@
 <template>
     <FormElement
-        :id="id"
         :value="label"
         :error="error"
         :title="title"
         type="text"
-        help="This will provide a short name to describe the output - this must be unique across workflows."
+        help="Provide a short, unique name to describe this output."
         @input="onInput"
     />
 </template>
@@ -26,30 +25,36 @@ export default {
             type: Boolean,
             default: false,
         },
-        label: {
-            type: String,
+        activeOutputs: {
+            type: Object,
             default: null,
         },
-        error: {
-            type: String,
-            required: null,
-        },
+    },
+    data() {
+        return {
+            error: null,
+        };
     },
     computed: {
-        id() {
-            return `__label__${this.name}`;
-        },
         title() {
             if (this.showDetails) {
-                return `Set Label for: ${this.name}`;
+                return `Label for: '${this.name}'`;
             } else {
                 return "Label";
             }
         },
+        label() {
+            const activeOutput = this.activeOutputs.get(this.name);
+            return activeOutput && activeOutput.label;
+        },
     },
     methods: {
         onInput(newLabel) {
-            this.$emit("onLabel", this.id, this.name, newLabel);
+            if (this.activeOutputs.labelOutput(this.name, newLabel)) {
+                this.error = null;
+            } else {
+                this.error = `Duplicate output label '${newLabel}' will be ignored.`;
+            }
         },
     },
 };

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -1,5 +1,6 @@
 <template>
     <FormElement
+        :id="id"
         :value="label"
         :error="error"
         :title="title"
@@ -36,6 +37,9 @@ export default {
         };
     },
     computed: {
+        id() {
+            return `__label__${this.name}`;
+        },
         title() {
             if (this.showDetails) {
                 return `Label for: '${this.name}'`;

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -1,0 +1,45 @@
+<template>
+    <FormElement
+        :id="id"
+        :value="label"
+        :error="error"
+        title="Label"
+        type="text"
+        help="This will provide a short name to describe the output - this must be unique across workflows."
+        @input="onInput"
+    />
+</template>
+
+<script>
+import FormElement from "components/Form/FormElement";
+
+export default {
+    components: {
+        FormElement,
+    },
+    props: {
+        name: {
+            type: String,
+            required: true,
+        },
+        label: {
+            type: String,
+            default: null,
+        },
+        error: {
+            type: String,
+            required: null,
+        },
+    },
+    computed: {
+        id() {
+            return `__label__${this.name}`;
+        },
+    },
+    methods: {
+        onInput(newLabel) {
+            this.$emit("onLabel", this.id, this.name, newLabel);
+        },
+    },
+};
+</script>

--- a/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormOutputLabel.vue
@@ -3,7 +3,7 @@
         :id="id"
         :value="label"
         :error="error"
-        title="Label"
+        :title="title"
         type="text"
         help="This will provide a short name to describe the output - this must be unique across workflows."
         @input="onInput"
@@ -22,6 +22,10 @@ export default {
             type: String,
             required: true,
         },
+        showDetails: {
+            type: Boolean,
+            default: false,
+        },
         label: {
             type: String,
             default: null,
@@ -34,6 +38,13 @@ export default {
     computed: {
         id() {
             return `__label__${this.name}`;
+        },
+        title() {
+            if (this.showDetails) {
+                return `Set Label for: ${this.name}`;
+            } else {
+                return "Label";
+            }
         },
     },
     methods: {

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -20,13 +20,11 @@
             v-for="(output, index) in outputs"
             :key="index"
             :output-name="output.name"
-            :output-label="getOutputLabel(output)"
-            :output-label-error="outputLabelError"
+            :active-outputs="node.activeOutputs"
             :inputs="node.inputs"
             :datatypes="datatypes"
             :form-data="formData"
             @onInput="onInput"
-            @onLabel="onLabel"
             @onDatatype="onDatatype"
         />
     </div>
@@ -58,7 +56,6 @@ export default {
     data() {
         return {
             formData: {},
-            outputLabelError: null,
         };
     },
     created() {
@@ -70,9 +67,6 @@ export default {
         },
         postJobActions() {
             return this.node.postJobActions;
-        },
-        activeOutputs() {
-            return this.node.activeOutputs;
         },
         outputs() {
             return this.node.outputs;
@@ -124,10 +118,6 @@ export default {
                 delete pjas[this.emailPayloadKey];
             }
         },
-        getOutputLabel(output) {
-            const activeOutput = this.activeOutputs.get(output.name);
-            return activeOutput && activeOutput.label;
-        },
         onInput(value, pjaKey) {
             let changed = false;
             const exists = pjaKey in this.formData;
@@ -145,13 +135,6 @@ export default {
             if (changed) {
                 this.formData = Object.assign({}, this.formData);
                 this.$emit("onChange", this.formData, true);
-            }
-        },
-        onLabel(pjaKey, outputName, newLabel) {
-            if (this.node.labelOutput(outputName, newLabel)) {
-                this.outputLabelError = null;
-            } else {
-                this.outputLabelError = `Duplicate output label '${newLabel}' will be ignored.`;
             }
         },
         onDatatype(pjaKey, outputName, newDatatype) {

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -150,7 +150,6 @@ export default {
         onLabel(pjaKey, outputName, newLabel) {
             if (this.node.labelOutput(outputName, newLabel)) {
                 this.outputLabelError = null;
-                this.onInput(newLabel, pjaKey);
             } else {
                 this.outputLabelError = `Duplicate output label '${newLabel}' will be ignored.`;
             }

--- a/client/src/components/Workflow/Editor/Index.vue
+++ b/client/src/components/Workflow/Editor/Index.vue
@@ -113,7 +113,7 @@
                             </div>
                         </div>
                         <div class="unified-panel-body workflow-right" ref="right-panel">
-                            <div class="m-1">
+                            <div class="m-2">
                                 <FormTool
                                     v-if="hasActiveNodeTool"
                                     :key="activeNodeId"

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -240,6 +240,7 @@ export default {
     },
     methods: {
         onChange() {
+            this.onRedraw();
             this.$emit("onChange");
         },
         onAddInput(input, terminal) {

--- a/client/src/components/Workflow/Editor/Node.vue
+++ b/client/src/components/Workflow/Editor/Node.vue
@@ -323,9 +323,6 @@ export default {
             this.setData(data);
             this.showLoading = false;
         },
-        labelOutput(outputName, label) {
-            return this.activeOutputs.labelOutput(outputName, label);
-        },
         onScrollTo() {
             this.scrolledTo = true;
             setTimeout(() => {

--- a/client/src/components/Workflow/Editor/NodeOutput.vue
+++ b/client/src/components/Workflow/Editor/NodeOutput.vue
@@ -70,7 +70,13 @@ export default {
         },
     },
     watch: {
-        output: function (newOutput) {
+        label() {
+            // See discussion at: https://github.com/vuejs/vue/issues/8030
+            this.$nextTick(() => {
+                this.$emit("onChange");
+            });
+        },
+        output(newOutput) {
             const oldTerminal = this.terminal;
             if (oldTerminal instanceof this.terminalClassForOutput(newOutput)) {
                 oldTerminal.update(newOutput);


### PR DESCRIPTION
This PR adds input fields to the subworkflow module forms, allowing users to relabel workflow outputs. Additionally it contains a fix to properly update the node connections when labels change. This PR also minimally increases the margin for forms in the right workflow editor panel, fixes a minor bug regarding the error highlighting for duplicate labels and adds corresponding tests.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Insert a workflow into a parent workflow
  2. Verify that the outputs of the subworkflow are editable in the corresponding form on the right
  3. Edit and save new labels for subworkflow outputs

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
