### PR TITLE
Linting: check for test expecting failure with outputs

### DIFF
--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -13,7 +13,7 @@ def lint_tsts(tool_xml, lint_ctx):
         lint_ctx.info("No tests found, that should be OK for data_sources.")
 
     num_valid_tests = 0
-    for test in tests:
+    for test_idx, test in enumerate(tests):
         has_test = False
         test_expect = ("expect_failure", "expect_exit_code", "expect_num_outputs")
         for te in test_expect:
@@ -30,7 +30,7 @@ def lint_tsts(tool_xml, lint_ctx):
         for param in test.findall("param"):
             name = param.attrib.get("name", None)
             if not name:
-                lint_ctx.error("Found test param tag without a name defined.")
+                lint_ctx.error(f"Test {test_idx + 1}: Found test param tag without a name defined.")
                 continue
             name = name.split("|")[-1]
             xpaths = [f"@name='{name}'",
@@ -48,7 +48,7 @@ def lint_tsts(tool_xml, lint_ctx):
                     found = True
                     break
             if not found:
-                lint_ctx.error(f"Test param {name} not found in the inputs")
+                lint_ctx.error(f"Test {test_idx + 1}: Test param {name} not found in the inputs")
 
         output_data_names, output_collection_names = _collect_output_names(tool_xml)
         found_output_test = False
@@ -56,23 +56,23 @@ def lint_tsts(tool_xml, lint_ctx):
             found_output_test = True
             name = output.attrib.get("name", None)
             if not name:
-                lint_ctx.warn("Found output tag without a name defined.")
+                lint_ctx.warn(f"Test {test_idx + 1}: Found output tag without a name defined.")
             else:
                 if name not in output_data_names:
-                    lint_ctx.error(f"Found output tag with unknown name [{name}], valid names [{output_data_names}]")
+                    lint_ctx.error(f"Test {test_idx + 1}: Found output tag with unknown name [{name}], valid names [{output_data_names}]")
 
         for output_collection in test.findall("output_collection"):
             found_output_test = True
             name = output_collection.attrib.get("name", None)
             if not name:
-                lint_ctx.warn("Found output_collection tag without a name defined.")
+                lint_ctx.warn(f"Test {test_idx + 1}: Found output_collection tag without a name defined.")
             else:
                 if name not in output_collection_names:
                     lint_ctx.warn(f"Found output_collection tag with unknown name [{name}], valid names [{output_collection_names}]")
 
         has_test = has_test or found_output_test
         if not has_test:
-            lint_ctx.warn("No outputs or expectations defined for tests, this test is likely invalid.")
+            lint_ctx.warn(f"Test {test_idx + 1}: No outputs or expectations defined for tests, this test is likely invalid.")
         else:
             num_valid_tests += 1
 

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -76,6 +76,9 @@ def lint_tsts(tool_xml, lint_ctx):
         else:
             num_valid_tests += 1
 
+    if "expect_failure" in test.attrib and found_output_test:
+        lint_ctx.error(f"Test {test_idx + 1}: Cannot specify outputs in a test expecting failure.")
+
     if num_valid_tests or datasource:
         lint_ctx.valid("%d test(s) found.", num_valid_tests)
     else:

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -13,7 +13,7 @@ def lint_tsts(tool_xml, lint_ctx):
         lint_ctx.info("No tests found, that should be OK for data_sources.")
 
     num_valid_tests = 0
-    for test_idx, test in enumerate(tests):
+    for test_idx, test in enumerate(tests, start=1):
         has_test = False
         test_expect = ("expect_failure", "expect_exit_code", "expect_num_outputs")
         for te in test_expect:
@@ -30,7 +30,7 @@ def lint_tsts(tool_xml, lint_ctx):
         for param in test.findall("param"):
             name = param.attrib.get("name", None)
             if not name:
-                lint_ctx.error(f"Test {test_idx + 1}: Found test param tag without a name defined.")
+                lint_ctx.error(f"Test {test_idx}: Found test param tag without a name defined.")
                 continue
             name = name.split("|")[-1]
             xpaths = [f"@name='{name}'",
@@ -48,7 +48,7 @@ def lint_tsts(tool_xml, lint_ctx):
                     found = True
                     break
             if not found:
-                lint_ctx.error(f"Test {test_idx + 1}: Test param {name} not found in the inputs")
+                lint_ctx.error(f"Test {test_idx}: Test param {name} not found in the inputs")
 
         output_data_names, output_collection_names = _collect_output_names(tool_xml)
         found_output_test = False
@@ -56,28 +56,28 @@ def lint_tsts(tool_xml, lint_ctx):
             found_output_test = True
             name = output.attrib.get("name", None)
             if not name:
-                lint_ctx.warn(f"Test {test_idx + 1}: Found output tag without a name defined.")
+                lint_ctx.warn(f"Test {test_idx}: Found output tag without a name defined.")
             else:
                 if name not in output_data_names:
-                    lint_ctx.error(f"Test {test_idx + 1}: Found output tag with unknown name [{name}], valid names [{output_data_names}]")
+                    lint_ctx.error(f"Test {test_idx}: Found output tag with unknown name [{name}], valid names [{output_data_names}]")
 
         for output_collection in test.findall("output_collection"):
             found_output_test = True
             name = output_collection.attrib.get("name", None)
             if not name:
-                lint_ctx.warn(f"Test {test_idx + 1}: Found output_collection tag without a name defined.")
+                lint_ctx.warn(f"Test {test_idx}: Found output_collection tag without a name defined.")
             else:
                 if name not in output_collection_names:
-                    lint_ctx.warn(f"Found output_collection tag with unknown name [{name}], valid names [{output_collection_names}]")
+                    lint_ctx.warn(f"Test {test_idx}: Found output_collection tag with unknown name [{name}], valid names [{output_collection_names}]")
 
         has_test = has_test or found_output_test
         if not has_test:
-            lint_ctx.warn(f"Test {test_idx + 1}: No outputs or expectations defined for tests, this test is likely invalid.")
+            lint_ctx.warn(f"Test {test_idx}: No outputs or expectations defined for tests, this test is likely invalid.")
         else:
             num_valid_tests += 1
 
     if "expect_failure" in test.attrib and found_output_test:
-        lint_ctx.error(f"Test {test_idx + 1}: Cannot specify outputs in a test expecting failure.")
+        lint_ctx.error(f"Test {test_idx}: Cannot specify outputs in a test expecting failure.")
 
     if num_valid_tests or datasource:
         lint_ctx.valid("%d test(s) found.", num_valid_tests)

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -244,11 +244,29 @@ TESTS_PARAM = """
             </when>
         </conditional>
     </inputs>
+    <outputs>
+        <data name="existent_output"/>
+    </outputs>
     <tests>
         <test expect_num_outputs="1">
             <param name="existent_test_name"/>
             <param name="cond_name|another_existent_test_name"/>
             <param name="non_existent_test_name"/>
+            <output name="existent_output"/>
+            <output name="nonexistent_output"/>
+        </test>
+    </tests>
+</tool>
+"""
+
+TESTS_EXPECT_FAILURE_OUTPUT = """
+<tool>
+    <outputs>
+        <data name="test"/>
+    </outputs>
+    <tests>
+        <test expect_failure="true">
+            <output name="test"/>
         </test>
     </tests>
 </tool>
@@ -348,14 +366,21 @@ TESTS = [
     (
         TESTS_WO_EXPECTATIONS, tests.lint_tsts,
         lambda x:
-            'No outputs or expectations defined for tests, this test is likely invalid.' in x.warn_messages
+            'Test 1: No outputs or expectations defined for tests, this test is likely invalid.' in x.warn_messages
             and 'No valid test(s) found.' in x.warn_messages
             and len(x.warn_messages) == 2 and len(x.error_messages) == 0
     ),
     (
         TESTS_PARAM, tests.lint_tsts,
         lambda x:
-            "Test param non_existent_test_name not found in the inputs" in x.error_messages
+            "Test 1: Test param non_existent_test_name not found in the inputs" in x.error_messages
+            and "Test 1: Found output tag with unknown name [nonexistent_output], valid names [['existent_output']]" in x.error_messages
+            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+    ),
+    (
+        TESTS_EXPECT_FAILURE_OUTPUT, tests.lint_tsts,
+        lambda x:
+            "Test 1: Cannot specify outputs in a test expecting failure." in x.error_messages
             and len(x.warn_messages) == 0 and len(x.error_messages) == 1
     )
 ]
@@ -375,6 +400,7 @@ TEST_IDS = [
     'outputs discover datatsets with tool provided metadata',
     'test without expectations',
     'test param missing from inputs',
+    'test expecting failure with outputs',
 ]
 
 


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/12958

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
