### PR TITLE
Split `run_tool_raw()` out of `BaseDatasetPopulator.run_tool()`

### DIFF
--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -160,11 +160,10 @@ class DatasetsApiTestCase(ApiTestCase):
             'input1': {'src': 'hda', 'id': hda_id},
             'sleep_time': 10,
         }
-        run_response = self.dataset_populator.run_tool(
+        run_response = self.dataset_populator.run_tool_raw(
             "cat_data_and_sleep",
             inputs,
             self.history_id,
-            assert_ok=False,
         )
         queued_id = run_response.json()["outputs"][0]["id"]
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -277,7 +277,7 @@ class ImportExportTests(BaseHistories):
     def test_import_export_failed_job(self):
         history_name = "for_export_include_failed_job"
         history_id = self.dataset_populator.new_history(name=history_name)
-        self.dataset_populator.run_tool('job_properties', inputs={'failbool': True}, history_id=history_id, assert_ok=False)
+        self.dataset_populator.run_tool_raw('job_properties', inputs={'failbool': True}, history_id=history_id)
         self.dataset_populator.wait_for_history(history_id, assert_ok=False)
 
         imported_history_id = self._reimport_history(history_id, history_name, assert_ok=False, wait_on_history_length=4, export_kwds={"include_deleted": "True"})

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -704,8 +704,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
                 "cat_data_and_sleep",
                 inputs,
                 history_id,
-                assert_ok=False,
-            ).json()
+            )
             update_time = datetime.utcnow().isoformat()
             collection_id = response['implicit_collections'][0]['id']
             for _ in range(20):
@@ -723,8 +722,7 @@ class HistoryContentsApiTestCase(ApiTestCase):
                 "collection_creates_dynamic_nested",
                 inputs,
                 history_id,
-                assert_ok=False,
-            ).json()
+            )
             update_time = datetime.utcnow().isoformat()
             collection_id = response['output_collections'][0]['id']
             for _ in range(20):

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -929,10 +929,11 @@ steps:
             inputs = {"thebool": "false",
                       "failbool": "false",
                       "rerun_remap_job_id": failed_dataset_one['creating_job']}
-            self.dataset_populator.run_tool(tool_id='job_properties',
-                                            inputs=inputs,
-                                            history_id=history_id,
-                                            assert_ok=True)
+            self.dataset_populator.run_tool(
+                tool_id='job_properties',
+                inputs=inputs,
+                history_id=history_id,
+            )
             unpaused_dataset_1 = self.dataset_populator.get_history_dataset_details(history_id, hid=5, wait=True, assert_ok=False)
             assert unpaused_dataset_1['state'] == 'ok'
             self.dataset_populator.wait_for_history(history_id, assert_ok=False)
@@ -973,10 +974,11 @@ steps:
             inputs = {"thebool": "false",
                       "failbool": "false",
                       "rerun_remap_job_id": failed_dataset_one['creating_job']}
-            self.dataset_populator.run_tool(tool_id='job_properties',
-                                            inputs=inputs,
-                                            history_id=history_id,
-                                            assert_ok=True)
+            self.dataset_populator.run_tool(
+                tool_id='job_properties',
+                inputs=inputs,
+                history_id=history_id,
+            )
             paused_colletion = self.dataset_populator.get_history_collection_details(history_id, hid=7, wait=True, assert_ok=False)
             first_paused_element = paused_colletion['elements'][0]['object']
             assert first_paused_element['state'] == 'ok'
@@ -1027,10 +1029,11 @@ test_data:
                                  },
                       "failbool": "false",
                       "rerun_remap_job_id": failed_dataset['creating_job']}
-            run_dict = self.dataset_populator.run_tool(tool_id='fail_identifier',
-                                                       inputs=inputs,
-                                                       history_id=history_id,
-                                                       assert_ok=True)
+            run_dict = self.dataset_populator.run_tool(
+                tool_id='fail_identifier',
+                inputs=inputs,
+                history_id=history_id,
+            )
             unpaused_dataset = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=False)
             assert unpaused_dataset['state'] == 'ok'
             contents = self.dataset_populator.get_history_dataset_content(history_id, hid=7, assert_ok=False)
@@ -1085,7 +1088,7 @@ test_data:
                 tool_id='collection_creates_list_of_pairs',
                 inputs=inputs,
                 history_id=history_id,
-                assert_ok=True)
+            )
             assert not run_response["output_collections"][0]["visible"]
             self.dataset_populator.wait_for_job(paused_step['jobs'][0]['id'])
             invocation = self.workflow_populator.get_invocation(job_summary.invocation_id, step_details=True)
