### PR TITLE
Change default `file_path` variable for galaxy reports

### DIFF
--- a/doc/source/admin/reports_options.rst
+++ b/doc/source/admin/reports_options.rst
@@ -28,7 +28,7 @@
 
 :Description:
     Where dataset files are stored.
-:Default: ``database/files``
+:Default: ``database/objects``
 :Type: str
 
 

--- a/lib/galaxy/config/sample/reports.yml.sample
+++ b/lib/galaxy/config/sample/reports.yml.sample
@@ -103,7 +103,7 @@ reports:
   #database_connection: sqlite:///./database/universe.sqlite?isolation_level=IMMEDIATE
 
   # Where dataset files are stored.
-  #file_path: database/files
+  #file_path: database/objects
 
   # Where temporary files are stored.
   #new_file_path: database/tmp

--- a/lib/galaxy/webapps/reports/config.py
+++ b/lib/galaxy/webapps/reports/config.py
@@ -28,7 +28,7 @@ class Configuration:
         self.database_connection = kwargs.get("database_connection", False)
         self.database_engine_options = get_database_engine_options(kwargs)
         # Where dataset files are stored
-        self.file_path = resolve_path(kwargs.get("file_path", "database/files"), self.root)
+        self.file_path = resolve_path(kwargs.get("file_path", "database/objects"), self.root)
         self.new_file_path = resolve_path(kwargs.get("new_file_path", "database/tmp"), self.root)
         self.id_secret = kwargs.get("id_secret", "USING THE DEFAULT IS NOT SECURE!")
         self.use_remote_user = string_as_bool(kwargs.get("use_remote_user", "False"))

--- a/lib/galaxy/webapps/reports/config_schema.yml
+++ b/lib/galaxy/webapps/reports/config_schema.yml
@@ -26,7 +26,7 @@ mapping:
 
       file_path:
         type: str
-        default: database/files
+        default: database/objects
         desc: |
           Where dataset files are stored.
 


### PR DESCRIPTION
Minor change to lib/galaxy/config/sample/reports.yml.sample and lib/galaxy/webapps/reports/config_schema.yml for the 'file_path' variable to match lib/galaxy/config/sample/galaxy.yml.sample 'file_path' default (fixes https://github.com/galaxyproject/galaxy/issues/13053)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Deploy Galaxy as described in documentation
  2. Open `$GALAXYROOT/lib/galaxy/config/sample/reports.yml.sample` and confirm that default value for `file_path` is `database/objects` and the default in `$GALAXYROOT/lib/galaxy/webapps/reports/config_schema.yml` is also `database/objects`. These should match the `file_path` value in `$GALAXYROOT/lib/galaxy/config/sample/reports.yml.sample`.

NB: This will NOT correct the issue where Galaxy reports has `database/files` hard coded for "Disk space maintenance"(https://github.com/galaxyproject/galaxy/issues/13054)

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
