### PR TITLE
[21.09] Use a dedicated engine for ToolShedRepositoryCache

### DIFF
--- a/lib/galaxy/tools/cache.py
+++ b/lib/galaxy/tools/cache.py
@@ -289,7 +289,7 @@ class ToolShedRepositoryCache:
     repositories: List[ToolShedRepository]
     repos_by_tuple: Dict[Tuple[str, str, str], List[ToolConfRepository]]
 
-    def __init__(self, config: config.Configuration): 
+    def __init__(self, config: config.Configuration):
         self.engine = self._build_engine(config)
         self.session = scoped_session(sessionmaker(self.engine))
         # Contains ToolConfRepository objects created from shed_tool_conf.xml entries
@@ -339,4 +339,3 @@ class ToolShedRepositoryCache:
         install_db_url = install_db_url or db_url
         install_database_options = config.database_engine_options if combined_install_database else config.install_database_engine_options
         return build_engine(install_db_url, install_database_options)
-


### PR DESCRIPTION
This may fix #12988

The error is this: the connection is (dropped? closed? invalidated?) before the session can execute the query. The error in the last traceback is related. There appears to be nothing helpful in the postgresql log. I wasn't able to find anything in our code that is obviously incorrect and may be causing those errors. 
I think one likely cause is that a connection from the connection pool managed by the engine somehow leaks into a different process. I don't know how. But according to [SQLAlchemy's documentation](https://docs.sqlalchemy.org/en/14/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork), this would lead to a variety of connection-related issues. The proposed solution creates a dedicated engine for the cache object. That way we all but eliminate the possibility of this kind of error. 

The solution is temporary and is only meant to patch 21.09. It will be refactored in 22.01 (which will include Alembic, and may handle engine construction differently).

Possible concern. I am not sure whether this would cause problems for the case when sqlite is used as the galaxy or the tool shed install database (i.e., 2 engines connected to the same db). My initial testing shows that nothing bad happens, but I'm not convinced yet. Still, I think this is safe to deploy, unless, of course, I'm missing something related to sqlite.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
