### PR TITLE
[21.09] Ensure tool_id/content_id is updated when refactoring workflows

### DIFF
--- a/lib/galaxy/workflow/refactor/execute.py
+++ b/lib/galaxy/workflow/refactor/execute.py
@@ -391,6 +391,10 @@ class WorkflowRefactorExecutor:
         self._inject_for_updated_step(step, execution)
         step_def["tool_version"] = tool_version
         step_def["tool_state"] = step.module.get_tool_state()
+        if step_def.get("tool_id"):
+            step_def["tool_id"] = step.module.get_content_id()
+        if step_def.get("content_id"):
+            step_def["content_id"] = step.module.get_content_id()
         self._patch_step(execution, step, step_def)
 
     def _apply_upgrade_all_steps(self, action: UpgradeAllStepsAction, execution: RefactorActionExecution):

--- a/lib/galaxy_test/base/workflow_fixtures.py
+++ b/lib/galaxy_test/base/workflow_fixtures.py
@@ -423,6 +423,10 @@ steps:
     in:
       input1: nested_workflow/workflow_output
       queries_0|input2: nested_workflow/workflow_output
+  compose_text_param:
+    tool_id: compose_text_param
+    tool_version: 0.1.0
+    label: compose_text_param
 """
 
 WORKFLOW_WITH_OUTPUT_ACTIONS = """


### PR DESCRIPTION
#13196 fixed #13153 on the front end but did not cover the case where a workflow might be modified purely via workflow refactor actions on the API (e.g. here: https://github.com/galaxyproject/planemo/pull/1214).

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
