### PR TITLE
Add support for CWL `CommandLineTool` and `ExpressionTool` to `DynamicToolManager.create_tool()`

### DIFF
--- a/lib/galaxy/managers/tools.py
+++ b/lib/galaxy/managers/tools.py
@@ -1,12 +1,13 @@
 import logging
-from typing import TYPE_CHECKING
-from uuid import uuid4
+from typing import Optional, TYPE_CHECKING, Union
+from uuid import UUID
 
 from sqlalchemy import sql
 
 from galaxy import exceptions
 from galaxy import model
 from galaxy.exceptions import DuplicatedIdentifierException
+from galaxy.tool_util.cwl import tool_proxy
 from .base import ModelManager, raise_filter_err
 from .executables import artifact_class
 
@@ -21,7 +22,7 @@ class DynamicToolManager(ModelManager):
     """
     model_class = model.DynamicTool
 
-    def get_tool_by_uuid(self, uuid):
+    def get_tool_by_uuid(self, uuid: Optional[Union[UUID, str]]):
         dynamic_tool = self._one_or_none(
             self.query().filter(self.model_class.uuid == uuid)
         )
@@ -40,52 +41,63 @@ class DynamicToolManager(ModelManager):
         return dynamic_tool
 
     def create_tool(self, trans, tool_payload, allow_load=True):
-        src = tool_payload.get("src", "representation")
-        is_path = src == "from_path"
-
-        if is_path:
-            tool_format, representation, object_id = artifact_class(None, tool_payload)
-        else:
-            assert src == "representation"
-            if "representation" not in tool_payload:
-                raise exceptions.ObjectAttributeMissingException(
-                    "A tool 'representation' is required."
-                )
-
-            representation = tool_payload["representation"]
-            if "class" not in representation:
-                raise exceptions.ObjectAttributeMissingException(
-                    "Current tool representations require 'class'."
-                )
-
-        enable_beta_formats = getattr(self.app.config, "enable_beta_tool_formats", False)
-        if not enable_beta_formats:
+        if not getattr(self.app.config, "enable_beta_tool_formats", False):
             raise exceptions.ConfigDoesNotAllowException("Set 'enable_beta_tool_formats' in Galaxy config to create dynamic tools.")
 
-        tool_format = representation["class"]
-        tool_directory = tool_payload.get("tool_directory", None)
-        tool_path = None
-        if tool_format == "GalaxyTool":
-            uuid = tool_payload.get("uuid", None)
-            if uuid is None:
-                uuid = uuid4()
+        dynamic_tool = None
+        uuid_str = tool_payload.get("uuid")
+        # Convert uuid_str to UUID or generate new if None
+        uuid = model.get_uuid(uuid_str)
+        if uuid_str:
+            # TODO: enforce via DB constraint and catch appropriate
+            # exception.
+            dynamic_tool = self.get_tool_by_uuid(uuid_str)
+            if dynamic_tool:
+                if not allow_load:
+                    raise DuplicatedIdentifierException(dynamic_tool.id)
+                assert dynamic_tool.uuid == uuid
+        if not dynamic_tool:
+            src = tool_payload.get("src", "representation")
+            is_path = src == "from_path"
 
-            tool_id = representation.get("id", None)
-            if tool_id is None:
-                tool_id = str(uuid)
+            if is_path:
+                tool_format, representation, _ = artifact_class(None, tool_payload)
+            else:
+                assert src == "representation"
+                representation = tool_payload.get("representation")
+                if not representation:
+                    raise exceptions.ObjectAttributeMissingException(
+                        "A tool 'representation' is required."
+                    )
 
-            tool_version = representation.get("version", None)
-            value = representation
-        else:
-            raise Exception(f"Unknown tool format [{tool_format}] encountered.")
-        # TODO: enforce via DB constraint and catch appropriate
-        # exception.
-        existing_tool = self.get_tool_by_uuid(uuid)
-        if existing_tool is not None and not allow_load:
-            raise DuplicatedIdentifierException(existing_tool.id)
-        elif existing_tool:
-            dynamic_tool = existing_tool
-        else:
+                tool_format = representation.get("class")
+                if not tool_format:
+                    raise exceptions.ObjectAttributeMissingException(
+                        "Current tool representations require 'class'."
+                    )
+
+            tool_path = tool_payload.get("path")
+            tool_directory = tool_payload.get("tool_directory")
+            if tool_format == "GalaxyTool":
+                tool_id = representation.get("id")
+                if not tool_id:
+                    tool_id = str(uuid)
+            elif tool_format in ("CommandLineTool", "ExpressionTool"):
+                # CWL tools
+                if is_path:
+                    proxy = tool_proxy(tool_path=tool_path, uuid=uuid)
+                else:
+                    # Build a tool proxy so that we can convert to the persistable
+                    # hash.
+                    proxy = tool_proxy(
+                        tool_object=representation["raw_process_reference"],
+                        tool_directory=tool_directory,
+                        uuid=uuid,
+                    )
+                tool_id = proxy.galaxy_id()
+            else:
+                raise Exception(f"Unknown tool format [{tool_format}] encountered.")
+            tool_version = representation.get("version")
             dynamic_tool = self.create(
                 tool_format=tool_format,
                 tool_id=tool_id,
@@ -93,9 +105,9 @@ class DynamicToolManager(ModelManager):
                 tool_path=tool_path,
                 tool_directory=tool_directory,
                 uuid=uuid,
-                value=value,
+                value=representation,
             )
-            self.app.toolbox.load_dynamic_tool(dynamic_tool)
+        self.app.toolbox.load_dynamic_tool(dynamic_tool)
         return dynamic_tool
 
     def list_tools(self, active=True):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -154,8 +154,10 @@ else:
     _HasTable = object
 
 
-def get_uuid(uuid=None):
-    if uuid is None:
+def get_uuid(uuid: Optional[Union[UUID, str]] = None):
+    if isinstance(uuid, UUID):
+        return uuid
+    if not uuid:
         return uuid4()
     return UUID(str(uuid))
 

--- a/lib/galaxy/tool_util/cwl/parser.py
+++ b/lib/galaxy/tool_util/cwl/parser.py
@@ -263,7 +263,7 @@ class ToolProxy(metaclass=ABCMeta):
 
     def __init__(self, tool, uuid, raw_process_reference=None, tool_path=None):
         self._tool = tool
-        self._uuid = uuid
+        self.uuid = uuid
         self._tool_path = tool_path
         self._raw_process_reference = raw_process_reference
         # remove input parameter formats from CWL files so that cwltool
@@ -284,7 +284,7 @@ class ToolProxy(metaclass=ABCMeta):
         raw_id = self._tool.tool.get("id", None)
         return raw_id
 
-    def galaxy_id(self):
+    def galaxy_id(self) -> str:
         raw_id = self.id
         tool_id = None
         # don't reduce "search.cwl#index" to search
@@ -292,7 +292,7 @@ class ToolProxy(metaclass=ABCMeta):
             tool_id = os.path.basename(raw_id)
             # tool_id = os.path.splitext(os.path.basename(raw_id))[0]
         if not tool_id:
-            return self._uuid
+            return str(self.uuid)
         if tool_id.startswith("#"):
             tool_id = tool_id[1:]
         return tool_id
@@ -329,7 +329,7 @@ class ToolProxy(metaclass=ABCMeta):
         return {
             "class": self._class,
             "pickle": unicodify(base64.b64encode(pickle.dumps(persisted_obj, pickle.HIGHEST_PROTOCOL))),
-            "uuid": self._uuid,
+            "uuid": self.uuid,
         }
 
     @staticmethod
@@ -1043,7 +1043,7 @@ class ToolStepProxy(BaseStepProxy):
 
     @property
     def tool_proxy(self):
-        # Neeeds to be cached so UUID that is loaded matches UUID generated with to_dict.
+        # Needs to be cached so UUID that is loaded matches UUID generated with to_dict.
         if self._tool_proxy is None:
             self._tool_proxy = _cwl_tool_object_to_proxy(self.cwl_tool_object, uuid=str(uuid4()))
         return self._tool_proxy
@@ -1063,7 +1063,7 @@ class ToolStepProxy(BaseStepProxy):
         outputs = self.galaxy_workflow_outputs_list()
         return {
             "id": self._index,
-            "tool_uuid": self.tool_proxy._uuid,  # TODO: make sure this is respected...
+            "tool_uuid": self.tool_proxy.uuid,  # TODO: make sure this is respected...
             "label": self.label,
             "position": {"left": 0, "top": 0},
             "type": "tool",


### PR DESCRIPTION
until the generation of a `DynamicTool` object.
`load_dynamic_tool()` support to follow.

Also:
- Move code to check if there is already a dynamic tool with the given uuid as first step.
- Improve and type annotate `get_uuid()`
- Ensure that `ToolProxy.galaxy_id()` returns a str
 
Work partially coming from https://github.com/galaxyproject/galaxy/pull/12909 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
