### PR TITLE
Avoid setting response headers through `trans` in datatypes

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -502,9 +502,10 @@ class BamNative(CompressedArchive, _BamOrSam):
                       'offset': offset})
 
     def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, offset=None, ck_size=None, **kwd):
+        headers = kwd.get("headers", {})
         preview = util.string_as_bool(preview)
         if offset is not None:
-            return self.get_chunk(trans, dataset, offset, ck_size)
+            return self.get_chunk(trans, dataset, offset, ck_size), headers
         elif to_ext or not preview:
             return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
         else:
@@ -522,7 +523,7 @@ class BamNative(CompressedArchive, _BamOrSam):
                                        chunk=self.get_chunk(trans, dataset, 0),
                                        column_number=column_number,
                                        column_names=column_names,
-                                       column_types=column_types)
+                                       column_types=column_types), headers
 
     def validate(self, dataset, **kwd):
         if not BamNative.is_bam(dataset.file_name):
@@ -1585,11 +1586,12 @@ class H5MLM(H5):
             return "HDF5 Model (%s)" % (nice_size(dataset.get_size()))
 
     def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, **kwd):
+        headers = kwd.get("headers", {})
         preview = util.string_as_bool(preview)
 
         if to_ext or not preview:
             to_ext = to_ext or dataset.extension
-            return self._serve_raw(trans, dataset, to_ext, **kwd)
+            return self._serve_raw(dataset, to_ext, headers, **kwd)
 
         rval = {}
         try:
@@ -1608,7 +1610,7 @@ class H5MLM(H5):
 
         repr_ = self.get_repr(dataset.file_name)
 
-        return f"<pre>{repr_}</pre><pre>{rval}</pre>"
+        return f"<pre>{repr_}</pre><pre>{rval}</pre>", headers
 
 
 class HexrdMaterials(H5):

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -198,6 +198,7 @@ class _BlastDb(Data):
         If preview is `True` allows us to format the data shown in the central pane via the "eye" icon.
         If preview is `False` triggers download.
         """
+        headers = kwd.get("headers", {})
         if not preview:
             return super().display_data(trans,
                                         data=data,
@@ -226,7 +227,7 @@ class _BlastDb(Data):
         if not msg:
             msg = title
         # Galaxy assumes HTML for the display of composite datatypes,
-        return smart_str(f"<html><head><title>{title}</title></head><body><pre>{msg}</pre></body></html>")
+        return smart_str(f"<html><head><title>{title}</title></head><body><pre>{msg}</pre></body></html>"), headers
 
     def merge(split_files, output_file):
         """Merge BLAST databases (not implemented for now)."""

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -6,17 +6,26 @@ import shutil
 import string
 import tempfile
 from inspect import isclass
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    TYPE_CHECKING,
+)
 
-import webob.exc
 from markupsafe import escape
 
 from galaxy import util
-from galaxy.datatypes.metadata import MetadataElement  # import directly to maintain ease of use in Datatype class definitions
+from galaxy.datatypes.metadata import (
+    MetadataElement,  # import directly to maintain ease of use in Datatype class definitions
+)
 from galaxy.datatypes.sniff import (
     build_sniff_from_prefix,
     FilePrefix,
 )
+from galaxy.exceptions import ObjectNotFound
 from galaxy.util import (
     compression_utils,
     file_reader,
@@ -24,7 +33,7 @@ from galaxy.util import (
     inflector,
     iter_start_of_line,
     smart_str,
-    unicodify
+    unicodify,
 )
 from galaxy.util.bunch import Bunch
 from galaxy.util.sanitize_html import sanitize_html
@@ -50,6 +59,8 @@ valid_strand = ['+', '-', '.']
 DOWNLOAD_FILENAME_PATTERN_DATASET = "Galaxy${hid}-[${name}].${ext}"
 DOWNLOAD_FILENAME_PATTERN_COLLECTION_ELEMENT = "Galaxy${hdca_hid}-[${hdca_name}__${element_identifier}].${ext}"
 DEFAULT_MAX_PEEK_SIZE = 1000000  # 1 MB
+
+Headers = Dict[str, Any]
 
 
 class DatatypeConverterNotFoundException(Exception):
@@ -300,7 +311,7 @@ class Data(metaclass=DataMeta):
             messagetype = "error"
         return error, msg, messagetype
 
-    def _archive_composite_dataset(self, trans, data, do_action='zip'):
+    def _archive_composite_dataset(self, trans, data, headers: Headers, do_action='zip'):
         # save a composite object into a compressed archive for downloading
         outfname = data.name[0:150]
         outfname = ''.join(c in FILENAME_VALID_CHARS and c or '_' for c in outfname)
@@ -332,9 +343,9 @@ class Data(metaclass=DataMeta):
                     msg = "Unable to create archive for download, please report this error"
                     continue
         if not error:
-            trans.response.headers.update(archive.get_headers())
-            return archive.response()
-        return trans.show_error_message(msg)
+            headers.update(archive.get_headers())
+            return archive.response(), headers
+        return trans.show_error_message(msg), headers
 
     def __archive_extra_files_path(self, extra_files_path):
         """Yield filepaths and relative filepaths for files in extra_files_path"""
@@ -344,12 +355,12 @@ class Data(metaclass=DataMeta):
                 rpath = os.path.relpath(fpath, extra_files_path)
                 yield fpath, rpath
 
-    def _serve_raw(self, trans, dataset, to_ext, **kwd):
-        trans.response.headers['Content-Length'] = str(os.stat(dataset.file_name).st_size)
-        trans.response.set_content_type("application/octet-stream")  # force octet-stream so Safari doesn't append mime extensions to filename
+    def _serve_raw(self, dataset, to_ext, headers: Headers, **kwd):
+        headers['Content-Length'] = str(os.stat(dataset.file_name).st_size)
+        headers["content-type"] = "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
         filename = self._download_filename(dataset, to_ext, hdca=kwd.get("hdca"), element_identifier=kwd.get("element_identifier"), filename_pattern=kwd.get("filename_pattern"))
-        trans.response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
-        return open(dataset.file_name, mode='rb')
+        headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return open(dataset.file_name, mode='rb'), headers
 
     def to_archive(self, dataset, name=""):
         """
