### PR TITLE
Don't use triple-quoted strings as comments

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -700,16 +700,14 @@ class ProBam(Bam):
 
 
 class BamInputSorted(BamNative):
-
-    sort_flag = '-n'
-    file_ext = 'qname_input_sorted.bam'
-
     """
     A class for BAM files that can formally be unsorted or queryname sorted.
     Alignments are either ordered based on the order with which the queries appear when producing the alignment,
     or ordered by their queryname.
     This notaby keeps alignments produced by paired end sequencing adjacent.
     """
+    sort_flag = '-n'
+    file_ext = 'qname_input_sorted.bam'
 
     def sniff(self, file_name):
         # We never want to sniff to this datatype

--- a/lib/galaxy/datatypes/images.py
+++ b/lib/galaxy/datatypes/images.py
@@ -416,19 +416,20 @@ class Analyze75(Binary):
     def __init__(self, **kwd):
         super().__init__(**kwd)
 
-        """The header file. Provides information about dimensions, identification, and processing history."""
+        # The header file provides information about dimensions, identification,
+        # and processing history.
         self.add_composite_file(
             'hdr',
             description='The Analyze75 header file.',
             is_binary=True)
 
-        """The image file.  Image data, whose data type and ordering are described by the header file."""
+        # The image file contains the actual data, whose data type and ordering
+        # are described by the header file.
         self.add_composite_file(
             'img',
             description='The Analyze75 image file.',
             is_binary=True)
 
-        """The optional t2m file."""
         self.add_composite_file(
             't2m',
             description='The Analyze75 t2m file.',

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -63,7 +63,6 @@ class Interval(Tabular):
     track_type = "FeatureTrack"
     data_sources = {"data": "tabix", "index": "bigwig"}
 
-    """Add metadata elements"""
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=3, desc="End column", param=metadata.ColumnParameter)
@@ -383,7 +382,6 @@ class Bed(Interval):
 
     column_names = ['Chrom', 'Start', 'End', 'Name', 'Score', 'Strand', 'ThickStart', 'ThickEnd', 'ItemRGB', 'BlockCount', 'BlockSizes', 'BlockStarts']
 
-    """Add metadata elements"""
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=3, desc="End column", param=metadata.ColumnParameter)
@@ -626,7 +624,6 @@ class Gff(Tabular, _RemoteCallMixin):
     data_sources = {"data": "interval_index", "index": "bigwig", "feature_search": "fli"}
     track_type = Interval.track_type
 
-    """Add metadata elements"""
     MetadataElement(name="columns", default=9, desc="Number of columns", readonly=True, visible=False)
     MetadataElement(name="column_types", default=['str', 'str', 'str', 'int', 'int', 'int', 'str', 'str', 'str'],
                     param=metadata.ColumnTypesParameter, desc="Column types", readonly=True, visible=False)
@@ -885,7 +882,6 @@ class Gff3(Gff):
     column_names = ['Seqid', 'Source', 'Type', 'Start', 'End', 'Score', 'Strand', 'Phase', 'Attributes']
     track_type = Interval.track_type
 
-    """Add metadata elements"""
     MetadataElement(name="column_types", default=['str', 'str', 'str', 'int', 'int', 'float', 'str', 'int', 'list'],
                     param=metadata.ColumnTypesParameter, desc="Column types", readonly=True, visible=False)
 
@@ -1006,7 +1002,6 @@ class Gtf(Gff):
     column_names = ['Seqname', 'Source', 'Feature', 'Start', 'End', 'Score', 'Strand', 'Frame', 'Attributes']
     track_type = Interval.track_type
 
-    """Add metadata elements"""
     MetadataElement(name="columns", default=9, desc="Number of columns", readonly=True, visible=False)
     MetadataElement(name="column_types", default=['str', 'str', 'str', 'int', 'int', 'float', 'str', 'int', 'list'],
                     param=metadata.ColumnTypesParameter, desc="Column types", readonly=True, visible=False)
@@ -1421,7 +1416,6 @@ class ENCODEPeak(Interval):
     column_names = ['Chrom', 'Start', 'End', 'Name', 'Score', 'Strand', 'SignalValue', 'pValue', 'qValue', 'Peak']
     data_sources = {"data": "tabix", "index": "bigwig"}
 
-    """Add metadata elements"""
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=3, desc="End column", param=metadata.ColumnParameter)
@@ -1441,7 +1435,6 @@ class ChromatinInteractions(Interval):
     data_sources = {"data": "tabix", "index": "bigwig"}
     column_names = ['Chrom1', 'Start1', 'End1', 'Chrom2', 'Start2', 'End2', 'Value']
 
-    """Add metadata elements"""
     MetadataElement(name="chrom1Col", default=1, desc="Chrom1 column", param=metadata.ColumnParameter)
     MetadataElement(name="start1Col", default=2, desc="Start1 column", param=metadata.ColumnParameter)
     MetadataElement(name="end1Col", default=3, desc="End1 column", param=metadata.ColumnParameter)

--- a/lib/galaxy/datatypes/molecules.py
+++ b/lib/galaxy/datatypes/molecules.py
@@ -745,6 +745,11 @@ class InChI(Tabular):
 
 
 class SMILES(Tabular):
+    # It is hard or impossible to sniff a SMILES File. We can try to import the
+    # first SMILES and check if it is a molecule, but currently it is not
+    # possible to use external libraries in datatype definition files.
+    # Moreover it seems impossible to include OpenBabel as Python library
+    # because OpenBabel is GPL licensed.
     file_ext = "smi"
     column_names = ['SMILES', 'TITLE']
     MetadataElement(name="columns", default=2, desc="Number of columns", readonly=True, visible=False)
@@ -767,40 +772,6 @@ class SMILES(Tabular):
         else:
             dataset.peek = 'file does not exist'
             dataset.blurb = 'file purged from disk'
-
-    '''
-    def sniff(self, filename):
-        """
-        Its hard or impossible to sniff a SMILES File. We can
-        try to import the first SMILES and check if it is a molecule, but
-        currently its not possible to use external libraries in datatype definition files.
-        Moreover it seems mpossible to inlcude OpenBabel as python library because OpenBabel
-        is GPL licensed.
-        """
-        self.molecule_number = count_lines(filename, non_empty = True)
-        word_count = count_lines(filename)
-
-        if self.molecule_number != word_count:
-            return False
-
-        if self.molecule_number > 0:
-            # test first 3 SMILES
-            smiles_lines = get_headers(filename, sep='\t', count=3)
-            for smiles_line in smiles_lines:
-                if len(smiles_line) > 2:
-                    return False
-                smiles = smiles_line[0]
-                try:
-                    # if we have atoms, we have a molecule
-                    if not len(pybel.readstring('smi', smiles).atoms) > 0:
-                        return False
-                except Exception:
-                    # if convert fails its not a smiles string
-                    return False
-            return True
-        else:
-            return False
-    '''
 
 
 @build_sniff_from_prefix

--- a/lib/galaxy/datatypes/mothur.py
+++ b/lib/galaxy/datatypes/mothur.py
@@ -318,7 +318,7 @@ class AlignReport(Tabular):
 
 class DistanceMatrix(Text):
     file_ext = 'mothur.dist'
-    """Add metadata elements"""
+
     MetadataElement(name="sequence_count", default=0, desc="Number of sequences", readonly=True, visible=True, optional=True, no_value='?')
 
     def init_meta(self, dataset, copy_from=None):
@@ -965,28 +965,29 @@ class Axes(Tabular):
 
 
 class SffFlow(Tabular):
+    """
+    https://mothur.org/wiki/flow_file/
+    The first line is the total number of flow values - 800 for Titanium data. For GS FLX it would be 400.
+    Following lines contain:
+
+    - SequenceName
+    - the number of useable flows as defined by 454's software
+    - the flow intensity for each base going in the order of TACG.
+
+    Example:
+
+    .. code-block::
+
+        800
+        GQY1XT001CQL4K 85 1.04 0.00 1.00 0.02 0.03 1.02 0.05 ...
+        GQY1XT001CQIRF 84 1.02 0.06 0.98 0.06 0.09 1.05 0.07 ...
+        GQY1XT001CF5YW 88 1.02 0.02 1.01 0.04 0.06 1.02 0.03 ...
+
+    """
+    file_ext = 'mothur.sff.flow'
+
     MetadataElement(name="flow_values", default="", no_value="", optional=True, desc="Total number of flow values", readonly=True)
     MetadataElement(name="flow_order", default="TACG", no_value="TACG", desc="Total number of flow values", readonly=False)
-    file_ext = 'mothur.sff.flow'
-    """
-        https://mothur.org/wiki/flow_file/
-        The first line is the total number of flow values - 800 for Titanium data. For GS FLX it would be 400.
-        Following lines contain:
-
-        - SequenceName
-        - the number of useable flows as defined by 454's software
-        - the flow intensity for each base going in the order of TACG.
-
-        Example:
-
-        .. code-block::
-
-          800
-          GQY1XT001CQL4K 85 1.04 0.00 1.00 0.02 0.03 1.02 0.05 ...
-          GQY1XT001CQIRF 84 1.02 0.06 0.98 0.06 0.09 1.05 0.07 ...
-          GQY1XT001CF5YW 88 1.02 0.02 1.01 0.04 0.06 1.02 0.03 ...
-
-    """
 
     def __init__(self, **kwd):
         super().__init__(**kwd)

--- a/lib/galaxy/datatypes/phylip.py
+++ b/lib/galaxy/datatypes/phylip.py
@@ -24,7 +24,6 @@ class Phylip(Text):
     edam_format = "format_1997"
     file_ext = "phylip"
 
-    """Add metadata elements"""
     MetadataElement(name="sequences", default=0, desc="Number of sequences", readonly=True,
                     visible=False, optional=True, no_value=0)
 

--- a/lib/galaxy/datatypes/proteomics.py
+++ b/lib/galaxy/datatypes/proteomics.py
@@ -976,13 +976,11 @@ class ImzML(Binary):
     def __init__(self, **kwd):
         super().__init__(**kwd)
 
-        """The metadata"""
         self.add_composite_file(
             'imzml',
             description='The imzML metadata component.',
             is_binary=False)
 
