### PR TITLE
[21.09] Fix workflow invocation name overflow

### DIFF
--- a/client/src/components/Workflow/Invocations.test.js
+++ b/client/src/components/Workflow/Invocations.test.js
@@ -75,12 +75,12 @@ describe("Invocations.vue with invocation", () => {
         expect(rows.length).toBe(1);
         const row = rows[0];
         const columns = row.findAll("td");
-        expect(columns.at(0).text()).toBe("workflow name");
-        expect(columns.at(1).text()).toBe("history name");
-        expect(columns.at(2).text()).toBe(moment.utc(invocationData.create_time).fromNow());
-        expect(columns.at(3).text()).toBe(moment.utc(invocationData.update_time).fromNow());
-        expect(columns.at(4).text()).toBe("scheduled");
-        expect(columns.at(5).text()).toBe("");
+        expect(columns.at(1).text()).toBe("workflow name");
+        expect(columns.at(2).text()).toBe("history name");
+        expect(columns.at(3).text()).toBe(moment.utc(invocationData.create_time).fromNow());
+        expect(columns.at(4).text()).toBe(moment.utc(invocationData.update_time).fromNow());
+        expect(columns.at(5).text()).toBe("scheduled");
+        expect(columns.at(6).text()).toBe("");
     });
 
     it("toggles detail rendering", async () => {

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -34,11 +34,27 @@
                         />
                     </b-card>
                 </template>
+                <template v-slot:cell(expand)="data">
+                    <b-link
+                        v-b-tooltip.hover.bottom
+                        title="Show Invocation Details"
+                        class="btn-sm fa fa-chevron-down"
+                        v-if="!data.detailsShowing"
+                        @click.stop="swapRowDetails(data)"
+                    />
+                    <b-link
+                        v-b-tooltip.hover.bottom
+                        title="Hide Invocation Details"
+                        class="btn-sm fa fa-chevron-up"
+                        v-if="data.detailsShowing"
+                        @click.stop="swapRowDetails(data)"
+                    />
+                </template>
                 <template v-slot:cell(workflow_id)="data">
                     <b-link
                         class="toggle-invocation-details"
                         v-b-tooltip
-                        title="Show Invocation details"
+                        :title="getWorkflowNameByInstanceId(data.item.workflow_id)"
                         href="#"
                         @click.stop="swapRowDetails(data)"
                     >
@@ -100,12 +116,13 @@ export default {
     },
     data() {
         const fields = [
+            { key: "expand", label: "", class: "col-button" },
             { key: "workflow_id", label: "Workflow", class: "col-name" },
             { key: "history_id", label: "History", class: "col-history" },
             { key: "create_time", label: "Invoked", class: "col-small" },
             { key: "update_time", label: "Updated", class: "col-small" },
             { key: "state", class: "col-small" },
-            { key: "execute", label: "", class: "col-execute" },
+            { key: "execute", label: "", class: "col-button" },
         ];
         return {
             invocationItemsModel: [],
@@ -166,7 +183,7 @@ export default {
 .table::v-deep .col-small {
     width: 100px;
 }
-.table::v-deep .col-execute {
+.table::v-deep .col-button {
     width: 50px;
 }
 </style>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -35,22 +35,20 @@
                     </b-card>
                 </template>
                 <template v-slot:cell(expand)="data">
-                    <div class="toggle-invocation-details">
-                        <b-link
-                            v-b-tooltip.hover.top
-                            title="Show Invocation Details"
-                            class="btn-sm fa fa-chevron-down"
-                            v-if="!data.detailsShowing"
-                            @click.stop="swapRowDetails(data)"
-                        />
-                        <b-link
-                            v-b-tooltip.hover.top
-                            title="Hide Invocation Details"
-                            class="btn-sm fa fa-chevron-up"
-                            v-if="data.detailsShowing"
-                            @click.stop="swapRowDetails(data)"
-                        />
-                    </div>
+                    <b-link
+                        v-b-tooltip.hover.top
+                        title="Show Invocation Details"
+                        class="btn-sm fa fa-chevron-down toggle-invocation-details"
+                        v-if="!data.detailsShowing"
+                        @click.stop="swapRowDetails(data)"
+                    />
+                    <b-link
+                        v-b-tooltip.hover.top
+                        title="Hide Invocation Details"
+                        class="btn-sm fa fa-chevron-up toggle-invocation-details"
+                        v-if="data.detailsShowing"
+                        @click.stop="swapRowDetails(data)"
+                    />
                 </template>
                 <template v-slot:cell(workflow_id)="data">
                     <div v-b-tooltip.hover.top :title="getWorkflowNameByInstanceId(data.item.workflow_id)">

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -152,6 +152,6 @@ export default {
 </script>
 <style scoped>
 .toggle-invocation-details {
-    word-break: break-all;
+    overflow-wrap: break-word;
 }
 </style>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -99,12 +99,12 @@ export default {
     },
     data() {
         const fields = [
-            { key: "workflow_id", label: "Workflow" },
-            { key: "history_id", label: "History" },
-            { key: "create_time", label: "Invoked" },
-            { key: "update_time", label: "Updated" },
-            { key: "state" },
-            { key: "execute", label: "" },
+            { key: "workflow_id", label: "Workflow", class: "col-name" },
+            { key: "history_id", label: "History", class: "col-history" },
+            { key: "create_time", label: "Invoked", class: "col-small" },
+            { key: "update_time", label: "Updated", class: "col-small" },
+            { key: "state", class: "col-small" },
+            { key: "execute", label: "", class: "col-execute" },
         ];
         return {
             invocationItemsModel: [],
@@ -153,5 +153,18 @@ export default {
 <style scoped>
 .toggle-invocation-details {
     overflow-wrap: break-word;
+}
+.table::v-deep .col-name {
+    width: 40%;
+    min-width: 20ch;
+}
+.table::v-deep .col-history {
+    width: 20%;
+}
+.table::v-deep .col-small {
+    width: 100px;
+}
+.table::v-deep .col-execute {
+    width: 50px;
 }
 </style>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -150,3 +150,8 @@ export default {
     },
 };
 </script>
+<style scoped>
+.toggle-invocation-details {
+    word-break: break-all;
+}
+</style>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -35,42 +35,39 @@
                     </b-card>
                 </template>
                 <template v-slot:cell(expand)="data">
-                    <b-link
-                        v-b-tooltip.hover.bottom
-                        title="Show Invocation Details"
-                        class="btn-sm fa fa-chevron-down"
-                        v-if="!data.detailsShowing"
-                        @click.stop="swapRowDetails(data)"
-                    />
-                    <b-link
-                        v-b-tooltip.hover.bottom
-                        title="Hide Invocation Details"
-                        class="btn-sm fa fa-chevron-up"
-                        v-if="data.detailsShowing"
-                        @click.stop="swapRowDetails(data)"
-                    />
+                    <div class="toggle-invocation-details">
+                        <b-link
+                            v-b-tooltip.hover.top
+                            title="Show Invocation Details"
+                            class="btn-sm fa fa-chevron-down"
+                            v-if="!data.detailsShowing"
+                            @click.stop="swapRowDetails(data)"
+                        />
+                        <b-link
+                            v-b-tooltip.hover.top
+                            title="Hide Invocation Details"
+                            class="btn-sm fa fa-chevron-up"
+                            v-if="data.detailsShowing"
+                            @click.stop="swapRowDetails(data)"
+                        />
+                    </div>
                 </template>
                 <template v-slot:cell(workflow_id)="data">
-                    <b-link
-                        class="toggle-invocation-details"
-                        v-b-tooltip
-                        :title="getWorkflowNameByInstanceId(data.item.workflow_id)"
-                        href="#"
-                        @click.stop="swapRowDetails(data)"
-                    >
-                        <b>{{ getWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
-                    </b-link>
+                    <div v-b-tooltip.hover.top :title="getWorkflowNameByInstanceId(data.item.workflow_id)">
+                        <b-link href="#" @click.stop="swapRowDetails(data)">
+                            <b>{{ getWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
+                        </b-link>
+                    </div>
                 </template>
                 <template v-slot:cell(history_id)="data">
-                    <b-link
-                        id="switch-to-history"
-                        v-b-tooltip
-                        title="Switch to History"
-                        href="#"
-                        @click.stop="switchHistory(data.item.history_id)"
+                    <div
+                        v-b-tooltip.hover.top
+                        :title="`Switch to History: ${getHistoryNameById(data.item.history_id)}`"
                     >
-                        <b>{{ getHistoryNameById(data.item.history_id) }}</b>
-                    </b-link>
+                        <b-link id="switch-to-history" href="#" @click.stop="switchHistory(data.item.history_id)">
+                            <b>{{ getHistoryNameById(data.item.history_id) }}</b>
+                        </b-link>
+                    </div>
                 </template>
                 <template v-slot:cell(create_time)="data">
                     <UtcDate :date="data.value" mode="elapsed" />

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -117,8 +117,8 @@ export default {
     data() {
         const fields = [
             { key: "expand", label: "", class: "col-button" },
-            { key: "workflow_id", label: "Workflow", class: "col-name" },
-            { key: "history_id", label: "History", class: "col-history" },
+            { key: "workflow_id", label: "Workflow", class: "col-name truncate" },
+            { key: "history_id", label: "History", class: "col-history truncate" },
             { key: "create_time", label: "Invoked", class: "col-small" },
             { key: "update_time", label: "Updated", class: "col-small" },
             { key: "state", class: "col-small" },
@@ -173,9 +173,7 @@ export default {
     min-width: 40rem;
 }
 .table::v-deep .col-name {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    width: 40%;
 }
 .table::v-deep .col-history {
     width: 20%;
@@ -185,5 +183,10 @@ export default {
 }
 .table::v-deep .col-button {
     width: 50px;
+}
+.table::v-deep .truncate {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 </style>

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -21,6 +21,7 @@
                 caption-top
                 :busy="loading"
                 fixed
+                class="invocations-table"
             >
                 <template v-slot:row-details="row">
                     <b-card>
@@ -151,12 +152,13 @@ export default {
 };
 </script>
 <style scoped>
-.toggle-invocation-details {
-    overflow-wrap: break-word;
+.invocations-table {
+    min-width: 40rem;
 }
 .table::v-deep .col-name {
-    width: 40%;
-    min-width: 20ch;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 .table::v-deep .col-history {
     width: 20%;

--- a/client/src/components/Workflow/Invocations.vue
+++ b/client/src/components/Workflow/Invocations.vue
@@ -51,7 +51,11 @@
                     />
                 </template>
                 <template v-slot:cell(workflow_id)="data">
-                    <div v-b-tooltip.hover.top :title="getWorkflowNameByInstanceId(data.item.workflow_id)">
+                    <div
+                        v-b-tooltip.hover.top
+                        :title="getWorkflowNameByInstanceId(data.item.workflow_id)"
+                        class="truncate"
+                    >
                         <b-link href="#" @click.stop="swapRowDetails(data)">
                             <b>{{ getWorkflowNameByInstanceId(data.item.workflow_id) }}</b>
                         </b-link>
@@ -59,8 +63,9 @@
                 </template>
                 <template v-slot:cell(history_id)="data">
                     <div
-                        v-b-tooltip.hover.top
-                        :title="`Switch to History: ${getHistoryNameById(data.item.history_id)}`"
+                        v-b-tooltip.hover.top.html
+                        :title="`<b>Switch to History:</b><br>${getHistoryNameById(data.item.history_id)}`"
+                        class="truncate"
                     >
                         <b-link id="switch-to-history" href="#" @click.stop="switchHistory(data.item.history_id)">
                             <b>{{ getHistoryNameById(data.item.history_id) }}</b>
@@ -112,8 +117,8 @@ export default {
     data() {
         const fields = [
             { key: "expand", label: "", class: "col-button" },
-            { key: "workflow_id", label: "Workflow", class: "col-name truncate" },
-            { key: "history_id", label: "History", class: "col-history truncate" },
+            { key: "workflow_id", label: "Workflow", class: "col-name" },
+            { key: "history_id", label: "History", class: "col-history" },
             { key: "create_time", label: "Invoked", class: "col-small" },
             { key: "update_time", label: "Updated", class: "col-small" },
             { key: "state", class: "col-small" },


### PR DESCRIPTION
Fixes #12857

![Screenshot from 2022-01-21 12-33-10](https://user-images.githubusercontent.com/46503462/150520198-a56e7449-c1e0-41db-b667-df5475490541.png)

- Added back the "expand" column to make it more obvious that the row has additional details and to display the full name as a tooltip when it gets truncated as @itisAliRH suggested. The previous expand button was removed in https://github.com/galaxyproject/galaxy/pull/9986. @guerler I hope adding back this column makes sense now :)


## How to test the changes?
- [x] Instructions for manual testing are as follows:
  - Follow instructions on #12857

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
