### PR TITLE
[21.09] Backport allow mapping of collection outputs to parameter inputs

### DIFF
--- a/client/src/components/Workflow/Editor/modules/terminals.js
+++ b/client/src/components/Workflow/Editor/modules/terminals.js
@@ -224,6 +224,15 @@ class BaseInputTerminal extends Terminal {
         this.datatypesMapper = attr.datatypesMapper;
         this.update(attr.input); // subclasses should implement this...
     }
+    setDefaultMapOver(connector) {
+        var other_output = connector.outputHandle;
+        if (other_output) {
+            var otherCollectionType = this._otherCollectionType(other_output);
+            if (otherCollectionType.isCollection) {
+                this.setMapOver(otherCollectionType);
+            }
+        }
+    }
     canAccept(other) {
         if (this._inputFilled()) {
             return new ConnectionAcceptable(
@@ -385,14 +394,7 @@ class InputTerminal extends BaseInputTerminal {
     }
     connect(connector) {
         super.connect(connector);
-        var other_output = connector.outputHandle;
-        if (!other_output) {
-            return;
-        }
-        var otherCollectionType = this._otherCollectionType(other_output);
-        if (otherCollectionType.isCollection) {
-            this.setMapOver(otherCollectionType);
-        }
+        this.setDefaultMapOver(connector);
     }
     attachable(other) {
         var otherCollectionType = this._otherCollectionType(other);
@@ -459,6 +461,10 @@ class InputParameterTerminal extends BaseInputTerminal {
     update(input) {
         this.type = input.type;
         this.optional = input.optional;
+    }
+    connect(connector) {
+        super.connect(connector);
+        this.setDefaultMapOver(connector);
     }
     effectiveType(parameterType) {
         return parameterType == "select" ? "text" : parameterType;

--- a/client/tests/qunit/tests/workflow_editor_tests.js
+++ b/client/tests/qunit/tests/workflow_editor_tests.js
@@ -871,9 +871,9 @@ QUnit.test("resetMapping", function (assert) {
 });
 
 QUnit.module("terminal mapping logic", {
-    newInputTerminal: function (mapOver, input, node) {
+    newInputTerminal: function (mapOver, input) {
         input = input || {};
-        node = node || this.newNode();
+        const node = this.newNode();
         if (!("extensions" in input)) {
             input["extensions"] = ["data"];
         }
@@ -889,26 +889,19 @@ QUnit.module("terminal mapping logic", {
         }
         return inputTerminal;
     },
-    newInputParameterTerminal: function (mapOver, input, node) {
-        input = input || {};
-        node = node || this.newNode();
-        if (!("type" in input)) {
-            input["type"] = "text";
-        }
+    newInputParameterTerminal: function () {
+        const node = this.newNode();
         const inputEl = $("<div>")[0];
         const inputTerminal = new Terminals.InputParameterTerminal({
             element: inputEl,
-            input: input,
+            input: {},
         });
         inputTerminal.node = node;
-        if (mapOver) {
-            inputTerminal.setMapOver(new Terminals.CollectionTypeDescription(mapOver));
-        }
         return inputTerminal;
     },
-    newInputCollectionTerminal: function (input, node) {
+    newInputCollectionTerminal: function (input) {
         input = input || {};
-        node = node || this.newNode();
+        const node = this.newNode();
         if (!("extensions" in input)) {
             input["extensions"] = ["data"];
         }
@@ -921,16 +914,12 @@ QUnit.module("terminal mapping logic", {
         });
         return inputTerminal;
     },
-    newOutputTerminal: function (mapOver, output, node) {
-        output = output || {};
-        node = node || this.newNode();
-        if (!("extensions" in output)) {
-            output["extensions"] = ["data"];
-        }
+    newOutputTerminal: function (mapOver) {
+        const node = this.newNode();
         const outputEl = $("<div>")[0];
         const outputTerminal = new Terminals.OutputTerminal({
             element: outputEl,
-            datatypes: output.extensions,
+            datatypes: ["data"],
             node: {},
         });
         outputTerminal.node = node;
@@ -939,24 +928,17 @@ QUnit.module("terminal mapping logic", {
         }
         return outputTerminal;
     },
-    newOutputCollectionTerminal: function (collectionType, output, node, mapOver) {
+    newOutputCollectionTerminal: function (collectionType) {
         collectionType = collectionType || "list";
-        output = output || {};
-        node = node || this.newNode();
-        if (!("extensions" in output)) {
-            output["extensions"] = ["data"];
-        }
+        const node = this.newNode();
         const outputEl = $("<div>")[0];
         const outputTerminal = new Terminals.OutputCollectionTerminal({
             element: outputEl,
-            datatypes: output.extensions,
+            datatypes: ["data"],
             collection_type: collectionType,
             node: {},
         });
         outputTerminal.node = node;
-        if (mapOver) {
-            outputTerminal.setMapOver(new Terminals.CollectionTypeDescription(mapOver));
-        }
         return outputTerminal;
     },
     newNode: function () {
@@ -1040,14 +1022,14 @@ QUnit.module("terminal mapping logic", {
     verifyNotMappedOver: function (assert, terminal) {
         assert.ok(!terminal.mapOver.isCollection);
     },
-    verifyDefaultMapOver: function(assert, inputTerminal1) {
-        const outputCollectionTerminal1 = this.newOutputCollectionTerminal("list");
-        assert.ok(!inputTerminal1.node.mapOver);
-        const connector = new Connector({}, outputCollectionTerminal1, inputTerminal1);
-        outputCollectionTerminal1.connect(connector);
-        assert.ok(inputTerminal1.node.mapOver);
-        inputTerminal1.disconnect(connector);
-        assert.ok(!inputTerminal1.node.mapOver);
+    verifyDefaultMapOver: function(assert, terminal) {
+        const outputCollectionTerminal = this.newOutputCollectionTerminal("list");
+        assert.ok(!terminal.node.mapOver);
+        const connector = new Connector({}, outputCollectionTerminal, terminal);
+        outputCollectionTerminal.connect(connector);
+        assert.ok(terminal.node.mapOver);
+        terminal.disconnect(connector);
+        assert.ok(!terminal.node.mapOver);
     }
 });
 

--- a/client/tests/qunit/tests/workflow_editor_tests.js
+++ b/client/tests/qunit/tests/workflow_editor_tests.js
@@ -1288,9 +1288,12 @@ QUnit.test("simple mapping over collection outputs works correctly", function (a
     this.verifyNotAttachable(assert, testTerminal1, connectedOutput);
 });
 
-QUnit.test("node input parameter mapping state over collection outputs works correctly", function (assert) {
+QUnit.test("node input terminal mapping state over collection outputs works correctly", function (assert) {
     const inputTerminal = this.newInputTerminal();
     this.verifyDefaultMapOver(assert, inputTerminal);
+});
+
+QUnit.test("node input parameter terminal mapping state over collection outputs works correctly", function (assert) {
     const inputParameterTerminal = this.newInputParameterTerminal();
     this.verifyDefaultMapOver(assert, inputParameterTerminal);
 });

--- a/client/tests/qunit/tests/workflow_editor_tests.js
+++ b/client/tests/qunit/tests/workflow_editor_tests.js
@@ -889,6 +889,23 @@ QUnit.module("terminal mapping logic", {
         }
         return inputTerminal;
     },
+    newInputParameterTerminal: function (mapOver, input, node) {
+        input = input || {};
+        node = node || this.newNode();
+        if (!("type" in input)) {
+            input["type"] = "text";
+        }
+        const inputEl = $("<div>")[0];
+        const inputTerminal = new Terminals.InputParameterTerminal({
+            element: inputEl,
+            input: input,
+        });
+        inputTerminal.node = node;
+        if (mapOver) {
+            inputTerminal.setMapOver(new Terminals.CollectionTypeDescription(mapOver));
+        }
+        return inputTerminal;
+    },
     newInputCollectionTerminal: function (input, node) {
         input = input || {};
         node = node || this.newNode();
@@ -1023,6 +1040,15 @@ QUnit.module("terminal mapping logic", {
     verifyNotMappedOver: function (assert, terminal) {
         assert.ok(!terminal.mapOver.isCollection);
     },
+    verifyDefaultMapOver: function(assert, inputTerminal1) {
+        const outputCollectionTerminal1 = this.newOutputCollectionTerminal("list");
+        assert.ok(!inputTerminal1.node.mapOver);
+        const connector = new Connector({}, outputCollectionTerminal1, inputTerminal1);
+        outputCollectionTerminal1.connect(connector);
+        assert.ok(inputTerminal1.node.mapOver);
+        inputTerminal1.disconnect(connector);
+        assert.ok(!inputTerminal1.node.mapOver);
+    }
 });
 
 QUnit.test("unconstrained input can be mapped over", function (assert) {
@@ -1280,13 +1306,9 @@ QUnit.test("simple mapping over collection outputs works correctly", function (a
     this.verifyNotAttachable(assert, testTerminal1, connectedOutput);
 });
 
-QUnit.test("node mapping state over collection outputs works correctly", function (assert) {
-    const inputTerminal1 = this.newInputTerminal();
-    const outputCollectionTerminal1 = this.newOutputCollectionTerminal("list");
-    assert.ok(!inputTerminal1.node.mapOver);
-    const connector = new Connector({}, outputCollectionTerminal1, inputTerminal1);
-    outputCollectionTerminal1.connect(connector);
-    assert.ok(inputTerminal1.node.mapOver);
-    inputTerminal1.disconnect(connector);
-    assert.ok(!inputTerminal1.node.mapOver);
+QUnit.test("node input parameter mapping state over collection outputs works correctly", function (assert) {
+    const inputTerminal = this.newInputTerminal();
+    this.verifyDefaultMapOver(assert, inputTerminal);
+    const inputParameterTerminal = this.newInputParameterTerminal();
+    this.verifyDefaultMapOver(assert, inputParameterTerminal);
 });


### PR DESCRIPTION
And add a selenium test

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