@@ -383,14 +394,15 @@ class Data(metaclass=DataMeta):
         TOOD: Document alternatives to overridding this method (data
         providers?).
         """
+        headers = kwd.get("headers", {})
         # Relocate all composite datatype display to a common location.
         composite_extensions = trans.app.datatypes_registry.get_composite_extensions()
         composite_extensions.append('html')  # for archiving composite datatypes
         # Prevent IE8 from sniffing content type since we're explicit about it.  This prevents intentionally text/plain
         # content from being rendered in the browser
-        trans.response.headers['X-Content-Type-Options'] = 'nosniff'
+        headers['X-Content-Type-Options'] = 'nosniff'
         if isinstance(data, str):
-            return smart_str(data)
+            return smart_str(data), headers
         if filename and filename != "index":
             # For files in extra_files_path
             extra_dir = data.dataset.extra_files_path_name
@@ -417,39 +429,39 @@ class Data(metaclass=DataMeta):
                             # preview=preview, filename=fname, to_ext=to_ext)
                             tmp_fh.write(f'<tr bgcolor="{bgcolor}"><td>{escape(fname)}</td></tr>\n')
                         tmp_fh.write('</table></body></html>\n')
-                    return self._yield_user_file_content(trans, data, tmp_file_name)
+                    return self._yield_user_file_content(trans, data, tmp_file_name, headers), headers
                 mime = mimetypes.guess_type(file_path)[0]
                 if not mime:
                     try:
                         mime = trans.app.datatypes_registry.get_mimetype_by_extension(".".split(file_path)[-1])
                     except Exception:
                         mime = "text/plain"
-                self._clean_and_set_mime_type(trans, mime)
-                return self._yield_user_file_content(trans, data, file_path)
+                self._clean_and_set_mime_type(trans, mime, headers)
+                return self._yield_user_file_content(trans, data, file_path, headers), headers
             else:
-                return webob.exc.HTTPNotFound(f"Could not find '{filename}' on the extra files path {file_path}.")
-        self._clean_and_set_mime_type(trans, data.get_mime())
+                raise ObjectNotFound(f"Could not find '{filename}' on the extra files path {file_path}.")
+        self._clean_and_set_mime_type(trans, data.get_mime(), headers)
 
         trans.log_event(f"Display dataset id: {str(data.id)}")
-        from galaxy.datatypes import (
+        from galaxy.datatypes import (  # DBTODO REMOVE THIS AT REFACTOR
             binary,
             images,
             text,
-        )  # DBTODO REMOVE THIS AT REFACTOR
+        )
 
         if to_ext or isinstance(
             data.datatype, binary.Binary
         ):  # Saving the file, or binary file
             if data.extension in composite_extensions:
-                return self._archive_composite_dataset(trans, data, do_action=kwd.get('do_action', 'zip'))
+                return self._archive_composite_dataset(trans, data, headers, do_action=kwd.get('do_action', 'zip'))
             else:
-                trans.response.headers['Content-Length'] = str(os.stat(data.file_name).st_size)
+                headers['Content-Length'] = str(os.stat(data.file_name).st_size)
                 filename = self._download_filename(data, to_ext, hdca=kwd.get("hdca"), element_identifier=kwd.get("element_identifier"), filename_pattern=kwd.get("filename_pattern"))
-                trans.response.set_content_type("application/octet-stream")  # force octet-stream so Safari doesn't append mime extensions to filename
-                trans.response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
-                return open(data.file_name, 'rb')
+                headers['content-type'] = "application/octet-stream"  # force octet-stream so Safari doesn't append mime extensions to filename
+                headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+                return open(data.file_name, 'rb'), headers
         if not os.path.exists(data.file_name):
-            raise webob.exc.HTTPNotFound(f"File Not Found ({data.file_name}).")
+            raise ObjectNotFound(f"File Not Found ({data.file_name}).")
         max_peek_size = DEFAULT_MAX_PEEK_SIZE  # 1 MB
         if isinstance(data.datatype, text.Html):
             max_peek_size = 10000000  # 10 MB for html
@@ -459,12 +471,12 @@ class Data(metaclass=DataMeta):
             or isinstance(data.datatype, images.Image)
             or os.stat(data.file_name).st_size < max_peek_size
         ):
-            return self._yield_user_file_content(trans, data, data.file_name)
+            return self._yield_user_file_content(trans, data, data.file_name, headers), headers
         else:
-            trans.response.set_content_type("text/html")
+            headers["content-type"] = "text/html"
             return trans.stream_template_mako("/dataset/large_file.mako",
                                               truncated_data=open(data.file_name, 'rb').read(max_peek_size),
-                                              data=data)
+                                              data=data), headers
 
     def display_as_markdown(self, dataset_instance, markdown_format_helpers):
         """Prepare for embedding dataset into a basic Markdown document.
