### PR TITLE
Fix redirect to login page when login is required to perform operations

### DIFF
--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -75,7 +75,7 @@ def json_pretty(func):
     return json(func, pretty=True)
 
 
-def require_login(verb="perform this action", use_panels=False, webapp='galaxy'):
+def require_login(verb="perform this action", use_panels=False):
     def argcatcher(func):
         @wraps(func)
         def decorator(self, trans, *args, **kwargs):
@@ -84,7 +84,7 @@ def require_login(verb="perform this action", use_panels=False, webapp='galaxy')
             else:
                 return trans.show_error_message(
                     'You must be <a target="galaxy_main" href="%s">logged in</a> to %s.'
-                    % (url_for(controller='user', action='login', webapp=webapp), verb), use_panels=use_panels)
+                    % (url_for(controller='login'), verb), use_panels=use_panels)
         return decorator
     return argcatcher
 

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -45,6 +45,7 @@ from tool_shed.util import (
 )
 from tool_shed.util.web_util import escape
 from tool_shed.utility_containers import ToolShedUtilityContainerManager
+from tool_shed.webapp.framework.decorators import require_login
 from tool_shed.webapp.util import ratings_util
 
 log = logging.getLogger(__name__)
@@ -812,7 +813,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("deprecate repository")
+    @require_login("deprecate repository")
     def deprecate(self, trans, **kwd):
         """Mark a repository in the tool shed as deprecated or not deprecated."""
         # Marking a repository in the tool shed as deprecated has no effect on any downloadable changeset
@@ -1607,7 +1608,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                                         status='error'))
 
     @web.expose
-    @web.require_login("manage email alerts")
+    @require_login("manage email alerts")
     def manage_email_alerts(self, trans, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
@@ -1638,7 +1639,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("manage repository")
+    @require_login("manage repository")
     def manage_repository(self, trans, id, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
@@ -1850,7 +1851,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("manage repository administrators")
+    @require_login("manage repository administrators")
     def manage_repository_admins(self, trans, id, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
@@ -1897,14 +1898,14 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("review repository revision")
+    @require_login("review repository revision")
     def manage_repository_reviews_of_revision(self, trans, **kwd):
         return trans.response.send_redirect(web.url_for(controller='repository_review',
                                                         action='manage_repository_reviews_of_revision',
                                                         **kwd))
 
     @web.expose
-    @web.require_login("multi select email alerts")
+    @require_login("multi select email alerts")
     def multi_select_email_alerts(self, trans, **kwd):
         if 'operation' in kwd:
             operation = kwd['operation'].lower()
@@ -2053,7 +2054,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
         return ''
 
     @web.expose
-    @web.require_login("rate repositories")
+    @require_login("rate repositories")
     def rate_repository(self, trans, **kwd):
         """ Rate a repository and return updated rating data. """
         message = escape(kwd.get('message', ''))
@@ -2260,7 +2261,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                                         status=status))
 
     @web.expose
-    @web.require_login("set email alerts")
+    @require_login("set email alerts")
     def set_email_alerts(self, trans, **kwd):
         """Set email alerts for selected repositories."""
         # This method is called from multiple grids, so the caller must be passed.
@@ -2300,7 +2301,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                                                         **kwd))
 
     @web.expose
-    @web.require_login("set repository as malicious")
+    @require_login("set repository as malicious")
     def set_malicious(self, trans, id, ctx_str, **kwd):
         malicious = kwd.get('malicious', '')
         if kwd.get('malicious_button', False):

--- a/lib/tool_shed/webapp/controllers/repository_review.py
+++ b/lib/tool_shed/webapp/controllers/repository_review.py
@@ -23,6 +23,7 @@ from tool_shed.util import (
 )
 from tool_shed.util.container_util import STRSEP
 from tool_shed.util.web_util import escape
+from tool_shed.webapp.framework.decorators import require_login
 from tool_shed.webapp.util import ratings_util
 
 log = logging.getLogger(__name__)
