### PR TITLE
Provide more context for lint context

### DIFF
--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -74,6 +74,9 @@ class LintMessage:
         rval = f".. {self.level.upper()}: {self.message}"
         if self.line is not None:
             rval += f" (line {self.line})"
+        if self.xpath is not None:
+            rval += f" [{self.xpath}]"
+
         return rval
 
 
@@ -95,7 +98,7 @@ class LintContext:
             return
         self.printed_linter_info = False
         self.message_list = []
-        
+
         # call linter
         lint_func(lint_target, self)
         # TODO: colorful emoji if in click CLI.

--- a/lib/galaxy/tool_util/lint.py
+++ b/lib/galaxy/tool_util/lint.py
@@ -63,6 +63,20 @@ def lint_xml_with(lint_context, tool_xml, extra_modules=None):
     return lint_tool_source_with(lint_context, tool_source, extra_modules=extra_modules)
 
 
+class LintMessage:
+    def __init__(self, level, message, line, xpath=None):
+        self.level = level
+        self.message = message
+        self.line = line
+        self.xpath = xpath
+
+    def __str__(self):
+        rval = f".. {self.level.upper()}: {self.message}"
+        if self.line is not None:
+            rval += f" (line {self.line})"
+        return rval
+
+
 # TODO: Nothing inherently tool-y about LintContext and in fact
 # it is reused for repositories in planemo. Therefore, it should probably
 # be moved to galaxy.util.lint.
@@ -80,10 +94,9 @@ class LintContext:
         if name in self.skip_types:
             return
         self.printed_linter_info = False
-        self.valid_messages = []
-        self.info_messages = []
-        self.warn_messages = []
-        self.error_messages = []
+        self.message_list = []
+        
+        # call linter
         lint_func(lint_target, self)
         # TODO: colorful emoji if in click CLI.
         if self.error_messages:
@@ -99,41 +112,65 @@ class LintContext:
             self.printed_linter_info = True
             print(f"Applying linter {name}... {status}")
 
-        for message in self.error_messages:
+        for message in self.message_list:
+            if message.level != "error":
+                continue
             self.found_errors = True
             print_linter_info()
-            print(f".. ERROR: {message}")
+            print(f"{message}")
 
         if self.level != LEVEL_ERROR:
-            for message in self.warn_messages:
+            for message in self.message_list:
+                if message.level != "warning":
+                    continue
                 self.found_warns = True
                 print_linter_info()
-                print(f".. WARNING: {message}")
+                print(f"{message}")
 
         if self.level == LEVEL_ALL:
-            for message in self.info_messages:
+            for message in self.message_list:
+                if message.level != "info":
+                    continue
                 print_linter_info()
-                print(f".. INFO: {message}")
-            for message in self.valid_messages:
+                print(f"{message}")
+            for message in self.message_list:
+                if message.level != "check":
+                    continue
                 print_linter_info()
-                print(f".. CHECK: {message}")
+                print(f"{message}")
 
-    def __handle_message(self, message_list, message, *args):
+    @property
+    def valid_messages(self):
+        return [x.message for x in self.message_list if x.level == "check"]
+
+    @property
+    def info_messages(self):
+        return [x.message for x in self.message_list if x.level == "info"]
+
+    @property
+    def warn_messages(self):
+        return [x.message for x in self.message_list if x.level == "warning"]
+
+    @property
+    def error_messages(self):
+        return [x.message for x in self.message_list if x.level == "error"]
+
+    def __handle_message(self, level, message, line, xpath, *args):
         if args:
             message = message % args
-        message_list.append(message)
+        self.message_list.append(LintMessage(level=level, message=message, line=line, xpath=xpath))
 
-    def valid(self, message, *args):
-        self.__handle_message(self.valid_messages, message, *args)
+    def valid(self, message, line=None, xpath=None, *args):
+        self.__handle_message("check", message, line, xpath, *args)
 
-    def info(self, message, *args):
-        self.__handle_message(self.info_messages, message, *args)
+    def info(self, message, line=None, xpath=None, *args):
+        self.__handle_message("info", message, line, xpath, *args)
 
-    def error(self, message, *args):
-        self.__handle_message(self.error_messages, message, *args)
+    def error(self, message, line=None, xpath=None, *args):
+        self.__handle_message("error", message, line, xpath, *args)
 
-    def warn(self, message, *args):
-        self.__handle_message(self.warn_messages, message, *args)
+    def warn(self, message, line=None, xpath=None, *args):
+        self.__handle_message("warning", message, line, xpath, *args)
 
     def failed(self, fail_level):
         found_warns = self.found_warns

--- a/lib/galaxy/tool_util/linters/citations.py
+++ b/lib/galaxy/tool_util/linters/citations.py
@@ -8,13 +8,17 @@ of the tool publish results.
 def lint_citations(tool_xml, lint_ctx):
     """Ensure tool contains at least one valid citation."""
     root = tool_xml.getroot()
+    if root is not None:
+        root_line = root.sourceline
+    else:
+        root_line = 1
     citations = root.findall("citations")
     if len(citations) > 1:
         lint_ctx.error("More than one citation section found, behavior undefined.", line=citations[1].sourceline)
         return
 
     if len(citations) == 0:
-        lint_ctx.warn("No citations found, consider adding citations to your tool.", line=root.sourceline)
+        lint_ctx.warn("No citations found, consider adding citations to your tool.", line=root_line)
         return
 
     valid_citations = 0
@@ -32,4 +36,4 @@ def lint_citations(tool_xml, lint_ctx):
         valid_citations += 1
 
     if valid_citations > 0:
-        lint_ctx.valid(f"Found {valid_citations} likely valid citations.", line=root.sourceline)
+        lint_ctx.valid(f"Found {valid_citations} likely valid citations.", line=root_line)

--- a/lib/galaxy/tool_util/linters/citations.py
+++ b/lib/galaxy/tool_util/linters/citations.py
@@ -10,30 +10,32 @@ def lint_citations(tool_xml, lint_ctx):
     root = tool_xml.getroot()
     if root is not None:
         root_line = root.sourceline
+        root_xpath = tool_xml.getpath(root)
     else:
         root_line = 1
+        root_xpath = None
     citations = root.findall("citations")
     if len(citations) > 1:
-        lint_ctx.error("More than one citation section found, behavior undefined.", line=citations[1].sourceline)
+        lint_ctx.error("More than one citation section found, behavior undefined.", line=citations[1].sourceline, xpath=tool_xml.getpath(citations[1]))
         return
 
     if len(citations) == 0:
-        lint_ctx.warn("No citations found, consider adding citations to your tool.", line=root_line)
+        lint_ctx.warn("No citations found, consider adding citations to your tool.", line=root_line, xpath=root_xpath)
         return
 
     valid_citations = 0
     for citation in citations[0]:
         if citation.tag != "citation":
-            lint_ctx.warn(f"Unknown tag discovered in citations block [{citation.tag}], will be ignored.", line=citation.sourceline)
+            lint_ctx.warn(f"Unknown tag discovered in citations block [{citation.tag}], will be ignored.", line=citation.sourceline, xpath=tool_xml.getpath(citation))
             continue
         citation_type = citation.attrib.get("type")
         if citation_type not in ('bibtex', 'doi'):
-            lint_ctx.warn(f"Unknown citation type discovered [{citation_type}], will be ignored.", line=citation.sourceline)
+            lint_ctx.warn(f"Unknown citation type discovered [{citation_type}], will be ignored.", line=citation.sourceline, xpath=tool_xml.getpath(citation))
             continue
         if citation.text is None or not citation.text.strip():
-            lint_ctx.error(f'Empty {citation_type} citation.', line=citation.sourceline)
+            lint_ctx.error(f'Empty {citation_type} citation.', line=citation.sourceline, xpath=tool_xml.getpath(citation))
             continue
         valid_citations += 1
 
     if valid_citations > 0:
-        lint_ctx.valid(f"Found {valid_citations} likely valid citations.", line=root_line)
+        lint_ctx.valid(f"Found {valid_citations} likely valid citations.", line=root_line, xpath=root_xpath)

--- a/lib/galaxy/tool_util/linters/citations.py
+++ b/lib/galaxy/tool_util/linters/citations.py
@@ -10,26 +10,26 @@ def lint_citations(tool_xml, lint_ctx):
     root = tool_xml.getroot()
     citations = root.findall("citations")
     if len(citations) > 1:
-        lint_ctx.error("More than one citation section found, behavior undefined.")
+        lint_ctx.error("More than one citation section found, behavior undefined.", line=citations[1].sourceline)
         return
 
     if len(citations) == 0:
-        lint_ctx.warn("No citations found, consider adding citations to your tool.")
+        lint_ctx.warn("No citations found, consider adding citations to your tool.", line=root.sourceline)
         return
 
     valid_citations = 0
     for citation in citations[0]:
         if citation.tag != "citation":
-            lint_ctx.warn(f"Unknown tag discovered in citations block [{citation.tag}], will be ignored.")
+            lint_ctx.warn(f"Unknown tag discovered in citations block [{citation.tag}], will be ignored.", line=citation.sourceline)
             continue
         citation_type = citation.attrib.get("type")
         if citation_type not in ('bibtex', 'doi'):
-            lint_ctx.warn("Unknown citation type discovered [%s], will be ignored.", citation_type)
+            lint_ctx.warn(f"Unknown citation type discovered [{citation_type}], will be ignored.", line=citation.sourceline)
             continue
         if citation.text is None or not citation.text.strip():
-            lint_ctx.error(f'Empty {citation_type} citation.')
+            lint_ctx.error(f'Empty {citation_type} citation.', line=citation.sourceline)
             continue
         valid_citations += 1
 
     if valid_citations > 0:
-        lint_ctx.valid("Found %d likely valid citations.", valid_citations)
+        lint_ctx.valid(f"Found {valid_citations} likely valid citations.", line=root.sourceline)

--- a/lib/galaxy/tool_util/linters/citations.py
+++ b/lib/galaxy/tool_util/linters/citations.py
@@ -39,3 +39,5 @@ def lint_citations(tool_xml, lint_ctx):
 
     if valid_citations > 0:
         lint_ctx.valid(f"Found {valid_citations} likely valid citations.", line=root_line, xpath=root_xpath)
+    else:
+        lint_ctx.warn("Found no valid citations.", line=root_line, xpath=root_xpath)

--- a/lib/galaxy/tool_util/linters/command.py
+++ b/lib/galaxy/tool_util/linters/command.py
@@ -24,7 +24,9 @@ def lint_command(tool_xml, lint_ctx):
         return
 
     command = get_command(tool_xml)
-    if "TODO" in command:
+    if command.text is None:
+        lint_ctx.error("Command is empty.", line=root_line, xpath=root_path)
+    elif "TODO" in command.text:
         lint_ctx.warn("Command template contains TODO text.", line=command.sourceline, xpath=tool_xml.getpath(command))
 
     command_attrib = command.attrib
@@ -41,7 +43,7 @@ def lint_command(tool_xml, lint_ctx):
     if interpreter_type:
         interpreter_info = f" with interpreter of type [{interpreter_type}]"
     if interpreter_type:
-        lint_ctx.info("Command uses deprecated 'interpreter' attribute.", line=command.sourceline, xpath=tool_xml.getpath(command))
+        lint_ctx.warn("Command uses deprecated 'interpreter' attribute.", line=command.sourceline, xpath=tool_xml.getpath(command))
     lint_ctx.info(f"Tool contains a command{interpreter_info}.", line=command.sourceline, xpath=tool_xml.getpath(command))
 
 

--- a/lib/galaxy/tool_util/linters/command.py
+++ b/lib/galaxy/tool_util/linters/command.py
@@ -10,16 +10,16 @@ def lint_command(tool_xml, lint_ctx):
     root = tool_xml.getroot()
     commands = root.findall("command")
     if len(commands) > 1:
-        lint_ctx.error("More than one command tag found, behavior undefined.")
+        lint_ctx.error("More than one command tag found, behavior undefined.", line=commands[1].sourceline)
         return
 
     if len(commands) == 0:
-        lint_ctx.error("No command tag found, must specify a command template to execute.")
+        lint_ctx.error("No command tag found, must specify a command template to execute.", line=root.sourceline)
         return
 
     command = get_command(tool_xml)
     if "TODO" in command:
