### PR TITLE
[21.09] Use yield_per option to limit amount of ORM objects loaded into memory

### DIFF
--- a/lib/galaxy/jobs/handler.py
+++ b/lib/galaxy/jobs/handler.py
@@ -237,11 +237,11 @@ class JobHandlerQueue(Monitors):
                 .outerjoin(model.User) \
                 .filter(model.Job.state.in_(in_list)
                         & (model.Job.handler == self.app.config.server_name)
-                        & or_((model.Job.user_id == null()), (model.User.active == true()))).all()
+                        & or_((model.Job.user_id == null()), (model.User.active == true()))).yield_per(model.YIELD_PER_ROWS)
         else:
             jobs_at_startup = self.sa_session.query(model.Job).enable_eagerloads(False) \
                 .filter(model.Job.state.in_(in_list)
-                        & (model.Job.handler == self.app.config.server_name)).all()
+                        & (model.Job.handler == self.app.config.server_name)).yield_per(model.YIELD_PER_ROWS)
 
         for job in jobs_at_startup:
             if not self.app.toolbox.has_tool(job.tool_id, job.tool_version, exact=True):

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -916,7 +916,7 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
         back_populates='job', lazy=True)
     output_dataset_collections = relationship('JobToImplicitOutputDatasetCollectionAssociation',
         back_populates='job', lazy=True)
-    post_job_actions = relationship('PostJobActionAssociation', back_populates='job', lazy=False)
+    post_job_actions = relationship('PostJobActionAssociation', back_populates='job', lazy=True)
     input_library_datasets = relationship('JobToInputLibraryDatasetAssociation',
         back_populates='job')
     output_library_datasets = relationship('JobToOutputLibraryDatasetAssociation',

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -135,6 +135,7 @@ JOB_METRIC_PRECISION = 26
 JOB_METRIC_SCALE = 7
 # Tags that get automatically propagated from inputs to outputs when running jobs.
 AUTO_PROPAGATED_TAGS = ["name"]
+YIELD_PER_ROWS = 100
 
 
 if TYPE_CHECKING:

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -204,7 +204,7 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
         query = query.limit(limit)
 
         out = []
-        for job in query.all():
+        for job in query.yield_per(model.YIELD_PER_ROWS):
             job_dict = job.to_dict(view, system_details=is_admin)
             j = self.encode_all_ids(trans, job_dict, True)
             if view == 'admin_job_list':


### PR DESCRIPTION
I've applied it only to non-legacy code where we don't need the entire
list up-front.

This might help with

>  I have an issue with the job handlers from a few days. Randomly one of them gets trapped in a death loop. It starts to monitor jobs, the memory ramps up until the systemd limit of 12GB and then is killed by sytemd

report by @gmauro on usegalaxy.eu

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
