### PR TITLE
Assorted Data Libraries fixes

### DIFF
--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -1,171 +1,183 @@
 <template>
-    <div>
-        <div class="form-inline d-flex align-items-center mb-2">
-            <b-button class="mr-1" @click="gotoFirstPage" title="go to first page">
-                <font-awesome-icon icon="home" />
-            </b-button>
-            <b-button id="create-new-lib" v-b-toggle.collapse-2 v-if="isAdmin" title="Create new folder" class="mr-1">
-                <font-awesome-icon icon="plus" />
-                {{ titleLibrary }}
-            </b-button>
-            <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
-            <b-form-checkbox v-if="isAdmin" class="mr-1" @input="toggle_include_deleted($event)" v-localize
-                >include deleted</b-form-checkbox
-            >
-            <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)" v-localize
-                >exclude restricted</b-form-checkbox
-            >
+    <CurrentUser v-slot="{ user }">
+        <div>
+            <div class="form-inline d-flex align-items-center mb-2">
+                <b-button class="mr-1" @click="gotoFirstPage" title="go to first page">
+                    <font-awesome-icon icon="home" />
+                </b-button>
+                <b-button
+                    id="create-new-lib"
+                    v-b-toggle.collapse-2
+                    v-if="user.is_admin"
+                    title="Create new folder"
+                    class="mr-1">
+                    <font-awesome-icon icon="plus" />
+                    {{ titleLibrary }}
+                </b-button>
+                <SearchField :typing-delay="0" @updateSearch="searchValue($event)" />
+                <b-form-checkbox v-if="user.is_admin" class="mr-1" @input="toggle_include_deleted($event)" v-localize
+                    >include deleted</b-form-checkbox
+                >
+                <b-form-checkbox class="mr-1" @input="toggle_exclude_restricted($event)" v-localize
+                    >exclude restricted</b-form-checkbox
+                >
+            </div>
+            <b-collapse v-model="isNewLibFormVisible" id="collapse-2">
+                <b-card>
+                    <b-form @submit.prevent="newLibrary">
+                        <b-input-group class="mb-2 new-row">
+                            <b-form-input v-model="newLibraryForm.name" required :placeholder="titleName" />
+                            <b-form-input
+                                v-model="newLibraryForm.description"
+                                required
+                                :placeholder="titleDescription" />
+                            <b-form-input v-model="newLibraryForm.synopsis" :placeholder="titleSynopsis" />
+                            <template v-slot:append>
+                                <b-button id="save_new_library" type="submit" :title="titleSave">
+                                    <font-awesome-icon :icon="['far', 'save']" />
+                                    {{ titleSave }}
+                                </b-button>
+                            </template>
+                        </b-input-group>
+                    </b-form>
+                </b-card>
+            </b-collapse>
+            <b-table
+                id="libraries_list"
+                striped
+                hover
+                :fields="fields"
+                :items="librariesList"
+                :per-page="perPage"
+                :current-page="currentPage"
+                show-empty
+                ref="libraries_list"
+                @filtered="onFiltered"
+                :filter="filter"
+                :filter-included-fields="filterOn">
+                <template v-slot:cell(name)="row">
+                    <textarea
+                        v-if="row.item.editMode"
+                        class="form-control input_library_name"
+                        v-model="row.item.name"
+                        rows="3" />
+
+                    <div class="deleted-item" v-else-if="row.item.deleted && include_deleted">{{ row.item.name }}</div>
+                    <b-link v-else :to="{ path: `folders/${row.item.root_folder_id}` }">{{ row.item.name }}</b-link>
+                </template>
+                <template v-slot:cell(description)="{ item }">
+                    <LibraryEditField
+                        @toggleDescriptionExpand="toggleDescriptionExpand(item)"
+                        :ref="`description-${item.id}`"
+                        :is-expanded="item.isExpanded"
+                        :is-edit-mode="item.editMode"
+                        :text="item.description"
+                        :changed-value.sync="item[newDescriptionProperty]" />
+                </template>
+                <template v-slot:cell(synopsis)="{ item }">
+                    <LibraryEditField
+                        @toggleDescriptionExpand="toggleDescriptionExpand(item)"
+                        :ref="`synopsis-${item.id}`"
+                        :is-expanded="item.isExpanded"
+                        :is-edit-mode="item.editMode"
+                        :text="item.synopsis"
+                        :changed-value.sync="item[newSynopsisProperty]" />
+                </template>
+                <template v-slot:cell(is_unrestricted)="row">
+                    <font-awesome-icon
+                        v-if="row.item.public && !row.item.deleted"
+                        title="Public library"
+                        icon="globe" />
+                </template>
+                <template v-slot:cell(buttons)="row">
+                    <b-button @click="undelete(row.item)" v-if="row.item.deleted" :title="'Undelete ' + row.item.name">
+                        <font-awesome-icon icon="unlock" />
+                        {{ titleUndelete }}
+                    </b-button>
+                    <b-button
+                        v-if="row.item.can_user_modify && row.item.editMode"
+                        size="sm"
+                        class="lib-btn permission_folder_btn"
+                        :title="'Permissions of ' + row.item.name"
+                        @click="saveChanges(row.item)">
+                        <font-awesome-icon :icon="['far', 'save']" />
+                        {{ titleSave }}
+                    </b-button>
+                    <b-button
+                        v-if="row.item.can_user_modify"
+                        size="sm"
+                        class="lib-btn edit_library_btn save_library_btn"
+                        :title="`Edit ${row.item.name}`"
+                        @click="toggleEditMode(row.item)">
+                        <div v-if="!row.item.editMode">
+                            <font-awesome-icon icon="pencil-alt" />
+                            {{ titleEdit }}
+                        </div>
+                        <div v-else>
+                            <font-awesome-icon :icon="['fas', 'times']" />
+                            {{ titleCancel }}
+                        </div>
+                    </b-button>
+                    <b-button
+                        v-if="user.is_admin"
+                        size="sm"
+                        class="lib-btn permission_library_btn"
+                        :title="'Permissions of ' + row.item.name"
+                        :to="{ path: `/${row.item.id}/permissions` }">
+                        <font-awesome-icon icon="users" />
+                        Manage
+                    </b-button>
+                    <b-button
+                        v-if="user.is_admin && row.item.editMode"
+                        size="sm"
+                        class="lib-btn delete-lib-btn"
+                        :title="`Delete ${row.item.name}`"
+                        @click="deleteLibrary(row.item)">
+                        <font-awesome-icon icon="trash" />
+                        {{ titleDelete }}
+                    </b-button>
+                </template>
+            </b-table>
+
+            <b-container>
+                <b-row class="justify-content-md-center">
+                    <b-col md="auto">
+                        <b-pagination
+                            v-model="currentPage"
+                            :total-rows="rows"
+                            :per-page="perPage"
+                            aria-controls="libraries_list">
+                        </b-pagination>
+                    </b-col>
+                    <b-col cols="1.5">
+                        <table>
+                            <tr>
+                                <td class="m-0 p-0">
+                                    <b-form-input
+                                        class="pagination-input-field"
+                                        id="paginationPerPage"
+                                        autocomplete="off"
+                                        type="number"
+                                        onkeyup="this.value|=0;if(this.value<1)this.value=1"
+                                        v-model="perPage" />
+                                </td>
+                                <td class="text-muted ml-1 paginator-text">
+                                    <span class="pagination-total-pages-text"
+                                        >{{ titlePerPage }}, {{ rows }} {{ titleTotal }}</span
+                                    >
+                                </td>
+                            </tr>
+                        </table>
+                    </b-col>
+                </b-row>
+            </b-container>
         </div>
