### PR TITLE
Remove is_multi_byte

### DIFF
--- a/lib/galaxy/datatypes/annotation.py
+++ b/lib/galaxy/datatypes/annotation.py
@@ -17,7 +17,7 @@ class SnapHmm(Text):
     file_ext = "snaphmm"
     edam_data = "data_1364"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "SNAP HMM model"
@@ -46,7 +46,7 @@ class Augustus(CompressedArchive):
     edam_data = "data_0950"
     compressed = True
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Augustus model"
             dataset.blurb = nice_size(dataset.get_size())

--- a/lib/galaxy/datatypes/anvio.py
+++ b/lib/galaxy/datatypes/anvio.py
@@ -61,7 +61,7 @@ class AnvioComposite(Html):
         """Returns the mime type of the datatype"""
         return 'text/html'
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = 'Anvio database (multiple files)'

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -82,7 +82,7 @@ class Ab1(Binary):
     edam_format = "format_3000"
     edam_data = "data_0924"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary ab1 sequence file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -167,7 +167,7 @@ class Cel(Binary):
         elif header_bytes.decode("utf8", errors="ignore").startswith('[CEL]'):
             dataset.metadata.version = "3"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.blurb = f"Cel version: {dataset.metadata.version}"
             dataset.peek = get_file_peek(dataset.file_name)
@@ -196,7 +196,7 @@ class CompressedArchive(Binary):
     file_ext = "compressed_archive"
     compressed = True
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Compressed binary file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -251,7 +251,7 @@ class Bref3(Binary):
     def sniff_prefix(self, sniff_prefix):
         return sniff_prefix.startswith_bytes(self._magic)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary bref3 file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -308,7 +308,7 @@ class CompressedZipArchive(CompressedArchive):
     """
     file_ext = "zip"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Compressed zip file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -410,7 +410,7 @@ class BamNative(CompressedArchive, _BamOrSam):
         except Exception:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary bam alignments file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -780,7 +780,7 @@ class CRAM(Binary):
             log.warning('%s, set_index_file Exception: %s', self, exc)
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = 'CRAM binary alignment file'
             dataset.blurb = 'binary data'
@@ -899,7 +899,7 @@ class H5(Binary):
         except Exception:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary HDF5 file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -961,7 +961,7 @@ class Loom(H5):
                     return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary Loom file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -1190,7 +1190,7 @@ class Anndata(H5):
             if dataset.metadata.shape is None:
                 dataset.metadata.shape = (int(dataset.metadata.obs_size), int(dataset.metadata.var_size))
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             tmp = dataset.metadata
 
@@ -1238,7 +1238,7 @@ class GmxBinary(Binary):
         # The first 4 bytes of any GROMACS binary file containing the magic number
         return sniff_prefix.magic_header('>1i') == self.magic_number
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f"Binary GROMACS {self.file_ext} file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -1377,7 +1377,7 @@ class Biom2(H5):
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, util.unicodify(e))
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             lines = ['Biom2 (HDF5) file']
             try:
@@ -1437,7 +1437,7 @@ class Cool(H5):
                     return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Cool (HDF5) file for storing genomic interaction data."
             dataset.blurb = nice_size(dataset.get_size())
@@ -1497,7 +1497,7 @@ class MCool(H5):
                     return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Multi-resolution Cool (HDF5) file for storing genomic interaction data."
             dataset.blurb = nice_size(dataset.get_size())
@@ -1570,7 +1570,7 @@ class H5MLM(H5):
             log.warning('%s, get model configuration Except: %s', self, e)
             return ""
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             repr_ = self.get_repr(dataset.file_name)
             dataset.peek = repr_[:self.max_peek_size]
@@ -1658,7 +1658,7 @@ class HexrdMaterials(H5):
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             lines = ['Material SpaceGroup Lattice']
             if dataset.metadata.materials:
@@ -1680,7 +1680,7 @@ class Scf(Binary):
     edam_data = "data_0924"
     file_ext = "scf"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary scf sequence file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -1707,7 +1707,7 @@ class Sff(Binary):
         # about the format, see http://www.ncbi.nlm.nih.gov/Traces/trace.cgi?cmd=show&f=formats&m=doc&s=format
         return sniff_prefix.startswith_bytes(b'.sff')
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary sff file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -1743,7 +1743,7 @@ class BigWig(Binary):
     def sniff_prefix(self, sniff_prefix):
         return sniff_prefix.magic_header("I") == self._magic
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f"Binary UCSC {self._name} file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -1782,7 +1782,7 @@ class TwoBit(Binary):
         magic = sniff_prefix.magic_header(">L")
         return magic == TWOBIT_MAGIC_NUMBER or magic == TWOBIT_MAGIC_NUMBER_SWAP
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary TwoBit format nucleotide file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -1865,7 +1865,7 @@ class SQlite(Binary):
             log.warning('%s, sniff Exception: %s', self, e)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "SQLite Database"
             lines = ['SQLite Database']
@@ -1931,7 +1931,7 @@ class GeminiSQLite(SQlite):
             return self.sniff_table_names(filename, table_names)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Gemini SQLite Database, version %s" % (dataset.metadata.gemini_version or 'unknown')
             dataset.blurb = nice_size(dataset.get_size())
@@ -2007,7 +2007,7 @@ class CuffDiffSQlite(SQlite):
             return self.sniff_table_names(filename, table_names)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "CuffDiff SQLite Database, version %s" % (dataset.metadata.cuffdiff_version or 'unknown')
             dataset.blurb = nice_size(dataset.get_size())
@@ -2252,7 +2252,7 @@ class IdpDB(SQlite):
             return self.sniff_table_names(filename, table_names)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "IDPickerDB SQLite file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -2328,7 +2328,7 @@ class NcbiTaxonomySQlite(SQlite):
             return self.sniff_table_names(filename, table_names)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "NCBI Taxonomy SQLite Database, version {} ({} taxons)".format(
                 getattr(dataset.metadata, "ncbitaxonomy_schema_version", "unknown"),
@@ -2379,7 +2379,7 @@ class ExcelXls(Binary):
         """Returns the mime type of the datatype"""
         return 'application/vnd.ms-excel'
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Microsoft Excel XLS file"
             dataset.blurb = data.nice_size(dataset.get_size())
@@ -2405,7 +2405,7 @@ class Sra(Binary):
         """
         return sniff_prefix.startswith_bytes(b'NCBI.sra')
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = 'Binary sra file'
             dataset.blurb = nice_size(dataset.get_size())
