### PR TITLE
Allow unit testing tool init to specify paths.

### DIFF
--- a/lib/galaxy/app_unittest_utils/tools_support.py
+++ b/lib/galaxy/app_unittest_utils/tools_support.py
@@ -83,14 +83,18 @@ class UsesTools(UsesApp):
         tool_id="test_tool",
         extra_file_contents=None,
         extra_file_path=None,
+        tool_path=None,
     ):
+        if tool_path is None:
+            self.tool_file = os.path.join(self.test_directory, filename)
+            contents_template = string.Template(tool_contents)
+            tool_contents = contents_template.safe_substitute(dict(version=version, profile=profile, tool_id=tool_id))
+            self.__write_tool(tool_contents)
+            if extra_file_contents and extra_file_path:
+                self.__write_tool(extra_file_contents, path=os.path.join(self.test_directory, extra_file_path))
+        else:
+            self.tool_file = tool_path
         self._init_app_for_tools()
-        self.tool_file = os.path.join(self.test_directory, filename)
-        contents_template = string.Template(tool_contents)
-        tool_contents = contents_template.safe_substitute(dict(version=version, profile=profile, tool_id=tool_id))
-        self.__write_tool(tool_contents)
-        if extra_file_contents and extra_file_path:
-            self.__write_tool(extra_file_contents, path=os.path.join(self.test_directory, extra_file_path))
         return self.__setup_tool()
 
     def _init_tool_for_path(self, tool_file):


### PR DESCRIPTION
Peeling out https://github.com/galaxyproject/galaxy/pull/12909/commits/86deec224a31f2006803800376f41a5cc7a21389 from https://github.com/galaxyproject/galaxy/pull/12909 `[WIP] Implement a subset of the Common Workflow Language`

Needed for https://github.com/galaxyproject/galaxy/commit/5385160bf9dc57ac4714ed78f28502289dcaed61#diff-b282dc3deb5d6c3b832af2f39a95646f0efe91ca2d13ee33be94752cf2f23028R548

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
