### PR TITLE
Beta History: additional small fixes at collection level

### DIFF
--- a/client/src/components/History/ContentItem/DatasetCollection/DscDescription.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscDescription.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="description">
-        A {{ dsc.collectionType | localize }} of {{ dsc.totalElements
-        }}<b v-if="isHomogeneous"> {{ homogeneousDatatype }}</b> datasets.
+        {{ dsc.collectionType | localize }} of {{ dsc.totalElements }}
+        <b v-if="isHomogeneous">{{ homogeneousDatatype }} </b>datasets
     </div>
 </template>
 

--- a/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
+++ b/client/src/components/History/ContentItem/DatasetCollection/DscUI.vue
@@ -41,14 +41,6 @@
                     icon="trash-restore"
                     @click.stop="$emit('undelete')" />
 
-                <IconButton
-                    class="px-1"
-                    state="ok"
-                    title="Collection"
-                    icon="folder"
-                    @click.stop="$emit('viewCollection')"
-                    variant="link" />
-
                 <div class="content-title title flex-grow-1 overflow-hidden" @click.stop="$emit('viewCollection')">
                     <h5 class="text-truncate">
                         <span class="hid">{{ dsc.hid }}</span>

--- a/client/src/components/History/CurrentCollection/CollectionOperations.vue
+++ b/client/src/components/History/CurrentCollection/CollectionOperations.vue
@@ -1,0 +1,33 @@
+<template>
+    <section>
+        <nav class="d-flex justify-content-end">
+            <b-button-group>
+                <IconButton
+                    v-if="isRoot"
+                    class="mb-2 mx-3"
+                    icon="download"
+                    title="Download Collection"
+                    :href="downloadCollectionUrl"
+                    download />
+            </b-button-group>
+        </nav>
+    </section>
+</template>
+
+<script>
+import IconButton from "components/IconButton";
+
+export default {
+    components: { IconButton },
+    props: {
+        isRoot: { type: Boolean, required: true },
+        collection: { type: Object, required: true },
+    },
+    computed: {
+        /** @return {String} */
+        downloadCollectionUrl() {
+            return `${this.collection.url}/download`;
+        },
+    },
+};
+</script>

--- a/client/src/components/History/CurrentCollection/Details.vue
+++ b/client/src/components/History/CurrentCollection/Details.vue
@@ -7,7 +7,6 @@
                 {{ dscName || "(Collection Name)" }}
             </h3>
             <p class="mt-1">
-                <i class="fas fa-folder"></i>
                 <DscDescription :dsc="dsc" />
             </p>
 

--- a/client/src/components/History/CurrentCollection/Panel.vue
+++ b/client/src/components/History/CurrentCollection/Panel.vue
@@ -13,11 +13,12 @@
                     </template>
 
                     <template v-slot:localNav>
-                        <IconButton
-                            icon="download"
-                            title="Download Collection"
-                            :href="downloadCollectionUrl"
-                            download />
+                        <!-- Empty -->
+                        <div />
+                    </template>
+
+                    <template v-slot:listcontrols>
+                        <CollectionOperations :collection="selectedCollection" :is-root="isRoot" />
                     </template>
 
                     <template v-slot:details>
@@ -61,12 +62,12 @@ import { DscProvider, CollectionContentProvider } from "components/providers/His
 import ExpandedItems from "../ExpandedItems";
 import Layout from "../Layout";
 import TopNav from "./TopNav";
+import CollectionOperations from "./CollectionOperations.vue";
 import Details from "./Details";
 import Scroller from "../Scroller";
 import { CollectionContentItem } from "../ContentItem";
 
 import { reportPayload } from "components/providers/History/ContentProvider/helpers";
-import IconButton from "components/IconButton";
 
 export default {
     filters: {
@@ -81,7 +82,7 @@ export default {
         Scroller,
         CollectionContentItem,
         ExpandedItems,
-        IconButton,
+        CollectionOperations,
     },
     props: {
         history: { type: History, required: true },
@@ -94,7 +95,7 @@ export default {
             return selected;
         },
         isRoot() {
-            return this.selectedCollection == this.selectedCollections[0];
+            return this.selectedCollection == this.rootCollection;
         },
         writable() {
             return this.isRoot;

--- a/client/src/components/History/model/DatasetCollection.js
+++ b/client/src/components/History/model/DatasetCollection.js
@@ -18,7 +18,7 @@ export class DatasetCollection extends Content {
     }
 
     get totalElements() {
-        if ("element_count" in this) {
+        if ("element_count" in this && this.element_count) {
             return this.element_count;
         }
         if (this.collection_type == "paired") {

--- a/client/src/components/History/model/DatasetCollection.js
+++ b/client/src/components/History/model/DatasetCollection.js
@@ -57,7 +57,7 @@ export class DatasetCollection extends Content {
      *  @return {Boolean}
      */
     get isHomogeneous() {
-        return this.elements_datatypes.length == 1;
+        return this.elements_datatypes?.length == 1;
     }
 
     /** Gets the datatype shared by all elements or an empty


### PR DESCRIPTION
Follow up on https://github.com/galaxyproject/galaxy/pull/13068
This PR address some more small changes around collections in the new Beta History panel.

>In the expanded view the “folder” icon should be removed from collection elements.

- Removed folder icons from collection items. As discussed in chat, collections should be visually differentiable from regular datasets, but for now, we will use the same or similar visual design as the legacy panel.

>In the expanded view the collection elements must have “save”, “link”, and “delete” icons.

- I leave these changes out of this PR because they are more related to regular `Datasets` which will be addressed in a different PR.

>The header of the expanded history should have save, modify, and tag icons as well as list the datatype.

- Move the Download Collection button from the top corner to a more visible location. When the name of the collection was long enough, the button was pushed out of the page. For this purpose, a new component *CollectionOperations* was added to the `listcontrols` slot with initially just this Download button so it may contain other operations in the future.

  ![Screenshot from 2021-12-20 19-40-50](https://user-images.githubusercontent.com/46503462/146816687-6f03f954-e971-4f96-8944-69701c8eccdf.png)

- The `Edit Collection` button activates the edition mode which contains can edit the name, annotations, and tags of the collection. This remains unchanged.

- Other small fixes. For additional details see each commit message.

## How to test the changes?
- [x] Instructions for manual testing are as follows:
  1. Activate the Beta History panel
  2. Create a couple of different collections and observe the changes.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