@@ -3348,10 +3351,11 @@ input1:
                                  },
                       "failbool": "false",
                       "rerun_remap_job_id": job_id}
-            self.dataset_populator.run_tool(tool_id='fail_identifier',
-                                            inputs=inputs,
-                                            history_id=history_id,
-                                            assert_ok=True)
+            self.dataset_populator.run_tool(
+                tool_id='fail_identifier',
+                inputs=inputs,
+                history_id=history_id,
+            )
             unpaused_dataset = self.dataset_populator.get_history_dataset_details(history_id, wait=True, assert_ok=False)
             assert unpaused_dataset['state'] == 'ok'
             assert unpaused_dataset['name'] == f"{name} suffix"

--- a/lib/galaxy_test/selenium/test_admin_app.py
+++ b/lib/galaxy_test/selenium/test_admin_app.py
@@ -211,10 +211,11 @@ class AdminAppTestCase(SeleniumTestCase):
         self.screenshot("admin_data_manager")
 
         with self.dataset_populator.test_history() as history_id:
-            run_response = self.dataset_populator.run_tool(tool_id="data_manager",
-                                                           inputs={"ignored_value": "test"},
-                                                           history_id=history_id,
-                                                           assert_ok=False)
+            run_response = self.dataset_populator.run_tool_raw(
+                tool_id="data_manager",
+                inputs={"ignored_value": "test"},
+                history_id=history_id,
+            )
             job_id = run_response.json()["jobs"][0]["id"]
             self.dataset_populator.wait_for_tool_run(history_id=history_id,
                                                      run_response=run_response,

--- a/lib/galaxy_test/selenium/test_history_panel_collections.py
+++ b/lib/galaxy_test/selenium/test_history_panel_collections.py
@@ -33,7 +33,6 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
             "cat_data_and_sleep",
             ok_inputs,
             history_id,
-            assert_ok=True,
         )
         ok_hid = ok_response["implicit_collections"][0]["hid"]
 
@@ -57,11 +56,10 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
             "input1": {'batch': True, 'values': [{"src": "hdca", "id": input_collection["id"]}]},
             "sleep_time": 60,
         }
