### PR TITLE
Modifications to next hid_counter generation

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -51,6 +51,7 @@ def db_next_hid(self, n=1):
     else:
         stmt = table.update().where(table.c.id == model.cached_id(self)).values(hid_counter=(table.c.hid_counter + n)).returning(table.c.hid_counter)
         next_hid = session.execute(stmt).scalar() - n
+    session.expire(self, ['hid_counter'])
     return next_hid
 
 

--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -11,6 +11,7 @@ from typing import Optional, Type
 from sqlalchemy import (
     and_,
     select,
+    update,
 )
 from sqlalchemy.orm import class_mapper, object_session, relation
 
@@ -32,27 +33,33 @@ class_mapper(model.HistoryDatasetCollectionAssociation).add_property(
 
 
 # Helper methods.
-def db_next_hid(self, n=1):
+def db_next_hid(history, n=1):
     """
-    db_next_hid( self )
-
-    Override __next_hid to generate from the database in a concurrency safe way.
-    Loads the next history ID from the DB and returns it.
-    It also saves the future next_id into the DB.
+    Generate from the database in a concurrency safe way.
+    Load the next history ID from the database and return it.
+    Save the future next_id in the database.
 
     :rtype:     int
-    :returns:   the next history id
+    :returns:   the next hid
     """
-    session = object_session(self)
-    table = self.table
-    if "postgres" not in session.bind.dialect.name:
-        next_hid = select([table.c.hid_counter], table.c.id == model.cached_id(self)).with_for_update().scalar()
-        table.update(table.c.id == self.id).execute(hid_counter=(next_hid + n))
-    else:
-        stmt = table.update().where(table.c.id == model.cached_id(self)).values(hid_counter=(table.c.hid_counter + n)).returning(table.c.hid_counter)
-        next_hid = session.execute(stmt).scalar() - n
-    session.expire(self, ['hid_counter'])
-    return next_hid
+    session = object_session(history)
+    engine = session.bind
+    table = history.__table__
+    history_id = model.cached_id(history)
+    update_stmt = update(table).where(table.c.id == history_id).values(hid_counter=table.c.hid_counter + n)
+
+    with engine.begin() as conn:
+        if engine.name in ['postgres', 'postgresql']:
+            stmt = update_stmt.returning(table.c.hid_counter)
+            hid = conn.execute(stmt).scalar()
+            hid -= n
+        else:
+            select_stmt = select(table.c.hid_counter).where(table.c.id == history_id).with_for_update()
+            hid = conn.execute(select_stmt).scalar()
+            conn.execute(update_stmt)
+
+    session.expire(history, ['hid_counter'])
+    return hid
 
 
 model.History._next_hid = db_next_hid  # type: ignore

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -935,6 +935,16 @@ class MappingTests(BaseModelTestCase):
         assert 'id' not in state.unloaded  # but other attributes have NOT been expired
         assert h.hid_counter == 2  # check this last: this causes thie hid_counter to be reloaded
 
+    def test_next_hid(self):
+        u = model.User(email="hid_abuser@example.com", password="password")
+        h = model.History(name="History for hid testing", user=u)
+        self.persist(u, h)
+        assert h.hid_counter == 1
+        h._next_hid()
+        assert h.hid_counter == 2
+        h._next_hid(n=3)
+        assert h.hid_counter == 5
+
     def _three_users(self, suffix):
         email_from = f"user_{suffix}e1@example.com"
         email_to = f"user_{suffix}e2@example.com"

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -621,7 +621,7 @@ class MappingTests(BaseModelTestCase):
         self.new_hda(h1, name="1")
         self.new_hda(h2, name="2")
         self.session().flush()
-        # db_next_hid modifies history, plus trigger on HDA means 2 additional audit rows per history
+        # _next_hid modifies history, plus trigger on HDA means 2 additional audit rows per history
 
         h1_audits = get_audit_table_entries(h1)
         h2_audits = get_audit_table_entries(h2)

--- a/test/unit/data/test_galaxy_mapping.py
+++ b/test/unit/data/test_galaxy_mapping.py
@@ -920,6 +920,21 @@ class MappingTests(BaseModelTestCase):
         assert security_agent.can_manage_dataset(u_from.all_roles(), d1.dataset)
         assert not security_agent.can_manage_dataset(u_other.all_roles(), d1.dataset)
 
+    def test_history_hid_counter_is_expired_after_next_hid_call(self):
+        u = model.User(email="hid_abuser@example.com", password="password")
+        h = model.History(name="History for hid testing", user=u)
+        self.persist(u, h)
+        state = inspect(h)
+        assert h.hid_counter == 1
+        assert 'hid_counter' not in state.unloaded
+        assert 'id' not in state.unloaded
+
+        h._next_hid()
+
+        assert 'hid_counter' in state.unloaded  # this attribute has been expired
+        assert 'id' not in state.unloaded  # but other attributes have NOT been expired
+        assert h.hid_counter == 2  # check this last: this causes thie hid_counter to be reloaded
+
     def _three_users(self, suffix):
         email_from = f"user_{suffix}e1@example.com"
         email_to = f"user_{suffix}e2@example.com"


### PR DESCRIPTION
A few modifications triggered by migration to SQLAlchemy 2.0 (ref #12651 

1. Key issue 1: bound metadata is no longer supported in SQLAlchemy 2.0 ([ref](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed)). The previous implementation relied on a bind accessible via the Table object's metadata property (see documentation: [order of resolution](https://docs.sqlalchemy.org/en/20/orm/contextual.html#sqlalchemy.orm.scoping.scoped_session.get_bind)). 
Solution: use an explicit connection.
2. Key issue 2: autocommit mode is no longer supported in SQLAlchemy 2.0 ([ref](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#autocommit-mode-removed-from-session-autobegin-support-added) and [ref](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#library-level-but-not-driver-level-autocommit-removed-from-both-core-and-orm)). Thus, for this to work, an explicit commit (or session flush) would be required. However, this operation should not affect the state of the session (as described in f63dc3b9df7a313c649d125f73d0ac6aa693514a).
Solution: use SQLAlchemy Core to obtain a connection from the engine: this will limit the commit to the operation.
3. Expire the hid_counter attribute. Once the operation commits, the value of the hid_counter attribute in the session is no longer consistent with the database. Expiring it will force it to be reloaded on the next access. This affects *only* this attribute (I've added a test verifying this behavior).
Note: this potentially affects current behavior whenever we access a history's hid_counter: (a) [in the `ModelImportStore`](https://github.com/galaxyproject/galaxy/blob/837332f6d1564c755b01225363b920444f34ec28/lib/galaxy/model/store/__init__.py#L148), (b) in the [`dev-detailed` and `betawebclient` views](https://github.com/galaxyproject/galaxy/blob/837332f6d1564c755b01225363b920444f34ec28/lib/galaxy/managers/histories.py#L353) and the [`_serialize` History method](https://github.com/galaxyproject/galaxy/blob/837332f6d1564c755b01225363b920444f34ec28/lib/galaxy/model/__init__.py#L2603), (c) in the [legacy history controller](https://github.com/galaxyproject/galaxy/blob/837332f6d1564c755b01225363b920444f34ec28/lib/galaxy/webapps/galaxy/controllers/history.py#L63), and (d) in the [`copy` History method](https://github.com/galaxyproject/galaxy/blob/837332f6d1564c755b01225363b920444f34ec28/lib/galaxy/model/__init__.py#L2582). The effects would be (1) a call to the database to refresh the attribute, and (2) the value may be different (but correct). But our tests pass.
4. Update SQLAlchemy sql expression syntax. Because some of it was 15 years old.
5. Move the whole thing into the model. There must have been a reason why it was initially placed into the module with all the mappings, but that was years ago, and with all the updates to the model and SQLAlchemy I don't think there's any reason to keep it there. Besides, the overridden code was never accessed.

Ping @assuntad23, @dannon: although (I think) this is unlikely, this might affect the client (iff there was a case when the supplied value of hid_counter was incorrect - i.e., outdated due to calls to db_next_hid)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