-        """The mass spectral data"""
         self.add_composite_file(
             'ibd',
             description='The mass spectral data component.',

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -87,7 +87,6 @@ class Sequence(data.Text):
     """Class describing a sequence"""
     edam_data = "data_2044"
 
-    """Add metadata elements"""
     MetadataElement(name="sequences", default=0, desc="Number of sequences", readonly=True, visible=False, optional=True, no_value=0)
 
     def set_meta(self, dataset, **kwd):
@@ -298,7 +297,6 @@ class Alignment(data.Text):
     """Class describing an alignment"""
     edam_data = "data_0863"
 
-    """Add metadata elements"""
     MetadataElement(name="species", desc="Species", default=[], param=metadata.SelectParameter, multiple=True, readonly=True, no_value=None)
 
     def split(cls, input_datasets, subdir_generator_function, split_params):
@@ -535,8 +533,8 @@ class csFasta(Sequence):
 
 @build_sniff_from_prefix
 class Fastg(Sequence):
-    """ Class representing a FASTG sequence """
-    """ http://fastg.sourceforge.net/FASTG_Spec_v1.00.pdf """
+    """ Class representing a FASTG sequence
+    http://fastg.sourceforge.net/FASTG_Spec_v1.00.pdf """
     edam_format = "format_3823"
     file_ext = "fastg"
 
@@ -548,14 +546,14 @@ class Fastg(Sequence):
            #FASTG:begin;
            #FASTG:version=*.*;
            #FASTG:properties;
-        """
-        """Or these can be combined on a line:
+
+        Or these can be combined on a line:
            #FASTG:begin:version=*.*:properties;
-        """
-        """FASTG must end with line:
+
+        FASTG must end with line:
            #FASTG:end;
-        """
-        """ Example FASTG file:
+
+        Example FASTG file:
             #FASTG:begin;
             #FASTG:version=1.0:assembly_name="tiny example";
             >chr1:chr1;
@@ -563,8 +561,7 @@ class Fastg(Sequence):
             >chr2;
             ACATACGCATATATATATATATATATAT[20:tandem:size=(10,8..12)|AT]TCAGGCA[1:alt|A,T,TT]GGAC
             #FASTG:end;
-        """
-        """
+
         >>> from galaxy.datatypes.sniff import get_test_fname
         >>> fname = get_test_fname( 'sequence.fasta' )
         >>> Fastg().sniff( fname )

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -45,7 +45,6 @@ class TabularData(data.Text):
     data_line_offset = 0
     max_peek_columns = 50
 
-    """Add metadata elements"""
     MetadataElement(name="comment_lines", default=0, desc="Number of comment lines", readonly=False, optional=True, no_value=0)
     MetadataElement(name="data_lines", default=0, desc="Number of data lines", readonly=True, visible=False, optional=True, no_value=0)
     MetadataElement(name="columns", default=0, desc="Number of columns", readonly=True, visible=False, no_value=0)
@@ -676,7 +675,6 @@ class Pileup(Tabular):
     line_class = "genomic coordinate"
     data_sources = {"data": "tabix"}
 
-    """Add metadata elements"""
     MetadataElement(name="chromCol", default=1, desc="Chrom column", param=metadata.ColumnParameter)
     MetadataElement(name="startCol", default=2, desc="Start column", param=metadata.ColumnParameter)
     MetadataElement(name="endCol", default=2, desc="End column", param=metadata.ColumnParameter)
@@ -852,7 +850,7 @@ class VcfGz(BaseVcf, binary.Binary):
 
     def set_meta(self, dataset, **kwd):
         super().set_meta(dataset, **kwd)
-        """ Creates the index for the VCF file. """
+        # Creates the index for the VCF file.
         # These metadata values are not accessible by users, always overwrite
         index_file = dataset.metadata.tabix_index
         if not index_file:
@@ -1079,16 +1077,14 @@ class BaseCSV(TabularData):
             return False
         if (auto_dialect.quotechar != self.dialect.quotechar):
             return False
-        """
-        Not checking for other dialect options
-        They may be mis detected from just the sample.
-        Or not effect the read such as doublequote
+        # Not checking for other dialect options
+        # They may be mis detected from just the sample.
+        # Or not effect the read such as doublequote
 
-        Optional: Check for headers as in the past.
-        Note No way around Python's csv calling Sniffer.sniff again.
-        Note Without checking the dialect returned by sniff
-              this test may be checking the wrong dialect.
-        """
+        # Optional: Check for headers as in the past.
+        # Note: No way around Python's csv calling Sniffer.sniff again.
+        # Note: Without checking the dialect returned by sniff
+        #       this test may be checking the wrong dialect.
         if not csv.Sniffer().has_header(big_peek):
             return False
         return True
@@ -1335,13 +1331,6 @@ class MatrixMarket(TabularData):
 
 @build_sniff_from_prefix
 class CMAP(TabularData):
-    MetadataElement(name="cmap_version", default='0.2', desc="version of cmap", readonly=True, visible=True, optional=False, no_value='0.2')
-    MetadataElement(name="label_channels", default=1, desc="the number of label channels", readonly=True, visible=True, optional=False, no_value=1)
-    MetadataElement(name="nickase_recognition_site_1", default=[], desc="comma separated list of label motif recognition sequences for channel 1", readonly=True, visible=True, optional=False, no_value=[])
-    MetadataElement(name="number_of_consensus_nanomaps", default=0, desc="the total number of consensus genome maps in the CMAP file", readonly=True, visible=True, optional=False, no_value=0)
-    MetadataElement(name="nickase_recognition_site_2", default=[], desc="comma separated list of label motif recognition sequences for channel 2", readonly=True, visible=True, optional=True, no_value=[])
-    MetadataElement(name="channel_1_color", default=[], desc="channel 1 color", readonly=True, visible=True, optional=True, no_value=[])
-    MetadataElement(name="channel_2_color", default=[], desc="channel 2 color", readonly=True, visible=True, optional=True, no_value=[])
     """
     # CMAP File Version:    2.0
     # Label Channels:   1
@@ -1356,6 +1345,14 @@ class CMAP(TabularData):
     182 58474736.7  10235   1   1   58820.9 35.4    13.5    13.5    -1.00   -1.00   -1.00   3.63    0.00    0.00    -1.00   0
     """
     file_ext = "cmap"
+
+    MetadataElement(name="cmap_version", default='0.2', desc="version of cmap", readonly=True, visible=True, optional=False, no_value='0.2')
+    MetadataElement(name="label_channels", default=1, desc="the number of label channels", readonly=True, visible=True, optional=False, no_value=1)
+    MetadataElement(name="nickase_recognition_site_1", default=[], desc="comma separated list of label motif recognition sequences for channel 1", readonly=True, visible=True, optional=False, no_value=[])
+    MetadataElement(name="number_of_consensus_nanomaps", default=0, desc="the total number of consensus genome maps in the CMAP file", readonly=True, visible=True, optional=False, no_value=0)
+    MetadataElement(name="nickase_recognition_site_2", default=[], desc="comma separated list of label motif recognition sequences for channel 2", readonly=True, visible=True, optional=True, no_value=[])
+    MetadataElement(name="channel_1_color", default=[], desc="channel 1 color", readonly=True, visible=True, optional=True, no_value=[])
+    MetadataElement(name="channel_2_color", default=[], desc="channel 2 color", readonly=True, visible=True, optional=True, no_value=[])
 
     def sniff_prefix(self, file_prefix: FilePrefix):
         handle = file_prefix.string_io()

--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -310,15 +310,16 @@ class Biom1(Json):
 
 @build_sniff_from_prefix
 class ImgtJson(Json):
+    """
+    https://github.com/repseqio/library-imgt/releases
+    Data coming from IMGT server may be used for academic research only,
+    provided that it is referred to IMGT®, and cited as:
+    "IMGT®, the international ImMunoGeneTics information system®
+    http://www.imgt.org (founder and director: Marie-Paule Lefranc, Montpellier, France)."
+    """
     file_ext = "imgt.json"
+
     MetadataElement(name="taxon_names", default=[], desc="taxonID: names", readonly=True, visible=True, no_value=[])
-    """
-        https://github.com/repseqio/library-imgt/releases
-        Data coming from IMGT server may be used for academic research only,
-        provided that it is referred to IMGT®, and cited as:
-        "IMGT®, the international ImMunoGeneTics information system®
-        http://www.imgt.org (founder and director: Marie-Paule Lefranc, Montpellier, France)."
-    """
 
     def set_peek(self, dataset, is_multi_byte=False):
         super().set_peek(dataset)
@@ -464,13 +465,12 @@ class Obo(Text):
 @build_sniff_from_prefix
 class Arff(Text):
     """
-        An ARFF (Attribute-Relation File Format) file is an ASCII text file that describes a list of instances sharing a set of attributes.
-        http://weka.wikispaces.com/ARFF
+    An ARFF (Attribute-Relation File Format) file is an ASCII text file that describes a list of instances sharing a set of attributes.
+    http://weka.wikispaces.com/ARFF
     """
     edam_format = "format_3581"
     file_ext = "arff"
 
-    """Add metadata elements"""
     MetadataElement(name="comment_lines", default=0, desc="Number of comment lines", readonly=True, optional=True, no_value=0)
     MetadataElement(name="columns", default=0, desc="Number of columns", readonly=True, visible=True, no_value=0)
 
@@ -636,24 +636,27 @@ class SnpEffDb(Text):
 
 
 class SnpSiftDbNSFP(Text):
-    """Class describing a dbNSFP database prepared fpr use by SnpSift dbnsfp """
+    """
+    Class describing a dbNSFP database prepared fpr use by SnpSift dbnsfp
+
+    The dbNSFP file is a tabular file with 1 header line.
+    The first 4 columns are required to be: chrom	pos	ref	alt
+    These match columns 1,2,4,5 of the VCF file
+    SnpSift requires the file to be block-gzipped and the indexed with samtools tabix
+
+    Example:
+    - Compress using block-gzip algorithm:
+    $ bgzip dbNSFP2.3.txt
+    - Create tabix index
+    $ tabix -s 1 -b 2 -e 2 dbNSFP2.3.txt.gz
+    """
+    file_ext = "snpsiftdbnsfp"
+    composite_type = 'auto_primary_file'
+
     MetadataElement(name='reference_name', default='dbSNFP', desc='Reference Name', readonly=True, visible=True, set_in_upload=True, no_value='dbSNFP')
     MetadataElement(name="bgzip", default=None, desc="dbNSFP bgzip", readonly=True, visible=True, no_value=None)
     MetadataElement(name="index", default=None, desc="Tabix Index File", readonly=True, visible=True, no_value=None)
     MetadataElement(name="annotation", default=[], desc="Annotation Names", readonly=True, visible=True, no_value=[])
-    file_ext = "snpsiftdbnsfp"
-    composite_type = 'auto_primary_file'
-    """
-    ## The dbNSFP file is a tabular file with 1 header line
-    ## The first 4 columns are required to be: chrom	pos	ref	alt
-    ## These match columns 1,2,4,5 of the VCF file
-    ## SnpSift requires the file to be block-gzipped and the indexed with samtools tabix
-    ## Example:
-    ## Compress using block-gzip algorithm
-    bgzip dbNSFP2.3.txt
-    ## Create tabix index
-    tabix -s 1 -b 2 -e 2 dbNSFP2.3.txt.gz
-    """
 
     def __init__(self, **kwd):
         super().__init__(**kwd)

--- a/lib/galaxy/dependencies/pinned-lint-requirements.txt
+++ b/lib/galaxy/dependencies/pinned-lint-requirements.txt
@@ -1,6 +1,6 @@
 attrs==21.2.0
 flake8==4.0.1
-flake8-bugbear==21.9.2
+flake8-bugbear==21.11.29
 flake8-import-order==0.18.1
 importlib-metadata==4.2.0
 mccabe==0.6.1
@@ -24,6 +24,6 @@ types-pkg-resources==0.1.3
 types-python-dateutil==2.8.3
 types-PyYAML==6.0.1
 types-requests==2.26.1
-types-six==1.16.2
+types-six==1.16.3
 typing_extensions==4.0.0
 zipp==3.6.0

--- a/lib/galaxy/jobs/runners/godocker.py
+++ b/lib/galaxy/jobs/runners/godocker.py
@@ -144,7 +144,7 @@ class GodockerJobRunner(AsynchronousJobRunner):
             return
 
         job_destination = job_wrapper.job_destination
-        """ Submit job to godocker """
+        # Submit job to godocker
         job_id = self.post_task(job_wrapper)
         if not job_id:
             log.error("Job creation failure.  No Response from GoDocker")
@@ -165,12 +165,12 @@ class GodockerJobRunner(AsynchronousJobRunner):
             else if the job is running or in pending state, simply
                     return the 'AsynchronousJobState object' (job_state).
         """
-        ''' This function is called by check_watched_items() where
-                    param job_state is an object of AsynchronousJobState.
-            Expected return type of this function is None or
-                    AsynchronousJobState object with updated running status.
-        '''
-        """ Get task from GoDocker """
+        # This function is called by check_watched_items() where param job_state
+        # is an object of AsynchronousJobState.
+        # Expected return type of this function is None or an
+        # AsynchronousJobState object with updated running status.
+
+        # Get task from GoDocker
         job_persisted_state = job_state.job_wrapper.get_state()
         job_status_god = self.get_task(job_state.job_id)
         log.debug(f"Job ID: {str(job_state.job_id)} Job Status: {str(job_status_god['status']['primary'])}")
@@ -222,10 +222,9 @@ class GodockerJobRunner(AsynchronousJobRunner):
 
     def stop_job(self, job_wrapper):
         """ Attempts to delete a dispatched executing Job in GoDocker """
-        '''This function is called by fail_job()
-           where param job = self.sa_session.query( self.app.model.Job ).get( job_state.job_wrapper.job_id )
-           No Return data expected
-        '''
+        # This function is called by fail_job() where
+        # param job = self.sa_session.query(self.app.model.Job).get(job_state.job_wrapper.job_id)
+        # No Return data expected
         job_id = job_wrapper.job_id
         log.debug(f"STOP JOB EXECUTION OF JOB ID: {str(job_id)}")
         # Get task status from GoDocker.
@@ -237,9 +236,9 @@ class GodockerJobRunner(AsynchronousJobRunner):
 
     def recover(self, job, job_wrapper):
         """ Recovers jobs stuck in the queued/running state when Galaxy started """
-        """ This method is called by galaxy at the time of startup.
-            Jobs in Running & Queued status in galaxy are put in the monitor_queue by creating an AsynchronousJobState object
-        """
+        # This method is called by Galaxy at startup time.
+        # Jobs in Running & Queued state in galaxy are put in the monitor_queue
+        # by creating an AsynchronousJobState object
         job_id = job_wrapper.job_id
         ajs = AsynchronousJobState(files_dir=job_wrapper.working_directory, job_wrapper=job_wrapper)
         ajs.job_id = str(job_id)

--- a/lib/galaxy/jobs/runners/kubernetes.py
+++ b/lib/galaxy/jobs/runners/kubernetes.py
@@ -91,7 +91,7 @@ class KubernetesJobRunner(AsynchronousJobRunner):
             kwargs['runner_param_specs'] = dict()
         kwargs['runner_param_specs'].update(runner_param_specs)
 
-        """Start the job runner parent object """
+        # Start the job runner parent object
         super().__init__(app, nworkers, **kwargs)
 
         self._pykube_api = pykube_client_from_dict(self.runner_params)

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -462,13 +462,13 @@ class JobLike:
 
 
 class User(Base, Dictifiable, RepresentById):
-    use_pbkdf2 = True
-    bootstrap_admin_user = False
-    # api_keys: 'List[APIKeys]'  already declared as relationship()
     """
     Data for a Galaxy user or admin and relations to their
     histories, credentials, and roles.
     """
+    use_pbkdf2 = True
+    bootstrap_admin_user = False
+    # api_keys: 'List[APIKeys]'  already declared as relationship()
 
     __tablename__ = 'galaxy_user'
 

--- a/lib/galaxy/tool_util/deps/resolvers/unlinked_tool_shed_packages.py
+++ b/lib/galaxy/tool_util/deps/resolvers/unlinked_tool_shed_packages.py
@@ -120,26 +120,6 @@ class UnlinkedToolShedPackageDependencyResolver(BaseGalaxyPackageDependencyResol
         log.debug("Picking dependency at '%s' as it was the last modified", latest_candidate.path)
         return latest_candidate
 
-    """
-    #Currently no need has been found for expand the verionsless method
-    #This is an example of how it could be done
-    def _find_dep_default( self, name, type='package', **kwds ):
-        try:
-            possibles = TODO
-            if len(possibles) == 0:
-                log.debug("Unable to find dependency,'%s' default '%s'", name, type)
-                return NullDependency(version=None, name=name)
-            elif len(possibles) == 1:
-                #Only one candidate found so ignore any preference rules
-                return possibles[0].dependency
-            else:
-                #Pick the preferred one
-                return self._select_preferred_dependency(possibles, by_owner=False).dependency
-        except Exception:
-            log.exception("Unexpected error hunting for dependency '%s' default '%s'", name, type)
-            return NullDependency(version=None, name=name)
-    """
-
 
 class CandidateDependency(Dependency):
     dict_collection_visible_keys = Dependency.dict_collection_visible_keys + ['dependency', 'path', 'owner']

--- a/lib/galaxy/visualization/data_providers/genome.py
+++ b/lib/galaxy/visualization/data_providers/genome.py
@@ -132,13 +132,10 @@ class GenomeDataProvider(BaseDataProvider):
 
     dataset_type: str
 
-    """
-    Mapping from column name to payload data; this mapping is used to create
-    filters. Key is column name, value is a dict with mandatory key 'index' and
-    optional key 'name'. E.g. this defines column 4
-
-    col_name_data_attr_mapping = {4 : { index: 5, name: 'Score' } }
-    """
+    # Mapping from column name to payload data; this mapping is used to create
+    # filters. Key is column name, value is a dict with mandatory key 'index'
+    # and optional key 'name'. E.g. this defines column 4:
+    # col_name_data_attr_mapping = {4 : { index: 5, name: 'Score' } }
     col_name_data_attr_mapping: Dict[Union[str, int], Dict] = {}
 
     def __init__(self, converted_dataset=None, original_dataset=None, dependencies=None,
@@ -318,11 +315,10 @@ class FilterableMixin:
 
 
 class TabixDataProvider(GenomeDataProvider, FilterableMixin):
-    dataset_type = 'tabix'
-
     """
     Tabix index data provider for the Galaxy track browser.
     """
+    dataset_type = 'tabix'
 
     col_name_data_attr_mapping: Dict[Union[str, int], Dict] = {4: {'index': 4, 'name': 'Score'}}
 
@@ -368,13 +364,12 @@ class TabixDataProvider(GenomeDataProvider, FilterableMixin):
 
 
 class IntervalDataProvider(GenomeDataProvider):
-    dataset_type = 'interval_index'
-
     """
     Processes interval data from native format to payload format.
 
     Payload format: [ uid (offset), start, end, name, strand, thick_start, thick_end, blocks ]
     """
+    dataset_type = 'interval_index'
 
     def get_iterator(self, data_file, chrom, start, end, **kwargs):
         raise Exception("Unimplemented Function")

--- a/lib/tool_shed/test/base/twilltestcase.py
+++ b/lib/tool_shed/test/base/twilltestcase.py
@@ -43,6 +43,7 @@ tc.options['equiv_refresh_interval'] = 0
 
 
 class ShedTwillTestCase(DrivenFunctionalTestCase):
+    """Class of FunctionalTestCase geared toward HTML interactions using the Twill library."""
 
     def setUp(self):
         # Security helper
@@ -65,8 +66,6 @@ class ShedTwillTestCase(DrivenFunctionalTestCase):
         self.test_db_util = test_db_util
         # TODO: Figure out a way to alter these attributes during tests.
         self.galaxy_tool_dependency_dir = os.environ.get('GALAXY_TEST_TOOL_DEPENDENCY_DIR')
-
-    """Class of FunctionalTestCase geared toward HTML interactions using the Twill library."""
 
     def check_for_strings(self, strings_displayed=None, strings_not_displayed=None):
         strings_displayed = strings_displayed or []

--- a/lib/tool_shed/test/functional/test_0000_basic_repository_features.py
+++ b/lib/tool_shed/test/functional/test_0000_basic_repository_features.py
@@ -265,8 +265,8 @@ class TestBasicRepositoryFeatures(ShedTwillTestCase):
         self.check_for_strings(strings_displayed=[error_message])
 
     def test_0105_contact_repository_owner(self):
-        '''Fill out and submit the form to contact the owner of a repository.'''
-        '''
+        '''Fill out and submit the form to contact the owner of a repository.
+
         This test should not actually send the email, since functional tests are designed to function without
         any external network connection. The embedded tool shed server these tests are running against has been configured
         with an SMTP server address that will not and should not resolve correctly. However, since the successful sending of

--- a/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
+++ b/lib/tool_shed/test/functional/test_0010_repository_with_tool_dependencies.py
@@ -36,8 +36,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
         self.create_category(name='Test 0010 Repository With Tool Dependencies', description='Tests for a repository with tool dependencies.')
 
     def test_0010_create_freebayes_repository_and_upload_tool_xml(self):
-        '''Create freebayes repository and upload only freebayes.xml.'''
-        '''
+        '''Create freebayes repository and upload only freebayes.xml.
+
         We are at step 1 - Create repository freebayes_0020 and upload only the tool XML.
         Uploading only the tool XML file should result in an invalid tool and an error message on
         upload, as well as on the manage repository page.
@@ -65,8 +65,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
         self.check_repository_invalid_tools_for_changeset_revision(repository, tip, strings_displayed=strings_displayed)
 
     def test_0015_upload_missing_tool_data_table_conf_file(self):
-        '''Upload the missing tool_data_table_conf.xml.sample file to the repository.'''
-        '''
+        '''Upload the missing tool_data_table_conf.xml.sample file to the repository.
+
         We are at step 2 - Upload the tool_data_table_conf.xml.sample file.
         Uploading the tool_data_table_conf.xml.sample alone should not make the tool valid, but the error message should change.
         '''
@@ -86,8 +86,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
         self.check_repository_invalid_tools_for_changeset_revision(repository, tip, strings_displayed=strings_displayed)
 
     def test_0020_upload_missing_sample_loc_file(self):
-        '''Upload the missing sam_fa_indices.loc.sample file to the repository.'''
-        '''
+        '''Upload the missing sam_fa_indices.loc.sample file to the repository.
+
         We are at step 3 - Upload the tool_data_table_conf.xml.sample file.
         Uploading the tool_data_table_conf.xml.sample alone should not make the tool valid, but the error message should change.
         '''
@@ -103,8 +103,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0025_upload_malformed_tool_dependency_xml(self):
-        '''Upload tool_dependencies.xml with bad characters in the readme tag.'''
-        '''
+        '''Upload tool_dependencies.xml with bad characters in the readme tag.
+
         We are at step 4 - Upload a tool_dependencies.xml file that should not parse correctly.
         Upload a tool_dependencies.xml file that contains <> in the text of the readme tag. This should show an error message about malformed xml.
         '''
@@ -120,8 +120,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0030_upload_invalid_tool_dependency_xml(self):
-        '''Upload tool_dependencies.xml defining version 0.9.5 of the freebayes package.'''
-        '''
+        '''Upload tool_dependencies.xml defining version 0.9.5 of the freebayes package.
+
         We are at step 5 - Upload a tool_dependencies.xml file that specifies a version that does not match the tool's requirements.
         This should result in a message about the tool dependency configuration not matching the tool's requirements.
         '''
@@ -137,8 +137,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0035_upload_valid_tool_dependency_xml(self):
-        '''Upload tool_dependencies.xml defining version 0.9.4_9696d0ce8a962f7bb61c4791be5ce44312b81cf8 of the freebayes package.'''
-        '''
+        '''Upload tool_dependencies.xml defining version 0.9.4_9696d0ce8a962f7bb61c4791be5ce44312b81cf8 of the freebayes package.
+
         We are at step 6 - Upload a valid tool_dependencies.xml file.
         At this stage, there should be no errors on the upload page, as every missing or invalid file has been corrected.
         '''
@@ -154,8 +154,8 @@ class TestFreebayesRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0040_verify_tool_dependencies(self):
-        '''Verify that the uploaded tool_dependencies.xml specifies the correct package versions.'''
-        '''
+        '''Verify that the uploaded tool_dependencies.xml specifies the correct package versions.
+
         We are at step 7 - Check for the appropriate strings on the manage repository page.
         Verify that the manage repository page now displays the valid tool dependencies, and that there are no invalid tools shown on the manage page.
         '''

--- a/lib/tool_shed/test/functional/test_0120_simple_repository_dependency_multiple_owners.py
+++ b/lib/tool_shed/test/functional/test_0120_simple_repository_dependency_multiple_owners.py
@@ -26,8 +26,8 @@ repository_datatypes_count = 0
 class TestRepositoryMultipleOwners(ShedTwillTestCase):
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other tests.
         Previously created accounts will not be re-created.
         """
@@ -45,8 +45,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_datatypes_repository(self):
-        """Create and populate the blast_datatypes_0120 repository"""
-        """
+        """Create and populate the blast_datatypes_0120 repository
+
         We are at step 1.
         Create and populate blast_datatypes.
         """
@@ -70,8 +70,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_verify_datatypes_repository(self):
-        '''Verify the blast_datatypes_0120 repository.'''
-        '''
+        '''Verify the blast_datatypes_0120 repository.
+
         We are at step 1a.
         Check for appropriate strings, most importantly BlastXml, BlastNucDb, and BlastProtDb,
         the datatypes that are defined in datatypes_conf.xml.
@@ -83,8 +83,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         repository_datatypes_count = int(self.get_repository_datatypes_count(repository))
 
     def test_0015_create_tool_repository(self):
-        """Create and populate the blastxml_to_top_descr_0120 repository"""
-        """
+        """Create and populate the blastxml_to_top_descr_0120 repository
+
         We are at step 2.
         Create and populate blastxml_to_top_descr_0120.
         """
@@ -108,8 +108,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_verify_tool_repository(self):
-        '''Verify the blastxml_to_top_descr_0120 repository.'''
-        '''
+        '''Verify the blastxml_to_top_descr_0120 repository.
+
         We are at step 2a.
         Check for appropriate strings, such as tool name, description, and version.
         '''
@@ -119,8 +119,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         self.display_manage_repository_page(repository, strings_displayed=strings_displayed)
 
     def test_0025_create_repository_dependency(self):
-        '''Create a repository dependency on blast_datatypes_0120.'''
-        '''
+        '''Create a repository dependency on blast_datatypes_0120.
+
         We are at step 3.
         Create a simple repository dependency for blastxml_to_top_descr_0120 that defines a dependency on blast_datatypes_0120.
         '''
@@ -131,8 +131,8 @@ class TestRepositoryMultipleOwners(ShedTwillTestCase):
         self.create_repository_dependency(repository=tool_repository, repository_tuples=[datatypes_tuple], filepath=dependency_xml_path)
 
     def test_0040_verify_repository_dependency(self):
-        '''Verify the created repository dependency.'''
-        '''
+        '''Verify the created repository dependency.
+
         We are at step 3a.
         Check the newly created repository dependency to ensure that it was defined and displays correctly.
         '''

--- a/lib/tool_shed/test/functional/test_0130_datatype_converters.py
+++ b/lib/tool_shed/test/functional/test_0130_datatype_converters.py
@@ -29,8 +29,8 @@ class TestDatatypeConverters(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_bed_to_gff_repository(self):
-        '''Create and populate bed_to_gff_0130.'''
-        '''
+        '''Create and populate bed_to_gff_0130.
+
         We are at step 1 - Create and populate the bed_to_gff_0130 repository.
         Create the bed_to_gff_0130 repository and populate it with the files needed for this test.
         '''
@@ -55,8 +55,8 @@ class TestDatatypeConverters(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_verify_tool_and_datatype(self):
-        '''Verify that a valid tool and datatype are contained within the repository.'''
-        '''
+        '''Verify that a valid tool and datatype are contained within the repository.
+
         We are at step 2 - Visit the manage repository page and make sure there is the appropriate valid tool and datatype.
         There should be a 'Convert BED to GFF' tool and a 'galaxy.datatypes.interval:Bed' datatype with extension 'bed'
         '''
@@ -66,8 +66,8 @@ class TestDatatypeConverters(ShedTwillTestCase):
         self.display_manage_repository_page(repository, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0015_verify_tool_panel_display(self):
-        '''Verify that the tool is configured not to be displayed in the tool panel.'''
-        '''
+        '''Verify that the tool is configured not to be displayed in the tool panel.
+
         We are at step 3
         Datatype converters that are associated with a datatype should have display in tool panel = False in the tool metadata.
         '''

--- a/lib/tool_shed/test/functional/test_0140_tool_help_images.py
+++ b/lib/tool_shed/test/functional/test_0140_tool_help_images.py
@@ -36,8 +36,8 @@ class TestToolHelpImages(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_htseq_count_repository(self):
-        '''Create and populate htseq_count_0140.'''
-        '''
+        '''Create and populate htseq_count_0140.
+
         We are at step 1 - Create and populate the htseq_count_0140 repository.
         Create the htseq_count_0140 repository and upload the tarball.
         '''
@@ -62,8 +62,8 @@ class TestToolHelpImages(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_load_tool_page(self):
-        '''Load the tool page and check for the image.'''
-        '''
+        '''Load the tool page and check for the image.
+
         We are at step 2
         Visit the manage_repository page and the tool page, and look for the image url
         similar to the following string:

--- a/lib/tool_shed/test/functional/test_0150_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_0150_prior_installation_required.py
@@ -80,8 +80,8 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_repository_dependency(self):
-        '''Create a repository dependency specifying convert_chars.'''
-        '''
+        '''Create a repository dependency specifying convert_chars.
+
         Column maker repository dependency:
             <repository toolshed="self.url" name="convert_chars" owner="test" changeset_revision="<tip>" prior_installation_required="True" />
         '''

--- a/lib/tool_shed/test/functional/test_0160_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_0160_circular_prior_installation_required.py
@@ -98,8 +98,8 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_create_repository_dependency(self):
-        '''Create a repository dependency specifying convert_chars.'''
-        '''
+        '''Create a repository dependency specifying convert_chars.
+
         Each of the three repositories should depend on the other two, to make this as circular as possible.
         '''
         filter_repository = self.test_db_util.get_repository_by_name_and_owner(filter_repository_name, common.test_user_1_name)

--- a/lib/tool_shed/test/functional/test_0170_complex_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_0170_complex_prior_installation_required.py
@@ -35,8 +35,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_matplotlib_repository(self):
-        '''Create and populate the package_matplotlib_1_2_0170 repository.'''
-        '''
+        '''Create and populate the package_matplotlib_1_2_0170 repository.
+
         This is step 1 - Create and populate repositories package_matplotlib_1_2_0170 and package_numpy_1_7_0170.
         '''
         category = self.create_category(name=category_name, description=category_description)
@@ -58,8 +58,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_numpy_repository(self):
-        '''Create and populate the package_numpy_1_7_0170 repository.'''
-        '''
+        '''Create and populate the package_numpy_1_7_0170 repository.
+
         This is step 1 - Create and populate repositories package_matplotlib_1_2_0170 and package_numpy_1_7_0170.
         '''
         category = self.create_category(name=category_name, description=category_description)
@@ -81,8 +81,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_complex_repository_dependency(self):
-        '''Create a dependency on package_numpy_1_7_0170.'''
-        '''
+        '''Create a dependency on package_numpy_1_7_0170.
+
         This is step 2 - Create a complex repository dependency on package_numpy_1_7_0170, and upload this to package_matplotlib_1_2_0170.
         package_matplotlib_1_2_0170 should depend on package_numpy_1_7_0170, with prior_installation_required
         set to True. When matplotlib is selected for installation, the result should be that numpy is compiled
@@ -118,8 +118,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_verify_generated_dependency(self):
-        '''Verify that matplotlib now has a package tool dependency and a complex repository dependency.'''
-        '''
+        '''Verify that matplotlib now has a package tool dependency and a complex repository dependency.
+
         This is step 3 - Verify that package_matplotlib_1_2_0170 now depends on package_numpy_1_7_0170, and that the inherited tool
                          dependency displays correctly.
         'Inhherited' in this case means that matplotlib should show a package tool dependency on numpy version 1.7, and a repository

--- a/lib/tool_shed/test/functional/test_0310_hg_api_features.py
+++ b/lib/tool_shed/test/functional/test_0310_hg_api_features.py
@@ -37,8 +37,8 @@ class TestHgWebFeatures(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_filtering_repository(self):
-        '''Create and populate the filtering_0310 repository.'''
-        '''
+        '''Create and populate the filtering_0310 repository.
+
         We are at step 1 - Create a repository.
         Create and populate the filtering_0310 repository.
         '''
@@ -70,8 +70,8 @@ class TestHgWebFeatures(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_clone(self):
-        '''Clone the repository to a local path.'''
-        '''
+        '''Clone the repository to a local path.
+
         We are at step 2 - Clone the repository to a local path.
         The repository should have the following files:
 

--- a/lib/tool_shed/test/functional/test_0400_repository_component_reviews.py
+++ b/lib/tool_shed/test/functional/test_0400_repository_component_reviews.py
@@ -4,7 +4,7 @@ repository_name = 'filtering_0400'
 repository_description = 'Galaxy filtering tool for test 0400'
 repository_long_description = 'Long description of Galaxy filtering tool for test 0400'
 
-'''
+"""
 1. Create users.
 2. Grant reviewer role to test_user_2.
 3. Check that the review components that are to be tested are defined in this tool shed instance.
@@ -32,15 +32,15 @@ repository_long_description = 'Long description of Galaxy filtering tool for tes
 25. Upload a new version of the tool.
 26. Review the new revision's functional tests component.
 27. Verify that the functional tests component review displays correctly.
-'''
+"""
 
 
 class TestRepositoryComponentReviews(ShedTwillTestCase):
-    '''Test repository component review features.'''
+    """Test repository component review features."""
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         We are at step 1.
         Create all the user accounts that are needed for this test script to run independently of other test.
         Previously created accounts will not be re-created.
@@ -59,8 +59,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_grant_reviewer_role(self):
-        '''Grant the repository reviewer role to test_user_2.'''
-        """
+        """Grant the repository reviewer role to test_user_2.
+
         We are at step 2.
         We now have an admin user (admin_user) and two non-admin users (test_user_1 and test_user_2). Grant the repository
         reviewer role to test_user_2, who will not be the owner of the reviewed repositories.
@@ -70,8 +70,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.grant_role_to_user(test_user_2, reviewer_role)
 
     def test_0010_verify_repository_review_components(self):
-        '''Ensure that the required review components exist.'''
-        """
+        """Ensure that the required review components exist.
+
         We are at step 3.
         We now have an admin user (admin_user) and two non-admin users (test_user_1 and test_user_2). Grant the repository
         reviewer role to test_user_2, who will not be the owner of the reviewed repositories.
@@ -84,8 +84,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.manage_review_components(strings_displayed=strings_displayed)
 
     def test_0015_create_repository(self):
-        """Create and populate the filtering repository"""
-        """
+        """Create and populate the filtering repository
+
         We are at step 4.
         Log in as test_user_1 and create the filtering repository, then upload a basic set of
         components to be reviewed in subsequent tests.
@@ -110,8 +110,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_review_initial_revision_data_types(self):
-        '''Review the datatypes component for the current tip revision.'''
-        """
+        """Review the datatypes component for the current tip revision.
+
         We are at step 5.
         Log in as test_user_2 and review the data types component of the filtering repository owned by test_user_1.
         # Review this revision:
@@ -132,8 +132,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.create_repository_review(repository, review_contents_dict)
 
     def test_0025_verify_datatype_review(self):
-        '''Verify that the datatypes component review displays correctly.'''
-        """
+        """Verify that the datatypes component review displays correctly.
+
         We are at step 6.
         Log in as test_user_1 and check that the filtering repository only has a review for the data types component.
         """
@@ -145,8 +145,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0030_review_initial_revision_functional_tests(self):
-        '''Review the functional tests component for the current tip revision.'''
-        """
+        """Review the functional tests component for the current tip revision.
+
         We are at step 7.
         Log in as test_user_2 and review the functional tests component for this repository. Since the repository
         has not been altered, this will update the existing review to add a component.
@@ -170,13 +170,13 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.review_repository(repository, review_contents_dict, user)
 
 #    def test_0030_verify_review_display( self ):
-#        '''Verify that private reviews are restricted to owner and reviewer, and non-private views are viewable by others.'''
+#        """Verify that private reviews are restricted to owner and reviewer, and non-private views are viewable by others."""
 #        # Currently not implemented because third parties cannot view reviews whether they are private or not.
 #        self.login( email=common.test_user_3_email, username=common.test_user_3_name )
 
     def test_0035_verify_functional_test_review(self):
-        '''Verify that the functional tests component review displays correctly.'''
-        """
+        """Verify that the functional tests component review displays correctly.
+
         We are at step 8.
         Log in as test_user_1 and check that the filtering repository now has reviews
         for the data types and functional tests components. Since the functional tests component was not marked as 'Not applicable',
@@ -190,8 +190,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0040_review_readme(self):
-        '''Review the readme component for the current tip revision.'''
-        """
+        """Review the readme component for the current tip revision.
+
         We are at step 9.
         Log in as test_user_2 and update the review with the readme component marked as 'Not applicable'.
         # Review this revision:
@@ -215,8 +215,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.review_repository(repository, review_contents_dict, user)
 
     def test_0045_verify_readme_review(self):
-        '''Verify that the readme component review displays correctly.'''
-        """
+        """Verify that the readme component review displays correctly.
+
         We are at step 10.
         Log in as test_user_1 and verify that the repository component reviews now include a review for the readme component.
         """
@@ -228,8 +228,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0050_review_repository_dependencies(self):
-        '''Review the repository dependencies component for the current tip revision.'''
-        """
+        """Review the repository dependencies component for the current tip revision.
+
         We are at step 11.
         Log in as test_user_2 and update the review with the repository dependencies component marked as 'Not applicable'.
         # Review this revision:
@@ -254,8 +254,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.review_repository(repository, review_contents_dict, user)
 
     def test_0055_verify_repository_dependency_review(self):
-        '''Verify that the repository dependencies component review displays correctly.'''
-        """
+        """Verify that the repository dependencies component review displays correctly.
+
         We are at step 12.
         Log in as test_user_1 and verify that the repository component reviews now include a review
         for the repository dependencies component.
@@ -268,8 +268,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0060_review_tool_dependencies(self):
-        '''Review the tool dependencies component for the current tip revision.'''
-        """
+        """Review the tool dependencies component for the current tip revision.
+
         We are at step 13.
         Log in as test_user_2 and update the review with the tool dependencies component marked as 'Not applicable'.
         # Review this revision:
@@ -295,8 +295,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.review_repository(repository, review_contents_dict, user)
 
     def test_0065_verify_tool_dependency_review(self):
-        '''Verify that the tool dependencies component review displays correctly.'''
-        """
+        """Verify that the tool dependencies component review displays correctly.
+
         We are at step 14.
         Log in as test_user_1 and verify that the repository component reviews now include a review
         for the tool dependencies component.
@@ -309,8 +309,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0070_review_tools(self):
-        '''Review the tools component for the current tip revision.'''
-        """
+        """Review the tools component for the current tip revision.
+
         We are at step 15.
         Log in as test_user_2 and update the review with the tools component given
         a favorable review, with 5 stars, and approved status.
@@ -338,8 +338,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.review_repository(repository, review_contents_dict, user)
 
     def test_0075_verify_tools_review(self):
-        '''Verify that the tools component review displays correctly.'''
-        """
+        """Verify that the tools component review displays correctly.
+
         We are at step 16.
         Log in as test_user_1 and verify that the repository component reviews now include a review
         for the tools component. As before, check for the presence of the comment on this review.
@@ -352,8 +352,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0080_review_workflows(self):
-        '''Review the workflows component for the current tip revision.'''
-        """
+        """Review the workflows component for the current tip revision.
+
         We are at step 17.
         Log in as test_user_2 and update the review with the workflows component marked as 'Not applicable'.
         # Review this revision:
@@ -381,8 +381,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.review_repository(repository, review_contents_dict, user)
 
     def test_0085_verify_workflows_review(self):
-        '''Verify that the workflows component review displays correctly.'''
-        """
+        """Verify that the workflows component review displays correctly.
+
         We are at step 18.
         Log in as test_user_1 and verify that the repository component reviews now include a review
         for the workflows component.
@@ -394,8 +394,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed)
 
     def test_0090_upload_readme_file(self):
-        '''Upload a readme file to the filtering repository.'''
-        """
+        """Upload a readme file to the filtering repository.
+
         We are at step 19.
         Log in as test_user_1, the repository owner, and upload readme.txt to the repository. This will create
         a new changeset revision for this repository, which will need to be reviewed.
@@ -413,8 +413,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0095_review_new_changeset_readme_component(self):
-        '''Update the filtering repository's readme component review to reflect the presence of the readme file.'''
-        """
+        """Update the filtering repository's readme component review to reflect the presence of the readme file.
+
         We are at step 20.
         There is now a new changeset revision in the repository's changelog, but it has no review associated with it.
         Get the previously reviewed changeset hash, and pass that and the review id to the create_repository_review
@@ -444,8 +444,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                                       copy_from=(str(last_review.changeset_revision), last_review.id))
 
     def test_0100_verify_readme_review(self):
-        '''Verify that the readme component review displays correctly.'''
-        """
+        """Verify that the readme component review displays correctly.
+
         We are at step 21.
         Log in as the repository owner (test_user_1) and check the repository component reviews to
         verify that the readme component is now reviewed and approved.
@@ -457,8 +457,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed)
 
     def test_0105_upload_test_data(self):
-        '''Upload the missing test data to the filtering repository.'''
-        """
+        """Upload the missing test data to the filtering repository.
+
         We are at step 22.
         Remain logged in as test_user_1 and upload test data to the repository. This will also create a
         new changeset revision that needs to be reviewed. This will replace the changeset hash associated with
@@ -477,8 +477,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0110_review_new_changeset_functional_tests(self):
-        '''Update the filtering repository's readme component review to reflect the presence of the readme file.'''
-        """
+        """Update the filtering repository's readme component review to reflect the presence of the readme file.
+
         We are at step 23.
         Log in as test_user_2 and get the last reviewed changeset hash, and pass that and the review id to
         the create_repository_review method, then update the copied review to approve the functional tests
@@ -505,8 +505,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                                       copy_from=(str(last_review.changeset_revision), last_review.id))
 
     def test_0115_verify_functional_tests_review(self):
-        '''Verify that the functional tests component review displays correctly.'''
-        """
+        """Verify that the functional tests component review displays correctly.
+
         We are at step 24.
         Log in as the repository owner, test_user_1, and verify that the new revision's functional tests component
         review has been updated with an approved status and favorable comment.
@@ -518,8 +518,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed)
 
     def test_0120_upload_new_tool_version(self):
-        '''Upload filtering 2.2.0 to the filtering repository.'''
-        """
+        """Upload filtering 2.2.0 to the filtering repository.
+
         We are at step 25.
         Log in as test_user_1 and upload a new version of the tool to the filtering repository. This will create
         a new downloadable revision, with no associated repository component reviews.
@@ -537,8 +537,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0125_review_new_changeset_functional_tests(self):
-        '''Update the filtering repository's review to apply to the new changeset with filtering 2.2.0.'''
-        """
+        """Update the filtering repository's review to apply to the new changeset with filtering 2.2.0.
+
         We are at step 26.
         Log in as test_user_2 and copy the last review for this repository to the new changeset. Then
         update the tools component review to refer to the new tool version.
@@ -564,8 +564,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                                       copy_from=(str(last_review.changeset_revision), last_review.id))
 
     def test_0135_verify_review_for_new_version(self):
-        '''Verify that the reviews display correctly for this changeset revision.'''
-        """
+        """Verify that the reviews display correctly for this changeset revision.
+
         We are at step 27.
         Log in as test_user_1 and check that the tools component review is for filtering 2.2.0, but that the other component
         reviews had their contents copied from the last reviewed changeset.

--- a/lib/tool_shed/test/functional/test_0410_repository_component_review_access_control.py
+++ b/lib/tool_shed/test/functional/test_0410_repository_component_review_access_control.py
@@ -19,8 +19,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
     '''Test repository component review features.'''
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other test.
         Previously created accounts will not be re-created.
         """
@@ -42,28 +42,28 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_grant_reviewer_role(self):
-        '''Grant the repository reviewer role to test_user_2.'''
-        """
+        '''Grant the repository reviewer role to test_user_2.
+
         We now have an admin user (admin_user) and three non-admin users (test_user_1, test_user_2, and test_user_3). Grant the repository
         reviewer role to test_user_2, who will not be the owner of the reviewed repositories, and do not grant any roles to test_user_3 yet.
-        """
+        '''
         reviewer_role = self.test_db_util.get_role_by_name('Repository Reviewer')
         test_user_2 = self.test_db_util.get_user(common.test_user_2_email)
         self.grant_role_to_user(test_user_2, reviewer_role)
 
     def test_0010_verify_repository_review_components(self):
-        '''Ensure that the required review components exist.'''
-        """
+        '''Ensure that the required review components exist.
+
         Make sure all the components we are to review are recorded in the database.
-        """
+        '''
         self.add_repository_review_component(name='Repository dependencies',
                                              description='Repository dependencies defined in a file named repository_dependencies.xml included in the repository')
         strings_displayed = ['Data types', 'Functional tests', 'README', 'Repository dependencies', 'Tool dependencies', 'Tools', 'Workflows']
         self.manage_review_components(strings_displayed=strings_displayed)
 
     def test_0015_create_repository(self):
-        """Create and populate the filtering repository"""
-        """
+        """Create and populate the filtering repository
+
         We are at step 1.
         Log in as test_user_1 and create the filtering repository, then upload a basic set of
         components to be reviewed in subsequent tests.
@@ -106,8 +106,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_review_repository(self):
-        '''Complete a review of the filtering repository.'''
-        '''
+        '''Complete a review of the filtering repository.
+
         We are at step 2 - Have test_user_2 complete a review of the repository.
         Review all components of the filtering repository, with the appropriate contents and approved/not approved/not applicable status.
         '''
@@ -123,8 +123,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.create_repository_review(repository, review_contents_dict)
 
     def test_0025_verify_repository_review(self):
-        '''Verify that the review was completed and displays properly.'''
-        '''
+        '''Verify that the review was completed and displays properly.
+
         We are at step 3 - Have test_user_1 browse the review.
         Verify that all the review components were submitted, and that the repository owner can see the review.
         '''
@@ -139,8 +139,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.verify_repository_reviews(repository, reviewer=user, strings_displayed=strings_displayed)
 
     def test_0030_browse_with_other_user(self):
-        '''Verify that test_user_3 is blocked from browsing the review.'''
-        '''
+        '''Verify that test_user_3 is blocked from browsing the review.
+
         We are at step 4 - Have test_user_3 browse the repository and make sure they are not allowed to browse the review.
         '''
         self.login(email=common.test_user_3_email, username=common.test_user_3_name)
@@ -155,8 +155,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.browse_component_review(review, strings_not_displayed=strings_not_displayed)
 
     def test_0035_grant_write_access_to_other_user(self):
-        '''Grant write access on the filtering_0410 repository to test_user_3.'''
-        '''
+        '''Grant write access on the filtering_0410 repository to test_user_3.
+
         We are at step 5 - Have test_user_1 give write permission on the repository to the test_user_3.
         '''
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -164,8 +164,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.grant_write_access(repository, usernames=[common.test_user_3_name])
 
     def test_0040_verify_test_user_3_can_browse_reviews(self):
-        '''Check that test_user_3 can now browse reviews.'''
-        '''
+        '''Check that test_user_3 can now browse reviews.
+
         We are at step 6 - Have test_user_3 browse the repository again and they should now have the ability to browse the review.
         '''
         self.login(email=common.test_user_3_email, username=common.test_user_3_name)
@@ -174,8 +174,8 @@ class TestRepositoryComponentReviews(ShedTwillTestCase):
         self.display_manage_repository_page(repository, strings_displayed=strings_displayed)
 
     def test_0045_verify_browse_review_with_write_access(self):
-        '''Check that test_user_3 can now display reviews.'''
-        '''
+        '''Check that test_user_3 can now display reviews.
+
         We are at step 7 - Have test_user_3 browse the review.
         '''
         self.login(email=common.test_user_3_email, username=common.test_user_3_name)

--- a/lib/tool_shed/test/functional/test_0420_citable_urls_for_repositories.py
+++ b/lib/tool_shed/test/functional/test_0420_citable_urls_for_repositories.py
@@ -28,8 +28,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
     '''Test repository citable url features.'''
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other tests.
         Previously created accounts will not be re-created.
         """
@@ -43,8 +43,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_repository(self):
-        """Create and populate the filtering_0420 repository"""
-        """
+        """Create and populate the filtering_0420 repository
+
         We are at step 1.
         Add and populate a repository to the tool shed with change set revision 0 (assume owner is test_user_1).
         """
@@ -72,8 +72,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
         first_changeset_hash = self.get_repository_tip(repository)
 
     def test_0010_upload_new_file_to_repository(self):
-        '''Upload a readme file to the repository in order to create a second changeset revision.'''
-        '''
+        '''Upload a readme file to the repository in order to create a second changeset revision.
+
         We are at step 2.
         Add valid change set revision 1.
         The repository should now contain two changeset revisions, 0:<revision hash> and 1:<revision hash>.
@@ -90,8 +90,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_load_user_view_page(self):
-        '''Load the /view/<username> page amd check for strings.'''
-        '''
+        '''Load the /view/<username> page amd check for strings.
+
         We are at step 3.
         Visit the following url and check for appropriate strings: <tool shed base url>/view/user1
         '''
@@ -112,8 +112,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
                               strings_displayed_in_iframe=strings_displayed_in_iframe)
 
     def test_0020_load_repository_view_page(self):
-        '''Load the /view/<user>/<repository> page and check for the appropriate strings.'''
-        '''
+        '''Load the /view/<user>/<repository> page and check for the appropriate strings.
+
         We are at step 4.
         Visit the following url and check for strings: <tool shed base url>/view/user1/filtering_0420
             Resulting page should contain change set revision 1
@@ -139,8 +139,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
                               strings_displayed_in_iframe=strings_displayed_in_iframe)
 
     def test_0025_load_view_page_for_previous_revision(self):
-        '''Load a citable url for a past changeset revision and verify that strings display.'''
-        '''
+        '''Load a citable url for a past changeset revision and verify that strings display.
+
         We are at step 5.
         Visit the following url and check for appropriate strings: <tool shed base url>/view/user1/filtering_0420/<revision 0>
             Resulting page should not contain change set revision 1, but should contain change set revision 0.
@@ -187,8 +187,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
                               strings_displayed=strings_displayed)
 
     def test_0035_load_sharable_url_with_invalid_repository_name(self):
-        '''Load a citable url with an invalid changeset revision specified.'''
-        '''
+        '''Load a citable url with an invalid changeset revision specified.
+
         We are at step 7
         Visit the following url and check for appropriate strings: <tool shed base url>/view/user1/!!invalid!!
         '''
@@ -210,8 +210,8 @@ class TestRepositoryCitableURLs(ShedTwillTestCase):
                               strings_displayed_in_iframe=strings_displayed_in_iframe)
 
     def test_0040_load_sharable_url_with_invalid_owner(self):
-        '''Load a citable url with an invalid owner.'''
-        '''
+        '''Load a citable url with an invalid owner.
+
         We are at step 8.
         Visit the following url and check for appropriate strings: <tool shed base url>/view/!!invalid!!
         '''

--- a/lib/tool_shed/test/functional/test_0430_browse_utilities.py
+++ b/lib/tool_shed/test/functional/test_0430_browse_utilities.py
@@ -28,8 +28,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
     '''Test browsing for Galaxy utilities.'''
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other tests.
         Previously created accounts will not be re-created.
         """
@@ -43,8 +43,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_datatypes_repository(self):
-        """Create and populate the emboss_datatypes_0430 repository"""
-        """
+        """Create and populate the emboss_datatypes_0430 repository
+
         We are at step 1.
         Create and populate the repository that will contain one or more datatypes.
         """
@@ -69,8 +69,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_emboss_repository(self):
-        """Create and populate the emboss_0430 repository"""
-        """
+        """Create and populate the emboss_0430 repository
+
         We are at step 1.
         Create the emboss_0430 repository, and populate it with tools.
         """
@@ -104,8 +104,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         self.check_repository_dependency(emboss_repository, datatypes_repository)
 
     def test_0020_create_tool_dependency_repository(self):
-        """Create and populate the freebayes_0430 repository"""
-        """
+        """Create and populate the freebayes_0430 repository
+
         We are at step 1.
         Create and populate the repository that will have a tool dependency defined.
         """
@@ -130,8 +130,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0025_browse_custom_datatypes(self):
-        '''Load the page to browse custom datatypes.'''
-        '''
+        '''Load the page to browse custom datatypes.
+
         We are at step 2.
         Verify that the uploaded emboss datatypes repository has added to the custom datatypes page.
         '''
@@ -141,8 +141,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         self.browse_custom_datatypes(strings_displayed=strings_displayed)
 
     def test_0030_browse_tools(self):
-        '''Load the page to browse tools.'''
-        '''
+        '''Load the page to browse tools.
+
         We are at step 3.
         Verify the existence of emboss tools in the browse tools page.
         '''
@@ -152,8 +152,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         self.browse_tools(strings_displayed=strings_displayed)
 
     def test_0035_browse_repository_dependencies(self):
-        '''Browse repository dependencies and look for a dependency on emboss_datatypes_0430.'''
-        '''
+        '''Browse repository dependencies and look for a dependency on emboss_datatypes_0430.
+
         We are at step 3.
         Verify that the browse repository dependencies page shows emboss_datatypes_0430 as a dependency of emboss_0430.
         '''
@@ -165,8 +165,8 @@ class TestToolShedBrowseUtilities(ShedTwillTestCase):
         self.browse_repository_dependencies(strings_displayed=strings_displayed)
 
     def test_0040_browse_tool_dependencies(self):
-        '''Browse tool dependencies and look for the right versions of freebayes and samtools.'''
-        '''
+        '''Browse tool dependencies and look for the right versions of freebayes and samtools.
+
         We are at step 4.
         Verify that the browse tool dependencies page shows the correct dependencies defined for freebayes_0430.
         '''

--- a/lib/tool_shed/test/functional/test_0440_deleting_dependency_definitions.py
+++ b/lib/tool_shed/test/functional/test_0440_deleting_dependency_definitions.py
@@ -52,8 +52,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
     '''Test metadata setting when dependency definitions are deleted.'''
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other tests.
         Previously created accounts will not be re-created.
         """
@@ -67,8 +67,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_column_maker_repository(self):
-        '''Create and populate a repository named column_maker_0440.'''
-        '''
+        '''Create and populate a repository named column_maker_0440.
+
         We are at simple repository dependencies, step 1 - Create and populate column_maker_0440 so that it has an installable revision 0.
         '''
         category = self.create_category(name='Test 0440 Deleted Dependency Definitions',
@@ -92,8 +92,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_convert_chars_repository(self):
-        '''Create and populate a repository named convert_chars_0440.'''
-        '''
+        '''Create and populate a repository named convert_chars_0440.
+
         We are at simple repository dependencies, step 2 - Create and populate convert_chars_0440 so that it has an installable revision 0.
         '''
         category = self.test_db_util.get_category_by_name('Test 0440 Deleted Dependency Definitions')
@@ -116,8 +116,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_dependency_on_convert_chars(self):
-        '''Create a dependency definition file that specifies column_maker_0440 and upload it to convert_chars_0440.'''
-        '''
+        '''Create a dependency definition file that specifies column_maker_0440 and upload it to convert_chars_0440.
+
         We are at simple repository dependencies, step 3 - Add a valid simple repository_dependencies.xml to
         convert_chars_0440 that points to the installable revision of column_maker_0440.
         '''
@@ -133,8 +133,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
         self.check_repository_dependency(convert_repository, column_repository)
 
     def test_0020_verify_dependency_metadata(self):
-        '''Verify that uploading the dependency moved metadata to the tip.'''
-        '''
+        '''Verify that uploading the dependency moved metadata to the tip.
+
         We are at simple repository dependencies, step 4 - Make sure the installable revision of convert_chars_0440 is now
         revision 1 (the tip) instead of revision 0.
         '''
@@ -147,8 +147,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
             (repository.name, len(repository.downloadable_revisions))
 
     def test_0025_delete_repository_dependency(self):
-        '''Delete the repository_dependencies.xml from convert_chars_0440.'''
-        '''
+        '''Delete the repository_dependencies.xml from convert_chars_0440.
+
         We are at simple repository dependencies, steps 5 and 6 - Delete repository_dependencies.xml from convert_chars_0440.
         Make sure convert_chars_0440 now has two installable revisions: 1 and 2
         '''
@@ -173,8 +173,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
             (repository.name, len(repository.downloadable_revisions))
 
     def test_0030_create_bwa_package_repository(self):
-        '''Create and populate the bwa_package_0440 repository.'''
-        '''
+        '''Create and populate the bwa_package_0440 repository.
+
         We are at complex repository dependencies, step 1 - Create and populate bwa_package_0440 so that it has a valid
         tool dependency definition and an installable revision 0.
         '''
@@ -198,8 +198,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0035_create_bwa_base_repository(self):
-        '''Create and populate the bwa_base_0440 repository.'''
-        '''
+        '''Create and populate the bwa_base_0440 repository.
+
         We are at complex repository dependencies, step 2 - Create and populate bwa_base_0440 so that it has an installable revision 0.
         This repository should contain a tool with a defined dependency that will be satisfied by the tool dependency defined in bwa_package_0440.
         '''
@@ -223,8 +223,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0040_create_dependency_on_bwa_package_repository(self):
-        '''Create a complex repository dependency on bwa_package_0440 and upload it to bwa_tool_0440.'''
-        '''
+        '''Create a complex repository dependency on bwa_package_0440 and upload it to bwa_tool_0440.
+
         We are at complex repository dependencies, step 3 - Add a valid complex repository dependency tool_dependencies.xml to
         bwa_base_0440 that points to the installable revision 0 of bwa_package_0440.
         '''
@@ -242,8 +242,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
                                           version='0.5.9')
 
     def test_0045_verify_dependency_metadata(self):
-        '''Verify that uploading the dependency moved metadata to the tip.'''
-        '''
+        '''Verify that uploading the dependency moved metadata to the tip.
+
         We are at complex repository dependencies, step 4 - Make sure that bwa_base_0440 installable revision is now revision 1
         instead of revision 0.
         '''
@@ -256,8 +256,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
             (repository.name, len(repository.downloadable_revisions))
 
     def test_0050_delete_complex_repository_dependency(self):
-        '''Delete the tool_dependencies.xml from bwa_base_0440.'''
-        '''
+        '''Delete the tool_dependencies.xml from bwa_base_0440.
+
         We are at complex repository dependencies, step 5 - Delete tool_dependencies.xml from bwa_base_0440,
         and make sure bwa_base_0440 now has two installable revisions: 1 and 2
         '''
@@ -280,8 +280,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
             (repository.name, len(repository.downloadable_revisions))
 
     def test_0055_create_bwa_tool_dependency_repository(self):
-        '''Create and populate the bwa_tool_dependency_0440 repository.'''
-        '''
+        '''Create and populate the bwa_tool_dependency_0440 repository.
+
         We are at tool dependencies, step 1 - Create and populate bwa_tool_dependency_0440 so that it has a valid tool
         dependency definition and an installable revision 0.
         '''
@@ -305,8 +305,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0060_delete_bwa_tool_dependency_definition(self):
-        '''Delete the tool_dependencies.xml file from bwa_tool_dependency_0440.'''
-        '''
+        '''Delete the tool_dependencies.xml file from bwa_tool_dependency_0440.
+
         We are at tool dependencies, step 2 - Delete tool_dependencies.xml from bwa_tool_dependency_0440.
         Make sure bwa_tool_dependency_0440 still has a downloadable changeset revision at the old tip.
         '''
@@ -329,8 +329,8 @@ class TestDeletedDependencies(ShedTwillTestCase):
             (repository.name, len(repository.downloadable_revisions))
 
     def test_0065_reupload_bwa_tool_dependency_definition(self):
-        '''Reupload the tool_dependencies.xml file to bwa_tool_dependency_0440.'''
-        '''
+        '''Reupload the tool_dependencies.xml file to bwa_tool_dependency_0440.
+
         We are at tool dependencies, step 3 - Add the same tool_dependencies.xml file to bwa_tool_dependency_0440, and make sure
         that bwa_tool_dependency_0440 still has a single installable revision 0.
         '''

--- a/lib/tool_shed/test/functional/test_0460_upload_to_repository.py
+++ b/lib/tool_shed/test/functional/test_0460_upload_to_repository.py
@@ -73,8 +73,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_datatypes_repository(self):
-        '''Create and populate the emboss_datatypes_0460 repository'''
-        '''
+        '''Create and populate the emboss_datatypes_0460 repository
+
         This is step 1 - Create and populate emboss_datatypes_0460.
         '''
         self.create_category(name=category_name, description=category_description)
@@ -97,8 +97,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_bwa_package_repository(self):
-        '''Create and populate the package_bwa_0_5_9_0460 repository.'''
-        '''
+        '''Create and populate the package_bwa_0_5_9_0460 repository.
+
         This is step 2 - Create and populate package_bwa_0_5_9_0460.
         '''
         category = self.test_db_util.get_category_by_name(category_name)
@@ -119,8 +119,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_tool_dependency_repositories(self):
-        '''Create repositories for testing complex dependency generation.'''
-        '''
+        '''Create repositories for testing complex dependency generation.
+
         This is step 3 - Create complex_dependency_test_1_0460, complex_dependency_test_2_0460, complex_dependency_test_3_0460,
         complex_dependency_test_4_0460, complex_dependency_test_5_0460. Each of these repositories will be populated in a way
         that tests a different way to achieve the same resulting dependency structure using complex tool dependencies.
@@ -144,8 +144,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                           strings_displayed=[])
 
     def test_0020_populate_complex_dependency_test_1_0460(self):
-        '''Populate complex_dependency_test_1_0460.'''
-        '''
+        '''Populate complex_dependency_test_1_0460.
+
         This is step 4 - Upload an uncompressed tool_dependencies.xml to complex_dependency_test_1_0460 that specifies
         a complex repository dependency on package_bwa_0_5_9_0460 without a specified changeset revision or tool shed url.
         '''
@@ -166,8 +166,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         self.display_repository_file_contents(repository, filename='tool_dependencies.xml', strings_displayed=[changeset_revision])
 
     def test_0025_populate_complex_dependency_test_2_0460(self):
-        '''Populate complex_dependency_test_2_0460.'''
-        '''
+        '''Populate complex_dependency_test_2_0460.
+
         This is step 5 - Upload an tarball with tool_dependencies.xml to complex_dependency_test_2_0460 that specifies
         a complex repository dependency on package_bwa_0_5_9_0460 without a specified changeset revision or tool shed url.
         '''
@@ -188,8 +188,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         self.display_repository_file_contents(repository, filename='tool_dependencies.xml', strings_displayed=[changeset_revision])
 
     def test_0030_populate_complex_dependency_test_3_0460(self):
-        '''Populate complex_dependency_test_3_0460.'''
-        '''
+        '''Populate complex_dependency_test_3_0460.
+
         This is step 6 - Upload an tarball with tool_dependencies.xml in a subfolder to complex_dependency_test_3_0460 that
         specifies a complex repository dependency on package_bwa_0_5_9_0460 without a specified changeset revision or tool shed url.
         '''
@@ -213,8 +213,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                               strings_displayed=[changeset_revision])
 
     def test_0035_create_repositories_for_url_upload(self):
-        '''Create and populate hg_tool_dependency_0460 and hg_subfolder_tool_dependency_0460.'''
-        '''
+        '''Create and populate hg_tool_dependency_0460 and hg_subfolder_tool_dependency_0460.
+
         This is step 7 - Create hg_tool_dependency_0460 and hg_subfolder_tool_dependency_0460 and populate with tool dependencies.
         '''
         category = self.test_db_util.get_category_by_name(category_name)
@@ -250,8 +250,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0040_url_upload_to_complex_test(self):
-        '''Populate complex_dependency_test_4_0460.'''
-        '''
+        '''Populate complex_dependency_test_4_0460.
+
         This is step 8 - Upload to complex_dependency_test_4_0460 using the url hg://<tool shed url>/repos/user1/hg_tool_dependency_0460.
         '''
         url = f'hg://{self.host}:{self.port}/repos/user1/hg_tool_dependency_0460'
@@ -274,8 +274,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                               strings_displayed=[changeset_revision])
 
     def test_0045_url_upload_to_complex_test(self):
-        '''Populate complex_dependency_test_4_0460.'''
-        '''
+        '''Populate complex_dependency_test_4_0460.
+
         This is step 9 - Upload to complex_dependency_test_5_0460 using the url hg://<tool shed url>/repos/user1/hg_subfolder_tool_dependency_0460.
         '''
         url = f'hg://{self.host}:{self.port}/repos/user1/hg_subfolder_tool_dependency_0460'
@@ -299,8 +299,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                               strings_displayed=[changeset_revision])
 
     def test_0050_create_repositories_for_simple_dependencies(self):
-        '''Create repositories for testing simple dependency generation.'''
-        '''
+        '''Create repositories for testing simple dependency generation.
+
         This is step 10 - Create repository_dependency_test_1_0460, repository_dependency_test_2_0460, repository_dependency_test_3_0460,
         repository_dependency_test_4_0460, repository_dependency_test_4_0460.. Each of these repositories will be populated in a way
         that tests a different way to achieve the same resulting dependency structure using complex tool dependencies.
@@ -324,8 +324,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                           strings_displayed=[])
 
     def test_0055_populate_repository_dependency_test_1_0460(self):
-        '''Populate repository_dependency_test_1_0460.'''
-        '''
+        '''Populate repository_dependency_test_1_0460.
+
         This is step 11 - Upload an uncompressed repository_dependencies.xml to repository_dependency_test_1_0460 that specifies a
         repository dependency on emboss_datatypes_0460 without a specified changeset revision or tool shed url.
         '''
@@ -346,8 +346,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         self.display_repository_file_contents(repository, filename='repository_dependencies.xml', strings_displayed=[changeset_revision])
 
     def test_0060_populate_repository_dependency_test_2_0460(self):
-        '''Populate repository_dependency_test_2_0460.'''
-        '''
+        '''Populate repository_dependency_test_2_0460.
+
         This is step 12 - Upload a tarball to repository_dependency_test_2_0460 with a repository_dependencies.xml in the root of the tarball.
         '''
         repository = self.test_db_util.get_repository_by_name_and_owner('repository_dependency_test_2_0460', common.test_user_1_name)
@@ -367,8 +367,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
         self.display_repository_file_contents(repository, filename='repository_dependencies.xml', strings_displayed=[changeset_revision])
 
     def test_0065_populate_repository_dependency_test_3_0460(self):
-        '''Populate repository_dependency_test_3_0460.'''
-        '''
+        '''Populate repository_dependency_test_3_0460.
+
         This is step 13 - Upload a tarball to repository_dependency_test_3_0460 with a repository_dependencies.xml in a
         subfolder within the tarball.
         '''
@@ -392,8 +392,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                               strings_displayed=[changeset_revision])
 
     def test_0070_create_repositories_for_url_upload(self):
