### PR TITLE
Add parquet to csv datatype converter

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -82,7 +82,9 @@
     <datatype extension="daa" type="galaxy.datatypes.binary:DAA" display_in_upload="true"/>
     <datatype extension="rma6" type="galaxy.datatypes.binary:RMA6" display_in_upload="true"/>
     <datatype extension="dmnd" type="galaxy.datatypes.binary:DMND" display_in_upload="false"/>
-    <datatype extension="parquet" type="galaxy.datatypes.binary:Parquet" display_in_upload="true"/>
+    <datatype extension="parquet" type="galaxy.datatypes.binary:Parquet" display_in_upload="true">
+      <converter file="parquet_to_csv_converter.xml" target_datatype="csv"/>
+    </datatype>
     <datatype extension="idat" type="galaxy.datatypes.binary:Idat" display_in_upload="true"/>
     <datatype extension="bigbed" type="galaxy.datatypes.binary:BigBed" mimetype="application/octet-stream" display_in_upload="true">
       <display file="ucsc/bigbed.xml"/>

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     csv = parquet = None
 
+
 def __main__():
     infile = sys.argv[1]
     outfile = sys.argv[2]
@@ -22,6 +23,7 @@ def __main__():
     if csv is None or parquet is None:
         raise Exception("Cannot run conversion, pyarrow is not installed.")
     csv.write_csv(parquet.read_table(infile), outfile)
+
 
 if __name__ == "__main__":
     __main__()

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""
+Input: parquet
+Output: csv
+"""
+import os
+import sys
+from pyarrow import csv
+from pyarrow import parquet
+
+def __main__():
+    infile = sys.argv[1]
+    outfile = sys.argv[2]
+
+    if not os.path.isfile(infile):
+        sys.stderr.write(f"Input file {infile!r} not found\n")
+        sys.exit(1)
+
+    csv.write_csv(parquet.read_table(infile), outfile)
+
+if __name__ == "__main__":
+    __main__()

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
@@ -6,7 +6,8 @@ Output: csv
 import os
 import sys
 try:
-    import pyarrow
+    import pyarrow.csv
+    import pyarrow.parquet
 except ImportError:
     pyarrow = None
 

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
@@ -5,8 +5,11 @@ Output: csv
 """
 import os
 import sys
-from pyarrow import csv
-from pyarrow import parquet
+try:
+    from pyarrow import csv
+    from pyarrow import parquet
+except ImportError:
+    csv = parquet = None
 
 def __main__():
     infile = sys.argv[1]
@@ -16,6 +19,8 @@ def __main__():
         sys.stderr.write(f"Input file {infile!r} not found\n")
         sys.exit(1)
 
+    if csv is None or parquet is None:
+        raise Exception("Cannot run conversion, pyarrow is not installed.")
     csv.write_csv(parquet.read_table(infile), outfile)
 
 if __name__ == "__main__":

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.py
@@ -6,10 +6,9 @@ Output: csv
 import os
 import sys
 try:
-    from pyarrow import csv
-    from pyarrow import parquet
+    import pyarrow
 except ImportError:
-    csv = parquet = None
+    pyarrow = None
 
 
 def __main__():
@@ -20,9 +19,9 @@ def __main__():
         sys.stderr.write(f"Input file {infile!r} not found\n")
         sys.exit(1)
 
-    if csv is None or parquet is None:
+    if pyarrow is None:
         raise Exception("Cannot run conversion, pyarrow is not installed.")
-    csv.write_csv(parquet.read_table(infile), outfile)
+    pyarrow.csv.write_csv(pyarrow.parquet.read_table(infile), outfile)
 
 
 if __name__ == "__main__":

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.xml
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.xml
@@ -12,8 +12,8 @@
     </outputs>
     <tests>
         <test>
-            <param name="input" ftype="parquet" value="1.parquet"/>
-            <output name="output" ftype="csv" value="1.csv"/>
+            <param name="input" ftype="parquet" value="parq_conv.parquet"/>
+            <output name="output" ftype="csv" value="parq_conv.csv"/>
         </test>
     </tests>
     <help>

--- a/lib/galaxy/datatypes/converters/parquet_to_csv_converter.xml
+++ b/lib/galaxy/datatypes/converters/parquet_to_csv_converter.xml
@@ -1,0 +1,21 @@
+<!-- In order to use this converter the admin has to install its dependency pyarrow e.g. through the Galaxy admin UI -->
+<tool id="CONVERTER_parquet_to_csv" name="Convert Parquet to csv" version="1.0.0" profile="19.05">
+    <requirements>
+        <requirement type="package" version="4.0.1">pyarrow</requirement>
+    </requirements>
+    <command>python '$__tool_directory__/parquet_to_csv_converter.py' '$input' '$output'</command>
+    <inputs>
+        <param name="input" type="data" format="parquet" label="Parquet file"/>
+    </inputs>
+    <outputs>
+        <data name="output" format="csv"/>
+    </outputs>
+    <tests>
+        <test>
+            <param name="input" ftype="parquet" value="1.parquet"/>
+            <output name="output" ftype="csv" value="1.csv"/>
+        </test>
+    </tests>
+    <help>
+    </help>
+</tool>


### PR DESCRIPTION
I have the mentioned test data ready for https://github.com/galaxyproject/galaxy-test-data but given this converter requires a "manual" `pyarrow` dependency resolution I am not sure whether to include the tests. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  1. install pyarrow as admin
  1. upload parquet file
  1. use the parquet dataset in any tool that requires csv
## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