-        lint_ctx.warn("Command template contains TODO text.")
+        lint_ctx.warn("Command template contains TODO text.", line=command.sourceline)
 
     command_attrib = command.attrib
     interpreter_type = None
@@ -29,14 +29,14 @@ def lint_command(tool_xml, lint_ctx):
         elif key == "detect_errors":
             detect_errors = value
             if detect_errors not in ["default", "exit_code", "aggressive"]:
-                lint_ctx.warn(f"Unknown detect_errors attribute [{detect_errors}]")
+                lint_ctx.warn(f"Unknown detect_errors attribute [{detect_errors}]", line=command.sourceline)
 
     interpreter_info = ""
     if interpreter_type:
         interpreter_info = f" with interpreter of type [{interpreter_type}]"
     if interpreter_type:
-        lint_ctx.info("Command uses deprecated 'interpreter' attribute.")
-    lint_ctx.info(f"Tool contains a command{interpreter_info}.")
+        lint_ctx.info("Command uses deprecated 'interpreter' attribute.", line=command.sourceline)
+    lint_ctx.info(f"Tool contains a command{interpreter_info}.", line=command.sourceline)
 
 
 def get_command(tool_xml):

--- a/lib/galaxy/tool_util/linters/command.py
+++ b/lib/galaxy/tool_util/linters/command.py
@@ -10,20 +10,22 @@ def lint_command(tool_xml, lint_ctx):
     root = tool_xml.getroot()
     if root is not None:
         root_line = root.sourceline
+        root_path = tool_xml.getpath(root)
     else:
         root_line = 1
+        root_path = None
     commands = root.findall("command")
     if len(commands) > 1:
-        lint_ctx.error("More than one command tag found, behavior undefined.", line=commands[1].sourceline)
+        lint_ctx.error("More than one command tag found, behavior undefined.", line=commands[1].sourceline, xpath=tool_xml.getpath(commands[1]))
         return
 
     if len(commands) == 0:
-        lint_ctx.error("No command tag found, must specify a command template to execute.", line=root_line)
+        lint_ctx.error("No command tag found, must specify a command template to execute.", line=root_line, xpath=root_path)
         return
 
     command = get_command(tool_xml)
     if "TODO" in command:
-        lint_ctx.warn("Command template contains TODO text.", line=command.sourceline)
+        lint_ctx.warn("Command template contains TODO text.", line=command.sourceline, xpath=tool_xml.getpath(command))
 
     command_attrib = command.attrib
     interpreter_type = None
@@ -33,14 +35,14 @@ def lint_command(tool_xml, lint_ctx):
         elif key == "detect_errors":
             detect_errors = value
             if detect_errors not in ["default", "exit_code", "aggressive"]:
-                lint_ctx.warn(f"Unknown detect_errors attribute [{detect_errors}]", line=command.sourceline)
+                lint_ctx.warn(f"Unknown detect_errors attribute [{detect_errors}]", line=command.sourceline, xpath=tool_xml.getpath(command))
 
     interpreter_info = ""
     if interpreter_type:
         interpreter_info = f" with interpreter of type [{interpreter_type}]"
     if interpreter_type:
-        lint_ctx.info("Command uses deprecated 'interpreter' attribute.", line=command.sourceline)
-    lint_ctx.info(f"Tool contains a command{interpreter_info}.", line=command.sourceline)
+        lint_ctx.info("Command uses deprecated 'interpreter' attribute.", line=command.sourceline, xpath=tool_xml.getpath(command))
+    lint_ctx.info(f"Tool contains a command{interpreter_info}.", line=command.sourceline, xpath=tool_xml.getpath(command))
 
 
 def get_command(tool_xml):

--- a/lib/galaxy/tool_util/linters/command.py
+++ b/lib/galaxy/tool_util/linters/command.py
@@ -8,13 +8,17 @@ from supplied inputs.
 def lint_command(tool_xml, lint_ctx):
     """Ensure tool contains exactly one command and check attributes."""
     root = tool_xml.getroot()
+    if root is not None:
+        root_line = root.sourceline
+    else:
+        root_line = 1
     commands = root.findall("command")
     if len(commands) > 1:
         lint_ctx.error("More than one command tag found, behavior undefined.", line=commands[1].sourceline)
         return
 
     if len(commands) == 0:
-        lint_ctx.error("No command tag found, must specify a command template to execute.", line=root.sourceline)
+        lint_ctx.error("No command tag found, must specify a command template to execute.", line=root_line)
         return
 
     command = get_command(tool_xml)

--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -57,8 +57,8 @@ def lint_general(tool_source, lint_ctx):
         lint_ctx.error(ERROR_ID_MSG, line=tool_line)
     else:
         lint_ctx.valid(VALID_ID_MSG % tool_id, line=tool_line)
-    if re.search(r"\s", tool_id):
-        lint_ctx.warn(WARN_ID_WHITESPACE_MSG % tool_id, line=tool_line)
+        if re.search(r"\s", tool_id):
+            lint_ctx.warn(WARN_ID_WHITESPACE_MSG % tool_id, line=tool_line)
 
     profile = tool_source.parse_profile()
     profile_valid = PROFILE_PATTERN.match(profile) is not None

--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -27,39 +27,47 @@ lint_tool_types = ["*"]
 
 def lint_general(tool_source, lint_ctx):
     """Check tool version, name, and id."""
+    # determine line to report for general problems with outputs
+    tool_xml = getattr(tool_source, "xml_tree", None)
+    try:
+        tool_line = tool_xml.find("./tool").sourceline
+    except:
+        tool_line = 0
     version = tool_source.parse_version() or ''
     parsed_version = packaging.version.parse(version)
     if not version:
-        lint_ctx.error(ERROR_VERSION_MSG)
+        lint_ctx.error(ERROR_VERSION_MSG, line=tool_line)
     elif isinstance(parsed_version, packaging.version.LegacyVersion):
-        lint_ctx.warn(WARN_VERSION_MSG % version)
+        lint_ctx.warn(WARN_VERSION_MSG % version, line=tool_line)
     elif version != version.strip():
-        lint_ctx.warn(WARN_WHITESPACE_MSG % ('Tool version', version))
+        lint_ctx.warn(WARN_WHITESPACE_MSG % ('Tool version', version), line=tool_line)
     else:
-        lint_ctx.valid(VALID_VERSION_MSG % version)
+        lint_ctx.valid(VALID_VERSION_MSG % version, line=tool_line)
 
     name = tool_source.parse_name()
     if not name:
-        lint_ctx.error(ERROR_NAME_MSG)
+        lint_ctx.error(ERROR_NAME_MSG, line=tool_line)
     elif name != name.strip():
-        lint_ctx.warn(WARN_WHITESPACE_MSG % ('Tool name', name))
+        lint_ctx.warn(WARN_WHITESPACE_MSG % ('Tool name', name), line=tool_line)
     else:
-        lint_ctx.valid(VALID_NAME_MSG % name)
+        lint_ctx.valid(VALID_NAME_MSG % name, line=tool_line)
 
     tool_id = tool_source.parse_id()
     if not tool_id:
-        lint_ctx.error(ERROR_ID_MSG)
+        lint_ctx.error(ERROR_ID_MSG, line=tool_line)
     else:
-        lint_ctx.valid(VALID_ID_MSG % tool_id)
+        lint_ctx.valid(VALID_ID_MSG % tool_id, line=tool_line)
+    if re.search(r"\s", tool_id):
+        lint_ctx.warn(WARN_ID_WHITESPACE_MSG % tool_id, line=tool_line)
 
     profile = tool_source.parse_profile()
     profile_valid = PROFILE_PATTERN.match(profile) is not None
     if not profile_valid:
-        lint_ctx.error(PROFILE_INVALID_MSG)
+        lint_ctx.error(PROFILE_INVALID_MSG, line=tool_line)
     elif profile == "16.01":
-        lint_ctx.valid(PROFILE_INFO_DEFAULT_MSG)
+        lint_ctx.valid(PROFILE_INFO_DEFAULT_MSG, line=tool_line)
     else:
-        lint_ctx.valid(PROFILE_INFO_SPECIFIED_MSG % profile)
+        lint_ctx.valid(PROFILE_INFO_SPECIFIED_MSG % profile, line=tool_line)
 
     requirements, containers = tool_source.parse_requirements_and_containers()
     for r in requirements:
@@ -72,6 +80,3 @@ def lint_general(tool_source, lint_ctx):
             elif r.version != r.version.strip():
                 lint_ctx.warn(
                     WARN_WHITESPACE_MSG % ('Requirement version', r.version))
-
-    if re.search(r"\s", tool_id):
-        lint_ctx.warn(WARN_ID_WHITESPACE_MSG % tool_id)

--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -19,6 +19,7 @@ PROFILE_INFO_SPECIFIED_MSG = "Tool specifies profile version [%s]."
 PROFILE_INVALID_MSG = "Tool specifies an invalid profile version [%s]."
 
 WARN_WHITESPACE_MSG = "%s contains whitespace, this may cause errors: [%s]."
+WARN_WHITESPACE_PRESUFFIX = "%s is pre/suffixed by whitespace, this may cause errors: [%s]."
 WARN_ID_WHITESPACE_MSG = (
     "Tool ID contains whitespace - this is discouraged: [%s].")
 
@@ -40,7 +41,7 @@ def lint_general(tool_source, lint_ctx):
     elif isinstance(parsed_version, packaging.version.LegacyVersion):
         lint_ctx.warn(WARN_VERSION_MSG % version, line=tool_line)
     elif version != version.strip():
-        lint_ctx.warn(WARN_WHITESPACE_MSG % ('Tool version', version), line=tool_line)
+        lint_ctx.warn(WARN_WHITESPACE_PRESUFFIX % ('Tool version', version), line=tool_line)
     else:
         lint_ctx.valid(VALID_VERSION_MSG % version, line=tool_line)
 
@@ -48,22 +49,22 @@ def lint_general(tool_source, lint_ctx):
     if not name:
         lint_ctx.error(ERROR_NAME_MSG, line=tool_line)
     elif name != name.strip():
-        lint_ctx.warn(WARN_WHITESPACE_MSG % ('Tool name', name), line=tool_line)
+        lint_ctx.warn(WARN_WHITESPACE_PRESUFFIX % ('Tool name', name), line=tool_line)
     else:
         lint_ctx.valid(VALID_NAME_MSG % name, line=tool_line)
 
     tool_id = tool_source.parse_id()
     if not tool_id:
         lint_ctx.error(ERROR_ID_MSG, line=tool_line)
+    elif re.search(r"\s", tool_id):
+        lint_ctx.warn(WARN_ID_WHITESPACE_MSG % tool_id, line=tool_line)
     else:
         lint_ctx.valid(VALID_ID_MSG % tool_id, line=tool_line)
-        if re.search(r"\s", tool_id):
-            lint_ctx.warn(WARN_ID_WHITESPACE_MSG % tool_id, line=tool_line)
 
     profile = tool_source.parse_profile()
     profile_valid = PROFILE_PATTERN.match(profile) is not None
     if not profile_valid:
-        lint_ctx.error(PROFILE_INVALID_MSG, line=tool_line)
+        lint_ctx.error(PROFILE_INVALID_MSG % profile, line=tool_line)
     elif profile == "16.01":
         lint_ctx.valid(PROFILE_INFO_DEFAULT_MSG, line=tool_line)
     else:

--- a/lib/galaxy/tool_util/linters/general.py
+++ b/lib/galaxy/tool_util/linters/general.py
@@ -31,7 +31,7 @@ def lint_general(tool_source, lint_ctx):
     tool_xml = getattr(tool_source, "xml_tree", None)
     try:
         tool_line = tool_xml.find("./tool").sourceline
-    except:
+    except AttributeError:
         tool_line = 0
     version = tool_source.parse_version() or ''
     parsed_version = packaging.version.parse(version)

