### PR TITLE
Allow duplicated static options

### DIFF
--- a/lib/galaxy/tool_util/linters/inputs.py
+++ b/lib/galaxy/tool_util/linters/inputs.py
@@ -77,7 +77,6 @@ def lint_inputs(tool_xml, lint_ctx):
             options = param.findall("./options")
             filters = param.findall("./options/filter")
             select_options = param.findall('./option')
-            select_options_text = [option.text.strip() if option.text is not None else option.attrib.get("value", "").capitalize() for option in select_options]
 
             if dynamic_options is not None:
                 lint_ctx.warn(f"Select parameter [{param_name}] uses deprecated 'dynamic_options' attribute.")
@@ -137,9 +136,20 @@ def lint_inputs(tool_xml, lint_ctx):
                 lint_ctx.error(f"Select parameter [{param_name}] has option without value")
             if any(option.text is None for option in select_options):
                 lint_ctx.warn(f"Select parameter [{param_name}] has option without text")
-            if len(set(select_options_text)) != len(select_options_text):
+
+            select_options_texts = list()
+            select_options_values = list()
+            for option in select_options:
+                value = option.attrib.get("value", "")
+                if option.text is None:
+                    text = value.capitalize()
+                else:
+                    text = option.text
+                select_options_texts.append((text, option.attrib.get("selected", "false")))
+                select_options_values.append((value, option.attrib.get("selected", "false")))
+            if len(set(select_options_texts)) != len(select_options_texts):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same text content")
-            if len({option.attrib.get("value") for option in select_options}) != len(select_options):
+            if len(set(select_options_values)) != len(select_options_values):
                 lint_ctx.error(f"Select parameter [{param_name}] has multiple options with the same value")
 
             multiple = string_as_bool(param_attrib.get("multiple", "false"))

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -3365,17 +3365,23 @@ value is ``select`` (i.e. ``<param type="select" ...>``).
 ```
 
 An option can also be annotated with ``selected="true"`` to specify a
-default option.
+default option (note that the first option is selected automatically
+if ``optional="false"``).
 
 ```xml
 <param name="col" type="select" label="From">
-    <option value="0" selected="true">Column 1 / Sequence name</option>
-    <option value="1">Column 2 / Source</option>
+    <option value="0">Column 1 / Sequence name</option>
+    <option value="1" selected="true">Column 2 / Source</option>
     <option value="2">Column 3 / Feature</option>
     <option value="6">Column 7 / Strand</option>
     <option value="7">Column 8 / Frame</option>
 </param>
 ```
+
+In general the values and the texts for the options need to be unique,
+but it is possible to specify an option two times if the 2nd has a different
+value for the ``selected`` attribute. This is handy if an option list is
+defined in a macro and different default value(s) are used.
 ]]>
 </xs:documentation>
     </xs:annotation>

--- a/test/unit/tool_util/test_tool_linters.py
+++ b/test/unit/tool_util/test_tool_linters.py
@@ -107,6 +107,17 @@ SELECT_DUPLICATED_OPTIONS = """
 </tool>
 """
 
+SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED = """
+<tool>
+    <inputs>
+        <param name="select" type="select" optional="true" multiple="true">
+            <option value="v">x</option>
+            <option value="v" selected="true">x</option>
+        </param>
+    </inputs>
+</tool>
+"""
+
 SELECT_DEPRECATIONS = """
 <tool name="BWA Mapper" id="bwa" version="1.0.1" display_interface="true" require_login="true" hidden="true">
     <description>The BWA Mapper</description>
@@ -332,6 +343,11 @@ TESTS = [
             and len(x.warn_messages) == 0 and len(x.error_messages) == 2
     ),
     (
+        SELECT_DUPLICATED_OPTIONS_WITH_DIFF_SELECTED, inputs.lint_inputs,
+        lambda x:
+            len(x.warn_messages) == 0 and len(x.error_messages) == 0
+    ),
+    (
         SELECT_DEPRECATIONS, inputs.lint_inputs,
         lambda x:
             "Select parameter [select_do] uses deprecated 'dynamic_options' attribute." in x.warn_messages
@@ -407,6 +423,7 @@ TEST_IDS = [
     'lint no when',
     'radio select incompatibilities',
     'select duplicated options',
+    'select duplicated options with different selected',
     'select deprecations',
     'select option definitions',
     'validator imcompatibilities',


### PR DESCRIPTION
if they define a different select.

- This is super handy to define different defaults if options are defined in a macro.
- Also it is already used in the wild (https://github.com/galaxyproject/tools-iuc/blob/c7b2b60384d54bf3ab5deca109cccba6d30b5c2e/tools/mothur/get.communitytype.xml#L60)
  - But the UI shows the duplicated option
  -  **I would suggest to backport this a few releases.**

Currently only the linter checks if a different value for the `select` attribute is given. The parser just overwrites earlier option with 
the same `value`. So the parser also allows to change the text.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
