### PR TITLE
Don't bind model's MetaData to engine

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -62,9 +62,6 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
     # Load the appropriate db module
     engine = build_engine(url, engine_options, database_query_profiling_proxy, trace_logger, slow_query_log_threshold, thread_local_log=thread_local_log, log_query_counts=log_query_counts)
 
-    # Connect the metadata to the database.
-    metadata.bind = engine
-
     model_modules = [model]
     if map_install_models:
         import galaxy.model.tool_shed_install.mapping  # noqa: F401
@@ -76,7 +73,7 @@ def init(file_path, url, engine_options=None, create_tables=False, map_install_m
 
     # Create tables if needed
     if create_tables:
-        metadata.create_all()
+        metadata.create_all(bind=engine)
         install_timestamp_triggers(engine)
         install_views(engine)
 

--- a/lib/galaxy/model/tool_shed_install/mapping.py
+++ b/lib/galaxy/model/tool_shed_install/mapping.py
@@ -11,12 +11,10 @@ def init(url, engine_options=None, create_tables=False):
     # Load the appropriate db module
     engine_options = engine_options or {}
     engine = build_engine(url, engine_options)
-    # Connect the metadata to the database.
-    metadata.bind = engine
     result = ModelMapping([install_model], engine=engine)
     # Create tables if needed
     if create_tables:
-        metadata.create_all()
+        metadata.create_all(bind=engine)
         # metadata.engine.commit()
     result.create_tables = create_tables
     # load local galaxy security policy

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -213,13 +213,11 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
                                  kwargs=dict(plugin_frameworks=[app.visualizations_registry], **kwargs))
     # Close any pooled database connections before forking
     try:
-        galaxy.model.mapping.metadata.bind.dispose()
+        app.model.engine.dispose()
     except Exception:
         log.exception("Unable to dispose of pooled galaxy model database connections.")
     try:
-        # This model may not actually be bound.
-        if galaxy.model.tool_shed_install.mapping.metadata.bind:
-            galaxy.model.tool_shed_install.mapping.metadata.bind.dispose()
+        app.install_model.engine.dispose()
     except Exception:
         log.exception("Unable to dispose of pooled toolshed install model database connections.")
 


### PR DESCRIPTION
Builds upon #12948, progress towards #12651.

Do not bind the engine to the model's `MetaData` because bound metadata is no longer supported in SQLAlchemy 2.0 ([ref](https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed)). 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