@@ -494,9 +506,9 @@ class Data(metaclass=DataMeta):
                 result += markdown_format_helpers.indicate_data_truncated()
         return result
 
-    def _yield_user_file_content(self, trans, from_dataset, filename):
+    def _yield_user_file_content(self, trans, from_dataset, filename, headers: Headers):
         """This method is responsible for sanitizing the HTML if needed."""
-        if trans.app.config.sanitize_all_html and trans.response.get_content_type() == "text/html":
+        if trans.app.config.sanitize_all_html and headers.get("content-type", None) == "text/html":
             # Sanitize anytime we respond with plain text/html content.
             # Check to see if this dataset's parent job is allowlisted
             # We cannot currently trust imported datasets for rendering.
@@ -815,11 +827,11 @@ class Data(metaclass=DataMeta):
         dataset_source = p_dataproviders.dataset.DatasetDataProvider(dataset)
         return p_dataproviders.chunk.Base64ChunkDataProvider(dataset_source, **settings)
 
-    def _clean_and_set_mime_type(self, trans, mime):
+    def _clean_and_set_mime_type(self, trans, mime, headers: Headers):
         if mime.lower() in XSS_VULNERABLE_MIME_TYPES:
             if not getattr(trans.app.config, "serve_xss_vulnerable_mimetypes", True):
                 mime = DEFAULT_MIME_TYPE
-        trans.response.set_content_type(mime)
+        headers["content-type"] = mime
 
     def handle_dataset_as_image(self, hda) -> str:
         raise Exception("Unimplemented Method")

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -250,6 +250,7 @@ class _Isa(data.Data):
            if `preview` is `True`, it returns a preview of the ISA dataset as a HTML page.
            The preview is triggered when user clicks on the eye icon of the composite dataset."""
 
+        headers = kwd.get("headers", {})
         # if it is not required a preview use the default behaviour of `display_data`
         if not preview:
             return super().display_data(trans, dataset, preview, filename, to_ext, **kwd)
@@ -295,9 +296,9 @@ class _Isa(data.Data):
 
         # Set mime type
         mime = 'text/html'
-        self._clean_and_set_mime_type(trans, mime)
+        self._clean_and_set_mime_type(trans, mime, headers)
 
-        return sanitize_html(html).encode('utf-8')
+        return sanitize_html(html).encode('utf-8'), headers
 
 
 # ISA-Tab class {{{1

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -716,16 +716,17 @@ class BaseFastq(Sequence):
         return self.check_first_block(file_prefix)
 
     def display_data(self, trans, dataset, preview=False, filename=None, to_ext=None, **kwd):
+        headers = kwd.get("headers", {})
         if preview:
             with compression_utils.get_fileobj(dataset.file_name) as fh:
                 max_peek_size = 1000000  # 1 MB
                 if os.stat(dataset.file_name).st_size < max_peek_size:
                     mime = "text/plain"
-                    self._clean_and_set_mime_type(trans, mime)
-                    return fh.read()
+                    self._clean_and_set_mime_type(trans, mime, headers)
+                    return fh.read(), headers
                 return trans.stream_template_mako("/dataset/large_file.mako",
                                                   truncated_data=fh.read(max_peek_size),
-                                                  data=dataset)
+                                                  data=dataset), headers
         else:
             return Sequence.display_data(self, trans, dataset, preview, filename, to_ext, **kwd)
 

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -125,6 +125,7 @@ class _SpalnDb(Data):
         If preview is `True` allows us to format the data shown in the central pane via the "eye" icon.
         If preview is `False` triggers download.
         """