-        running_response = self.dataset_populator.run_tool(
+        running_response = self.dataset_populator.run_tool_raw(
             "cat_data_and_sleep",
             running_inputs,
             history_id,
-            assert_ok=False,
         )
         try:
             assert_status_code_is(running_response, 200)
@@ -119,15 +117,11 @@ class HistoryPanelCollectionsTestCase(SeleniumTestCase):
         running_inputs = {
             "sleep_time": 180,
         }
-        running_response = self.dataset_populator.run_tool(
+        payload = self.dataset_populator.run_tool(
             "collection_creates_dynamic_nested",
             running_inputs,
             history_id,
-            assert_ok=False,
         )
-        assert_status_code_is(running_response, 200)
-
-        payload = running_response.json()
         assert payload["output_collections"]
         assert payload["jobs"]
         assert len(payload["jobs"]) > 0

--- a/test/integration/objectstore/test_jobs.py
+++ b/test/integration/objectstore/test_jobs.py
@@ -56,7 +56,6 @@ class ObjectStoreJobsIntegrationTestCase(BaseObjectStoreIntegrationTestCase):
                 "create_10",
                 create_10_inputs,
                 history_id,
-                assert_ok=True,
             )
             self.dataset_populator.wait_for_history(history_id)
 

--- a/test/integration/objectstore/test_selection.py
+++ b/test/integration/objectstore/test_selection.py
@@ -84,7 +84,6 @@ class ObjectStoreSelectionIntegrationTestCase(BaseObjectStoreIntegrationTestCase
                     tool_id,
                     inputs,
                     history_id,
-                    assert_ok=True,
                 )
                 self.dataset_populator.wait_for_history(history_id)
 

--- a/test/integration/test_data_manager.py
+++ b/test/integration/test_data_manager.py
@@ -67,15 +67,17 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         self.install_repository("devteam", "data_manager_sam_fasta_index_builder", "cc4ef4d38cf9")
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
-                run_response = self.dataset_populator.run_tool(tool_id=FETCH_TOOL_ID,
-                                                               inputs=FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=FETCH_TOOL_ID,
+                    inputs=FETCH_GENOME_DBKEYS_ALL_FASTA_INPUT,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
-                run_response = self.dataset_populator.run_tool(tool_id=SAM_FASTA_ID,
-                                                               inputs=SAM_FASTA_INPUT,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=SAM_FASTA_ID,
+                    inputs=SAM_FASTA_INPUT,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
 
     @skip_if_toolshed_down
@@ -88,16 +90,18 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
                 # First run should work
-                run_response = self.dataset_populator.run_tool(tool_id=FETCH_TOOL_ID,
-                                                inputs=inputs,
-                                                history_id=history_id,
-                                                assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=FETCH_TOOL_ID,
+                    inputs=inputs,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
                 # Second run should fail
-                run_response = self.dataset_populator.run_tool(tool_id=FETCH_TOOL_ID,
-                                                inputs=inputs,
-                                                history_id=history_id,
-                                                assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=FETCH_TOOL_ID,
+                    inputs=inputs,
+                    history_id=history_id,
+                )
                 with pytest.raises(AssertionError):
                     self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
 
@@ -108,10 +112,11 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         self.install_repository('iuc', 'data_manager_manual', '1ed87dee9e68')
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
-                run_response = self.dataset_populator.run_tool(tool_id=DATA_MANAGER_MANUAL_ID,
-                                                               inputs=DATA_MANAGER_MANUAL_INPUT,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=DATA_MANAGER_MANUAL_ID,
+                    inputs=DATA_MANAGER_MANUAL_INPUT,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
 
         entries = self._app.tool_data_tables.get("all_fasta").get_entries('dbkey', 'dm6', 'dbkey')
@@ -133,15 +138,17 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         inputs['dbkey_source|dbkey'] = 'another_unique_dbkey_value'
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
-                run_response = self.dataset_populator.run_tool(tool_id=FETCH_TOOL_ID,
-                                                               inputs=inputs,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=FETCH_TOOL_ID,
+                    inputs=inputs,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
-                run_response = self.dataset_populator.run_tool(tool_id=DATA_MANAGER_MANUAL_ID,
-                                                               inputs=DATA_MANAGER_MANUAL_INPUT,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=DATA_MANAGER_MANUAL_ID,
+                    inputs=DATA_MANAGER_MANUAL_INPUT,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
 
         entries = self._app.tool_data_tables.get("all_fasta").get_entries('dbkey', 'another_unique_dbkey_value', 'dbkey')

--- a/test/integration/test_data_manager_refgenie.py
+++ b/test/integration/test_data_manager_refgenie.py
@@ -77,10 +77,11 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         self.install_repository('iuc', 'data_manager_manual', '1ed87dee9e68')
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
-                run_response = self.dataset_populator.run_tool(tool_id=DATA_MANAGER_MANUAL_ID,
-                                                               inputs=DATA_MANAGER_MANUAL_INPUT,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=DATA_MANAGER_MANUAL_ID,
+                    inputs=DATA_MANAGER_MANUAL_INPUT,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
 
         entries = self._app.tool_data_tables.get("all_fasta").get_entries('dbkey', 'dm6', 'dbkey')
@@ -97,10 +98,11 @@ class DataManagerIntegrationTestCase(integration_util.IntegrationTestCase, UsesS
         self.install_repository('iuc', 'data_manager_manual', '1ed87dee9e68')
         with self._different_user(email="%s@galaxy.org" % self.username):
             with self.dataset_populator.test_history() as history_id:
-                run_response = self.dataset_populator.run_tool(tool_id=DATA_MANAGER_MANUAL_ID,
-                                                               inputs=DATA_MANAGER_MANUAL_INPUT_DBKEY,
-                                                               history_id=history_id,
-                                                               assert_ok=False)
+                run_response = self.dataset_populator.run_tool_raw(
+                    tool_id=DATA_MANAGER_MANUAL_ID,
+                    inputs=DATA_MANAGER_MANUAL_INPUT_DBKEY,
+                    history_id=history_id,
+                )
                 self.dataset_populator.wait_for_tool_run(history_id=history_id, run_response=run_response, timeout=CONDA_AUTO_INSTALL_JOB_TIMEOUT)
 
         entries = self._app.tool_data_tables.get("__dbkeys__").get_entries('name', 'dm7', 'name')

--- a/test/integration/test_interactivetools_api.py
+++ b/test/integration/test_interactivetools_api.py
@@ -89,7 +89,7 @@ class BaseInteractiveToolsIntegrationTestCase(ContainerizedIntegrationTestCase):
 class RunsInterativeToolTests:
 
     def test_simple_execution(self):
-        response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, self.history_id, assert_ok=True)
+        response_dict = self.dataset_populator.run_tool("interactivetool_simple", {}, self.history_id)
         assert "jobs" in response_dict, response_dict
         jobs = response_dict["jobs"]
         assert isinstance(jobs, list)
@@ -103,7 +103,7 @@ class RunsInterativeToolTests:
         assert content == "moo cow\n", content
 
     def test_multi_server_realtime_tool(self):
-        response_dict = self.dataset_populator.run_tool("interactivetool_two_entry_points", {}, self.history_id, assert_ok=True)
+        response_dict = self.dataset_populator.run_tool("interactivetool_two_entry_points", {}, self.history_id)
         assert "jobs" in response_dict, response_dict
         jobs = response_dict["jobs"]
         assert isinstance(jobs, list)

--- a/test/integration/test_job_recovery.py
+++ b/test/integration/test_job_recovery.py
@@ -30,12 +30,11 @@ class JobRecoveryBeforeHandledIntegerationTestCase(integration_util.IntegrationT
 
     def test_recovery(self):
         history_id = self.dataset_populator.new_history()
-        self.dataset_populator.run_tool(
+        self.dataset_populator.run_tool_raw(
             "exit_code_oom",
             {},
             history_id,
-            assert_ok=False,
-        ).json()
+        )
         self.restart(handle_reconfig=self.handle_reconfigure_galaxy_config_kwds)
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)
@@ -57,12 +56,11 @@ class JobRecoveryAfterHandledIntegerationTestCase(integration_util.IntegrationTe
 
     def test_recovery(self):
         history_id = self.dataset_populator.new_history()
-        self.dataset_populator.run_tool(
+        self.dataset_populator.run_tool_raw(
             "exit_code_oom",
             {},
             history_id,
-            assert_ok=False,
-        ).json()
+        )
         self.restart(handle_reconfig=self.handle_reconfigure_galaxy_config_kwds)
         self.dataset_populator = DatasetPopulator(self.galaxy_interactor)
         self.dataset_populator.wait_for_history(history_id, assert_ok=True)

--- a/test/integration/test_kubernetes_runner.py
+++ b/test/integration/test_kubernetes_runner.py
@@ -239,8 +239,7 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
                 "cat_data_and_sleep",
                 running_inputs,
                 history_id,
-                assert_ok=False,
-            ).json()
+            )
             job_dict = running_response["jobs"][0]
 
             app = self._app
@@ -273,11 +272,10 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
                 "input1": {"src": "hda", "id": hda1["id"]},
                 "sleep_time": 240,
             }
-            running_response = self.dataset_populator.run_tool(
+            running_response = self.dataset_populator.run_tool_raw(
                 "cat_data_and_sleep",
                 running_inputs,
                 history_id,
-                assert_ok=False,
             )
             job_dict = running_response.json()["jobs"][0]
 
@@ -306,11 +304,10 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
         inputs = {
             'failbool': True
         }
-        running_response = self.dataset_populator.run_tool(
+        running_response = self.dataset_populator.run_tool_raw(
             "job_properties",
             inputs,
             self.history_id,
-            assert_ok=False,
         )
         result = self.dataset_populator.wait_for_tool_run(run_response=running_response, history_id=self.history_id, assert_ok=False).json()
         details = self.dataset_populator.get_job_details(result['jobs'][0]['id'], full=True).json()
@@ -329,7 +326,6 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
                 {'input': {"src": "hda", "id": hda1["id"]},
                  'column': [1]},
                 self.history_id,
-                assert_ok=True,
             )
 
     @skip_without_tool('galaxy_slots_and_memory')
@@ -338,7 +334,6 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
             'galaxy_slots_and_memory',
             {},
             self.history_id,
-            assert_ok=True
         )
         dataset_content = self.dataset_populator.get_history_dataset_content(self.history_id, hid=1).strip()
         CPU = '2'
@@ -356,11 +351,10 @@ class BaseKubernetesIntegrationTestCase(BaseJobEnvironmentIntegrationTestCase, M
 
     @skip_without_tool('create_2')
     def test_walltime_limit(self):
-        running_response = self.dataset_populator.run_tool(
+        running_response = self.dataset_populator.run_tool_raw(
             'create_2',
             {'sleep_time': 60},
             self.history_id,
-            assert_ok=False
         )
         result = self.dataset_populator.wait_for_tool_run(run_response=running_response,
                                                           history_id=self.history_id,

--- a/test/integration/test_local_job_cancellation.py
+++ b/test/integration/test_local_job_cancellation.py
@@ -22,8 +22,7 @@ class CancelsJob:
             "cat_data_and_sleep",
             running_inputs,
             history_id,
-            assert_ok=False,
-        ).json()
+        )
         job_dict = running_response["jobs"][0]
         return job_dict["id"]
 


### PR DESCRIPTION
so that the former always returns a `Response` object while the latter returns the response content.

This is in line with the approach suggested by @jmchilton in https://github.com/galaxyproject/galaxy/pull/12634#issuecomment-933955322

Also:
- In `CwlPopulator.run_cwl_job()` wait for the run only if `assert_ok` is True; if the `wait()` call fails, summarize history also for workflow runs.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
