### PR TITLE
Add dynamic step to FormNumber range slider

### DIFF
--- a/client/src/components/Form/Elements/FormNumber.test.js
+++ b/client/src/components/Form/Elements/FormNumber.test.js
@@ -107,4 +107,27 @@ describe("FormInput", () => {
             await checkFractionsAlert(key);
         }
     });
+
+    it("should calculate the right step for floats", async () => {
+        const expectStep = async (value, expectedStep) => {
+            const props = { value: value, type: "float", min: 0, max: 1 };
+            const wrapper = await mountFormNumber(props);
+            expect(wrapper.vm.step).toBe(expectedStep);
+        };
+
+        //minimum step 0.1 - maximum step 0.001
+        const testValues = [
+            { value: undefined, step: 0.1 },
+            { value: "", step: 0.1 },
+            { value: 0, step: 0.1 },
+            { value: 0.5, step: 0.1 },
+            { value: 0.55, step: 0.01 },
+            { value: 0.555, step: 0.001 },
+            { value: 0.5555, step: 0.001 },
+            { value: 25e-100, step: 0.001 },
+        ];
+        for (let index = 0; index < testValues.length; index++) {
+            expectStep(testValues[index].value, testValues[index].step);
+        }
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13187

By default, the step of the range slider is 1, so it couldn't represent fractions.

This PR fixes that behavior and assumes a minimum step precision of 0.1 and a maximum of 0.001 dynamically adapting depending on the current value.
This minimum and maximum step limit is arbitrary and can be further adjusted or parameterized if needed.

![slider](https://user-images.githubusercontent.com/46503462/150826048-8c0065d9-f8c7-45a0-b406-930feadf49f1.gif)


## How to test the changes?
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] Instructions for manual testing are as follows:
  - Follow instructions on https://github.com/galaxyproject/galaxy/issues/13187
  - Check that moving the slider now allows for fine-grained changes

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
