### PR TITLE
Enable setting SQLALCHEMY_WARN_20

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -12,6 +12,7 @@ env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_DEPENDENCIES_INSTALL_WEASYPRINT: '1'
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: api-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/api_paste.yaml
+++ b/.github/workflows/api_paste.yaml
@@ -12,6 +12,7 @@ env:
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_USE_UVICORN: false
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: api-legacy-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,6 +12,7 @@ env:
   GALAXY_TEST_AMQP_URL: 'amqp://localhost:5672//'
   GALAXY_TEST_DBURI: 'postgresql://postgres:postgres@localhost:5432/galaxy?client_encoding=utf8'
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: integration-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration_selenium.yaml
+++ b/.github/workflows/integration_selenium.yaml
@@ -12,6 +12,7 @@ env:
   GALAXY_TEST_RAISE_EXCEPTION_ON_HISTORYLESS_HDA: '1'
   GALAXY_TEST_SELENIUM_RETRIES: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: integration-selenium-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/selenium.yaml
+++ b/.github/workflows/selenium.yaml
@@ -13,6 +13,7 @@ env:
   GALAXY_TEST_SELENIUM_RETRIES: 1
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: selenium-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/selenium_beta.yaml
+++ b/.github/workflows/selenium_beta.yaml
@@ -14,6 +14,7 @@ env:
   GALAXY_TEST_SELENIUM_BETA_HISTORY: 1
   GALAXY_TEST_SKIP_FLAKEY_TESTS_ON_ERROR: 1
   YARN_INSTALL_OPTS: --frozen-lockfile
+  GALAXY_CONFIG_SQLALCHEMY_WARN_20: '1'
 concurrency:
   group: selenium-beta-${{ github.ref }}
   cancel-in-progress: true

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -620,7 +620,35 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._override_tempdir(kwargs)
+        self._configure_sqlalchemy20_warnings(kwargs)
         self._process_config(kwargs)
+
+    def _configure_sqlalchemy20_warnings(self, kwargs):
+        """
+        This method should be deleted after migration to SQLAlchemy 2.0 is complete.
+        To enable warnings, set `GALAXY_CONFIG_SQLALCHEMY_WARN_20=1`,
+        """
+        warn = kwargs.get('sqlalchemy_warn_20', False)
+        if warn:
+            import sqlalchemy
+            sqlalchemy.util.deprecations.SQLALCHEMY_WARN_20 = True
+            self._setup_sqlalchemy20_warnings_filters()
+
+    def _setup_sqlalchemy20_warnings_filters(self):
+        import warnings
+        from sqlalchemy.exc import RemovedIn20Warning
+        # Always display RemovedIn20Warning warnings.
+        warnings.filterwarnings('always', category=RemovedIn20Warning)
+        # Optionally, enable filters for specific warnings (raise error, or log, etc.)
+        # messages = [
+        #     r"replace with warning text to match",
+        # ]
+        # for msg in messages:
+        #     warnings.filterwarnings('error', message=msg, category=RemovedIn20Warning)
+        #
+        # See documentation:
+        # https://docs.python.org/3.7/library/warnings.html#the-warnings-filter
+        # https://docs.sqlalchemy.org/en/14/changelog/migration_20.html#migration-to-2-0-step-three-resolve-all-removedin20warnings
 
     def _load_schema(self):
         # Schemas are symlinked to the root of the galaxy-app package

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -628,7 +628,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         This method should be deleted after migration to SQLAlchemy 2.0 is complete.
         To enable warnings, set `GALAXY_CONFIG_SQLALCHEMY_WARN_20=1`,
         """
-        warn = kwargs.get('sqlalchemy_warn_20', False)
+        warn = string_as_bool(kwargs.get('sqlalchemy_warn_20', False))
         if warn:
             import sqlalchemy
             sqlalchemy.util.deprecations.SQLALCHEMY_WARN_20 = True


### PR DESCRIPTION
This adds an option to enable SQLAlchemy's `RemovedIn20Warnings` flag. This is part of the plan for migrating to SQLAlchemy 2.0 (see #12541, steps 5 and 6).

For more context, see:
https://github.com/galaxyproject/galaxy/pull/13164#issuecomment-1013291453
https://github.com/galaxyproject/galaxy/issues/12541#issuecomment-1012522620

## How to test the changes?
- [x] Instructions for manual testing are as follows:
Follow the inline comments to set the env var; start Galaxy, your terminal should contain "RemovedIn20Warning".

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
