### PR TITLE
Prevent select all in FilesDialog when no entries and select empty resource

### DIFF
--- a/client/src/components/FilesDialog/FilesDialog.vue
+++ b/client/src/components/FilesDialog/FilesDialog.vue
@@ -230,7 +230,9 @@ export default {
         },
         /** check if all objects in this folders are selected **/
         checkIfAllSelected() {
-            const isAllSelected = this.items.every(({ id }) => this.model.exists(id) || this.isDirectorySelected(id));
+            const isAllSelected =
+                this.items.length &&
+                this.items.every(({ id }) => this.model.exists(id) || this.isDirectorySelected(id));
 
             if (isAllSelected && !this.isDirectorySelected(this.currentDirectory.id)) {
                 // if all selected, select current folder
@@ -252,6 +254,13 @@ export default {
                     item.isLeaf ? this.model.add(item) : this.selectDirectory(item);
                 }
             }
+
+            if (!isUnselectAll && this.items.length !== 0) {
+                this.selectedDirectories.push(this.currentDirectory);
+            } else if (this.isDirectorySelected(this.currentDirectory.id)) {
+                this.selectDirectory(this.currentDirectory);
+            }
+
             this.hasValue = this.model.count() > 0;
             this.formatRows();
         },


### PR DESCRIPTION
This PR fixes issue #13105.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
