### PR TITLE
Add documentation for test/param/metadata in xsd

### DIFF
--- a/doc/schema_template.md
+++ b/doc/schema_template.md
@@ -81,6 +81,7 @@ $tag:tool|outputs|collection|discover_datasets://complexType[@name='OutputCollec
 $tag:tool|tests://complexType[@name='Tests']
 $tag:tool|tests|test://complexType[@name='Test']
 $tag:tool|tests|test|param://complexType[@name='TestParam']
+$tag:tool|tests|test|param|metadata://complexType[@name='TestParamMetadata']
 $tag:tool|tests|test|param|collection://complexType[@name='TestCollection']
 $tag:tool|tests|test|repeat://complexType[@name='TestRepeat']
 $tag:tool|tests|test|section://complexType[@name='TestSection']

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1732,14 +1732,21 @@ The following demonstrates verifying XML content with XPath-like expressions.
     </xs:choice>
   </xs:group>
   <xs:complexType name="TestParamMetadata">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[
+This directive specifies metadata that should be set for a test data parameter.
+
+See [planemo documentation](https://planemo.readthedocs.io/en/latest/writing_how_do_i.html#test-metadata)
+]]></xs:documentation>
+    </xs:annotation>
     <xs:attribute name="name" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Documentation for name</xs:documentation>
+        <xs:documentation xml:lang="en">Name of the metadata element of the data parameter</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="value" type="xs:string" use="required">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Documentation for value</xs:documentation>
+        <xs:documentation xml:lang="en">Value to set</xs:documentation>
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>


### PR DESCRIPTION
currently only linking to a stub at the planemo docs

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
