### PR TITLE
Add Back button in file source navigation and ftp helper text

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -3,7 +3,9 @@
         :error-message="errorMessage"
         :options-show="optionsShow"
         :modal-show="modalShow"
-        :hide-modal="() => (modalShow = false)">
+        :hide-modal="() => (modalShow = false)"
+        :back-func="() => load()"
+        :undo-show="undoShow">
         <template v-slot:search>
             <data-dialog-search v-model="filter" />
         </template>
@@ -261,7 +263,10 @@ export default {
             this.filter = null;
             this.optionsShow = false;
             this.undoShow = !this.urlTracker.atRoot();
-            if (this.urlTracker.atRoot()) {
+            if (this.urlTracker.atRoot() || this.errorMessage) {
+                if (this.errorMessage) {
+                  this.errorMessage = null
+                }
                 this.services
                     .getFileSources()
                     .then((items) => {

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -4,7 +4,7 @@
         :options-show="optionsShow"
         :modal-show="modalShow"
         :hide-modal="() => (modalShow = false)"
-        :back-func="() => load()"
+        :back-func="load"
         :undo-show="undoShow">
         <template v-slot:search>
             <data-dialog-search v-model="filter" />

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -5,10 +5,21 @@
         :modal-show="modalShow"
         :hide-modal="() => (modalShow = false)"
         :back-func="() => load()"
-        :undo-show="undoShow"
-        :show-ftp-helper="showFTPHelper">
+        :undo-show="undoShow">
         <template v-slot:search>
             <data-dialog-search v-model="filter" />
+        </template>
+        <template v-slot:helper>
+            <b-alert v-if="showFTPHelper" variant="info" show>
+                This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
+                <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials. For help visit the
+                <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.
+                <span v-if="oidcEnabled"
+                    ><br />If you are signed-in to Galaxy using a third-party identity and you
+                    <strong>do not have a Galaxy password</strong> please use the reset password option in the login
+                    form with your email to create a password for your account.</span
+                >
+            </b-alert>
         </template>
         <template v-slot:options>
             <data-dialog-table
@@ -46,6 +57,7 @@
 
 <script>
 import Vue from "vue";
+import { getGalaxyInstance } from "../../app";
 import SelectionDialogMixin from "components/SelectionDialog/SelectionDialogMixin";
 import { selectionStates } from "components/SelectionDialog/selectionStates";
 import { UrlTracker } from "components/DataDialog/utilities";
@@ -94,6 +106,8 @@ export default {
             currentDirectory: undefined,
             showFTPHelper: false,
             selectAllIcon: selectionStates.unselected,
+            ftpUploadSite: getGalaxyInstance()?.config?.ftp_upload_site,
+            oidcEnabled: getGalaxyInstance()?.config?.enable_oidc,
         };
     },
     created: function () {
@@ -267,9 +281,7 @@ export default {
             this.optionsShow = false;
             this.undoShow = !this.urlTracker.atRoot();
             if (this.urlTracker.atRoot() || this.errorMessage) {
-                if (this.errorMessage) {
-                    this.errorMessage = null;
-                }
+                this.errorMessage = null;
                 this.services
                     .getFileSources()
                     .then((items) => {

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -262,13 +262,13 @@ export default {
         /** Performs server request to retrieve data records **/
         load: function (record) {
             this.currentDirectory = this.urlTracker.getUrl(record);
-            this.showFTPHelper = record?.url === 'gxftp://';
+            this.showFTPHelper = record?.url === "gxftp://";
             this.filter = null;
             this.optionsShow = false;
             this.undoShow = !this.urlTracker.atRoot();
             if (this.urlTracker.atRoot() || this.errorMessage) {
                 if (this.errorMessage) {
-                  this.errorMessage = null
+                    this.errorMessage = null;
                 }
                 this.services
                     .getFileSources()

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -5,7 +5,8 @@
         :modal-show="modalShow"
         :hide-modal="() => (modalShow = false)"
         :back-func="() => load()"
-        :undo-show="undoShow">
+        :undo-show="undoShow"
+        :show-ftp-helper="showFTPHelper">
         <template v-slot:search>
             <data-dialog-search v-model="filter" />
         </template>
@@ -91,6 +92,7 @@ export default {
             showDetails: true,
             isBusy: false,
             currentDirectory: undefined,
+            showFTPHelper: false,
             selectAllIcon: selectionStates.unselected,
         };
     },
@@ -260,6 +262,7 @@ export default {
         /** Performs server request to retrieve data records **/
         load: function (record) {
             this.currentDirectory = this.urlTracker.getUrl(record);
+            this.showFTPHelper = record?.url === 'gxftp://';
             this.filter = null;
             this.optionsShow = false;
             this.undoShow = !this.urlTracker.atRoot();

--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -10,7 +10,7 @@
             <data-dialog-search v-model="filter" />
         </template>
         <template v-slot:helper>
-            <b-alert v-if="showFTPHelper" variant="info" show>
+            <b-alert v-if="showFTPHelper" id="helper" variant="info" show>
                 This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
                 <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials. For help visit the
                 <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.

--- a/client/src/components/FilesDialog/testingData.js
+++ b/client/src/components/FilesDialog/testingData.js
@@ -1,3 +1,4 @@
+export const ftpId = "_ftp";
 export const rootId = "pdb-gzip";
 export const directoryId = "gxfiles://pdb-gzip/directory1";
 export const subDirectoryId = "gxfiles://pdb-gzip/directory1/subdirectory1";
@@ -20,6 +21,16 @@ export const rootResponse = [
         uri_root: "gxfiles://pdb-gzip",
         label: "PDB",
         doc: "Protein Data Bank (PDB)",
+        writable: true,
+        requires_roles: null,
+        requires_groups: null,
+    },
+    {
+        id: "empty-dir",
+        type: "posix",
+        uri_root: "gxfiles://empty-dir",
+        label: "Empty Directory",
+        doc: "Empty Directory",
         writable: true,
         requires_roles: null,
         requires_groups: null,
@@ -172,3 +183,5 @@ export const subsubdirectoryResponse = [
         path: "directory1/subdirectory1/subsubdirectory",
     },
 ];
+
+export const someErrorText = "some error text";

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -3,8 +3,6 @@
         modal-class="selection-dialog-modal"
         v-if="modalShow"
         visible
-        ok-only
-        ok-title="Close"
         :static="modalStatic"
         @hide="hideModal">
         <template v-slot:modal-header>
@@ -15,10 +13,19 @@
             <slot name="options" v-if="optionsShow"> </slot>
             <div v-else><span class="fa fa-spinner fa-spin" /> <span>Please wait...</span></div>
         </div>
-        <template v-if="!errorMessage" v-slot:modal-footer>
-            <div class="w-100">
+        <template v-slot:modal-footer>
+            <div v-if="!errorMessage" class="w-100">
                 <slot name="buttons"> </slot>
                 <b-btn size="sm" class="float-right selection-dialog-modal-cancel" @click="hideModal"> Cancel </b-btn>
+            </div>
+            <div v-else class="w-100">
+              <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc()">
+                <font-awesome-icon :icon="['fas', 'caret-left']"/>
+                Back
+              </b-btn>
+              <b-btn size="sm" class="float-right" variant="primary" id="close-btn" @click="hideModal">
+                Close
+              </b-btn>
             </div>
         </template>
     </b-modal>
@@ -27,6 +34,7 @@
 <script>
 import Vue from "vue";
 import BootstrapVue from "bootstrap-vue";
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 Vue.use(BootstrapVue);
 
@@ -56,6 +64,17 @@ export default {
             type: Function,
             required: true,
         },
+        backFunc: {
+          type: Function,
+          required: true,
+        },
+        undoShow: {
+          type: Boolean,
+          required: true,
+        },
+    },
+    components: {
+      FontAwesomeIcon,
     },
 };
 </script>

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -1,18 +1,17 @@
 <template>
-    <b-modal
-        modal-class="selection-dialog-modal"
-        v-if="modalShow"
-        visible
-        :static="modalStatic"
-        @hide="hideModal">
+    <b-modal modal-class="selection-dialog-modal" v-if="modalShow" visible :static="modalStatic" @hide="hideModal">
         <template v-slot:modal-header>
             <slot name="search"> </slot>
         </template>
         <b-alert v-if="showFtpHelper" variant="info" show>
-          This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
-          <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials.
-          For help visit the <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.
-          <span v-if="oidcEnabled"><br/>If you are signed-in to Galaxy using a third-party identity and you <strong>do not have a Galaxy password</strong> please use the reset password option in the login form with your email to create a password for your account.</span>
+            This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
+            <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials. For help visit the
+            <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.
+            <span v-if="oidcEnabled"
+                ><br />If you are signed-in to Galaxy using a third-party identity and you
+                <strong>do not have a Galaxy password</strong> please use the reset password option in the login form
+                with your email to create a password for your account.</span
+            >
         </b-alert>
         <b-alert v-if="errorMessage" variant="danger" show v-html="errorMessage" />
         <div v-else>
@@ -25,13 +24,11 @@
                 <b-btn size="sm" class="float-right selection-dialog-modal-cancel" @click="hideModal"> Cancel </b-btn>
             </div>
             <div v-else class="w-100">
-              <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc()">
-                <font-awesome-icon :icon="['fas', 'caret-left']"/>
-                Back
-              </b-btn>
-              <b-btn size="sm" class="float-right" variant="primary" id="close-btn" @click="hideModal">
-                Close
-              </b-btn>
+                <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc()">
+                    <font-awesome-icon :icon="['fas', 'caret-left']" />
+                    Back
+                </b-btn>
+                <b-btn size="sm" class="float-right" variant="primary" id="close-btn" @click="hideModal"> Close </b-btn>
             </div>
         </template>
     </b-modal>
@@ -72,26 +69,26 @@ export default {
             required: true,
         },
         backFunc: {
-          type: Function,
-          required: true,
+            type: Function,
+            required: true,
         },
         undoShow: {
-          type: Boolean,
-          required: true,
+            type: Boolean,
+            required: true,
         },
         showFtpHelper: {
-          type: Boolean,
-          required: false,
+            type: Boolean,
+            required: false,
         },
     },
     components: {
-      FontAwesomeIcon,
+        FontAwesomeIcon,
     },
     data() {
-      return {
-        ftpUploadSite: getGalaxyInstance().config.ftp_upload_site,
-        oidcEnabled: getGalaxyInstance().config.enable_oidc,
-      }
+        return {
+            ftpUploadSite: getGalaxyInstance().config.ftp_upload_site,
+            oidcEnabled: getGalaxyInstance().config.enable_oidc,
+        };
     },
 };
 </script>

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -8,6 +8,12 @@
         <template v-slot:modal-header>
             <slot name="search"> </slot>
         </template>
+        <b-alert v-if="showFtpHelper" variant="info" show>
+          This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
+          <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials.
+          For help visit the <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.
+          <span v-if="oidcEnabled"><br/>If you are signed-in to Galaxy using a third-party identity and you <strong>do not have a Galaxy password</strong> please use the reset password option in the login form with your email to create a password for your account.</span>
+        </b-alert>
         <b-alert v-if="errorMessage" variant="danger" show v-html="errorMessage" />
         <div v-else>
             <slot name="options" v-if="optionsShow"> </slot>
@@ -33,6 +39,7 @@
 
 <script>
 import Vue from "vue";
+import { getGalaxyInstance } from "app";
 import BootstrapVue from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
@@ -72,9 +79,19 @@ export default {
           type: Boolean,
           required: true,
         },
+        showFtpHelper: {
+          type: Boolean,
+          required: false,
+        },
     },
     components: {
       FontAwesomeIcon,
+    },
+    data() {
+      return {
+        ftpUploadSite: getGalaxyInstance().config.ftp_upload_site,
+        oidcEnabled: getGalaxyInstance().config.enable_oidc,
+      }
     },
 };
 </script>

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -70,11 +70,12 @@ export default {
         },
         backFunc: {
             type: Function,
-            required: true,
+            required: false,
+            default: () => {},
         },
         undoShow: {
             type: Boolean,
-            required: true,
+            required: false,
         },
         showFtpHelper: {
             type: Boolean,
@@ -86,8 +87,8 @@ export default {
     },
     data() {
         return {
-            ftpUploadSite: getGalaxyInstance().config.ftp_upload_site,
-            oidcEnabled: getGalaxyInstance().config.enable_oidc,
+            ftpUploadSite: getGalaxyInstance()?.config?.ftp_upload_site,
+            oidcEnabled: getGalaxyInstance()?.config?.enable_oidc,
         };
     },
 };

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -3,32 +3,29 @@
         <template v-slot:modal-header>
             <slot name="search"> </slot>
         </template>
-        <b-alert v-if="showFtpHelper" variant="info" show>
-            This Galaxy server allows you to upload files via FTP. To upload some files, log in to the FTP server at
-            <strong>{{ ftpUploadSite }}</strong> using your Galaxy credentials. For help visit the
-            <a href="https://galaxyproject.org/ftp-upload/" target="_blank">tutorial</a>.
-            <span v-if="oidcEnabled"
-                ><br />If you are signed-in to Galaxy using a third-party identity and you
-                <strong>do not have a Galaxy password</strong> please use the reset password option in the login form
-                with your email to create a password for your account.</span
-            >
-        </b-alert>
+        <slot name="helper"> </slot>
         <b-alert v-if="errorMessage" variant="danger" show v-html="errorMessage" />
         <div v-else>
             <slot name="options" v-if="optionsShow"> </slot>
             <div v-else><span class="fa fa-spinner fa-spin" /> <span>Please wait...</span></div>
         </div>
         <template v-slot:modal-footer>
-            <div v-if="!errorMessage" class="w-100">
-                <slot name="buttons"> </slot>
-                <b-btn size="sm" class="float-right selection-dialog-modal-cancel" @click="hideModal"> Cancel </b-btn>
-            </div>
-            <div v-else class="w-100">
-                <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc()">
-                    <font-awesome-icon :icon="['fas', 'caret-left']" />
-                    Back
-                </b-btn>
-                <b-btn size="sm" class="float-right" variant="primary" id="close-btn" @click="hideModal"> Close </b-btn>
+            <div class="w-100">
+                <div v-if="!errorMessage">
+                    <slot name="buttons"> </slot>
+                    <b-btn size="sm" class="float-right selection-dialog-modal-cancel" @click="hideModal">
+                        Cancel
+                    </b-btn>
+                </div>
+                <div v-else>
+                    <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc()">
+                        <font-awesome-icon :icon="['fas', 'caret-left']" />
+                        Back
+                    </b-btn>
+                    <b-btn size="sm" class="float-right" variant="primary" id="close-btn" @click="hideModal">
+                        Close
+                    </b-btn>
+                </div>
             </div>
         </template>
     </b-modal>
@@ -36,7 +33,6 @@
 
 <script>
 import Vue from "vue";
-import { getGalaxyInstance } from "app";
 import BootstrapVue from "bootstrap-vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
@@ -77,19 +73,9 @@ export default {
             type: Boolean,
             required: false,
         },
-        showFtpHelper: {
-            type: Boolean,
-            required: false,
-        },
     },
     components: {
         FontAwesomeIcon,
-    },
-    data() {
-        return {
-            ftpUploadSite: getGalaxyInstance()?.config?.ftp_upload_site,
-            oidcEnabled: getGalaxyInstance()?.config?.enable_oidc,
-        };
     },
 };
 </script>

--- a/client/src/components/SelectionDialog/SelectionDialog.vue
+++ b/client/src/components/SelectionDialog/SelectionDialog.vue
@@ -18,7 +18,7 @@
                     </b-btn>
                 </div>
                 <div v-else>
-                    <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc()">
+                    <b-btn id="back-btn" size="sm" class="float-left" v-if="undoShow" @click="backFunc">
                         <font-awesome-icon :icon="['fas', 'caret-left']" />
                         Back
                     </b-btn>


### PR DESCRIPTION
This PR adds the `Back` button for file source explorer when a navigation error and FTP helper text and oidc when `enable_oidc` in config is `true` when exploring FTP files.

Fixes the first and the second requirements in #12193

![Screen Shot 2021-12-25 at 7 55 10 PM](https://user-images.githubusercontent.com/8046843/147406871-6b810bcf-cca2-4ee3-9b57-6a59acb37352.png)
![Screen Shot 2021-12-25 at 6 52 30 PM](https://user-images.githubusercontent.com/8046843/147406883-740b6785-48ad-4686-880d-b593cf983529.png)
![Screen Shot 2021-12-25 at 6 48 21 PM](https://user-images.githubusercontent.com/8046843/147406894-5ab16e61-637a-46bc-8286-e4a4a0b38cb6.png)
![Screen Shot 2021-12-25 at 6 48 10 PM](https://user-images.githubusercontent.com/8046843/147406899-6c8c4209-eb0f-4728-ac04-465b4de98f45.png)

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
