### PR TITLE
Move `wait_for_invocation_and_jobs()` method to `BaseWorkflowPopulator`

### DIFF
--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -42,6 +42,7 @@ import json
 import os
 import random
 import string
+import time
 import unittest
 from abc import ABCMeta, abstractmethod
 from functools import wraps
@@ -1210,6 +1211,14 @@ class BaseWorkflowPopulator(BasePopulator):
                 workflow_request["inputs_by"] = "step_uuid"
 
         return workflow_request, history_id, workflow_id
+
+    def wait_for_invocation_and_jobs(self, history_id, workflow_id, invocation_id, assert_ok=True):
+        state = self.wait_for_invocation(workflow_id, invocation_id)
+        if assert_ok:
+            assert state == "scheduled", state
+        time.sleep(.5)
+        self.dataset_populator.wait_for_history_jobs(history_id, assert_ok=assert_ok)
+        time.sleep(.5)
 
 
 class RunJobsSummary(NamedTuple):


### PR DESCRIPTION
Also remove redundant `wait_for_invocation()` call inside it.

This comes from the CWL branch.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
