### PR TITLE
Support running celery when cwd is not galaxy_root by setting $GALAXY_ROOT_DIR

### DIFF
--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -27,15 +27,17 @@ def get_galaxy_app():
 @lru_cache(maxsize=1)
 def get_app_properties():
     config_file = os.environ.get("GALAXY_CONFIG_FILE")
-    if not config_file:
-        galaxy_root_dir = os.environ.get('GALAXY_ROOT_DIR')
-        if galaxy_root_dir:
-            config_file = find_config(config_file, galaxy_root_dir)
+    galaxy_root_dir = os.environ.get('GALAXY_ROOT_DIR')
+    if not config_file and galaxy_root_dir:
+        config_file = find_config(config_file, galaxy_root_dir)
     if config_file:
-        return load_app_properties(
+        properties = load_app_properties(
             config_file=os.path.abspath(config_file),
             config_section='galaxy',
         )
+        if galaxy_root_dir:
+            properties['root_dir'] = galaxy_root_dir
+        return properties
 
 
 @lru_cache(maxsize=1)

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -627,6 +627,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         config_schema_path = os.path.join(os.path.dirname(__file__), os.pardir, 'config_schema.yml')
         if os.path.exists(GALAXY_CONFIG_SCHEMA_PATH):
             config_schema_path = GALAXY_CONFIG_SCHEMA_PATH
+        elif not os.path.exists(config_schema_path):
+            # Not a package, but cwd is not galaxy_root
+            config_schema_path = os.path.join(self.root, GALAXY_CONFIG_SCHEMA_PATH)
         return AppSchema(config_schema_path, GALAXY_APP_NAME)
 
     def _override_tempdir(self, kwargs):


### PR DESCRIPTION
`celery beat` writes a state file to cwd, so it can't (and shouldn't) be run with galaxy_root as cwd in production setups. It ~~may be~~ is possible to control where this file is written (with the `-s <path>` option to `celery beat`), but it should also be possible to run without explicitly setting cwd to galaxy_root, which is what this PR allows.

Without this change you get an error like this when running `celery --app galaxy.celery worker --concurrency 2 -l debug` from somewhere other than galaxy_root:

```pytb
Usage: celery [OPTIONS] COMMAND [ARGS]...

Error: Invalid value for '-A' / '--app':
Unable to load celery application.
While trying to load the module galaxy.celery the following error occurred:
Traceback (most recent call last):
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.8/site-packages/celery/app/utils.py", line 384, in find_app
    sym = symbol_by_name(app, imp=imp)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.8/site-packages/kombu/utils/imports.py", line 61, in symbol_by_name
    return getattr(module, cls_name) if cls_name else module
AttributeError: module 'galaxy' has no attribute 'celery'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.8/site-packages/celery/bin/celery.py", line 53, in convert
    return find_app(value)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.8/site-packages/celery/app/utils.py", line 387, in find_app
    sym = imp(app)
  File "/cvmfs/test.galaxyproject.org/venv/lib/python3.8/site-packages/celery/utils/imports.py", line 100, in import_from_cwd
    return imp(module, package=package)
  File "/cvmfs/test.galaxyproject.org/deps/_conda/envs/__python@3.8/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/celery/__init__.py", line 63, in <module>
    broker = get_broker()
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/celery/__init__.py", line 50, in get_broker
    config = get_config()
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/celery/__init__.py", line 46, in get_config
    return Configuration(**kwargs)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config/__init__.py", line 621, in __init__
    super().__init__(**kwargs)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config/__init__.py", line 155, in __init__
    self.schema = self._load_schema()  # Load schema from schema definition file
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config/__init__.py", line 630, in _load_schema
    return AppSchema(config_schema_path, GALAXY_APP_NAME)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config/schema.py", line 41, in __init__
    self.raw_schema = self._read_schema(schema_path)
  File "/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config/schema.py", line 48, in _read_schema
    with open(path) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/cvmfs/test.galaxyproject.org/galaxy/lib/galaxy/config/../config_schema.yml'
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