--- a/lib/galaxy/tool_util/linters/help.py
+++ b/lib/galaxy/tool_util/linters/help.py
@@ -7,15 +7,20 @@ from galaxy.util import (
 
 def lint_help(tool_xml, lint_ctx):
     """Ensure tool contains exactly one valid RST help block."""
-    # determine line to report for general problems with outputs
+    # determine line to report for general problems with help
     root = tool_xml.getroot()
+    if root is not None:
+        root_line = root.sourceline
+    else
+        root_line = 1
+
     helps = root.findall("help")
     if len(helps) > 1:
         lint_ctx.error("More than one help section found, behavior undefined.", line=helps[1].sourceline)
         return
 
     if len(helps) == 0:
-        lint_ctx.warn("No help section found, consider adding a help section to your tool.", line=root.sourceline)
+        lint_ctx.warn("No help section found, consider adding a help section to your tool.", line=root_line)
         return
 
     help = helps[0].text or ''
@@ -23,7 +28,7 @@ def lint_help(tool_xml, lint_ctx):
         lint_ctx.warn("Help section appears to be empty.", line=helps[0].sourceline)
         return
 
-    lint_ctx.valid("Tool contains help section.", line=root.sourceline)
+    lint_ctx.valid("Tool contains help section.", line=root_line)
     invalid_rst = rst_invalid(help)
 
     if "TODO" in help:

--- a/lib/galaxy/tool_util/linters/help.py
+++ b/lib/galaxy/tool_util/linters/help.py
@@ -7,31 +7,32 @@ from galaxy.util import (
 
 def lint_help(tool_xml, lint_ctx):
     """Ensure tool contains exactly one valid RST help block."""
+    # determine line to report for general problems with outputs
     root = tool_xml.getroot()
     helps = root.findall("help")
     if len(helps) > 1:
-        lint_ctx.error("More than one help section found, behavior undefined.")
+        lint_ctx.error("More than one help section found, behavior undefined.", line=helps[1].sourceline)
         return
 
     if len(helps) == 0:
-        lint_ctx.warn("No help section found, consider adding a help section to your tool.")
+        lint_ctx.warn("No help section found, consider adding a help section to your tool.", line=root.sourceline)
         return
 
     help = helps[0].text or ''
     if not help.strip():
-        lint_ctx.warn("Help section appears to be empty.")
+        lint_ctx.warn("Help section appears to be empty.", line=helps[0].sourceline)
         return
 
-    lint_ctx.valid("Tool contains help section.")
+    lint_ctx.valid("Tool contains help section.", line=root.sourceline)
     invalid_rst = rst_invalid(help)
 
     if "TODO" in help:
-        lint_ctx.warn("Help contains TODO text.")
+        lint_ctx.warn("Help contains TODO text.", line=helps[0].sourceline)
 
     if invalid_rst:
-        lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].")
+        lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].", line=helps[0].sourceline)
     else:
-        lint_ctx.valid("Help contains valid reStructuredText.")
+        lint_ctx.valid("Help contains valid reStructuredText.", line=helps[0].sourceline)
 
 
 def rst_invalid(text):

--- a/lib/galaxy/tool_util/linters/help.py
+++ b/lib/galaxy/tool_util/linters/help.py
@@ -11,33 +11,34 @@ def lint_help(tool_xml, lint_ctx):
     root = tool_xml.getroot()
     if root is not None:
         root_line = root.sourceline
-    else
+        root_path = tool_xml.getpath(root)
+    else:
         root_line = 1
-
+        root_path = None
     helps = root.findall("help")
     if len(helps) > 1:
-        lint_ctx.error("More than one help section found, behavior undefined.", line=helps[1].sourceline)
+        lint_ctx.error("More than one help section found, behavior undefined.", line=helps[1].sourceline, xpath=tool_xml.getpath(helps[1]))
         return
 
     if len(helps) == 0:
-        lint_ctx.warn("No help section found, consider adding a help section to your tool.", line=root_line)
+        lint_ctx.warn("No help section found, consider adding a help section to your tool.", line=root_line, xpath=root_path)
         return
 
     help = helps[0].text or ''
     if not help.strip():
-        lint_ctx.warn("Help section appears to be empty.", line=helps[0].sourceline)
+        lint_ctx.warn("Help section appears to be empty.", line=helps[0].sourceline, xpath=tool_xml.getpath(helps[0]))
         return
 
-    lint_ctx.valid("Tool contains help section.", line=root_line)
+    lint_ctx.valid("Tool contains help section.", line=helps[0].sourceline, xpath=tool_xml.getpath(helps[0]))
     invalid_rst = rst_invalid(help)
 
     if "TODO" in help:
-        lint_ctx.warn("Help contains TODO text.", line=helps[0].sourceline)
+        lint_ctx.warn("Help contains TODO text.", line=helps[0].sourceline, xpath=tool_xml.getpath(helps[0]))
 
     if invalid_rst:
-        lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].", line=helps[0].sourceline)
+        lint_ctx.warn(f"Invalid reStructuredText found in help - [{invalid_rst}].", line=helps[0].sourceline, xpath=tool_xml.getpath(helps[0]))
     else:
-        lint_ctx.valid("Help contains valid reStructuredText.", line=helps[0].sourceline)
+        lint_ctx.valid("Help contains valid reStructuredText.", line=helps[0].sourceline, xpath=tool_xml.getpath(helps[0]))
 
 
 def rst_invalid(text):

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -49,7 +49,7 @@ def lint_inputs(tool_xml, lint_ctx):
     # determine line to report for general problems with outputs
     try:
         tool_line = tool_xml.find("./tool").sourceline
-    except:
+    except AttributeError:
         tool_line = 0
     datasource = is_datasource(tool_xml)
     inputs = tool_xml.findall("./inputs//param")

--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -49,8 +49,10 @@ def lint_inputs(tool_xml, lint_ctx):
     # determine line to report for general problems with outputs
     try:
         tool_line = tool_xml.find("./tool").sourceline
+        tool_path = tool_xml.getpath(tool_xml.find("./tool"))
     except AttributeError:
-        tool_line = 0
+        tool_line = 1
+        tool_path = None
     datasource = is_datasource(tool_xml)
     inputs = tool_xml.findall("./inputs//param")
     num_inputs = 0
@@ -58,7 +60,7 @@ def lint_inputs(tool_xml, lint_ctx):
         num_inputs += 1
         param_attrib = param.attrib
         if "name" not in param_attrib and "argument" not in param_attrib:
-            lint_ctx.error("Found param input with no name specified.", line=param.sourceline)
+            lint_ctx.error("Found param input with no name specified.", line=param.sourceline, xpath=tool_xml.getpath(param))
             continue
         param_name = _parse_name(param_attrib.get("name"), param_attrib.get("argument"))
         if "name" in param_attrib and "argument" in param_attrib:
@@ -66,16 +68,16 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.warn(f"Param input [{param_name}] 'name' attribute is redundant if argument implies the same name.")
 
         if "type" not in param_attrib:
-            lint_ctx.error(f"Param input [{param_name}] input with no type specified.", line=param.sourceline)
+            lint_ctx.error(f"Param input [{param_name}] input with no type specified.", line=param.sourceline, xpath=tool_xml.getpath(param))
             continue
         param_type = param_attrib["type"]
 
         if not is_valid_cheetah_placeholder(param_name):
-            lint_ctx.warn(f"Param input [{param_name}] is not a valid Cheetah placeholder.", line=param.sourceline)
+            lint_ctx.warn(f"Param input [{param_name}] is not a valid Cheetah placeholder.", line=param.sourceline, xpath=tool_xml.getpath(param))
 
         if param_type == "data":
             if "format" not in param_attrib:
-                lint_ctx.warn(f"Param input [{param_name}] with no format specified - 'data' format will be assumed.", line=param.sourceline)
+                lint_ctx.warn(f"Param input [{param_name}] with no format specified - 'data' format will be assumed.", line=param.sourceline, xpath=tool_xml.getpath(param))
         elif param_type == "select":
             # get dynamic/statically defined options
             dynamic_options = param.get("dynamic_options", None)
@@ -84,11 +86,11 @@ def lint_inputs(tool_xml, lint_ctx):
             select_options = param.findall('./option')
 
             if dynamic_options is not None:
-                lint_ctx.warn(f"Select parameter [{param_name}] uses deprecated 'dynamic_options' attribute.", line=param.sourceline)
+                lint_ctx.warn(f"Select parameter [{param_name}] uses deprecated 'dynamic_options' attribute.", line=param.sourceline, xpath=tool_xml.getpath(param))
 
             # check if options are defined by exactly one possibility
             if (dynamic_options is not None) + (len(options) > 0) + (len(select_options) > 0) != 1:
-                lint_ctx.error(f"Select parameter [{param_name}] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute.", line=param.sourceline)
+                lint_ctx.error(f"Select parameter [{param_name}] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute.", line=param.sourceline, xpath=tool_xml.getpath(param))
 
             # lint dynamic options
             if len(options) == 1:
@@ -98,10 +100,10 @@ def lint_inputs(tool_xml, lint_ctx):
                 for f in filters:
                     ftype = f.get("type", None)
                     if ftype is None:
-                        lint_ctx.error(f"Select parameter [{param_name}] contains filter without type.", line=f.sourceline)
+                        lint_ctx.error(f"Select parameter [{param_name}] contains filter without type.", line=f.sourceline, xpath=tool_xml.getpath(f))
                         continue
                     if ftype not in FILTER_TYPES:
-                        lint_ctx.error(f"Select parameter [{param_name}] contains filter with unknown type '{ftype}'.", line=f.sourceline)
+                        lint_ctx.error(f"Select parameter [{param_name}] contains filter with unknown type '{ftype}'.", line=f.sourceline, xpath=tool_xml.getpath(f))
                         continue
                     if ftype in ['add_value', 'data_meta']:
                         filter_adds_options = True
@@ -114,33 +116,33 @@ def lint_inputs(tool_xml, lint_ctx):
                 if (from_file is None and from_parameter is None
                         and from_dataset is None and from_data_table is None
                         and not filter_adds_options):