-        <b-collapse v-model="isNewLibFormVisible" id="collapse-2">
-            <b-card>
-                <b-form @submit.prevent="newLibrary">
-                    <b-input-group class="mb-2 new-row">
-                        <b-form-input v-model="newLibraryForm.name" required :placeholder="titleName" />
-                        <b-form-input v-model="newLibraryForm.description" required :placeholder="titleDescription" />
-                        <b-form-input v-model="newLibraryForm.synopsis" :placeholder="titleSynopsis" />
-                        <template v-slot:append>
-                            <b-button id="save_new_library" type="submit" :title="titleSave">
-                                <font-awesome-icon :icon="['far', 'save']" />
-                                {{ titleSave }}
-                            </b-button>
-                        </template>
-                    </b-input-group>
-                </b-form>
-            </b-card>
-        </b-collapse>
-        <b-table
-            id="libraries_list"
-            striped
-            hover
-            :fields="fields"
-            :items="librariesList"
-            :per-page="perPage"
-            :current-page="currentPage"
-            show-empty
-            ref="libraries_list"
-            @filtered="onFiltered"
-            :filter="filter"
-            :filter-included-fields="filterOn">
-            <template v-slot:cell(name)="row">
-                <textarea
-                    v-if="row.item.editMode"
-                    class="form-control input_library_name"
-                    v-model="row.item.name"
-                    rows="3" />
-
-                <div class="deleted-item" v-else-if="row.item.deleted && include_deleted">{{ row.item.name }}</div>
-                <b-link v-else :to="{ path: `folders/${row.item.root_folder_id}` }">{{ row.item.name }}</b-link>
-            </template>
-            <template v-slot:cell(description)="{ item }">
-                <LibraryEditField
-                    @toggleDescriptionExpand="toggleDescriptionExpand(item)"
-                    :ref="`description-${item.id}`"
-                    :is-expanded="item.isExpanded"
-                    :is-edit-mode="item.editMode"
-                    :text="item.description"
-                    :changed-value.sync="item[newDescriptionProperty]" />
-            </template>
-            <template v-slot:cell(synopsis)="{ item }">
-                <LibraryEditField
-                    @toggleDescriptionExpand="toggleDescriptionExpand(item)"
-                    :ref="`synopsis-${item.id}`"
-                    :is-expanded="item.isExpanded"
-                    :is-edit-mode="item.editMode"
-                    :text="item.synopsis"
-                    :changed-value.sync="item[newSynopsisProperty]" />
-            </template>
-            <template v-slot:cell(is_unrestricted)="row">
-                <font-awesome-icon v-if="row.item.public && !row.item.deleted" title="Public library" icon="globe" />
-            </template>
-            <template v-slot:cell(buttons)="row">
-                <b-button @click="undelete(row.item)" v-if="row.item.deleted" :title="'Undelete ' + row.item.name">
-                    <font-awesome-icon icon="unlock" />
-                    {{ titleUndelete }}
-                </b-button>
-                <b-button
-                    v-if="row.item.can_user_modify && row.item.editMode"
-                    size="sm"
-                    class="lib-btn permission_folder_btn"
-                    :title="'Permissions of ' + row.item.name"
-                    @click="saveChanges(row.item)">
-                    <font-awesome-icon :icon="['far', 'save']" />
-                    {{ titleSave }}
-                </b-button>
-                <b-button
-                    v-if="row.item.can_user_modify"
-                    size="sm"
-                    class="lib-btn edit_library_btn save_library_btn"
-                    :title="`Edit ${row.item.name}`"
-                    @click="toggleEditMode(row.item)">
-                    <div v-if="!row.item.editMode">
-                        <font-awesome-icon icon="pencil-alt" />
-                        {{ titleEdit }}
-                    </div>
-                    <div v-else>
-                        <font-awesome-icon :icon="['fas', 'times']" />
-                        {{ titleCancel }}
-                    </div>
-                </b-button>
-                <b-button
-                    v-if="row.item.can_user_manage && !row.item.editMode"
-                    size="sm"
-                    class="lib-btn permission_library_btn"
-                    :title="'Permissions of ' + row.item.name"
-                    :to="{ path: `/${row.item.id}/permissions` }">
-                    <font-awesome-icon icon="users" />
-                    Manage
-                </b-button>
-                <b-button
-                    v-if="isAdmin && row.item.editMode"
-                    size="sm"
-                    class="lib-btn delete-lib-btn"
-                    :title="`Delete ${row.item.name}`"
-                    @click="deleteLibrary(row.item)">
-                    <font-awesome-icon icon="trash" />
-                    {{ titleDelete }}
-                </b-button>
-            </template>
-        </b-table>
-
-        <b-container>
-            <b-row class="justify-content-md-center">
-                <b-col md="auto">
-                    <b-pagination
-                        v-model="currentPage"
-                        :total-rows="rows"
-                        :per-page="perPage"
-                        aria-controls="libraries_list">
-                    </b-pagination>
-                </b-col>
-                <b-col cols="1.5">
-                    <table>
-                        <tr>
-                            <td class="m-0 p-0">
-                                <b-form-input
-                                    class="pagination-input-field"
-                                    id="paginationPerPage"
-                                    autocomplete="off"
-                                    type="number"
-                                    onkeyup="this.value|=0;if(this.value<1)this.value=1"
-                                    v-model="perPage" />
-                            </td>
-                            <td class="text-muted ml-1 paginator-text">
-                                <span class="pagination-total-pages-text"
-                                    >{{ titlePerPage }}, {{ rows }} {{ titleTotal }}</span
-                                >
-                            </td>
-                        </tr>
-                    </table>
-                </b-col>
-            </b-row>
-        </b-container>
-    </div>
+    </CurrentUser>
 </template>
 
 <script>
 import _l from "utils/localization";
 import Vue from "vue";
