### PR TITLE
XML macros: add named yields, tokenized macros, tokens for attributes, and fix replacement of toplevel yield

### DIFF
--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -203,16 +203,12 @@ def _expand_yield_statements(macro_def, expand_el):
         _xml_replace(yield_el, expand_el_children)
 
     # Replace yields at the top level of a macro, seems hacky approach
-    replace_yield = True
-    while replace_yield:
-        for i, macro_def_el in enumerate(macro_def):
-            if macro_def_el.tag == "yield":
-                for target in expand_el_children:
-                    i += 1
-                    macro_def.insert(i, deepcopy(target))
-                macro_def.remove(macro_def_el)
-                continue
-        replace_yield = False
+    for i, macro_def_el in enumerate(macro_def):
+        if macro_def_el.tag == "yield":
+            for target in expand_el_children:
+                i += 1
+                macro_def.insert(i, deepcopy(target))
+            macro_def.remove(macro_def_el)
 
 
 def _load_macros(macros_el, xml_base_dir):

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -383,8 +383,10 @@ class XmlMacroDef:
         self.element = el
         parameters = {}
         tokens = []
-        token_quote = el.attrib.get("token_quote", "@")
+        token_quote = "@"
         for key, value in el.attrib.items():
+            if key == "token_quote":
+                token_quote = value
             if key == "tokens":
                 for token in value.split(","):
                     tokens.append((token, REQUIRED_PARAMETER))

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -160,97 +160,12 @@ def _expand_macro(element, expand_el, macros, tokens):
 
 def _expand_yield_statements(macro_def, expand_el):
     """
-    Modifies the macro_def element by replacing all <yield/> tags below the
-    macro_def element by the children  of the expand_el
-
-    >>> from galaxy.util import XML, xml_to_string
-    >>> expand_el = XML('''
-    ...     <expand macro="test">
-    ...         <token name="token1">
-    ...             <content_of_token1/>
-    ...             <more_content_of_token1/>
-    ...         </token>
-    ...         <sub_of_expand_1/>
-    ...         <token name="token2">
-    ...             <content_of_token2/>
-    ...             <more_content_of_token2/>
-    ...         </token>
-    ...         <sub_of_expand_2/>
-    ...     </expand>''')
-    >>> macro_def = XML('''
-    ... <xml name="test">
-    ...     <A><yield/></A>
-    ...     <yield name="token1"/>
-    ...     <B><yield/><yield name="token2"/></B>
-    ... </xml>''')
-    >>> _expand_yield_statements(macro_def, expand_el)
-    >>> print(xml_to_string(macro_def, pretty=True))
-    <?xml version="1.0" ?>
-    <xml name="test">
-        <A>
-            <sub_of_expand_1/>
-            <sub_of_expand_2/>
-        </A>
-        <content_of_token1/>
-        <more_content_of_token1/>
-        <B>
-            <sub_of_expand_1/>
-            <sub_of_expand_2/>
-            <content_of_token2/>
-            <more_content_of_token2/>
-        </B>
-    </xml>
-    >>> # test replacement of top level yields
-    >>> macro_def = XML('''
-    ... <xml name="test">
-    ...     <blah/>
-    ...     <yield/>
-    ...     <blah>
-    ...         <yield name="token1"/>
-    ...     </blah>
-    ...     <yield name="token2"/>
-    ... </xml>''')
-    >>> _expand_yield_statements(macro_def, expand_el)
-    >>> print(xml_to_string(macro_def, pretty=True))
-    <?xml version="1.0" ?>
-    <xml name="test">
-        <blah/>
-        <sub_of_expand_1/>
-        <sub_of_expand_2/>
-        <blah>
-            <content_of_token1/>
-            <more_content_of_token1/>
-        </blah>
-        <content_of_token2/>
-        <more_content_of_token2/>
-    </xml>
-    >>> # test recursion like replacements
-    >>> expand_el = XML('''
-    ...     <expand macro="test">
-    ...         <token name="token1">
-    ...             <T1><yield name="token2"/></T1>
-    ...         </token>
-    ...         <token name="token2">
-    ...             <T2><yield/></T2>
-    ...         </token>
-    ...         <T/>
-    ...     </expand>''')
-    >>> macro_def = XML('''
-    ... <xml name="test">
-    ...     <A><yield name="token1"/></A>
-    ... </xml>''')
-    >>> _expand_yield_statements(macro_def, expand_el)
-    >>> print(xml_to_string(macro_def, pretty=True))
-    <?xml version="1.0" ?>
-    <xml name="test">
-        <A>
-            <T1>
-                <T2>
-                    <T/>
-                </T2>
-            </T1>
-        </A>
-    </xml>
+    Modifies the macro_def element by replacing 
+    
+    1. all named yield tags by the content of the corresponding token tags
+       - token tags need to be direct children of the expand
+       - processed in order of definition of the token tags
+    2. all unnamed yield tags by the non-token children of the expand tag
     """
     # replace named yields
     for token_el in expand_el.findall('./token'):

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -64,7 +64,7 @@ def imported_macro_paths(root):
 
 def _import_macros(root, path):
     """
-    root the parsed XML tree 
+    root the parsed XML tree
     path the path to the main xml document
     """
     xml_base_dir = os.path.dirname(path)
