### PR TITLE
Trigger visualization update on chart initialization

### DIFF
--- a/client/src/mvc/visualization/chart/views/groups.js
+++ b/client/src/mvc/visualization/chart/views/groups.js
@@ -70,19 +70,27 @@ var GroupView = Backbone.View.extend({
                             value: data_columns,
                         });
                         self.chart.state("ok", "Metadata initialized...");
+                        const params = {};
+                        visitInputs(inputs, (input, name) => {
+                            params[name] = input.value;
+                        });
+                        self.redraw(params);
                         const instance = appendVueComponent(self.$el, FormDisplay, {
                             inputs: inputs,
                         });
                         instance.$on("onChange", (data) => {
-                            self.group.set(data);
-                            self.chart.set("modified", true);
-                            self.chart.trigger("redraw");
+                            self.redraw(data);
                         });
                         process.resolve();
                     },
                 });
             });
         }
+    },
+    redraw(data) {
+        this.group.set(data);
+        this.chart.set("modified", true);
+        this.chart.trigger("redraw");
     },
 });
 


### PR DESCRIPTION
Fix for a recent change in how form components are initialized. Since the FormDisplay component is mounted in the backbone-based charts groups element without listeners, this PR collects the initial form data and triggers a chart redraw. This won't be necessary in the future when the charts wrapper is vueified.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Create a bar diagram using a tabular file
  2. Notice how the initial plot is not drawn

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
