### PR TITLE
Sort icon on List Collection Creator

### DIFF
--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -211,7 +211,7 @@ import BootstrapVue from "bootstrap-vue";
 import draggable from "vuedraggable";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faSortAlphaDown, faUndo} from "@fortawesome/free-solid-svg-icons";
+import { faSortAlphaDown, faUndo } from "@fortawesome/free-solid-svg-icons";
 
 library.add(faSortAlphaDown, faUndo);
 

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -114,11 +114,18 @@
                                 {{ l("link.") }}
                             </li>
                             <li>
-                                {{ l("Click the") }}
+                                {{ l("Click ") }}
                                 <i data-target=".reset">
-                                    {{ l("Start over") }}
+                                    <font-awesome-icon icon="redo"/>
                                 </i>
-                                {{ l("link to begin again as if you had just opened the interface.") }}
+                                {{ l("to begin again as if you had just opened the interface.") }}
+                            </li>
+                            <li>
+                                {{ l("Click ") }}
+                                <i data-target=".sort-items">
+                                    <font-awesome-icon icon="sort-alpha-down"/>
+                                </i>
+                                {{ l("to sort datasets alphabetically.") }}
                             </li>
                             <li>
                                 {{ l("Click the") }}
@@ -143,15 +150,12 @@
                     </template>
                     <template v-slot:middle-content>
                         <div class="collection-elements-controls">
-                            <a
-                                class="reset"
-                                href="javascript:void(0);"
-                                role="button"
-                                :title="titleUndoButton"
-                                @click="reset"
-                            >
-                                {{ l("Start over") }}
-                            </a>
+                            <b-button class="reset" :title="titleUndoButton" @click="reset">
+                                <font-awesome-icon icon="redo" />
+                            </b-button>
+                            <b-button class="sort-items" :title="titleSortButton" @click="sortByName">
+                                <font-awesome-icon icon="sort-alpha-down" />
+                            </b-button>
                             <a
                                 class="clear-selected"
                                 v-if="atLeastOneDatasetIsSelected"
@@ -205,6 +209,11 @@ import "ui/hoverhighlight";
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
 import draggable from "vuedraggable";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faSortAlphaDown, faRedo } from "@fortawesome/free-solid-svg-icons";
+
+library.add(faSortAlphaDown, faRedo);
 
 Vue.use(BootstrapVue);
 export default {
@@ -214,11 +223,12 @@ export default {
         this._elementsSetUp();
         this.saveOriginalNames();
     },
-    components: { DatasetCollectionElementView, draggable },
+    components: { DatasetCollectionElementView, draggable, FontAwesomeIcon },
     data: function () {
         return {
             state: "build", //error
             titleUndoButton: _l("Undo all reordering and discards"),
+            titleSortButton: _l("Sort datasets by name"),
             titleDeselectButton: _l("De-select all selected datasets"),
             noElementsHeader: _l("No datasets were selected"),
             discardedElementsHeader: _l("No elements left. Would you like to"),
@@ -406,6 +416,18 @@ export default {
         reset: function () {
             this._instanceSetUp();
             this.getOriginalNames();
+        },
+        sortByName: function () {
+            this.workingElements.sort(this.compareNames);
+        },
+        compareNames: function (a, b) {
+            if (a.name < b.name) {
+                return -1;
+            }
+            if (a.name > b.name) {
+                return 1;
+            }
+            return 0;
         },
         /** string rep */
         toString: function () {

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -116,7 +116,7 @@
                             <li>
                                 {{ l("Click ") }}
                                 <i data-target=".reset">
-                                    <font-awesome-icon icon="redo" />
+                                    <font-awesome-icon icon="undo" />
                                 </i>
                                 {{ l("to begin again as if you had just opened the interface.") }}
                             </li>
@@ -151,7 +151,7 @@
                     <template v-slot:middle-content>
                         <div class="collection-elements-controls">
                             <b-button class="reset" :title="titleUndoButton" @click="reset">
-                                <font-awesome-icon icon="redo" />
+                                <font-awesome-icon icon="undo" />
                             </b-button>
                             <b-button class="sort-items" :title="titleSortButton" @click="sortByName">
                                 <font-awesome-icon icon="sort-alpha-down" />
@@ -211,9 +211,9 @@ import BootstrapVue from "bootstrap-vue";
 import draggable from "vuedraggable";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { library } from "@fortawesome/fontawesome-svg-core";
-import { faSortAlphaDown, faRedo } from "@fortawesome/free-solid-svg-icons";
+import { faSortAlphaDown, faUndo} from "@fortawesome/free-solid-svg-icons";
 
-library.add(faSortAlphaDown, faRedo);
+library.add(faSortAlphaDown, faUndo);
 
 Vue.use(BootstrapVue);
 export default {

--- a/client/src/components/Collections/ListCollectionCreator.vue
+++ b/client/src/components/Collections/ListCollectionCreator.vue
@@ -116,14 +116,14 @@
                             <li>
                                 {{ l("Click ") }}
                                 <i data-target=".reset">
-                                    <font-awesome-icon icon="redo"/>
+                                    <font-awesome-icon icon="redo" />
                                 </i>
                                 {{ l("to begin again as if you had just opened the interface.") }}
                             </li>
                             <li>
                                 {{ l("Click ") }}
                                 <i data-target=".sort-items">
-                                    <font-awesome-icon icon="sort-alpha-down"/>
+                                    <font-awesome-icon icon="sort-alpha-down" />
                                 </i>
                                 {{ l("to sort datasets alphabetically.") }}
                             </li>


### PR DESCRIPTION
Papercut to add feature request in #11941 
I added a font awesome icon for the sort button, because the side by side text looked odd, then decided to convert the font awesome button to a font awesome icon as well. 
I also updated the help text section to display the icons instead of text. 


![Screenshot from 2021-11-18 17-19-57](https://user-images.githubusercontent.com/26912553/142506535-7c1342d0-1456-4ae9-b582-7aa812d4fb77.png)


https://user-images.githubusercontent.com/26912553/142506913-34d82ea6-f4b7-404f-85c2-3d345ae895b8.mp4


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows:
  1. Create a List Collection with items out of order
  2. Click the Sort button
  3. Click the Start over button

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
