### PR TITLE
[21.09] Show yaml files in preview

### DIFF
--- a/lib/galaxy/datatypes/text.py
+++ b/lib/galaxy/datatypes/text.py
@@ -875,6 +875,13 @@ class Yaml(Text):
         """Returns the mime type of the datatype"""
         return 'application/yaml'
 
+    def _yield_user_file_content(self, trans, from_dataset, filename):
+        # Override non-standard application/yaml mediatype with
+        # non-standard text/x-yaml, so preview is shown in preview iframe,
+        # instead of downloading the file.
+        trans.response.set_content_type('text/x-yaml')
+        return super()._yield_user_file_content(trans, from_dataset, filename)
+
     def _looks_like_yaml(self, file_prefix):
         # Pattern used by SequenceSplitLocations
         if file_prefix.file_size < 50000 and not file_prefix.truncated:


### PR DESCRIPTION
The `application/yaml` mediatype might be the logical mediatype for yaml
(there's no standard yet), but we want to see a textual preview (in the
absence of a viewer).
Fixes https://github.com/galaxyproject/galaxy/issues/13168

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
Upload a yaml file, click on the eye icon. The file showed be displayed in the center frame.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
