### PR TITLE
Don't store stdout/stderr in info field

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -1549,13 +1549,6 @@ class JobWrapper(HasResourceParameters):
             dataset.visible = False
         dataset.blurb = 'done'
         dataset.peek = 'no peek'
-        dataset.info = (dataset.info or '')
-        if context['stdout'].strip():
-            # Ensure white space between entries
-            dataset.info = f"{dataset.info.rstrip()}\n{context['stdout'].strip()}"
-        if context['stderr'].strip():
-            # Ensure white space between entries
-            dataset.info = f"{dataset.info.rstrip()}\n{context['stderr'].strip()}"
         dataset.tool_version = self.version_string
         dataset.set_size()
         if 'uuid' in context:

--- a/lib/galaxy/managers/hdas.py
+++ b/lib/galaxy/managers/hdas.py
@@ -402,7 +402,7 @@ class HDASerializer(  # datasets._UnflattenedMetadataDatasetAssociationSerialize
             'history_id': self.serialize_id,
 
             # remapped
-            'misc_info': self._remap_from('info'),
+            'misc_info': lambda i, k, **c: i.misc_info,
             'misc_blurb': self._remap_from('blurb'),
             'file_ext': self._remap_from('extension'),
             'file_path': self._remap_from('file_name'),

--- a/lib/galaxy/metadata/set_metadata.py
+++ b/lib/galaxy/metadata/set_metadata.py
@@ -323,13 +323,6 @@ def set_metadata_portable():
                     context = expression_context
                 dataset.blurb = 'done'
                 dataset.peek = 'no peek'
-                dataset.info = (dataset.info or '')
-                if context['stdout'].strip():
-                    # Ensure white space between entries
-                    dataset.info = f"{dataset.info.rstrip()}\n{context['stdout'].strip()}"
-                if context['stderr'].strip():
-                    # Ensure white space between entries
-                    dataset.info = f"{dataset.info.rstrip()}\n{context['stderr'].strip()}"
                 dataset.tool_version = version_string
                 if 'uuid' in context:
                     dataset.dataset.uuid = context['uuid']

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -3525,6 +3525,17 @@ class DatasetInstance:
     def ext(self):
         return self.extension
 
+    @property
+    def misc_info(self):
+        creating_job = self.creating_job
+        stdout_stderr_combined = ''
+        if creating_job:
+            tool_stdout = f"{creating_job.tool_stdout.rstrip()}\n" if creating_job.tool_stdout else ""
+            tool_stderr = f"{creating_job.tool_stderr.rstrip()}" if creating_job.tool_stderr else ""
+            info = f"{self.info.rstrip()}\n" if self.info else ""
+            stdout_stderr_combined = f"{info}{tool_stdout}{tool_stderr}"
+        return stdout_stderr_combined[:255]
+
     def get_dataset_state(self):
         # self._state is currently only used when setting metadata externally
         # leave setting the state as-is, we'll currently handle this specially in the external metadata code
@@ -4276,7 +4287,7 @@ class HistoryDatasetAssociation(DatasetInstance, HasTags, Dictifiable, UsesAnnot
                     genome_build=hda.dbkey,
                     validated_state=hda.validated_state,
                     validated_state_message=hda.validated_state_message,
-                    misc_info=hda.info.strip() if isinstance(hda.info, str) else hda.info,
+                    misc_info=hda.misc_info,
                     misc_blurb=hda.blurb)
 
         rval.update(original_rval)
@@ -4714,7 +4725,7 @@ class LibraryDataset(Base, RepresentById):
                     file_ext=ldda.ext,
                     data_type=f"{ldda.datatype.__class__.__module__}.{ldda.datatype.__class__.__name__}",
                     genome_build=ldda.dbkey,
-                    misc_info=ldda.info,
+                    misc_info=ldda.misc_info,
                     misc_blurb=ldda.blurb,
                     peek=(lambda ldda: ldda.display_peek() if ldda.peek and ldda.peek != 'no peek' else None)(ldda))
         if ldda.dataset.uuid is None:
@@ -4859,7 +4870,7 @@ class LibraryDatasetDatasetAssociation(DatasetInstance, HasName, RepresentById):
                     file_ext=ldda.ext,
                     data_type=f"{ldda.datatype.__class__.__module__}.{ldda.datatype.__class__.__name__}",
                     genome_build=ldda.dbkey,
-                    misc_info=ldda.info,
+                    misc_info=ldda.misc_info,
                     misc_blurb=ldda.blurb,
                     created_from_basename=ldda.created_from_basename)
         if ldda.dataset.uuid is None:

--- a/tools/data_source/upload.py
+++ b/tools/data_source/upload.py
@@ -52,6 +52,7 @@ def file_err(msg, dataset):
             os.remove(dataset.path)
         except Exception:
             pass
+    print(msg, file=sys.stderr)
     return dict(type='dataset',
                 ext='data',
                 dataset_id=dataset.dataset_id,


### PR DESCRIPTION
This is pretty nonsensical given that we do this for each output dataset,
when that is a property of the job that produced this file. It just
takes up unncessary storage in the database (pretty minor to be fair, we
limit the column to 255 chars). It also happens we have a
bug in the extended metadata mode where we don't limit the size of the
info property. That lead to a 12G dataset_attrs.txt json file, killing the job handler on usegalaxy.eu

If we do want to display something like this we should build it dynamically
from the job stdout/stderr, but I don't see why we would. This information is
available in the dataset details view.


## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
