### PR TITLE
[21.09] Show error message when history id is invalid

### DIFF
--- a/client/src/components/HistoryView.vue
+++ b/client/src/components/HistoryView.vue
@@ -69,27 +69,12 @@ export default {
         ajaxCall: function (url) {
             axios
                 .get(url)
-                .then((response) => {
-                    if (response.data.error_msg) {
-                        this.errorMessages.push(response.data.error_msg);
-                    } else {
-                        this.updateHistoryView(response);
-                    }
-                })
-                .catch((e) => {
-                    this.showError(
-                        "Error fetching histories -- reload the page to retry this request.  Please contact an administrator if the problem persists.",
-                        e
-                    );
-                });
+                .then((response) => this.updateHistoryView(response))
+                .catch((error) => this.errorMessages.push(error));
         },
         updateHistoryView: function (response) {
             this.historyData = response.data;
             this.historyHistory = response.data.history;
-        },
-        showError: function (errorMsg, verbose) {
-            console.error(verbose);
-            this.errorMessages.push(errorMsg);
         },
         makeHistoryView: function (history) {
             const options = {

--- a/client/src/components/HistoryView.vue
+++ b/client/src/components/HistoryView.vue
@@ -70,7 +70,7 @@ export default {
             axios
                 .get(url)
                 .then((response) => this.updateHistoryView(response))
-                .catch((error) => this.errorMessages.push(error));
+                .catch((error) => this.errorMessages.push(error.response.data.err_msg));
         },
         updateHistoryView: function (response) {
             this.historyData = response.data;

--- a/client/src/components/HistoryView.vue
+++ b/client/src/components/HistoryView.vue
@@ -1,38 +1,43 @@
 <template>
     <div id="structured-history-view">
-        <div id="history-view-controls" class="clear">
-            <div class="float-left">
-                <span v-if="historyHistory['purged'] == false">
-                    <span v-if="historyData.user_is_owner == false">
-                        <button id="import" class="btn btn-secondary">Import and start using history</button>
-                    </span>
-                    <span v-if="historyData.user_is_owner && historyData.history_is_current == false">
-                        <button id="switch-history" class="btn btn-secondary" @click="switchHistory">
-                            Switch to this history
+        <div v-if="errorMessages.length > 0">
+            <div :key="index" v-for="(error, index) in errorMessages">
+                <div class="alert alert-danger" role="alert">{{ error }}</div>
+            </div>
+        </div>
+        <div v-else>
+            <div id="history-view-controls" class="clear">
+                <div class="float-left">
+                    <span v-if="historyHistory && historyHistory['purged'] == false">
+                        <span v-if="historyData.user_is_owner == false">
+                            <button id="import" class="btn btn-secondary">Import and start using history</button>
+                        </span>
+                        <span v-if="historyData.user_is_owner && historyData.history_is_current == false">
+                            <button id="switch-history" class="btn btn-secondary" @click="switchHistory">
+                                Switch to this history
+                            </button>
+                        </span>
+                        <button id="show-structure" class="btn btn-secondary" @click="showStructure">
+                            Show structure
                         </button>
                     </span>
-                    <button id="show-structure" class="btn btn-secondary" @click="showStructure">Show structure</button>
-                </span>
+                </div>
+                <div class="float-right">
+                    <button id="toggle-deleted" class="btn btn-secondary">Include deleted</button>
+                    <button id="toggle-hidden" class="btn btn-secondary">Include hidden</button>
+                </div>
             </div>
-            <div class="float-right">
-                <button id="toggle-deleted" class="btn btn-secondary">Include deleted</button>
-                <button id="toggle-hidden" class="btn btn-secondary">Include hidden</button>
-            </div>
+            <div
+                v-if="historyHistory"
+                :id="'history-' + historyHistory['id']"
+                class="history-panel unified-panel-body"
+                style="overflow: auto"
+            ></div>
         </div>
-        <!-- eslint-disable-next-line vue/require-v-for-key -->
-        <div v-for="error in errorMessages">
-            <div class="alert alert-danger" role="alert">{{ error }}</div>
-        </div>
-        <div
-            :id="'history-' + historyHistory['id']"
-            class="history-panel unified-panel-body"
-            style="overflow: auto"
-        ></div>
     </div>
 </template>
 
 <script>
-import $ from "jquery";
 import { getAppRoot } from "onload/loadConfig";
 import axios from "axios";
 import Vue from "vue";
@@ -58,14 +63,18 @@ export default {
     },
     created: function () {
         const url = getAppRoot() + "history/view/" + this.id;
-        this.ajaxCall(url, this.updateHistoryView);
+        this.ajaxCall(url);
     },
     methods: {
-        ajaxCall: function (url, callBack) {
+        ajaxCall: function (url) {
             axios
                 .get(url)
                 .then((response) => {
-                    callBack(response);
+                    if (response.data.error_msg) {
+                        this.errorMessages.push(response.data.error_msg);
+                    } else {
+                        this.updateHistoryView(response);
+                    }
                 })
                 .catch((e) => {
                     this.showError(
@@ -83,23 +92,21 @@ export default {
             this.errorMessages.push(errorMsg);
         },
         makeHistoryView: function (history) {
-            $(function () {
-                const options = {
-                    hasMasthead: history.use_panels ? "true" : "false",
-                    userIsOwner: history.user_is_owner ? "true" : "false",
-                    isCurrent: history.history_is_current ? "true" : "false",
-                    historyJSON: history.history,
-                    showDeletedJson: history.show_deleted,
-                    showHiddenJson: history.show_hidden,
-                    initialModeDeleted: history.show_deleted ? "showing_deleted" : "not_showing_deleted",
-                    initialModeHidden: history.show_hidden ? "showing_hidden" : "not_showing_hidden",
-                    allowUserDatasetPurge: history.allow_user_dataset_purge ? "true" : "false",
-                };
-                options.viewToUse = options.userIsOwner
-                    ? { location: "mvc/history/history-view-edit", className: "HistoryViewEdit" }
-                    : { location: "mvc/history/history-view", className: "HistoryView" };
-                HistoryView.historyEntry(options);
-            });
+            const options = {
+                hasMasthead: history.use_panels ? "true" : "false",
+                userIsOwner: history.user_is_owner ? "true" : "false",
+                isCurrent: history.history_is_current ? "true" : "false",
+                historyJSON: history.history,
+                showDeletedJson: history.show_deleted,
+                showHiddenJson: history.show_hidden,
+                initialModeDeleted: history.show_deleted ? "showing_deleted" : "not_showing_deleted",
+                initialModeHidden: history.show_hidden ? "showing_hidden" : "not_showing_hidden",
+                allowUserDatasetPurge: history.allow_user_dataset_purge ? "true" : "false",
+            };
+            options.viewToUse = options.userIsOwner
+                ? { location: "mvc/history/history-view-edit", className: "HistoryViewEdit" }
+                : { location: "mvc/history/history-view", className: "HistoryView" };
+            return HistoryView.historyEntry(options);
         },
         showStructure: function () {
             const Galaxy = getGalaxyInstance();

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -578,7 +578,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             else:
                 error_msg = ('An error occurred getting the history data from the server. '
                              + 'Please contact a Galaxy administrator if the problem persists.')
-            return trans.show_error_message(error_msg, use_panels=use_panels)
+            return {"error_msg": error_msg}
 
         return {
             "history": history_dictionary,

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -29,7 +29,10 @@ from galaxy.util import (
     string_as_bool,
     unicodify
 )
-from galaxy.web import url_for
+from galaxy.web import (
+    expose_api,
+    url_for
+)
 from galaxy.web.framework.helpers import (
     grids,
     iff,
@@ -543,7 +546,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             'template': html_template
         }
 
-    @web.expose
+    @expose_api
     @web.json
     def view(self, trans, id=None, show_deleted=False, show_hidden=False, use_panels=True):
         """
@@ -555,30 +558,19 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
 
         history_dictionary = {}
         user_is_owner = False
-        try:
-            if id:
-                history_to_view = self.history_manager.get_accessible(self.decode_id(id), trans.user,
-                    current_history=trans.history)
-                user_is_owner = history_to_view.user == trans.user
-                history_is_current = history_to_view == trans.history
-            else:
-                history_to_view = trans.history
-                user_is_owner = True
-                history_is_current = True
+        if id:
+            history_to_view = self.history_manager.get_accessible(self.decode_id(id), trans.user,
+                current_history=trans.history)
+            user_is_owner = history_to_view.user == trans.user
+            history_is_current = history_to_view == trans.history
+        else:
+            history_to_view = trans.history
+            user_is_owner = True
+            history_is_current = True
 
-            # include all datasets: hidden, deleted, and purged
-            history_dictionary = self.history_serializer.serialize_to_view(history_to_view,
-                view='dev-detailed', user=trans.user, trans=trans)
-
-        except Exception as exc:
-            user_id = str(trans.user.id) if trans.user else '(anonymous)'
-            log.exception('Error bootstrapping history for user %s', user_id)
-            if isinstance(exc, exceptions.ItemAccessibilityException):
-                error_msg = 'You do not have permission to view this history.'
-            else:
-                error_msg = ('An error occurred getting the history data from the server. '
-                             + 'Please contact a Galaxy administrator if the problem persists.')
-            return {"error_msg": error_msg}
+        # include all datasets: hidden, deleted, and purged
+        history_dictionary = self.history_serializer.serialize_to_view(history_to_view,
+            view='dev-detailed', user=trans.user, trans=trans)
 
         return {
             "history": history_dictionary,

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -30,7 +30,7 @@ from galaxy.util import (
     unicodify
 )
 from galaxy.web import (
-    expose_api,
+    expose_api_anonymous,
     url_for
 )
 from galaxy.web.framework.helpers import (
@@ -546,7 +546,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             'template': html_template
         }
 
-    @expose_api
+    @expose_api_anonymous
     def view(self, trans, id=None, show_deleted=False, show_hidden=False, use_panels=True):
         """
         View a history. If a history is importable, then it is viewable by any user.

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -547,7 +547,6 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
         }
 
     @expose_api
-    @web.json
     def view(self, trans, id=None, show_deleted=False, show_hidden=False, use_panels=True):
         """
         View a history. If a history is importable, then it is viewable by any user.


### PR DESCRIPTION
An error discovered by @wm75 and @bgruening 
This PR shows an error on fetching history with an invalid id. As a nice bonus, I removed jquery from this component (not sure what was the purpose of putting it there)

How it's now:
https://usegalaxy.eu/histories/view?id=randomid

After this fix:

  
![image](https://user-images.githubusercontent.com/15801412/143586926-45639e36-079a-44f8-97f5-de3b2e317a28.png)


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
