### PR TITLE
Don't template version command using cheetah

### DIFF
--- a/lib/galaxy/tools/evaluation.py
+++ b/lib/galaxy/tools/evaluation.py
@@ -456,10 +456,6 @@ class ToolEvaluator:
         param_dict = self.param_dict
         interpreter = self.tool.interpreter
         version_string_cmd_raw = self.tool.version_string_cmd
-        if version_string_cmd_raw:
-            version_command_template = string.Template(version_string_cmd_raw)
-            version_string_cmd = version_command_template.safe_substitute({"__tool_directory__": self.compute_environment.tool_directory()})
-            command = f"{version_string_cmd} > {self.compute_environment.version_path()} 2>&1;\n{command}"
         command_line = None
         if not command:
             return
@@ -483,6 +479,10 @@ class ToolEvaluator:
             tool_dir = os.path.abspath(self.tool.tool_dir)
             abs_executable = os.path.join(tool_dir, executable)
             command_line = command_line.replace(executable, f"{interpreter} {shlex.quote(abs_executable)}", 1)
+        if version_string_cmd_raw:
+            version_command_template = string.Template(version_string_cmd_raw)
+            version_string_cmd = version_command_template.safe_substitute({"__tool_directory__": self.compute_environment.tool_directory()})
+            command_line = f"{version_string_cmd} > {self.compute_environment.version_path()} 2>&1;\n{command_line}"
         self.command_line = command_line
 
     def _build_config_files(self):

--- a/test/functional/tools/version_command_plain.xml
+++ b/test/functional/tools/version_command_plain.xml
@@ -1,6 +1,6 @@
 <tool id="version_command_plain" name="version_command_plain" version="1.0.0">
     <version_command><![CDATA[
-VERSION="4.0.0" echo "$VERSION"
+VERSION="4.0.0"; echo "$VERSION"
     ]]></version_command>
     <command><![CDATA[
 cp '$input' '$output'

--- a/test/functional/tools/version_command_plain.xml
+++ b/test/functional/tools/version_command_plain.xml
@@ -1,6 +1,6 @@
 <tool id="version_command_plain" name="version_command_plain" version="1.0.0">
     <version_command><![CDATA[
-echo "4.0.0"
+VERSION="4.0.0" echo "$VERSION"
     ]]></version_command>
     <command><![CDATA[
 cp '$input' '$output'


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/tools-iuc/issues/4318#issuecomment-1008919902.
Introduced in https://github.com/galaxyproject/galaxy/pull/12459/commits/f5bc22f73a058b8d92ab6d5c0b7b57dcd8cff3df by accident, we previously did not template the version command with cheetah, and we should continue to not do that.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
