### PR TITLE
Sync tool identifier string with tool version in workflow editor

### DIFF
--- a/client/src/components/Form/Elements/FormNumber.vue
+++ b/client/src/components/Form/Elements/FormNumber.vue
@@ -30,7 +30,6 @@
 export default {
     props: {
         value: {
-            type: [String, Number],
             required: true,
         },
         type: {

--- a/client/src/components/Form/FormElement.test.js
+++ b/client/src/components/Form/FormElement.test.js
@@ -3,8 +3,6 @@ import { getLocalVue } from "jest/helpers";
 import Vue from "vue";
 import FormElement from "./FormElement";
 
-jest.mock("app");
-
 const localVue = getLocalVue();
 
 describe("FormElement", () => {

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -1,0 +1,67 @@
+import { mount } from "@vue/test-utils";
+import { getLocalVue } from "jest/helpers";
+import FormTool from "./FormTool";
+import MockCurrentUser from "components/providers/MockCurrentUser";
+import MockConfigProvider from "components/providers/MockConfigProvider";
+
+const localVue = getLocalVue();
+
+describe("FormTool", () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = mount(FormTool, {
+            propsData: {
+                id: "input",
+                datatypes: [],
+                getNode: () => {
+                    return {
+                        id: "id",
+                        config_form: {
+                            id: "tool_id+1.0",
+                            name: "tool_name",
+                            version: "1.0",
+                            description: "description",
+                            inputs: [],
+                            help: "help_text",
+                            versions: ["1.0", "2.0", "3.0"],
+                        },
+                        outputs: [],
+                        postJobActions: [],
+                    };
+                },
+                getManager: () => {
+                    return {
+                        nodes: [],
+                    };
+                },
+            },
+            localVue,
+            stubs: {
+                CurrentUser: MockCurrentUser({ id: "fakeuser" }),
+                ConfigProvider: MockConfigProvider({ id: "fakeconfig" }),
+                FormElement: { template: "<div>form-element</div>" },
+                ToolFooter: { template: "<div>tool-footer</div>" },
+            },
+        });
+    });
+
+    it("check props", async () => {
+        const dropdowns = wrapper.findAll(".dropdown-item");
+        let version = dropdowns.at(3);
+        expect(version.text()).toBe("Switch to 2.0");
+        let state = wrapper.emitted().onSetData[0][1];
+        expect(state.tool_version).toEqual("1.0");
+        expect(state.tool_id).toEqual("tool_id+1.0");
+        await version.trigger("click");
+        state = wrapper.emitted().onSetData[1][1];
+        expect(state.tool_version).toEqual("2.0");
+        expect(state.tool_id).toEqual("tool_id+2.0");
+        version = dropdowns.at(2);
+        expect(version.text()).toBe("Switch to 3.0");
+        await version.trigger("click");
+        state = wrapper.emitted().onSetData[2][1];
+        expect(state.tool_version).toEqual("3.0");
+        expect(state.tool_id).toEqual("tool_id+3.0");
+    });
+});

--- a/client/src/components/Workflow/Editor/Forms/FormTool.test.js
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.test.js
@@ -31,9 +31,7 @@ describe("FormTool", () => {
                     };
                 },
                 getManager: () => {
-                    return {
-                        nodes: [],
-                    };
+                    return {};
                 },
             },
             localVue,
@@ -46,13 +44,13 @@ describe("FormTool", () => {
         });
     });
 
-    it("check props", async () => {
+    it("check version change", async () => {
         const dropdowns = wrapper.findAll(".dropdown-item");
-        let version = dropdowns.at(3);
-        expect(version.text()).toBe("Switch to 2.0");
         let state = wrapper.emitted().onSetData[0][1];
         expect(state.tool_version).toEqual("1.0");
         expect(state.tool_id).toEqual("tool_id+1.0");
+        let version = dropdowns.at(3);
+        expect(version.text()).toBe("Switch to 2.0");
         await version.trigger("click");
         state = wrapper.emitted().onSetData[1][1];
         expect(state.tool_version).toEqual("2.0");

--- a/client/src/components/Workflow/Editor/Forms/FormTool.vue
+++ b/client/src/components/Workflow/Editor/Forms/FormTool.vue
@@ -155,9 +155,16 @@ export default {
             const payload = Object.assign({}, this.mainValues, this.sectionValues);
             console.debug("FormTool - Posting changes.", payload);
             const options = this.node.config_form;
+            let toolId = options.id;
+            let toolVersion = options.version;
+            if (newVersion) {
+                toolId = toolId.replace(toolVersion, newVersion);
+                toolVersion = newVersion;
+                console.debug("FormTool - Tool version changed.", toolId, toolVersion);
+            }
             this.$emit("onSetData", this.node.id, {
-                tool_id: options.id,
-                tool_version: newVersion || options.version,
+                tool_id: toolId,
+                tool_version: toolVersion,
                 type: "tool",
                 inputs: payload,
             });


### PR DESCRIPTION
Fixes #13153. Thank you for reporting this issue @cat-bro.

## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
