### PR TITLE
Add mulled-hash command to galaxy-tool-util

### DIFF
--- a/doc/source/admin/special_topics/mulled_containers.rst
+++ b/doc/source/admin/special_topics/mulled_containers.rst
@@ -44,8 +44,8 @@ Automatic build of Linux containers
 We utilize mulled_ with involucro_ to automatically convert all packages in Bioconda_ into Linux containers images 
 (Docker and rkt at the moment) and make them available at the `BioContainers Quay.io account`_.
 
-We have developed small utilities around this technology stack, which is currently included in galaxy-lib_.
-Here is a short introduction:
+We have developed small utilities around this technology stack, which is currently included in the ``galaxy-tool-util``
+package, which can be installed simply using ``pip install galaxy-tool-util``. Here is a short introduction:
 
 Search for containers
 ^^^^^^^^^^^^^^^^^^^^^
@@ -59,6 +59,19 @@ This will search for Docker containers (in the biocontainers organisation on qua
 The user can specify the location(s) for a search using the ``--destination`` option. The search term is specified using ``--search``. Multiple search terms can be specified simultaneously; in this case, the search will also encompass multi-package containers. For example, ``--search samtools bamtools``, will return ``mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa:c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0``, in addition to all individual samtools and bamtools results.
 
 If the user wishes to specify a quay.io organization or Conda channel for the search, this may be done using the ``--organization`` and ``--channel`` options respectively, e.g. ``--channel conda-forge``. Enabling ``--json`` causes results to be returned in JSON format.
+
+
+Calculate a mulled hash
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Each mulled container is identified with a hash such as ``mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e``. You can calculate this hash using the ``mulled-hash`` command, submitting a comma-separated list of package names:
+
+.. code-block:: bash
+
+   $ mulled-hash samtools=1.3.1,bedtools=2.22
+   mulled-v2-8186960447c5cb2faa697666dc1e6d919ad23f3e:d52e471b5bfa168ac813d54fc5dfe7f96ade56e6
+
+The user can specify whether to generate hashes for either version 1 or version 2 containers with ``--hash``; version 2 is the default.
 
 
 Build all packages from bioconda from the last 24h
@@ -123,7 +136,8 @@ you could do something along these lines.
 
 Build Singularity containers from Docker containers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Singularity containers can be built from Docker containers using the mulled-update-singularity-containers command.
+
+Singularity containers can be built from Docker containers using the ``mulled-update-singularity-containers`` command.
 
 To generate a single container:
 
@@ -166,4 +180,3 @@ Containers, once generated, should be tested. This can be achieved by affixing `
 .. _involucro: https://github.com/involucro/involucro
 .. _Bioconda: https://bioconda.github.io/
 .. _BioContainers Quay.io account: https://quay.io/organization/biocontainers
-.. _galaxy-lib: https://github.com/galaxyproject/galaxy-lib

--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -5,11 +5,8 @@ Examples
 
 Produce a mulled hash with:
 
-    mulled-hash 'samtools=1.3.1--4,bedtools=2.22'
+    mulled-hash samtools=1.3.1,bedtools=2.22
 """
-
-import logging
-import sys
 
 from ._cli import arg_parser
 from .mulled_build import target_str_to_targets
@@ -17,8 +14,6 @@ from .util import (
     v1_image_name,
     v2_image_name,
 )
-
-log = logging.getLogger(__name__)
 
 
 def main(argv=None):
@@ -29,12 +24,10 @@ def main(argv=None):
     args = parser.parse_args()
     targets = target_str_to_targets(args.targets)
     image_name = v2_image_name if args.hash == 'v2' else v1_image_name
-    sys.stdout.write(image_name(targets))
-    sys.stdout.write('\n')
+    print(image_name(targets))
 
 
 __all__ = ("main", )
-
 
 if __name__ == '__main__':
     main()

--- a/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
+++ b/lib/galaxy/tool_util/deps/mulled/mulled_hash.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+"""Produce a mulled hash for specified conda targets.
+
+Examples
+
+Produce a mulled hash with:
+
+    mulled-hash 'samtools=1.3.1--4,bedtools=2.22'
+"""
+
+import logging
+import sys
+
+from ._cli import arg_parser
+from .mulled_build import target_str_to_targets
+from .util import (
+    v1_image_name,
+    v2_image_name,
+)
+
+log = logging.getLogger(__name__)
+
+
+def main(argv=None):
+    """Main entry-point for the CLI tool."""
+    parser = arg_parser(argv, globals())
+    parser.add_argument('targets', metavar="TARGETS", default=None, help="Comma-separated packages for calculating the mulled hash.")
+    parser.add_argument('--hash', dest="hash", choices=["v1", "v2"], default="v2")
+    args = parser.parse_args()
+    targets = target_str_to_targets(args.targets)
+    image_name = v2_image_name if args.hash == 'v2' else v1_image_name
+    sys.stdout.write(image_name(targets))
+    sys.stdout.write('\n')
+
+
+__all__ = ("main", )
+
+
+if __name__ == '__main__':
+    main()

--- a/packages/tool_util/setup.py
+++ b/packages/tool_util/setup.py
@@ -57,6 +57,7 @@ ENTRY_POINTS = '''
         mulled-build-files=galaxy.tool_util.deps.mulled.mulled_build_files:main
         mulled-list=galaxy.tool_util.deps.mulled.mulled_list:main
         mulled-update-singularity-containers=galaxy.tool_util.deps.mulled.mulled_update_singularity_containers:main
+        mulled-hash=galaxy.tool_util.deps.mulled.mulled_hash:main
 '''
 PACKAGE_DATA = {
     # Be sure to update MANIFEST.in for source dist.

--- a/test/unit/tool_util/mulled/test_mulled_build.py
+++ b/test/unit/tool_util/mulled/test_mulled_build.py
@@ -6,6 +6,7 @@ from galaxy.tool_util.deps.mulled.mulled_build import (
     DEFAULT_BASE_IMAGE,
     DEFAULT_EXTENDED_BASE_IMAGE,
     mull_targets,
+    target_str_to_targets
 )
 from ..util import external_dependency_management
 
@@ -27,3 +28,10 @@ def test_mulled_build_files_cli(tmpdir):
     target = build_target('zlib')
     mull_targets([target], command='build-and-test', singularity=True, singularity_image_dir=singularity_image_dir)
     assert singularity_image_dir.join('zlib').exists()
+
+
+def test_target_str_to_targets():
+    target_str = 'samtools=1.3.1--4,bedtools=2.22'
+    targets = target_str_to_targets(target_str)
+    assert (targets[0].package, targets[0].version, targets[0].build) == ('samtools', '1.3.1', '4')
+    assert (targets[1].package, targets[1].version, targets[1].build) == ('bedtools', '2.22', None)


### PR DESCRIPTION
A script as part of `galaxy-tool-util` which provides the mulled hash for a list of packages.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Install galaxy-tool-util from this branch and try the command `mulled-hash samtools=1.3.1,bedtools=2.22`. I have not written a test as this is just an argparse wrapper around existing functions.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
