### PR TITLE
Misc fixes - round 5

### DIFF
--- a/lib/galaxy/tool_util/provided_metadata.py
+++ b/lib/galaxy/tool_util/provided_metadata.py
@@ -109,10 +109,9 @@ class LegacyToolProvidedMetadata(BaseToolProvidedMetadata):
                 try:
                     line = stringify_dictionary_keys(json.loads(line))
                     assert 'type' in line
-                except Exception:
-                    log.exception(f"({getattr(job_wrapper, 'job_id', None)}) Got JSON data from tool, but data is improperly formatted or no \"type\" key in data")
-                    log.debug(f'Offending data was: {line}')
-                    continue
+                except Exception as e:
+                    message = f"Got JSON data from tool, but line is improperly formatted or no \"type\" key in: [{line}]"
+                    raise ValueError(message) from e
                 # Set the dataset id if it's a dataset entry and isn't set.
                 # This isn't insecure.  We loop the job's output datasets in
                 # the finish method, so if a tool writes out metadata for a

--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -57,7 +57,10 @@ def test_get_package_hash():
 @external_dependency_management
 def test_singularity_search():
     sing1 = singularity_search('mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa')
+    sing1_versions = {result['version'] for result in sing1}
+    assert {
+        'c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0',
+        'f471ba33d45697daad10614c5bd25a67693f67f1-0',
+        'fc33176431a4b9ef3213640937e641d731db04f1-0'}.issubset(sing1_versions)
     sing2 = singularity_search('mulled-v2-19fa9431f5863b2be81ff13791f1b00160ed0852')
-    assert sing1[0]['version'] in ['c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0', 'fc33176431a4b9ef3213640937e641d731db04f1-0']
-    assert sing1[1]['version'] in ['c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0', 'fc33176431a4b9ef3213640937e641d731db04f1-0']
     assert sing2 == []


### PR DESCRIPTION
Three assorted fixes:
- Fix running `test/release.sh` on the dev branch
  Fix for https://github.com/galaxyproject/galaxy/runs/4457794797?check_suite_focus=true

  ```
  # >>>> make_forks()
  Cloning into '/tmp/galaxy_release_test_cQZHDb9B/work'...
  done.
  + cd /tmp/galaxy_release_test_cQZHDb9B/work
  + git config user.name 'Test User'
  + git config user.email test@example.org
  # Checking out ref '9bddbada0d3f7835ecafd12220a76dcfb6e3daca' as 'dev'
  + git checkout --no-track -b dev 9bddbada0d3f7835ecafd12220a76dcfb6e3daca
  fatal: A branch named 'dev' already exists.
  ```

  Also add `log_exec` to a few git commands

- Fix `test_singularity_search` unit test broken by a new container version

- Don't silently ignore failure to process legacy tool-provided metadata

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
