### PR TITLE
Merge 21.09 forward + minor fix

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import (
     defer,
     joinedload,
 )
+from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.orm.session import sessionmaker
 from sqlitedict import SqliteDict
 
@@ -287,7 +288,8 @@ class ToolShedRepositoryCache:
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
     def __init__(self, session: sessionmaker):
-        self.session = session()
+        engine = session().bind
+        self.session = scoped_session(sessionmaker(engine))
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []
         # Repositories loaded from database

--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -289,7 +289,7 @@ class ToolShedRepositoryCache:
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
     def __init__(self, session: install_model_scoped_session):
-        engine = session().bind
+        engine = session.get_bind()
         self.session = scoped_session(sessionmaker(engine))
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
         self.local_repositories = []


### PR DESCRIPTION
1. Merge 21.09 into dev
2. Minor fix: retrieve engine from scoped_session via get_bind
For ref: https://docs.sqlalchemy.org/en/14/orm/contextual.html?highlight=scoped_session#sqlalchemy.orm.scoping.scoped_session.get_bind

I wasn't able to find a description of the `bind` attribute in the docs, although it is present in the source code. It is my understanding that it will work in most cases. However, accessing it via `get_bind()` ensures that the correct resolultion order is applied (see method documentation). So, this ensures it will work in all cases.
(the method is on `scoped_session`, not `Session` accessed via `scoped_session()`)

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
