### PR TITLE
Drop stream_template_mako function, replace with fill_template_mako

### DIFF
--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -474,9 +474,9 @@ class Data(metaclass=DataMeta):
             return self._yield_user_file_content(trans, data, data.file_name, headers), headers
         else:
             headers["content-type"] = "text/html"
-            return trans.stream_template_mako("/dataset/large_file.mako",
-                                              truncated_data=open(data.file_name, 'rb').read(max_peek_size),
-                                              data=data), headers
+            return trans.fill_template_mako("/dataset/large_file.mako",
+                                            truncated_data=open(data.file_name, 'rb').read(max_peek_size),
+                                            data=data), headers
 
     def display_as_markdown(self, dataset_instance, markdown_format_helpers):
         """Prepare for embedding dataset into a basic Markdown document.

--- a/lib/galaxy/datatypes/sequence.py
+++ b/lib/galaxy/datatypes/sequence.py
@@ -721,9 +721,9 @@ class BaseFastq(Sequence):
                     mime = "text/plain"
                     self._clean_and_set_mime_type(trans, mime, headers)
                     return fh.read(), headers
-                return trans.stream_template_mako("/dataset/large_file.mako",
-                                                  truncated_data=fh.read(max_peek_size),
-                                                  data=dataset), headers
+                return trans.fill_template_mako("/dataset/large_file.mako",
+                                                truncated_data=fh.read(max_peek_size),
+                                                data=dataset), headers
         else:
             return Sequence.display_data(self, trans, dataset, preview, filename, to_ext, **kwd)
 

--- a/lib/galaxy/datatypes/tabular.py
+++ b/lib/galaxy/datatypes/tabular.py
@@ -103,9 +103,9 @@ class TabularData(data.Text):
                 return open(dataset.file_name, mode='rb'), headers
             else:
                 headers["content-type"] = "text/html"
-                return trans.stream_template_mako("/dataset/large_file.mako",
-                                                  truncated_data=open(dataset.file_name).read(max_peek_size),
-                                                  data=dataset), headers
+                return trans.fill_template_mako("/dataset/large_file.mako",
+                                                truncated_data=open(dataset.file_name).read(max_peek_size),
+                                                data=dataset), headers
         else:
             column_names = 'null'
             if dataset.metadata.column_names:

--- a/lib/galaxy/webapps/base/webapp.py
+++ b/lib/galaxy/webapps/base/webapp.py
@@ -960,24 +960,6 @@ class GalaxyWebTransaction(base.DefaultWebTransaction, context.ProvidesHistoryCo
         data.update(kwargs)
         return template.render(**data)
 
-    def stream_template_mako(self, filename, **kwargs):
-        template = self.webapp.mako_template_lookup.get_template(filename)
-        data = dict(caller=self, t=self, trans=self, h=helpers, util=util, request=self.request, response=self.response, app=self.app)
-        data.update(self.template_context)
-        data.update(kwargs)
-
-        def render(environ, start_response):
-            response_write = start_response(self.response.wsgi_status(), self.response.wsgi_headeritems())
-
-            class StreamBuffer:
-                def write(self, d):
-                    response_write(d.encode('utf-8'))
-            buffer = StreamBuffer()
-            context = mako.runtime.Context(buffer, **data)
-            template.render_context(context)
-            return []
-        return render
-
     def qualified_url_for_path(self, path):
         return url_for(path, qualified=True)
 

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -554,7 +554,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         truncated, dataset_data = self.hda_manager.text_data(dataset, preview=True)
         # Get annotation.
         dataset.annotation = self.get_item_annotation_str(trans.sa_session, trans.user, dataset)
-        return trans.stream_template_mako("/dataset/item_content.mako", item=dataset, item_data=dataset_data, truncated=truncated)
+        return trans.fill_template_mako("/dataset/item_content.mako", item=dataset, item_data=dataset_data, truncated=truncated)
 
     @web.expose
     def annotate_async(self, trans, id, new_annotation=None, **kwargs):

--- a/lib/galaxy/webapps/galaxy/controllers/history.py
+++ b/lib/galaxy/webapps/galaxy/controllers/history.py
@@ -635,7 +635,7 @@ class HistoryController(BaseUIController, SharableMixin, UsesAnnotations, UsesIt
             view='dev-detailed', user=trans.user, trans=trans)
         history_dictionary['annotation'] = self.get_item_annotation_str(trans.sa_session, history.user, history)
 
-        return trans.stream_template_mako("history/display.mako", item=history, item_data=[],
+        return trans.fill_template_mako("history/display.mako", item=history, item_data=[],
             user_is_owner=user_is_owner, history_dict=history_dictionary,
             user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings)
 

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -442,15 +442,15 @@ class VisualizationController(BaseUIController, SharableMixin, UsesVisualization
             # TODO: simplest path from A to B but not optimal - will be difficult to do reg visualizations any other way
             # TODO: this will load the visualization twice (once above, once when the iframe src calls 'saved')
             encoded_visualization_id = trans.security.encode_id(visualization.id)
-            return trans.stream_template_mako('visualization/display_in_frame.mako',
-                                              item=visualization, encoded_visualization_id=encoded_visualization_id,
-                                              user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings,
-                                              content_only=True)
+            return trans.fill_template_mako('visualization/display_in_frame.mako',
+                                            item=visualization, encoded_visualization_id=encoded_visualization_id,
+                                            user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings,
+                                            content_only=True)
 
         visualization_config = self.get_visualization_config(trans, visualization)
-        return trans.stream_template_mako("visualization/display.mako", item=visualization, item_data=visualization_config,
-                                          user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings,
-                                          content_only=True)
+        return trans.fill_template_mako("visualization/display.mako", item=visualization, item_data=visualization_config,
+                                        user_item_rating=user_item_rating, ave_item_rating=ave_item_rating, num_ratings=num_ratings,
+                                        content_only=True)
 
     @web.expose
     @web.json

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -288,7 +288,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         stored.annotation = self.get_item_annotation_str(trans.sa_session, stored.user, stored)
         for step in stored.latest_workflow.steps:
             step.annotation = self.get_item_annotation_str(trans.sa_session, stored.user, step)
-        return trans.stream_template_mako("/workflow/item_content.mako", item=stored, item_data=stored.latest_workflow.steps)
+        return trans.fill_template_mako("/workflow/item_content.mako", item=stored, item_data=stored.latest_workflow.steps)
 
     @web.expose
     @web.require_login("use Galaxy workflows")


### PR DESCRIPTION
Addresses #13016. Performance impact is likely negligible, and we want to remove these templates anyway, so probably not worth migrating `stream_template_mako` to use a `StreamingResponse`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
