### PR TITLE
Fix Cloud object store 

### DIFF
--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -400,8 +400,6 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         except Exception:
             log.exception("Trouble checking existence of S3 key '%s'", rel_path)
             return False
-        if rel_path[0] == '/':
-            raise
         return exists
 
     def _in_cache(self, rel_path):

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -186,11 +186,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
             missing_config = []
             if provider == "aws":
                 akey = auth_element.get("access_key")
-                if akey is None:
-                    missing_config.append("access_key")
                 skey = auth_element.get("secret_key")
-                if skey is None:
-                    missing_config.append("secret_key")
 
                 config["auth"] = {
                     "access_key": akey,

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -727,6 +727,65 @@ def test_config_parse_cloud():
             assert len(extra_dirs) == 2
 
 
+CLOUD_AWS_NO_AUTH_TEST_CONFIG = """<object_store type="cloud" provider="aws">
+     <auth />
+     <bucket name="unique_bucket_name_all_lowercase" use_reduced_redundancy="False" />
+     <cache path="database/object_store_cache" size="1000" />
+     <extra_dir type="job_work" path="database/job_working_directory_cloud"/>
+     <extra_dir type="temp" path="database/tmp_cloud"/>
+</object_store>
+"""
+
+
+def test_config_parse_cloud_noauth_for_aws():
+    for config_str in [CLOUD_AWS_NO_AUTH_TEST_CONFIG]:
+        with TestConfig(config_str, clazz=UnitializedCloudObjectStore) as (directory, object_store):
+
+            assert object_store.bucket_name == "unique_bucket_name_all_lowercase"
+            assert object_store.use_rr is False
+
+            assert object_store.host is None
+            assert object_store.port == 6000
+            assert object_store.multipart is True
+            assert object_store.is_secure is True
+            assert object_store.conn_path == "/"
+
+            assert object_store.cache_size == 1000.0
+            assert object_store.staging_path == "database/object_store_cache"
+            assert object_store.extra_dirs["job_work"] == "database/job_working_directory_cloud"
+            assert object_store.extra_dirs["temp"] == "database/tmp_cloud"
+
+            as_dict = object_store.to_dict()
+            _assert_has_keys(as_dict, ["provider", "auth", "bucket", "connection", "cache", "extra_dirs", "type"])
+
+            _assert_key_has_value(as_dict, "type", "cloud")
+
+            auth_dict = as_dict["auth"]
+            bucket_dict = as_dict["bucket"]
+            connection_dict = as_dict["connection"]
+            cache_dict = as_dict["cache"]
+
+            provider = as_dict["provider"]
+            assert provider == "aws"
+            print(auth_dict["access_key"])
+            _assert_key_has_value(auth_dict, "access_key", None)
+            _assert_key_has_value(auth_dict, "secret_key", None)
+
+            _assert_key_has_value(bucket_dict, "name", "unique_bucket_name_all_lowercase")
+            _assert_key_has_value(bucket_dict, "use_reduced_redundancy", False)
+
+            _assert_key_has_value(connection_dict, "host", None)
+            _assert_key_has_value(connection_dict, "port", 6000)
+            _assert_key_has_value(connection_dict, "multipart", True)
+            _assert_key_has_value(connection_dict, "is_secure", True)
+
+            _assert_key_has_value(cache_dict, "size", 1000.0)
+            _assert_key_has_value(cache_dict, "path", "database/object_store_cache")
+
+            extra_dirs = as_dict["extra_dirs"]
+            assert len(extra_dirs) == 2
+
+
 AZURE_BLOB_TEST_CONFIG = """<object_store type="azure_blob">
     <auth account_name="azureact" account_key="password123" />
     <container name="unique_container_name" max_chunk_size="250"/>


### PR DESCRIPTION
###  Apply s3.py fix to cloud.py
If rel_path is starts with /, an exception is raised at _key_exists method.
This bug has already been fixed in s3.py 37dfd4292a69e4f76dcec785361649956eb1c8ca .
Apply same fix to cloud.py

### Make access_key and secket_key for aws optional
Access_key and secret_key are not required
because boto3(library for aws) looks at various configuration locations.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. create credential file for aws.
  2. remove access_key and secret_key from auth tag in conf/object_storage.xml
  3. Make sure galaxy can upload and download files from s3 

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
