### PR TITLE
[21.09] Fixes for HTML sanitization

### DIFF
--- a/client/src/components/admin/SanitizeAllow.vue
+++ b/client/src/components/admin/SanitizeAllow.vue
@@ -35,7 +35,14 @@
                             <template v-slot:rows>
                                 <template v-for="(row, allowedIdx) in toolshedAllowed">
                                     <tr :key="allowedIdx">
-                                        <td>{{ row.tool_name }}</td>
+                                        <td>
+                                            <span v-if="row.tool_name">
+                                                {{ row.tool_name }}
+                                            </span>
+                                            <span v-else>
+                                                <i>Not installed</i>
+                                            </span>
+                                        </td>
                                         <td>
                                             <template v-for="(part, part_idx) in row.tool_id">
                                                 <template v-if="part_idx > 0">/</template><span :key="part_idx">{{ part }}</span>
@@ -73,7 +80,14 @@
                             <template v-slot:rows>
                                 <template v-for="(row, localAllowedIdx) in localAllowed">
                                     <tr :key="localAllowedIdx">
-                                        <td>{{ row.tool_name }}</td>
+                                        <td>
+                                            <span v-if="row.tool_name">
+                                                {{ row.tool_name }}
+                                            </span>
+                                            <span v-else>
+                                                <i>Not installed</i>
+                                            </span>
+                                        </td>
                                         <td>{{ row.tool_id[0] }}</td>
                                         <td>
                                             <button @click="sanitizeHTML(row.ids.allowed)">Sanitize HTML</button>

--- a/client/src/components/admin/SanitizeAllow.vue
+++ b/client/src/components/admin/SanitizeAllow.vue
@@ -45,7 +45,8 @@
                                         </td>
                                         <td>
                                             <template v-for="(part, part_idx) in row.tool_id">
-                                                <template v-if="part_idx > 0">/</template><span :key="part_idx">{{ part }}</span>
+                                                <template v-if="part_idx > 0">/</template
+                                                ><span :key="part_idx">{{ part }}</span>
                                             </template>
                                         </td>
                                         <td>

--- a/client/src/components/admin/SanitizeAllow.vue
+++ b/client/src/components/admin/SanitizeAllow.vue
@@ -146,7 +146,7 @@ export default {
     methods: {
         allowHTML(tool_id) {
             axios
-                .put(`${getAppRoot()}api/sanitize_allow?tool_id=${tool_id}`, {
+                .put(`${getAppRoot()}api/sanitize_allow?tool_id=${encodeURIComponent(tool_id)}`, {
                     params: {
                         tool_id: tool_id,
                     },

--- a/client/src/components/admin/SanitizeAllow.vue
+++ b/client/src/components/admin/SanitizeAllow.vue
@@ -38,7 +38,7 @@
                                         <td>{{ row.tool_name }}</td>
                                         <td>
                                             <template v-for="(part, part_idx) in row.tool_id">
-                                                <span :key="part_idx">{{ part }}</span>
+                                                <template v-if="part_idx > 0">/</template><span :key="part_idx">{{ part }}</span>
                                             </template>
                                         </td>
                                         <td>

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -974,7 +974,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
                 log.warning("Sanitize log file explicitly specified as '%s' but does not exist, continuing with no tools allowlisted.", self.sanitize_allowlist_file)
         else:
             with open(self.sanitize_allowlist_file) as f:
-                self.sanitize_allowlist = sorted([line.strip() for line in f.readlines() if not line.startswith('#')])
+                self.sanitize_allowlist = sorted(line.strip() for line in f.readlines() if line.strip() and not line.startswith('#'))
 
     def ensure_tempdir(self):
         self._ensure_directory(self.new_file_path)

--- a/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
+++ b/lib/galaxy/webapps/galaxy/api/sanitize_allow.py
@@ -52,26 +52,32 @@ class SanitizeAllowController(BaseAPIController):
 
     def _generate_allowlist(self, trans):
         sanitize_dict = dict(blocked_toolshed=[], allowed_toolshed=[], blocked_local=[], allowed_local=[])
-        ids = None
         for tool_id in trans.app.config.sanitize_allowlist:
+            installed_name = ""
+            installed_ids = {'full': '',
+                             'allowed': tool_id,
+                             'owner': '',
+                             'repository': '',
+                             'tool': ''}
             for toolbox_id in trans.app.toolbox.tools_by_id:
-                tool = trans.app.toolbox.tools_by_id[toolbox_id]
                 if toolbox_id.startswith(tool_id):
+                    tool = trans.app.toolbox.tools_by_id[toolbox_id]
+                    installed_name = tool.name
                     full_id = tool.id
-                    ids = {'full': full_id,
-                           'allowed': tool_id,
-                           'owner': '/'.join(full_id.split('/')[:3]),
-                           'repository': '/'.join(full_id.split('/')[:4]),
-                           'tool': '/'.join(full_id.split('/')[:5])}
+                    installed_ids = {'full': full_id,
+                                     'allowed': tool_id,
+                                     'owner': '/'.join(full_id.split('/')[:3]),
+                                     'repository': '/'.join(full_id.split('/')[:4]),
+                                     'tool': '/'.join(full_id.split('/')[:5])}
                     break
-            tool_dict = dict(tool_name=tool.name, tool_id=tool_id.split('/'), ids=ids, allowed=True, toolshed='/' in tool_id)
+            tool_dict = dict(tool_name=installed_name, tool_id=tool_id.split('/'), ids=installed_ids, allowed=True, toolshed='/' in tool_id)
             if '/' in tool_id:
                 sanitize_dict['allowed_toolshed'].append(tool_dict)
             else:
                 sanitize_dict['allowed_local'].append(tool_dict)
         for tool_id in sorted(trans.app.toolbox.tools_by_id):
-            tool = trans.app.toolbox.tools_by_id[tool_id]
             if not tool_id.startswith(tuple(trans.app.config.sanitize_allowlist)):
+                tool = trans.app.toolbox.tools_by_id[tool_id]
                 ids = {'full': tool_id,
                        'owner': '/'.join(tool_id.split('/')[:3]),
                        'repository': '/'.join(tool_id.split('/')[:4]),


### PR DESCRIPTION
Fixed several bugs found while testing with a pre-existing allowlist file, which contains empty lines and tools that are not installed on the instance.
- having an empty line made all the tools to be rendered (because the new code uses startswith)
- the tool name for orphan items from the allowlist (=no corresponding tool installed) had an unrelated value (always considered to be "upload1" in our instance): now returning an empty value in the api + showing a more explicit "Not installed" message in the ui
- addind a tool to the allow list from the UI when it has a `+` in the version didn't work

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
