### PR TITLE
Refactor uploadbox / partially remove jQuery

### DIFF
--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -55,7 +55,6 @@
 <script>
 import _l from "utils/localization";
 import _ from "underscore";
-import $ from "jquery";
 import { getGalaxyInstance } from "app";
 import UploadRow from "mvc/upload/composite/composite-row";
 import UploadBoxMixin from "./UploadBoxMixin";

--- a/client/src/components/Upload/Composite.vue
+++ b/client/src/components/Upload/Composite.vue
@@ -60,6 +60,7 @@ import { getGalaxyInstance } from "app";
 import UploadRow from "mvc/upload/composite/composite-row";
 import UploadBoxMixin from "./UploadBoxMixin";
 import { uploadModelsToPayload } from "./helpers";
+import { submitUpload } from "utils/uploadbox";
 
 export default {
     mixins: [UploadBoxMixin],
@@ -138,7 +139,7 @@ export default {
                     extension: this.extension,
                 });
             });
-            $.uploadchunk({
+            submitUpload({
                 url: this.app.uploadPath,
                 data: uploadModelsToPayload(this.collection.filter(), this.history_id, true),
                 success: (message) => {

--- a/client/src/components/Upload/UploadBoxMixin.js
+++ b/client/src/components/Upload/UploadBoxMixin.js
@@ -12,6 +12,7 @@ import LazyLimited from "mvc/lazy/lazy-limited";
 import { findExtension } from "./utils";
 import { filesDialog } from "utils/data";
 import { getAppRoot } from "onload";
+import { UploadQueue } from "utils/uploadbox";
 import axios from "axios";
 
 const localize = _l;
@@ -69,7 +70,8 @@ export default {
         },
         initUploadbox(options) {
             const $uploadBox = this.$uploadBox();
-            this.uploadbox = $uploadBox.uploadbox(options);
+            options.$uploadBox = $uploadBox;
+            this.uploadbox = new UploadQueue(options);
             if (this.lazyLoadMax !== null) {
                 const $uploadBox = this.$uploadBox();
                 this.loader = new LazyLimited({

--- a/client/src/utils/data.js
+++ b/client/src/utils/data.js
@@ -8,6 +8,7 @@ import { mountUploadModal } from "components/Upload";
 import { uploadModelsToPayload } from "components/Upload/helpers";
 import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
+import { submitUpload } from "utils/uploadbox";
 
 // This should be moved more centrally (though still hanging off Galaxy for
 // external use?), and populated from the store; just using this as a temporary
@@ -93,7 +94,7 @@ export function create(options) {
         return options.history_id;
     }
     getHistory().then((history_id) => {
-        $.uploadchunk({
+        submitUpload({
             url: `${getAppRoot()}api/tools/fetch`,
             success: (response) => {
                 if (history_panel) {

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -243,7 +243,7 @@ export class UploadQueue {
         if (files && files.length && !this.isRunning) {
             files.forEach((file) => {
                 const fileSetKey = file.name + file.size; // Concat name and size to create a "file signature".
-                if (!this.fileSet.has(fileSetKey)) {
+                if (file.mode === "new" || !this.fileSet.has(fileSetKey)) {
                     this.fileSet.add(fileSetKey);
                     const index = this.nextIndex++;
                     this.queue.set(index, file);

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -100,7 +100,7 @@ export function submitUpload(config) {
     }
     const tusEndpoint = `${getAppRoot()}api/upload/resumable_upload/`;
     tusUpload(data, 0, tusEndpoint, cnf);
-};
+}
 
 (($) => {
     // add event properties
@@ -207,7 +207,7 @@ export class UploadQueue {
 
     // open file browser for selection
     select() {
-        this.uploadinput.dialog()
+        this.uploadinput.dialog();
     }
 
     // remove all entries from queue
@@ -232,10 +232,7 @@ export class UploadQueue {
 
     // set options
     configure(options) {
-        this.opts = Object.assign(
-            this.opts,
-            options
-        );
+        this.opts = Object.assign(this.opts, options);
         return this.opts;
     }
 
@@ -278,12 +275,7 @@ export class UploadQueue {
             this.queue_running = true;
         }
 
-        // get an identifier from the queue
-        var index = -1;
-        for (const key in this.queue) {
-            index = key;
-            break;
-        }
+        const index = this._nextIndex();
 
         // remove from queue
         this.remove(index);
@@ -307,5 +299,14 @@ export class UploadQueue {
                 this.opts.progress(index, percentage);
             },
         });
+    }
+
+    _nextIndex() {
+        var index = -1;
+        for (const key in this.queue) {
+            index = key;
+            break;
+        }
+        return index;
     }
 }

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -69,7 +69,7 @@ function tusUpload(data, index, tusEndpoint, cnf) {
 // Posts chunked files to the API.
 export function submitUpload(config) {
     // set options
-    var cnf = $.extend(
+    const cnf = Object.assign(
         {},
         {
             data: {},

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -212,7 +212,7 @@ export class UploadQueue {
 
     // remove all entries from queue
     reset() {
-        for (let index in this.queue) {
+        for (const index in this.queue) {
             this.remove(index);
         }
     }

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -69,24 +69,21 @@ function tusUpload(data, index, tusEndpoint, cnf) {
 // Posts chunked files to the API.
 export function submitUpload(config) {
     // set options
-    const cnf = Object.assign(
-        {},
-        {
-            data: {},
-            success: () => {},
-            error: () => {},
-            warning: () => {},
-            progress: () => {},
-            attempts: 70000,
-            timeout: 5000,
-            url: null,
-            error_file: "File not provided.",
-            error_attempt: "Maximum number of attempts reached.",
-            error_tool: "Tool submission failed.",
-            chunkSize: 10485760,
-        },
-        config
-    );
+    const cnf = {
+        data: {},
+        success: () => {},
+        error: () => {},
+        warning: () => {},
+        progress: () => {},
+        attempts: 70000,
+        timeout: 5000,
+        url: null,
+        error_file: "File not provided.",
+        error_attempt: "Maximum number of attempts reached.",
+        error_tool: "Tool submission failed.",
+        chunkSize: 10485760,
+        ...config,
+    };
 
     // initial validation
     var data = cnf.data;
@@ -161,24 +158,21 @@ export function submitUpload(config) {
 
 export class UploadQueue {
     constructor(options) {
-        this.opts = Object.assign(
-            {
-                dragover: () => {},
-                dragleave: () => {},
-                announce: (d) => {},
-                initialize: (d) => {},
-                progress: (d, m) => {},
-                success: (d, m) => {},
-                warning: (d, m) => {},
-                error: (d, m) => {
-                    alert(m);
-                },
-                complete: () => {},
-                multiple: true,
+        this.opts = {
+            dragover: () => {},
+            dragleave: () => {},
+            announce: (d) => {},
+            initialize: (d) => {},
+            progress: (d, m) => {},
+            success: (d, m) => {},
+            warning: (d, m) => {},
+            error: (d, m) => {
+                alert(m);
             },
-            options
-        );
-
+            complete: () => {},
+            multiple: true,
+            ...options,
+        };
         this.queue = new Map(); // items stored by key (referred to as index)
         this.nextIndex = 0;
         this.fileSet = new Set(); // Used for fast duplicate checking

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -192,7 +192,7 @@ export class UploadQueue {
         this.queue_stop = false;
 
         // element
-        this.uploadinput = $(options.$uploadBox).uploadinput({
+        this.uploadinput = options.$uploadBox.uploadinput({
             multiple: this.opts.multiple,
             onchange: (files) => {
                 _.each(files, (file) => {

--- a/client/src/utils/uploadbox.js
+++ b/client/src/utils/uploadbox.js
@@ -212,7 +212,7 @@ export class UploadQueue {
 
     // remove all entries from queue
     reset() {
-        for (index in this.queue) {
+        for (let index in this.queue) {
             this.remove(index);
         }
     }

--- a/client/src/utils/uploadbox.test.js
+++ b/client/src/utils/uploadbox.test.js
@@ -1,0 +1,16 @@
+import { UploadQueue } from "./uploadbox";
+
+describe("UploadQueue", () => {
+    it("returns the correct next index", async () => {
+        const stubOptions = {
+            $uploadBox: {
+                uploadinput: () => {},
+            },
+        };
+        const uploadQueue = new UploadQueue(stubOptions);
+
+        uploadQueue.queue[0] = "a";
+        uploadQueue.queue[1] = "b";
+        expect(uploadQueue._nextIndex()).toEqual("0");
+    });
+});

--- a/client/src/utils/uploadbox.test.js
+++ b/client/src/utils/uploadbox.test.js
@@ -1,16 +1,205 @@
 import { UploadQueue } from "./uploadbox";
 
 describe("UploadQueue", () => {
-    it("returns the correct next index", async () => {
+    const mockDialog = jest.fn();
+
+    function TestUploadQueue(options) {
+        // Provide a stub for the $uploadBox default value (used in constuctor);
+        // and a mocked dialog function (used in select).
         const stubOptions = {
             $uploadBox: {
-                uploadinput: () => {},
+                uploadinput: () => ({ dialog: mockDialog }),
             },
         };
-        const uploadQueue = new UploadQueue(stubOptions);
+        if (options) {
+            Object.assign(stubOptions, options);
+        }
+        return new UploadQueue(stubOptions);
+    }
 
-        uploadQueue.queue[0] = "a";
-        uploadQueue.queue[1] = "b";
-        expect(uploadQueue._nextIndex()).toEqual("0");
+    function StubFile(name = null, size = 0) {
+        this.name = name;
+        this.size = size;
+    }
+
+    test("a queue is initialized to correct state", () => {
+        const q = TestUploadQueue({ foo: 1 });
+        expect(q.size).toEqual(0);
+        expect(q.isRunning).toBe(false);
+        expect(q.opts.foo).toEqual(1); // passed as options
+        expect(q.opts.multiple).toBe(true); // default value
+    });
+
+    test("calling select calls uploadinput.dialog", () => {
+        const q = TestUploadQueue();
+        expect(mockDialog.mock.calls.length).toBe(0);
+        q.select();
+        expect(mockDialog.mock.calls.length).toBe(1); // called once
+    });
+
+    test("resetting the queue removes all files from it", () => {
+        const q = TestUploadQueue();
+        q.add([new StubFile("a"), new StubFile("b")]);
+        expect(q.size).toEqual(2);
+        q.reset();
+        expect(q.size).toEqual(0);
+    });
+
+    test("calling configure updates options", () => {
+        const q = TestUploadQueue({ foo: 1 });
+        expect(q.opts.foo).toEqual(1);
+        expect(q.opts.bar).toBeUndefined();
+        q.configure({ bar: 2 }); // overwrite bar
+        expect(q.opts.foo).toEqual(1); // value unchangee
+        expect(q.opts.bar).toEqual(2); // value overwritten
+    });
+
+    describe("checking browser compatibility", () => {
+        const compatibleBrowser = {
+            File: 1,
+            FormData: 1,
+            XMLHttpRequest: 1,
+            FileList: 1,
+        };
+        const incompatibleBrowser = Object.assign(
+            {},
+            compatibleBrowser,
+            { File: 0 } // set File to 0 to make it incompatible.
+        );
+        let spy;
+
+        beforeEach(() => {
+            spy = jest.spyOn(window, "window", "get");
+            spy.mockImplementation(() => compatibleBrowser);
+        });
+
+        afterEach(() => {
+            spy.mockRestore();
+        });
+
+        test("calling compatible checks 4 window properties", () => {
+            const q = TestUploadQueue();
+            expect(spy.mock.calls.length).toEqual(0);
+            q.compatible();
+            expect(spy.mock.calls.length).toEqual(4);
+        });
+
+        test("calling compatible returns truthy or falsy depending on values of 4 window properties", () => {
+            const q = TestUploadQueue();
+            expect(q.compatible()).toBeTruthy();
+            spy.mockImplementation(() => incompatibleBrowser); // make browser incompatible
+            expect(q.compatible()).toBeFalsy();
+        });
+    });
+
+    test("calling start sets isRunning to true", () => {
+        const q = TestUploadQueue();
+        q._process = jest.fn(); // mock this, otherwise it'll reset isRunning after it's done.
+        expect(q.isRunning).toBe(false);
+        q.start();
+        expect(q.isRunning).toBe(true);
+    });
+
+    test("calling start is a noop if queue is running", () => {
+        const q = TestUploadQueue();
+        const mockedProcess = jest.fn();
+        q._process = mockedProcess();
+        q.isRunning = true;
+        q.start();
+        expect(mockedProcess.mock.calls.length === 0); // function was not called
+    });
+
+    test("calling start processes all files in queue", () => {
+        const q = TestUploadQueue();
+        const mockedSubmit = jest.fn((index) => q._process());
+        q._submitUpload = mockedSubmit;
+        const spy = jest.spyOn(q, "_process");
+
+        q.add([new StubFile("a"), new StubFile("b")]);
+        q.start();
+        expect(q.size).toEqual(0);
+        expect(spy.mock.calls.length).toEqual(3); // called for 2,1,0 files.
+        spy.mockRestore(); // not necessary, but safer, in case we later modify implementation.
+    });
+    test("calling stop sets isPaused to true", () => {
+        const q = TestUploadQueue();
+        q.start();
+        expect(q.isPaused).toBe(false);
+        q.stop();
+        expect(q.isPaused).toBe(true);
+    });
+
+    describe("adding files", () => {
+        test("adding files increases the queue size by the number of files", () => {
+            const q = TestUploadQueue();
+            expect(q.size).toEqual(0);
+            q.add([new StubFile("a"), new StubFile("b")]);
+            expect(q.size).toEqual(2);
+            q.add([new StubFile("c")]);
+            expect(q.size).toEqual(3);
+        });
+
+        test("adding files increases the next index by the number of files", () => {
+            const q = TestUploadQueue();
+            expect(q.nextIndex).toEqual(0);
+            q.add([new StubFile("a"), new StubFile("b")]);
+            expect(q.nextIndex).toEqual(2);
+        });
+
+        test("duplicate files are not added to the queue", () => {
+            const q = TestUploadQueue();
+            const file1 = new StubFile("a", 1);
+            const file2 = new StubFile("a", 1);
+            q.add([file1, file2]); // file2 is a duplicate of file1, so only 1 file is added
+            expect(q.size).toEqual(1); // queue size incremented by 1
+            expect(q.nextIndex).toEqual(1); // next index value incremented by 1
+        });
+
+        test("adding a file calls opts.announce with correct arguments", () => {
+            const mockAnnounce = jest.fn();
+            const q = TestUploadQueue({ announce: mockAnnounce });
+            const file = new StubFile("a");
+            expect(mockAnnounce.mock.calls.length).toBe(0);
+            q.add([file]);
+            expect(mockAnnounce.mock.calls.length).toBe(1); // called once
+            expect(mockAnnounce.mock.calls[0][0]).toBe(0); // first arg is index=0
+            expect(mockAnnounce.mock.calls[0][1]).toBe(file); // second arg is file
+        });
+    });
+
+    describe("removing files", () => {
+        test("removing a file reduces the queue size by 1", () => {
+            const q = TestUploadQueue();
+            q.add([new StubFile("a"), new StubFile("b")]);
+            expect(q.size).toEqual(2);
+            q.remove(0);
+            expect(q.size).toEqual(1);
+        });
+
+        test("removing a file by index out of sequence is allowed", () => {
+            const q = TestUploadQueue();
+            const file1 = new StubFile("a");
+            const file2 = new StubFile("b");
+            const file3 = new StubFile("c");
+            q.add([file1, file2, file3]);
+            expect(q.size).toEqual(3);
+            q.remove(1); // remove file2 (which has index=1)
+            expect(q.size).toEqual(2);
+            expect(q.queue.get(0)).toBe(file1);
+            expect(q.queue.get(1)).toBeUndefined();
+            expect(q.queue.get(2)).toBe(file3);
+        });
+
+        test("removing a file via _firstItemIndex, obeys FIFO protocol", () => {
+            const q = TestUploadQueue();
+            q.add([new StubFile("a"), new StubFile("b")]);
+            let nextIndex = q._firstItemIndex();
+            expect(nextIndex).toEqual(0);
+            q.remove(nextIndex);
+            nextIndex = q._firstItemIndex();
+            expect(nextIndex).toEqual(1);
+            q.remove(nextIndex);
+            expect(q._firstItemIndex()).toBeUndefined();
+        });
     });
 });

--- a/client/src/utils/uploadbox.test.js
+++ b/client/src/utils/uploadbox.test.js
@@ -17,9 +17,10 @@ describe("UploadQueue", () => {
         return new UploadQueue(stubOptions);
     }
 
-    function StubFile(name = null, size = 0) {
+    function StubFile(name = null, size = 0, mode = null) {
         this.name = name;
         this.size = size;
+        this.mode = mode;
     }
 
     test("a queue is initialized to correct state", () => {
@@ -146,13 +147,17 @@ describe("UploadQueue", () => {
             expect(q.nextIndex).toEqual(2);
         });
 
-        test("duplicate files are not added to the queue", () => {
+        test("duplicate files are not added to the queue, unless the mode is set to 'new'", () => {
             const q = TestUploadQueue();
             const file1 = new StubFile("a", 1);
             const file2 = new StubFile("a", 1);
+            const file3 = new StubFile("a", 1, "new");
             q.add([file1, file2]); // file2 is a duplicate of file1, so only 1 file is added
             expect(q.size).toEqual(1); // queue size incremented by 1
             expect(q.nextIndex).toEqual(1); // next index value incremented by 1
+            q.add([file3]); // file3 is a duplicate of file1 and file2, but its mode is "new"
+            expect(q.size).toEqual(2); // queue size incremented by 1
+            expect(q.nextIndex).toEqual(2); // next index value incremented by 1
         });
 
         test("adding a file calls opts.announce with correct arguments", () => {


### PR DESCRIPTION
Refactor uploadbox.js, adjust calling code:
- Replace jQuery's `$.fn.uploadbox` with a JavaScript class (there's still some jQuery left in this module)
- Implement queue as a Map
- Address some performance issues
- Add unit tests

**Notes on performance:**
1. For all practical purposes, the gains are negligible. However, I think using a map is an improvement (no need to convert integers to strings for indexes; no need to call delete on object properties when all we need is to dequeue an item; no need to iterate over object properties; reset() becomes trivial). 
2. The previous `add` function had quadratic time complexity: for each item to be added to the queue, we iterated over the queue to generate a list of duplicates (i.e., `(n(n-1))/2`). A duplicate is defined here as a file having the same name and size as another file - so all we need is to keep track of the set of name/size combinations seen so far, which can be done with a Set, which has constant lookup time, which gives us linear time complexity for the function.

However, there seems to be no practical performance issue at the moment: (a) this only matters when n is sufficiently large, and (b) the check for duplicates happens only if the file's mode is *not* set to `new` (I'm not familiar enough with the client code to estimate how likely that would be). Still, here's how the old and new implementations compare under such conditions (large n, `file.mode!="new"`):

| n | old | new |
|---:|---:|---:|
100 | 1 | 0
1,000 | 11 | 1
10,000 | 805 | 6 
20,000 | 3,930 | 8
30,000 | 15,722 | 10
40,000 | n/a | 14
50,000 | n/a | 16
100,000 | n/a | 29
1,000,000 | n/a | 473

(values are in milliseconds, mean of 3; tested with a standalone function using Jest - i.e., no browser)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
