### PR TITLE
Disable cleanup thread for cloud object store in set metadata

### DIFF
--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -445,7 +445,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
             else:
                 log.debug("Pulled key '%s' into cache to %s", rel_path, self._get_cache_path(rel_path))
                 self.transfer_progress = 0  # Reset transfer progress counter
-                with open(self._get_cache_path(rel_path), "w+") as downloaded_file_handle:
+                with open(self._get_cache_path(rel_path), "wb+") as downloaded_file_handle:
                     key.save_content(downloaded_file_handle)
                 return True
         except Exception:

--- a/lib/galaxy/objectstore/cloud.py
+++ b/lib/galaxy/objectstore/cloud.py
@@ -57,7 +57,8 @@ class CloudConfigMixin:
             "cache": {
                 "size": self.cache_size,
                 "path": self.staging_path,
-            }
+            },
+            'enable_cache_monitor': False,
         }
 
 
@@ -76,6 +77,7 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
         bucket_dict = config_dict['bucket']
         connection_dict = config_dict.get('connection', {})
         cache_dict = config_dict['cache']
+        self.enable_cache_monitor = config_dict.get('enable_cache_monitor', True)
 
         self.provider = config_dict["provider"]
         self.credentials = config_dict["auth"]
@@ -100,8 +102,17 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
 
         self.conn = self._get_connection(self.provider, self.credentials)
         self.bucket = self._get_bucket(self.bucket_name)
+        self.start_cache_monitor()
+        # Test if 'axel' is available for parallel download and pull the key into cache
+        try:
+            subprocess.call('axel')
+            self.use_axel = True
+        except OSError:
+            self.use_axel = False
+
+    def start_cache_monitor(self):
         # Clean cache only if value is set in galaxy.ini
-        if self.cache_size != -1:
+        if self.cache_size != -1 and self.enable_cache_monitor:
             # Convert GBs to bytes for comparison
             self.cache_size = self.cache_size * 1073741824
             # Helper for interruptable sleep
@@ -109,12 +120,6 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
             self.cache_monitor_thread = threading.Thread(target=self.__cache_monitor)
             self.cache_monitor_thread.start()
             log.info("Cache cleaner manager started")
-        # Test if 'axel' is available for parallel download and pull the key into cache
-        try:
-            subprocess.call('axel')
-            self.use_axel = True
-        except OSError:
-            self.use_axel = False
 
     @staticmethod
     def _get_connection(provider, credentials):
@@ -710,3 +715,11 @@ class Cloud(ConcreteObjectStore, CloudConfigMixin):
 
     def _get_store_usage_percent(self):
         return 0.0
+
+    def shutdown(self):
+        self.running = False
+        thread = getattr(self, 'cache_monitor_thread', None)
+        if thread:
+            log.debug("Shutting down thread")
+            self.sleeper.wake()
+            thread.join(5)

--- a/test/unit/objectstore/test_objectstore.py
+++ b/test/unit/objectstore/test_objectstore.py
@@ -723,6 +723,8 @@ def test_config_parse_cloud():
             _assert_key_has_value(cache_dict, "size", 1000.0)
             _assert_key_has_value(cache_dict, "path", "database/object_store_cache")
 
+            _assert_key_has_value(as_dict, "enable_cache_monitor", False)
+
             extra_dirs = as_dict["extra_dirs"]
             assert len(extra_dirs) == 2
 


### PR DESCRIPTION
### When using cloud object store, set_meta.py never ends
1. use cloud object store
2. set metadata_strategy: extended in galaxy.yaml
3. set_meta.py never ends because of  cleanup thread 

This bug has already been fixed at s3.py.
Applied same fix to cloud.py.
Added a test to verify that enable_cache_monitor is false in config_to_dict return value .

### Cannot download from cloud storage to cache dir
1. Use cloud object store
2. Delete object_store_cache content
3. When galaxy tries to download a file, An Exception will be thrown.

Changed open mode from "w+" to "wb+".
I cannot write a unit test for this change because it require s3.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
