### PR TITLE
Fix test_deserialize_* unit tests

### DIFF
--- a/lib/galaxy/tools/remote_tool_eval.py
+++ b/lib/galaxy/tools/remote_tool_eval.py
@@ -63,6 +63,7 @@ class ToolApp(MinimalToolApp):
         self.genome_builds = GenomeBuilds(self)
         self.tool_data_tables = tool_data_table_manager
         self.file_sources = file_sources
+        self.biotools_metadata_source = None
 
 
 def main(TMPDIR, WORKING_DIRECTORY, IMPORT_STORE_DIRECTORY):

--- a/test/unit/app/tools/test_tool_deserialization.py
+++ b/test/unit/app/tools/test_tool_deserialization.py
@@ -40,6 +40,7 @@ outputs:
 
 class ToolApp(GalaxyDataTestApp):
     name = 'galaxy'
+    biotools_metadata_source = None
     job_search = None
 
 


### PR DESCRIPTION
Fix:

```
    def test_deserialize_xml_tool(tool_app):

>       tool = _deserialize(tool_app, tool_source_class='XmlToolSource', raw_tool_source=XML_TOOL)

test/unit/app/tools/test_tool_deserialization.py:59:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test/unit/app/tools/test_tool_deserialization.py:54: in _deserialize
    return create_tool_from_source(app, tool_source=tool_source)
lib/galaxy/tools/__init__.py:278: in create_tool_from_source
    tool = ToolClass(config_file, tool_source, app, **kwds)
lib/galaxy/tools/__init__.py:606: in __init__
    raise e
lib/galaxy/tools/__init__.py:603: in __init__
    self.parse(tool_source, guid=guid, dynamic=dynamic)

        if has_missing_data:
            biotools_reference = self.biotools_reference
>           metadata_source = self.app.biotools_metadata_source
E           AttributeError: 'ToolApp' object has no attribute 'biotools_metadata_source'

lib/galaxy/tools/__init__.py:1032: AttributeError
```

introduced merging forward https://github.com/galaxyproject/galaxy/pull/13202 .

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