-        '''Create and populate hg_repository_dependency_0460 and hg_subfolder_repository_dependency_0460.'''
-        '''
+        '''Create and populate hg_repository_dependency_0460 and hg_subfolder_repository_dependency_0460.
+
         This is step 14 - Create hg_repository_dependency_0460 and hg_subfolder_repository_dependency_0460 and populate
         with repository dependencies.
         '''
@@ -430,8 +430,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0075_url_upload_to_complex_test(self):
-        '''Populate repository_dependency_test_4_0460.'''
-        '''
+        '''Populate repository_dependency_test_4_0460.
+
         This is step 15 - Upload to repository_dependency_test_4_0460 using the url
         hg://<tool shed url>/repos/user1/hg_repository_dependency_0460.
         '''
@@ -455,8 +455,8 @@ class TestAutomaticDependencyRevision(ShedTwillTestCase):
                                               strings_displayed=[changeset_revision])
 
     def test_0080_url_upload_to_complex_test(self):
-        '''Populate repository_dependency_test_4_0460.'''
-        '''
+        '''Populate repository_dependency_test_4_0460.
+
         This is step 16 - Upload to repository_dependency_test_5_0460 using the url
         hg://<tool shed url>/repos/user1/hg_subfolder_repository_dependency_0460.
         '''

--- a/lib/tool_shed/test/functional/test_0470_tool_dependency_repository_type.py
+++ b/lib/tool_shed/test/functional/test_0470_tool_dependency_repository_type.py
@@ -71,8 +71,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         self.test_db_util.get_private_role(test_user_1)
 
     def test_0005_create_libx11_repository(self):
-        '''Create and populate package_x11_client_1_5_proto_7_0_0470.'''
-        '''
+        '''Create and populate package_x11_client_1_5_proto_7_0_0470.
+
         This is step 1 - Create and populate a repository named package_x11_client_1_5_proto_7_0.
 
         Create and populate a repository named package_x11_client_1_5_proto_7_0 that contains only a single file named tool_dependencies.xml.
@@ -97,8 +97,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_emboss_5_0_0_repository(self):
-        '''Create and populate package_emboss_5_0_0_0470.'''
-        '''
+        '''Create and populate package_emboss_5_0_0_0470.
+
         This is step 2 - Create a repository named package_emboss_5_0_0 of type "Unrestricted".
 
         Create a repository named package_emboss_5_0_0 of type "Unrestricted" that has a repository dependency definition that defines the
@@ -124,8 +124,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_emboss_5_repository(self):
-        '''Create and populate emboss_5_0470.'''
-        '''
+        '''Create and populate emboss_5_0470.
+
         This is step 3 - Create a repository named emboss_5 of type "Unrestricted".
 
         Create a repository named emboss_5 of type "Unrestricted" that has a tool-dependencies.xml file defining a complex repository dependency
@@ -151,8 +151,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_upload_updated_tool_dependency_to_package_x11(self):
-        '''Upload a new tool_dependencies.xml to package_x11_client_1_5_proto_7_0_0470.'''
-        '''
+        '''Upload a new tool_dependencies.xml to package_x11_client_1_5_proto_7_0_0470.
+
         This is step 4 - Add a comment to the tool_dependencies.xml file to be uploaded to the package_x11_client_1_5_prot_7_0 repository, creating
         a new installable changeset revision at the repository tip.
         '''
