### PR TITLE
Allow admin access to datasets API

### DIFF
--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -107,8 +107,7 @@ class DatasetsApiTestCase(ApiTestCase):
         self.dataset_populator.make_private(history_id=self.history_id, dataset_id=hda['id'])
         with self._different_user():
             show_response = self._get(f"datasets/{hda['id']}")
-            self._assert_status_code_is(show_response, 400)
-            assert show_response.json()['err_msg'] == 'You are not allowed to access this dataset'
+            self._assert_status_code_is(show_response, 403)
 
     def test_admin_can_update_permissions(self):
         # Create private dataset

--- a/lib/galaxy_test/api/test_datasets.py
+++ b/lib/galaxy_test/api/test_datasets.py
@@ -110,6 +110,22 @@ class DatasetsApiTestCase(ApiTestCase):
             self._assert_status_code_is(show_response, 400)
             assert show_response.json()['err_msg'] == 'You are not allowed to access this dataset'
 
+    def test_admin_can_update_permissions(self):
+        # Create private dataset
+        hda = self.dataset_populator.new_dataset(self.history_id)
+        dataset_id = hda['id']
+        self.dataset_populator.make_private(history_id=self.history_id, dataset_id=dataset_id)
+
+        # Admin removes restrictions
+        payload = {"action": "remove_restrictions"}
+        update_response = self._put(f"datasets/{dataset_id}/permissions", payload, admin=True, json=True)
+        self._assert_status_code_is_ok(update_response)
+
+        # Other users can access the dataset
+        with self._different_user():
+            show_response = self._get(f"datasets/{hda['id']}")
+            self._assert_status_code_is_ok(show_response)
+
     def __assert_matches_hda(self, input_hda, query_hda):
         self._assert_has_keys(query_hda, "id", "name")
         assert input_hda["name"] == query_hda["name"]

--- a/lib/galaxy_test/api/test_histories.py
+++ b/lib/galaxy_test/api/test_histories.py
@@ -586,7 +586,7 @@ class SharingHistoryTestCase(ApiTestCase, BaseHistories, SharingApiTests):
         # Other users cannot access the dataset
         with self._different_user():
             show_response = self._get(f"datasets/{hda_id}")
-            self._assert_status_code_is(show_response, 400)
+            self._assert_status_code_is(show_response, 403)
 
         sharing_response = self._set_resource_sharing(history_id, "publish")
         assert sharing_response["published"] is True


### PR DESCRIPTION
Some of the endpoints in the datasets API were using the [get_hda_or_ldda](https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/webapps/base/controller.py#L984) function to retrieve the dataset association. Since this code is around 10 years old I figured out that we probably should use the existing manager's methods instead which also take into account Admin access and unify the error handling.

This should take care of the other API related issue in https://github.com/galaxyproject/galaxy/issues/13001#issuecomment-981717424

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