@@ -2749,7 +2749,7 @@ class PostgresqlArchive(CompressedArchive):
                 return 'postgresql/db/PG_VERSION' in temptar.getnames()
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f"PostgreSQL Archive ({nice_size(dataset.get_size())})"
             dataset.blurb = "PostgreSQL version %s" % (dataset.metadata.version or 'unknown')
@@ -2803,7 +2803,7 @@ class Fast5Archive(CompressedArchive):
             log.warning('%s, sniff Exception: %s', self, e)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f"FAST5 Archive ({nice_size(dataset.get_size())})"
             dataset.blurb = "%s sequences" % (dataset.metadata.fast5_count or 'unknown')
@@ -2897,7 +2897,7 @@ class SearchGuiArchive(CompressedArchive):
             log.warning('%s, sniff Exception: %s', self, e)
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "SearchGUI Archive, version %s" % (dataset.metadata.searchgui_version or 'unknown')
             dataset.blurb = nice_size(dataset.get_size())
@@ -2919,7 +2919,7 @@ class NetCDF(Binary):
     edam_format = "format_3650"
     edam_data = "data_0943"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary netCDF file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -2974,7 +2974,7 @@ class Dcd(Binary):
         except Exception:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary CHARMM/NAMD dcd file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -3025,7 +3025,7 @@ class Vel(Binary):
         except Exception:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary CHARMM velocity file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -3115,7 +3115,7 @@ class ICM(Binary):
     file_ext = "icm"
     edam_data = "data_0950"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary ICM (interpolated context model) file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -3180,7 +3180,7 @@ class BafTar(CompressedArchive):
     def get_type(self):
         return "Bruker BAF directory archive"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = self.get_type()
             dataset.blurb = nice_size(dataset.get_size())
@@ -3282,7 +3282,7 @@ class Pretext(Binary):
         # file contains binary data.
         return sniff_prefix.startswith_bytes(b'pstm')
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary pretext file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -3324,7 +3324,7 @@ class JP2(Binary):
         except Exception:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary JPEG 2000 file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -3379,7 +3379,7 @@ class Npz(CompressedArchive):
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f"Binary Numpy npz {dataset.metadata.nfiles} files ({nice_size(dataset.get_size())})"
             dataset.blurb = nice_size(dataset.get_size())
@@ -3440,7 +3440,7 @@ class HexrdImagesNpz(Npz):
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             lines = [f"Binary Hexrd Image npz {dataset.metadata.nfiles} files ({nice_size(dataset.get_size())})",
                      f"Panel: {dataset.metadata.panel_id} Frames: {dataset.metadata.nframes} Shape: {dataset.metadata.shape}"]
@@ -3497,7 +3497,7 @@ class HexrdEtaOmeNpz(Npz):
         except Exception as e:
             log.warning('%s, set_meta Exception: %s', self, e)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             lines = [f"Binary Hexrd Eta-Ome npz {dataset.metadata.nfiles} files ({nice_size(dataset.get_size())})",
                      f"Eta-Ome HKLs: {dataset.metadata.HKLs} Frames: {dataset.metadata.nframes}"]

--- a/lib/galaxy/datatypes/blast.py
+++ b/lib/galaxy/datatypes/blast.py
@@ -56,7 +56,7 @@ class BlastXml(GenericXml):
     edam_format = "format_3331"
     edam_data = "data_0857"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
@@ -176,7 +176,7 @@ class BlastXml(GenericXml):
 class _BlastDb(Data):
     """Base class for BLAST database datatype."""
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text."""
         if not dataset.dataset.purged:
             dataset.peek = "BLAST database (multiple files)"
@@ -314,7 +314,7 @@ class LastDb(Data):
     file_ext = 'lastdb'
     composite_type = 'basic'
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text."""
         if not dataset.dataset.purged:
             dataset.peek = "LAST database (multiple files)"

