### PR TITLE
[21.05] Fix mulled unit tests by checking that known versions are returned

### DIFF
--- a/test/unit/tool_util/mulled/test_mulled_search.py
+++ b/test/unit/tool_util/mulled/test_mulled_search.py
@@ -50,7 +50,10 @@ def test_get_package_hash():
 @external_dependency_management
 def test_singularity_search():
     sing1 = singularity_search('mulled-v2-0560a8046fc82aa4338588eca29ff18edab2c5aa')
+    sing1_versions = {result['version'] for result in sing1}
+    assert {
+        'c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0',
+        'f471ba33d45697daad10614c5bd25a67693f67f1-0',
+        'fc33176431a4b9ef3213640937e641d731db04f1-0'}.issubset(sing1_versions)
     sing2 = singularity_search('mulled-v2-19fa9431f5863b2be81ff13791f1b00160ed0852')
-    assert sing1[0]['version'] in ['c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0', 'fc33176431a4b9ef3213640937e641d731db04f1-0']
-    assert sing1[1]['version'] in ['c17ce694dd57ab0ac1a2b86bb214e65fedef760e-0', 'fc33176431a4b9ef3213640937e641d731db04f1-0']
     assert sing2 == []


### PR DESCRIPTION
Backport of https://github.com/galaxyproject/galaxy/commit/e7386d52300e1bcb062b193875959fb325289241

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
