### PR TITLE
Replace backref with back_populates

### DIFF
--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -77,7 +77,6 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.orderinglist import ordering_list
 from sqlalchemy.orm import (
     aliased,
-    backref,
     column_property,
     deferred,
     joinedload,
@@ -8486,7 +8485,8 @@ class Vault(Base):
 
     key = Column(Text, primary_key=True)
     parent_key = Column(Text, ForeignKey(key), index=True, nullable=True)
-    children = relationship('Vault', backref=backref('parent', remote_side=[key]))
+    children = relationship('Vault', back_populates='parent')
+    parent = relationship('Vault', back_populates='children', remote_side=[key])
     value = Column(Text, nullable=True)
     create_time = Column(DateTime, default=now)
     update_time = Column(DateTime, default=now, onupdate=now)


### PR DESCRIPTION
Both do the job; however, using `back_populates` instead of `backref` has several advantages in the context of Galaxy's model,  which is why all `backref` instances have been replaced with `back_populates`.

See #12064 for rationale (PR description: Notable issues >> back_populates vs. backref)

(Sorry I missed this in the initial review!)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