--- a/lib/galaxy/datatypes/constructive_solid_geometry.py
+++ b/lib/galaxy/datatypes/constructive_solid_geometry.py
@@ -107,7 +107,7 @@ class Ply:
                             element_tuple = (items[1], int(items[2]))
                             dataset.metadata.other_elements.append(element_tuple)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = f"Faces: {str(dataset.metadata.face)}, Vertices: {str(dataset.metadata.vertex)}"
@@ -430,7 +430,7 @@ class Vtk:
             blurb += str(dataset.metadata.dataset_type)
         return blurb or 'VTK data'
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = self.get_blurb(dataset)

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -259,12 +259,9 @@ class Data(metaclass=DataMeta):
 
     max_optional_metadata_filesize = property(get_max_optional_metadata_filesize, set_max_optional_metadata_filesize)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """
         Set the peek and blurb text
-
-        :param is_multi_byte: deprecated
-        :type  is_multi_byte: bool
         """
         if not dataset.dataset.purged:
             dataset.peek = ''
@@ -893,7 +890,7 @@ class Text(Data):
                 return None
         return data_lines
 
-    def set_peek(self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=None, line_wrap=True, **kwd):
+    def set_peek(self, dataset, line_count=None, WIDTH=256, skipchars=None, line_wrap=True, **kwd):
         """
         Set the peek.  This method is used by various subclasses of Text.
         """
@@ -1090,12 +1087,9 @@ def get_test_fname(fname):
     return full_path
 
 
-def get_file_peek(file_name, is_multi_byte=False, WIDTH=256, LINE_COUNT=5, skipchars=None, line_wrap=True):
+def get_file_peek(file_name, WIDTH=256, LINE_COUNT=5, skipchars=None, line_wrap=True):
     """
     Returns the first LINE_COUNT lines wrapped to WIDTH.
-
-    :param is_multi_byte: deprecated
-    :type  is_multi_byte: bool
 
     >>> def assert_peek_is(file_name, expected, *args, **kwd):
     ...     path = get_test_fname(file_name)

--- a/lib/galaxy/datatypes/flow.py
+++ b/lib/galaxy/datatypes/flow.py
@@ -19,7 +19,7 @@ class FCS(Binary):
     """Class describing an FCS binary file"""
     file_ext = "fcs"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Binary FCS file"
             dataset.blurb = data.nice_size(dataset.get_size())

--- a/lib/galaxy/datatypes/gis.py
+++ b/lib/galaxy/datatypes/gis.py
@@ -46,7 +46,7 @@ class Shapefile(Binary):
         rval.append('</ul></div></html>\n')
         return "\n".join(rval)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text."""
         if not dataset.dataset.purged:
             dataset.peek = "Shapefile data"

--- a/lib/galaxy/datatypes/graph.py
+++ b/lib/galaxy/datatypes/graph.py
@@ -22,7 +22,7 @@ class Xgmml(xml.GenericXml):
     """
     file_ext = "xgmml"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """
         Set the peek and blurb text
         """
@@ -68,7 +68,7 @@ class Sif(tabular.Tabular):
     """
     file_ext = "sif"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """
         Set the peek and blurb text
         """

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -50,7 +50,7 @@ class Image(data.Data):
         super().__init__(**kwd)
         self.image_formats = [self.file_ext.upper()]
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f'Image in {dataset.extension} format'
             dataset.blurb = nice_size(dataset.get_size())
