### PR TITLE
Remove `jquery.complexify` from everywhere

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -51,7 +51,6 @@ const paths = {
         backbone: ["backbone.js", "backbone.js"],
         "@galaxyproject/bootstrap-tour": ["build/js/bootstrap-tour.js", "bootstrap-tour.js"],
         jquery: ["dist/jquery.js", "jquery/jquery.js"],
-        "jquery.complexify": ["jquery.complexify.js", "jquery/jquery.complexify.js"],
         "jquery.cookie": ["jquery.cookie.js", "jquery/jquery.cookie.js"],
         "jquery-migrate": ["dist/jquery-migrate.js", "jquery/jquery.migrate.js"],
         "jquery-mousewheel": ["jquery.mousewheel.js", "jquery/jquery.mousewheel.js"],

--- a/client/package.json
+++ b/client/package.json
@@ -53,7 +53,6 @@
     "jquery-migrate": "~1.4",
     "jquery-mousewheel": "^3.1.13",
     "jquery-ui": "^1.12.1",
-    "jquery.complexify": "^0.5.2",
     "jquery.cookie": "^1.4.1",
     "jspdf": "^2.4.0",
     "linkifyjs": "^2.1.9",

--- a/client/src/libs/jquery.custom.js
+++ b/client/src/libs/jquery.custom.js
@@ -20,7 +20,6 @@ require("imports-loader?imports=default|jqueryVendor|jQuery!libs/farbtastic");
 //require("imports-loader?imports=default|jquery|jqueryVendor,define=>false!jquery.cookie");
 require("imports-loader?imports=default|jqueryVendor|jQuery!libs/jquery/jquery.dynatree");
 require("imports-loader?imports=default|jqueryVendor|jQuery!libs/jquery/jquery.wymeditor");
-require("imports-loader?imports=default|jqueryVendor|jQuery!jquery.complexify");
 require("imports-loader?imports=default|jqueryVendor|jQuery!jquery-migrate");
 
 // require("imports-loader?jQuery=jqueryVendor!../ui/autocom_tagging");

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7509,11 +7509,6 @@ jquery-ui@^1.12.1:
   dependencies:
     jquery ">=1.8.0 <4.0.0"
 
-jquery.complexify@^0.5.2:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/jquery.complexify/-/jquery.complexify-0.5.2.tgz#8c8834ca08cee9476f1d975128d49526adcc4ae9"
-  integrity sha1-jIg0ygjO6UdvHZdRKNSVJq3MSuk=
-
 jquery.cookie@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jquery.cookie/-/jquery.cookie-1.4.1.tgz#d63dce209eab691fe63316db08ca9e47e0f9385b"

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/user/change_password.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/user/change_password.mako
@@ -1,14 +1,4 @@
 <%inherit file="/base.mako"/>
-<script>
-$(function() {
-  $("[name='password']").complexify({'minimumChars':6}, function(valid, complexity){
-    var progressBar = $('.progress-bar');
-    var color = valid ? 'lightgreen' : 'red';
-    progressBar.css('background-color', color);
-    progressBar.css({'width': complexity + '%'});
-  });
-});
-</script>
 
 <div class="toolForm">
     <form name="change_password" id="change_password" action="${h.url_for( controller='user', action='change_password' )}" method="post" >
@@ -40,3 +30,25 @@ $(function() {
         </div>
     </form>
 </div>
+
+<script>
+var pwInput = document.getElementById('password_input');
+pwInput.onkeyup = function() {
+    var pw = pwInput.value;
+    var progress_bar = document.getElementById('password_strength');
+
+    var strongPasswordRegex = new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})");
+    var mediumPasswordRegex = new RegExp("^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})");
+
+    if (strongPasswordRegex.test(pw)) {
+        progress_bar.style.backgroundColor = 'lightgreen';
+        progress_bar.style.width = '100%';
+    } else if (mediumPasswordRegex.test(pw)) {
+        progress_bar.style.backgroundColor = 'orange';
+        progress_bar.style.width = '60%';
+    } else {
+        progress_bar.style.backgroundColor = 'red';
+        progress_bar.style.width = '30%';
+    }
+};
+</script>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/user/change_password.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/user/change_password.mako
@@ -14,10 +14,10 @@
         %endif
         <div class="form-row">
             <label>New password:</label>
-            <input type="password" name="password" value="" size="40"/>
+            <input id="password_input" type="password" name="password" value="" size="40"/>
         </div>
         <div class="progress">
-            <div id="complexity-bar" class="progress-bar" role="progressbar">
+            <div id="password_strength" class="progress-bar" role="progressbar">
                 Strength
             </div>
         </div>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/user/change_password.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/user/change_password.mako
@@ -14,12 +14,7 @@
         %endif
         <div class="form-row">
             <label>New password:</label>
-            <input id="password_input" type="password" name="password" value="" size="40"/>
-        </div>
-        <div class="progress">
-            <div id="password_strength" class="progress-bar" role="progressbar">
-                Strength
-            </div>
+            <input type="password" name="password" value="" size="40"/>
         </div>
         <div class="form-row">
             <label>Confirm:</label>
@@ -30,25 +25,3 @@
         </div>
     </form>
 </div>
-
-<script>
-var pwInput = document.getElementById('password_input');
-pwInput.onkeyup = function() {
-    var pw = pwInput.value;
-    var progress_bar = document.getElementById('password_strength');
-
-    var strongPasswordRegex = new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})");
-    var mediumPasswordRegex = new RegExp("^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})");
-
-    if (strongPasswordRegex.test(pw)) {
-        progress_bar.style.backgroundColor = 'lightgreen';
-        progress_bar.style.width = '100%';
-    } else if (mediumPasswordRegex.test(pw)) {
-        progress_bar.style.backgroundColor = 'orange';
-        progress_bar.style.width = '60%';
-    } else {
-        progress_bar.style.backgroundColor = 'red';
-        progress_bar.style.width = '30%';
-    }
-};
-</script>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/user/register.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/user/register.mako
@@ -77,26 +77,6 @@
                 $(".errormessage").html(message);
             }
 
