### PR TITLE
[21.09] Copy HDCA member items to new history when copying history

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2410,6 +2410,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, RepresentByI
         self.user = user
         # Objects to eventually add to history
         self._pending_additions = []
+        self._item_by_hid_cache = None
 
     @reconstructor
     def init_on_load(self):
@@ -2566,7 +2567,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, RepresentByI
         else:
             hdcas = self.active_dataset_collections
         for hdca in hdcas:
-            new_hdca = hdca.copy(flush=False, element_destination=new_history)
+            new_hdca = hdca.copy(flush=False, element_destination=new_history, set_hid=False)
             new_history.add_dataset_collection(new_hdca, set_hid=False)
             db_session.add(new_hdca)
 
@@ -2578,6 +2579,11 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, RepresentByI
         db_session.flush()
 
         return new_history
+
+    def get_dataset_by_hid(self, hid):
+        if self._item_by_hid_cache is None:
+            self._item_by_hid_cache = {dataset.hid: dataset for dataset in self.datasets}
+        return self._item_by_hid_cache.get(hid)
 
     @property
     def has_possible_members(self):
@@ -5702,7 +5708,7 @@ class HistoryDatasetCollectionAssociation(
                 break
         return matching_collection
 
-    def copy(self, element_destination=None, dataset_instance_attributes=None, flush=True):
+    def copy(self, element_destination=None, dataset_instance_attributes=None, flush=True, set_hid=True):
         """
         Create a copy of this history dataset collection association. Copy
         underlying collection.
@@ -5729,7 +5735,7 @@ class HistoryDatasetCollectionAssociation(
         hdca.collection = collection_copy
         object_session(self).add(hdca)
         hdca.copy_tags_from(self.history.user, self)
-        if element_destination:
+        if element_destination and set_hid:
             element_destination.stage_addition(hdca)
             element_destination.add_pending_items()
         if flush:
@@ -5937,18 +5943,22 @@ class DatasetCollectionElement(Base, Dictifiable, RepresentById):
                     flush=flush
                 )
             else:
-                new_element_object = element_object.copy(flush=flush, copy_tags=element_object.tags)
-                for attribute, value in dataset_instance_attributes.items():
-                    setattr(new_element_object, attribute, value)
+                new_element_object = element_destination.get_dataset_by_hid(element_object.hid)
+                if new_element_object and new_element_object.dataset and new_element_object.dataset.id == element_object.dataset_id:
+                    element_object = new_element_object
+                else:
+                    new_element_object = element_object.copy(flush=flush, copy_tags=element_object.tags)
+                    for attribute, value in dataset_instance_attributes.items():
+                        setattr(new_element_object, attribute, value)
 
-                new_element_object.visible = False
-                if destination is not None and element_object.hidden_beneath_collection_instance:
-                    new_element_object.hidden_beneath_collection_instance = destination
-                # Ideally we would not need to give the following
-                # element an HID and it would exist in the history only
-                # as an element of the containing collection.
-                element_destination.stage_addition(new_element_object)
-                element_object = new_element_object
+                    new_element_object.visible = False
+                    if destination is not None and element_object.hidden_beneath_collection_instance:
+                        new_element_object.hidden_beneath_collection_instance = destination
+                    # Ideally we would not need to give the following
+                    # element an HID and it would exist in the history only
+                    # as an element of the containing collection.
+                    element_destination.stage_addition(new_element_object)
+                    element_object = new_element_object
 
         new_element = DatasetCollectionElement(
             element=element_object,

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -2566,7 +2566,7 @@ class History(Base, HasTags, Dictifiable, UsesAnnotations, HasName, RepresentByI
         else:
             hdcas = self.active_dataset_collections
         for hdca in hdcas:
-            new_hdca = hdca.copy(flush=False)
+            new_hdca = hdca.copy(flush=False, element_destination=new_history)
             new_history.add_dataset_collection(new_hdca, set_hid=False)
             db_session.add(new_hdca)
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -230,9 +230,7 @@ class HistoriesApiTestCase(ApiTestCase, BaseHistories):
         assert source_hda['name'] == copied_hda['name'] == 'data0'
         assert source_hda['id'] != copied_hda['id']
         assert source_hda['history_id'] != copied_hda['history_id']
-        # FIXME: history copy doesn't necessarily maintain the same hid order,
-        # since it first copies the relevant datasets and then the collections.
-        # assert source_hda['hid'] == copied_hda['hid'] == 2
+        assert source_hda['hid'] == copied_hda['hid'] == 2
 
 
 class ImportExportHistoryTestCase(ApiTestCase, BaseHistories):

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -412,6 +412,9 @@ class BaseDatasetPopulator(BasePopulator):
         history_id = create_history_response.json()["id"]
         return history_id
 
+    def copy_history(self, history_id, name="API Test Copied History", **kwds) -> Response:
+        return self._post("histories", data={"name": name, "history_id": history_id, **kwds})
+
     def upload_payload(self, history_id: str, content: str = None, **kwds) -> dict:
         name = kwds.get("name", "Test_Dataset")
         dbkey = kwds.get("dbkey", "?")


### PR DESCRIPTION
When copying histories with HDCAs we were only making copies of the `DatasetCollectionElement`s , but we were not copying the HDAs, which meant that HDCAs would still reference the original HDA, which is a problem if they are deleted in the copy.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