@@ -354,7 +354,7 @@ class Gmaj(data.Data):
     file_ext = "gmaj.zip"
     copy_safe_peek = False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if hasattr(dataset, 'history_id'):
                 params = {
@@ -539,7 +539,7 @@ class Star(data.Text):
     https://relion.readthedocs.io/en/latest/Reference/Conventions.html"""
     file_ext = "star"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -595,7 +595,7 @@ class Laj(data.Text):
     file_ext = "laj"
     copy_safe_peek = False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if hasattr(dataset, 'history_id'):
                 params = {

--- a/lib/galaxy/datatypes/isa.py
+++ b/lib/galaxy/datatypes/isa.py
@@ -141,7 +141,7 @@ class _Isa(data.Data):
     # Set peek {{{2
     ################################################################
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text. Get first lines of the main file and set it as the peek."""
 
         main_file = self._get_main_file(dataset)

--- a/lib/galaxy/datatypes/microarrays.py
+++ b/lib/galaxy/datatypes/microarrays.py
@@ -36,7 +36,7 @@ class GenericMicroarrayFile(data.Text):
                     readonly=True, visible=True,
                     optional=True, no_value=0)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if dataset.metadata.block_count == 1:
                 dataset.blurb = f"{dataset.metadata.file_type} {dataset.metadata.version_number}: Format {dataset.metadata.file_format}, 1 block, {dataset.metadata.number_of_optional_header_records} headers and {dataset.metadata.number_of_data_columns} columns"

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -48,7 +48,7 @@ class GenericMolFile(Text):
     """
     MetadataElement(name="number_of_molecules", default=0, desc="Number of molecules", readonly=True, visible=True, optional=True, no_value=0)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if (dataset.metadata.number_of_molecules == 1):
                 dataset.blurb = "1 molecule"
@@ -394,7 +394,7 @@ class OBFS(Binary):
         self.add_composite_file('molecule.cml', optional=True,
                                 is_binary=False, description='Molecule File')
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text."""
         if not dataset.dataset.purged:
             dataset.peek = "OpenBabel Fastsearch Index"
@@ -441,7 +441,7 @@ class PHAR(GenericMolFile):
     """
     file_ext = "phar"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "pharmacophore"
@@ -509,7 +509,7 @@ class PDB(GenericMolFile):
             log.error('Error finding chain_ids: %s', unicodify(e))
             raise
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             atom_numbers = count_special_lines("^ATOM", dataset.file_name)
             hetatm_numbers = count_special_lines("^HETATM", dataset.file_name)
@@ -561,7 +561,7 @@ class PDBQT(GenericMolFile):
         else:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             root_numbers = count_special_lines("^ROOT", dataset.file_name)
             branch_numbers = count_special_lines("^BRANCH", dataset.file_name)
@@ -662,7 +662,7 @@ class PQR(GenericMolFile):
             log.error('Error finding chain_ids: %s', unicodify(e))
             raise
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             atom_numbers = count_special_lines("^ATOM", dataset.file_name)
             hetatm_numbers = count_special_lines("^HETATM", dataset.file_name)
@@ -677,7 +677,7 @@ class PQR(GenericMolFile):
 class grd(Text):
     file_ext = "grd"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "grids for docking"
@@ -689,7 +689,7 @@ class grd(Text):
 class grdtgz(Binary):
     file_ext = "grd.tgz"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = 'binary data'
             dataset.blurb = "compressed grids for docking"
@@ -712,7 +712,7 @@ class InChI(Tabular):
         """
         dataset.metadata.number_of_molecules = self.count_data_lines(dataset)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if (dataset.metadata.number_of_molecules == 1):
                 dataset.blurb = "1 molecule"
@@ -757,7 +757,7 @@ class SMILES(Tabular):
         """
         dataset.metadata.number_of_molecules = self.count_data_lines(dataset)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if dataset.metadata.number_of_molecules == 1:
                 dataset.blurb = "1 molecule"
@@ -818,7 +818,7 @@ class CML(GenericXml):
         """
         dataset.metadata.number_of_molecules = count_special_lines(r'^\s*<molecule', dataset.file_name)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if (dataset.metadata.number_of_molecules == 1):
                 dataset.blurb = "1 molecule"
@@ -971,7 +971,7 @@ class GRO(GenericMolFile):
                 return False
         return True
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             atom_number = int(dataset.peek.split('\n')[1])

--- a/lib/galaxy/datatypes/msa.py
+++ b/lib/galaxy/datatypes/msa.py
@@ -31,14 +31,14 @@ class InfernalCM(Text):
     MetadataElement(name="cm_version", default="1/a", desc="Infernal Covariance Model version",
                     readonly=True, visible=True, optional=True, no_value=0)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name, is_multi_byte=is_multi_byte)
+            dataset.peek = get_file_peek(dataset.file_name)
             if dataset.metadata.number_of_models == 1:
                 dataset.blurb = "1 model"
             else:
                 dataset.blurb = f"{dataset.metadata.number_of_models} models"
-            dataset.peek = get_file_peek(dataset.file_name, is_multi_byte=is_multi_byte)
+            dataset.peek = get_file_peek(dataset.file_name)
         else:
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disc'
@@ -71,7 +71,7 @@ class Hmmer(Text):
     edam_data = "data_1364"
     edam_format = "format_1370"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "HMMER Database"
@@ -115,7 +115,7 @@ class HmmerPress(Binary):
     file_ext = 'hmmpress'
     composite_type = 'basic'
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text."""
         if not dataset.dataset.purged:
             dataset.peek = "HMMER Binary database"
@@ -151,7 +151,7 @@ class Stockholm_1_0(Text):
 
     MetadataElement(name="number_of_models", default=0, desc="Number of multiple alignments", readonly=True, visible=True, optional=True, no_value=0)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if (dataset.metadata.number_of_models == 1):
                 dataset.blurb = "1 alignment"
@@ -230,7 +230,7 @@ class MauveXmfa(Text):
 
     MetadataElement(name="number_of_models", default=0, desc="Number of alignmened sequences", readonly=True, visible=True, optional=True, no_value=0)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             if (dataset.metadata.number_of_models == 1):
                 dataset.blurb = "1 alignment"

--- a/lib/galaxy/datatypes/neo4j.py
+++ b/lib/galaxy/datatypes/neo4j.py
@@ -42,7 +42,7 @@ class Neo4j(Html):
         """Returns the mime type of the datatype"""
         return 'text/html'
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = 'Neo4j database (multiple files)'

--- a/lib/galaxy/datatypes/ngsindex.py
+++ b/lib/galaxy/datatypes/ngsindex.py
@@ -42,7 +42,7 @@ class BowtieIndex(Html):
             f.write("\n".join(rval))
             f.write('\n')
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = f"Bowtie index file ({dataset.metadata.sequence_space})"
             dataset.blurb = f"{dataset.metadata.sequence_space} space"

--- a/lib/galaxy/datatypes/phylip.py
+++ b/lib/galaxy/datatypes/phylip.py
@@ -38,9 +38,9 @@ class Phylip(Text):
         except Exception:
             raise Exception("Header does not correspond to PHYLIP header.")
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
-            dataset.peek = get_file_peek(dataset.file_name, is_multi_byte=is_multi_byte)
+            dataset.peek = get_file_peek(dataset.file_name)
             if dataset.metadata.sequences:
                 dataset.blurb = f"{util.commaify(str(dataset.metadata.sequences))} sequences"
             else:

--- a/lib/galaxy/datatypes/plant_tribes.py
+++ b/lib/galaxy/datatypes/plant_tribes.py
@@ -24,7 +24,7 @@ class Smat(Text):
         except Exception:
             return f"ESTScan scores matrices ({nice_size(dataset.get_size())})"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "ESTScan scores matrices"
@@ -131,7 +131,7 @@ class PlantTribesKsComponents(Tabular):
         if len(significant_components) > 0:
             dataset.metadata.number_comp = max(significant_components)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             if (dataset.metadata.number_comp == 1):
@@ -165,7 +165,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptortho"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesOrtho, self).set_peek(dataset)
 #        dataset.blurb = "Proteins orthogroup fasta files: %d items" % dataset.metadata.num_files
 #
@@ -177,7 +177,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptorthocs"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesOrthoCodingSequence, self).set_peek(dataset)
 #        dataset.blurb = "Protein and coding sequences orthogroup fasta files: %d items" % dataset.metadata.num_files
 #
@@ -188,7 +188,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "pttgf"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesTargetedGeneFamilies, self).set_peek(dataset)
 #        dataset.blurb = "Targeted gene families"
 #
@@ -200,7 +200,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "pttree"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesPhylogeneticTree, self).set_peek(dataset)
 #        dataset.blurb = "Phylogenetic trees: %d items" % dataset.metadata.num_files
 #