+        headers = kwd.get("headers", {})
         if not preview:
             return super().display_data(
                 trans,
@@ -134,6 +135,7 @@ class _SpalnDb(Data):
                 to_ext=to_ext,
                 size=size,
                 offset=offset,
+                headers=headers,
                 **kwd
             )
         if self.file_ext == "spalndbn":
@@ -158,7 +160,7 @@ class _SpalnDb(Data):
         return smart_str(
             "<html><head><title>%s</title></head><body><pre>%s</pre></body></html>"
             % (title, msg)
-        )
+        ), headers
 
     def merge(split_files, output_file):
         """Merge spaln databases (not implemented)."""

--- a/lib/galaxy/webapps/galaxy/api/datasets.py
+++ b/lib/galaxy/webapps/galaxy/api/datasets.py
@@ -157,9 +157,11 @@ class DatasetsController(BaseGalaxyAPIController, UsesVisualizationMixin):
         datatype prior to display (the defult if raw is unspecified or explicitly false.
         """
         raw = util.string_as_bool(raw)
-        return self.service.display(
+        display_data, headers = self.service.display(
             trans, history_content_id, history_id, preview, filename, to_ext, raw, **kwd
         )
+        trans.response.headers.update(headers)
+        return display_data
 
     @web.expose_api
     def get_content_as_text(self, trans, dataset_id):

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -188,7 +188,9 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         # Ensure ck_size is an integer before passing through to datatypes.
         if ck_size:
             ck_size = int(ck_size)
-        return data.datatype.display_data(trans, data, preview, filename, to_ext, offset=offset, ck_size=ck_size, **kwd)
+        display_data, headers = data.datatype.display_data(trans, data, preview, filename, to_ext, offset=offset, ck_size=ck_size, **kwd)
+        trans.response.headers.update(headers)
+        return display_data
 
     @web.legacy_expose_api_anonymous
     def get_edit(self, trans, dataset_id=None, **kwd):

--- a/lib/galaxy/webapps/galaxy/services/datasets.py
+++ b/lib/galaxy/webapps/galaxy/services/datasets.py
@@ -367,6 +367,7 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
         datatype prior to display (the defult if raw is unspecified or explicitly false.
         """
         decoded_content_id = self.decode_id(history_content_id)
+        headers = {}
         rval: Any = ''
         try:
             hda = self.hda_manager.get_accessible(decoded_content_id, trans.user)
@@ -384,14 +385,14 @@ class DatasetsService(ServiceBase, UsesVisualizationMixin):
                 display_kwd = kwd.copy()
                 if 'key' in display_kwd:
                     del display_kwd["key"]
-                rval = hda.datatype.display_data(trans, hda, preview, filename, to_ext, **display_kwd)
+                rval, headers = hda.datatype.display_data(trans, hda, preview, filename, to_ext, **display_kwd)
         except galaxy_exceptions.MessageException:
             raise
         except Exception as e:
             log.exception("Server error getting display data for dataset (%s) from history (%s)",
                           history_content_id, history_id)
             raise galaxy_exceptions.InternalServerError(f"Could not get display data for dataset: {util.unicodify(e)}")
-        return rval
+        return rval, headers
 
     def get_content_as_text(
         self,


### PR DESCRIPTION
An alternative (or additional) solution to #12929

This PR moves the setting of the headers in `display_data` and its overrides to a parameter so it can be passed around and returns this dictionary with the headers as a tuple along with the actual content. This way, the headers are set in the response at the web controller layer and not in the `datatypes` package.

### Reason
The `display_data` function access `trans.response` to set or get the response headers for different kinds of response contents.
The `trans.response` is no longer present in FastAPI mode (unless we decide to merge #12929 which has its own issues, see https://github.com/galaxyproject/galaxy/pull/12929#issuecomment-971777171) and, in addition, we are trying to avoid or reduce the use of god objects as much as we can.

This solution still doesn't feel like the cleanest one, since `display_data` is too related to web content representation it is hard to completely decouple from it. But probably this function should be refactored down the road to unify the contents to display since right now it can return, raw text, HTML, MAKO templates, file contents, etc., and then simply handle the expected headers content type in the web controllers layer.


## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