@@ -40,7 +41,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
     repositories_with_no_tool_tests_grid = repository_review_grids.RepositoriesWithNoToolTestsGrid()
 
     @web.expose
-    @web.require_login("approve repository review")
+    @require_login("approve repository review")
     def approve_repository_review(self, trans, **kwd):
         # The value of the received id is the encoded review id.
         message = escape(kwd.get('message', ''))
@@ -64,7 +65,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                                         status=status))
 
     @web.expose
-    @web.require_login("browse components")
+    @require_login("browse components")
     def browse_components(self, trans, **kwd):
         if 'operation' in kwd:
             operation = kwd['operation'].lower()
@@ -75,7 +76,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.component_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("browse review")
+    @require_login("browse review")
     def browse_review(self, trans, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
@@ -106,7 +107,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         trans.sa_session.flush()
 
     @web.expose
-    @web.require_login("create component")
+    @require_login("create component")
     def create_component(self, trans, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
@@ -136,7 +137,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("create review")
+    @require_login("create review")
     def create_review(self, trans, **kwd):
         # The value of the received id is the encoded repository id.
         message = escape(kwd.get('message', ''))
@@ -202,7 +203,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                                         **kwd))
 
     @web.expose
-    @web.require_login("edit component")
+    @require_login("edit component")
     def edit_component(self, trans, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')
@@ -232,7 +233,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("edit review")
+    @require_login("edit review")
     def edit_review(self, trans, **kwd):
         # The value of the received id is the encoded review id.
         message = escape(kwd.get('message', ''))
@@ -363,7 +364,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("manage components")
+    @require_login("manage components")
     def manage_components(self, trans, **kwd):
         if 'operation' in kwd:
             operation = kwd['operation'].lower()
@@ -384,7 +385,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.component_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("manage repositories ready for review")
+    @require_login("manage repositories ready for review")
     def manage_repositories_ready_for_review(self, trans, **kwd):
         """
         A repository is ready to be reviewed if one of the following conditions is met:
@@ -410,7 +411,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.repositories_ready_for_review_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("manage repositories reviewed by me")
+    @require_login("manage repositories reviewed by me")
     def manage_repositories_reviewed_by_me(self, trans, **kwd):
         # The value of the received id is the encoded repository id.
         if 'operation' in kwd:
@@ -422,7 +423,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.repositories_reviewed_by_me_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("manage repositories with invalid tests")
+    @require_login("manage repositories with invalid tests")
     def manage_repositories_with_invalid_tests(self, trans, **kwd):
         """
         Display a list of repositories that contain tools, have not yet been reviewed, and have invalid functional tests.  Tests are defined as
@@ -444,7 +445,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.repositories_with_no_tool_tests_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("manage repositories with reviews")
+    @require_login("manage repositories with reviews")
     def manage_repositories_with_reviews(self, trans, **kwd):
         # The value of the received id is the encoded repository id.
         if 'operation' in kwd:
@@ -460,7 +461,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.repositories_with_reviews_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("manage repositories without reviews")
+    @require_login("manage repositories without reviews")
     def manage_repositories_without_reviews(self, trans, **kwd):
         if 'operation' in kwd:
             operation = kwd['operation'].lower()
@@ -475,7 +476,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.repositories_without_reviews_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("manage repository reviews")
+    @require_login("manage repository reviews")
     def manage_repository_reviews(self, trans, mine=False, **kwd):
         # The value of the received id is the encoded repository id.
         message = escape(kwd.get('message', ''))
@@ -523,7 +524,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("manage repository reviews of revision")
+    @require_login("manage repository reviews of revision")
     def manage_repository_reviews_of_revision(self, trans, **kwd):
         # The value of the received id is the encoded repository id.
         message = escape(kwd.get('message', ''))
@@ -547,7 +548,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("repository reviews by user")
+    @require_login("repository reviews by user")
     def repository_reviews_by_user(self, trans, **kwd):
 
         if 'operation' in kwd:
@@ -571,7 +572,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.repository_reviews_by_user_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("reviewed repositories i own")
+    @require_login("reviewed repositories i own")
     def reviewed_repositories_i_own(self, trans, **kwd):
         # The value of the received id is the encoded repository id.
         if 'operation' in kwd:
@@ -587,7 +588,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
         return self.reviewed_repositories_i_own_grid(trans, **kwd)
 
     @web.expose
-    @web.require_login("select previous review")
+    @require_login("select previous review")
     def select_previous_review(self, trans, **kwd):
         # The value of the received id is the encoded repository id.
         message = escape(kwd.get('message', ''))
@@ -608,7 +609,7 @@ class RepositoryReviewController(BaseUIController, ratings_util.ItemRatings):
                                    status=status)
 
     @web.expose
