### PR TITLE
Explicit singularity cache

### DIFF
--- a/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
+++ b/lib/galaxy/config/sample/container_resolvers_conf.xml.sample
@@ -7,6 +7,10 @@
   <!-- explicit: resolves container URI for a job through explict container
        tags in the tool XML wrapper. -->
        
+  <cached_explicit_singularity />
+  <!-- cached_explicit_singularity: stores an explicit container on the
+       filesystem and use the stored image to run the jobs.  -->
+
   <!-- All mulled flavors below work by default unless enable_mulled_containers is
        set to false in the galaxy.yaml config file. -->
 

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -402,8 +402,8 @@ class SingularityContainer(Container, HasDockerLikeVolumes):
 
     def build_singularity_pull_command(self, cache_path):
         return singularity_util.pull_singularity_command(
-            image_identifier = self.container_id,
-            cache_path = cache_path,
+            image_identifier=self.container_id,
+            cache_path=cache_path,
             **self.get_singularity_target_kwds()
         )
 

--- a/lib/galaxy/tool_util/deps/container_classes.py
+++ b/lib/galaxy/tool_util/deps/container_classes.py
@@ -400,6 +400,13 @@ class SingularityContainer(Container, HasDockerLikeVolumes):
             **self.get_singularity_target_kwds()
         )
 
+    def build_singularity_pull_command(self, cache_path):
+        return singularity_util.pull_singularity_command(
+            image_identifier = self.container_id,
+            cache_path = cache_path,
+            **self.get_singularity_target_kwds()
+        )
+
     def containerize_command(self, command):
 
         env = []

--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -2,16 +2,11 @@
 import logging
 import os
 
-from ..container_resolvers import ContainerResolver
-from ..container_classes import SingularityContainer
-
-from .mulled import CliContainerResolver
-
-from ..singularity_util import pull_singularity_command
-
-from ..requirements import ContainerDescription
-
 from galaxy.util.commands import shell
+from .mulled import CliContainerResolver
+from ..container_classes import SingularityContainer
+from ..container_resolvers import ContainerResolver
+from ..requirements import ContainerDescription
 
 log = logging.getLogger(__name__)
 

--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -69,7 +69,7 @@ class CachedExplicitSingularityContainerResolver(CliContainerResolver):
     def _init_cache_directory(self):
         os.makedirs(self.cache_directory_path, exist_ok=True)
 