@@ -211,7 +211,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptphylip"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesPhylip, self).set_peek(dataset)
 #        dataset.blurb = "Orthogroup phylip multiple sequence alignments: %d items" % dataset.metadata.num_files
 #
@@ -222,7 +222,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptalign"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesMultipleSequenceAlignment, self).set_peek(dataset)
 #        dataset.blurb = "Proteins orthogroup alignments: %d items" % dataset.metadata.num_files
 #
@@ -233,7 +233,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptalignca"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset:
 #        super(PlantTribesMultipleSequenceAlignmentCodonAlignment, self).set_peek(dataset)
 #        dataset.blurb = "Protein and coding sequences orthogroup alignments: %d items" % dataset.metadata.num_files
 #
@@ -244,7 +244,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptaligntrimmed"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesMultipleSequenceAlignmentTrimmed, self).set_peek(dataset)
 #        dataset.blurb = "Trimmed proteins orthogroup alignments: %d items" % dataset.metadata.num_files
 #
@@ -255,7 +255,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptaligntrimmedca"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesMultipleSequenceAlignmentTrimmedCodonAlignment, self).set_peek(dataset)
 #        dataset.blurb = "Trimmed protein and coding sequences orthogroup alignments: %d items" % dataset.metadata.num_files
 #
@@ -266,7 +266,7 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptalignfiltered"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesMultipleSequenceAlignmentFiltered, self).set_peek(dataset)
 #        dataset.blurb = "Filtered proteins orthogroup alignments: %d items" % dataset.metadata.num_files
 #
@@ -277,6 +277,6 @@ class PlantTribesKsComponents(Tabular):
 #    """
 #    file_ext = "ptalignfilteredca"
 #
-#    def set_peek(self, dataset, is_multi_byte=False):
+#    def set_peek(self, dataset):
 #        super(PlantTribesMultipleSequenceAlignmentFilteredCodonAlignment, self).set_peek(dataset)
 #        dataset.blurb = "Filtered protein and coding sequences orthogroup alignments: %d items" % dataset.metadata.num_files

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -83,7 +83,7 @@ class MzTab(Text):
     def __init__(self, **kwd):
         super().__init__(**kwd)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -133,7 +133,7 @@ class MzTab2(MzTab):
     def __init__(self, **kwd):
         super().__init__(**kwd)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -601,7 +601,7 @@ class ProteomicsXml(GenericXml):
         pattern = r'<(\w*:)?%s' % self.root
         return re.search(pattern, line) is not None
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -759,7 +759,7 @@ class Mgf(Text):
     edam_format = "format_3651"
     file_ext = "mgf"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -787,7 +787,7 @@ class MascotDat(Text):
     edam_format = "format_3713"
     file_ext = "mascotdat"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -829,7 +829,7 @@ class ThermoRAW(Binary):
         except Exception:
             return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Thermo Finnigan RAW file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -869,7 +869,7 @@ class SPLibNoIndex(Text):
     """SPlib without index file """
     file_ext = "splib_noindex"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -910,7 +910,7 @@ class SPLib(Msp):
         rval.append('</ul></div></html>')
         return "\n".join(rval)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -55,7 +55,7 @@ class SequenceSplitLocations(data.Text):
     """
     file_ext = "fqtoc"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             try:
                 parsed_data = json.load(open(dataset.file_name))
@@ -110,7 +110,7 @@ class Sequence(data.Text):
             dataset.metadata.data_lines = data_lines
             dataset.metadata.sequences = sequences
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
             if dataset.metadata.sequences:
@@ -614,7 +614,7 @@ class Fastg(Sequence):
             return
         return Sequence.set_meta(self, dataset, **kwd)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
             if dataset.metadata.sequences:
@@ -935,7 +935,7 @@ class Maf(Alignment):
         indexes.write(open(index_file.file_name, 'wb'))
         dataset.metadata.maf_index = index_file
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             # The file must exist on disk for the get_file_peek() method
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -1147,7 +1147,7 @@ class RNADotPlotMatrix(data.Data):
     edam_format = "format_3466"
     file_ext = "rna_eps"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = 'RNA Dot Plot format (Postscript derivative)'
             dataset.blurb = nice_size(dataset.get_size())

--- a/lib/galaxy/datatypes/spaln.py
+++ b/lib/galaxy/datatypes/spaln.py
@@ -94,7 +94,7 @@ class _SpalnDb(Data):
             f.write("\n".join(rval))
             f.write("\n")
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text."""
         if not dataset.dataset.purged:
             dataset.peek = "spaln database (multiple files)"

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -57,7 +57,7 @@ class TabularData(data.Text):
     def set_meta(self, dataset, **kwd):
         raise NotImplementedError
 
