### PR TITLE
Avoid imports of history provider internals

### DIFF
--- a/client/src/components/DatasetInformation/DatasetAttributes.test.js
+++ b/client/src/components/DatasetInformation/DatasetAttributes.test.js
@@ -9,8 +9,6 @@ import flushPromises from "flush-promises";
 
 const localVue = getLocalVue();
 
-jest.mock("components/providers/History/caching");
-
 function buildWrapper(conversion_disable = false) {
     return mount(DatasetAttributes, {
         propsData: {

--- a/client/src/components/DatasetInformation/DatasetInformation.test.js
+++ b/client/src/components/DatasetInformation/DatasetInformation.test.js
@@ -7,7 +7,6 @@ import datasetResponse from "./testData/datasetResponse";
 import flushPromises from "flush-promises";
 import moment from "moment";
 
-jest.mock("components/providers/History/caching");
 const HDA_ID = "FOO_HDA_ID";
 
 const mockDatasetProvider = {
@@ -21,7 +20,7 @@ const mockDatasetProvider = {
 
 const localVue = getLocalVue();
 
-describe("DatasetInformation/DatasetInformation.vue", () => {
+describe("DatasetInformation/DatasetInformation", () => {
     let wrapper;
     let datasetInfoTable;
     let axiosMock;

--- a/client/src/components/History/ContentItem/GenericContentItem/DatasetCollectionUIWrapper.test.js
+++ b/client/src/components/History/ContentItem/GenericContentItem/DatasetCollectionUIWrapper.test.js
@@ -5,8 +5,6 @@ import flushPromises from "flush-promises";
 import datasetCollectionRaw from "components/providers/History/test/json/DatasetCollection.json";
 import datasetCollectionContent from "components/providers/History/test/json/DatasetCollection.nested.json";
 
-jest.mock("components/providers/History/caching");
-
 describe("DatasetUIWrapper.vue with Dataset", () => {
     let wrapper;
     let propsData;

--- a/client/src/components/History/ContentItem/GenericContentItem/DatasetUIWrapper.test.js
+++ b/client/src/components/History/ContentItem/GenericContentItem/DatasetUIWrapper.test.js
@@ -3,8 +3,6 @@ import DatasetUI from "components/History/ContentItem/Dataset/DatasetUI";
 import { shallowMount } from "@vue/test-utils";
 import raw from "components/providers/History/test/json/Dataset.json";
 
-jest.mock("components/providers/History/caching");
-
 describe("DatasetUIWrapper.vue with Dataset", () => {
     let wrapper;
     let propsData;

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -109,9 +109,8 @@ export async function getHistoryById(id, since) {
 
 /**
  * Create new history
- * @param {Object} props Optional history props
  */
-export async function createNewHistory(props = {}) {
+export async function createNewHistory() {
     // TODO: adjust api, keep this for later
     // const url = `/histories`;
     // const data = Object.assign({ name: "New History" }, props);
@@ -199,10 +198,9 @@ export async function secureHistory(history) {
     return await getHistoryById(id);
 }
 
-// #endregion
-
-// #region "Current History"
-
+/**
+ * Content Current History
+ */
 export async function getCurrentHistoryFromServer() {
     const url = "/history/current_history_json";
     const response = await api.get(url, {
@@ -223,31 +221,9 @@ export async function setCurrentHistoryOnServer(history_id) {
     return doResponse(response);
 }
 
-// #endregion
-
-// #region Content Queries
-
 /**
- * Loads specific fields for provided content object, handy for loading
- * visualizations or any other field that's too unwieldy to reasonably include
- * in the standard content caching cycle.
- *
- * @param {Object} content content object
- * @param {Array} fields Array of fields to load
+ * Content Queries
  */
-export async function loadContentFields(content, fields = []) {
-    if (fields.length) {
-        const { history_id, id, history_content_type: type } = content;
-        const url = `/histories/${history_id}/contents/${type}s/${id}`;
-        const params = { keys: fields.join(",") };
-        const response = await api.get(url, { params });
-        if (response.status != 200) {
-            throw new Error(response);
-        }
-        return response.data;
-    }
-    return null;
-}
 
 /**
  * Generic content query function originally intended to help with bulk updates
@@ -308,27 +284,6 @@ export async function updateContentFields(content, newFields = {}) {
 }
 
 /**
- * Undeletes content flagged as deleted.
- * @param {Object} content
- */
-export async function undeleteContent(content) {
-    return await updateContentFields(content, {
-        deleted: false,
-    });
-}
-
-/**
- * Marks as purged
- * @param {*} history
- * @param {*} content
- */
-export async function purgeContent(history, content) {
-    const url = `/histories/${history.id}/contents/${content.id}?purge=True`;
-    const response = await api.delete(url);
-    return doResponse(response);
-}
-
-/**
  * Bulk update endpoint (TODO: rewrite)
  *
  * @param {*} history
@@ -349,9 +304,9 @@ export async function bulkContentUpdate(history, type_ids = [], fields = {}) {
     return doResponse(response);
 }
 
-// #endregion
-
-// #region Collections
+/**
+ * Collections
+ */
 
 export async function createDatasetCollection(history, inputs = {}) {
     const defaults = {
@@ -377,14 +332,13 @@ export async function deleteDatasetCollection(collection, recursive = false, pur
     return doResponse(response);
 }
 
-// #endregion
-
-// #region Job Queries
-
+/**
+ * Job Queries
+ */
 const jobStash = new Map();
 const toolStash = new Map();
 
-export async function loadJobById(jobId) {
+async function loadJobById(jobId) {
     if (!jobStash.has(jobId)) {
         const url = `/jobs/${jobId}?full=false`;
         const response = await api.get(url);
@@ -394,7 +348,7 @@ export async function loadJobById(jobId) {
     return jobStash.get(jobId);
 }
 
-export async function loadToolForJob(job) {
+async function loadToolForJob(job) {
     const { tool_id, history_id } = job;
     const key = `${tool_id}-${history_id}`;
     if (!toolStash.has(key)) {
@@ -410,5 +364,3 @@ export async function loadToolFromJob(jobId) {
     const job = await loadJobById(jobId);
     return await loadToolForJob(job);
 }
-
-// #endregion

--- a/client/src/components/History/model/queries.js
+++ b/client/src/components/History/model/queries.js
@@ -158,16 +158,6 @@ export async function deleteHistoryById(id, purge = false) {
 }
 
 /**
- * Undelete a deleted (but not purged) history
- * @param {String} id Encoded history id
- */
-export async function undeleteHistoryById(id) {
-    const url = `/histories/deleted/${id}/undelete`;
-    const response = await api.post(url, null, { params: stdHistoryParams });
-    return doResponse(response);
-}
-
-/**
  * Update specific fields in history
  * @param {Object} history
  * @param {Object} payload fields to update

--- a/client/src/components/HistoryExport/Index.test.js
+++ b/client/src/components/HistoryExport/Index.test.js
@@ -4,8 +4,6 @@ import { getLocalVue } from "jest/helpers";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 
-jest.mock("components/providers/History/caching");
-
 const TEST_PLUGINS_URL = "/api/remote_files/plugins";
 
 const localVue = getLocalVue();

--- a/client/src/components/HistoryExport/ToLink.test.js
+++ b/client/src/components/HistoryExport/ToLink.test.js
@@ -12,7 +12,6 @@ const TEST_EXPORTS_URL = `/api/histories/${TEST_HISTORY_ID}/exports`;
 const TEST_JOB_ID = "test1234job";
 
 jest.mock("components/JobStates/wait");
-jest.mock("components/providers/History/caching");
 
 describe("ToLink.vue", () => {
     let axiosMock;

--- a/client/src/components/HistoryExport/ToRemoteFile.test.js
+++ b/client/src/components/HistoryExport/ToRemoteFile.test.js
@@ -12,7 +12,6 @@ const TEST_JOB_ID = "job123789";
 const TEST_EXPORTS_URL = `/api/histories/${TEST_HISTORY_ID}/exports`;
 
 jest.mock("components/JobStates/wait");
-jest.mock("components/providers/History/caching");
 
 describe("ToRemoteFile.vue", () => {
     let axiosMock;

--- a/client/src/components/HistoryImport.test.js
+++ b/client/src/components/HistoryImport.test.js
@@ -13,7 +13,6 @@ const TEST_SOURCE_URL = "http://galaxy.example/import";
 const TEST_PLUGINS_URL = "/api/remote_files/plugins";
 
 jest.mock("components/JobStates/wait");
-jest.mock("components/providers/History/caching");
 
 describe("HistoryImport.vue", () => {
     let axiosMock;

--- a/client/src/components/JobInformation/JobInformation.test.js
+++ b/client/src/components/JobInformation/JobInformation.test.js
@@ -11,7 +11,6 @@ import flushPromises from "flush-promises";
 import createCache from "vuex-cache";
 
 jest.mock("app");
-jest.mock("components/providers/History/caching");
 
 const JOB_ID = "test_id";
 

--- a/client/src/components/JobInformation/JobOutputs.test.js
+++ b/client/src/components/JobInformation/JobOutputs.test.js
@@ -1,7 +1,6 @@
 import JobOutputs from "./JobOutputs";
 import { shallowMount } from "@vue/test-utils";
 
-jest.mock("components/providers/History/caching");
 jest.mock("components/providers/DatasetCollectionProvider");
 
 describe("JobInformation/JobOutputs.vue", () => {

--- a/client/src/components/JobParameters/JobParameters.test.js
+++ b/client/src/components/JobParameters/JobParameters.test.js
@@ -9,7 +9,6 @@ import raw from "components/providers/History/test/json/Dataset.json";
 import { userStore } from "store/userStore";
 import { configStore } from "store/configStore";
 
-jest.mock("components/providers/History/caching");
 const observe = jest.fn();
 const unobserve = jest.fn();
 

--- a/client/src/components/Masthead/Masthead.test.js
+++ b/client/src/components/Masthead/Masthead.test.js
@@ -8,7 +8,6 @@ import { loadWebhookMenuItems } from "./_webhooks";
 jest.mock("app");
 jest.mock("layout/menu");
 jest.mock("./_webhooks");
-jest.mock("components/providers/History/caching");
 
 describe("Masthead.vue", () => {
     let wrapper;

--- a/client/src/components/Upload/UploadModal.test.js
+++ b/client/src/components/Upload/UploadModal.test.js
@@ -10,7 +10,6 @@ import MockCurrentUser from "../providers/MockCurrentUser";
 import MockCurrentHistory from "components/providers/History/UserHistories/MockCurrentHistory";
 
 jest.mock("app");
-jest.mock("components/providers/History/caching");
 
 const propsData = {
     chunkUploadSize: 1024,

--- a/client/src/components/User/RecentInvocations.test.js
+++ b/client/src/components/User/RecentInvocations.test.js
@@ -5,7 +5,6 @@ import flushPromises from "flush-promises";
 
 import RecentInvocations from "./RecentInvocations.vue";
 
-jest.mock("components/providers/History/caching");
 jest.mock("./UserServices");
 
 const localVue = getLocalVue();

--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -4,8 +4,6 @@ import { getLocalVue } from "jest/helpers";
 import invocationData from "./test/json/invocation.json";
 import moment from "moment";
 
-jest.mock("components/providers/History/caching");
-
 const localVue = getLocalVue();
 
 describe("Invocations.vue without invocation", () => {

--- a/client/src/components/WorkflowInvocationState/JobStep.test.js
+++ b/client/src/components/WorkflowInvocationState/JobStep.test.js
@@ -3,8 +3,6 @@ import JobStep from "./JobStep";
 import { mount } from "@vue/test-utils";
 import jobs from "./test/json/jobs.json";
 
-jest.mock("components/providers/History/caching");
-
 import { createLocalVue } from "@vue/test-utils";
 
 // create an extended `Vue` constructor

--- a/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
+++ b/client/src/components/WorkflowInvocationState/WorkflowInvocationState.test.js
@@ -10,7 +10,6 @@ const invocationJobsSummaryById = {
     states: {},
     populated_state: "ok",
 };
-jest.mock("components/providers/History/caching");
 
 const localVue = getLocalVue();
 

--- a/client/src/components/providers/History/caching/index.js
+++ b/client/src/components/providers/History/caching/index.js
@@ -17,34 +17,3 @@ export {
 
 export { wipeDatabase, clearHistoryDateStore } from "./CacheApi";
 
-// TODO: The above exports bypass the worker completely for now, swap back to below to use.
-//import { toPromise, toOperator } from "./workerClient";
-///**
-// * monitor cache for changes
-// */
-//export const monitorContentQuery = toOperator("monitorContentQuery");
-//export const monitorDscQuery = toOperator("monitorDscQuery");
-//export const monitorHistoryContent = toOperator("monitorHistoryContent");
-//export const monitorCollectionContent = toOperator("monitorCollectionContent");
-//
-///**
-// * Loaders
-// */
-//export const loadHistoryContents = toOperator("loadHistoryContents");
-//export const loadDscContent = toOperator("loadDscContent");
-//
-///**
-// * Cache promise functions
-// */
-//export const cacheContent = toPromise("cacheContent");
-//export const getCachedContent = toPromise("getCachedContent");
-//export const uncacheContent = toPromise("uncacheContent");
-//export const bulkCacheContent = toPromise("bulkCacheContent");
-//export const cacheCollectionContent = toPromise("cacheCollectionContent");
-//export const getCachedCollectionContent = toPromise("getCachedCollectionContent");
-//export const bulkCacheDscContent = toPromise("bulkCacheDscContent");
-//export const getContentByTypeId = toPromise("getContentByTypeId");
-//
-//// Debugging
-//export const wipeDatabase = toPromise("wipeDatabase");
-//export const clearHistoryDateStore = toPromise("clearHistoryDateStore");

--- a/client/src/components/providers/History/caching/index.js
+++ b/client/src/components/providers/History/caching/index.js
@@ -16,4 +16,3 @@ export {
 } from "./CacheApi";
 
 export { wipeDatabase, clearHistoryDateStore } from "./CacheApi";
-


### PR DESCRIPTION
Remove unused imports and unused functions. Minor clean up of History providers.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
