### PR TITLE
Fix header content-length, add test for send_file

### DIFF
--- a/lib/galaxy/web/framework/base.py
+++ b/lib/galaxy/web/framework/base.py
@@ -488,10 +488,12 @@ def send_file(start_response, trans, body):
     base = trans.app.config.nginx_x_accel_redirect_base
     apache_xsendfile = trans.app.config.apache_xsendfile
     if base:
+        trans.response.headers.pop('content-length', None)
         trans.response.headers['X-Accel-Redirect'] = \
             base + os.path.abspath(body.name)
         body = [b""]
     elif apache_xsendfile:
+        trans.response.headers.pop('content-length', None)
         trans.response.headers['X-Sendfile'] = os.path.abspath(body.name)
         body = [b""]
     # Fall back on sending the file in chunks

--- a/test/unit/webapps/test_send_file.py
+++ b/test/unit/webapps/test_send_file.py
@@ -1,0 +1,70 @@
+import tempfile
+
+import pytest
+from fastapi.applications import FastAPI
+from fastapi.middleware.wsgi import WSGIMiddleware
+from fastapi.testclient import TestClient
+
+from galaxy.util.bunch import Bunch
+from galaxy.web.framework.base import (
+    Response,
+    send_file,
+)
+
+CONTENT = 'content'
+
+
+def setup_fastAPI(fh, nginx_x_accel_redirect_base=None, apache_xsendfile=None):
+
+    def wsgi_application(env, start_response):
+        trans = Bunch(
+            response=Response(),
+            app=Bunch(config=Bunch(nginx_x_accel_redirect_base=nginx_x_accel_redirect_base, apache_xsendfile=apache_xsendfile))
+        )
+        trans.response.headers['content-length'] = len(CONTENT)
+        trans.response.set_content_type('application/octet-stream')
+        return send_file(start_response, trans, fh)
+
+    app = FastAPI()
+    app.mount('/test/send_file', WSGIMiddleware(wsgi_application))
+    return app
+
+
+@pytest.fixture
+def test_file_handle():
+    with tempfile.NamedTemporaryFile() as fh:
+        fh.write(b"content")
+        fh.flush()
+        fh.seek(0)
+        yield fh
+
+
+def test_sendfile_nginx(test_file_handle):
+    app = setup_fastAPI(test_file_handle, nginx_x_accel_redirect_base='/base')
+    client = TestClient(app)
+    response = client.get("/test/send_file")
+    assert response.status_code == 200
+    assert response.headers['x-accel-redirect'] == f"/base{test_file_handle.name}"
+    assert 'content-length' not in response.headers
+    assert not response.content
+
+
+def test_sendfile_apache(test_file_handle):
+    app = setup_fastAPI(test_file_handle, apache_xsendfile='/base')
+    client = TestClient(app)
+    response = client.get("/test/send_file")
+    assert response.status_code == 200
+    assert response.headers['X-Sendfile'] == test_file_handle.name
+    assert 'content-length' not in response.headers
+    assert not response.content
+
+
+def test_sendfile_in_process(test_file_handle):
+    app = setup_fastAPI(test_file_handle)
+    client = TestClient(app)
+    response = client.get("/test/send_file")
+    assert response.status_code == 200
+    assert 'X-Sendfile' not in response.headers
+    assert 'x-accel-redirect' not in response.headers
+    assert response.headers['content-length'] == str(len(CONTENT))
+    assert response.content.decode() == 'content'


### PR DESCRIPTION
The uvicorn stack is a little less permissive and fails because
of the wrong content length.
Noticed by @davelopez, without this fix and one of the proxy sendfile settings activated it would fail with
```
h11._util.LocalProtocolError: Too little data for declared Content-Length
```

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
