### PR TITLE
[21.09] Fix adding new files via tarball upload

### DIFF
--- a/lib/tool_shed/util/commit_util.py
+++ b/lib/tool_shed/util/commit_util.py
@@ -17,7 +17,7 @@ from tool_shed.util import basic_util, hg_util, shed_util_common as suc
 
 log = logging.getLogger(__name__)
 
-UNDESIRABLE_DIRS = ['.hg', '.svn', '.git', '.cvs']
+UNDESIRABLE_DIRS = ['.hg', '.svn', '.git', '.cvs', '.idea']
 UNDESIRABLE_FILES = ['.hg_archival.txt', 'hgrc', '.DS_Store', 'tool_test_output.html', 'tool_test_output.json']
 
 
@@ -155,7 +155,6 @@ def handle_directory_changes(app, host, username, repository, full_path, filenam
     content_alert_str = ''
     files_to_remove = []
     filenames_in_archive = [os.path.join(full_path, name) for name in filenames_in_archive]
-    repo = repository.hg_repo
     if remove_repo_files_not_in_tar and not repository.is_new():
         # We have a repository that is not new (it contains files), so discover those files that are in the
         # repository, but not in the uploaded archive.
@@ -177,27 +176,11 @@ def handle_directory_changes(app, host, username, repository, full_path, filenam
             # Remove files in the repository (relative to the upload point) that are not in
             # the uploaded archive.
             try:
-                hg_util.remove_file(repo_path, repo_file, force=True)
+                hg_util.remove_file(repo_path, repo_file)
             except Exception as e:
-                log.debug(f"Error removing files using the mercurial API, so trying a different approach, the error was: {str(e)}")
-                relative_selected_file = repo_file.split('repo_%d' % repository.id)[1].lstrip('/')
-                repo.dirstate.remove(relative_selected_file)
-                repo.dirstate.write()
-                absolute_selected_file = os.path.abspath(repo_file)
-                if os.path.isdir(absolute_selected_file):
-                    try:
-                        os.rmdir(absolute_selected_file)
-                    except OSError:
-                        # The directory is not empty.
-                        pass
-                elif os.path.isfile(absolute_selected_file):
-                    os.remove(absolute_selected_file)
-                    dir = os.path.split(absolute_selected_file)[0]
-                    try:
-                        os.rmdir(dir)
-                    except OSError:
-                        # The directory is not empty.
-                        pass
+                error_message = (f"Error removing file {repo_file} in mercurial repo:\n{e}")
+                log.debug(error_message)
+                return 'error', error_message, files_to_remove, content_alert_str, 0, 0
     # See if any admin users have chosen to receive email alerts when a repository is updated.
     # If so, check every uploaded file to ensure content is appropriate.
     check_contents = check_file_contents_for_email_alerts(app)

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -210,12 +210,12 @@ def get_rev_label_from_changeset_revision(repo, changeset_revision, include_date
     return rev, label
 
 
-def remove_file(repo_path, selected_file):
+def remove_path(repo_path, selected_file):
     cmd = ['hg', 'remove', '--force', selected_file]
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
-        error_message = f"Error removing file '{selected_file}': {unicodify(e)}"
+        error_message = f"Error removing path '{selected_file}': {unicodify(e)}"
         if isinstance(e, subprocess.CalledProcessError):
             output = unicodify(e.output)
             if 'is untracked' in output:
@@ -278,7 +278,7 @@ __all__ = (
     'get_revision_label_from_ctx',
     'get_rev_label_from_changeset_revision',
     'pull_repository',
-    'remove_file',
+    'remove_path',
     'reversed_lower_upper_bounded_changelog',
     'reversed_upper_bounded_changelog',
     'update_repository',

--- a/lib/tool_shed/util/hg_util.py
+++ b/lib/tool_shed/util/hg_util.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 import subprocess
 import tempfile
 from datetime import datetime
@@ -209,17 +210,24 @@ def get_rev_label_from_changeset_revision(repo, changeset_revision, include_date
     return rev, label
 
 
-def remove_file(repo_path, selected_file, force=True):
-    cmd = ['hg', 'remove']
-    if force:
-        cmd.append('--force')
-    cmd.append(selected_file)
+def remove_file(repo_path, selected_file):
+    cmd = ['hg', 'remove', '--force', selected_file]
     try:
         subprocess.check_output(cmd, stderr=subprocess.STDOUT, cwd=repo_path)
     except Exception as e:
         error_message = f"Error removing file '{selected_file}': {unicodify(e)}"
         if isinstance(e, subprocess.CalledProcessError):
-            error_message += f"\nOutput was:\n{unicodify(e.output)}"
+            output = unicodify(e.output)
+            if 'is untracked' in output:
+                # That's ok, happens if we add a new file or directory via tarball upload,
+                # just delete the file or dir on disk
+                selected_file_path = os.path.join(repo_path, selected_file)
+                if os.path.isdir(selected_file_path):
+                    shutil.rmtree(selected_file_path)
+                else:
+                    os.remove(selected_file_path)
+                return
+            error_message += f"\nOutput was:\n{output}"
         raise Exception(error_message)
 
 

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -2156,7 +2156,7 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                 tip = repository.tip()
                 for selected_file in selected_files_to_delete:
                     try:
-                        hg_util.remove_file(repo_dir, selected_file)
+                        hg_util.remove_path(repo_dir, selected_file)
                     except Exception as e:
                         status = 'error'
                         message = f"Error removing file {selected_file} in mercurial repo:\n{e}"

--- a/lib/tool_shed/webapp/controllers/repository.py
+++ b/lib/tool_shed/webapp/controllers/repository.py
@@ -2156,29 +2156,11 @@ class RepositoryController(BaseUIController, ratings_util.ItemRatings):
                 tip = repository.tip()
                 for selected_file in selected_files_to_delete:
                     try:
-                        hg_util.remove_file(repo_dir, selected_file, force=True)
+                        hg_util.remove_file(repo_dir, selected_file)
                     except Exception as e:
-                        log.debug("Error removing the following file using the mercurial API:\n %s", selected_file)
-                        log.debug("The error was: %s", util.unicodify(e))
-                        log.debug("Attempting to remove the file using a different approach.")
-                        relative_selected_file = selected_file.split('repo_%d' % repository.id)[1].lstrip('/')
-                        repo.dirstate.remove(relative_selected_file)
-                        repo.dirstate.write()
-                        absolute_selected_file = os.path.abspath(selected_file)
-                        if os.path.isdir(absolute_selected_file):
-                            try:
-                                os.rmdir(absolute_selected_file)
-                            except OSError:
-                                # The directory is not empty
-                                pass
-                        elif os.path.isfile(absolute_selected_file):
-                            os.remove(absolute_selected_file)
-                            dir = os.path.split(absolute_selected_file)[0]
-                            try:
-                                os.rmdir(dir)
-                            except OSError:
-                                # The directory is not empty
-                                pass
+                        status = 'error'
+                        message = f"Error removing file {selected_file} in mercurial repo:\n{e}"
+                        log.debug(message)
                 # Commit the change set.
                 if not commit_message:
                     commit_message = 'Deleted selected files'

--- a/test/unit/shed_unit/test_hg_util.py
+++ b/test/unit/shed_unit/test_hg_util.py
@@ -1,0 +1,57 @@
+import pytest
+
+from tool_shed.util import hg_util
+
+
+def test_init_repository(tmpdir):
+    hg_util.init_repository(str(tmpdir))
+    assert (tmpdir / '.hg').exists()
+
+
+def test_init_repository_fails(tmpdir):
+    test_init_repository(tmpdir)
+    with pytest.raises(Exception) as exc_info:
+        test_init_repository(tmpdir)
+    assert 'Error initializing repository' in str(exc_info.value)
+
+
+def test_add_file_and_commmit_changeset(tmpdir):
+    test_init_repository(tmpdir)
+    path_to_add = (tmpdir / 'test.txt')
+    path_to_add.write('test')
+    hg_util.add_changeset(str(tmpdir), str(path_to_add))
+    hg_util.commit_changeset(str(tmpdir), str(path_to_add), 'testuser', 'testcommit')
+    return path_to_add
+
+
+def test_add_dir_and_commit_changeset(tmpdir):
+    test_init_repository(tmpdir)
+    path_to_add = tmpdir.mkdir('abc')
+    (path_to_add / 'test.txt').write('bla')
+    hg_util.add_changeset(str(tmpdir), str(path_to_add))
+    hg_util.commit_changeset(str(tmpdir), str(path_to_add), 'testuser', 'testcommit')
+    return path_to_add
+
+
+def test_remove_tracked_file(tmpdir):
+    path_to_remove = test_add_file_and_commmit_changeset(tmpdir)
+    hg_util.remove_path(str(tmpdir), path_to_remove)
+
+
+def test_remove_untracked_file(tmpdir):
+    test_init_repository(tmpdir)
+    untracked_path = tmpdir / 'untracked.txt'
+    untracked_path.write('bla')
+    hg_util.remove_path(str(tmpdir), str(untracked_path))
+
+
+def test_remove_tracked_dir(tmpdir):
+    path_to_remove = test_add_dir_and_commit_changeset(tmpdir)
+    hg_util.remove_path(str(tmpdir), path_to_remove)
+
+
+def test_remove_nonexistant_file_fails(tmpdir):
+    test_init_repository(tmpdir)
+    with pytest.raises(Exception) as exc_info:
+        hg_util.remove_path(str(tmpdir), str(tmpdir / 'some path'))
+    assert 'Error removing path' in str(exc_info.value)


### PR DESCRIPTION
The API of `repo.dirstate.write` has changed and takes a `tr` parameter now. I've removed the whole fallback since it fails and uses internals of mercurial that we should probably not be using anyway.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