@@ -223,6 +223,33 @@ def _expand_yield_statements(macro_def, expand_el):
         </blah>
         <content_of_token2/>
         <more_content_of_token2/>
+    </xml>
+    >>> # test recursion like replacements
+    >>> expand_el = XML('''
+    ...     <expand macro="test">
+    ...         <token name="token1">
+    ...             <T1><yield name="token2"/></T1>
+    ...         </token>
+    ...         <token name="token2">
+    ...             <T2><yield/></T2>
+    ...         </token>
+    ...         <T/>
+    ...     </expand>''')
+    >>> macro_def = XML('''
+    ... <xml name="test">
+    ...     <A><yield name="token1"/></A>
+    ... </xml>''')
+    >>> _expand_yield_statements(macro_def, expand_el)
+    >>> print(xml_to_string(macro_def, pretty=True))
+    <?xml version="1.0" ?>
+    <xml name="test">
+        <A>
+            <T1>
+                <T2>
+                    <T/>
+                </T2>
+            </T1>
+        </A>
     </xml>
     """
     # replace named yields

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -197,18 +197,10 @@ def _expand_yield_statements(macro_def, expand_el):
             <sub_of_expand_2/>
         </xml>
     """
-    yield_els = [yield_el for macro_def_el in macro_def for yield_el in macro_def_el.findall('.//yield')]
+    yield_els = [yield_el for yield_el in macro_def.findall('.//yield')]
     expand_el_children = list(expand_el)
     for yield_el in yield_els:
         _xml_replace(yield_el, expand_el_children)
-
-    # Replace yields at the top level of a macro, seems hacky approach
-    for i, macro_def_el in enumerate(macro_def):
-        if macro_def_el.tag == "yield":
-            for target in expand_el_children:
-                i += 1
-                macro_def.insert(i, deepcopy(target))
-            macro_def.remove(macro_def_el)
 
 
 def _load_macros(macros_el, xml_base_dir):

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -159,8 +159,7 @@ def _expand_yield_statements(macro_def, expand_el):
     Modifies the macro_def element by replacing all <yield/> tags below the
     macro_def element by the children  of the expand_el
 
-    >>> from lxml.etree import tostring
-    >>> from galaxy.util import XML
+    >>> from galaxy.util import XML, xml_to_string
     >>> expand_el = XML('''
     ...     <expand macro="test">
     ...         <sub_of_expand_1/>
@@ -172,12 +171,15 @@ def _expand_yield_statements(macro_def, expand_el):
     ...     <B><yield/></B>
     ... </xml>''')
     >>> _expand_yield_statements(macro_def, expand_el)
-    >>> print(tostring(macro_def).decode('UTF-8'))
+    >>> print(xml_to_string(macro_def, pretty=True))
+    <?xml version="1.0" ?>
     <xml name="test">
-        <A><sub_of_expand_1/>
+        <A>
+            <sub_of_expand_1/>
             <sub_of_expand_2/>
         </A>
-        <B><sub_of_expand_1/>
+        <B>
+            <sub_of_expand_1/>
             <sub_of_expand_2/>
         </B>
     </xml>
@@ -189,15 +191,16 @@ def _expand_yield_statements(macro_def, expand_el):
     ...     <yield/>
     ... </xml>''')
     >>> _expand_yield_statements(macro_def, expand_el)
-    >>> print(tostring(macro_def).decode('UTF-8'))
+    >>> print(xml_to_string(macro_def, pretty=True))
+    <?xml version="1.0" ?>
     <xml name="test">
         <blah/>
         <sub_of_expand_1/>
-            <sub_of_expand_2/>
+        <sub_of_expand_2/>
         <blah/>
         <sub_of_expand_1/>
-            <sub_of_expand_2/>
-        </xml>
+        <sub_of_expand_2/>
+    </xml>
     """
     yield_els = [yield_el for yield_el in macro_def.findall('.//yield')]
     expand_el_children = list(expand_el)

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -1,5 +1,5 @@
 import os
-from copy import deepcopy
+from copy import copy, deepcopy
 
 from galaxy.util import parse_xml
 
@@ -23,7 +23,7 @@ def load_with_references(path):
     # that are not included in the macros node
     macros_el = _macros_el(root)
     if macros_el is not None:
-        macros_copy = deepcopy(macros_el)
+        macros_copy = copy(macros_el)
         macros_el.clear()
     else:
         macros_copy = None

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -157,6 +157,9 @@ def _expand_macro(element, expand_el, macros, tokens):
 
 def _expand_yield_statements(macro_def, expand_el):
     """
+    Modifies the macro_def element by replacing all <yield/> tags below the
+    macro_def element by the children  of the expand_el
+
     >>> from lxml.etree import tostring
     >>> from galaxy.util import XML
     >>> expand_el = XML('''

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -165,7 +165,7 @@ def _expand_macros(elements, macros, tokens, visited=None):
             if expand_el is None:
                 break
             if visited is None:
