### PR TITLE
Prevent a future regression 

### DIFF
--- a/lib/galaxy/model/migrate/versions/0180_add_vault_table.py
+++ b/lib/galaxy/model/migrate/versions/0180_add_vault_table.py
@@ -22,4 +22,12 @@ def upgrade(migrate_engine):
 
 def downgrade(migrate_engine):
     meta.bind = migrate_engine
-    vault.drop()
+    # This revision is not part of 21.09, but in 22.01 it will be handled by Alembic.
+    # It is possible to reach a state (via upgrading/downgrading) where this table
+    # will have been dropped by Alembic, but SQLAlchemy Migrate (our previous
+    # db migrations tool) will have version 180 (which includes this table).
+    # Downgrading from such a state would raise an error - which this code prevents.
+    try:
+        vault.drop()
+    except Exception:
+        pass


### PR DESCRIPTION
This prevents an unlikely, yet possible regression that may happen in dev after we have switched to Alembic.

The `vault` table was added *after* 21.09, so in 22.01 it will be created with an Alembic revision - which is needed for a smooth upgrade from 21.09. If upgrading from the dev branch, the `create_table` statement in the revision script won't be executed, since the table is already in the database. However, the following steps would lead to an error:

step 1: upgrade from pre-alembic dev to 22.01
step 2: downgrade from 22.01 back to dev (vault table dropped by Alembic)
step 3: in dev, downgrade to a previous db version >> error! (trying to drop a nonexistent table)

After step 2, we'd end up with the current SQLAlchemy Migrate db version 180, which assumes the existence of the `vault` table (which was dropped in step 2 by Alembic!).

See this for context: https://github.com/galaxyproject/galaxy/pull/13108#discussion_r789344708

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
