### PR TITLE
Move ``galaxy_tasks`` decorator to ``galaxy.celery``

### DIFF
--- a/lib/galaxy/app_unittest_utils/celery_helper.py
+++ b/lib/galaxy/app_unittest_utils/celery_helper.py
@@ -4,12 +4,15 @@ from functools import wraps
 def rebind_container_to_task(app):
     import galaxy.app
     galaxy.app.app = app
-    from galaxy.celery import tasks
+    from galaxy.celery import (
+        CELERY_TASKS,
+        tasks,
+    )
 
     def magic_bind_dynamic(func):
         return wraps(func)(app.magic_partial(func, shared=None))
 
-    for task in tasks.CELERY_TASKS:
+    for task in CELERY_TASKS:
         task_fn = getattr(tasks, task, None)
         if task_fn:
             task_fn = getattr(task_fn, '__wrapped__', task_fn)

--- a/lib/galaxy/celery/__init__.py
+++ b/lib/galaxy/celery/__init__.py
@@ -1,12 +1,21 @@
 import os
-from functools import lru_cache
+from functools import (
+    lru_cache,
+    wraps,
+)
 
-from celery import Celery
+from celery import (
+    Celery,
+    shared_task,
+)
+from kombu import serialization
+from lagom import magic_bind_to_container
 
 from galaxy.config import Configuration
 from galaxy.main_config import find_config
 from galaxy.util.custom_logging import get_logger
 from galaxy.util.properties import load_app_properties
+from ._serialization import schema_dumps, schema_loads
 
 log = get_logger(__name__)
 
@@ -73,6 +82,40 @@ if prune_interval > 0:
         },
     }
 celery_app.conf.timezone = 'UTC'
+
+
+CELERY_TASKS = []
+PYDANTIC_AWARE_SERIALIER_NAME = 'pydantic-aware-json'
+
+
+serialization.register(
+    PYDANTIC_AWARE_SERIALIER_NAME,
+    encoder=schema_dumps,
+    decoder=schema_loads,
+    content_type='application/json'
+)
+
+
+def galaxy_task(*args, **celery_task_kwd):
+    if 'serializer' not in celery_task_kwd:
+        celery_task_kwd['serializer'] = PYDANTIC_AWARE_SERIALIER_NAME
+
+    def decorate(func):
+        CELERY_TASKS.append(func.__name__)
+
+        @shared_task(**celery_task_kwd)
+        @wraps(func)
+        def wrapper(*args, **kwds):
+            app = get_galaxy_app()
+            assert app
+            return magic_bind_to_container(app)(func)(*args, **kwds)
+
+        return wrapper
+
+    if len(args) == 1 and callable(args[0]):
+        return decorate(args[0])
+    else:
+        return decorate
 
 
 if __name__ == '__main__':

--- a/scripts/celery_shell.py
+++ b/scripts/celery_shell.py
@@ -1,8 +1,32 @@
-from scripts.db_shell import *
+"""
+Run this script from galaxy's root with
+```
+ipython -i scripts/celery_shell.py -- -c config/galaxy.yml
+```
+"""
+import logging
+import os
+
+WARNING_MODULES = ['parso', 'asyncio', 'galaxy.datatypes']
+for mod in WARNING_MODULES:
+    logger = logging.getLogger(mod)
+    logger.setLevel('WARNING')
+
+from scripts.db_shell import config
+os.environ['GALAXY_CONFIG_FILE'] = os.environ.get('GALAXY_CONFIG_FILE', config['config_file'])
 
 from galaxy.celery import get_galaxy_app
+from galaxy.celery import tasks  # noqa: F401
 
-from galaxy.celery.tasks import *
+HELP = """
+============
+Run celery tasks interactively.
+tasks are collected in task module.
+
+To run recalculate_user_disk_usage for user 1 in a celery worker
+type
+>>> tasks.recalculate_user_disk_usage.deley(user_id=1)
+"""
 
 app = get_galaxy_app()
-assert app, 'Set GALAXY_CONFIG_FILE to the path of your galaxy.yml file'
+print(HELP)

--- a/scripts/celery_shell.py
+++ b/scripts/celery_shell.py
@@ -1,0 +1,8 @@
+from scripts.db_shell import *
+
+from galaxy.celery import get_galaxy_app
+
+from galaxy.celery.tasks import *
+
+app = get_galaxy_app()
+assert app, 'Set GALAXY_CONFIG_FILE to the path of your galaxy.yml file'

--- a/scripts/db_shell.py
+++ b/scripts/db_shell.py
@@ -36,7 +36,8 @@ from galaxy.model.orm.scripts import get_config
 registry = Registry()
 registry.load_datatypes()
 set_datatypes_registry(registry)
-db_url = get_config(sys.argv)['db_url']
+config = get_config(sys.argv)
+db_url = config['db_url']
 sa_session = init('/tmp/', db_url).context
 
 


### PR DESCRIPTION
That means we can import additional tasks that use `galaxy_task` in
`galaxy.celery.tasks` without circular imports.

Also add a small interactive shell for executing celery tasks.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