-    def set_peek(self, dataset, line_count=None, is_multi_byte=False, WIDTH=256, skipchars=None, line_wrap=False, **kwd):
+    def set_peek(self, dataset, line_count=None, WIDTH=256, skipchars=None, line_wrap=False, **kwd):
         super().set_peek(dataset, line_count=line_count, WIDTH=WIDTH, skipchars=skipchars, line_wrap=line_wrap)
         if dataset.metadata.comment_lines:
             dataset.blurb = f"{dataset.blurb}, {util.commaify(str(dataset.metadata.comment_lines))} comments"

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -34,7 +34,7 @@ class Html(Text):
     edam_format = "format_2331"
     file_ext = "html"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "HTML file"
             dataset.blurb = nice_size(dataset.get_size())
@@ -70,7 +70,7 @@ class Json(Text):
     edam_format = "format_3464"
     file_ext = "json"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "JavaScript Object Notation (JSON)"
@@ -148,7 +148,7 @@ class ExpressionJson(Json):
 class Ipynb(Json):
     file_ext = "ipynb"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "Jupyter Notebook"
@@ -225,7 +225,7 @@ class Biom1(Json):
     MetadataElement(name="table_columns", default=[], desc="table_columns", param=MetadataParameter, readonly=True, visible=False, optional=True, no_value=[])
     MetadataElement(name="table_column_metadata_headers", default=[], desc="table_column_metadata_headers", param=MetadataParameter, readonly=True, visible=True, optional=True, no_value=[])
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         super().set_peek(dataset)
         if not dataset.dataset.purged:
             dataset.blurb = "Biological Observation Matrix v1"
@@ -320,7 +320,7 @@ class ImgtJson(Json):
         http://www.imgt.org (founder and director: Marie-Paule Lefranc, Montpellier, France)."
     """
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         super().set_peek(dataset)
         if not dataset.dataset.purged:
             dataset.blurb = "IMGT Library"
@@ -385,7 +385,7 @@ class GeoJson(Json):
     """
     file_ext = "geojson"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         super().set_peek(dataset)
         if not dataset.dataset.purged:
             dataset.blurb = "GeoJSON"
@@ -434,7 +434,7 @@ class Obo(Text):
     edam_format = "format_2549"
     file_ext = "obo"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "Open Biomedical Ontology (OBO)"
@@ -474,7 +474,7 @@ class Arff(Text):
     MetadataElement(name="comment_lines", default=0, desc="Number of comment lines", readonly=True, optional=True, no_value=0)
     MetadataElement(name="columns", default=0, desc="Number of columns", readonly=True, visible=True, no_value=0)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = get_file_peek(dataset.file_name)
             dataset.blurb = "Attribute-Relation File Format (ARFF)"
@@ -701,7 +701,7 @@ class SnpSiftDbNSFP(Text):
         except Exception as e:
             log.warning("set_meta fname: %s  %s", dataset.file_name if dataset and dataset.file_name else 'Unkwown', unicodify(e))
 
-        def set_peek(self, dataset, is_multi_byte=False):
+        def set_peek(self, dataset):
             if not dataset.dataset.purged:
                 dataset.peek = f"{dataset.metadata.reference_name} :  {','.join(dataset.metadata.annotation)}"
                 dataset.blurb = f'{dataset.metadata.reference_name}'

--- a/lib/galaxy/datatypes/tracks.py
+++ b/lib/galaxy/datatypes/tracks.py
@@ -42,7 +42,7 @@ class UCSCTrackHub(Html):
         rval.append('</ul></html>')
         return "\n".join(rval)
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = "Track Hub structure: Visualization in UCSC Track Hub"
         else:

--- a/lib/galaxy/datatypes/triples.py
+++ b/lib/galaxy/datatypes/triples.py
@@ -35,7 +35,7 @@ class Triples(data.Data):
         """
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -59,7 +59,7 @@ class NTriples(data.Text, Triples):
             return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -82,7 +82,7 @@ class N3(data.Text, Triples):
         """
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -109,7 +109,7 @@ class Turtle(data.Text, Triples):
             return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -135,7 +135,7 @@ class Rdf(xml.GenericXml, Triples):
             return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -160,7 +160,7 @@ class Jsonld(text.Json, Triples):
                 return True
         return False
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -182,7 +182,7 @@ class HDT(binary.Binary, Triples):
             if f.read(4) == b"$HDT":
                 return True
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)

