### PR TITLE
Drop old sqlalchemy patterns that break reports app

### DIFF
--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -211,16 +211,6 @@ def app_pair(global_conf, load_app_kwds=None, wsgi_preflight=True, **kwargs):
         webapp = wrap_if_allowed(webapp, app.application_stack, wrap_in_static,
                                  args=(global_conf,),
                                  kwargs=dict(plugin_frameworks=[app.visualizations_registry], **kwargs))
-    # Close any pooled database connections before forking
-    try:
-        app.model.engine.dispose()
-    except Exception:
-        log.exception("Unable to dispose of pooled galaxy model database connections.")
-    try:
-        app.install_model.engine.dispose()
-    except Exception:
-        log.exception("Unable to dispose of pooled toolshed install model database connections.")
-
     app.application_stack.register_postfork_function(postfork_setup)
 
     for th in threading.enumerate():

--- a/lib/galaxy/webapps/reports/buildapp.py
+++ b/lib/galaxy/webapps/reports/buildapp.py
@@ -72,12 +72,6 @@ def app_factory(global_conf, load_app_kwds=None, **kwargs):
         webapp = wrap_if_allowed(webapp, app.application_stack, wrap_in_static,
                                  args=(global_conf,),
                                  kwargs=kwargs)
-    # Close any pooled database connections before forking
-    try:
-        galaxy.model.mapping.metadata.bind.dispose()
-    except Exception:
-        log.exception("Unable to dispose of pooled galaxy model database connections.")
-    # Return
     return webapp
 
 

--- a/lib/galaxy/webapps/reports/controllers/history.py
+++ b/lib/galaxy/webapps/reports/controllers/history.py
@@ -90,9 +90,9 @@ class History(BaseUIController):
         # transform lists to dict with email as key and
         # number of (history/dataset)/size of history as value
         histories = {_.email if _.email is not None else "Unknown": int(_.history)
-                     for _ in histories.execute()}
+                     for _ in trans.sa_session.execute(histories)}
         datasets = {_.email if _.email is not None else "Unknown": (int(_.dataset), int(_.size))
-                    for _ in datasets.execute()}
+                    for _ in trans.sa_session.execute(datasets)}
 
         sort_keys = (
             lambda v: v[0].lower(),
@@ -157,7 +157,7 @@ class History(BaseUIController):
 
         # execute requests, replace None fields by "Unknown"
         data = [(_.name if _.name is not None else "NoNamedHistory", _.state)
-                for _ in histories.execute()]
+                for _ in trans.sa_session.execute(histories)]
 
         # sort by names descending or ascending
         data.sort(key=lambda v: v[0].lower(), reverse=reverse)

--- a/lib/galaxy/webapps/reports/controllers/home.py
+++ b/lib/galaxy/webapps/reports/controllers/home.py
@@ -30,13 +30,13 @@ class HomePage(BaseUIController, ReportQueryBuilder):
 
         recent_jobs = sa.select(
             (
-                (model.Job.table.c.id),
-                (model.Job.table.c.create_time).label('create_time'),
-                (model.Job.table.c.update_time).label('update_time')
+                (model.Job.id),
+                (model.Job.create_time).label('create_time'),
+                (model.Job.update_time).label('update_time')
             )
         )
 
-        for job in recent_jobs.execute():
+        for job in trans.sa_session.execute(recent_jobs):
             if(job.create_time >= start_days
                and job.create_time < end_date_buffer):
                 if(job.create_time >= start_hours

--- a/lib/galaxy/webapps/reports/controllers/tools.py
+++ b/lib/galaxy/webapps/reports/controllers/tools.py
@@ -100,8 +100,8 @@ class Tools(BaseUIController):
                                          whereclause=(galaxy.model.Job.table.c.state == 'error'),
                                          group_by=['tool'])
 
-        tools_and_jobs_ok = dict(list(tools_and_jobs_ok.execute()))
-        tools_and_jobs_error = dict(list(tools_and_jobs_error.execute()))
+        tools_and_jobs_ok = dict(list(trans.sa_session.execute(tools_and_jobs_ok)))
+        tools_and_jobs_error = dict(list(trans.sa_session.execute(tools_and_jobs_error)))
 
         # select each job name one time
         tools = list(set(tools_and_jobs_ok.keys()) | set(tools_and_jobs_error.keys()))
@@ -154,8 +154,8 @@ class Tools(BaseUIController):
                                         whereclause=and_(galaxy.model.Job.table.c.state == 'error', galaxy.model.Job.table.c.tool_id == tool),
                                         group_by=['date'])
 
-        date_and_jobs_ok = dict(list(date_and_jobs_ok.execute()))
-        date_and_jobs_error = dict(list(date_and_jobs_error.execute()))
+        date_and_jobs_ok = dict(list(trans.sa_session.execute(date_and_jobs_ok)))
+        date_and_jobs_error = dict(list(trans.sa_session.execute(date_and_jobs_error)))
 
         # select each date
         dates = list(set(date_and_jobs_ok.keys()) | set(date_and_jobs_error.keys()))