@@ -172,8 +172,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
             len(package_x11_repository.metadata_revisions)
 
     def test_0025_upload_updated_tool_dependency_to_package_emboss(self):
-        '''Upload a new tool_dependencies.xml to package_emboss_5_0_0_0470.'''
-        '''
+        '''Upload a new tool_dependencies.xml to package_emboss_5_0_0_0470.
+
         This is step 5 - Add a comment to the tool_dependencies.xml file for the package_emboss_5_0_0 repository, eliminating
         the change set_revision attribute so that it gets automatically populated when uploaded. After uploading the file,
         the package_emboss_5_0_0 repository should have 2 installable changeset revisions.
@@ -194,8 +194,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
             len(package_emboss_repository.metadata_revisions)
 
     def test_0030_upload_updated_tool_dependency_to_emboss_5_repository(self):
-        '''Upload a new tool_dependencies.xml to emboss_5_0470.'''
-        '''
+        '''Upload a new tool_dependencies.xml to emboss_5_0470.
+
         This is step 6 - Add a comment to the tool_dependencies.xml file in the emboss_5 repository, eliminating the
         changeset_revision attribute so that it gets automatically populated when uploaded. After uploading the file,
         the emboss5 repository should have 2 installable metadata revisions.
@@ -214,24 +214,24 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         assert len(emboss_repository.metadata_revisions) == 2, 'package_emboss_5_0_0_0470 has incorrect number of metadata revisions'
 
     def test_0035_modify_package_x11_repository_type(self):
