### PR TITLE
Fix running test/integration/test_remote_files.py directly.

### DIFF
--- a/test/functional/tools/export_remote.py
+++ b/test/functional/tools/export_remote.py
@@ -1,0 +1,1 @@
+../../../lib/galaxy/tools/bundled/data_export/export_remote.py

--- a/test/functional/tools/export_remote.xml
+++ b/test/functional/tools/export_remote.xml
@@ -1,0 +1,1 @@
+../../../lib/galaxy/tools/bundled/data_export/export_remote.xml

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <toolbox tool_path="${tool_conf_dir}" is_shed_conf="false">
   <tool file="upload.xml"/>
+  <tool file="export_remote.xml"/>
   <section id="test" name="Test Section">
     <tool file="multi_data_optional.xml" />
     <tool file="paths_as_file.xml" />


### PR DESCRIPTION
Noticed the tool was removed in https://github.com/galaxyproject/galaxy/pull/13035/files#diff-a4c6a629466aed28ef86982600acabb5642b9c7247318530cea6fd2cc2baabb5L4 but I guess it was broken because these symlinks were missing.

## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Try running ``pytest test/integration/test_remote_files.py::RemoteFilesIntegrationTestCase::test_export_remote_tool_default`` without these changes and notice the failure.
  2. Try running again after the changes and it should pass.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
