### PR TITLE
[21.09] Fix private history publishing

### DIFF
--- a/lib/galaxy/managers/histories.py
+++ b/lib/galaxy/managers/histories.py
@@ -351,6 +351,21 @@ class HistoryManager(sharable.SharableModelManager, deletable.PurgableManagerMix
             )
         ).first())
 
+    def make_members_public(self, trans, item):
+        """ Make the non-purged datasets in history public.
+        Performs permissions check.
+        """
+        for hda in item.activatable_datasets:
+            dataset = hda.dataset
+            if not trans.app.security_agent.dataset_is_public(dataset):
+                if trans.app.security_agent.can_manage_dataset(trans.user.all_roles(), dataset):
+                    try:
+                        trans.app.security_agent.make_dataset_public(hda.dataset)
+                    except Exception:
+                        log.warning(f"Unable to make dataset with id: {dataset.id} public")
+                else:
+                    log.warning(f"User without permissions tried to make dataset with id: {dataset.id} public")
+
 
 class HistoryExportView:
 

--- a/lib/galaxy/managers/sharable.py
+++ b/lib/galaxy/managers/sharable.py
@@ -360,6 +360,14 @@ class SharableModelManager(base.ModelManager, secured.OwnableManagerMixin, secur
         to provide the extra information, otherwise, it will be None by default."""
         return None
 
+    def make_members_public(self, trans, item):
+        """ Make potential elements of this item public.
+
+        This method must be overridden in managers that need to change permissions of internal elements
+        contained associated with the given item.
+        """
+        pass
+
     def update_current_sharing_with_users(self, item, new_users_shared_with: Set[User], flush=True):
         """Updates the currently list of users this item is shared with by adding new
         users and removing missing ones."""
@@ -672,7 +680,11 @@ class ShareableService:
         return self._get_sharing_status(trans, item)
 
     def enable_link_access(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+        """Makes this item accessible by link.
+        If this item contains other elements they will be publicly accessible too.
+        """
         item = self._get_item_by_id(trans, id)
+        self.manager.make_members_public(trans, item)
         self.manager.make_importable(item)
         return self._get_sharing_status(trans, item)
 
@@ -682,7 +694,11 @@ class ShareableService:
         return self._get_sharing_status(trans, item)
 
     def publish(self, trans, id: EncodedDatabaseIdField) -> SharingStatus:
+        """Makes this item publicly accessible.
+        If this item contains other elements they will be publicly accessible too.
+        """
         item = self._get_item_by_id(trans, id)
+        self.manager.make_members_public(trans, item)
         self.manager.publish(item)
         return self._get_sharing_status(trans, item)
 

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -565,6 +565,28 @@ class SharingHistoryTestCase(ApiTestCase, BaseHistories, SharingApiTests):
         assert len(sharing_response["users_shared_with"]) == 1
         assert sharing_response["users_shared_with"][0]["id"] == target_user_id
 
+    def test_sharing_private_history_makes_datasets_public(self):
+        history_id = self.dataset_populator.new_history()
+        hda = self.dataset_populator.new_dataset(history_id)
+        hda_id = hda["id"]
+
+        self.dataset_populator.make_private(history_id, hda_id)
+
+        # Other users cannot access the dataset
+        with self._different_user():
+            show_response = self._get(f"datasets/{hda_id}")
+            self._assert_status_code_is(show_response, 400)
+
+        sharing_response = self._set_resource_sharing(history_id, "publish")
+        assert sharing_response["published"] is True
+
+        # Other users can access the dataset after publishing
+        with self._different_user():
+            show_response = self._get(f"datasets/{hda_id}")
+            self._assert_status_code_is(show_response, 200)
+            hda = show_response.json()
+            assert hda["id"] == hda_id
+
     def _share_history_with_payload(self, history_id, payload):
         sharing_response = self._put(f"histories/{history_id}/share_with_users", data=payload, json=True)
         self._assert_status_code_is(sharing_response, 200)


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13001

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Share a history containing private datasets (that you own) by making it accessible via link or publishing it
  - Other users can access the private datasets

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
