### PR TITLE
[21.09] Add tools to IMPLICITLY_REQUIRED_TOOL_FILES in tools/__init__.py

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -205,6 +205,21 @@ IMPLICITLY_REQUIRED_TOOL_FILES: Dict[str, Dict] = {
     # minimum example:
     # "foobar": {"required": REQUIRE_FULL_DIRECTORY}
     # if no version is specified, all versions without explicit RequiredFiles will be selected
+    "circos": {"required": REQUIRE_FULL_DIRECTORY},
+    "cp_image_math": {"required": {"includes": [{"path": "cp_common_functions.py", "path_type": "literal"}]}},
+    "enumerate_charges": {"required": {"includes": [{"path": "site_substructures.smarts", "path_type": "literal"}]}},
+    "fasta_compute_length": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
+    "fasta_concatenate0": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
+    "filter_tabular": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
+    "flanking_features_1": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
+    "gops_intersect_1": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
+    "gops_subtract_1": {"required": {"includes": [{"path": "utils/*", "path_type": "glob"}]}},
+    "maxquant": {"required": {"includes": [{"path": "mqparam.py", "path_type": "literal"}]}},
+    "maxquant_mqpar": {"required": {"includes": [{"path": "mqparam.py", "path_type": "literal"}]}},
+    "query_tabular": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
+    "shasta": {"required": {"includes": [{"path": "configs/*", "path_type": "glob"}]}},
+    "sqlite_to_tabular": {"required": {"includes": [{"path": "*.py", "path_type": "glob"}]}},
+    "sucos_max_score": {"required": {"includes": [{"path": "utils.py", "path_type": "literal"}]}},
 }
 
 


### PR DESCRIPTION
Add some entries to the IMPLICITLY_REQUIRED_TOOL_FILES of files that are needed at runtime but not referred to by name in the tool command.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [X] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
