### PR TITLE
Remove duplicated pydantic models

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -99,7 +99,7 @@ UpdateTimeField = Field(
 CollectionType = str  # str alias for now
 
 CollectionTypeField = Field(
-    ...,
+    default=None,
     title="Collection Type",
     description=(
         "The type of the collection, can be `list`, `paired`, or define subcollections using `:` "
@@ -977,13 +977,15 @@ class CollectionElementIdentifier(Model):
     )
 
 
+# Required for self-referencing models
+# See https://pydantic-docs.helpmanual.io/usage/postponed_annotations/#self-referencing-models
 CollectionElementIdentifier.update_forward_refs()
 
 
 class CreateNewCollectionPayload(Model):
-    collection_type: CollectionType = CollectionTypeField
-    element_identifiers: List[CollectionElementIdentifier] = Field(
-        ...,
+    collection_type: Optional[CollectionType] = CollectionTypeField
+    element_identifiers: Optional[List[CollectionElementIdentifier]] = Field(
+        default=None,
         title="Element Identifiers",
         description="List of elements that should be in the new collection.",
     )

--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -964,7 +964,7 @@ class CollectionElementIdentifier(Model):
         title="ID",
         description="The encoded ID of the element.",
     )
-    collection_type: Optional[CollectionType]
+    collection_type: Optional[CollectionType] = CollectionTypeField
     element_identifiers: Optional[List['CollectionElementIdentifier']] = Field(
         default=None,
         title="Element Identifiers",

--- a/lib/galaxy/webapps/galaxy/services/history_contents.py
+++ b/lib/galaxy/webapps/galaxy/services/history_contents.py
@@ -58,9 +58,9 @@ from galaxy.schema.fields import (
 from galaxy.schema.schema import (
     AnyHistoryContentItem,
     AnyJobStateSummary,
-    ColletionSourceType,
     ContentsNearResult,
     ContentsNearStats,
+    CreateNewCollectionPayload,
     DatasetAssociationRoles,
     DeleteHistoryContentPayload,
     DeleteHistoryContentResult,
@@ -138,67 +138,6 @@ class CreateHistoryContentPayloadFromCopy(CreateHistoryContentPayloadBase):
             "- The encoded id from the HDA\n"
             "- The encoded id from the HDCA\n"
         ),
-    )
-
-
-class CollectionElementIdentifier(Model):
-    name: Optional[str] = Field(
-        None,
-        title="Name",
-        description="The name of the element.",
-    )
-    src: ColletionSourceType = Field(
-        ...,
-        title="Source",
-        description="The source of the element.",
-    )
-    id: Optional[EncodedDatabaseIdField] = Field(
-        None,
-        title="ID",
-        description="The encoded ID of the element.",
-    )
-    tags: List[str] = Field(
-        default=[],
-        title="Tags",
-        description="The list of tags associated with the element.",
-    )
-    element_identifiers: Optional[List['CollectionElementIdentifier']] = Field(
-        default=None,
-        title="Element Identifiers",
-        description="List of elements that should be in the new nested collection.",
-    )
-    collection_type: Optional[str] = Field(
-        default=None,
-        title="Collection Type",
-        description="The type of the nested collection. For example, `list`, `paired`, `list:paired`.",
-    )
-
-
-# Required for self-referencing models
-# See https://pydantic-docs.helpmanual.io/usage/postponed_annotations/#self-referencing-models
-CollectionElementIdentifier.update_forward_refs()
-
-
-class CreateNewCollectionPayload(Model):
-    collection_type: Optional[str] = Field(
-        default=None,
-        title="Collection Type",
-        description="The type of the collection. For example, `list`, `paired`, `list:paired`.",
-    )
-    element_identifiers: Optional[List[CollectionElementIdentifier]] = Field(
-        default=None,
-        title="Element Identifiers",
-        description="List of elements that should be in the new collection.",
-    )
-    name: Optional[str] = Field(
-        default=None,
-        title="Name",
-        description="The name of the new collection.",
-    )
-    hide_source_items: Optional[bool] = Field(
-        default=False,
-        title="Hide Source Items",
-        description="Whether to mark the original HDAs as hidden.",
     )
 
 


### PR DESCRIPTION
`CreateNewCollectionPayload` and `CollectionElementIdentifier` ended up duplicated while modernizing in parallel *history_contents* and *dataset_collections* APIs in https://github.com/galaxyproject/galaxy/pull/12578 and https://github.com/galaxyproject/galaxy/pull/12781 respectively.

They also contained minor discrepancies that are now unified.

Thank you @nsoranzo for noticing!

## How to test the changes?
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
