### PR TITLE
Allow param_value filter to refer to parameters with multiple values

### DIFF
--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -276,14 +276,12 @@ class ParamValueFilter(Filter):
             if not hasattr(ref, ref_attribute):
                 return []  # ref does not have attribute, so we cannot filter, return empty list
             ref = getattr(ref, ref_attribute)
-        log.error(f"ParamValue ref {ref}")
         if ref is None:
             ref = []
         elif isinstance(ref, list):
             ref = [str(_) for _ in ref]
         else:
             ref = [str(ref)]
-        log.error(f"ParamValue ref {ref}")
         rval = []
         for fields in options:
             if self.keep == (fields[self.column] in ref):
@@ -674,10 +672,10 @@ class DynamicOptions:
             try:
                 datasets = _get_ref_data(other_values, self.dataset_ref_name)
             except KeyError:  # no such dataset
-                log.warning(f"{self.tool_param.name} could not create dynamic options from_dataset: {self.dataset_ref_name} unknown")
+                log.warning(f"Parameter {self.tool_param.name}: could not create dynamic options from_dataset: {self.dataset_ref_name} unknown")
                 return []
             except ValueError:  # not a valid dataset
-                log.warning(f"{self.tool_param.name} could not create dynamic options from_dataset: {self.dataset_ref_name} not a data or collection parameter")
+                log.warning(f"Parameter {self.tool_param.name}: could not create dynamic options from_dataset: {self.dataset_ref_name} not a data or collection parameter")
                 return []
 
             options = []

--- a/lib/galaxy/tools/parameters/dynamic_options.py
+++ b/lib/galaxy/tools/parameters/dynamic_options.py
@@ -157,6 +157,7 @@ class DataMetaFilter(Filter):
             self.column = d_option.column_spec_to_index(self.column)
         self.multiple = string_as_bool(elem.get("multiple", "False"))
         self.separator = elem.get("separator", ",")
+        log.error(f"data_meta.init: ref_name {self.ref_name} key {self.key} column {self.column} multiple {self.multiple} separator {self.separator}")
 
     def get_dependency_name(self):
         return self.ref_name
@@ -275,10 +276,17 @@ class ParamValueFilter(Filter):
             if not hasattr(ref, ref_attribute):
                 return []  # ref does not have attribute, so we cannot filter, return empty list
             ref = getattr(ref, ref_attribute)
-        ref = str(ref)
+        log.error(f"ParamValue ref {ref}")
+        if ref is None:
+            ref = []
+        elif isinstance(ref, list):
+            ref = [str(_) for _ in ref]
+        else:
+            ref = [str(ref)]
+        log.error(f"ParamValue ref {ref}")
         rval = []
         for fields in options:
-            if self.keep == (fields[self.column] == ref):
+            if self.keep == (fields[self.column] in ref):
                 rval.append(fields)
         return rval
 
@@ -666,10 +674,10 @@ class DynamicOptions:
             try:
                 datasets = _get_ref_data(other_values, self.dataset_ref_name)
             except KeyError:  # no such dataset
-                log.warning(f"could not create dynamic options from_dataset: {self.dataset_ref_name} unknown")
+                log.warning(f"{self.tool_param.name} could not create dynamic options from_dataset: {self.dataset_ref_name} unknown")
                 return []
             except ValueError:  # not a valid dataset
-                log.warning(f"could not create dynamic options from_dataset: {self.dataset_ref_name} not a data or collection parameter")
+                log.warning(f"{self.tool_param.name} could not create dynamic options from_dataset: {self.dataset_ref_name} not a data or collection parameter")
                 return []
 
             options = []

--- a/test/functional/tool-data/fasta_indexes.loc
+++ b/test/functional/tool-data/fasta_indexes.loc
@@ -1,4 +1,4 @@
 hg19_value	hg19	hg19_name	hg19_path
 hg18_value	hg18	hg18_name	hg18_path
-hg38_value	hg38	hg38_name	hg38_path
+mm10_value	mm10	mm10_name	mm10_path
 

--- a/test/functional/tool-data/fasta_indexes.loc
+++ b/test/functional/tool-data/fasta_indexes.loc
@@ -1,2 +1,4 @@
 hg19_value	hg19	hg19_name	hg19_path
 hg18_value	hg18	hg18_name	hg18_path
+hg38_value	hg38	hg38_name	hg38_path
+

--- a/test/functional/tools/filter_param_value.xml
+++ b/test/functional/tools/filter_param_value.xml
@@ -32,11 +32,11 @@
     <tests>
         <test expect_failure="false">
             <param name="select1" value="hg18_value,hg19_value"/>
