### PR TITLE
[21.09] Fix hide collections in batch

### DIFF
--- a/lib/galaxy/schema/schema.py
+++ b/lib/galaxy/schema/schema.py
@@ -646,7 +646,7 @@ class UpdateHistoryContentsBatchPayload(BaseModel):
         description="A list of content items to update with the changes.",
     )
     deleted: Optional[bool] = Field(
-        default=False,
+        default=None,
         title="Deleted",
         description=(
             "This will check the uploading state if not deleting (i.e: deleted=False), "
@@ -654,7 +654,7 @@ class UpdateHistoryContentsBatchPayload(BaseModel):
         ),
     )
     visible: Optional[bool] = Field(
-        default=False,
+        default=None,
         title="Visible",
         description=(
             "Show or hide history contents"

--- a/lib/galaxy_test/api/test_history_contents.py
+++ b/lib/galaxy_test/api/test_history_contents.py
@@ -249,6 +249,32 @@ class HistoryContentsApiTestCase(ApiTestCase):
         assert objects[0]["deleted"] is False
         assert objects[0]["visible"] is True
 
+    def test_update_batch_collections(self):
+        hdca = self._create_pair_collection()
+        assert hdca["deleted"] is False
+        assert hdca["visible"] is True
+
+        # update deleted flag => true
+        payload = dict(items=[{"history_content_type": "dataset_collection", "id": hdca["id"]}], deleted=True)
+        update_response = self._raw_update_batch(payload)
+        objects = update_response.json()
+        assert objects[0]["deleted"] is True
+        assert objects[0]["visible"] is True
+
+        # update visibility flag => false
+        payload = dict(items=[{"history_content_type": "dataset_collection", "id": hdca["id"]}], visible=False)
+        update_response = self._raw_update_batch(payload)
+        objects = update_response.json()
+        assert objects[0]["deleted"] is True
+        assert objects[0]["visible"] is False
+
+        # update both flags
+        payload = dict(items=[{"history_content_type": "dataset_collection", "id": hdca["id"]}], deleted=False, visible=True)
+        update_response = self._raw_update_batch(payload)
+        objects = update_response.json()
+        assert objects[0]["deleted"] is False
+        assert objects[0]["visible"] is True
+
     def test_update_type_failures(self):
         hda1 = self._wait_for_new_hda()
         update_response = self._raw_update(hda1["id"], dict(deleted='not valid'))


### PR DESCRIPTION
Fixes #13199

When the payload contained the default values for visible and deleted fields they were ignored by the `update_batch` endpoint. Just leaving the default value as None will fix it.

Includes a test for collections similar to the existing one for datasets.

### Note when merging forward
  - The API test in 4f104cfbd7cb10ba612115db0a2742dad12b3754 can be included but one method needs to be renamed, see commit message.
  - The actual fix in 161a3d95dbf2d3688c66fa39a14acbecdab9a504 can be dropped as this code has been refactored in the dev branch and is already fixed.


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