--- a/lib/galaxy/datatypes/xml.py
+++ b/lib/galaxy/datatypes/xml.py
@@ -29,7 +29,7 @@ class GenericXml(data.Text):
     edam_format = "format_2332"
     file_ext = "xml"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -79,7 +79,7 @@ class MEMEXml(GenericXml):
     """MEME XML Output data"""
     file_ext = "memexml"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -94,7 +94,7 @@ class CisML(GenericXml):
     """CisML XML data"""  # see: http://www.ncbi.nlm.nih.gov/pubmed/15001475
     file_ext = "cisml"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -148,7 +148,7 @@ class Dzi(GenericXml):
         """ Returns a list of visualizations for datatype"""
         return ['openseadragon']
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
             dataset.blurb = "Deep Zoom Image"
@@ -180,7 +180,7 @@ class Phyloxml(GenericXml):
     edam_format = "format_3159"
     file_ext = "phyloxml"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         """Set the peek and blurb text"""
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
@@ -221,7 +221,7 @@ class Owl(GenericXml):
     edam_format = "format_3262"
     file_ext = "owl"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
             dataset.blurb = "Web Ontology Language OWL"
@@ -245,7 +245,7 @@ class Sbml(GenericXml):
     edam_data = "data_2024"
     edam_format = "format_2585"
 
-    def set_peek(self, dataset, is_multi_byte=False):
+    def set_peek(self, dataset):
         if not dataset.dataset.purged:
             dataset.peek = data.get_file_peek(dataset.file_name)
             dataset.blurb = "System Biology Markup Language SBML"

--- a/lib/galaxy/tool_util/parser/interface.py
+++ b/lib/galaxy/tool_util/parser/interface.py
@@ -18,7 +18,6 @@ class ToolSource(metaclass=ABCMeta):
     """ This interface represents an abstract source to parse tool
     information from.
     """
-    default_is_multi_byte = False
     language: str
 
     @abstractmethod
@@ -70,12 +69,6 @@ class ToolSource(metaclass=ABCMeta):
 
     def parse_xrefs(self) -> List[Dict[str, str]]:
         """Parse list of external resource URIs and types."""
-
-    def parse_is_multi_byte(self):
-        """ Parse is_multi_byte from tool - TODO: figure out what this is and
-        document.
-        """
-        return self.default_is_multi_byte
 
     def parse_display_interface(self, default):
         """ Parse display_interface - fallback to default for the tool type

--- a/lib/galaxy/tool_util/parser/xml.py
+++ b/lib/galaxy/tool_util/parser/xml.py
@@ -117,9 +117,6 @@ class XmlToolSource(ToolSource):
     def parse_description(self):
         return xml_text(self.root, "description")
 
-    def parse_is_multi_byte(self):
-        return self._get_attribute_as_bool("is_multi_byte", self.default_is_multi_byte)
-
     def parse_display_interface(self, default):
         return self._get_attribute_as_bool("display_interface", default)
 

--- a/lib/galaxy/tool_util/parser/yaml.py
+++ b/lib/galaxy/tool_util/parser/yaml.py
@@ -56,9 +56,6 @@ class YamlToolSource(ToolSource):
         xrefs = self.root_dict.get("xrefs", [])
         return [dict(value=xref["value"], reftype=xref["type"]) for xref in xrefs if xref["type"]]
 
-    def parse_is_multi_byte(self):
-        return self.root_dict.get("is_multi_byte", self.default_is_multi_byte)
-
     def parse_sanitize(self):
         return self.root_dict.get("sanitize", True)
 

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -863,8 +863,6 @@ class Tool(Dictifiable):
             else:
                 raise Exception(f"Missing tool 'version' for tool with id '{self.id}' at '{tool_source}'")
 
-        # Support multi-byte tools
-        self.is_multi_byte = tool_source.parse_is_multi_byte()
         # Legacy feature, ignored by UI.
         self.force_history_refresh = False
 

--- a/lib/tool_shed/webapp/templates/admin/tool_shed_repository/view_tool_metadata.mako
+++ b/lib/tool_shed/webapp/templates/admin/tool_shed_repository/view_tool_metadata.mako
@@ -137,11 +137,6 @@ ${render_galaxy_repository_actions( repository )}
                     <div style="clear: both"></div>
                 </div>
                 <div class="form-row">
-                    <label>Is multi-byte:</label>
-                    ${tool.is_multi_byte|h}
-                    <div style="clear: both"></div>
-                </div>
-                <div class="form-row">
                     <label>Forces a history refresh:</label>
                     ${tool.force_history_refresh|h}
                     <div style="clear: both"></div>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/repository/view_tool_metadata.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/repository/view_tool_metadata.mako
@@ -198,11 +198,6 @@
                     <div style="clear: both"></div>
                 </div>
                 <div class="form-row">
-                    <label>Is multi-byte:</label>
-                    ${tool.is_multi_byte | h}
-                    <div style="clear: both"></div>
-                </div>
-                <div class="form-row">
                     <label>Forces a history refresh:</label>
                     ${tool.force_history_refresh | h}
                     <div style="clear: both"></div>

--- a/templates/admin/tool_shed_repository/view_tool_metadata.mako
+++ b/templates/admin/tool_shed_repository/view_tool_metadata.mako
@@ -137,11 +137,6 @@ ${render_galaxy_repository_actions( repository )}
                     <div style="clear: both"></div>
                 </div>
                 <div class="form-row">
-                    <label>Is multi-byte:</label>
-                    ${tool.is_multi_byte|h}
-                    <div style="clear: both"></div>
-                </div>
-                <div class="form-row">
                     <label>Forces a history refresh:</label>
                     ${tool.force_history_refresh|h}
                     <div style="clear: both"></div>

--- a/test/unit/tool_util/test_parsing.py
+++ b/test/unit/tool_util/test_parsing.py
@@ -11,7 +11,7 @@ from galaxy.util import galaxy_directory
 
 
 TOOL_XML_1 = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <xrefs>
         <xref type="bio.tools">bwa</xref>
@@ -266,9 +266,6 @@ class XmlLoaderTestCase(BaseLoaderTestCase):
     def test_name(self):
         assert self._tool_source.parse_name() == "BWA Mapper"
 
-    def test_is_multi_byte(self):
-        assert self._tool_source.parse_is_multi_byte()
-
     def test_display_interface(self):
         assert self._tool_source.parse_display_interface(False)
 
@@ -428,9 +425,6 @@ class YamlLoaderTestCase(BaseLoaderTestCase):
 
     def test_name(self):
         assert self._tool_source.parse_name() == "Bowtie Mapper"
-
-    def test_is_multi_byte(self):
-        assert not self._tool_source.parse_is_multi_byte()
 
     def test_display_interface(self):
         assert not self._tool_source.parse_display_interface(False)
@@ -664,9 +658,6 @@ class SpecialToolLoaderTestCase(BaseLoaderTestCase):
         assert tool_module[0] == "galaxy.tools"
         assert tool_module[1] == "ExportHistoryTool"
         assert self._tool_source.parse_tool_type() == "export_history"
-
-    def test_is_multi_byte(self):
-        assert not self._tool_source.parse_is_multi_byte()
 
     def test_version_command(self):
         assert self._tool_source.parse_version_command() is None

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -13,7 +13,7 @@ from galaxy.tool_util.parser.xml import XmlToolSource
 from galaxy.util import etree
 
 WHITESPACE_IN_VERSIONS_AND_NAMES = """