-            <param name="select2" value="hg38_value" />
+            <param name="select2" value="mm10_value" />
             <output name="output">
                 <assert_contents>
                     <has_line line="hg18_value,hg19_value" />    
-                    <has_line line="hg38_value" />    
+                    <has_line line="mm10_value" />    
                 </assert_contents>
             </output>
         </test>

--- a/test/functional/tools/filter_param_value.xml
+++ b/test/functional/tools/filter_param_value.xml
@@ -1,0 +1,51 @@
+<tool id="filter_param_value" name="filter_param_value" version="0.1.0">
+    <description>Filter input with the param_value</description>
+    <command><![CDATA[
+        echo $select1 > '$output' && 
+        echo $select2 >> '$output'
+    ]]></command>
+    <inputs>
+        <!-- define 2 selects that are initialised with entries from a data table
+             and use param_value filters to ensure that disjoint elements are
+             selected (one of them is multiple="true" to ensure that also list of
+             elements can be used in the filter) -->
+        <param name="select1" type="select" multiple="true">
+            <options from_data_table="test_fasta_indexes">
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <filter type="param_value" column="0" ref="select2" keep="false"/>
+            </options>
+        </param>
+        <param name="select2" type="select">
+            <options  from_data_table="test_fasta_indexes">
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <filter type="param_value" column="0" ref="select1" keep="false"/>
+            </options>
+        </param>
+    </inputs>
+
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+
+    <tests>
+        <test expect_failure="false">
+            <param name="select1" value="hg18_value,hg19_value"/>
+            <param name="select2" value="hg38_value" />
+            <output name="output">
+                <assert_contents>
+                    <has_line line="hg18_value,hg19_value" />    
+                    <has_line line="hg38_value" />    
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_failure="true">
+            <param name="select1" value="hg18_value,hg19_value"/>
+            <param name="select2" value="hg18_value" />
+        </test>
+    </tests>
+
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/filter_param_value.xml
+++ b/test/functional/tools/filter_param_value.xml
@@ -13,7 +13,7 @@
             <options from_data_table="test_fasta_indexes">
                 <column name="value" index="0"/>
                 <column name="name" index="1"/>
-                <filter type="param_value" column="0" ref="select2" keep="false"/>
+                <!-- <filter type="param_value" column="0" ref="select2" keep="false"/> -->
             </options>
         </param>
         <param name="select2" type="select">

--- a/test/functional/tools/filter_param_value.xml
+++ b/test/functional/tools/filter_param_value.xml
@@ -13,11 +13,13 @@
             <options from_data_table="test_fasta_indexes">
                 <column name="value" index="0"/>
                 <column name="name" index="1"/>
-                <!-- <filter type="param_value" column="0" ref="select2" keep="false"/> -->
+                <!-- unfortunatelly this does not work (bug?): at the moment ane can
+                     not refer to other inputs that are defined below)
+                    <filter type="param_value" column="0" ref="select2" keep="false"/> -->
             </options>
         </param>
         <param name="select2" type="select">
-            <options  from_data_table="test_fasta_indexes">
+            <options from_data_table="test_fasta_indexes">
                 <column name="value" index="0"/>
                 <column name="name" index="1"/>
                 <filter type="param_value" column="0" ref="select1" keep="false"/>

