### PR TITLE
Add duplicate_file_to_collection tool

### DIFF
--- a/lib/galaxy/config/sample/tool_conf.xml.sample
+++ b/lib/galaxy/config/sample/tool_conf.xml.sample
@@ -42,6 +42,7 @@
     <tool file="${model_tools_path}/build_list.xml" />
     <tool file="${model_tools_path}/build_list_1.2.0.xml" />
     <tool file="${model_tools_path}/extract_dataset.xml" />
+    <tool file="${model_tools_path}/duplicate_file_to_collection.xml" />
   </section>
   <section id="expression_tools" name="Expression Tools">
     <tool file="expression_tools/parse_values_from_file.xml"/>

--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -3510,6 +3510,20 @@ class FilterFromFileTool(DatabaseOperationTool):
         )
 
 
+class DuplicateFileToCollectionTool(DatabaseOperationTool):
+    tool_type = 'duplicate_file_to_collection'
+
+    def produce_outputs(self, trans, out_data, output_collections, incoming, history, **kwds):
+        hda = incoming["input"]
+        number = incoming["number"]
+        element_identifier = incoming["element_identifier"]
+        elements = {f"{element_identifier} {n}": hda.copy(copy_tags=hda.tags, flush=False) for n in range(number)}
+
+        output_collections.create_collection(
+            next(iter(self.outputs.values())), "output", elements=elements, propagate_hda_tags=False
+        )
+
+
 # Populate tool_type to ToolClass mappings
 tool_types = {}
 TOOL_CLASSES: List[Type[Tool]] = [
@@ -3526,6 +3540,7 @@ TOOL_CLASSES: List[Type[Tool]] = [
     MergeCollectionTool,
     RelabelFromFileTool,
     FilterFromFileTool,
+    DuplicateFileToCollectionTool,
     BuildListCollectionTool,
     ExtractDatasetCollectionTool,
     DataDestinationTool

--- a/lib/galaxy/tools/duplicate_file_to_collection.xml
+++ b/lib/galaxy/tools/duplicate_file_to_collection.xml
@@ -1,0 +1,56 @@
+<tool id="__DUPLICATE_FILE_TO_COLLECTION__"
+      name="Duplicate file to collection"
+      version="1.0.0"
+      tool_type="duplicate_file_to_collection">
+    <description></description>
+    <type class="DuplicateFileToCollectionTool" module="galaxy.tools" />
+    <action module="galaxy.tools.actions.model_operations"
+            class="ModelOperationToolAction"/>
+    <!-- <edam_operations>
+    </edam_operations> -->
+    <inputs>
+        <param type="dataset" name="input" label="Input Dataset" help="A dataset which will be duplicated."/>
+        <param type="integer" name="number" label="Size of output collection" help="Number of times to duplicate the input dataset."/>
+        <param type="text" name="element_identifier" label="Element identifier" help="Each element in the output collection will be assigned this identifier, with an integer appended." />
+    </inputs>
+    <outputs>
+        <collection name="output" format_source="input" type_source="input" label="${on_string} (duplicated)" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" value="simple_line.txt" />
+            <param name="number" value="2" />
+            <param name="element_identifier" value="test" />
+            <output_collection name="output_filtered" type="list" count="2">
+                <element name="test 1">
+                  <assert_contents>
+                    <has_text_matching expression="^This is a line of text.\n$" />
+                  </assert_contents>
+                </element>
+                <element name="test 2">
+                    <assert_contents>
+                      <has_text_matching expression="^This is a line of text.\n$" />
+                    </assert_contents>
+                  </element>
+            </output_collection>
+        </test>
+    </tests>
+    <help><![CDATA[
+
+========
+Synopsis
+========
+
+Creates a collection of arbitrary size by duplicating an input dataset N times, where N is a user-specified integer.
+
+===========
+Description
+===========
+
+This tool allows creation of a dataset collection of arbitrary size. It takes an input dataset and an integer parameter, which specifies the number of times to duplicate the dataset in the output collection. In addition, the user can specify the base name for the element identifier to use in the output. For example, if `Number` is specified as 3 and `Element identifier` as 'Element', the output collection will contain three identical datasets, with the identifiers `Element 1`, `Element 2` and `Element 3`.
+
+.. class:: infomark
+
+This tool will create new history datasets but your quota usage will not increase.
+    ]]></help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -273,5 +273,6 @@
   <tool file="${model_tools_path}/build_list.xml" />
   <tool file="${model_tools_path}/build_list_1.2.0.xml" />
   <tool file="${model_tools_path}/extract_dataset.xml" />
+  <tool file="${model_tools_path}/duplicate_file_to_collection.xml" />
 
 </toolbox>


### PR DESCRIPTION
Add a tool for duplicating an input dataset N times (where N is an integer parameter).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
