### PR TITLE
Create select() construct explicitly

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -356,8 +356,8 @@ class JobHandlerQueue(Monitors):
             job_filter_conditions = (
                 (model.Job.state == model.Job.states.NEW),
                 (model.Job.handler == self.app.config.server_name),
-                ~model.Job.table.c.id.in_(hda_not_ready),
-                ~model.Job.table.c.id.in_(ldda_not_ready))
+                ~model.Job.table.c.id.in_(select(hda_not_ready)),
+                ~model.Job.table.c.id.in_(select(ldda_not_ready)))
             if self.app.config.user_activation_on:
                 job_filter_conditions = job_filter_conditions + (
                     or_((model.Job.user_id == null()), (model.User.active == true())),)


### PR DESCRIPTION
Silences
```
/opt/galaxy/server/lib/galaxy/jobs/handler.py:360: SAWarning: Coercing
Subquery object into a select() for use in IN(); please pass a select()
construct explicitly
```
Fixes #12981

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
