### PR TITLE
converting forward and reverse filters to reactive Vue array

### DIFF
--- a/client/src/components/Collections/PairedListCollectionCreator.test.js
+++ b/client/src/components/Collections/PairedListCollectionCreator.test.js
@@ -119,7 +119,7 @@ describe("PairedListCollectionCreator", () => {
                 hideSourceItems: false,
             },
         });
-        await wrapper.vm.$nextTick()
+        await wrapper.vm.$nextTick();
         //change filter to _R1/_R2
         wrapper.find("div.forward-unpaired-filter > input").setValue("_R1");
         await wrapper.vm.$nextTick();

--- a/client/src/components/Collections/PairedListCollectionCreator.test.js
+++ b/client/src/components/Collections/PairedListCollectionCreator.test.js
@@ -102,4 +102,39 @@ describe("PairedListCollectionCreator", () => {
         const pairname = wrapper.find("span.pair-name");
         expect(pairname.text()).toBe("UII_moo_1");
     });
+
+    it("autopairs correctly when filters are typed in", async () => {
+        wrapper = mount(PairedListCollectionCreator, {
+            propsData: {
+                initialElements: DATA._4,
+                creationFn: () => {
+                    return;
+                },
+                oncreate: () => {
+                    return;
+                },
+                oncancel: () => {
+                    return;
+                },
+                hideSourceItems: false,
+            },
+        });
+        await wrapper.vm.$nextTick()
+        //change filter to _R1/_R2
+        wrapper.find("div.forward-unpaired-filter > input").setValue("_R1");
+        await wrapper.vm.$nextTick();
+        wrapper.find("div.reverse-unpaired-filter > input").setValue("_R2");
+        await wrapper.vm.$nextTick();
+        //assert forward filter
+        const forwardFilter = wrapper.find("div.forward-unpaired-filter > input").element.value;
+        expect(forwardFilter).toBe("_R1");
+        //assert reverse filter
+        const reverseFilter = wrapper.find("div.reverse-unpaired-filter > input").element.value;
+        expect(reverseFilter).toBe("_R2");
+        // click Autopair
+        wrapper.find("a.autopair-link").trigger("click");
+        await wrapper.vm.$nextTick();
+        //assert all pairs matched
+        expect(wrapper.findAll("li.dataset unpaired").length == 0).toBeTruthy();
+    });
 });

--- a/client/src/components/Collections/PairedListCollectionCreator.vue
+++ b/client/src/components/Collections/PairedListCollectionCreator.vue
@@ -258,7 +258,7 @@
                                         <input
                                             type="text"
                                             :placeholder="filterTextPlaceholder"
-                                            v-model="filters[0]"
+                                            v-model="forwardFilter"
                                             title="filterTextTitle" />
                                         <div class="input-group-append" :title="chooseFilterTitle">
                                             <button
@@ -317,7 +317,7 @@
                                         <input
                                             type="text"
                                             :placeholder="filterTextPlaceholder"
-                                            v-model="filters[1]"
+                                            v-model="reverseFilter"
                                             title="filterTextTitle" />
                                         <div class="input-group-append" :title="chooseFilterTitle">
                                             <button
@@ -359,7 +359,7 @@
                                         </ol>
                                     </div>
                                     <div class="paired-column flex-column no-flex column truncate">
-                                        <ol class="column-datasets" v-if="filters[0] !== '' && filters[1] !== ''">
+                                        <ol class="column-datasets" v-if="forwardFilter !== '' && reverseFilter !== ''">
                                             <li
                                                 v-for="(pairableElement, index) in pairableElements"
                                                 :key="index"
