### PR TITLE
Enable display of BAM data without sequence info

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -467,7 +467,7 @@ class BamNative(CompressedArchive, _BamOrSam):
     def get_chunk(self, trans, dataset, offset=0, ck_size=None):
         if not offset == -1:
             try:
-                with pysam.AlignmentFile(dataset.file_name, "rb") as bamfile:
+                with pysam.AlignmentFile(dataset.file_name, "rb", check_sq=False) as bamfile:
                     ck_size = 300  # 300 lines
                     ck_data = ""
                     header_line_count = 0


### PR DESCRIPTION
Unaligned BAM files like produced, e.g., by picard FastqToSam will not have sequence information present in their header.
This change should allow Galaxy to display such files instead of just a
```
Could not display BAM file, error was:
file has no sequences defined (mode='rb') - is it SAM/BAM format? Consider opening with check_sq=False
```
message.

Proposing just the minimal required change atm to document the issue and its solution.
If somebody can take over providing test data that would be great because I don't have the time right now.