### PR TITLE
Reduce false positives tests in pulsar testing

### DIFF
--- a/lib/galaxy/datatypes/assembly.py
+++ b/lib/galaxy/datatypes/assembly.py
@@ -167,28 +167,25 @@ class Velvet(Html):
         """
         log.debug(f"Velvet log info  {'JJ regenerate_primary_file'}")
         gen_msg = ''
-        try:
-            efp = dataset.extra_files_path
-            log_path = os.path.join(efp, 'Log')
-            with open(log_path) as f:
-                log_content = f.read(1000)
-            log_msg = re.sub(r'/\S*/', '', log_content)
-            log.debug(f"Velveth log info  {log_msg}")
-            paired_end_reads = re.search(r'-(short|long)Paired', log_msg) is not None
-            dataset.metadata.paired_end_reads = paired_end_reads
-            long_reads = re.search(r'-long', log_msg) is not None
-            dataset.metadata.long_reads = long_reads
-            short2_reads = re.search(r'-short(Paired)?2', log_msg) is not None
-            dataset.metadata.short2_reads = short2_reads
-            dataset.info = re.sub(r'.*velveth \S+', 'hash_length', re.sub(r'\n', ' ', log_msg))
-            if paired_end_reads:
-                gen_msg = f"{gen_msg} Paired-End Reads"
-            if long_reads:
-                gen_msg = f"{gen_msg} Long Reads"
-            if len(gen_msg) > 0:
-                gen_msg = f"Uses: {gen_msg}"
-        except Exception:
-            log.debug(f"Velveth could not read Log file in {efp}")
+        efp = dataset.extra_files_path
+        log_path = os.path.join(efp, 'Log')
+        with open(log_path) as f:
+            log_content = f.read(1000)
+        log_msg = re.sub(r'/\S*/', '', log_content)
+        log.debug(f"Velveth log info  {log_msg}")
+        paired_end_reads = re.search(r'-(short|long)Paired', log_msg) is not None
+        dataset.metadata.paired_end_reads = paired_end_reads
+        long_reads = re.search(r'-long', log_msg) is not None
+        dataset.metadata.long_reads = long_reads
+        short2_reads = re.search(r'-short(Paired)?2', log_msg) is not None
+        dataset.metadata.short2_reads = short2_reads
+        dataset.info = re.sub(r'.*velveth \S+', 'hash_length', re.sub(r'\n', ' ', log_msg))
+        if paired_end_reads:
+            gen_msg = f"{gen_msg} Paired-End Reads"
+        if long_reads:
+            gen_msg = f"{gen_msg} Long Reads"
+        if len(gen_msg) > 0:
+            gen_msg = f"Uses: {gen_msg}"
         log.debug(f"Velveth log info  {gen_msg}")
         rval = ['<html><head><title>Velvet Galaxy Composite Dataset </title></head><p/>']
         # rval.append('<div>Generated:<p/><code> %s </code></div>' %(re.sub('\n','<br>',log_msg)))

--- a/test/functional/tools/composite_output.xml
+++ b/test/functional/tools/composite_output.xml
@@ -19,7 +19,7 @@ cp '$input.extra_files_path'/Log '$output.extra_files_path'/nested/nested_log
                 <composite_data value="velveth_test1/Roadmaps" />
                 <composite_data value="velveth_test1/Log" />
             </param>
-            <output name="output" file="velveth_test1/output.html">
+            <output name="output" file="velveth_test1/output.html" lines_diff="2">
                 <extra_files type="file" name="Sequences" value="velveth_test1/Sequences" />
                 <extra_files type="file" name="Roadmaps" value="velveth_test1/Roadmaps" />
                 <extra_files type="file" name="Log" value="composite_output_expected_log" />

--- a/test/functional/tools/composite_output_tests.xml
+++ b/test/functional/tools/composite_output_tests.xml
@@ -20,7 +20,7 @@
         <composite_data value="velveth_test1/Roadmaps" />
         <composite_data value="velveth_test1/Log"/>
       </param>
-      <output name="output" file="velveth_test1/output.html">
+      <output name="output" file="velveth_test1/output.html" lines_diff="2">
         <extra_files type="file" name="Sequences" value="velveth_test1/Sequences" />
         <extra_files type="file" name="Roadmaps" value="velveth_test1/Roadmaps" />
         <extra_files type="file" name="Log" value="composite_output_expected_log" />

--- a/test/functional/tools/metadata.xml
+++ b/test/functional/tools/metadata.xml
@@ -8,26 +8,26 @@ echo '$input.metadata.base_name' > '$output_of_input_metadata'
         <param name="input" type="data" format="velvet" label="Velvet Dataset" help="Prepared by velveth."/>
     </inputs>
     <outputs>
-        <data name="output_of_input_metadata" format="txt" />
-        <data name="output_copy_of_input" format="velvet" />
+        <data name="output_of_input_metadata" format="txt"/>
+        <data name="output_copy_of_input" format="velvet"/>
     </outputs>
     <tests>
         <test>
-            <param name="input" value="velveth_test1/output.html" ftype="velvet" >
-                <composite_data value="velveth_test1/Sequences" />
-                <composite_data value="velveth_test1/Roadmaps" />
+            <param name="input" value="velveth_test1/output.html" ftype="velvet">
+                <composite_data value="velveth_test1/Sequences"/>
+                <composite_data value="velveth_test1/Roadmaps"/>
                 <composite_data value="velveth_test1/Log"/>
-                <metadata name="base_name" value="Example Metadata" />
+                <metadata name="base_name" value="Example Metadata"/>
             </param>
             <!-- This ouptut tests setting input metadata above -->
             <output name="output_of_input_metadata" ftype="txt">
                 <assert_contents>
-                    <has_line line="Example Metadata" />
+                    <has_line line="Example Metadata"/>
                 </assert_contents>
             </output>
             <!-- This output tests an assertion about output metadata -->
-            <output name="output_copy_of_input" file="velveth_test1/output.html">
-                <metadata name="base_name" value="velvet" />
+            <output name="output_copy_of_input" file="velveth_test1/output.html" lines_diff="2">
+                <metadata name="base_name" value="velvet"/>
             </output>
         </test>
     </tests>


### PR DESCRIPTION
In pulsar's test suite we see:
```
>           raise JobOutputsError(found_exceptions, job_stdio)
E           galaxy.tool_util.verify.interactor.JobOutputsError: Output output:  different than expected, difference (using diff):
E           ( /tmp/tmpqc8czzkmoutput.html v. /tmp/tmpx1t1ajeioutput.html )
E           --- local_file
E           +++ history_data
E           @@ -1,5 +1,5 @@
E            <html><head><title>Velvet Galaxy Composite Dataset </title></head><p/>
E           -<div>Generated:<p/> Uses:  Paired-End Reads </div>
E           +<div>Generated:<p/>  </div>
E            <div>Velveth dataset:<p/><ul>
E            <li><a href="Sequences" type="text/plain">Sequences (Sequences)</a></li>
E            <li><a href="Roadmaps" type="text/plain">Roadmaps (Roadmaps)</a></li>
```
`Uses:  Paired-End Reads` is generated in `regenerate_primary_file`,
which doesn't necessarily run in all cases.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
