### PR TITLE
[21.09] Handle unique tag name constraints

### DIFF
--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -2,6 +2,8 @@ import logging
 import re
 from typing import Dict
 
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.scoping import scoped_session
 from sqlalchemy.sql import select
 from sqlalchemy.sql.expression import func
@@ -245,7 +247,18 @@ class TagHandler:
         return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name).first()
 
     def _create_tag_instance(self, tag_name):
-        return galaxy.model.Tag(type=0, name=tag_name)
+        # For good performance caller should first check if there's already an appropriate tag
+        Session = sessionmaker(self.sa_session.bind)
+        tag = galaxy.model.Tag(type=0, name=tag_name)
+        with Session() as separate_session:
+            separate_session.add(tag)
+            try:
+                separate_session.commit()
+                separate_session.flush()
+            except IntegrityError:
+                # tag already exists, get from database
+                separate_session.rollback()
+        return self._get_tag(tag_name)
 
     def _get_or_create_tag(self, tag_str):
         """Get or create a Tag object from a tag string."""

--- a/test/unit/managers/test_TagHandler.py
+++ b/test/unit/managers/test_TagHandler.py
@@ -100,6 +100,12 @@ class TagHandlerTestCase(BaseTestCase):
         self.tag_handler.delete_item_tags(user=self.user, item=hda)
         self.assertEqual(hda.tags, [])
 
+    def test_unique_constraint_applied(self):
+        tag_name = 'abc'
+        tag = self.tag_handler._create_tag_instance(tag_name)
+        same_tag = self.tag_handler._create_tag_instance(tag_name)
+        assert tag.id == same_tag.id
+
     def test_item_has_tag(self):
         hda = self._create_vanilla_hda()
         tags = ['tag1']


### PR DESCRIPTION
The idea is to create the tag one by one in a separate session, and
catch any violations.

Fixes https://github.com/galaxyproject/galaxy/issues/13213

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
