### PR TITLE
Drop non-actionable warnings from LibraryPermissionsWarning

### DIFF
--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryPermissionsWarning.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryPermissionsWarning.vue
@@ -3,11 +3,10 @@
         <div class="text-center">
             <b-alert show variant="warning" v-if="is_admin">
                 You are logged in as an <strong>administrator</strong> therefore you can manage any folder on this
-                Galaxy instance. Please make sure you understand the consequences.
+                Galaxy instance.
             </b-alert>
             <b-alert show variant="warning" v-else>
-                You can assign any number of roles to any of the following permission types. However please read
-                carefully the implications of such actions.
+                You can assign any number of roles to any of the following permission types.
             </b-alert>
         </div>
     </div>


### PR DESCRIPTION
This sounds pretty scary, and without a link to further reading I don't think this is helpful.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
