### PR TITLE
Delay iframe creation for news until clicked

### DIFF
--- a/config/plugins/webhooks/news/script.js
+++ b/config/plugins/webhooks/news/script.js
@@ -1,10 +1,5 @@
-function removeNewsOverlay() {
+function hideNewsOverlay() {
     document.getElementById("news-container").style.visibility = "hidden";
-}
-
-function showNewsOverlay() {
-    document.getElementById("news-container").style.visibility = "visible";
-    newsSeen();
 }
 
 function newsSeen() {
@@ -20,45 +15,6 @@ function newsUnseen() {
     const newsIconSpan = document.querySelector("#news .fa-bell");
     newsIconSpan.classList.remove("far");
     newsIconSpan.classList.add("fa");
-}
-
-function addNewsIframe() {
-    var currentGalaxyVersion = Galaxy.config.version_major;
-
-    // TODO/@hexylena: By 21.01 we will have a proper solution for this. For
-    // now we'll hardcode the version users 'see'. @hexylena will remove this
-    // code when she writes the user-facing release notes, and then will file
-    // an issue for how we'll fix this properly.
-    if (currentGalaxyVersion == "22.01") {
-        currentGalaxyVersion = "21.09";
-    }
-
-    const releaseNotes = `https://docs.galaxyproject.org/en/latest/releases/${currentGalaxyVersion}_announce_user.html`;
-    const lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
-    // Check that they've seen the current version's release notes.
-    if (lastSeenVersion != currentGalaxyVersion) {
-        newsUnseen();
-    } else {
-        newsSeen();
-    }
-
-    document.querySelector("body.full-content").insertAdjacentHTML(
-        "afterbegin",
-        `
-            <div id="news-container" style="visibility: hidden">
-                <div id="news-screen-overlay"></div>
-                <div id="news-screen">
-                    <div id="news-header">
-                        <iframe id="news-embed" src="${releaseNotes}" width="80%" height="80%"></iframe>
-                    </div>
-                </div>
-            </div>`
-    );
-
-    // Clicking outside of GTN closes it
-    document.getElementById("news-screen").addEventListener("click", () => {
-        removeNewsOverlay();
-    });
 }
 
 /* The masthead icon may not exist yet when this webhook executes; we need this to wait for that to happen.
@@ -91,13 +47,50 @@ elementReadyNews("#news a").then((el) => {
     clean = el.cloneNode(true);
     el.parentNode.replaceChild(clean, el);
 
-    // This gets added by default.
-    addNewsIframe();
+    let currentGalaxyVersion = Galaxy.config.version_major;
+
+    // TODO/@hexylena: By 21.01 we will have a proper solution for this. For
+    // now we'll hardcode the version users 'see'. @hexylena will remove this
+    // code when she writes the user-facing release notes, and then will file
+    // an issue for how we'll fix this properly.
+    if (currentGalaxyVersion == "22.01") {
+        currentGalaxyVersion = "21.09";
+    }
+
+    const releaseNotes = `https://docs.galaxyproject.org/en/latest/releases/${currentGalaxyVersion}_announce_user.html`;
+    const lastSeenVersion = window.localStorage.getItem("galaxy-news-seen-release");
+    // Check that they've seen the current version's release notes.
+    if (lastSeenVersion != currentGalaxyVersion) {
+        newsUnseen();
+    } else {
+        newsSeen();
+    }
 
     clean.addEventListener("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
-        showNewsOverlay();
+
+        // If element doesn't exist, add it.
+        if (document.getElementById("news-container") == null) {
+            document.querySelector("body.full-content").insertAdjacentHTML(
+                "afterbegin",
+                `
+                    <div id="news-container" style="visibility: hidden">
+                        <div id="news-screen-overlay"></div>
+                        <div id="news-screen">
+                            <div id="news-header">
+                                <iframe id="news-embed" src="${releaseNotes}" width="80%" height="80%"></iframe>
+                            </div>
+                        </div>
+                    </div>`
+            );
+            // Clicking outside of GTN closes it
+            document.getElementById("news-screen").addEventListener("click", () => {
+                hideNewsOverlay();
+            });
+        }
+        document.getElementById("news-container").style.visibility = "visible";
+        newsSeen();
     });
 });
 
@@ -105,6 +98,6 @@ elementReadyNews("#news a").then((el) => {
 document.addEventListener("keydown", (e) => {
     // Check for escape button - "27"
     if (e.which === 27 || e.keyCode === 27) {
-        removeNewsOverlay();
+        hideNewsOverlay();
     }
 });


### PR DESCRIPTION
## How to test the changes?
(Select all options that apply)
- [x] Instructions for manual testing are as follows:
  1. Watch network tab on page reload, ensure announce isn't loading.
  2. Click news, observe traffic.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