-        '''Set package_x11_client_1_5_proto_7_0 type tool_dependency_definition.'''
-        '''
+        '''Set package_x11_client_1_5_proto_7_0 type tool_dependency_definition.
+
         This is step 7 - Change the repository type of the package_x11_client_1_5_proto_7_0 repository to be tool_dependency_definition.
         '''
         package_x11_repository = self.test_db_util.get_repository_by_name_and_owner(package_libx11_repository_name, common.test_user_1_name)
         self.edit_repository_information(package_x11_repository, repository_type='tool_dependency_definition')
 
     def test_0040_modify_package_emboss_repository_type(self):
-        '''Set package_emboss_5_0_0 to type tool_dependency_definition.'''
-        '''
+        '''Set package_emboss_5_0_0 to type tool_dependency_definition.
+
         This is step 8 - Change the repository type of the package_emboss_5_0_0 repository to be tool_dependency_definition.
         '''
         package_emboss_repository = self.test_db_util.get_repository_by_name_and_owner(package_emboss_repository_name, common.test_user_1_name)
         self.edit_repository_information(package_emboss_repository, repository_type='tool_dependency_definition')
 
     def test_0045_reset_repository_metadata(self):
-        '''Reset metadata on package_emboss_5_0_0_0470 and package_x11_client_1_5_proto_7_0.'''
-        '''
+        '''Reset metadata on package_emboss_5_0_0_0470 and package_x11_client_1_5_proto_7_0.
+
         This is step 9 - Reset metadata on the package_emboss_5_0_0 and package_x11_client_1_5_proto_7_0 repositories. They should
         now have only their tip as the installable revision.
         '''
@@ -245,8 +245,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
             len(package_x11_repository.metadata_revisions)
 
     def test_0050_reset_emboss_5_metadata(self):
-        '''Reset metadata on emboss_5.'''
-        '''
+        '''Reset metadata on emboss_5.
+
         This is step 10 - Reset metadata on the emboss_5 repository. It should now have only its tip as the installable revision.
         '''
         emboss_repository = self.test_db_util.get_repository_by_name_and_owner(emboss_repository_name, common.test_user_1_name)