-<tool name=" BWA Mapper " id="bwa tool" version=" 1.0.1 " is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name=" BWA Mapper " id="bwa tool" version=" 1.0.1 " display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <requirements>
         <requirement type="package" version=" 1.2.5 "> bwa </requirement>
@@ -30,7 +30,7 @@ WHITESPACE_IN_VERSIONS_AND_NAMES = """
 """
 
 REQUIREMENT_WO_VERSION = """
-<tool name="BWA Mapper" id="bwa_tool" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa_tool" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <requirements>
         <requirement type="package">bwa</requirement>
@@ -48,14 +48,14 @@ REQUIREMENT_WO_VERSION = """
 """
 
 NO_SECTIONS_XML = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
 </tool>
 """
 
 NO_WHEN_IN_CONDITIONAL_XML = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
@@ -100,7 +100,7 @@ SELECT_DUPLICATED_OPTIONS = """
 """
 
 SELECT_DEPRECATIONS = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
@@ -139,7 +139,7 @@ SELECT_OPTION_DEFINITIONS = """
 """
 
 VALIDATOR_INCOMPATIBILITIES = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
@@ -152,7 +152,7 @@ VALIDATOR_INCOMPATIBILITIES = """
 """
 
 VALIDATOR_CORRECT = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <inputs>
@@ -199,7 +199,7 @@ VALIDATOR_CORRECT = """
 # check that linter accepts format source for collection elements as means to specify format
 # and that the linter warns if format and format_source are used
 OUTPUTS_COLLECTION_FORMAT_SOURCE = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <outputs>
@@ -213,7 +213,7 @@ OUTPUTS_COLLECTION_FORMAT_SOURCE = """
 
 # check that linter does not complain about missing format if from_tool_provided_metadata is used
 OUTPUTS_DISCOVER_TOOL_PROVIDED_METADATA = """
-<tool name="BWA Mapper" id="bwa" version="1.0.1" is_multi_byte="true" display_interface="true" require_login="true" hidden="true">
+<tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
     <version_command interpreter="python">bwa.py --version</version_command>
     <outputs>


### PR DESCRIPTION
Was this seemingly introduced here (2009): https://github.com/galaxyproject/galaxy/blob/3e3b3f9eee47f3c8d47dbc7e7c2287a52171de65/lib/galaxy/jobs/__init__.py#L475 https://github.com/galaxyproject/galaxy/commit/3e3b3f9eee47f3c8d47dbc7e7c2287a52171de65

Has been deprecated in datatypes in 2017: https://github.com/galaxyproject/galaxy/pull/5062

At other places it was unclear what the even was: https://github.com/galaxyproject/galaxy/blob/9140d95621d954979b349876c33536e3de0e2327/lib/galaxy/tool_util/parser/interface.py#L75

Also has never been documented.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
