### PR TITLE
[21.09] Catch exceptions when job.user is None

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2221,12 +2221,9 @@ class JobWrapper(HasResourceParameters):
     @property
     def user(self):
         job = self.get_job()
-        if job.user is not None:
-            return job.user.email
-        elif job.galaxy_session is not None and job.galaxy_session.user is not None:
-            return job.galaxy_session.user.email
-        elif job.history is not None and job.history.user is not None:
-            return job.history.user.email
+        user_email = job.get_user_email()
+        if user_email:
+            return user_email
         elif job.galaxy_session is not None:
             return f"anonymous@{job.galaxy_session.remote_addr.split()[-1]}"
         else:

--- a/lib/galaxy/jobs/actions/post.py
+++ b/lib/galaxy/jobs/actions/post.py
@@ -54,7 +54,7 @@ class EmailAction(DefaultJobAction):
                 else:
                     host = socket.getfqdn()
                 frm = f'galaxy-no-reply@{host}'
-            to = job.user.email
+            to = job.get_user_email()
             subject = f"Galaxy job completion notification from history '{job.history.name}'"
             outdata = ',\n'.join(ds.dataset.display_name() for ds in job.output_datasets)
             body = f"Your Galaxy job generating dataset(s):\n\n{outdata}\n\nis complete as of {datetime.datetime.now().strftime('%I:%M')}. Click the link below to access your data: \n{link}"

--- a/lib/galaxy/managers/jobs.py
+++ b/lib/galaxy/managers/jobs.py
@@ -411,11 +411,7 @@ def view_show_job(trans, job, full: bool) -> typing.Dict:
         ))
 
         if is_admin:
-            if job.user:
-                job_dict['user_email'] = job.user.email
-            else:
-                job_dict['user_email'] = None
-
+            job_dict['user_email'] = job.get_user_email()
             job_dict['job_metrics'] = summarize_job_metrics(trans, job)
     return job_dict
 

--- a/lib/galaxy/model/__init__.py
+++ b/lib/galaxy/model/__init__.py
@@ -1125,6 +1125,15 @@ class Job(Base, JobLike, UsesCreateAndUpdateTime, Dictifiable, RepresentById):
     def set_tool_id(self, tool_id):
         self.tool_id = tool_id
 
+    def get_user_email(self):
+        if self.user is not None:
+            return self.user.email
+        elif self.galaxy_session is not None and self.galaxy_session.user is not None:
+            return self.galaxy_session.user.email
+        elif self.history is not None and self.history.user is not None:
+            return self.history.user.email
+        return None
+
     def set_tool_version(self, tool_version):
         self.tool_version = tool_version
 

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -210,10 +210,7 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
             if view == 'admin_job_list':
                 j['decoded_job_id'] = job.id
             if user_details:
-                try:
-                    j['user_email'] = job.user.email
-                except AttributeError:  # when job.user is None
-                    j['user_email'] = None
+                j['user_email'] = job.get_user_email()
             out.append(j)
 
         return out

--- a/lib/galaxy/webapps/galaxy/api/jobs.py
+++ b/lib/galaxy/webapps/galaxy/api/jobs.py
@@ -210,7 +210,10 @@ class JobController(BaseGalaxyAPIController, UsesVisualizationMixin):
             if view == 'admin_job_list':
                 j['decoded_job_id'] = job.id
             if user_details:
-                j['user_email'] = job.user.email
+                try:
+                    j['user_email'] = job.user.email
+                except AttributeError:  # when job.user is None
+                    j['user_email'] = None
             out.append(j)
 
         return out

--- a/lib/galaxy/webapps/reports/controllers/jobs.py
+++ b/lib/galaxy/webapps/reports/controllers/jobs.py
@@ -143,7 +143,7 @@ class SpecifiedDateListGrid(grids.Grid):
 
         def get_value(self, trans, grid, job):
             if job.user:
-                return escape(job.user.email)
+                return escape(job.get_user_email())
             return 'anonymous'
 
     class EmailColumn(grids.GridColumn):
@@ -279,10 +279,7 @@ class Jobs(BaseUIController, ReportQueryBuilder):
                 # that submitted the job.
                 job_id = kwd.get('id', None)
                 job = get_job(trans, job_id)
-                if job.user:
-                    kwd['email'] = job.user.email
-                else:
-                    kwd['email'] = None  # For anonymous users
+                kwd['email'] = job.get_user_email()
                 return trans.response.send_redirect(web.url_for(controller='jobs',
                                                                 action='user_per_month',
                                                                 **kwd))

--- a/templates/webapps/reports/job_info.mako
+++ b/templates/webapps/reports/job_info.mako
@@ -37,8 +37,8 @@
             <tr>
                 <td colspan="2">${job.tool_id}</td>
                 <td>
-                    %if job.user and job.user.email:
-                        ${job.user.email}
+                    %if job.get_user_email():
+                        ${job.get_user_email()}
                     %else:
                         anonymous
                     %endif


### PR DESCRIPTION
prevents the following error:

galaxy.web.framework.decorators ERROR 2022-01-17 14:52:09,619 [p:18,w:1,m:0] [uWSGIWorker1Core1] Uncaught exception in exposed API method:
Traceback (most recent call last):
  File "lib/galaxy/web/framework/decorators.py", line 282, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "lib/galaxy/webapps/galaxy/api/jobs.py", line 113, in index
    j['user_email'] = job.user.email
AttributeError: 'NoneType' object has no attribute 'email'

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