-            var pwInput = document.getElementById('password_input');
-            pwInput.onkeyup = function() {
-                var pw = pwInput.value;
-                var progress_bar = document.getElementById('password_strength');
-
-                var strongPasswordRegex = new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})");
-                var mediumPasswordRegex = new RegExp("^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})");
-
-                if (strongPasswordRegex.test(pw)) {
-                    progress_bar.style.backgroundColor = 'lightgreen';
-                    progress_bar.style.width = '100%';
-                } else if (mediumPasswordRegex.test(pw)) {
-                    progress_bar.style.backgroundColor = 'orange';
-                    progress_bar.style.width = '60%';
-                } else {
-                    progress_bar.style.backgroundColor = 'red';
-                    progress_bar.style.width = '30%';
-                }
-            };
-
             $('#registration').bind('submit', function(e) {
                 $('#send').attr('disabled', 'disabled');
 
@@ -141,11 +121,6 @@
             <div class="form-row">
                 <label>Password:</label>
                 <input id="password_input" type="password" name="password" value="" size="40"/>
-            </div>
-            <div class="progress">
-                <div id="password_strength" class="progress-bar" role="progressbar">
-                    Strength
-                </div>
             </div>
             <div class="form-row">
                 <label>Confirm password:</label>

--- a/lib/tool_shed/webapp/templates/webapps/tool_shed/user/register.mako
+++ b/lib/tool_shed/webapp/templates/webapps/tool_shed/user/register.mako
@@ -77,13 +77,25 @@
                 $(".errormessage").html(message);
             }
 
-            $("[name='password']").complexify({'minimumChars':6}, function(valid, complexity){
-                var progressBar = $('.progress-bar');
-                var color = valid ? 'lightgreen' : 'red';
+            var pwInput = document.getElementById('password_input');
+            pwInput.onkeyup = function() {
+                var pw = pwInput.value;
+                var progress_bar = document.getElementById('password_strength');
 
-                progressBar.css('background-color', color);
-                progressBar.css({'width': complexity + '%'});
-            });
+                var strongPasswordRegex = new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#\$%\^&\*])(?=.{8,})");
+                var mediumPasswordRegex = new RegExp("^(((?=.*[a-z])(?=.*[A-Z]))|((?=.*[a-z])(?=.*[0-9]))|((?=.*[A-Z])(?=.*[0-9])))(?=.{6,})");
+
+                if (strongPasswordRegex.test(pw)) {
+                    progress_bar.style.backgroundColor = 'lightgreen';
+                    progress_bar.style.width = '100%';
+                } else if (mediumPasswordRegex.test(pw)) {
+                    progress_bar.style.backgroundColor = 'orange';
+                    progress_bar.style.width = '60%';
+                } else {
+                    progress_bar.style.backgroundColor = 'red';
+                    progress_bar.style.width = '30%';
+                }
+            };
 
             $('#registration').bind('submit', function(e) {
                 $('#send').attr('disabled', 'disabled');
@@ -131,7 +143,7 @@
                 <input id="password_input" type="password" name="password" value="" size="40"/>
             </div>
             <div class="progress">
-                <div id="complexity-bar" class="progress-bar" role="progressbar">
+                <div id="password_strength" class="progress-bar" role="progressbar">
                     Strength
                 </div>
             </div>


### PR DESCRIPTION
Entirely remove `jquery.complexify` and replace password strength check with vanilla js function by testing regex string.
Part of jquery elimination #11939

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. enter a password in the toolshed register user page or use forgot password link
  2. if the password is longer than 6 and contains at least one uppercase/lowercase letter and number, strength is medium; if longer than 8 and contain at least one character, strength is strong, else is weak

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
