### PR TITLE
Update interactivetool_pyiron.xml

### DIFF
--- a/tools/interactive/interactivetool_pyiron.xml
+++ b/tools/interactive/interactivetool_pyiron.xml
@@ -29,7 +29,7 @@
 
         ## change into the directory where the notebooks are located
         export HOME=/home/jovyan &&
-        export PATH=${HOME}/.local/bin:\${PATH} &&
+        export PATH=\${HOME}/.local/bin:\${PATH} &&
         cd ./jupyter/ &&
         cp \${HOME}/examples/* ./ &&
 

--- a/tools/interactive/interactivetool_pyiron.xml
+++ b/tools/interactive/interactivetool_pyiron.xml
@@ -1,4 +1,4 @@
-<tool id="interactive_tool_pyiron" tool_type="interactive" name="PyIron Interactive Jupyter Notebook" version="0.2">
+<tool id="interactive_tool_pyiron" tool_type="interactive" name="PyIron Interactive Jupyter Notebook" version="0.2.1" profile="21.09">
     <requirements>
         <container type="docker">quay.io/bgruening/docker-jupyter-notebook:pyiron</container>
     </requirements>


### PR DESCRIPTION
A backslash is missing.

```
Traceback (most recent call last):
  File "/opt/galaxy/server/lib/galaxy/jobs/runners/__init__.py", line 243, in prepare_job
    job_wrapper.prepare()
  File "/opt/galaxy/server/lib/galaxy/jobs/__init__.py", line 1161, in prepare
    self.command_line, self.extra_filenames, self.environment_variables = tool_evaluator.build()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 462, in build
    raise e
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 458, in build
    self.__build_command_line()
  File "/opt/galaxy/server/lib/galaxy/tools/evaluation.py", line 483, in __build_command_line
    command_line = fill_template(command, context=param_dict, python_template_version=self.tool.python_template_version)
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 107, in fill_template
    raise first_exception or e
  File "/opt/galaxy/server/lib/galaxy/util/template.py", line 80, in fill_template
    return unicodify(t, log_exception=False)
  File "/opt/galaxy/server/lib/galaxy/util/__init__.py", line 1060, in unicodify
    value = str(value)
  File "/opt/galaxy/venv/lib/python3.6/site-packages/Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1637853876_069603_82698.py", line 107, in respond
NameMapper.NotFound: cannot find 'HOME'
```

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
