### PR TITLE
Show display applications together with visualizations in center panel

### DIFF
--- a/client/src/components/Visualizations/DisplayApplications.test.js
+++ b/client/src/components/Visualizations/DisplayApplications.test.js
@@ -1,0 +1,66 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import DisplayApplications from "./DisplayApplications";
+import MockProvider from "components/providers/MockProvider";
+
+const localVue = getLocalVue();
+
+describe("DisplayApplications", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(DisplayApplications, {
+            propsData: {
+                datasetId: "dataset-id",
+            },
+            stubs: {
+                DatasetProvider: MockProvider({
+                    result: {
+                        display_apps: [
+                            {
+                                label: "app-1",
+                                links: [
+                                    {
+                                        href: "link-href-1",
+                                        text: "link-text-1",
+                                        target: "link-target-1",
+                                    },
+                                ],
+                            },
+                            {
+                                label: "app-2",
+                                links: [
+                                    {
+                                        href: "link-href-2",
+                                        text: "link-text-2",
+                                        target: "link-target-2",
+                                    },
+                                    {
+                                        href: "link-href-3",
+                                        text: "link-text-3",
+                                        target: "link-target-3",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    resultLabel: "item",
+                }),
+            },
+            localVue,
+        });
+    });
+
+    it("check props", async () => {
+        const labels = wrapper.findAll(".font-weight-bold");
+        for (let i = 0; i < 2; i++) {
+            expect(labels.at(i).text()).toBe(`${i + 1}. app-${i + 1}`);
+        }
+        const links = wrapper.findAll("a");
+        for (let i = 0; i < 3; i++) {
+            expect(links.at(i).attributes("href")).toBe(`link-href-${i + 1}`);
+            expect(links.at(i).attributes("target")).toBe(`link-target-${i + 1}`);
+            expect(links.at(i).text()).toBe(`link-text-${i + 1}`);
+        }
+    });
+});

--- a/client/src/components/Visualizations/DisplayApplications.vue
+++ b/client/src/components/Visualizations/DisplayApplications.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <DatasetProvider :id="datasetId" v-slot="{ item: dataset, loading }">
+        <DatasetProvider :id="datasetId" v-slot="{ item: dataset }">
             <b-alert v-if="dataset && dataset.display_apps && dataset.display_apps.length > 0" variant="info" show>
                 You can display your dataset with the following links:
                 <div class="p-2">

--- a/client/src/components/Visualizations/DisplayApplications.vue
+++ b/client/src/components/Visualizations/DisplayApplications.vue
@@ -8,9 +8,7 @@
                         <span class="font-weight-bold">{{ displayKey + 1 }}. {{ displayApp.label }}</span>
                         <span v-for="(link, linkKey) in displayApp.links" :key="linkKey">
                             <span v-if="linkKey == 0">(</span>
-                            <b-link :href="link.href" :target="link.target" variant="primary" size="sm">{{
-                                link.text
-                            }}</b-link>
+                            <b-link :href="link.href" :target="link.target">{{ link.text }}</b-link>
                             <span v-if="linkKey != displayApp.links.length - 1">, </span>
                             <span v-else>)</span>
                         </span>

--- a/client/src/components/Visualizations/DisplayApplications.vue
+++ b/client/src/components/Visualizations/DisplayApplications.vue
@@ -1,14 +1,27 @@
 <template>
     <div>
-        {{ datasetId }}
+        <UrlDataProvider :url="url" v-slot="{ result: dataset, loading }">
+            <div v-if="dataset && dataset.display_apps">
+                {{ dataset.display_apps }}
+            </div>
+        </UrlDataProvider>
     </div>
 </template>
 <script>
+import { UrlDataProvider } from "components/providers/UrlDataProvider";
 export default {
+    components: {
+        UrlDataProvider,
+    },
     props: {
         datasetId: {
             type: String,
             required: true,
+        },
+    },
+    computed: {
+        url() {
+            return `api/datasets/${this.datasetId}`;
         },
     },
 };

--- a/client/src/components/Visualizations/DisplayApplications.vue
+++ b/client/src/components/Visualizations/DisplayApplications.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <UrlDataProvider :url="url" v-slot="{ result: dataset, loading }">
+        <DatasetProvider :id="datasetId" v-slot="{ item: dataset, loading }">
             <b-alert v-if="dataset && dataset.display_apps && dataset.display_apps.length > 0" variant="info" show>
-                You may visualize your dataset using the following external links:
+                You can display your dataset with the following links:
                 <div class="p-2">
                     <div v-for="(displayApp, displayKey) in dataset.display_apps" :key="displayKey">
                         <span class="font-weight-bold">{{ displayKey + 1 }}. {{ displayApp.label }}</span>
@@ -16,26 +16,21 @@
                         </span>
                     </div>
                 </div>
-                <div>or select a local visualization from below.</div>
+                <div>or select a visualization from below.</div>
             </b-alert>
-        </UrlDataProvider>
+        </DatasetProvider>
     </div>
 </template>
 <script>
-import { UrlDataProvider } from "components/providers/UrlDataProvider";
+import { DatasetProvider } from "components/providers";
 export default {
     components: {
-        UrlDataProvider,
+        DatasetProvider,
     },
     props: {
         datasetId: {
             type: String,
             required: true,
-        },
-    },
-    computed: {
-        url() {
-            return `api/datasets/${this.datasetId}`;
         },
     },
 };

--- a/client/src/components/Visualizations/DisplayApplications.vue
+++ b/client/src/components/Visualizations/DisplayApplications.vue
@@ -1,0 +1,15 @@
+<template>
+    <div>
+        {{ datasetId }}
+    </div>
+</template>
+<script>
+export default {
+    props: {
+        datasetId: {
+            type: String,
+            required: true,
+        },
+    },
+};
+</script>

--- a/client/src/components/Visualizations/DisplayApplications.vue
+++ b/client/src/components/Visualizations/DisplayApplications.vue
@@ -1,9 +1,23 @@
 <template>
     <div>
         <UrlDataProvider :url="url" v-slot="{ result: dataset, loading }">
-            <div v-if="dataset && dataset.display_apps">
-                {{ dataset.display_apps }}
-            </div>
+            <b-alert v-if="dataset && dataset.display_apps && dataset.display_apps.length > 0" variant="info" show>
+                You may visualize your dataset using the following external links:
+                <div class="p-2">
+                    <div v-for="(displayApp, displayKey) in dataset.display_apps" :key="displayKey">
+                        <span class="font-weight-bold">{{ displayKey + 1 }}. {{ displayApp.label }}</span>
+                        <span v-for="(link, linkKey) in displayApp.links" :key="linkKey">
+                            <span v-if="linkKey == 0">(</span>
+                            <b-link :href="link.href" :target="link.target" variant="primary" size="sm">{{
+                                link.text
+                            }}</b-link>
+                            <span v-if="linkKey != displayApp.links.length - 1">, </span>
+                            <span v-else>)</span>
+                        </span>
+                    </div>
+                </div>
+                <div>or select a local visualization from below.</div>
+            </b-alert>
         </UrlDataProvider>
     </div>
 </template>

--- a/client/src/components/Visualizations/Index.vue
+++ b/client/src/components/Visualizations/Index.vue
@@ -1,0 +1,20 @@
+<template>
+    <div>
+        <PluginList :dataset-id="datasetId" />
+    </div>
+</template>
+<script>
+import DisplayApplications from "./DisplayApplications";
+import PluginList from "./PluginList";
+export default {
+    components: {
+        PluginList,
+    },
+    props: {
+        datasetId: {
+            type: String,
+            required: true,
+        },
+    },
+};
+</script>

--- a/client/src/components/Visualizations/Index.vue
+++ b/client/src/components/Visualizations/Index.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <DisplayApplications v-if="datasetId" :dataset-id="datasetId" />
         <PluginList :dataset-id="datasetId" />
     </div>
 </template>
@@ -9,6 +10,7 @@ import PluginList from "./PluginList";
 export default {
     components: {
         PluginList,
+        DisplayApplications,
     },
     props: {
         datasetId: {

--- a/client/src/components/Visualizations/Index.vue
+++ b/client/src/components/Visualizations/Index.vue
@@ -15,7 +15,7 @@ export default {
     props: {
         datasetId: {
             type: String,
-            required: true,
+            default: null,
         },
     },
 };

--- a/client/src/components/Visualizations/PluginList.vue
+++ b/client/src/components/Visualizations/PluginList.vue
@@ -67,6 +67,12 @@ import { getGalaxyInstance } from "app";
 import axios from "axios";
 
 export default {
+    props: {
+        datasetId: {
+            type: String,
+            default: null,
+        },
+    },
     data() {
         return {
             plugins: [],
@@ -82,13 +88,11 @@ export default {
         };
     },
     created() {
-        const Galaxy = getGalaxyInstance();
         let url = `${getAppRoot()}api/plugins`;
-        const dataset_id = Galaxy.params.dataset_id;
-        if (dataset_id) {
+        if (this.datasetId) {
             this.fixed = true;
-            this.selected = dataset_id;
-            url += `?dataset_id=${dataset_id}`;
+            this.selected = this.datasetId;
+            url += `?dataset_id=${this.datasetId}`;
         }
         axios
             .get(url)

--- a/client/src/entry/analysis/AnalysisRouter.js
+++ b/client/src/entry/analysis/AnalysisRouter.js
@@ -41,7 +41,7 @@ import RecentInvocations from "components/User/RecentInvocations.vue";
 import ToolsView from "components/ToolsView/ToolsView.vue";
 import ToolsJson from "components/ToolsView/ToolsSchemaJson/ToolsJson.vue";
 import HistoryList from "mvc/history/history-list";
-import PluginList from "components/PluginList.vue";
+import VisualizationsList from "components/Visualizations/Index";
 import QueryStringParsing from "utils/query-string-parsing";
 import DatasetError from "components/DatasetInformation/DatasetError";
 import DatasetAttributes from "components/DatasetInformation/DatasetAttributes";
@@ -75,10 +75,10 @@ export const getAnalysisRouter = (Galaxy) => {
             "(/)pages(/)edit(/)": "show_pages_edit",
             "(/)pages(/)sharing(/)": "show_pages_sharing",
             "(/)pages(/)(:action_id)": "show_pages",
-            "(/)visualizations(/)": "show_plugins",
+            "(/)visualizations(/)": "show_visualizations",
             "(/)visualizations(/)edit(/)": "show_visualizations_edit",
             "(/)visualizations(/)sharing(/)": "show_visualizations_sharing",
-            "(/)visualizations/(:action_id)": "show_visualizations",
+            "(/)visualizations/(:action_id)": "show_visualizations_grid",
             "(/)workflows/import": "show_workflows_import",
             "(/)workflows/trs_import": "show_workflows_trs_import",
             "(/)workflows/trs_search": "show_workflows_trs_search",
@@ -175,7 +175,13 @@ export const getAnalysisRouter = (Galaxy) => {
             this._display_vue_helper(ExternalIdentities);
         },
 
-        show_visualizations: function (action_id) {
+        show_visualizations: function () {
+            this._display_vue_helper(VisualizationsList, {
+                datasetId: QueryStringParsing.get("id"),
+            });
+        },
+
+        show_visualizations_grid: function (action_id) {
             const activeTab = action_id == "list_published" ? "shared" : "user";
             this.page.display(
                 new GridShared.View({
@@ -327,10 +333,6 @@ export const getAnalysisRouter = (Galaxy) => {
                 pluralName: "Pages",
                 modelClass: "Page",
             });
-        },
-
-        show_plugins: function () {
-            this._display_vue_helper(PluginList);
         },
 
         show_workflows: function () {


### PR DESCRIPTION
This PR adds an info alert to the top of the visualization list if a dataset can be visualized with display applications. This can be particularly useful for the new history which does not list display applications when a dataset is expanded. Note: while working on this PR I noticed that the `DatasetProvider` although coupled to the `rxProviders` is not properly updating when the dataset type is manually changed. It currently requires a page refresh, however this issue is unrelated to this PR and should be debugged separately.

<img width="792" alt="image" src="https://user-images.githubusercontent.com/2105447/144431558-8321f0a3-db5e-43e9-bcfc-c7496fcb1df2.png">


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. Select a dataset from the history with a datatype supported by external display applications e.g. bed, bam.
  2. Click on the visualization icon in the expanded dataset view
  3. Notice that the display applications are shown at the top of the center page.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