@@ -437,9 +437,10 @@ export default {
     mixins: [mixin],
     created() {
         this.strategy = this.autopairLCS;
+        //TODO convert to Fwd/Rev
         // Setup inital filters and shallow copy the items
-        const initFilters = this.commonFilters[this.filters] || this.commonFilters[this.DEFAULT_FILTERS];
-        this.filters = JSON.parse(JSON.stringify(initFilters));
+        this.forwardFilter = this.commonFilters[this.DEFAULT_FILTERS][0];
+        this.reverseFilter = this.commonFilters[this.DEFAULT_FILTERS][1];
         this._elementsSetUp();
     },
     components: {
@@ -464,7 +465,8 @@ export default {
                 dot12s: [".1.fastq", ".2.fastq"],
             },
             DEFAULT_FILTERS: "illumina",
-            filters: this.DEFAULT_FILTERS,
+            forwardFilter: "",
+            reverseFilter: "",
             automaticallyPair: true,
             initialPairsPossible: true,
             matchPercentage: 0.99,
@@ -691,8 +693,8 @@ export default {
             removeExtensions = removeExtensions ? removeExtensions : this.removeExtensions;
             let fwdName = fwd.name;
             let revName = rev.name;
-            const fwdNameFilter = fwdName.replace(new RegExp(this.filters[0]), "");
-            const revNameFilter = revName.replace(new RegExp(this.filters[1]), "");
+            const fwdNameFilter = fwdName.replace(new RegExp(this.forwardFilter), "");
+            const revNameFilter = revName.replace(new RegExp(this.reverseFilter), "");
             let lcs = this._naiveStartingAndEndingLCS(fwdNameFilter, revNameFilter);
             /** remove url prefix if files were uploaded by url */
             const lastSlashIndex = lcs.lastIndexOf("/");
@@ -726,11 +728,11 @@ export default {
             return () => this._unpair(pair);
         },
         clickClearFilters: function () {
-            Vue.set(this.filters, 0, "");
-            Vue.set(this.filters, 1, "");
+            this.forwardFilter = "";
+            this.reverseFilter = "";
         },
         splitByFilter: function () {
-            var filters = [new RegExp(this.filters[0]), new RegExp(this.filters[1])];
+            var filters = [new RegExp(this.forwardFilter), new RegExp(this.reverseFilter)];
             var split = [[], []];
             this.workingElements.forEach((e) => {
                 filters.forEach((filter, i) => {
@@ -838,7 +840,7 @@ export default {
             var _regexps = [];
             function getRegExps() {
                 if (!_regexps.length) {
-                    _regexps = [new RegExp(this.filters[0]), new RegExp(this.filters[1])];
+                    _regexps = [new RegExp(this.forwardFilter), new RegExp(this.reverseFilter)];
                 }
                 return _regexps;
             }
@@ -926,8 +928,8 @@ export default {
             };
         },
         changeFilters: function (filter) {
-            Vue.set(this.filters, 0, this.commonFilters[filter][0]);
-            Vue.set(this.filters, 1, this.commonFilters[filter][1]);
+            this.forwardFilter = this.commonFilters[filter][0];
+            this.reverseFilter = this.commonFilters[filter][1];
         },
         clickedCreate: function (collectionName) {
             this.checkForDuplicates();
@@ -960,12 +962,12 @@ export default {
     computed: {
         forwardElements: {
             get() {
-                return this.filterElements(this.workingElements, this.filters[0]);
+                return this.filterElements(this.workingElements, this.forwardFilter);
             },
         },
         reverseElements: {
             get() {
-                return this.filterElements(this.workingElements, this.filters[1]);
+                return this.filterElements(this.workingElements, this.reverseFilter);
             },
         },
         pairableElements: {

--- a/client/tests/qunit/test-data/paired-collection-creator.data.js
+++ b/client/tests/qunit/test-data/paired-collection-creator.data.js
@@ -28,6 +28,15 @@ var datasets3 = [
     {name: "UII_moo_1.2.fastq", state: STATES.OK}
 ]
 
+var datasets4= [
+    { name: "SET1-01_R1.fastq", state: STATES.OK },
+    { name: "SET1-01_R2.fastq", state: STATES.OK },
+    { name: "SET1-02_R1.fastq", state: STATES.OK },
+    { name: "SET1-02_R2.fastq", state: STATES.OK },
+    { name: "SET1-03_R1.fastq", state: STATES.OK },
+    { name: "SET1-03_R2.fastq", state: STATES.OK },
+]
+
 var datasets1CreateRequestJSON = {
     type: "dataset_collection",
     collection_type: "list:paired",
@@ -161,5 +170,6 @@ export default {
     _1: datasets1,
     _1requestJSON: datasets1CreateRequestJSON,
     _2: datasets2,
-    _3: datasets3
+    _3: datasets3,
+    _4: datasets4
 };


### PR DESCRIPTION
Fixing #13140; cleared up confusion over what attribute was changing when you typed a filter in. 
Before It was just forwardFilter/reverseFilter, but the filters array is what is used when autopairing.  I removed all references to forward/reverse, and instead just modify the filters Array. 
I needed to make the array a reactive Vue array, so that changes made to it propogate, since I'm changing the array in a non-reactive way (by indexing in). 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [X] Instructions for manual testing are as follows: Cov20093_R1.fastq, Cov20093_R2.fastq, Cov20094_R1.fastq, Cov20094_R2.fastq
  1. Add the following four datasets to your history (just the names are important): 
       Cov20093_R1.fastq, Cov20093_R2.fastq, Cov20094_R1.fastq, Cov20094_R2.fastq
  2. Create a List of Pairs Collection
  3. Play with the filters, clear them, use the drop down, etc. but eventually TYPE in the filters _R1/_R2 
  4. Click Auto-pair
  5. Note that the pairs are made correctly.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
