### PR TITLE
Quote conda prefix in install command

### DIFF
--- a/lib/galaxy/tool_util/deps/conda_util.py
+++ b/lib/galaxy/tool_util/deps/conda_util.py
@@ -431,7 +431,7 @@ def install_conda(conda_context, force_conda_build=False):
     with tempfile.NamedTemporaryFile(suffix=".sh", prefix="conda_install", delete=False) as temp:
         script_path = temp.name
     download_cmd = commands.download_command(conda_link(), to=script_path)
-    install_cmd = ['bash', script_path, '-b', '-p', conda_context.conda_prefix]
+    install_cmd = ['bash', script_path, '-b', '-p', shlex.quote(conda_context.conda_prefix)]
     package_targets = [
         f"conda={CONDA_VERSION}",
     ]


### PR DESCRIPTION
You can see this fail in our first_startup tests at https://github.com/galaxyproject/galaxy/runs/4547495148?check_suite_focus=true#step:11:1827

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
