### PR TITLE
Try cimg/node:14 to fix circleci js builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - run: tox -e test_galaxy_packages
   js_lint:
     docker:
-      - image: circleci/node:14-browsers
+      - image: cimg/node:14.15
     <<: *set_workdir
     steps:
       - *restore_yarn_cache


### PR DESCRIPTION
Swaps circleci build to use the newer circleCI image `cimg/node:14.15`, which matches our specified `.node_version`.  Somehow it was defaulting to node 12 with the (now defunct) `circleci/node:14-browsers` image.


## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
