### PR TITLE
Fix Rerun in the new form

### DIFF
--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -47,9 +47,10 @@ describe("FormElement", () => {
         await wrapper.setProps({ default_value: "default_value", collapsible_value: "collapsible_value" });
         expect(wrapper.find(".ui-form-title-text").text()).toEqual("title_text");
         expect(wrapper.findAll("span[title='Disable']").length).toEqual(1);
+        expect(wrapper.emitted().input[0][0]).toEqual("initial_value");
         wrapper.find(".ui-form-collapsible-icon").trigger("click");
-        expect(wrapper.emitted().input[0][0]).toEqual("collapsible_value");
-        expect(wrapper.emitted().input[0][1]).toEqual("input");
+        expect(wrapper.emitted().input[1][0]).toEqual("collapsible_value");
+        expect(wrapper.emitted().input[1][1]).toEqual("input");
         await Vue.nextTick();
         await wrapper.setProps({
             collapsedEnableText: "Enable Collapsible",
@@ -58,7 +59,7 @@ describe("FormElement", () => {
         expect(wrapper.findAll("span[title='Enable Collapsible']").length).toEqual(1);
         expect(wrapper.findAll("span[title='Disable Collapsible']").length).toEqual(0);
         wrapper.find(".ui-form-collapsible-icon").trigger("click");
-        expect(wrapper.emitted().input[1][0]).toEqual("default_value");
+        expect(wrapper.emitted().input[2][0]).toEqual("default_value");
         await Vue.nextTick();
         expect(wrapper.findAll("span[title='Disable Collapsible']").length).toEqual(1);
         expect(wrapper.findAll("span[title='Enable Collapsible']").length).toEqual(0);

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -212,9 +212,6 @@ export default {
     created() {
         this.initialState();
     },
-    mounted() {
-        this.setValue(this.currentValue);
-    },
     methods: {
         /** Submits a changed value. */
         setValue(value) {
@@ -225,6 +222,7 @@ export default {
          * Determines to wether expand or collapse the input.
          */
         initialState() {
+            this.setValue(this.value);
             const collapsibleValue = this.collapsibleValue;
             const value = JSON.stringify(this.value);
             this.connected = value == JSON.stringify(this.connectedValue);

--- a/client/src/components/Form/FormElement.vue
+++ b/client/src/components/Form/FormElement.vue
@@ -212,6 +212,9 @@ export default {
     created() {
         this.initialState();
     },
+    mounted() {
+        this.setValue(this.currentValue);
+    },
     methods: {
         /** Submits a changed value. */
         setValue(value) {

--- a/client/src/components/Tool/ToolForm.vue
+++ b/client/src/components/Tool/ToolForm.vue
@@ -233,6 +233,7 @@ export default {
         },
         onUpdate() {
             this.disabled = true;
+            console.debug("ToolForm - Updating input parameters.", this.formData);
             updateToolFormData(this.formConfig.id, this.currentVersion, this.history_id, this.formData)
                 .then((data) => {
                     this.formConfig = data;
@@ -250,6 +251,7 @@ export default {
         requestTool(newVersion) {
             this.currentVersion = newVersion || this.currentVersion;
             this.disabled = true;
+            console.debug("ToolForm - Requesting tool.", this.id);
             return getToolFormData(this.id, this.currentVersion, this.job_id, this.history_id)
                 .then((data) => {
                     this.formConfig = data;

--- a/client/src/components/Workflow/Editor/Forms/FormSection.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormSection.vue
@@ -134,7 +134,7 @@ export default {
             this.setEmailAction(this.formData);
             if (changed) {
                 this.formData = Object.assign({}, this.formData);
-                this.$emit("onChange", this.formData, true);
+                this.$emit("onChange", this.formData);
             }
         },
         onDatatype(pjaKey, outputName, newDatatype) {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -144,11 +144,9 @@ export default {
             this.mainValues = values;
             this.postChanges();
         },
-        onChangeSection(values, refreshOnChange = false) {
+        onChangeSection(values) {
             this.sectionValues = values;
-            if (refreshOnChange) {
-                this.postChanges();
-            }
+            this.postChanges();
         },
         onChangeVersion(newVersion) {
             this.messageText = `Now you are using '${this.node.config_form.name}' version ${newVersion}.`;


### PR DESCRIPTION
As discussed offline with @guerler, I open this PR to solve the problem that I discovered while working on  https://github.com/galaxyproject/galaxy/pull/12937 
When you click rerun, onChange event is not triggered, thus the value is not updated on the client-side that results in sending empty inputs object and the server fills it up with default values (ignoring input from original job).

This is one of the possible solutions to this problem. 
Another would be filling `inputs` payload with default data on the client-side.  


A short gif explaining the problem, recorded in https://github.com/galaxyproject/galaxy/pull/12937.
If you want to reproduce it locally and don't want to checkout 12937, try color input on `dev` 

![showproblem](https://user-images.githubusercontent.com/15801412/143488121-b45c47d5-dbcf-4371-8771-e554da8e9900.gif)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