@@ -207,7 +207,7 @@ class Tools(BaseUIController):
                                 galaxy.model.Job.table.c.update_time - galaxy.model.Job.table.c.create_time),
                                from_obj=[galaxy.model.Job.table])
 
-        jobs_times = [(name, (create, update, time)) for name, create, update, time in jobs_times.execute()]
+        jobs_times = [(name, (create, update, time)) for name, create, update, time in trans.sa_session.execute(jobs_times)]
         for tool, attr in jobs_times:
             if tool not in data:
                 data[tool] = {"last": [(attr[1], attr[0])], "avg": [attr[2]]}
@@ -270,7 +270,7 @@ class Tools(BaseUIController):
                                whereclause=galaxy.model.Job.table.c.tool_id == tool,
                                group_by=['date'])
 
-        months = list(jobs_times.execute())
+        months = list(trans.sa_session.execute(jobs_times.execute))
         months.sort(key=sort_keys[sort_by], reverse=reverse)
         if user_cutoff:
             months = months[:user_cutoff]
@@ -300,11 +300,22 @@ class Tools(BaseUIController):
 
         if tool_name is None:
             raise ValueError("Tool can't be none")
-        tool_errors = [[unicodify(a), b] for a, b in
-                       sa.select((galaxy.model.Job.table.c.tool_stderr, galaxy.model.Job.table.c.create_time),
-                        from_obj=[galaxy.model.Job.table],
-                        whereclause=and_(galaxy.model.Job.table.c.tool_id == tool_name,
-                                         galaxy.model.Job.table.c.state == 'error')).execute()]
+        tool_errors = [
+            [unicodify(a), b]
+            for a, b in trans.sa_session.execute(
+                sa.select(
+                    (
+                        galaxy.model.Job.table.c.tool_stderr,
+                        galaxy.model.Job.table.c.create_time,
+                    ),
+                    from_obj=[galaxy.model.Job.table],
+                    whereclause=and_(
+                        galaxy.model.Job.table.c.tool_id == tool_name,
+                        galaxy.model.Job.table.c.state == "error",
+                    ),
+                )
+            )
+        ]
 
         counter = {}
         for error in tool_errors:

--- a/lib/galaxy/webapps/reports/controllers/users.py
+++ b/lib/galaxy/webapps/reports/controllers/users.py
@@ -43,7 +43,7 @@ class Users(BaseUIController, ReportQueryBuilder):
                       group_by=self.group_by_month(galaxy.model.User.table.c.create_time),
                       order_by=[_order])
         users = []
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             users.append((row.date.strftime("%Y-%m"),
                           row.num_users,
                           row.date.strftime("%B"),
@@ -74,7 +74,7 @@ class Users(BaseUIController, ReportQueryBuilder):
                       group_by=self.group_by_day(galaxy.model.User.table.c.create_time),
                       order_by=[sa.desc('date')])
         users = []
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             users.append((row.date.strftime("%Y-%m-%d"),
                           row.date.strftime("%d"),
                           row.num_users,
@@ -105,7 +105,7 @@ class Users(BaseUIController, ReportQueryBuilder):
                       from_obj=[galaxy.model.User.table],
                       order_by=[galaxy.model.User.table.c.email])
         users = []
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             users.append(row.email)
         return trans.fill_template('/webapps/reports/registered_users_specified_date.mako',
                                    specified_date=start_date,
@@ -211,7 +211,7 @@ class Users(BaseUIController, ReportQueryBuilder):
             group_by=['username'],
             order_by=[sa.desc('username'), 'history'])
 
-        histories = [(_.username if _.username is not None else "Unknown", _.history) for _ in req.execute()]
+        histories = [(_.username if _.username is not None else "Unknown", _.history) for _ in trans.sa_session.execute(req)]
         histories.sort(key=sort_keys[sorting], reverse=reverse)
         if user_cutoff != 0:
             histories = histories[:user_cutoff]

--- a/lib/galaxy/webapps/reports/controllers/workflows.py
+++ b/lib/galaxy/webapps/reports/controllers/workflows.py
@@ -196,7 +196,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                      model.StoredWorkflow.table.c.id))
 
         trends = dict()
-        for workflow in all_workflows.execute():
+        for workflow in trans.sa_session.execute(all_workflows):
             workflow_day = int(workflow.date.strftime("%-d")) - 1
             workflow_month = int(workflow.date.strftime("%-m"))
             workflow_month_name = workflow.date.strftime("%B")
@@ -212,7 +212,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                 trends[key][workflow_day] += 1
 
         workflows = []
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             month_name = row.date.strftime("%B")
             year = int(row.date.strftime("%Y"))
 
@@ -281,7 +281,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                                                                   model.User.table)])
         currday = datetime.today()
         trends = dict()
-        for workflow in all_workflows_per_user.execute():
+        for workflow in trans.sa_session.execute(all_workflows_per_user):
             curr_user = re.sub(r'\W+', '', workflow.user_email)
             try:
                 day = currday - workflow.date