-                v = list()
+                v = []
             else:
                 v = visited
             _expand_macro(expand_el, macros, tokens, v)

--- a/lib/galaxy/util/xml_macros.py
+++ b/lib/galaxy/util/xml_macros.py
@@ -38,7 +38,7 @@ def load_with_references(path):
 
     # readd the stashed children of the macros node
     # TODO is this this really necesary? Since macro nodes are removed anyway just below.
-    if macros_copy:
+    if macros_copy is not None:
         _xml_set_children(macros_el, list(macros_copy))
 
     for el in root.xpath('//macro'):

--- a/test/unit/tool_util/test_tool_loader.py
+++ b/test/unit/tool_util/test_tool_loader.py
@@ -30,6 +30,15 @@ class TestToolDirectory:
             return parse_xml(path)
 
 
+def test_no_macros():
+    """
+    Test tool loaded in absence of a macros node.
+    """
+    with TestToolDirectory() as tool_dir:
+        tool_dir.write('<tool/>')
+        tool_dir.load(preprocess=True)
+
+
 def test_loader_simple():
     """
     Test simple macro replacement.

--- a/test/unit/tool_util/test_tool_loader.py
+++ b/test/unit/tool_util/test_tool_loader.py
@@ -644,3 +644,30 @@ def test_loader_specify_nested_macro_by_token():
     <A/>
     <B/>
 </tool>'''
+
+
+def test_loader_circular_macros():
+    """
+    check the cycles in nested macros are detected
+    """
+    with TestToolDirectory() as tool_dir:
+        tool_dir.write('''
+<tool>
+    <macros>
+        <xml name="a">
+            <A>
+                <expand macro="b"/>
+            </A>
+        </xml>
+        <xml name="b">
+            <B>
+                <expand macro="a"/>
+            </B>
+        </xml>
+    </macros>
+    <expand macro="a"/>
+</tool>''')
+        try:
+            tool_dir.load()
+        except AssertionError as a:
+            assert str(a) == "Cycle in nested macros: already expanded ['a', 'b'] can't expand 'a' again"


### PR DESCRIPTION
Originally I wanted to find out what exactly happens if there are multiple yield tags.. hoping that I can somehow control that each yield is replaced with the corresponding child of the expand tag. This did not work. So I added named yields and two other extensions that I were missing in the past:

**Named yields**

Essentially `<yield name="XYZ"/>` is replaced by the content of `<template name="XYZ"/>`. Unnamed yields work as before and named and unnamed yields can be mixed.

An example:

```xml
    <xml name="named_yields_example">
      <conditional>
        <param type="select">
          <option value="a">A</option>
          <option value="b">B</option>
          <yield name="more_options"/>
        </param>
        <when value="a">
          <param type="select">
            <yield />
          </param>
        </when>
        <when value="b">
          <param ... />
        </when>
        <yield name="more_whens">
      </conditional>
    </xml>
```

```xml
        <expand macro="named_yields_example">
          <token name="more_options">
            <option value="c">C</option>
          </token>
          <token name="more_whens">
            <when value="c">
              <param type="select">
                <yield />
              </param>
            </when>
          </token>
          <options from_data_table="tophat2_indexes">
            <filter type="sort_by" column="2"/>
            <validator type="no_options" message="No genomes are available for the selected input dataset"/>
          </options>
        </expand>
```

The choice of `token` as tag name may be sub-optimal... since tokens are also used to parametrize macro parameters. Should be easy to change if desired. 


**Allow that the name of nested macros can be controlled by tokens:**

For instance 

```xml
<xml name="example">
    <expand macro="@TOKEN_NAME@"/>`
</xml>
```

See https://github.com/galaxyproject/galaxy/blob/372439c088ee6b7b7b1a5751713891582928d39e/test/unit/tool_util/test_tool_loader.py#L611 for a complete example

**Allow token expansion also for attributes**

```xml
<tool>
    <macros>
        <token name="__ATTR_NAME">name</token>
    </macros>
    <another>
        <tag __ATTR_NAME="blah" />
    </another>
</tool>
```

Here the token can't be surrounded by `@` character (i.e. `@ATTR_NAME@`) since the xml file needs to proper xml (because it is parsed before token/macro expansion). But it seems that for tokens surrounding the token by `@` is a (undocumented) convention only, anyway. 

Docs have been added here: https://github.com/galaxyproject/planemo/pull/1212 (not all changes are yet documented, but will be when this is merged).

I'm happy if there are more suggestions to make this more expressive / powerful / elegant :). Real recursion would be cool but also dangerous .. also could not think of a way to express a stopping condition.


Fix: If there are multiple top level yield statements only the last was replaced

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
