### PR TITLE
[21.09] Fix error getting toolshed repo metadata when no repo found

### DIFF
--- a/lib/tool_shed/webapp/api/repositories.py
+++ b/lib/tool_shed/webapp/api/repositories.py
@@ -379,7 +379,7 @@ class RepositoriesController(BaseAPIController):
                     if metadata.includes_tools:
                         metadata_dict['tools'] = metadata.metadata['tools']
                     all_metadata[f'{int(changeset)}:{changehash}'] = metadata_dict
-            if repository_found is not None:
+            if repository_found:
                 all_metadata['current_changeset'] = repository_found[0]
                 # all_metadata[ 'found_changesets' ] = repository_found
                 return json.dumps(all_metadata)


### PR DESCRIPTION
Fixes
```
IndexError: list index out of range
  File "galaxy/web/framework/decorators.py", line 312, in decorator
    rval = func(self, trans, *args, **kwargs)
  File "tool_shed/webapp/api/repositories.py", line 383, in index
    all_metadata['current_changeset'] = repository_found[0]
```

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