-                    lint_ctx.error(f"Select parameter [{param_name}] options tag defines no options. Use 'from_dataset', 'from_data_table', or a filter that adds values.", line=options[0].sourceline)
+                    lint_ctx.error(f"Select parameter [{param_name}] options tag defines no options. Use 'from_dataset', 'from_data_table', or a filter that adds values.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
 
                 if from_file is not None:
-                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'from_file' attribute.", line=options[0].sourceline)
+                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'from_file' attribute.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
                 if from_parameter is not None:
-                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'from_parameter' attribute.", line=options[0].sourceline)
+                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'from_parameter' attribute.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
 
                 if from_dataset is not None and from_data_table is not None:
-                    lint_ctx.error(f"Select parameter [{param_name}] options uses 'from_dataset' and 'from_data_table' attribute.", line=options[0].sourceline)
+                    lint_ctx.error(f"Select parameter [{param_name}] options uses 'from_dataset' and 'from_data_table' attribute.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
 
                 if options[0].get("meta_file_key", None) is not None and from_dataset is None:
-                    lint_ctx.error(f"Select parameter [{param_name}] 'meta_file_key' is only compatible with 'from_dataset'.", line=options[0].sourceline)
+                    lint_ctx.error(f"Select parameter [{param_name}] 'meta_file_key' is only compatible with 'from_dataset'.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
 
                 if options[0].get("options_filter_attribute", None) is not None:
-                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'options_filter_attribute' attribute.", line=options[0].sourceline)
+                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'options_filter_attribute' attribute.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
 
                 if options[0].get("transform_lines", None) is not None:
-                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'transform_lines' attribute.", line=options[0].sourceline)
+                    lint_ctx.warn(f"Select parameter [{param_name}] options uses deprecated 'transform_lines' attribute.", line=options[0].sourceline, xpath=tool_xml.getpath(options[0]))
 
             elif len(options) > 1:
-                lint_ctx.error(f"Select parameter [{param_name}] contains multiple options elements", line=options[1].sourceline)
+                lint_ctx.error(f"Select parameter [{param_name}] contains multiple options elements", line=options[1].sourceline, xpath=tool_xml.getpath(options[1]))
 
             # lint statically defined options
             if any('value' not in option.attrib for option in select_options):
-                lint_ctx.error(f"Select parameter [{param_name}] has option without value", line=param.sourceline)
+                lint_ctx.error(f"Select parameter [{param_name}] has option without value", line=param.sourceline, xpath=tool_xml.getpath(param))
             if any(option.text is None for option in select_options):
-                lint_ctx.warn(f"Select parameter [{param_name}] has option without text", line=param.sourceline)
+                lint_ctx.warn(f"Select parameter [{param_name}] has option without text", line=param.sourceline, xpath=tool_xml.getpath(param))
 
             select_options_texts = list()
             select_options_values = list()
@@ -153,22 +155,22 @@ def lint_inputs(tool_xml, lint_ctx):
                 select_options_texts.append((text, option.attrib.get("selected", "false")))
                 select_options_values.append((value, option.attrib.get("selected", "false")))
             if len(set(select_options_texts)) != len(select_options_texts):
-                lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same text content", line=param.sourceline)
+                lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same text content", line=param.sourceline, xpath=tool_xml.getpath(param))
             if len(set(select_options_values)) != len(select_options_values):
-                lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value", line=param.sourceline)
+                lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value", line=param.sourceline, xpath=tool_xml.getpath(param))
 
             multiple = string_as_bool(param_attrib.get("multiple", "false"))
             optional = string_as_bool(param_attrib.get("optional", multiple))
             if param_attrib.get("display") == "checkboxes":
                 if not multiple:
-                    lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute', line=param.sourceline)
+                    lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute', line=param.sourceline, xpath=tool_xml.getpath(param))
                 if not optional:
-                    lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute', line=param.sourceline)
+                    lint_ctx.error(f'Select [{param_name}] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute', line=param.sourceline, xpath=tool_xml.getpath(param))
             if param_attrib.get("display") == "radio":
                 if multiple:
-                    lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with multiple="true"', line=param.sourceline)
+                    lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with multiple="true"', line=param.sourceline, xpath=tool_xml.getpath(param))
                 if optional:
-                    lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with optional="true"', line=param.sourceline)
+                    lint_ctx.error(f'Select [{param_name}] display="radio" is incompatible with optional="true"', line=param.sourceline, xpath=tool_xml.getpath(param))
         # TODO: Validate type, much more...
 
         # lint validators
@@ -177,36 +179,36 @@ def lint_inputs(tool_xml, lint_ctx):
             vtype = validator.attrib['type']
             if param_type in PARAMETER_VALIDATOR_TYPE_COMPATIBILITY:
                 if vtype not in PARAMETER_VALIDATOR_TYPE_COMPATIBILITY[param_type]:
-                    lint_ctx.error(f"Parameter [{param_name}]: validator with an incompatible type '{vtype}'", line=validator.sourceline)
+                    lint_ctx.error(f"Parameter [{param_name}]: validator with an incompatible type '{vtype}'", line=validator.sourceline, xpath=tool_xml.getpath(validator))
             for attrib in ATTRIB_VALIDATOR_COMPATIBILITY:
                 if attrib in validator.attrib and vtype not in ATTRIB_VALIDATOR_COMPATIBILITY[attrib]:
-                    lint_ctx.error(f"Parameter [{param_name}]: attribute '{attrib}' is incompatible with validator of type '{vtype}'", line=validator.sourceline)
+                    lint_ctx.error(f"Parameter [{param_name}]: attribute '{attrib}' is incompatible with validator of type '{vtype}'", line=validator.sourceline, xpath=tool_xml.getpath(validator))
             if vtype == "expression" and validator.text is None:
                 lint_ctx.error(f"Parameter [{param_name}]: expression validator without content")
             if vtype not in ["expression", "regex"] and validator.text is not None:
-                lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')", line=validator.sourceline)
+                lint_ctx.warn(f"Parameter [{param_name}]: '{vtype}' validators are not expected to contain text (found '{validator.text}')", line=validator.sourceline, xpath=tool_xml.getpath(validator))
             if vtype in ["in_range", "length", "dataset_metadata_in_range"] and ("min" not in validator.attrib and "max" not in validator.attrib):
-                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)", line=validator.sourceline)
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'min' or 'max' attribute(s)", line=validator.sourceline, xpath=tool_xml.getpath(validator))
             if vtype in ["metadata"] and ("check" not in validator.attrib and "skip" not in validator.attrib):
-                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'check' or 'skip' attribute(s) {validator.attrib}", line=validator.sourceline)
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'check' or 'skip' attribute(s) {validator.attrib}", line=validator.sourceline, xpath=tool_xml.getpath(validator))
             if vtype in ["value_in_data_table", "value_not_in_data_table", "dataset_metadata_in_data_table", "dataset_metadata_not_in_data_table"] and "table_name" not in validator.attrib:
-                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'table_name' attribute", line=validator.sourceline)
+                lint_ctx.error(f"Parameter [{param_name}]: '{vtype}' validators need to define the 'table_name' attribute", line=validator.sourceline, xpath=tool_xml.getpath(validator))
 
     conditional_selects = tool_xml.findall("./inputs//conditional")
     for conditional in conditional_selects:
         conditional_name = conditional.get('name')
         if not conditional_name:
-            lint_ctx.error("Conditional without a name", line=conditional.sourceline)
+            lint_ctx.error("Conditional without a name", line=conditional.sourceline, xpath=tool_xml.getpath(conditional))
         if conditional.get("value_from"):
             # Probably only the upload tool use this, no children elements
             continue
         first_param = conditional.find("param")
         if first_param is None:
-            lint_ctx.error(f"Conditional [{conditional_name}] has no child <param>", line=conditional.sourceline)
+            lint_ctx.error(f"Conditional [{conditional_name}] has no child <param>", line=conditional.sourceline, xpath=tool_xml.getpath(conditional))
             continue
         first_param_type = first_param.get('type')
         if first_param_type not in ['select', 'boolean']:
-            lint_ctx.warn(f'Conditional [{conditional_name}] first param should have type="select" /> or type="boolean"', line=first_param_type.sourceline)
+            lint_ctx.warn(f'Conditional [{conditional_name}] first param should have type="select" /> or type="boolean"', line=first_param.sourceline, xpath=tool_xml.getpath(first_param))
             continue
 
         if first_param_type == 'select':
@@ -219,37 +221,37 @@ def lint_inputs(tool_xml, lint_ctx):
             ]
 
         if string_as_bool(first_param.get('optional', False)):
-            lint_ctx.warn(f"Conditional [{conditional_name}] test parameter cannot be optional", line=first_param_type.sourceline)
+            lint_ctx.warn(f"Conditional [{conditional_name}] test parameter cannot be optional", line=first_param.sourceline, xpath=tool_xml.getpath(first_param))
 
         whens = conditional.findall('./when')
         if any('value' not in when.attrib for when in whens):
-            lint_ctx.error(f"Conditional [{conditional_name}] when without value", line=conditional.sourceline)
+            lint_ctx.error(f"Conditional [{conditional_name}] when without value", line=conditional.sourceline, xpath=tool_xml.getpath(conditional))
 
         when_ids = [w.get('value') for w in whens]
 
         for option_id in option_ids:
             if option_id not in when_ids:
-                lint_ctx.warn(f"Conditional [{conditional_name}] no <when /> block found for {first_param_type} option '{option_id}'", line=conditional.sourceline)
+                lint_ctx.warn(f"Conditional [{conditional_name}] no <when /> block found for {first_param_type} option '{option_id}'", line=conditional.sourceline, xpath=tool_xml.getpath(conditional))
 
         for when_id in when_ids:
             if when_id not in option_ids:
                 if first_param_type == 'select':
-                    lint_ctx.warn(f"Conditional [{conditional_name}] no <option /> found for when block '{when_id}'", line=conditional.sourceline)
+                    lint_ctx.warn(f"Conditional [{conditional_name}] no <option /> found for when block '{when_id}'", line=conditional.sourceline, xpath=tool_xml.getpath(conditional))
                 else:
-                    lint_ctx.warn(f"Conditional [{conditional_name}] no truevalue/falsevalue found for when block '{when_id}'", line=conditional.sourceline)
+                    lint_ctx.warn(f"Conditional [{conditional_name}] no truevalue/falsevalue found for when block '{when_id}'", line=conditional.sourceline, xpath=tool_xml.getpath(conditional))
 
     if datasource:
         for datasource_tag in ('display', 'uihints'):
             if not any(param.tag == datasource_tag for param in inputs):
-                lint_ctx.info(f"{datasource_tag} tag usually present in data sources", line=tool_line)
+                lint_ctx.info(f"{datasource_tag} tag usually present in data sources", line=tool_line, xpath=tool_path)
 
     if num_inputs:
-        lint_ctx.info(f"Found {num_inputs} input parameters.", line=tool_line)
+        lint_ctx.info(f"Found {num_inputs} input parameters.", line=tool_line, xpath=tool_path)
     else:
         if datasource:
-            lint_ctx.info("No input parameters, OK for data sources", line=tool_line)
+            lint_ctx.info("No input parameters, OK for data sources", line=tool_line, xpath=tool_path)
         else:
-            lint_ctx.warn("Found no input parameters.", line=tool_line)
+            lint_ctx.warn("Found no input parameters.", line=tool_line, xpath=tool_path)
 
 
 def lint_repeats(tool_xml, lint_ctx):
@@ -257,9 +259,9 @@ def lint_repeats(tool_xml, lint_ctx):
     repeats = tool_xml.findall("./inputs//repeat")
     for repeat in repeats:
         if "name" not in repeat.attrib:
-            lint_ctx.error("Repeat does not specify name attribute.", line=repeat.sourceline)
+            lint_ctx.error("Repeat does not specify name attribute.", line=repeat.sourceline, xpath=tool_xml.getpath(repeat))
         if "title" not in repeat.attrib:
-            lint_ctx.error("Repeat does not specify title attribute.", line=repeat.sourceline)
+            lint_ctx.error("Repeat does not specify title attribute.", line=repeat.sourceline, xpath=tool_xml.getpath(repeat))
 
 
 def _find_with_attribute(element, tag, attribute, test_value=None):

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -9,7 +9,7 @@ def lint_output(tool_xml, lint_ctx):
     # determine line to report for general problems with outputs
     try:
         tool_line = tool_xml.find("./tool").sourceline
-    except:
+    except AttributeError:
         tool_line = 0
     outputs = tool_xml.findall("./outputs")
     if len(outputs) == 0:

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -52,6 +52,7 @@ def lint_output(tool_xml, lint_ctx):
         if not format_set:
             lint_ctx.warn(f"Tool {output.tag} output {output.attrib.get('name', 'with missing name')} doesn't define an output format.", line=output.sourceline, xpath=tool_xml.getpath(output))
 
+    # TODO: check for different labels in case of multiple outputs
     lint_ctx.info(f"{num_outputs} outputs found.", line=outputs[0].sourceline)
 
 

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -9,28 +9,30 @@ def lint_output(tool_xml, lint_ctx):
     # determine line to report for general problems with outputs
     try:
         tool_line = tool_xml.find("./tool").sourceline
+        tool_path = tool_xml.getpath(tool_xml.find("./tool"))
     except AttributeError:
         tool_line = 0
+        tool_path = None
     outputs = tool_xml.findall("./outputs")
     if len(outputs) == 0:
-        lint_ctx.warn("Tool contains no outputs section, most tools should produce outputs.", line=tool_line)
+        lint_ctx.warn("Tool contains no outputs section, most tools should produce outputs.", line=tool_line, xpath=tool_path)
         return
     if len(outputs) > 1:
-        lint_ctx.warn("Tool contains multiple output sections, behavior undefined.", line=outputs[1].sourceline)
+        lint_ctx.warn("Tool contains multiple output sections, behavior undefined.", line=outputs[1].sourceline, xpath=tool_xml.getpath(outputs[1]))
     num_outputs = 0
     for output in list(outputs[0]):
         if output.tag not in ["data", "collection"]:
-            lint_ctx.warn(f"Unknown element found in outputs [{output.tag}]", line=output.sourceline)
+            lint_ctx.warn(f"Unknown element found in outputs [{output.tag}]", line=output.sourceline, xpath=tool_xml.getpath(output))
             continue
         num_outputs += 1
         if "name" not in output.attrib:
-            lint_ctx.warn("Tool output doesn't define a name - this is likely a problem.", line=output.sourceline)
+            lint_ctx.warn("Tool output doesn't define a name - this is likely a problem.", line=output.sourceline, xpath=tool_xml.getpath(output))
         else:
             if not is_valid_cheetah_placeholder(output.attrib["name"]):
-                lint_ctx.warn("Tool output name [%s] is not a valid Cheetah placeholder.", output.attrib["name"], line=output.sourceline)
+                lint_ctx.warn("Tool output name [%s] is not a valid Cheetah placeholder.", output.attrib["name"], line=output.sourceline, xpath=tool_xml.getpath(output))
 
         format_set = False
-        if __check_format(output, lint_ctx):
+        if __check_format(tool_xml, output, lint_ctx):
             format_set = True
         if output.tag == "data":
             if "auto_format" in output.attrib and output.attrib["auto_format"]:
@@ -38,29 +40,29 @@ def lint_output(tool_xml, lint_ctx):
 
         elif output.tag == "collection":
             if "type" not in output.attrib:
-                lint_ctx.warn("Collection output with undefined 'type' found.", line=output.sourceline)
+                lint_ctx.warn("Collection output with undefined 'type' found.", line=output.sourceline, xpath=tool_xml.getpath(output))
             if "structured_like" in output.attrib and "inherit_format" in output.attrib:
                 format_set = True
         for sub in output:
             if __check_pattern(sub):
                 format_set = True
-            elif __check_format(sub, lint_ctx, allow_ext=True):
+            elif __check_format(tool_xml, sub, lint_ctx, allow_ext=True):
                 format_set = True
 
         if not format_set:
-            lint_ctx.warn(f"Tool {output.tag} output {output.attrib.get('name', 'with missing name')} doesn't define an output format.", line=output.sourceline)
+            lint_ctx.warn(f"Tool {output.tag} output {output.attrib.get('name', 'with missing name')} doesn't define an output format.", line=output.sourceline, xpath=tool_xml.getpath(output))
 
     lint_ctx.info(f"{num_outputs} outputs found.", line=outputs[0].sourceline)
 
 
-def __check_format(node, lint_ctx, allow_ext=False):
+def __check_format(tool_xml, node, lint_ctx, allow_ext=False):
     """
     check if format/ext/format_source attribute is set in a given node
     issue a warning if the value is input
     return true (node defines format/ext) / false (else)
     """
     if "format_source" in node.attrib and ("ext" in node.attrib or "format" in node.attrib):
-        lint_ctx.warn(f"Tool {node.tag} output {node.attrib.get('name', 'with missing name')} should use either format_source or format/ext", line=node.sourceline)
+        lint_ctx.warn(f"Tool {node.tag} output {node.attrib.get('name', 'with missing name')} should use either format_source or format/ext", line=node.sourceline, xpath=tool_xml.getpath(node))
     if "format_source" in node.attrib:
         return True
     # if allowed (e.g. for discover_datasets), ext takes precedence over format
@@ -70,7 +72,7 @@ def __check_format(node, lint_ctx, allow_ext=False):
     if fmt is None:
         fmt = node.attrib.get("format")
     if fmt == "input":
-        lint_ctx.warn(f"Using format='input' on {node.tag}, format_source attribute is less ambiguous and should be used instead.", line=node.sourceline)
+        lint_ctx.warn(f"Using format='input' on {node.tag}, format_source attribute is less ambiguous and should be used instead.", line=node.sourceline, xpath=tool_xml.getpath(node))
     return fmt is not None
 
 

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -6,27 +6,28 @@ from ..parser.output_collection_def import NAMED_PATTERNS
 
 def lint_output(tool_xml, lint_ctx):
     """Check output elements, ensure there is at least one and check attributes."""
+    # determine line to report for general problems with outputs
+    try:
+        tool_line = tool_xml.find("./tool").sourceline
+    except:
+        tool_line = 0
     outputs = tool_xml.findall("./outputs")
     if len(outputs) == 0:
-        lint_ctx.warn("Tool contains no outputs section, most tools should produce outputs.")
-    if len(outputs) > 1:
-        lint_ctx.warn("Tool contains multiple output sections, behavior undefined.")
-
-    num_outputs = 0
-    if len(outputs) == 0:
-        lint_ctx.warn("No outputs found")
+        lint_ctx.warn("Tool contains no outputs section, most tools should produce outputs.", line=tool_line)
         return
-
+    if len(outputs) > 1:
+        lint_ctx.warn("Tool contains multiple output sections, behavior undefined.", line=outputs[1].sourceline)
+    num_outputs = 0
     for output in list(outputs[0]):
         if output.tag not in ["data", "collection"]:
-            lint_ctx.warn(f"Unknown element found in outputs [{output.tag}]")
+            lint_ctx.warn(f"Unknown element found in outputs [{output.tag}]", line=output.sourceline)
             continue
         num_outputs += 1
         if "name" not in output.attrib:
-            lint_ctx.warn("Tool output doesn't define a name - this is likely a problem.")
+            lint_ctx.warn("Tool output doesn't define a name - this is likely a problem.", line=output.sourceline)
         else:
             if not is_valid_cheetah_placeholder(output.attrib["name"]):
-                lint_ctx.warn("Tool output name [%s] is not a valid Cheetah placeholder.", output.attrib["name"])
+                lint_ctx.warn("Tool output name [%s] is not a valid Cheetah placeholder.", output.attrib["name"], line=output.sourceline)
 
         format_set = False
         if __check_format(output, lint_ctx):
@@ -37,7 +38,7 @@ def lint_output(tool_xml, lint_ctx):
 
         elif output.tag == "collection":
             if "type" not in output.attrib:
-                lint_ctx.warn("Collection output with undefined 'type' found.")
+                lint_ctx.warn("Collection output with undefined 'type' found.", line=output.sourceline)
             if "structured_like" in output.attrib and "inherit_format" in output.attrib:
                 format_set = True
         for sub in output:
@@ -47,9 +48,9 @@ def lint_output(tool_xml, lint_ctx):
                 format_set = True
 
         if not format_set:
-            lint_ctx.warn(f"Tool {output.tag} output {output.attrib.get('name', 'with missing name')} doesn't define an output format.")
+            lint_ctx.warn(f"Tool {output.tag} output {output.attrib.get('name', 'with missing name')} doesn't define an output format.", line=output.sourceline)
 
-    lint_ctx.info("%d outputs found.", num_outputs)
+    lint_ctx.info(f"{num_outputs} outputs found.", line=outputs[0].sourceline)
 
 
 def __check_format(node, lint_ctx, allow_ext=False):
@@ -59,7 +60,7 @@ def __check_format(node, lint_ctx, allow_ext=False):
     return true (node defines format/ext) / false (else)
     """
     if "format_source" in node.attrib and ("ext" in node.attrib or "format" in node.attrib):
-        lint_ctx.warn(f"Tool {node.tag} output {node.attrib.get('name', 'with missing name')} should use either format_source or format/ext")
+        lint_ctx.warn(f"Tool {node.tag} output {node.attrib.get('name', 'with missing name')} should use either format_source or format/ext", line=node.sourceline)
     if "format_source" in node.attrib:
         return True
     # if allowed (e.g. for discover_datasets), ext takes precedence over format
@@ -69,7 +70,7 @@ def __check_format(node, lint_ctx, allow_ext=False):
     if fmt is None:
         fmt = node.attrib.get("format")
     if fmt == "input":
-        lint_ctx.warn(f"Using format='input' on {node.tag}, format_source attribute is less ambiguous and should be used instead.")
+        lint_ctx.warn(f"Using format='input' on {node.tag}, format_source attribute is less ambiguous and should be used instead.", line=node.sourceline)
     return fmt is not None
 
 

--- a/lib/galaxy/tool_util/linters/outputs.py
+++ b/lib/galaxy/tool_util/linters/outputs.py
@@ -27,9 +27,9 @@ def lint_output(tool_xml, lint_ctx):
         num_outputs += 1
         if "name" not in output.attrib:
             lint_ctx.warn("Tool output doesn't define a name - this is likely a problem.", line=output.sourceline, xpath=tool_xml.getpath(output))
-        else:
-            if not is_valid_cheetah_placeholder(output.attrib["name"]):
-                lint_ctx.warn("Tool output name [%s] is not a valid Cheetah placeholder.", output.attrib["name"], line=output.sourceline, xpath=tool_xml.getpath(output))
+            # TODO make this an error if there is no discover_datasets / from_work_dir (is this then still a problem)
+        elif not is_valid_cheetah_placeholder(output.attrib["name"]):
+            lint_ctx.warn(f'Tool output name [{output.attrib["name"]}] is not a valid Cheetah placeholder.', line=output.sourceline, xpath=tool_xml.getpath(output))
 
         format_set = False
         if __check_format(tool_xml, output, lint_ctx):
@@ -62,7 +62,7 @@ def __check_format(tool_xml, node, lint_ctx, allow_ext=False):
     return true (node defines format/ext) / false (else)
     """
     if "format_source" in node.attrib and ("ext" in node.attrib or "format" in node.attrib):
-        lint_ctx.warn(f"Tool {node.tag} output {node.attrib.get('name', 'with missing name')} should use either format_source or format/ext", line=node.sourceline, xpath=tool_xml.getpath(node))
+        lint_ctx.warn(f"Tool {node.tag} output '{node.attrib.get('name', 'with missing name')}' should use either format_source or format/ext", line=node.sourceline, xpath=tool_xml.getpath(node))
     if "format_source" in node.attrib:
         return True
     # if allowed (e.g. for discover_datasets), ext takes precedence over format
@@ -90,5 +90,6 @@ def __check_pattern(node):
         return False
     pattern = node.attrib["pattern"]
     regex_pattern = NAMED_PATTERNS.get(pattern, pattern)
+    # TODO error on wrong pattern or non-regexp
     if "(?P<ext>" in regex_pattern:
         return True

--- a/lib/galaxy/tool_util/linters/stdio.py
+++ b/lib/galaxy/tool_util/linters/stdio.py
@@ -7,43 +7,44 @@ def lint_stdio(tool_source, lint_ctx):
     # determine line to report for general problems with stdio
     try:
         tool_line = tool_xml.find("./tool").sourceline
+        tool_path = tool_xml.getpath(tool_xml.find("./tool"))
     except AttributeError:
         tool_line = 0
-    
+        tool_path = None
     stdios = tool_xml.findall("./stdio") if tool_xml else []
 
     if not stdios:
         command = get_command(tool_xml) if tool_xml else None
         if command is None or not command.get("detect_errors"):
             if tool_source.parse_profile() <= "16.01":
-                lint_ctx.info("No stdio definition found, tool indicates error conditions with output written to stderr.", line=tool_line)
+                lint_ctx.info("No stdio definition found, tool indicates error conditions with output written to stderr.", line=tool_line, xpath=tool_path)
             else:
-                lint_ctx.info("No stdio definition found, tool indicates error conditions with non-zero exit codes.", line=tool_line)
+                lint_ctx.info("No stdio definition found, tool indicates error conditions with non-zero exit codes.", line=tool_line, xpath=tool_path)
         return
 
     if len(stdios) > 1:
-        lint_ctx.error("More than one stdio tag found, behavior undefined.", line=stdios[1].sourceline)
+        lint_ctx.error("More than one stdio tag found, behavior undefined.", line=stdios[1].sourceline, xpath=tool_xml.getpath(stdios[1]))
         return
 
     stdio = stdios[0]
     for child in list(stdio):
         if child.tag == "regex":
-            _lint_regex(child, lint_ctx)
+            _lint_regex(tool_xml, child, lint_ctx)
         elif child.tag == "exit_code":
-            _lint_exit_code(child, lint_ctx)
+            _lint_exit_code(tool_xml, child, lint_ctx)
         else:
             message = "Unknown stdio child tag discovered [%s]. "
             message += "Valid options are exit_code and regex."
-            lint_ctx.warn(message % child.tag, line=child.sourceline)
+            lint_ctx.warn(message % child.tag, line=child.sourceline, xpath=tool_xml.getpath(child))
 
 
-def _lint_exit_code(child, lint_ctx):
+def _lint_exit_code(tool_xml, child, lint_ctx):
     for key in child.attrib.keys():
         if key not in ["description", "level", "range"]:
-            lint_ctx.warn(f"Unknown attribute [{key}] encountered on exit_code tag.", line=child.sourceline)
+            lint_ctx.warn(f"Unknown attribute [{key}] encountered on exit_code tag.", line=child.sourceline, xpath=tool_xml.getpath(child))
 
 
-def _lint_regex(child, lint_ctx):
+def _lint_regex(tool_xml, child, lint_ctx):
     for key in child.attrib.keys():
         if key not in ["description", "level", "match", "source"]:
-            lint_ctx.warn(f"Unknown attribute [{key}] encountered on regex tag.", line=child.sourceline)
+            lint_ctx.warn(f"Unknown attribute [{key}] encountered on regex tag.", line=child.sourceline, xpath=tool_xml.getpath(child))

--- a/lib/galaxy/tool_util/linters/stdio.py
+++ b/lib/galaxy/tool_util/linters/stdio.py
@@ -7,7 +7,7 @@ def lint_stdio(tool_source, lint_ctx):
     # determine line to report for general problems with stdio
     try:
         tool_line = tool_xml.find("./tool").sourceline
-    except:
+    except AttributeError:
         tool_line = 0
     
     stdios = tool_xml.findall("./stdio") if tool_xml else []

--- a/lib/galaxy/tool_util/linters/stdio.py
+++ b/lib/galaxy/tool_util/linters/stdio.py
@@ -42,9 +42,13 @@ def _lint_exit_code(tool_xml, child, lint_ctx):
     for key in child.attrib.keys():
         if key not in ["description", "level", "range"]:
             lint_ctx.warn(f"Unknown attribute [{key}] encountered on exit_code tag.", line=child.sourceline, xpath=tool_xml.getpath(child))
+        # TODO lint range, or is regexp in xsd sufficient?
+        # TODO lint required attributes
 
 
 def _lint_regex(tool_xml, child, lint_ctx):
     for key in child.attrib.keys():
         if key not in ["description", "level", "match", "source"]:
             lint_ctx.warn(f"Unknown attribute [{key}] encountered on regex tag.", line=child.sourceline, xpath=tool_xml.getpath(child))
+        # TODO lint match (re.compile)
+        # TODO lint required attributes

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -91,9 +91,9 @@ def lint_tsts(tool_xml, lint_ctx):
         lint_ctx.error(f"Test {test_idx}: Cannot specify outputs in a test expecting failure.")
 
     if num_valid_tests or datasource:
-        lint_ctx.valid(f"{num_valid_tests} test(s) found.", line=tests_line, xpath=tool_xml.getpath(test))
+        lint_ctx.valid(f"{num_valid_tests} test(s) found.", line=tests_line, xpath=tests_path)
     else:
-        lint_ctx.warn("No valid test(s) found.", line=tests_line, xpath=tool_xml.getpath(test))
+        lint_ctx.warn("No valid test(s) found.", line=tests_line, xpath=tests_path)
 
 
 def _collect_output_names(tool_xml):

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -6,14 +6,13 @@ from ._util import is_datasource
 def lint_tsts(tool_xml, lint_ctx):
     # determine line to report for general problems with tests
     try:
-        tests_line = tool_xml.find("./tool").sourceline
-    except:
-        tests_line = 0
-    try:
         tests_line = tool_xml.find("./tests").sourceline
-    except:
+    except AttributeError:
+        tests_line = 1
+    try:
+        tests_line = tool_xml.find("./tool").sourceline
+    except AttributeError:
         pass
-
     tests = tool_xml.findall("./tests/test")
     datasource = is_datasource(tool_xml)
     if not tests and not datasource:

--- a/lib/galaxy/tool_util/linters/tests.py
+++ b/lib/galaxy/tool_util/linters/tests.py
@@ -83,7 +83,7 @@ def lint_tsts(tool_xml, lint_ctx):
 
         has_test = has_test or found_output_test
         if not has_test:
-            lint_ctx.warn("Test {test_idx}: No outputs or expectations defined for tests, this test is likely invalid.", line=test.sourceline, xpath=tool_xml.getpath(test))
+            lint_ctx.warn(f"Test {test_idx}: No outputs or expectations defined for tests, this test is likely invalid.", line=test.sourceline, xpath=tool_xml.getpath(test))
         else:
             num_valid_tests += 1
 

--- a/lib/galaxy/tool_util/linters/xml_order.py
+++ b/lib/galaxy/tool_util/linters/xml_order.py
@@ -47,22 +47,20 @@ def lint_xml_order(tool_xml, lint_ctx):
     tool_root = tool_xml.getroot()
 
     if tool_root.attrib.get('tool_type', '') == 'data_source':
-        _validate_for_tags(tool_root, lint_ctx, DATASOURCE_TAG_ORDER)
+        tag_ordering = DATASOURCE_TAG_ORDER
     else:
-        _validate_for_tags(tool_root, lint_ctx, TAG_ORDER)
+        tag_ordering = TAG_ORDER
 
-
-def _validate_for_tags(root, lint_ctx, tag_ordering):
     last_tag = None
     last_key = None
-    for elem in root:
+    for elem in tool_root:
         tag = elem.tag
         if tag in tag_ordering:
             key = tag_ordering.index(tag)
             if last_key:
                 if last_key > key:
-                    lint_ctx.warn(f"Best practice violation [{tag}] elements should come before [{last_tag}]")
+                    lint_ctx.warn(f"Best practice violation [{tag}] elements should come before [{last_tag}]", line=elem.sourceline, xpath=tool_xml.getpath(elem))
             last_tag = tag
             last_key = key
         else:
-            lint_ctx.info(f"Unknown tag [{tag}] encountered, this may result in a warning in the future.")
+            lint_ctx.info(f"Unknown tag [{tag}] encountered, this may result in a warning in the future.", line=elem.sourceline, xpath=tool_xml.getpath(elem))

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -75,8 +75,14 @@ HELP_INVALID_RST = """
 """
 
 # test tool xml for inputs linter
-NO_INPUTS_SECTION_XML = """
+INPUTS_NO_INPUTS = """
 <tool>
+</tool>
+"""
+
+INPUTS_NO_INPUTS_DATASOURCE = """
+<tool tool_type="data_source">
+    <inputs/>
 </tool>
 """
 
@@ -88,19 +94,99 @@ INPUTS_REDUNDANT_NAME = """
 </tool>
 """
 
-NO_WHEN_IN_CONDITIONAL_XML = """
+INPUTS_VALID = """
 <tool>
     <inputs>
-        <conditional name="labels">
-            <param name="label_select" type="select" label="Points to label">
+        <param name="txt_param" type="text"/>
+        <param name="int_param" type="integer"/>
+    </inputs>
+</tool>
+"""
+
+INPUTS_PARAM_NAME = """
+<tool>
+    <inputs>
+        <param type="text"/>
+        <param name="" type="text"/>
+        <param name="2" type="text"/>
+        <param argument="--valid" type="text"/>
+    </inputs>
+</tool>
+"""
+
+INPUTS_PARAM_TYPE = """
+<tool>
+    <inputs>
+        <param name="valid_name"/>
+        <param argument="--another-valid-name" type=""/>
+    </inputs>
+</tool>
+"""
+
+INPUTS_DATA_PARAM = """
+<tool>
+    <inputs>
+        <param name="valid_name" type="data"/>
+    </inputs>
+</tool>
+"""
+
+INPUTS_CONDITIONAL = """
+<tool>
+    <inputs>
+        <conditional>
+            <param name="select" type="select"/>
+        </conditional>
+        <conditional name="cond_wo_param">
+        </conditional>
+        <conditional name="cond_w_mult_param">
+            <param name="select3" type="select"><option value="A">A</option><option value="B">B</option></param>
+            <param name="select4" type="select"><option value="A">A</option><option value="B">B</option></param>
+            <when value="A"/>
+            <when value="B"/>
+        </conditional>
+        <conditional name="cond_boolean">
+            <param name="bool" type="boolean"/>
+            <when value="true"/>
+            <when value="false"/>
+            <when value="False"/>
+        </conditional>
+        <conditional name="cond_text">
+            <param name="text" type="text"/>
+        </conditional>
+        <conditional name="cond_w_optional_select">
+            <param name="optionalselect" type="select" optional="true"><option value="A">A</option><option value="B">B</option></param>
+            <when value="A"/>
+            <when value="B"/>
+        </conditional>
+        <conditional name="cond_w_multiple_select">
+            <param name="multipleselect" type="select" multiple="true"><option value="A">A</option><option value="B">B</option></param>
+            <when value="A"/>
+            <when value="B"/>
+        </conditional>
+        <conditional name="when_wo_value">
+            <param name="select3" type="select"><option value="A">A</option><option value="B">B</option></param>
+            <when/>
+            <when value="A"/>
+            <when value="B"/>
+        </conditional>
+        <conditional name="missing_when">
+            <param name="label_select" type="select">
                 <option value="none" selected="True">None</option>
             </param>
+        </conditional>
+        <conditional name="missing_option">
+            <param name="missing_option" type="select">
+                <option value="none" selected="True">None</option>
+            </param>
+            <when value="none"/>
+            <when value="absent"/>
         </conditional>
     </inputs>
 </tool>
 """
 
-RADIO_SELECT_INCOMPATIBILITIES = """
+INPUTS_SELECT_INCOMPATIBLE_DISPLAY = """
 <tool>
     <inputs>
         <param name="radio_select" type="select" display="radio" optional="true" multiple="true">
@@ -120,7 +206,7 @@ RADIO_SELECT_INCOMPATIBILITIES = """
 </tool>
 """
 
-SELECT_DUPLICATED_OPTIONS = """
+INPUTS_SELECT_DUPLICATED_OPTIONS = """
 <tool>
     <inputs>
         <param name="select" type="select" optional="true" multiple="true">
@@ -143,6 +229,7 @@ SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED = """
 """
 
 SELECT_DEPRECATIONS = """
+INPUTS_SELECT_DEPRECATIONS = """
 <tool>
     <inputs>
         <param name="select_do" type="select" dynamic_options="blah()"/>
@@ -156,7 +243,7 @@ SELECT_DEPRECATIONS = """
 </tool>
 """
 
-SELECT_OPTION_DEFINITIONS = """
+INPUTS_SELECT_OPTION_DEFINITIONS = """
 <tool>
     <inputs>
         <param name="select_noopt" type="select"/>
@@ -175,27 +262,44 @@ SELECT_OPTION_DEFINITIONS = """
             <option>option wo value</option>
             <option value="value"/>
         </param>
-    </inputs>
-</tool>
-"""
-
-VALIDATOR_INCOMPATIBILITIES = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
-    <inputs>
-        <param name="param_name" type="text">
-            <validator type="in_range">TEXT</validator>
-            <validator type="regex" filename="blah"/>
+        <param name="select_meta_file_key_incomp" type="select">
+            <options from_data_table="xyz" meta_file_key="dbkey"/>
         </param>
     </inputs>
 </tool>
 """
 
-VALIDATOR_CORRECT = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+INPUTS_SELECT_FILTER = """
+<tool>
+    <inputs>
+        <param name="select_filter_types" type="select">
+            <options from_data_table="xyz">
+                <filter/>
+                <filter type="unknown_filter_type"/>
+            </options>
+        </param>
+    </inputs>
+</tool>
+"""
+
+INPUTS_VALIDATOR_INCOMPATIBILITIES = """
+<tool>
+    <inputs>
+        <param name="param_name" type="text">
+            <validator type="in_range">TEXT</validator>
+            <validator type="regex" filename="blah"/>
+            <validator type="expression"/>
+            <validator type="value_in_data_table"/>
+        </param>
+        <param name="another_param_name" type="data" format="bed">
+            <validator type="metadata"/>
+        </param>
+    </inputs>
+</tool>
+"""
+
+INPUTS_VALIDATOR_CORRECT = """
+<tool>
     <inputs>
         <param name="data_param" type="data" format="data">
             <validator type="metadata" check="md1,md2" skip="md3,md4" message="cutom validation message" negate="true"/>
@@ -233,6 +337,16 @@ VALIDATOR_CORRECT = """
             <validator type="in_range" min="0" max="100" exclude_min="true" exclude_max="true" negate="true"/>
             <validator type="expression" message="cutom validation message">somepythonexpression</validator>
         </param>
+    </inputs>
+</tool>
+"""
+
+REPEATS = """
+<tool>
+    <inputs>
+        <repeat>
+            <param name="another_param_name" type="data" format="bed"/>
+        </repeat>
     </inputs>
 </tool>
 """
@@ -385,10 +499,18 @@ TESTS = [
             and len(x.info_messages) == 0 and len(x.valid_messages) == 1 and len(x.warn_messages) == 1 and len(x.error_messages) == 0
     ),
     (
-        NO_INPUTS_SECTION_XML, inputs.lint_inputs,
+        INPUTS_NO_INPUTS, inputs.lint_inputs,
         lambda x:
             'Found no input parameters.' in x.warn_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 0
+            and len(x.info_messages) == 0 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 0
+    ),
+    (
+        INPUTS_NO_INPUTS_DATASOURCE, inputs.lint_inputs,
+        lambda x:
+            'No input parameters, OK for data sources' in x.info_messages
+            and 'display tag usually present in data sources' in x.info_messages
+            and 'uihints tag usually present in data sources' in x.info_messages
+            and len(x.info_messages) == 3 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
         INPUTS_REDUNDANT_NAME, inputs.lint_inputs,
@@ -397,13 +519,53 @@ TESTS = [
             and len(x.warn_messages) == 1 and len(x.error_messages) == 0
     ),
     (
-        NO_WHEN_IN_CONDITIONAL_XML, inputs.lint_inputs,
+        INPUTS_VALID, inputs.lint_inputs,
         lambda x:
-            "Conditional [labels] no <when /> block found for select option 'none'" in x.warn_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 0
+            "Found 2 input parameters." in x.info_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
-        RADIO_SELECT_INCOMPATIBILITIES, inputs.lint_inputs,
+        INPUTS_PARAM_NAME, inputs.lint_inputs,
+        lambda x:
+            "Found 4 input parameters." in x.info_messages
+            and 'Param input [2] is not a valid Cheetah placeholder.' in x.warn_messages
+            and 'Found param input with no name specified.' in x.error_messages
+            and 'Param input with empty name.' in x.error_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 2
+    ),
+    (
+        INPUTS_PARAM_TYPE, inputs.lint_inputs,
+        lambda x:
+            "Found 2 input parameters." in x.info_messages
+            and 'Param input [valid_name] input with no type specified.' in x.error_messages
+            and 'Param input [another_valid_name] with empty type specified.' in x.error_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+    ),
+    (
+        INPUTS_DATA_PARAM, inputs.lint_inputs,
+        lambda x:
+            "Found 1 input parameters." in x.info_messages
+            and "Param input [valid_name] with no format specified - 'data' format will be assumed." in x.warn_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 0
+    ),
+    (
+        INPUTS_CONDITIONAL, inputs.lint_inputs,
+        lambda x:
+            "Conditional without a name" in x.error_messages
+            and "Select parameter of a conditional [select] options have to be defined by 'option' children elements." in x.error_messages
+            and 'Conditional [cond_wo_param] needs exactly one child <param> found 0' in x.error_messages
+            and 'Conditional [cond_w_mult_param] needs exactly one child <param> found 2' in x.error_messages
+            and 'Conditional [cond_text] first param should have type="select" (or type="boolean" which is discouraged)' in x.error_messages
+            and 'Conditional [cond_boolean] first param of type="boolean" is discouraged, use a select' in x.warn_messages
+            and "Conditional [cond_boolean] no truevalue/falsevalue found for when block 'False'" in x.warn_messages
+            and 'Conditional [cond_w_optional_select] test parameter cannot be optional="true"' in x.warn_messages
+            and 'Conditional [cond_w_multiple_select] test parameter cannot be multiple="true"' in x.warn_messages
+            and "Conditional [when_wo_value] when without value" in x.error_messages
+            and "Conditional [missing_when] no <when /> block found for select option 'none'" in x.warn_messages
+            and len(x.warn_messages) == 6 and len(x.error_messages) == 6
+    ),
+    (
+        INPUTS_SELECT_INCOMPATIBLE_DISPLAY, inputs.lint_inputs,
         lambda x:
             'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages
             and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages
@@ -412,7 +574,7 @@ TESTS = [
             and len(x.warn_messages) == 0 and len(x.error_messages) == 4
     ),
     (
-        SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs,
+        INPUTS_SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs,
         lambda x:
             'Select parameter [select] has multiple options with the same text content' in x.error_messages
             and 'Select parameter [select] has multiple options with the same value' in x.error_messages
@@ -425,6 +587,7 @@ TESTS = [
     ),
     (
         SELECT_DEPRECATIONS, inputs.lint_inputs,
+        INPUTS_SELECT_DEPRECATIONS, inputs.lint_inputs,
         lambda x:
             "Select parameter [select_do] uses deprecated 'dynamic_options' attribute." in x.warn_messages
             and "Select parameter [select_ff] options uses deprecated 'from_file' attribute." in x.warn_messages
@@ -434,29 +597,47 @@ TESTS = [
             and len(x.warn_messages) == 5 and len(x.error_messages) == 0
     ),
     (
-        SELECT_OPTION_DEFINITIONS, inputs.lint_inputs,
+        INPUTS_SELECT_OPTION_DEFINITIONS, inputs.lint_inputs,
         lambda x:
             "Select parameter [select_noopt] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute." in x.error_messages
             and "Select parameter [select_noopts] options tag defines no options. Use 'from_dataset', 'from_data_table', or a filter that adds values." in x.error_messages
             and "Select parameter [select_fd_op] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute." in x.error_messages
-            and "Select parameter [select_fd_op] contains multiple options elements" in x.error_messages
+            and "Select parameter [select_fd_op] contains multiple options elements." in x.error_messages
             and "Select parameter [select_fd_fdt] options uses 'from_dataset' and 'from_data_table' attribute." in x.error_messages
             and "Select parameter [select_noval_notext] has option without value" in x.error_messages
             and "Select parameter [select_noval_notext] has option without text" in x.warn_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 6
+            and "Select parameter [select_meta_file_key_incomp] 'meta_file_key' is only compatible with 'from_dataset'." in x.error_messages
+            and len(x.warn_messages) == 1 and len(x.error_messages) == 7
     ),
     (
-        VALIDATOR_INCOMPATIBILITIES, inputs.lint_inputs,
+        INPUTS_SELECT_FILTER, inputs.lint_inputs,
+        lambda x:
+            "Select parameter [select_filter_types] contains filter without type." in x.error_messages
+            and "Select parameter [select_filter_types] contains filter with unknown type 'unknown_filter_type'." in x.error_messages
+            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+    ),
+    (
+        INPUTS_VALIDATOR_INCOMPATIBILITIES, inputs.lint_inputs,
         lambda x:
             "Parameter [param_name]: 'in_range' validators are not expected to contain text (found 'TEXT')" in x.warn_messages
             and "Parameter [param_name]: validator with an incompatible type 'in_range'" in x.error_messages
             and "Parameter [param_name]: 'in_range' validators need to define the 'min' or 'max' attribute(s)" in x.error_messages
             and "Parameter [param_name]: attribute 'filename' is incompatible with validator of type 'regex'" in x.error_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 3
+            and "Parameter [param_name]: expression validator without content" in x.error_messages
+            and "Parameter [another_param_name]: 'metadata' validators need to define the 'check' or 'skip' attribute(s)" in x.error_messages
+            and "Parameter [param_name]: 'value_in_data_table' validators need to define the 'table_name' attribute" in x.error_messages
+            and len(x.warn_messages) == 1 and len(x.error_messages) == 6
     ),
     (
-        VALIDATOR_CORRECT, inputs.lint_inputs,
+        INPUTS_VALIDATOR_CORRECT, inputs.lint_inputs,
         lambda x: len(x.warn_messages) == 0 and len(x.error_messages) == 0
+    ),
+    (
+        REPEATS, inputs.lint_repeats,
+        lambda x:
+            "Repeat does not specify name attribute." in x.error_messages
+            and "Repeat does not specify title attribute." in x.error_messages
+            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
     ),
     (
         OUTPUTS_COLLECTION_FORMAT_SOURCE, outputs.lint_output,
@@ -501,16 +682,23 @@ TEST_IDS = [
     'help: empty',
     'help: with todo',
     'help: with invalid restructured text',
-    'lint no sections',
-    'input with redundant name',
-    'lint no when',
-    'radio select incompatibilities',
-    'select duplicated options',
-    'select duplicated options with different selected',
-    'select deprecations',
-    'select option definitions',
-    'validator imcompatibilities',
-    'validator all correct',
+    'inputs: no inputs sections',
+    'inputs: no inputs sections for datasource',
+    'inputs: redundant param name',
+    'inputs: valid',
+    'inputs: param name',
+    'inputs: param type',
+    'inputs: data param',
+    'inputs: conditional',
+    'inputs: select with incompatible display',
+    'inputs: select duplicated options',
+    'inputs: select duplicated options with different selected',
+    'inputs: select deprecations',
+    'inputs: select option definitions',
+    'inputs: select filter',
+    'inputs: validator incompatibilities',
+    'inputs: validator all correct',
+    'repeats',
     'outputs collection static elements with format_source',
     'outputs discover datatsets with tool provided metadata',
     'test without expectations',

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -12,20 +12,13 @@ from galaxy.tool_util.linters import (
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
 
+# tests tool xml for general linter
 WHITESPACE_IN_VERSIONS_AND_NAMES = """
 <tool name=" BWA Mapper " id="bwa tool" version=" 1.0.1 " display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <requirements>
         <requirement type="package" version=" 1.2.5 "> bwa </requirement>
     </requirements>
-    <version_command interpreter="python">bwa.py --version</version_command>
-    <inputs>
-        <param name="select_fd_op" type="select">
-            <options from_dataset="xyz"/>
-            <options from_data_table="xyz"/>
-            <option value="x">x</option>
-        </param>
-    </inputs>
 </tool>
 """
 
@@ -36,21 +29,12 @@ REQUIREMENT_WO_VERSION = """
         <requirement type="package">bwa</requirement>
         <requirement type="package" version="1.2.5"></requirement>
     </requirements>
-    <version_command interpreter="python">bwa.py --version</version_command>
-    <inputs>
-        <param name="select_fd_op" type="select">
-            <options from_dataset="xyz"/>
-            <options from_data_table="xyz"/>
-            <option value="x">x</option>
-        </param>
-    </inputs>
 </tool>
 """
 
-NO_SECTIONS_XML = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+# test tool xml for inputs linter  
+NO_INPUTS_SECTION_XML = """
+<tool>
 </tool>
 """
 
@@ -63,9 +47,7 @@ INPUTS_REDUNDANT_NAME = """
 """
 
 NO_WHEN_IN_CONDITIONAL_XML = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <inputs>
         <conditional name="labels">
             <param name="label_select" type="select" label="Points to label">
@@ -119,9 +101,7 @@ SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED = """
 """
 
 SELECT_DEPRECATIONS = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <inputs>
         <param name="select_do" type="select" dynamic_options="blah()"/>
         <param name="select_ff" type="select">
@@ -215,12 +195,12 @@ VALIDATOR_CORRECT = """
 </tool>
 """
 
+# test tool xml for outputs linter
+
 # check that linter accepts format source for collection elements as means to specify format
 # and that the linter warns if format and format_source are used
 OUTPUTS_COLLECTION_FORMAT_SOURCE = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <outputs>
         <collection name="output_collection" type="paired">
             <data name="forward" format_source="input_readpair" />
@@ -232,9 +212,7 @@ OUTPUTS_COLLECTION_FORMAT_SOURCE = """
 
 # check that linter does not complain about missing format if from_tool_provided_metadata is used
 OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
-    <description>The BWA Mapper</description>
-    <version_command interpreter="python">bwa.py --version</version_command>
+<tool>
     <outputs>
         <data name="output">
             <discover_datasets from_tool_provided_metadata="true"/>
@@ -309,7 +287,7 @@ TESTS = [
             and len(x.warn_messages) == 1 and len(x.error_messages) == 1
     ),
     (
-        NO_SECTIONS_XML, inputs.lint_inputs,
+        NO_INPUTS_SECTION_XML, inputs.lint_inputs,
         lambda x:
             'Found no input parameters.' in x.warn_messages
             and len(x.warn_messages) == 1 and len(x.error_messages) == 0

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -735,7 +735,8 @@ TESTS = [
     (
         INPUTS_CONDITIONAL, inputs.lint_inputs,
         lambda x:
-            "Conditional without a name" in x.error_messages
+            'Found 10 input parameters.' in x.info_messages
+            and "Conditional without a name" in x.error_messages
             and "Select parameter of a conditional [select] options have to be defined by 'option' children elements." in x.error_messages
             and 'Conditional [cond_wo_param] needs exactly one child <param> found 0' in x.error_messages
             and 'Conditional [cond_w_mult_param] needs exactly one child <param> found 2' in x.error_messages
@@ -746,23 +747,25 @@ TESTS = [
             and 'Conditional [cond_w_multiple_select] test parameter cannot be multiple="true"' in x.warn_messages
             and "Conditional [when_wo_value] when without value" in x.error_messages
             and "Conditional [missing_when] no <when /> block found for select option 'none'" in x.warn_messages
-            and len(x.warn_messages) == 6 and len(x.error_messages) == 6
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 6 and len(x.error_messages) == 6
     ),
     (
         INPUTS_SELECT_INCOMPATIBLE_DISPLAY, inputs.lint_inputs,
         lambda x:
-            'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages
+            'Found 3 input parameters.' in x.info_messages
+            and 'Select [radio_select] display="radio" is incompatible with optional="true"' in x.error_messages
             and 'Select [radio_select] display="radio" is incompatible with multiple="true"' in x.error_messages
             and 'Select [checkboxes_select] `display="checkboxes"` is incompatible with `optional="false"`, remove the `display` attribute' in x.error_messages
             and 'Select [checkboxes_select] `display="checkboxes"` is incompatible with `multiple="false"`, remove the `display` attribute' in x.error_messages
-            and len(x.warn_messages) == 0 and len(x.error_messages) == 4
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 4
     ),
     (
         INPUTS_SELECT_DUPLICATED_OPTIONS, inputs.lint_inputs,
         lambda x:
-            'Select parameter [select] has multiple options with the same text content' in x.error_messages
+            'Found 1 input parameters.' in x.info_messages
+            and 'Select parameter [select] has multiple options with the same text content' in x.error_messages
             and 'Select parameter [select] has multiple options with the same value' in x.error_messages
-            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 2
     ),
     (
         SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED, inputs.lint_inputs,
@@ -773,17 +776,19 @@ TESTS = [
         SELECT_DEPRECATIONS, inputs.lint_inputs,
         INPUTS_SELECT_DEPRECATIONS, inputs.lint_inputs,
         lambda x:
-            "Select parameter [select_do] uses deprecated 'dynamic_options' attribute." in x.warn_messages
+            'Found 3 input parameters.' in x.info_messages
+            and "Select parameter [select_do] uses deprecated 'dynamic_options' attribute." in x.warn_messages
             and "Select parameter [select_ff] options uses deprecated 'from_file' attribute." in x.warn_messages
             and "Select parameter [select_fp] options uses deprecated 'from_parameter' attribute." in x.warn_messages
             and "Select parameter [select_ff] options uses deprecated 'transform_lines' attribute." in x.warn_messages
             and "Select parameter [select_fp] options uses deprecated 'options_filter_attribute' attribute." in x.warn_messages
-            and len(x.warn_messages) == 5 and len(x.error_messages) == 0
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 5 and len(x.error_messages) == 0
     ),
     (
         INPUTS_SELECT_OPTION_DEFINITIONS, inputs.lint_inputs,
         lambda x:
-            "Select parameter [select_noopt] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute." in x.error_messages
+            'Found 6 input parameters.' in x.info_messages
+            and "Select parameter [select_noopt] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute." in x.error_messages
             and "Select parameter [select_noopts] options tag defines no options. Use 'from_dataset', 'from_data_table', or a filter that adds values." in x.error_messages
             and "Select parameter [select_fd_op] options have to be defined by either 'option' children elements, a 'options' element or the 'dynamic_options' attribute." in x.error_messages
             and "Select parameter [select_fd_op] contains multiple options elements." in x.error_messages
@@ -791,30 +796,34 @@ TESTS = [
             and "Select parameter [select_noval_notext] has option without value" in x.error_messages
             and "Select parameter [select_noval_notext] has option without text" in x.warn_messages
             and "Select parameter [select_meta_file_key_incomp] 'meta_file_key' is only compatible with 'from_dataset'." in x.error_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 7
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 7
     ),
     (
         INPUTS_SELECT_FILTER, inputs.lint_inputs,
         lambda x:
-            "Select parameter [select_filter_types] contains filter without type." in x.error_messages
+            'Found 1 input parameters.' in x.info_messages
+            and "Select parameter [select_filter_types] contains filter without type." in x.error_messages
             and "Select parameter [select_filter_types] contains filter with unknown type 'unknown_filter_type'." in x.error_messages
-            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 2
     ),
     (
         INPUTS_VALIDATOR_INCOMPATIBILITIES, inputs.lint_inputs,
         lambda x:
-            "Parameter [param_name]: 'in_range' validators are not expected to contain text (found 'TEXT')" in x.warn_messages
+            'Found 2 input parameters.' in x.info_messages
+            and "Parameter [param_name]: 'in_range' validators are not expected to contain text (found 'TEXT')" in x.warn_messages
             and "Parameter [param_name]: validator with an incompatible type 'in_range'" in x.error_messages
             and "Parameter [param_name]: 'in_range' validators need to define the 'min' or 'max' attribute(s)" in x.error_messages
             and "Parameter [param_name]: attribute 'filename' is incompatible with validator of type 'regex'" in x.error_messages
             and "Parameter [param_name]: expression validator without content" in x.error_messages
             and "Parameter [another_param_name]: 'metadata' validators need to define the 'check' or 'skip' attribute(s)" in x.error_messages
             and "Parameter [param_name]: 'value_in_data_table' validators need to define the 'table_name' attribute" in x.error_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 6
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 6
     ),
     (
         INPUTS_VALIDATOR_CORRECT, inputs.lint_inputs,
-        lambda x: len(x.warn_messages) == 0 and len(x.error_messages) == 0
+        lambda x:
+            'Found 5 input parameters.' in x.info_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
         OUTPUTS_MISSING, outputs.lint_output,
@@ -863,34 +872,35 @@ TESTS = [
     (
         OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA, outputs.lint_output,
         lambda x:
-            len(x.warn_messages) == 0 and len(x.error_messages) == 0
+            '1 outputs found.' in x.info_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
         REPEATS, inputs.lint_repeats,
         lambda x:
             "Repeat does not specify name attribute." in x.error_messages
             and "Repeat does not specify title attribute." in x.error_messages
-            and len(x.warn_messages) == 0 and len(x.error_messages) == 2
+            and len(x.info_messages) == 0 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 2
     ),
     (
         STDIO_DEFAULT_FOR_DEFAULT_PROFILE, stdio.lint_stdio,
         lambda x:
             "No stdio definition found, tool indicates error conditions with output written to stderr." in x.info_messages
-            and len(x.info_messages) == 1 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
 
     ),
     (
         STDIO_DEFAULT_FOR_NONLEGACY_PROFILE, stdio.lint_stdio,
         lambda x:
             "No stdio definition found, tool indicates error conditions with non-zero exit codes." in x.info_messages
-            and len(x.info_messages) == 1 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
 
     ),
     (
         STDIO_MULTIPLE_STDIO, stdio.lint_stdio,
         lambda x:
             "More than one stdio tag found, behavior undefined." in x.error_messages
-            and len(x.info_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 1
+            and len(x.info_messages) == 0 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 1
 
     ),
     (
@@ -899,7 +909,7 @@ TESTS = [
             "Unknown stdio child tag discovered [reqex]. Valid options are exit_code and regex." in x.warn_messages
             and "Unknown attribute [descriptio] encountered on exit_code tag." in x.warn_messages
             and "Unknown attribute [descriptio] encountered on regex tag." in x.warn_messages
-            and len(x.info_messages) == 0 and len(x.warn_messages) == 3 and len(x.error_messages) == 0
+            and len(x.info_messages) == 0 and len(x.valid_messages) == 0 and len(x.warn_messages) == 3 and len(x.error_messages) == 0
 
     ),
     (

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -145,14 +145,6 @@ INPUTS_NO_INPUTS_DATASOURCE = """
 </tool>
 """
 
-INPUTS_REDUNDANT_NAME = """
-<tool>
-    <inputs>
-        <param name="param_name" argument="--param-name" type="text"/>
-    </inputs>
-</tool>
-"""
-
 INPUTS_VALID = """
 <tool>
     <inputs>
@@ -169,6 +161,7 @@ INPUTS_PARAM_NAME = """
         <param name="" type="text"/>
         <param name="2" type="text"/>
         <param argument="--valid" type="text"/>
+        <param name="param_name" argument="--param-name" type="text"/>
     </inputs>
 </tool>
 """
@@ -697,12 +690,6 @@ TESTS = [
             and len(x.info_messages) == 3 and len(x.valid_messages) == 0 and len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
-        INPUTS_REDUNDANT_NAME, inputs.lint_inputs,
-        lambda x:
-            "Param input [param_name] 'name' attribute is redundant if argument implies the same name." in x.warn_messages
-            and len(x.warn_messages) == 1 and len(x.error_messages) == 0
-    ),
-    (
         INPUTS_VALID, inputs.lint_inputs,
         lambda x:
             "Found 2 input parameters." in x.info_messages
@@ -711,11 +698,12 @@ TESTS = [
     (
         INPUTS_PARAM_NAME, inputs.lint_inputs,
         lambda x:
-            "Found 4 input parameters." in x.info_messages
+            "Found 5 input parameters." in x.info_messages
             and 'Param input [2] is not a valid Cheetah placeholder.' in x.warn_messages
             and 'Found param input with no name specified.' in x.error_messages
             and 'Param input with empty name.' in x.error_messages
-            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 2
+            and "Param input [param_name] 'name' attribute is redundant if argument implies the same name." in x.warn_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 2 and len(x.error_messages) == 2
     ),
     (
         INPUTS_PARAM_TYPE, inputs.lint_inputs,
@@ -951,7 +939,6 @@ TEST_IDS = [
     'help: with invalid restructured text',
     'inputs: no inputs sections',
     'inputs: no inputs sections for datasource',
-    'inputs: redundant param name',
     'inputs: valid',
     'inputs: param name',
     'inputs: param type',

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -280,7 +280,6 @@ SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED = """
 </tool>
 """
 
-SELECT_DEPRECATIONS = """
 INPUTS_SELECT_DEPRECATIONS = """
 <tool>
     <inputs>
@@ -773,7 +772,6 @@ TESTS = [
             len(x.warn_messages) == 0 and len(x.error_messages) == 0
     ),
     (
-        SELECT_DEPRECATIONS, inputs.lint_inputs,
         INPUTS_SELECT_DEPRECATIONS, inputs.lint_inputs,
         lambda x:
             'Found 3 input parameters.' in x.info_messages

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -12,6 +12,7 @@ from galaxy.tool_util.linters import (
     outputs,
     stdio,
     tests,
+    xml_order,
 )
 from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
@@ -544,6 +545,15 @@ TESTS_EXPECT_FAILURE_OUTPUT = """
 </tool>
 """
 
+# tool xml for xml_order linter
+XML_ORDER = """
+<tool>
+    <wrong_tag/>
+    <command/>
+    <stdio/>
+</tool>
+"""
+
 TESTS = [
     (
         CITATIONS_MULTIPLE, citations.lint_citations,
@@ -911,6 +921,13 @@ TESTS = [
         lambda x:
             "Test 1: Cannot specify outputs in a test expecting failure." in x.error_messages
             and len(x.warn_messages) == 0 and len(x.error_messages) == 1
+    ),
+    (
+        XML_ORDER, xml_order.lint_xml_order,
+        lambda x:
+            'Unknown tag [wrong_tag] encountered, this may result in a warning in the future.' in x.info_messages
+            and 'Best practice violation [stdio] elements should come before [command]' in x.warn_messages
+            and len(x.info_messages) == 1 and len(x.valid_messages) == 0 and len(x.warn_messages) == 1 and len(x.error_messages) == 0
     )
 ]
 
@@ -963,6 +980,7 @@ TEST_IDS = [
     'test without expectations',
     'test param missing from inputs',
     'test expecting failure with outputs',
+    'xml_order'
 ]
 
 


### PR DESCRIPTION
The tool linter currently "only" provides a message. It might be cool if the output would allow more easily to find the problem. Here I try to add the source line / xpath to the linter messages. 

This would be particularly helpful if integrated in 3rd party software like the GLS: https://github.com/galaxyproject/galaxy-language-server/issues/180

TODO:

- [ ] extend the `lint_tool_source` function to return the lint context(s) 
- [ ] test if macros influence line numbers / xpath
- [x] get source file (https://bugs.launchpad.net/lxml/+bug/1952737)
- [x] check if `#include ` works
  - this is cheetah specific, ie unrelated
- [x] Full unit test coverage for linters, i.e., test the output of each linter message
- [ ] `lint_general` gets tool_source and determines requirements not via xml foo, so extended output is not yet possible
- warning / error specific codes and a possibility to filter for them. 
  - another time :)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