-    def resolve(self, enabled_container_types, tool_info, **kwds):
+    def resolve(self, enabled_container_types, tool_info, install=False, **kwds):
         """Find a container explicitly mentioned in tool description.
 
         This ignores the tool requirements and assumes the tool author crafted
@@ -88,7 +88,7 @@ class CachedExplicitSingularityContainerResolver(CliContainerResolver):
                 return container_description
             image_id = container_description.identifier
             cache_path = os.path.normpath(os.path.join(self.cache_directory_path, image_id))
-            if not os.path.exists(cache_path):
+            if install and not os.path.exists(cache_path):
                 destination_info = {}
                 destination_for_container_type = kwds.get(
                     'destination_for_container_type')

--- a/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
+++ b/lib/galaxy/tool_util/deps/container_resolvers/explicit.py
@@ -1,10 +1,17 @@
 """This module describes the :class:`ExplicitContainerResolver` ContainerResolver plugin."""
 import logging
+import os
 
-from ..container_resolvers import (
-    ContainerResolver,
-)
+from ..container_resolvers import ContainerResolver
+from ..container_classes import SingularityContainer
+
+from .mulled import CliContainerResolver
+
+from ..singularity_util import pull_singularity_command
+
 from ..requirements import ContainerDescription
+
+from galaxy.util.commands import shell
 
 log = logging.getLogger(__name__)
 
@@ -52,6 +59,64 @@ class ExplicitSingularityContainerResolver(ExplicitContainerResolver):
                 return container_description
 
         return None
+
+
+class CachedExplicitSingularityContainerResolver(CliContainerResolver):
+    resolver_type = 'cached_explicit_singularity'
+    container_type = 'singularity'
+    cli = 'singularity'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cache_directory_path = kwargs.get("cache_directory", os.path.join(kwargs['app_info'].container_image_cache_path, "singularity", "explicit"))
+        self._init_cache_directory()
+
+    def _init_cache_directory(self):
+        os.makedirs(self.cache_directory_path, exist_ok=True)
+
+    def resolve(self, enabled_container_types, tool_info, **kwds):
+        """Find a container explicitly mentioned in tool description.
+
+        This ignores the tool requirements and assumes the tool author crafted
+        a correct container. We use singularity here to fetch docker containers,
+        hence the container_description hack here.
+        """
+        for container_description in tool_info.container_descriptions:  # type: ContainerDescription
+            if container_description.type == 'docker':
+                desc_dict = container_description.to_dict()
+                desc_dict['type'] = self.container_type
+                desc_dict['identifier'] = f"docker://{container_description.identifier}"
+                container_description = container_description.from_dict(desc_dict)
+            if not self._container_type_enabled(container_description, enabled_container_types):
+                return None
+            if not self.cli_available:
+                return container_description
+            image_id = container_description.identifier
+            cache_path = os.path.normpath(os.path.join(self.cache_directory_path, image_id))
+            if not os.path.exists(cache_path):
+                destination_info = {}
+                destination_for_container_type = kwds.get(
+                    'destination_for_container_type')
+                if destination_for_container_type:
+                    destination_info = destination_for_container_type(
+                        self.container_type)
+                container = SingularityContainer(
+                    container_description.identifier,
+                    self.app_info,
+                    tool_info,
+                    destination_info,
+                    {},
+                    container_description)
+                command = container.build_singularity_pull_command(cache_path=cache_path)
+                shell(command)
+            # Point to container in the cache in stead.
+            container_description.identifier = cache_path
+            return container_description
+        else:  # No container descriptions found
+            return None
+
+    def __str__(self):
+        return f"CachedExplicitSingularityContainerResolver[cache_directory={self.cache_directory_path}]"
 
 
 class BaseAdminConfiguredContainerResolver(ContainerResolver):
@@ -162,6 +227,7 @@ class MappingContainerResolver(BaseAdminConfiguredContainerResolver):
 __all__ = (
     "ExplicitContainerResolver",
     "ExplicitSingularityContainerResolver",
+    "CachedExplicitSingularityContainerResolver",
     "FallbackContainerResolver",
     "FallbackSingularityContainerResolver",
     "FallbackNoRequirementsContainerResolver",

--- a/lib/galaxy/tool_util/deps/singularity_util.py
+++ b/lib/galaxy/tool_util/deps/singularity_util.py
@@ -29,6 +29,19 @@ def pull_mulled_singularity_command(docker_image_identifier,
     return command_parts
 
 
+def pull_singularity_command(image_identifier: str,
+                             cache_path: str,
+                             singularity_cmd: str = DEFAULT_SINGULARITY_COMMAND,
+                             sudo: bool = DEFAULT_SUDO,
+                             sudo_cmd: str = DEFAULT_SUDO_COMMAND):
+    # Make sure cache dir exists
+    dirname = os.path.dirname(os.path.normpath(cache_path))
+    os.makedirs(dirname, exist_ok=True)
+    command_parts = _singularity_prefix(singularity_cmd, sudo, sudo_cmd)
+    command_parts.extend(["build", cache_path, image_identifier])
+    return command_parts
+
+
 def build_singularity_run_command(
     container_command,
     image,
@@ -84,4 +97,5 @@ def _singularity_prefix(
     return command_parts
 
 
-__all__ = ("build_singularity_run_command", "pull_mulled_singularity_command")
+__all__ = ("build_singularity_run_command", "pull_mulled_singularity_command",
+           "pull_singularity_command")


### PR DESCRIPTION
Fixes #13031 

When running singularity on a cluster (most common use case for singularity?) when having an explicit container, the container is pulled on each run by default. (As there is no shared cache). This punishes quay.io way too much. This is a shared resource and hundreds or thousands of pulls may occur when an explicit container is hosted there.

By setting a cache, the pull only happens once per image per galaxy instance. Much better!

I accomplished this by copying some of the code from the mulled container resolvers. For some reason a SingularityContainer instance is instantiated to call its method to get a command back to build the container. Very convoluted and ugly, but I get this is because we need to get the `singularity_cmd` from the destination. I do not like this, but copy pasting was the fastest way to get this working.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Enable cached_explicit_singularity resolver in containers_resolvers conf.
  2. Check if a job with an explicit container runs correctly.

I have done the manual testing myself already. If automated testing is desired I can add this as well.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