--- a/lib/tool_shed/test/functional/test_0480_tool_dependency_xml_verification.py
+++ b/lib/tool_shed/test/functional/test_0480_tool_dependency_xml_verification.py
@@ -39,8 +39,8 @@ class TestDependencyDefinitionValidation(ShedTwillTestCase):
         self.test_db_util.get_private_role(test_user_1)
 
     def test_0005_create_tool_dependency_repository(self):
-        '''Create and populate package_invalid_tool_dependency_xml_1_0_0.'''
-        '''
+        '''Create and populate package_invalid_tool_dependency_xml_1_0_0.
+
         This is step 1 - Create a repository package_invalid_tool_dependency_xml_1_0_0.
 
         Create a repository named package_invalid_tool_dependency_xml_1_0_0 that will contain only a single file named tool_dependencies.xml.
@@ -63,8 +63,8 @@ class TestDependencyDefinitionValidation(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_populate_tool_dependency_repository(self):
-        '''Verify package_invalid_tool_dependency_xml_1_0_0.'''
-        '''
+        '''Verify package_invalid_tool_dependency_xml_1_0_0.
+
         This is step 3 - Verify repository. The uploaded tool dependency XML should not have resulted in a new changeset.
         '''
         repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)

--- a/lib/tool_shed/test/functional/test_0530_repository_admin_feature.py
+++ b/lib/tool_shed/test/functional/test_0530_repository_admin_feature.py
@@ -49,10 +49,10 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_filtering_repository(self):
-        """Create and populate the filtering_0530 repository."""
-        '''
+        """Create and populate the filtering_0530 repository.
+
         This is step 1 - Create new repository as user user1.
-        '''
+        """
         category = self.create_category(name=category_name, description=category_description)
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
         repository = self.get_or_create_repository(name=repository_name,
@@ -72,8 +72,8 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_verify_repository_admin_role_exists(self):
-        '''Verify that the role filtering_0530_user1_admin exists.'''
-        '''
+        '''Verify that the role filtering_0530_user1_admin exists.
+
         This is step 2 - Check to make sure a new role was created named filtering_0530_user1_admin.
         '''
         test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
@@ -81,8 +81,8 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         assert repository_admin_role is not None, 'Admin role for filtering_0530 was not created.'
 
     def test_0015_verify_repository_role_association(self):
-        '''Verify that the filtering_0530_user1_admin role is associated with the filtering_0530 repository.'''
-        '''
+        '''Verify that the filtering_0530_user1_admin role is associated with the filtering_0530 repository.
+
         This is step 3 - Check to make sure a new repository_role_association record was created with appropriate repository id and role id.
         '''
         repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)
@@ -92,8 +92,8 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         assert repository_role_association is not None, 'Repository filtering_0530 is not associated with the filtering_0530_user1_admin role.'
 
     def test_0020_rename_repository(self):
-        '''Rename the repository to renamed_filtering_0530.'''
-        '''
+        '''Rename the repository to renamed_filtering_0530.
+
         This is step 4 - Change the name of the repository created in step 1 - this can be done as long as the repository has not
         been installed or cloned.
         '''
@@ -102,22 +102,9 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         self.test_db_util.refresh(repository)
         assert repository.name == 'renamed_filtering_0530', 'Repository was not renamed to renamed_filtering_0530.'
 
-    def test_0025_check_admin_role_name(self):
-        return
-        '''Check that a role renamed_filtering_0530_user1_admin now exists, and filtering_0530_user1_admin does not.'''
-        '''
-        This is step 5 - Make sure the name of the role initially inspected in Step 2 has been changed to reflect the
-        new repository name from Step 4.
-        '''
-        test_user_1 = self.test_db_util.get_user(common.test_user_1_email)
-        old_repository_admin_role = self.test_db_util.get_role(test_user_1, f'filtering_0530_{test_user_1.username}_admin')
-        assert old_repository_admin_role is None, 'Admin role filtering_0530_user1_admin incorrectly exists.'
-        new_repository_admin_role = self.test_db_util.get_role(test_user_1, f'renamed_filtering_0530_{test_user_1.username}_admin')
-        assert new_repository_admin_role is not None, 'Admin role renamed_filtering_0530_user1_admin does not exist.'
-
     def test_0030_verify_access_denied(self):
-        '''Make sure a non-admin user can't modify the repository.'''
-        '''
+        '''Make sure a non-admin user can't modify the repository.
+
         This is step 6 - Log into the Tool Shed as a user that is not the repository owner (e.g., user2) and make sure the repository
         name and description cannot be changed.
         '''
@@ -132,8 +119,8 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         self.check_for_strings(strings_displayed=strings_displayed, strings_not_displayed=strings_not_displayed)
 
     def test_0035_grant_admin_role(self):
-        '''Grant the repository admin role to user2.'''
-        '''
+        '''Grant the repository admin role to user2.
+
         This is step 7 - As user user1, add user user2 as a repository admin user.
         '''
         self.login(email=common.test_user_1_email, username=common.test_user_1_name)
@@ -142,8 +129,8 @@ class TestRepositoryAdminRole(ShedTwillTestCase):
         self.assign_admin_role(repository, test_user_2)
 
     def test_0040_rename_repository_as_repository_admin(self):
-        '''Rename the repository as user2.'''
-        '''
+        '''Rename the repository as user2.
+
         This is step 8 - Log into the Tool Shed as user user2 and make sure the repository name and description can now be changed.
         '''
         self.login(email=common.test_user_2_email, username=common.test_user_2_name)

--- a/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
+++ b/lib/tool_shed/test/functional/test_1120_install_repository_with_complex_dependencies.py
@@ -265,8 +265,8 @@ class TestInstallingComplexRepositoryDependencies(ShedTwillTestCase):
             raise AssertionError(f'Repository name package_bwa_0_5_9_0100 not found in env.sh.\nContents of env.sh: {contents}')
 
     def test_0060_verify_tool_dependency_uninstallation(self):
-        '''Uninstall the package_bwa_0_5_9_0100 repository.'''
-        '''
+        '''Uninstall the package_bwa_0_5_9_0100 repository.
+
         Uninstall the repository that defines a tool dependency relationship on BWA 0.5.9, and verify
         that this results in the compiled binary package also being removed.
         '''

--- a/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
+++ b/lib/tool_shed/test/functional/test_1140_simple_repository_dependency_multiple_owners.py
@@ -31,8 +31,8 @@ running_standalone = False
 class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other tests.
         Previously created accounts will not be re-created.
         """
@@ -50,8 +50,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_datatypes_repository(self):
-        """Create and populate the blast_datatypes_0120 repository"""
-        """
+        """Create and populate the blast_datatypes_0120 repository
+
         We are at step 1.
         Create and populate blast_datatypes.
         """
@@ -76,8 +76,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0010_verify_datatypes_repository(self):
-        '''Verify the blast_datatypes_0120 repository.'''
-        '''
+        '''Verify the blast_datatypes_0120 repository.
+
         We are at step 1a.
         Check for appropriate strings, most importantly BlastXml, BlastNucDb, and BlastProtDb,
         the datatypes that are defined in datatypes_conf.xml.
@@ -89,8 +89,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         repository_datatypes_count = int(self.get_repository_datatypes_count(repository))
 
     def test_0015_create_tool_repository(self):
-        """Create and populate the blastxml_to_top_descr_0120 repository"""
-        """
+        """Create and populate the blastxml_to_top_descr_0120 repository
+
         We are at step 2.
         Create and populate blastxml_to_top_descr_0120.
         """
@@ -117,8 +117,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0020_verify_tool_repository(self):
-        '''Verify the blastxml_to_top_descr_0120 repository.'''
-        '''
+        '''Verify the blastxml_to_top_descr_0120 repository.
+
         We are at step 2a.
         Check for appropriate strings, such as tool name, description, and version.
         '''
@@ -128,8 +128,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         self.display_manage_repository_page(repository, strings_displayed=strings_displayed)
 
     def test_0025_create_repository_dependency(self):
-        '''Create a repository dependency on blast_datatypes_0120.'''
-        '''
+        '''Create a repository dependency on blast_datatypes_0120.
+
         We are at step 3.
         Create a simple repository dependency for blastxml_to_top_descr_0120 that defines a dependency on blast_datatypes_0120.
         '''
@@ -142,8 +142,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
             self.create_repository_dependency(repository=tool_repository, repository_tuples=[datatypes_tuple], filepath=dependency_xml_path)
 
     def test_0040_verify_repository_dependency(self):
-        '''Verify the created repository dependency.'''
-        '''
+        '''Verify the created repository dependency.
+
         We are at step 3a.
         Check the newly created repository dependency to ensure that it was defined and displays correctly.
         '''
@@ -152,8 +152,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
         self.check_repository_dependency(tool_repository, datatypes_repository)
 
     def test_0045_install_blastxml_to_top_descr(self):
-        '''Install the blastxml_to_top_descr_0120 repository to Galaxy.'''
-        '''
+        '''Install the blastxml_to_top_descr_0120 repository to Galaxy.
+
         We are at step 1, Galaxy side.
         Install blastxml_to_top_descr_0120 to Galaxy, with repository dependencies, so that the datatypes repository is also installed.
         '''
@@ -169,8 +169,8 @@ class TestInstallRepositoryMultipleOwners(ShedTwillTestCase):
                                 new_tool_panel_section_label='Test 0120')
 
     def test_0050_verify_repository_installation(self):
-        '''Verify installation of blastxml_to_top_descr_0120 and blast_datatypes_0120.'''
-        '''
+        '''Verify installation of blastxml_to_top_descr_0120 and blast_datatypes_0120.
+
         We are at step 1a, Galaxy side.
         Check that the blastxml_to_top_descr_0120 and blast_datatypes_0120 repositories installed correctly, and that there
         are now new datatypes in the registry matching the ones defined in blast_datatypes_0120. Also check that

--- a/lib/tool_shed/test/functional/test_1150_datatype_converters.py
+++ b/lib/tool_shed/test/functional/test_1150_datatype_converters.py
@@ -56,8 +56,8 @@ class TestDatatypeConverters(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0010_install_datatype_converter_to_galaxy(self):
-        '''Install bed_to_gff_converter_0130 into the running Galaxy instance.'''
-        '''
+        '''Install bed_to_gff_converter_0130 into the running Galaxy instance.
+
         We are at step 1 - Install the bed_to_gff_converter repository.
         Install bed_to_gff_converter_0130, checking that the option to select the tool panel section is *not* displayed.
         '''
@@ -77,8 +77,8 @@ class TestDatatypeConverters(ShedTwillTestCase):
                                 includes_tools_for_display_in_tool_panel=False)
 
     def test_0015_uninstall_and_verify_tool_panel_section(self):
-        '''Uninstall bed_to_gff_converter_0130 and verify that the saved tool_panel_section is None.'''
-        '''
+        '''Uninstall bed_to_gff_converter_0130 and verify that the saved tool_panel_section is None.
+
         We are at step 3 - Make sure the bed_to_gff_converter tool is not displayed in the tool panel.
         The previous tool panel section for a tool is only recorded in the metadata when a repository is uninstalled,
         so we have to uninstall it first, then verify that it was not assigned a tool panel section.

--- a/lib/tool_shed/test/functional/test_1160_tool_help_images.py
+++ b/lib/tool_shed/test/functional/test_1160_tool_help_images.py
@@ -32,8 +32,8 @@ class TestToolHelpImages(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_htseq_count_repository(self):
-        '''Create and populate htseq_count_0140.'''
-        '''
+        '''Create and populate htseq_count_0140.
+
         We are at step 1 - Create and populate the htseq_count_0140 repository.
         Create the htseq_count_0140 repository and upload the tarball.
         '''
@@ -59,8 +59,8 @@ class TestToolHelpImages(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0010_load_tool_page(self):
-        '''Load the tool page and check for the image URL.'''
-        '''
+        '''Load the tool page and check for the image URL.
+
         This is a duplicate of test method _0010 in test_0140_tool_help_images.
         '''
         repository = self.test_db_util.get_repository_by_name_and_owner(repository_name, common.test_user_1_name)

--- a/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1170_prior_installation_required.py
@@ -95,8 +95,8 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0015_create_repository_dependency(self):
-        '''Create a repository dependency specifying convert_chars.'''
-        '''
+        '''Create a repository dependency specifying convert_chars.
+
         Column maker repository dependency:
             <repository toolshed="self.url" name="convert_chars" owner="test" changeset_revision="<tip>" prior_installation_required="True" />
         '''

--- a/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1180_circular_prior_installation_required.py
@@ -129,8 +129,8 @@ class TestSimplePriorInstallation(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0020_create_repository_dependency(self):
-        '''Create a repository dependency specifying convert_chars.'''
-        '''
+        '''Create a repository dependency specifying convert_chars.
+
         Each of the three repositories should depend on the other two, to make this as circular as possible.
         '''
         global running_standalone

--- a/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
+++ b/lib/tool_shed/test/functional/test_1190_complex_prior_installation_required.py
@@ -39,8 +39,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         self.test_db_util.get_private_role(admin_user)
 
     def test_0005_create_matplotlib_repository(self):
-        '''Create and populate the package_matplotlib_1_2_0170 repository.'''
-        '''
+        '''Create and populate the package_matplotlib_1_2_0170 repository.
+
         This is step 1 - Create and populate repositories package_matplotlib_1_2_0170 and package_numpy_1_7_0170.
         '''
         global running_standalone
@@ -65,8 +65,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0010_create_numpy_repository(self):
-        '''Create and populate the package_numpy_1_7_0170 repository.'''
-        '''
+        '''Create and populate the package_numpy_1_7_0170 repository.
+
         This is step 1 - Create and populate repositories package_matplotlib_1_2_0170 and package_numpy_1_7_0170.
         '''
         global running_standalone
@@ -90,8 +90,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0015_create_complex_repository_dependency(self):
-        '''Create a dependency on package_numpy_1_7_0170.'''
-        '''
+        '''Create a dependency on package_numpy_1_7_0170.
+
         This is step 2 - Create a complex repository dependency on package_numpy_1_7_0170, and upload this to package_matplotlib_1_2_0170.
         package_matplotlib_1_2_0170 should depend on package_numpy_1_7_0170, with prior_installation_required
         set to True. When matplotlib is selected for installation, the result should be that numpy is compiled
@@ -129,8 +129,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                              strings_not_displayed=[])
 
     def test_0020_verify_generated_dependency(self):
-        '''Verify that matplotlib now has a package tool dependency and a complex repository dependency.'''
-        '''
+        '''Verify that matplotlib now has a package tool dependency and a complex repository dependency.
+
         This is step 3 - Verify that package_matplotlib_1_2_0170 now depends on package_numpy_1_7_0170, and that the inherited tool
                          dependency displays correctly.
         'Inhherited' in this case means that matplotlib should show a package tool dependency on numpy version 1.7, and a repository
@@ -143,8 +143,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
         self.display_manage_repository_page(matplotlib_repository, strings_displayed=['numpy', '1.7', 'package', changeset_revision])
 
     def test_0025_install_matplotlib_repository(self):
-        '''Install the package_matplotlib_1_2_0170 repository.'''
-        '''
+        '''Install the package_matplotlib_1_2_0170 repository.
+
         This is step 4 - Install package_matplotlib_1_2_0170 with repository dependencies.
         '''
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
@@ -163,8 +163,8 @@ class TestComplexPriorInstallation(ShedTwillTestCase):
                                 includes_tools_for_display_in_tool_panel=False)
 
     def test_0030_verify_installation_order(self):
-        '''Verify that the numpy repository was installed before the matplotlib repository.'''
-        '''
+        '''Verify that the numpy repository was installed before the matplotlib repository.
+
         This is step 5 - Verify that the prior_installation_required attribute resulted in package_numpy_1_7_0170 being installed first.
         In the previous step, package_matplotlib_1_2_0170 was selected for installation, but package_numpy_1_7_0170 had the
         prior_installation_required attribute set. Confirm that this resulted in package_numpy_1_7_0170 being installed before

--- a/lib/tool_shed/test/functional/test_1410_update_manager.py
+++ b/lib/tool_shed/test/functional/test_1410_update_manager.py
@@ -24,8 +24,8 @@ class TestUpdateManager(ShedTwillTestCase):
     '''Test the Galaxy update manager.'''
 
     def test_0000_initiate_users(self):
-        """Create necessary user accounts and login as an admin user."""
-        """
+        """Create necessary user accounts and login as an admin user.
+
         Create all the user accounts that are needed for this test script to run independently of other tests.
         Previously created accounts will not be re-created.
         """
@@ -43,8 +43,8 @@ class TestUpdateManager(ShedTwillTestCase):
         self.test_db_util.get_galaxy_private_role(galaxy_admin_user)
 
     def test_0005_create_filtering_repository(self):
-        '''Create and populate the filtering_1410 repository.'''
-        '''
+        '''Create and populate the filtering_1410 repository.
+
         We are at step 1 - Create and populate the filtering_1410 repository.
         Create filtering_1410 and upload the tool tarball to it.
         '''
@@ -67,8 +67,8 @@ class TestUpdateManager(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_install_filtering_repository(self):
-        '''Install the filtering_1410 repository.'''
-        '''
+        '''Install the filtering_1410 repository.
+
         We are at step 2 - Install filtering_1410 to Galaxy.
         Install the filtering repository to Galaxy.
         '''
@@ -89,8 +89,8 @@ class TestUpdateManager(ShedTwillTestCase):
         self.verify_tool_metadata_for_installed_repository(installed_repository)
 
     def test_0015_upload_readme_file(self):
-        '''Upload readme.txt to filtering_1410.'''
-        '''
+        '''Upload readme.txt to filtering_1410.
+
         We are at step 3 - Upload a readme file.
         Upload readme.txt. This will have the effect of making the installed changeset revision not be the most recent downloadable revision,
         but without generating a second downloadable revision. Then sleep for 3 seconds to make sure the update manager picks up the new
@@ -109,8 +109,8 @@ class TestUpdateManager(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_check_for_displayed_update(self):
-        '''Browse installed repositories and verify update.'''
-        '''
+        '''Browse installed repositories and verify update.
+
         We are at step 4 - Verify that the browse page now shows an update available.
         The browse page should now show filtering_1410 as installed, but with a yellow box indicating that there is an update available.
         '''

--- a/lib/tool_shed/test/functional/test_1420_tool_dependency_environment_inheritance.py
+++ b/lib/tool_shed/test/functional/test_1420_tool_dependency_environment_inheritance.py
@@ -72,8 +72,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
         self.test_db_util.get_private_role(test_user_1)
 
     def test_0005_create_lapack_repository(self):
-        '''Create and populate package_lapack_3_4_1420.'''
-        '''
+        '''Create and populate package_lapack_3_4_1420.
+
         This is step 1 - Create repository package_lapack_3_4_1420.
 
         All tool dependency definitions should download and extract a tarball containing precompiled binaries from the local
@@ -106,8 +106,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_atlas_repository(self):
-        '''Create and populate package_atlas_3_10_1420.'''
-        '''
+        '''Create and populate package_atlas_3_10_1420.
+
         This is step 1 - Create repository package_atlas_3_10_1420.
 
         All tool dependency definitions should download and extract a tarball containing precompiled binaries from the local
@@ -140,8 +140,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_bzlib_repository(self):
-        '''Create and populate package_bzlib_1_0_1420.'''
-        '''
+        '''Create and populate package_bzlib_1_0_1420.
+
         This is step 1 - Create repository package_bzlib_1_0_1420.
 
         All tool dependency definitions should download and extract a tarball containing precompiled binaries from the local
@@ -174,8 +174,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_create_boost_repository(self):
-        '''Create and populate package_boost_1_53_1420.'''
-        '''
+        '''Create and populate package_boost_1_53_1420.
+
         This is step 1 - Create repository package_boost_1_53_1420.
 
         All tool dependency definitions should download and extract a tarball containing precompiled binaries from the local
@@ -208,8 +208,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0025_create_numpy_repository(self):
-        '''Create and populate package_numpy_1_7_1420.'''
-        '''
+        '''Create and populate package_numpy_1_7_1420.
+
         This is step 1 - Create repository package_numpy_1_7_1420.
 
         All tool dependency definitions should download and extract a tarball containing precompiled binaries from the local
@@ -242,8 +242,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0030_create_rdkit_repository(self):
-        '''Create and populate package_rdkit_2012_12_1420.'''
-        '''
+        '''Create and populate package_rdkit_2012_12_1420.
+
         This is step 1 - Create repository package_rdkit_2012_12_1420.
 
         All tool dependency definitions should download and extract a tarball containing precompiled binaries from the local
@@ -276,8 +276,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0035_install_rdkit_2012_12_repository(self):
-        '''Install the package_rdkit_2012_12_1420 repository into Galaxy.'''
-        '''
+        '''Install the package_rdkit_2012_12_1420 repository into Galaxy.
+
         This is step 4 - Install package_rdkit_2012_12_1420 into Galaxy.
 
         Install package_rdkit_2012_12_1420 with tool dependencies selected to be installed. The result of this should be
@@ -295,8 +295,8 @@ class TestEnvironmentInheritance(ShedTwillTestCase):
                                 post_submit_strings_displayed=post_submit_strings_displayed)
 
     def test_0040_verify_env_sh_contents(self):
-        '''Check the env.sh file for the appropriate contents.'''
-        '''
+        '''Check the env.sh file for the appropriate contents.
+
         This is step 5 - Verify that the env.sh file for package_rdkit_2012_12_1420 also defines the variables inherited from package_numpy_1_7_1420
         and package_boost_1_53_1420. Test for the numpy and boost tool dependency paths.
         '''

--- a/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
+++ b/lib/tool_shed/test/functional/test_1430_repair_installed_repository.py
@@ -51,8 +51,8 @@ class TestRepairRepository(ShedTwillTestCase):
         self.test_db_util.get_private_role(test_user_1)
 
     def test_0005_create_filter_repository(self):
-        '''Create and populate the filter_1430 repository.'''
-        '''
+        '''Create and populate the filter_1430 repository.
+
         This is step 1 - Create and populate the filter_1430 repository.
 
         This repository will be depended on by the column_1430 repository.
@@ -75,8 +75,8 @@ class TestRepairRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_column_repository(self):
-        '''Create and populate the column_1430 repository.'''
-        '''
+        '''Create and populate the column_1430 repository.
+
         This is step 2 - Create and populate the column_1430 repository.
 
         This repository will depend on the filter_1430 repository.
@@ -99,8 +99,8 @@ class TestRepairRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_create_repository_dependency(self):
-        '''Create a dependency on filter_1430.'''
-        '''
+        '''Create a dependency on filter_1430.
+
         This is step 3 - Upload a repository_dependencies.xml file to the column_1430 repository that creates a repository
         dependency on the filter_1430 repository.
         '''
@@ -115,8 +115,8 @@ class TestRepairRepository(ShedTwillTestCase):
         self.create_repository_dependency(column_repository, [repository_dependency_tuple], filepath=filepath)
 
     def test_0020_install_column_repository(self):
-        '''Install the column_1430 repository into Galaxy.'''
-        '''
+        '''Install the column_1430 repository into Galaxy.
+
         This is step 1 (galaxy side) - Install the column_1430 repository, making sure to check the checkbox to
         handle repository dependencies so that the filter_1430 repository is also installed. Make sure to install
         the repositories in a specified section of the tool panel.
@@ -132,8 +132,8 @@ class TestRepairRepository(ShedTwillTestCase):
                                 install_repository_dependencies=True)
 
     def test_0025_uninstall_filter_repository(self):
-        '''Uninstall the filter_1430 repository from Galaxy.'''
-        '''
+        '''Uninstall the filter_1430 repository from Galaxy.
+
         This is step 2 - Uninstall the filter_1430 repository.
         '''
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner('filter_1430', common.test_user_1_name)

--- a/lib/tool_shed/test/functional/test_1440_missing_env_sh_files.py
+++ b/lib/tool_shed/test/functional/test_1440_missing_env_sh_files.py
@@ -45,8 +45,8 @@ class TestMissingEnvSh(ShedTwillTestCase):
         self.test_db_util.get_private_role(test_user_1)
 
     def test_0005_create_package_repository(self):
-        '''Create and populate package_env_sh_1_0_1440.'''
-        '''
+        '''Create and populate package_env_sh_1_0_1440.
+
         This is step 1 - Create repository package_env_sh_1_0_1440.
 
         Create and populate a repository that is designed to fail a tool dependency installation. This tool dependency should
@@ -71,8 +71,8 @@ class TestMissingEnvSh(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_create_filter_repository(self):
-        '''Create and populate filter_1440.'''
-        '''
+        '''Create and populate filter_1440.
+
         This is step 2 - Create a repository that defines a complex repository dependency on the repository created in
         step 1, with prior_install_required and set_environment_for_install.
         '''
@@ -104,8 +104,8 @@ class TestMissingEnvSh(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0015_install_filter_repository(self):
-        '''Install the filter_1440 repository to galaxy.'''
-        '''
+        '''Install the filter_1440 repository to galaxy.
+
         This is step 3 - Attempt to install the second repository into a galaxy instance, verify that it is installed but
         missing tool dependencies.
         '''

--- a/lib/tool_shed/test/functional/test_1450_installing_datatypes_sniffers.py
+++ b/lib/tool_shed/test/functional/test_1450_installing_datatypes_sniffers.py
@@ -64,8 +64,8 @@ class TestInstallDatatypesSniffers(ShedTwillTestCase):
         repository_datatypes_count = self.get_repository_datatypes_count(repository)
 
     def test_0010_install_datatypes_repository(self):
-        '''Install the proteomics_datatypes_1450 repository into the Galaxy instance.'''
-        '''
+        '''Install the proteomics_datatypes_1450 repository into the Galaxy instance.
+
         This includes steps 1 and 2 - Get a count of datatypes and sniffers.
         Store a count of the current datatypes registry and sniffers in global variables, to compare with the updated count
         after changing the installation status of the proteomics_datatypes_1450 repository.
@@ -88,8 +88,8 @@ class TestInstallDatatypesSniffers(ShedTwillTestCase):
         self.display_galaxy_browse_repositories_page(strings_displayed=strings_displayed)
 
     def test_0015_verify_datatypes_count(self):
-        '''Verify that datatypes were added in the previous step.'''
-        '''
+        '''Verify that datatypes were added in the previous step.
+
         This is step 3 - Verify the count of datatypes and sniffers is the previous count + the datatypes
                          contained within proteomics_datatypes_1450.
         Compare the current datatypes registry and sniffers with the values that were retrieved in the previous step.
@@ -103,8 +103,8 @@ class TestInstallDatatypesSniffers(ShedTwillTestCase):
             (current_sniffers, base_sniffers_count)
 
     def test_0020_deactivate_datatypes_repository(self):
-        '''Deactivate the installed proteomics_datatypes_1450 repository.'''
-        '''
+        '''Deactivate the installed proteomics_datatypes_1450 repository.
+
         This is step 4 - Deactivate proteomics_datatypes_1450, verify the count of datatypes and sniffers is equal to
                          the count determined in step 1.
         Deactivate proteomics_datatypes_1450 and check that the in-memory datatypes and sniffers match the base values
@@ -122,8 +122,8 @@ class TestInstallDatatypesSniffers(ShedTwillTestCase):
             (current_sniffers, base_sniffers_count)
 
     def test_0025_reactivate_datatypes_repository(self):
-        '''Reactivate the deactivated proteomics_datatypes_1450 repository.'''
-        '''
+        '''Reactivate the deactivated proteomics_datatypes_1450 repository.
+
         This is step 5 - Reactivate proteomics_datatypes, verify that the count of datatypes and sniffers has been
                          increased by the contents of the repository.
         '''
@@ -141,8 +141,8 @@ class TestInstallDatatypesSniffers(ShedTwillTestCase):
             (current_sniffers, base_sniffers_count)
 
     def test_0030_uninstall_datatypes_repository(self):
-        '''Uninstall the installed proteomics_datatypes_1450 repository.'''
-        '''
+        '''Uninstall the installed proteomics_datatypes_1450 repository.
+
         This is step 6 - Uninstall proteomics_datatypes_1450, verify the count of datatypes and sniffers is equal
                          to the count determined in step 1.
         Uninstall proteomics_datatypes_1450 and check that the in-memory datatypes and sniffers match the base values
@@ -159,8 +159,8 @@ class TestInstallDatatypesSniffers(ShedTwillTestCase):
             (current_sniffers, base_sniffers_count)
 
     def test_0035_reinstall_datatypes_repository(self):
-        '''Reinstall the uninstalled proteomics_datatypes_1450 repository.'''
-        '''
+        '''Reinstall the uninstalled proteomics_datatypes_1450 repository.
+
         This is step 7 - Reinstall proteomics_datatypes_1450, verify that the count of datatypes and sniffers has been
                          increased by the contents of the repository.
         '''

--- a/lib/tool_shed/test/functional/test_1460_data_managers.py
+++ b/lib/tool_shed/test/functional/test_1460_data_managers.py
@@ -44,8 +44,8 @@ class TestDataManagers(ShedTwillTestCase):
         self.test_db_util.get_private_role(test_user_1)
 
     def test_0010_create_data_manager_repository(self):
-        '''Create and populate data_manager_1460.'''
-        '''
+        '''Create and populate data_manager_1460.
+
         This is step 1 - Create repository data_manager_1460.
 
         Create and populate a repository that contains a Data manager.
@@ -69,8 +69,8 @@ class TestDataManagers(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_install_data_manager_repository(self):
-        '''Install the data_manager_1460 repository to galaxy.'''
-        '''
+        '''Install the data_manager_1460 repository to galaxy.
+
         This is step 3 - Attempt to install the repository into a galaxy instance, verify that it is installed.
         '''
         self.galaxy_login(email=common.admin_email, username=common.admin_username)

--- a/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
+++ b/lib/tool_shed/test/functional/test_1470_updating_installed_repositories.py
@@ -56,8 +56,8 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0010_install_filtering_to_galaxy(self):
-        '''Install the filtering_1470 repository to galaxy.'''
-        '''
+        '''Install the filtering_1470 repository to galaxy.
+
         This is step 1 - Install a repository into Galaxy.
         '''
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
@@ -78,8 +78,8 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
                                                       strings_displayed=strings_displayed)
 
     def test_0015_update_repository(self):
-        '''Upload a readme file to the filtering_1470 repository.'''
-        '''
+        '''Upload a readme file to the filtering_1470 repository.
+
         This is step 2 - In the Tool Shed, update the repository from Step 1.
 
         Importantly, this update should *not* create a new installable changeset revision, because that would
@@ -98,8 +98,8 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
                          strings_not_displayed=[])
 
     def test_0020_get_repository_updates(self):
-        '''Get updates to the installed repository.'''
-        '''
+        '''Get updates to the installed repository.
+
         This is step 3 - In Galaxy, get updates to the repository.
         '''
         self.galaxy_login(email=common.admin_email, username=common.admin_username)
@@ -108,8 +108,8 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
         self.update_installed_repository(installed_repository)
 
     def test_0025_uninstall_repository(self):
-        '''Uninstall the filtering_1470 repository.'''
-        '''
+        '''Uninstall the filtering_1470 repository.
+
         This is step 4 - In Galaxy, uninstall the repository.
         '''
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(repository_name,
@@ -117,8 +117,8 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
         self.uninstall_repository(installed_repository)
 
     def test_0030_reinstall_repository(self):
-        '''Reinstall the filtering_1470 repository.'''
-        '''
+        '''Reinstall the filtering_1470 repository.
+
         This is step 5 - In Galaxy, reinstall the repository.
         '''
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(repository_name,
@@ -126,8 +126,8 @@ class TestUpdateInstalledRepository(ShedTwillTestCase):
         self.reinstall_repository(installed_repository)
 
     def test_0035_verify_absence_of_ghosts(self):
-        '''Check the count of repositories in the database named filtering_1470 and owned by user1.'''
-        '''
+        '''Check the count of repositories in the database named filtering_1470 and owned by user1.
+
         This is step 6 - Make sure step 5 created no white ghosts.
         '''
         installed_repository = self.test_db_util.get_installed_repository_by_name_owner(repository_name,

--- a/lib/tool_shed/webapp/model/__init__.py
+++ b/lib/tool_shed/webapp/model/__init__.py
@@ -156,7 +156,7 @@ class User(Base, Dictifiable, _HasTable):
         message = validate_password_str(cleartext)
         if message:
             raise Exception(f"Invalid password: {message}")
-        """Set 'self.password' to the digest of 'cleartext'."""
+        # Set 'self.password' to the digest of 'cleartext'.
         self.password = new_secure_hash(text_type=cleartext)
 
 

--- a/scripts/update_shed_config_path.py
+++ b/scripts/update_shed_config_path.py
@@ -37,7 +37,6 @@ def create_database(config_file):
         print('Unable to determine correct database connection.')
         exit(1)
 
-    '''Initialize the database file.'''
     # Initialize the database connection.
     engine = create_engine(database_connection)
     MetaData(bind=engine)

--- a/tools/stats/grouping.py
+++ b/tools/stats/grouping.py
@@ -83,13 +83,11 @@ def main():
         round_val.append(do_round)
         default_val.append(float(default) if default != '' else None)
 
-    """
-    At this point, ops, cols and rounds will look something like this:
-    ops:  ['mean', 'min', 'c']
-    cols: ['1', '3', '4']
-    round_val: ['no', 'yes' 'no']
-    default_val: [0, 1, None]
-    """
+    # At this point, ops, cols and rounds will look something like this:
+    # ops:  ['mean', 'min', 'c']
+    # cols: ['1', '3', '4']
+    # round_val: ['no', 'yes' 'no']
+    # default_val: [0, 1, None]
 
     try:
         group_col = int(sys.argv[3]) - 1


### PR DESCRIPTION
They are expressions that get uselessly evaluated.

These were reported as B018 errors by flake8-bugbear 21.11.28 , but B018 for strings has then been disabled in 21.11.29 since these strings can also be used as inline attribute doc strings or module variable docstrings (not our case though).

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