@@ -299,7 +299,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                 if container < spark_limit:
                     trends[curr_user][container] += 1
 
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             workflows.append((row.user_email,
                               row.total_workflows))
 
@@ -342,7 +342,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                                              from_obj=[model.StoredWorkflow.table])
 
         trends = dict()
-        for workflow in all_workflows_user_month.execute():
+        for workflow in trans.sa_session.execute(all_workflows_user_month):
             workflow_day = int(workflow.date.strftime("%-d")) - 1
             workflow_month = int(workflow.date.strftime("%-m"))
             workflow_month_name = workflow.date.strftime("%B")
@@ -358,7 +358,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                 trends[key][workflow_day] += 1
 
         workflows = []
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             workflows.append((row.date.strftime("%Y-%m"),
                               row.total_workflows,
                               row.date.strftime("%B"),
@@ -426,7 +426,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
 
         currday = date.today()
         trends = dict()
-        for run in all_runs_per_workflow.execute():
+        for run in trans.sa_session.execute(all_runs_per_workflow):
             curr_tool = re.sub(r'\W+', '', str(run.workflow_id))
             try:
                 day = currday - run.date
@@ -445,7 +445,7 @@ class Workflows(BaseUIController, ReportQueryBuilder):
                     trends[curr_tool][container] += 1
 
         runs = []
-        for row in q.execute():
+        for row in trans.sa_session.execute(q):
             runs.append((row.workflow_name,
                          row.total_runs,
                          row.workflow_id))

--- a/lib/tool_shed/webapp/buildapp.py
+++ b/lib/tool_shed/webapp/buildapp.py
@@ -12,8 +12,6 @@ from paste import httpexceptions
 from routes.middleware import RoutesMiddleware
 
 import galaxy.webapps.base.webapp
-import tool_shed.webapp.model
-import tool_shed.webapp.model.mapping
 from galaxy import util
 from galaxy.util import asbool
 from galaxy.util.properties import load_app_properties
@@ -196,12 +194,6 @@ def app_factory(global_conf, load_app_kwds=None, **kwargs):
         webapp = wrap_if_allowed(webapp, app.application_stack, wrap_in_static,
                                  args=(global_conf,),
                                  kwargs=kwargs)
-    # Close any pooled database connections before forking
-    try:
-        tool_shed.webapp.model.mapping.metadata.bind.dispose()
-    except Exception:
-        log.exception("Unable to dispose of pooled tool_shed model database connections.")
-    # Return
     return webapp
 
 

--- a/scripts/cleanup_datasets/admin_cleanup_datasets.py
+++ b/scripts/cleanup_datasets/admin_cleanup_datasets.py
@@ -189,7 +189,7 @@ def administrative_delete_datasets(app, cutoff_time, cutoff_days,
     # Add all datasets associated with Histories to our list
     hda_ids = []
     hda_ids.extend(
-        [row.id for row in hda_ids_query.execute()])
+        [row.id for row in app.sa_session.execute(hda_ids_query)])
 
     # Now find the tool_id that generated the dataset (even if it was copied)
     tool_matched_ids = []
@@ -215,7 +215,7 @@ def administrative_delete_datasets(app, cutoff_time, cutoff_days,
                               app.model.History.table)
                       .join(app.model.HistoryDatasetAssociation.table)],
             use_labels=True)
-        for result in user_query.execute():
+        for result in app.sa_session.execute(user_query):
             user_notifications[result[app.model.User.table.c.email]].append(
                 (result[app.model.HistoryDatasetAssociation.table.c.name],
                  result[app.model.History.table.c.name]))

--- a/scripts/cleanup_datasets/cleanup_datasets.py
+++ b/scripts/cleanup_datasets/cleanup_datasets.py
@@ -297,7 +297,7 @@ def delete_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_r
     # and add it to our accrued list of Datasets for later processing.  We mark  as deleted all of its
     # LibraryDatasetDatasetAssociations.  Then we mark the LibraryDataset as purged.  We then process our
     # list of Datasets.
-    library_dataset_ids = [row.id for row in library_dataset_ids_query.execute()]
+    library_dataset_ids = [row.id for row in app.sa_session.execute(library_dataset_ids_query)]
     dataset_ids = []
     for library_dataset_id in library_dataset_ids:
         log.info("######### Processing LibraryDataset id: %d", library_dataset_id)
@@ -322,7 +322,7 @@ def delete_datasets(app, cutoff_time, remove_from_disk, info_only=False, force_r
         log.info("Marked LibraryDataset id %d as purged", ld.id)
         app.sa_session.flush()
     # Add all datasets associated with Histories to our list
-    dataset_ids.extend([row.id for row in history_dataset_ids_query.execute()])
+    dataset_ids.extend([row.id for row in app.sa_session.execute(history_dataset_ids_query)])
     # Process each of the Dataset objects
     for dataset_id in dataset_ids:
         dataset = app.sa_session.query(app.model.Dataset).get(dataset_id)


### PR DESCRIPTION
also removes the engine.dispose() after fork, that's handled via a hook in `build_engine`.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