--- a/test/functional/tools/filter_param_value_ref_attribute.xml
+++ b/test/functional/tools/filter_param_value_ref_attribute.xml
@@ -1,0 +1,116 @@
+<tool id="filter_param_value_ref_attribute" name="filter_param_value_ref_attribute" version="0.1.0">
+    <description>Filter input with the param_value</description>
+    <command><![CDATA[
+        #if $select_single
+            echo $select_single >> '$output' &&
+        #end if
+        #if $select_mult
+            echo $select_mult >> '$output' &&
+        #end if
+        #if $select_coll
+            echo $select_coll >> '$output' &&
+        #end if
+        true
+    ]]></command>
+    <inputs>
+        <!-- this tests the param_value filter with the ref_attribute attribute 
+             (so ref is dataset(s) or a dataset collection), the following pairs
+             test param_value filter refering:
+             - dataset 
+             - multiple datasets
+             - a collection
+
+             in each case the data and the select input are optional to allow
+             to test them separately -->
+
+        <!-- 1. dataset (here with non-default keep) -->
+        <param name="data_single" type="data" format="bed" optional="true"/>
+        <param name="select_single" type="select" multiple="true" optional="true">
+            <options from_data_table="test_fasta_indexes">
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <filter type="param_value" column="1" ref="data_single" ref_attribute="metadata.dbkey" keep="false"/>
+            </options>
+        </param>
+        
+        <!-- 2. same, but with a data input accepting multiple datasets 
+            (which may have different dbkeys .. but we can not specify them in a test) -->
+        <param name="data_mult" format="bed" type="data" multiple="true" optional="true"/>
+        <param name="select_mult" type="select" multiple="true" optional="true">
+            <options from_data_table="test_fasta_indexes">
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <filter type="param_value" column="1" ref="data_mult" ref_attribute="metadata.dbkey"/>
+            </options>
+        </param>
+        
+        <!-- 3. same, but with a collection input (elements may have different dbkeys) -->
+        <param name="data_coll" format="bed" type="data_collection" collection_type="list" optional="true"/>
+        <param name="select_coll" type="select" multiple="true" optional="true">
+            <options from_data_table="test_fasta_indexes">
+                <column name="value" index="0"/>
+                <column name="name" index="1"/>
+                <filter type="param_value" column="1" ref="data_coll" ref_attribute="metadata.dbkey"/>
+            </options>
+        </param>
+    </inputs>
+
+    <outputs>
+        <data format="txt" name="output" />
+    </outputs>
+
+    <tests>
+        <test expect_failure="false">
+            <param name="data_single" value="1.bed" ftype="bed" dbkey="hg19"/>
+            <param name="select_single" value="hg18_value,mm10_value"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="hg18_value,mm10_value"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_failure="true">
+            <param name="data_single" value="1.bed" ftype="bed" dbkey="hg19"/>
+            <param name="select_single" value="hg19_value"/>
+        </test>
+        <test expect_failure="false">
+            <param name="data_mult" value="1.bed,2.bed" dbkey="hg19"/>
+            <param name="select_mult" value="hg19_value"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="hg19_value"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_failure="true">
+            <param name="data_mult" value="1.bed,2.bed" dbkey="hg19"/>
+            <param name="select_mult" value="hg18_value"/>
+        </test>
+        <test expect_failure="false">
+            <param name="data_coll">
+                <collection type="list">
+                    <element name="element1" ftype="bed" value="1.bed" dbkey="hg18"/>
+                    <element name="element2" ftype="bed" value="2.bed" dbkey="hg19"/>
+               </collection>
+            </param>
+            <param name="select_coll" value="hg18_value,hg19_value"/>
+            <output name="output">
+                <assert_contents>
+                    <has_line line="hg18_value,hg19_value"/>
+                </assert_contents>
+            </output>
+        </test>
+        <test expect_failure="true">
+            <param name="data_coll">
+                <collection type="list">
+                    <element name="element1" ftype="bed" value="1.bed" dbkey="hg18"/>
+                    <element name="element2" ftype="bed" value="2.bed" dbkey="hg19"/>
+               </collection>
+            </param>
+            <param name="select_coll" value="mm10_value"/>
+        </test>
+    </tests>
+
+    <help>
+    </help>
+</tool>

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -47,6 +47,7 @@
   <tool file="inputs_as_json_with_paths.xml" />
   <tool file="inputs_as_json_with_staging_path_and_source_path.xml" />
   <tool file="filter_multiple_splitter.xml" />
+  <tool file="filter_param_value.xml" />
   <tool file="filter_static_regexp.xml" />
   <tool file="select_from_dataset.xml" />
   <tool file="select_from_dataset_optional.xml" />

--- a/test/functional/tools/samples_tool_conf.xml
+++ b/test/functional/tools/samples_tool_conf.xml
@@ -48,6 +48,7 @@
   <tool file="inputs_as_json_with_staging_path_and_source_path.xml" />
   <tool file="filter_multiple_splitter.xml" />
   <tool file="filter_param_value.xml" />
+  <tool file="filter_param_value_ref_attribute.xml" />
   <tool file="filter_static_regexp.xml" />
   <tool file="select_from_dataset.xml" />
   <tool file="select_from_dataset_optional.xml" />


### PR DESCRIPTION
Consider this:

```
<param name="A"/>
<param name="B" type="select">
    <options ...>
        <filter type="param_value" column="0" ref="A" keep="false"/>
    </options>
</param>
```

then this already works if `A` is a simple parameter (`text`, `int`, ...) but it failed if `A` is a select is a select parameter with `multiple="true"`. 

The filter also did not work if `ref_attribute` is used for data parameters with `multiple="true"` and collection inputs.

Also there were no test so far for the `param_value` filter.

- [ ] seems that one can only refer to parameters that are defined above, i.e. I might need to comment https://github.com/galaxyproject/galaxy/blob/23d5c97810d2c6d1578cca4317ed5e21ba90f0e8/test/functional/tools/filter_param_value.xml#L16 .. would call this another bug 

I would like to call this a bug and backport it .. ?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
