### PR TITLE
[21.09] Fix dataset details button when using prefix

### DIFF
--- a/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
+++ b/client/src/components/History/ContentItem/Dataset/DatasetMenu.vue
@@ -261,8 +261,9 @@ export default {
 
         // wierd iframe navigation
         visualize() {
+            const showDetailsUrl = `/datasets/${this.dataset.id}/details`;
             const redirectParams = {
-                path: this.dataset.getUrl("show_params"),
+                path: showDetailsUrl,
                 title: "Dataset details",
                 tryIframe: false,
             };
@@ -274,13 +275,14 @@ export default {
         },
 
         showDetails() {
+            const showDetailsUrl = `/datasets/${this.dataset.id}/details`;
             const redirectParams = {
-                path: this.dataset.getUrl("show_params"),
+                path: showDetailsUrl,
                 title: "Dataset details",
                 tryIframe: false,
             };
             if (!this.iframeAdd(redirectParams)) {
-                this.backboneRoute(this.dataset.getUrl("show_params"));
+                this.backboneRoute(showDetailsUrl);
             }
         },
 

--- a/client/src/components/plugins/legacyNavigation.js
+++ b/client/src/components/plugins/legacyNavigation.js
@@ -51,7 +51,7 @@ export const legacyNavigationMixin = {
         // galaxy router, wrapper for backbone router
         backboneRoute(path, ...args) {
             try {
-                getGalaxyInstance().router.push(prependPath(path), ...args);
+                getGalaxyInstance().router.push(path, ...args);
             } catch (err) {
                 console.warn("Failed galaxy route change", err, ...arguments);
                 throw err;

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -280,15 +280,16 @@ export var DatasetListItemView = _super.extend(
                 faIcon: "fa-info-circle",
                 onclick: (ev) => {
                     const Galaxy = getGalaxyInstance();
+                    const showDetailsUrl = `/datasets/${this.model.get("id")}/details`;
                     if (Galaxy.frame && Galaxy.frame.active) {
                         ev.preventDefault();
                         Galaxy.frame.add({
-                            url: this.model.urls.show_params,
+                            url: showDetailsUrl,
                             title: `Dataset Details of ${this.model.get("name")}`,
                         });
                     } else if (Galaxy.router) {
                         ev.preventDefault();
-                        Galaxy.router.push(this.model.urls.show_params);
+                        Galaxy.router.push(showDetailsUrl);
                         Galaxy.trigger("activate-hda", this.model.get("id"));
                     }
                 },


### PR DESCRIPTION
If Galaxy is served at a prefix we can't push the prefixed URL into
Galaxy.router.

This fix probably also fixes a few more issues with path prefixes when
using the beta history, considering the legacyNavigationMixin
incorrectly (I think) added the prefix before pushing a route into the
router.

Fixes https://github.com/galaxyproject/galaxy/issues/13089.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