-import { getGalaxyInstance } from "app";
 import { getAppRoot } from "onload/loadConfig";
 import BootstrapVue from "bootstrap-vue";
 import { Services } from "./services";
@@ -175,6 +187,7 @@ import { initLibrariesIcons } from "components/Libraries/icons";
 import { MAX_DESCRIPTION_LENGTH, DEFAULT_PER_PAGE, onError } from "components/Libraries/library-utils";
 import LibraryEditField from "components/Libraries/LibraryEditField";
 import SearchField from "components/Libraries/LibraryFolder/SearchField";
+import CurrentUser from "components/providers/CurrentUser";
 
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
@@ -187,6 +200,7 @@ export default {
         FontAwesomeIcon,
         LibraryEditField,
         SearchField,
+        CurrentUser,
     },
     computed: {
         rows() {
@@ -194,7 +208,6 @@ export default {
         },
     },
     data() {
-        const galaxy = getGalaxyInstance();
         return {
             newDescriptionProperty: "newDescription",
             newSynopsisProperty: "newSynopsis",
@@ -209,7 +222,6 @@ export default {
             filterOn: [],
             excluded: [],
             filter: null,
-            isAdmin: galaxy.user.isAdmin(),
             newLibraryForm: {
                 name: "",
                 description: "",

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -85,50 +85,48 @@
                     <font-awesome-icon icon="unlock" />
                     {{ titleUndelete }}
                 </b-button>
-                <div v-else-if="isAdmin">
-                    <b-button
-                        v-if="row.item.can_user_modify && row.item.editMode"
-                        size="sm"
-                        class="lib-btn permission_folder_btn"
-                        :title="'Permissions of ' + row.item.name"
-                        @click="saveChanges(row.item)">
-                        <font-awesome-icon :icon="['far', 'save']" />
-                        {{ titleSave }}
-                    </b-button>
-                    <b-button
-                        v-if="row.item.can_user_modify"
-                        size="sm"
-                        class="lib-btn edit_library_btn save_library_btn"
-                        :title="`Edit ${row.item.name}`"
-                        @click="toggleEditMode(row.item)">
-                        <div v-if="!row.item.editMode">
-                            <font-awesome-icon icon="pencil-alt" />
-                            {{ titleEdit }}
-                        </div>
-                        <div v-else>
-                            <font-awesome-icon :icon="['fas', 'times']" />
-                            {{ titleCancel }}
-                        </div>
-                    </b-button>
-                    <b-button
-                        v-if="row.item.can_user_manage && !row.item.editMode"
-                        size="sm"
-                        class="lib-btn permission_library_btn"
-                        :title="'Permissions of ' + row.item.name"
-                        :to="{ path: `/${row.item.id}/permissions` }">
-                        <font-awesome-icon icon="users" />
-                        Manage
-                    </b-button>
-                    <b-button
-                        v-if="row.item.editMode"
-                        size="sm"
-                        class="lib-btn delete-lib-btn"
-                        :title="`Delete ${row.item.name}`"
-                        @click="deleteLibrary(row.item)">
-                        <font-awesome-icon icon="trash" />
-                        {{ titleDelete }}
-                    </b-button>
-                </div>
+                <b-button
+                    v-if="row.item.can_user_modify && row.item.editMode"
+                    size="sm"
+                    class="lib-btn permission_folder_btn"
+                    :title="'Permissions of ' + row.item.name"
+                    @click="saveChanges(row.item)">
+                    <font-awesome-icon :icon="['far', 'save']" />
+                    {{ titleSave }}
+                </b-button>
+                <b-button
+                    v-if="row.item.can_user_modify"
+                    size="sm"
+                    class="lib-btn edit_library_btn save_library_btn"
+                    :title="`Edit ${row.item.name}`"
+                    @click="toggleEditMode(row.item)">
+                    <div v-if="!row.item.editMode">
+                        <font-awesome-icon icon="pencil-alt" />
+                        {{ titleEdit }}
+                    </div>
+                    <div v-else>
+                        <font-awesome-icon :icon="['fas', 'times']" />
+                        {{ titleCancel }}
+                    </div>
+                </b-button>
+                <b-button
+                    v-if="row.item.can_user_manage && !row.item.editMode"
+                    size="sm"
+                    class="lib-btn permission_library_btn"
+                    :title="'Permissions of ' + row.item.name"
+                    :to="{ path: `/${row.item.id}/permissions` }">
+                    <font-awesome-icon icon="users" />
+                    Manage
+                </b-button>
+                <b-button
+                    v-if="isAdmin && row.item.editMode"
+                    size="sm"
+                    class="lib-btn delete-lib-btn"
+                    :title="`Delete ${row.item.name}`"
+                    @click="deleteLibrary(row.item)">
+                    <font-awesome-icon icon="trash" />
+                    {{ titleDelete }}
+                </b-button>
             </template>
         </b-table>
 

--- a/client/src/components/Libraries/LibrariesList.vue
+++ b/client/src/components/Libraries/LibrariesList.vue
@@ -75,10 +75,7 @@
                     :changed-value.sync="item[newSynopsisProperty]" />
             </template>
             <template v-slot:cell(is_unrestricted)="row">
-                <font-awesome-icon
-                    v-if="row.item.public && !row.item.deleted"
-                    title="Unrestricted dataset"
-                    icon="globe" />
+                <font-awesome-icon v-if="row.item.public && !row.item.deleted" title="Public library" icon="globe" />
             </template>
             <template v-slot:cell(buttons)="row">
                 <b-button @click="undelete(row.item)" v-if="row.item.deleted" :title="'Undelete ' + row.item.name">

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolder.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <CurrentUser v-slot="{ user }">
         <div>
             <FolderTopBar
                 @updateSearch="updateSearchValue($event)"
@@ -208,7 +208,7 @@
                             Edit
                         </b-button>
                         <b-button
-                            v-if="row.item.can_manage && !row.item.deleted"
+                            v-if="user.is_admin"
                             size="sm"
                             class="lib-btn permission_lib_btn"
                             :title="`Permissions of ${row.item.name}`"
@@ -267,7 +267,7 @@
                 </b-row>
             </b-container>
         </div>
-    </div>
+    </CurrentUser>
 </template>
 
 <script>
@@ -284,6 +284,7 @@ import FolderTopBar from "./TopToolbar/FolderTopBar";
 import { initFolderTableIcons } from "components/Libraries/icons";
 import { MAX_DESCRIPTION_LENGTH, DEFAULT_PER_PAGE } from "components/Libraries/library-utils";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import CurrentUser from "components/providers/CurrentUser";
 
 initFolderTableIcons();
 
@@ -316,6 +317,7 @@ export default {
         FolderTopBar,
         UtcDate,
         FontAwesomeIcon,
+        CurrentUser,
     },
     data() {
         return {

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.test.js
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.test.js
@@ -62,7 +62,7 @@ const UNRESTRICTED_MESSAGE = '[data-test-id="unrestricted-msg"]';
 const DATASET_TABLE = '[data-test-id="dataset-table"]';
 const PEEK_VIEW = '[data-test-id="peek-view"]';
 
-async function mountLibraryDatasetWrapper(localVue, expectDatasetId) {
+async function mountLibraryDatasetWrapper(localVue, expectDatasetId, isAdmin = false) {
     const propsData = {
         dataset_id: expectDatasetId,
         folder_id: FOLDER_ID,
@@ -73,6 +73,13 @@ async function mountLibraryDatasetWrapper(localVue, expectDatasetId) {
         stubs: {
             DatatypesProvider: mockDatatypesProvider,
             GenomeProvider: mockGenomeProvider,
+            CurrentUser: {
+                render() {
+                    return this.$scopedSlots.default({
+                        user: { is_admin: isAdmin },
+                    });
+                },
+            },
         },
     });
     await flushPromises();
@@ -82,8 +89,9 @@ async function mountLibraryDatasetWrapper(localVue, expectDatasetId) {
 describe("Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue", () => {
     const localVue = getLocalVue();
 
-    it("should display all buttons when user can modify and manage dataset", async () => {
-        const wrapper = await mountLibraryDatasetWrapper(localVue, UNRESTRICTED_DATASET_ID);
+    it("should display all buttons when user is Admin", async () => {
+        const isAdmin = true;
+        const wrapper = await mountLibraryDatasetWrapper(localVue, UNRESTRICTED_DATASET_ID, isAdmin);
 
         expect(wrapper.find(MODIFY_BUTTON).exists()).toBe(true);
         expect(wrapper.find(AUTO_DETECT_BUTTON).exists()).toBe(true);
@@ -97,8 +105,9 @@ describe("Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue", () =
         expect(wrapper.find(AUTO_DETECT_BUTTON).exists()).toBe(false);
     });
 
-    it("should not display 'Permissions' button when user cannot manage dataset", async () => {
-        const wrapper = await mountLibraryDatasetWrapper(localVue, CANNOT_MANAGE_DATASET_ID);
+    it("should not display 'Permissions' button when user is not an administrator", async () => {
+        const isAdmin = false;
+        const wrapper = await mountLibraryDatasetWrapper(localVue, CANNOT_MANAGE_DATASET_ID, isAdmin);
 
         expect(wrapper.find(PERMISSIONS_BUTTON).exists()).toBe(false);
     });

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderDataset/LibraryDataset.vue
@@ -1,130 +1,132 @@
 <template>
-    <div v-if="dataset">
-        <div v-if="!isEditMode">
-            <LibraryBreadcrumb :current-id="dataset_id" :full_path="dataset.full_path" />
-            <!-- Toolbar -->
-            <b-button
-                title="Download dataset"
-                class="mr-1 mb-2"
-                @click="download(datasetDownloadFormat, dataset_id)"
-                data-test-id="download-btn">
-                <font-awesome-icon icon="download" />
-                Download
-            </b-button>
-            <b-button
-                @click="importToHistory"
-                title="Import dataset into history"
-                class="mr-1 mb-2"
-                data-test-id="import-history-btn">
-                <font-awesome-icon icon="book" />
-                to History
-            </b-button>
-            <span v-if="dataset.can_user_modify">
+    <CurrentUser v-slot="{ user }">
+        <div v-if="dataset">
+            <div v-if="!isEditMode">
+                <LibraryBreadcrumb :current-id="dataset_id" :full_path="dataset.full_path" />
+                <!-- Toolbar -->
                 <b-button
-                    @click="isEditMode = true"
-                    title="Modify library item"
+                    title="Download dataset"
                     class="mr-1 mb-2"
-                    data-test-id="modify-btn">
-                    <font-awesome-icon icon="pencil-alt" />
-                    Modify
+                    @click="download(datasetDownloadFormat, dataset_id)"
+                    data-test-id="download-btn">
+                    <font-awesome-icon icon="download" />
+                    Download
                 </b-button>
                 <b-button
-                    title="Attempt to detect the format of dataset"
-                    @click="detectDatatype"
+                    @click="importToHistory"
+                    title="Import dataset into history"
                     class="mr-1 mb-2"
-                    data-test-id="auto-detect-btn">
-                    <font-awesome-icon icon="redo" />
-                    Auto-detect datatype
+                    data-test-id="import-history-btn">
+                    <font-awesome-icon icon="book" />
+                    to History
                 </b-button>
-            </span>
-            <b-button
-                title="Manage permissions"
-                v-if="dataset.can_user_manage"
-                class="mr-1 mb-2"
-                :to="{
-                    name: 'LibraryFolderDatasetPermissions',
-                    params: { folder_id: folder_id, dataset_id: dataset_id },
-                }"
-                data-test-id="permissions-btn">
-                <font-awesome-icon icon="users" />
-                Permissions
-            </b-button>
+                <span v-if="dataset.can_user_modify">
+                    <b-button
+                        @click="isEditMode = true"
+                        title="Modify library item"
+                        class="mr-1 mb-2"
+                        data-test-id="modify-btn">
+                        <font-awesome-icon icon="pencil-alt" />
+                        Modify
+                    </b-button>
+                    <b-button
+                        title="Attempt to detect the format of dataset"
+                        @click="detectDatatype"
+                        class="mr-1 mb-2"
+                        data-test-id="auto-detect-btn">
+                        <font-awesome-icon icon="redo" />
+                        Auto-detect datatype
+                    </b-button>
+                </span>
+                <b-button
+                    title="Manage permissions"
+                    v-if="user.is_admin"
+                    class="mr-1 mb-2"
+                    :to="{
+                        name: 'LibraryFolderDatasetPermissions',
+                        params: { folder_id: folder_id, dataset_id: dataset_id },
+                    }"
+                    data-test-id="permissions-btn">
+                    <font-awesome-icon icon="users" />
+                    Permissions
+                </b-button>
+            </div>
+            <div v-if="dataset.is_unrestricted" data-test-id="unrestricted-msg">
+                This dataset is unrestricted so everybody with the link can access it.
+                <copy-to-clipboard
+                    message="A link to current dataset was copied to your clipboard"
+                    :text="currentRouteName"
+                    title="Copy link to this dataset " />
+            </div>
+            <!-- Table -->
+            <b-table
+                v-if="table_items"
+                :fields="fields"
+                :items="table_items"
+                class="dataset_table mt-2"
+                thead-class="d-none"
+                striped
+                small
+                data-test-id="dataset-table">
+                <template v-slot:cell(name)="row">
+                    <strong>{{ row.item.name }}</strong>
+                </template>
+                <template v-slot:cell(value)="row">
+                    <div v-if="isEditMode">
+                        <b-form-input
+                            v-if="row.item.name === fieldTitles.name"
+                            :value="row.item.value"
+                            v-model="modifiedDataset.name" />
+                        <DatatypesProvider
+                            v-else-if="row.item.name === fieldTitles.file_ext"
+                            v-slot="{ item: datatypes, loading: loadingDatatypes }">
+                            <SingleItemSelector
+                                collection-name="Data Types"
+                                :loading="loadingDatatypes"
+                                :items="datatypes"
+                                :current-item-id="dataset.file_ext"
+                                @update:selected-item="onSelectedDatatype" />
+                        </DatatypesProvider>
+                        <GenomeProvider
+                            v-else-if="row.item.name === fieldTitles.genome_build"
+                            v-slot="{ item: genomes, loading: loadingGenomes }">
+                            <SingleItemSelector
+                                collection-name="Genomes"
+                                :loading="loadingGenomes"
+                                :items="genomes"
+                                :current-item-id="dataset.genome_build"
+                                @update:selected-item="onSelectedGenome" />
+                        </GenomeProvider>
+                        <b-form-input
+                            v-else-if="row.item.name === fieldTitles.message"
+                            :value="row.item.value"
+                            v-model="modifiedDataset.message" />
+                        <b-form-input
+                            v-else-if="row.item.name === fieldTitles.misc_info"
+                            :value="row.item.value"
+                            v-model="modifiedDataset.misc_info" />
+                        <div v-else>{{ row.item.value }}</div>
+                    </div>
+                    <div v-else>
+                        <div>{{ row.item.value }}</div>
+                    </div>
+                </template>
+            </b-table>
+            <!-- Edit Controls -->
+            <div v-if="isEditMode">
+                <b-button @click="isEditMode = false" class="mr-1 mb-2">
+                    <font-awesome-icon :icon="['fas', 'times']" />
+                    Cancel
+                </b-button>
+                <b-button @click="updateDataset" class="mr-1 mb-2">
+                    <font-awesome-icon :icon="['far', 'save']" />
+                    Save
+                </b-button>
+            </div>
+            <!-- Peek View -->
+            <div v-if="dataset.peek" v-html="dataset.peek" data-test-id="peek-view" />
         </div>
-        <div v-if="dataset.is_unrestricted" data-test-id="unrestricted-msg">
-            This dataset is unrestricted so everybody with the link can access it.
-            <copy-to-clipboard
-                message="A link to current dataset was copied to your clipboard"
-                :text="currentRouteName"
-                title="Copy link to this dataset " />
-        </div>
-        <!-- Table -->
-        <b-table
-            v-if="table_items"
-            :fields="fields"
-            :items="table_items"
-            class="dataset_table mt-2"
-            thead-class="d-none"
-            striped
-            small
-            data-test-id="dataset-table">
-            <template v-slot:cell(name)="row">
-                <strong>{{ row.item.name }}</strong>
-            </template>
-            <template v-slot:cell(value)="row">
-                <div v-if="isEditMode">
-                    <b-form-input
-                        v-if="row.item.name === fieldTitles.name"
-                        :value="row.item.value"
-                        v-model="modifiedDataset.name" />
-                    <DatatypesProvider
-                        v-else-if="row.item.name === fieldTitles.file_ext"
-                        v-slot="{ item: datatypes, loading: loadingDatatypes }">
-                        <SingleItemSelector
-                            collection-name="Data Types"
-                            :loading="loadingDatatypes"
-                            :items="datatypes"
-                            :current-item-id="dataset.file_ext"
-                            @update:selected-item="onSelectedDatatype" />
-                    </DatatypesProvider>
-                    <GenomeProvider
-                        v-else-if="row.item.name === fieldTitles.genome_build"
-                        v-slot="{ item: genomes, loading: loadingGenomes }">
-                        <SingleItemSelector
-                            collection-name="Genomes"
-                            :loading="loadingGenomes"
-                            :items="genomes"
-                            :current-item-id="dataset.genome_build"
-                            @update:selected-item="onSelectedGenome" />
-                    </GenomeProvider>
-                    <b-form-input
-                        v-else-if="row.item.name === fieldTitles.message"
-                        :value="row.item.value"
-                        v-model="modifiedDataset.message" />
-                    <b-form-input
-                        v-else-if="row.item.name === fieldTitles.misc_info"
-                        :value="row.item.value"
-                        v-model="modifiedDataset.misc_info" />
-                    <div v-else>{{ row.item.value }}</div>
-                </div>
-                <div v-else>
-                    <div>{{ row.item.value }}</div>
-                </div>
-            </template>
-        </b-table>
-        <!-- Edit Controls -->
-        <div v-if="isEditMode">
-            <b-button @click="isEditMode = false" class="mr-1 mb-2">
-                <font-awesome-icon :icon="['fas', 'times']" />
-                Cancel
-            </b-button>
-            <b-button @click="updateDataset" class="mr-1 mb-2">
-                <font-awesome-icon :icon="['far', 'save']" />
-                Save
-            </b-button>
-        </div>
-        <!-- Peek View -->
-        <div v-if="dataset.peek" v-html="dataset.peek" data-test-id="peek-view" />
-    </div>
+    </CurrentUser>
 </template>
 
 <script>
@@ -142,6 +144,7 @@ import { fieldTitles } from "components/Libraries/LibraryFolder/LibraryFolderDat
 import { GenomeProvider, DatatypesProvider } from "components/providers";
 import SingleItemSelector from "components/SingleItemSelector";
 import { buildFields } from "components/Libraries/library-utils";
+import CurrentUser from "components/providers/CurrentUser";
 
 library.add(faUsers, faRedo, faBook, faDownload, faPencilAlt, faTimes, faSave);
 
@@ -163,6 +166,7 @@ export default {
         GenomeProvider,
         DatatypesProvider,
         SingleItemSelector,
+        CurrentUser,
     },
     data() {
         return {

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderDatasetPermissions.vue
@@ -59,16 +59,6 @@
                         Users without access permission <strong>cannot</strong> have other permissions on this dataset.
                         If there are no access roles set on the dataset it is considered <strong>unrestricted</strong>."
                 @input="setUserPermissionsPreferences" />
-            <PermissionsInputField
-                v-if="manage_dataset_roles"
-                :id="dataset_id"
-                :permission_type="manage_dataset_roles_type"
-                :initial_value="manage_dataset_roles"
-                :api-root-url="apiRootUrl"
-                title="Roles that can manage permissions on the dataset"
-                alert="User with <strong>any</strong> of these roles can manage permissions of this dataset.
-                        If you remove yourself you will lose the ability manage this dataset unless you are an admin."
-                @input="setUserPermissionsPreferences" />
             <b-button
                 data-toggle="tooltip"
                 data-placement="top"
@@ -128,10 +118,8 @@ export default {
             is_admin: undefined,
             access_dataset_roles: undefined,
             modify_item_roles: undefined,
-            manage_dataset_roles: undefined,
             access_dataset_roles_type: "access_dataset_roles",
             modify_item_roles_type: "modify_item_roles",
-            manage_dataset_roles_type: "manage_dataset_roles",
             apiRootUrl: `${getAppRoot()}api/libraries/datasets`,
         };
     },
@@ -156,7 +144,6 @@ export default {
         assignFetchedPermissions(fetched_permissions) {
             this.access_dataset_roles = extractRoles(fetched_permissions.access_dataset_roles);
             this.modify_item_roles = extractRoles(fetched_permissions.modify_item_roles);
-            this.manage_dataset_roles = extractRoles(fetched_permissions.manage_dataset_roles);
             console.log(this.access_dataset_roles);
         },
         toggleDatasetPrivacy(isMakePrivate) {
@@ -187,11 +174,7 @@ export default {
             this.services.setPermissions(
                 this.apiRootUrl,
                 this.dataset_id,
-                [
-                    { "access_ids[]": this.access_dataset_roles },
-                    { "modify_ids[]": this.modify_item_roles },
-                    { "manage_ids[]": this.manage_dataset_roles },
-                ],
+                [{ "access_ids[]": this.access_dataset_roles }, { "modify_ids[]": this.modify_item_roles }],
                 (fetched_permissions) => {
                     Toast.success("Permissions saved.");
                     this.assignFetchedPermissions(fetched_permissions);

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <b-button variant="link" @click="onGoBack">Go back</b-button>
         <PermissionsHeader v-if="folder" :name="folder.name" />
         <b-container fluid>
             <div class="dataset_table">
@@ -125,6 +126,9 @@ export default {
                     console.error(error);
                 }
             );
+        },
+        onGoBack() {
+            this.$router.go(-1);
         },
     },
 };

--- a/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
+++ b/client/src/components/Libraries/LibraryFolder/LibraryFolderPermissions/LibraryFolderPermissions.vue
@@ -6,16 +6,6 @@
             <div class="dataset_table">
                 <h2 class="text-center">Folder permissions</h2>
                 <PermissionsInputField
-                    v-if="manage_folder_role_list"
-                    :id="folder_id"
-                    :permission_type="manage_type"
-                    :initial_value="manage_folder_role_list"
-                    :api-root-url="apiRootUrl"
-                    alert="User with <strong>any</strong> of these roles can manage permissions on this folder."
-                    title="Roles that can manage permissions on this folder"
-                    @input="setUserPermissionsPreferences" />
-
-                <PermissionsInputField
                     v-if="add_library_item_role_list"
                     :id="folder_id"
                     :permission_type="add_type"
@@ -25,7 +15,6 @@
                     alert="User with <strong>any</strong> of these roles can add items to this folder (folders and
                                 datasets)."
                     @input="setUserPermissionsPreferences" />
-
                 <PermissionsInputField
                     v-if="modify_folder_role_list"
                     :id="folder_id"
@@ -84,9 +73,7 @@ export default {
             folder: undefined,
             add_library_item_role_list: undefined,
             modify_folder_role_list: undefined,
-            manage_folder_role_list: undefined,
             add_type: "add_library_item_role_list",
-            manage_type: "manage_folder_role_list",
             modify_type: "modify_folder_role_list",
             apiRootUrl: `${getAppRoot()}api/folders`,
         };
@@ -96,7 +83,6 @@ export default {
         this.services = new Services({ root: this.root });
         this.services.getFolderPermissions(this.folder_id).then((fetched_permissions) => {
             this.add_library_item_role_list = extractRoles(fetched_permissions.add_library_item_role_list);
-            this.manage_folder_role_list = extractRoles(fetched_permissions.manage_folder_role_list);
             this.modify_folder_role_list = extractRoles(fetched_permissions.modify_folder_role_list);
         });
         this.services.getFolder(this.folder_id).then((response) => {
@@ -112,11 +98,7 @@ export default {
             this.services.setPermissions(
                 this.apiRootUrl,
                 this.folder_id,
-                [
-                    { "add_ids[]": this.add_library_item_role_list },
-                    { "manage_ids[]": this.manage_folder_role_list },
-                    { "modify_ids[]": this.modify_folder_role_list },
-                ],
+                [{ "add_ids[]": this.add_library_item_role_list }, { "modify_ids[]": this.modify_folder_role_list }],
                 (fetched_permissions) => {
                     Toast.success("Permissions saved.");
                     this.permissions = fetched_permissions;

--- a/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
+++ b/client/src/components/Libraries/LibraryFolder/TopToolbar/FolderTopBar.vue
@@ -90,7 +90,7 @@
                         </button>
                     </div>
                     <button
-                        v-if="logged_dataset_manipulation"
+                        v-if="canDelete"
                         data-toggle="tooltip"
                         title="Mark items deleted"
                         class="primary-button toolbtn-bulk-delete logged-dataset-manipulation mr-1"
@@ -100,7 +100,7 @@
                         Delete
                     </button>
                     <FolderDetails class="mr-1" :id="folder_id" :metadata="metadata" />
-                    <div class="form-check logged-dataset-manipulation mr-1" v-if="logged_dataset_manipulation">
+                    <div class="form-check logged-dataset-manipulation mr-1" v-if="canDelete">
                         <b-form-checkbox
                             id="checkbox-1"
                             :checked="include_deleted"
@@ -215,10 +215,8 @@ export default {
         contains_file_or_folder: function () {
             return this.folderContents.find((el) => el.type === "folder" || el.type === "file");
         },
-        logged_dataset_manipulation: function () {
-            const Galaxy = getGalaxyInstance();
-            // logic from legacy code
-            return !!(this.contains_file_or_folder && Galaxy.user && !Galaxy.user.isAnonymous());
+        canDelete: function () {
+            return !!(this.contains_file_or_folder && this.is_admin);
         },
         dataset_manipulation: function () {
             const Galaxy = getGalaxyInstance();

--- a/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
+++ b/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
@@ -13,16 +13,6 @@
             title="Roles that can access the library"
             @input="setUserPermissionsPreferences" />
         <PermissionsInputField
-            v-if="manage_library_role_list"
-            :id="library_id"
-            :permission_type="manage_type"
-            :initial_value="manage_library_role_list"
-            :api-root-url="apiRootUrl"
-            alert="User with <strong>any</strong> of these roles can manage permissions on this library (includes giving access)."
-            title="Roles that can manage permissions on this library"
-            @input="setUserPermissionsPreferences" />
-
-        <PermissionsInputField
             v-if="add_library_item_role_list"
             :id="library_id"
             :permission_type="add_type"
@@ -80,12 +70,10 @@ export default {
             permissions: undefined,
             library: undefined,
             add_library_item_role_list: undefined,
-            manage_library_role_list: undefined,
             modify_library_role_list: undefined,
             access_library_role_list: undefined,
             apiRootUrl: `${getAppRoot()}api/libraries`,
             add_type: "add_library_item_role_list",
-            manage_type: "manage_library_role_list",
             modify_type: "modify_library_role_list",
             access_type: "access_library_role_list",
         };
@@ -96,7 +84,6 @@ export default {
         this.services.getLibraryPermissions(this.library_id).then((fetched_permissions) => {
             console.log("fetched_permissions", fetched_permissions);
             this.add_library_item_role_list = extractRoles(fetched_permissions.add_library_item_role_list);
-            this.manage_library_role_list = extractRoles(fetched_permissions.manage_library_role_list);
             this.modify_library_role_list = extractRoles(fetched_permissions.modify_library_role_list);
             this.access_library_role_list = extractRoles(fetched_permissions.access_library_role_list);
         });
@@ -115,7 +102,6 @@ export default {
                 this.library_id,
                 [
                     { "add_ids[]": this.add_library_item_role_list },
-                    { "manage_ids[]": this.manage_library_role_list },
                     { "modify_ids[]": this.modify_library_role_list },
                     { "access_ids[]": this.access_library_role_list },
                 ],

--- a/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
+++ b/client/src/components/Libraries/LibraryPermissions/LibraryPermissions.vue
@@ -1,5 +1,6 @@
 <template>
     <div>
+        <b-button variant="link" @click="onGoBack">Go back to Libraries</b-button>
         <PermissionsHeader v-if="library" :name="library.name" />
         <h2 class="text-center">Library permissions</h2>
         <PermissionsInputField
@@ -127,6 +128,9 @@ export default {
                     console.error(error);
                 }
             );
+        },
+        onGoBack() {
+            this.$router.go(-1);
         },
     },
 };

--- a/lib/galaxy/managers/libraries.py
+++ b/lib/galaxy/managers/libraries.py
@@ -71,7 +71,11 @@ class LibraryManager:
         """
         changed = False
         if not trans.user_is_admin:
-            raise exceptions.ItemAccessibilityException('Only administrators can update libraries.')
+            current_user_roles = trans.get_current_user_roles()
+            library_modify_roles = self.get_modify_roles(trans, library)
+            user_can_modify = any(role in library_modify_roles for role in current_user_roles)
+            if not user_can_modify:
+                raise exceptions.ItemAccessibilityException("You don't have permission update libraries.")
         if library.deleted:
             raise exceptions.RequestParameterInvalidException('You cannot modify a deleted library. Undelete it first.')
         if name is not None:

--- a/lib/galaxy_test/api/test_libraries.py
+++ b/lib/galaxy_test/api/test_libraries.py
@@ -71,6 +71,24 @@ class LibrariesApiTestCase(ApiTestCase):
         assert library['description'] == 'ChangedDescription'
         assert library['synopsis'] == 'ChangedSynopsis'
 
+    def test_update_non_admins_with_permission(self):
+        library = self.library_populator.new_library("UpdateTestLibraryNonAdmin")
+        library_id = library["id"]
+        role_id = self.library_populator.user_private_role_id()
+        data = dict(name='ChangedName', description='ChangedDescription', synopsis='ChangedSynopsis')
+        # User has no permission by default
+        create_response = self._patch(f"libraries/{library['id']}", data=data)
+        self._assert_status_code_is(create_response, 403)
+        # Grant modify permission
+        self.library_populator.set_modify_permission(library_id, role_id)
+        create_response = self._patch(f"libraries/{library['id']}", data=data)
+        self._assert_status_code_is(create_response, 200)
+        library = create_response.json()
+        self._assert_has_keys(library, 'name', 'description', 'synopsis')
+        assert library['name'] == 'ChangedName'
+        assert library['description'] == 'ChangedDescription'
+        assert library['synopsis'] == 'ChangedSynopsis'
+
     def test_create_private_library_legacy_permissions(self):
         library = self.library_populator.new_library("LegacyPermissionTestLibrary")
         library_id = library["id"]

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -1629,8 +1629,7 @@ class LibraryPopulator:
             "LIBRARY_ADD_in": perm_list,
             "LIBRARY_MANAGE_in": perm_list,
         }
-        response = self.galaxy_interactor.post(f"libraries/{library_id}/permissions", data=permissions, admin=True, json=True)
-        api_asserts.assert_status_code_is(response, 200)
+        self._set_permissions(library_id, permissions)
 
     def set_permissions_with_action(self, library_id, role_id=None, action=None):
         perm_list = role_id or []
@@ -1642,6 +1641,29 @@ class LibraryPopulator:
             "manage_ids[]": perm_list,
             "modify_ids[]": perm_list,
         }
+        self._set_permissions(library_id, permissions)
+
+    def set_access_permission(self, library_id, role_id, action=None):
+        self._set_single_permission(library_id, role_id, permission="access_ids[]", action=action)
+
+    def set_add_permission(self, library_id, role_id, action=None):
+        self._set_single_permission(library_id, role_id, permission="add_ids[]", action=action)
+
+    def set_manage_permission(self, library_id, role_id, action=None):
+        self._set_single_permission(library_id, role_id, permission="manage_ids[]", action=action)
+
+    def set_modify_permission(self, library_id, role_id, action=None):
+        self._set_single_permission(library_id, role_id, permission="modify_ids[]", action=action)
+
+    def _set_single_permission(self, library_id, role_id, permission, action=None):
+        action = action or "set_permissions"
+        permissions = {
+            "action": action,
+            permission: role_id or [],
+        }
+        self._set_permissions(library_id, permissions)
+
+    def _set_permissions(self, library_id, permissions):
         response = self.galaxy_interactor.post(f"libraries/{library_id}/permissions", data=permissions, admin=True, json=True)
         api_asserts.assert_status_code_is(response, 200)
 


### PR DESCRIPTION
This PR tries to fix #12003 (or maybe not... see below) and addresses a backend issue for #12004 that led to #12023 as a provisional fix. Along with some other small papercuts around navigating *Data Libraries*.

## Backend Changes
- There is a specific permission to "modify" libraries, this includes changing the library name, description, synopsis, and the same for the subfolders, including some metadata about the datasets. But the API only allowed admin users to perform any modification on the library level. This has been fixed in eff762cc1ad8f8fd3187fae07e6b731ec4c571da.

## UI Changes
- User with the appropriate permissions can now see the corresponding buttons on the UI.
  ![Screenshot from 2022-01-13 14-24-01](https://user-images.githubusercontent.com/46503462/149338283-4dec5d7e-3de0-4636-8fea-e9f6dc1f689b.png)
- Delete actions (even just list deleted items) are only accessible for admins in the API so they have been hidden for any other kind of user.
- Added "Go back" links in the permissions views for libraries and folders. You can always use the browser back button, but it was kind of a papercut. Unfortunately, we can not use the breadcrumbs for folders permissions because the folder model doesn't contain the ids of all the possible parent folders (like the datasets), only the names, and direct parent id. Not sure if it's worth adding it though.

## What about #12003?
Apparently, granting "manage" permissions to other non-admin users doesn't make sense with the current API. It will require the user to have access to **all roles in the system** to actually be useful (afaik) because [trying to get a role that the user doesn't own](https://github.com/galaxyproject/galaxy/blob/320c6a36b582c62b2c24aa584044ae179176cb17/lib/galaxy/webapps/galaxy/services/libraries.py#L266) will fail.
So far, the only sensible solution I see is to leave the permission management in libraries in the hands of the admins. So apart from only showing the manage buttons for admins, in my opinion, removing the manage roles input entirely will make the UI less confusing since this feature cannot be really used by non-admin users.

![removemanage](https://user-images.githubusercontent.com/46503462/149345349-495b4c6d-340f-4872-9122-c0a246c79190.png)

Anyway, I may be wrong and maybe there is an easy fix that doesn't require exposing all the roles to the user or rewriting quite some role management code, so I leave it here for discussion :smiley: 

## TODO
- [x] Decide what to do with #12003 and do it.
  - See https://github.com/galaxyproject/galaxy/pull/13159#issuecomment-1012208427


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Go to Data Libraries as an admin and give different permission to other users.
  - Play around Data Libraries with those users and check that all the operations that are shown can be performed by that user.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
