### PR TITLE
Add tox environment and GitHub workflow for reports startup test

### DIFF
--- a/.ci/first_startup.sh
+++ b/.ci/first_startup.sh
@@ -1,16 +1,32 @@
 #!/bin/sh
+case "$1" in
+    galaxy|"")
+        SCRIPT=./run.sh
+        PORT=8080
+        LOGFILE=galaxy.log
+        ;;
+    reports)
+        SCRIPT=./run_reports.sh
+        PORT=9001
+        LOGFILE=reports_webapp.log
+        ;;
+    *)
+        echo "ERROR: Unrecognized app"
+        exit 1
+        ;;
+esac
 TRIES=120
-URL=http://localhost:8080
+URL=http://localhost:$PORT
 EXIT_CODE=1
 i=0
 echo "Testing for correct startup:"
-bash run.sh --daemon && \
+$SCRIPT --daemon && \
     while [ "$i" -le $TRIES ]; do
         curl --max-time 1 "$URL" && EXIT_CODE=0 && break
         sleep 1
         i=$((i + 1))
     done
-bash run.sh --skip-wheels --stop-daemon
+$SCRIPT --skip-wheels --stop-daemon
 echo "exit code:$EXIT_CODE, showing startup log:"
-cat galaxy.log
+cat "$LOGFILE"
 exit $EXIT_CODE

--- a/.github/workflows/reports_startup.yaml
+++ b/.github/workflows/reports_startup.yaml
@@ -1,0 +1,56 @@
+name: Reports startup
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+env:
+  YARN_INSTALL_OPTS: --frozen-lockfile
+concurrency:
+  group: reports-startup-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+
+  test:
+    name: Reports startup test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.10']
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: 'galaxy root'
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Get full Python version
+      id: full-python-version
+      shell: bash
+      run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
+    - name: Cache pip dir
+      uses: actions/cache@v1
+      id: pip-cache
+      with:
+        path: ~/.cache/pip
+        key: pip-cache-${{ matrix.python-version }}-${{ hashFiles('galaxy root/requirements.txt') }}
+    - name: Cache tox env
+      uses: actions/cache@v2
+      with:
+        path: .tox
+        key: tox-cache-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('galaxy root/requirements.txt') }}-reports-startup
+    - uses: mvdbeek/gha-yarn-cache@master
+      with:
+        yarn-lock-file: 'galaxy root/client/yarn.lock'
+    - name: Install tox
+      run: pip install tox
+    - name: run tests
+      run: tox -e reports_startup
+      working-directory: 'galaxy root'

--- a/scripts/common_startup_functions.sh
+++ b/scripts/common_startup_functions.sh
@@ -43,7 +43,7 @@ parse_common_args() {
                 shift
                 ;;
             --daemon|start)
-                circusd_args="$circusd_args --daemon --log-output $GALAXY_LOG"
+                circusd_args="$circusd_args --daemon --log-output $LOG_FILE"
                 paster_args="$paster_args --daemon"
                 gunicorn_args="$gunicorn_args --daemon"
                 GALAXY_DAEMON_LOG="$GALAXY_LOG"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # envlist is the list of environments that are tested when `tox` is run without any option
 # hyphens in an environment name are used to delimit factors
-envlist = py36-first_startup, py36-lint, py36-lint_docstring_include_list, py36-mypy, py36-unit, test_galaxy_packages, validate_test_tools
+envlist = py37-first_startup, py37-lint, py37-lint_docstring_include_list, py37-mypy, py37-reports_startup, py37-unit, test_galaxy_packages, validate_test_tools
 skipsdist = True
 
 [testenv]
@@ -10,7 +10,7 @@ commands =
     lint: bash .ci/flake8_wrapper.sh
     lint_docstring: bash .ci/flake8_wrapper_docstrings.sh --exclude
     lint_docstring_include_list: bash .ci/flake8_wrapper_docstrings.sh --include
-
+    reports_startup: bash .ci/first_startup.sh reports
     unit: bash run_tests.sh -u
     # start with test here but obviously someday all of it...
     mypy: mypy test lib


### PR DESCRIPTION
Also:
- Fix tox envlist still using py36
- Partially fix running reports with `APP_WEBSERVER=dev`

I've not included testing with `APP_WEBSERVER=dev` since this will soon go away with https://github.com/galaxyproject/galaxy/pull/13071 .

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
