### PR TITLE
[21.05] Increase pip minimum version in startup script

### DIFF
--- a/scripts/common_startup.sh
+++ b/scripts/common_startup.sh
@@ -115,7 +115,7 @@ if [ $SET_VENV -eq 1 ] && [ $CREATE_VENV -eq 1 ]; then
                     echo "Creating Conda environment for Galaxy: $GALAXY_CONDA_ENV"
                     echo "To avoid this, use the --no-create-venv flag or set \$GALAXY_CONDA_ENV to an"
                     echo "existing environment before starting Galaxy."
-                    $CONDA_EXE create --yes --override-channels --channel conda-forge --channel defaults --name "$GALAXY_CONDA_ENV" 'python=3.6' 'pip>=9' 'virtualenv>=16'
+                    $CONDA_EXE create --yes --override-channels --channel conda-forge --channel defaults --name "$GALAXY_CONDA_ENV" 'python=3.6' 'pip>=19.0' 'virtualenv>=16'
                     unset __CONDA_INFO
                 fi
                 conda_activate
@@ -181,7 +181,7 @@ fi
 : ${PYPI_INDEX_URL:="https://pypi.python.org/simple"}
 : ${GALAXY_DEV_REQUIREMENTS:="./lib/galaxy/dependencies/dev-requirements.txt"}
 if [ $REPLACE_PIP -eq 1 ]; then
-    python -m pip install 'pip>=8.1'
+    python -m pip install 'pip>=19.0'
 fi
 
 requirement_args="-r requirements.txt"

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -113,7 +113,7 @@ setup_python() {
         set_conda_exe
         if [ -n "$CONDA_EXE" ] && \
                 check_conda_env ${GALAXY_CONDA_ENV:="_galaxy_"}; then
-            # You almost surely have pip >= 8.1 and running `conda install ... pip>=8.1` every time is slow
+            # You almost surely have the required minimum pip version and running `conda install ... pip>=<min_ver>` every time is slow
             REPLACE_PIP=0
             [ -n "$PYTHONPATH" ] && { echo 'Unsetting $PYTHONPATH'; unset PYTHONPATH; }
             if [ "$CONDA_DEFAULT_ENV" != "$GALAXY_CONDA_ENV" ]; then


### PR DESCRIPTION
Pip <19.0 cannot install abi3 wheels, so for example on Python >3.6 it would (try to) build a cryptography wheel, which is not needed since cp36-abi3 wheels are already available on PyPI: https://cryptography.io/en/latest/faq/#why-are-there-no-wheels-for-my-python3-x-version

Fix https://github.com/galaxyproject/galaxy/issues/13023 .

xref: https://github.com/galaxyproject/planemo/issues/1208#issuecomment-984831111

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
