### PR TITLE
[21.09] Fix metadata source access in tool shed

### DIFF
--- a/lib/galaxy/tools/__init__.py
+++ b/lib/galaxy/tools/__init__.py
@@ -1022,8 +1022,9 @@ class Tool(Dictifiable):
         has_missing_data = len(edam_operations) == 0 or len(edam_topics) == 0
         if has_missing_data:
             biotools_reference = self.biotools_reference
-            if biotools_reference:
-                biotools_entry = self.app.biotools_metadata_source.get_biotools_metadata(biotools_reference)
+            metadata_source = self.app.biotools_metadata_source
+            if biotools_reference and metadata_source:
+                biotools_entry = metadata_source.get_biotools_metadata(biotools_reference)
                 if biotools_entry:
                     edam_info = biotools_entry.edam_info
                     if len(edam_operations) == 0:

--- a/test/unit/unittest_utils/galaxy_mock.py
+++ b/test/unit/unittest_utils/galaxy_mock.py
@@ -103,6 +103,7 @@ class MockApp(di.Container):
         self.user_manager = UserManager(self)
         self.execution_timer_factory = Bunch(get_timer=StructuredExecutionTimer)
         self.is_job_handler = False
+        self.biotools_metadata_source = None
         rebind_container_to_task(self)
 
         def url_for(*args, **kwds):


### PR DESCRIPTION
Fixes:
```
Unexpected HTTP status code: 500: {"err_msg": "Metadata may have been defined for some items in revision '8f1b150a2487'.  Correct the following problems if necessary and reset metadata.<br/><b>abyss-pe.xml<\/b> - 'NoneType' object has no attribute 'get_biotools_metadata'<br/>"}
```
in https://github.com/galaxyproject/tools-iuc/runs/4792653893?check_suite_focus=true

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
