### PR TITLE
Fix selenium test via dropping redundant test case

### DIFF
--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -141,7 +141,6 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         # prefetch citations so they will be available quickly when rendering tool form.
         citations_api = self.api_get("tools/bibtex/citations")
         citation_count = len(citations_api)
-        assert len(citations_api) == citation_count, len(citations_api)
         self.tool_open("bibtex")
         self.components.tool_form.about.wait_for_and_click()
 

--- a/lib/galaxy_test/selenium/test_tool_form.py
+++ b/lib/galaxy_test/selenium/test_tool_form.py
@@ -140,20 +140,20 @@ class ToolFormTestCase(SeleniumTestCase, UsesHistoryItemAssertions):
         self.home()
         # prefetch citations so they will be available quickly when rendering tool form.
         citations_api = self.api_get("tools/bibtex/citations")
-        assert len(citations_api) == 29, len(citations_api)
+        citation_count = len(citations_api)
+        assert len(citations_api) == citation_count, len(citations_api)
         self.tool_open("bibtex")
         self.components.tool_form.about.wait_for_and_click()
 
         @retry_assertion_during_transitions
         def assert_citations_visible():
             references = self.components.tool_form.reference.all()
-            assert len(references) == 29
+            assert len(references) == citation_count
             return references
 
         references = assert_citations_visible()
-
-        doi_resolved_citation = references[1]
-        assert "enabling efficient sequence analysis" in doi_resolved_citation.text
+        doi_resolved_citation = references[0]
+        assert "platform for interactive" in doi_resolved_citation.text
         self.screenshot("tool_form_citations_formatted")
 
     def _check_dataset_details_for_inttest_value(self, hid, expected_value="42"):

--- a/test/functional/tools/bibtex.xml
+++ b/test/functional/tools/bibtex.xml
@@ -31,7 +31,7 @@ echo '$input1' > '$out_file1'
     ]]></help>
     <citations>
         <citation type="doi">10.1101/gr.4086505</citation>
-        <citation type="doi">10.6084/m9.figshare.979190</citation>
+        <!--<citation type="doi">10.6084/m9.figshare.979190</citation>-->
         <citation type="bibtex">
 @misc{Garrison2015,
   author = {Garrison, Erik},


### PR DESCRIPTION
This fixes the (currently) broken selenium test at `lib/galaxy_test/selenium/test_tool_form.py::ToolFormTestCase::test_bibtex_rendering`

The DOI link does not resolve: the response is consistently `503 Service Temporarily Unavailable`. The DOI is correct though: it resolves if accessed via url: [https://doi.org/10.6084/m9.figshare.979190](https://doi.org/10.6084/m9.figshare.979190).

The bibtex tool contains 29 citations; 2 of them are of DOI type. I think we need only one to verify correct processing of this citation type (unless these 2 citations trigger different processing?), so dropping the offending citation seems the simplest solution here.



## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
