### PR TITLE
Fix flaky legacy API tests (hopefully)

### DIFF
--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -193,7 +193,7 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
 
     def test_create_anonymous_fails(self):
         post_data = dict(name="CannotCreate")
-        create_response = self._post("histories", data=post_data, anon=True, json=True)
+        create_response = self._post("histories", data=post_data, anon=True)
         self._assert_status_code_is(create_response, 403)
 
     def test_create_without_session_fails(self):

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -49,7 +49,7 @@ class LibrariesApiTestCase(ApiTestCase):
     def test_nonadmin(self):
         # Anons can't create libs
         data = dict(name="CreateTestLibrary")
-        create_response = self._post("libraries", data=data, admin=False, anon=True, json=True)
+        create_response = self._post("libraries", data=data, admin=False, anon=True)
         self._assert_status_code_is(create_response, 403)
         # Anons can't delete libs
         library = self.library_populator.new_library("AnonDeleteTestLibrary")


### PR DESCRIPTION
```
lib/galaxy_test/api/test_libraries.py::LibrariesApiTestCase::test_nonadmin
lib/galaxy_test/api/test_histories.py::HistoriesApiTestCase::test_create_anonymous_fails
```
Those two API tests have been particularly flaky lately. [With a rather cryptic `Connection reset by peer` error](https://github.com/galaxyproject/galaxy/runs/4312032283?check_suite_focus=true#step:8:1719). I tried to debug and see what may be the problem but as soon as you debug or run them locally they magically pass... :magic_wand: 

First I thought it may be caused by those endpoints being refactored, but the thing is this seems to happen only on legacy API tests when we simulate anonymous requests with `anon=True`, so it never reaches the actual endpoint code because it just gets caught at the API decorator level:
https://github.com/galaxyproject/galaxy/blob/38a69b19b55b41e2fc079de94a94eee5c1c6a9f5/lib/galaxy/web/framework/decorators.py#L269

The only thing I can think of that may be affecting them is the `json=True` in the request (although it doesn't make much sense to me) that we were forced to introduce to make it work with a previous version of FastAPI.

Let's see if removing this helps those tests, now that we are not forced to explicitly send JSON payloads in the request with the newer version of FastAPI :crossed_fingers: 



## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