-    @web.require_login("view or manage repository")
+    @require_login("view or manage repository")
     def view_or_manage_repository(self, trans, **kwd):
         repository = repository_util.get_repository_in_tool_shed(trans.app, kwd['id'])
         if trans.user_is_admin or repository.user == trans.user:

--- a/lib/tool_shed/webapp/controllers/upload.py
+++ b/lib/tool_shed/webapp/controllers/upload.py
@@ -27,6 +27,7 @@ from tool_shed.util import (
     xml_util
 )
 from tool_shed.util.web_util import escape
+from tool_shed.webapp.framework.decorators import require_login
 
 log = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ log = logging.getLogger(__name__)
 class UploadController(BaseUIController):
 
     @web.expose
-    @web.require_login('upload', use_panels=True)
+    @require_login('upload', use_panels=True)
     def upload(self, trans, **kwd):
         message = escape(kwd.get('message', ''))
         status = kwd.get('status', 'done')

--- a/lib/tool_shed/webapp/controllers/user.py
+++ b/lib/tool_shed/webapp/controllers/user.py
@@ -16,6 +16,7 @@ from galaxy.security.validate_user_input import (
 from galaxy.web import url_for
 from galaxy.web.form_builder import CheckboxField
 from galaxy.webapps.galaxy.controllers.user import User as BaseUser
+from tool_shed.webapp.framework.decorators import require_login
 
 log = logging.getLogger(__name__)
 
@@ -282,7 +283,7 @@ class User(BaseUser):
                                    status=status)
 
     @web.expose
-    @web.require_login()
+    @require_login()
     def api_keys(self, trans, cntrller, **kwd):
         params = util.Params(kwd)
         message = escape(util.restore_text(params.get('message', '')))
@@ -299,7 +300,7 @@ class User(BaseUser):
 
     # For REMOTE_USER, we need the ability to just edit the username
     @web.expose
-    @web.require_login("to manage the public name")
+    @require_login("to manage the public name")
     def edit_username(self, trans, cntrller, **kwd):
         params = util.Params(kwd)
         is_admin = cntrller == 'admin' and trans.user_is_admin

--- a/lib/tool_shed/webapp/framework/decorators.py
+++ b/lib/tool_shed/webapp/framework/decorators.py
@@ -1,0 +1,20 @@
+import logging
+from functools import wraps
+
+from galaxy.web.framework import url_for
+
+log = logging.getLogger(__name__)
+
+
+def require_login(verb="perform this action", use_panels=False):
+    def argcatcher(func):
+        @wraps(func)
+        def decorator(self, trans, *args, **kwargs):
+            if trans.get_user():
+                return func(self, trans, *args, **kwargs)
+            else:
+                return trans.show_error_message(
+                    'You must be <a target="galaxy_main" href="%s">logged in</a> to %s.'
+                    % (url_for(controller='user', action='login'), verb), use_panels=use_panels)
+        return decorator
+    return argcatcher


### PR DESCRIPTION
This partially fixes #12735. With this fix the user is correctly redirected to the login page instead of being shown a session error. However, after login the user is redirected to the Galaxy start page and **not** to the specific workflow import page. Implementing a specific redirect after login can be done but should probably not be part of this PR.

Thank you for reporting this issue @hexylena.

## How to test the changes?
See #12735 for instructions.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
