### PR TITLE
[21.09] Reconstruct separate scoped session for ToolShedRepositoryCache

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import (
     defer,
     joinedload,
 )
+from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from sqlitedict import SqliteDict
 
@@ -287,7 +288,8 @@ class ToolShedRepositoryCache:
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
     def __init__(self, session: sessionmaker):
-        self.session = session()
+        engine = session().bind
+        self.session = scoped_session(sessionmaker(engine))
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []
         # Repositories loaded from database


### PR DESCRIPTION
If we just construct a single session, but the underlying connection is closed, we can't use the session anymore, at all. There's some nuance to this, and I wasn't able to simulate a connection that got closed or write a test, but I did deploy this on usegalaxy.org and it fixed the exceptions we'd see when triggering a toolbox reload, so I'm confident this fixes #12988.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
