### PR TITLE
Fix publicPath and asset handling when using webpack-dev-server for HMR

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -207,16 +207,21 @@ module.exports = (env = {}, argv = {}) => {
                     warnings: false,
                 },
             },
+            devMiddleware: {
+                publicPath: '/static/dist'
+            },
             hot: true,
-            // proxy *everything* to the galaxy server
-            // someday, this can be a more limited set -- e.g. `/api`, `/auth`
             port: 8081,
             host: "0.0.0.0",
+            // proxy *everything* to the galaxy server.
+            // someday, when we have a fully API-driven independent client, this
+            // can be a more limited set -- e.g. `/api`, `/auth`
             proxy: {
-                "/": {
+                "**": {
                     target: process.env.GALAXY_URL || "http://localhost:8080",
                     secure: process.env.CHANGE_ORIGIN ? !process.env.CHANGE_ORIGIN : true,
                     changeOrigin: !!process.env.CHANGE_ORIGIN,
+                    logLevel: 'debug'
                 },
             },
         },


### PR DESCRIPTION
This resolves an issue stemming from the change to publicPath in #13103 which prevents the webpack-dev-server from handling assets correctly and you'll get served stale files from disk instead of the in-memory updated assets.  

## How to test the changes?
(Select all options that apply)
- [ ] Instructions for manual testing are as follows:
  1. use webpack-dev-server

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
