### PR TITLE
Add more required dependencies for installed Galaxy

### DIFF
--- a/lib/galaxy/webapps/galaxy/api/__init__.py
+++ b/lib/galaxy/webapps/galaxy/api/__init__.py
@@ -27,7 +27,7 @@ from starlette.routing import NoMatchFound
 try:
     from starlette_context import context as request_context
 except ImportError:
-    request_context = None
+    request_context = None  # type: ignore[assignment]
 
 from galaxy import (
     app as galaxy_app,

--- a/packages/app/requirements.txt
+++ b/packages/app/requirements.txt
@@ -2,7 +2,7 @@ galaxy-auth
 galaxy-data
 galaxy-job-execution
 galaxy-job-metrics
-galaxy-tool-util[cwl]
+galaxy-tool-util[cwl,edam]
 galaxy-web-framework
 galaxy-web-stack
 
@@ -24,3 +24,4 @@ sqlitedict
 svgwrite
 tuswsgi
 typing-extensions
+Whoosh

--- a/packages/webapps/requirements.txt
+++ b/packages/webapps/requirements.txt
@@ -6,4 +6,6 @@ Mako
 pydantic
 python-multipart  # required to support form parsing in FastAPI/Starlette
 starlette
+starlette-context
 typing-extensions
+uvicorn

--- a/packages/webapps/requirements.txt
+++ b/packages/webapps/requirements.txt
@@ -9,3 +9,4 @@ starlette
 starlette-context
 typing-extensions
 uvicorn
+Whoosh


### PR DESCRIPTION
Noticed this while working on https://github.com/galaxyproject/gravity/pull/14 ... otherwise this almost works. Maybe the default way to run a dev instance should be to `pip install -e` the packages on disk ?

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
