### PR TITLE
[21.09] Fix staticUrlToPrefixed url rewriting

### DIFF
--- a/client/src/layout/masthead.js
+++ b/client/src/layout/masthead.js
@@ -44,7 +44,7 @@ export class MastheadState {
 }
 
 function staticUrlToPrefixed(appRoot, url) {
-    return url?.startsWith("/") ? `${appRoot}${url}` : url;
+    return url?.startsWith("/") ? `${appRoot}${url.substring(1)}` : url;
 }
 
 export function mountMasthead(el, options, mastheadState) {


### PR DESCRIPTION
The fix here prevents joining the app root, which ends with a slash with a url that starts with a slash.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
