### PR TITLE
Hide form fields and button upon successful submission of bug report

### DIFF
--- a/client/src/components/DatasetInformation/DatasetError.test.js
+++ b/client/src/components/DatasetInformation/DatasetError.test.js
@@ -62,7 +62,7 @@ describe("DatasetError", () => {
         expect(wrapper.findAll("#dataset-error-email").length).toBe(0);
     });
 
-    it("success message hides form fields and button", async () => {
+    it("hides form fields and button on success", async () => {
         const wrapper = buildWrapper();
         const fieldsAndButton = "#fieldsAndButton";
         expect(wrapper.find(fieldsAndButton).exists()).toBe(true);
@@ -70,7 +70,7 @@ describe("DatasetError", () => {
         expect(wrapper.find(fieldsAndButton).exists()).toBe(false);
     });
 
-    it("error message does not hide form fields and button", async () => {
+    it("does not hide form fields and button on error", async () => {
         const wrapper = buildWrapper();
         const fieldsAndButton = "#fieldsAndButton";
         expect(wrapper.find(fieldsAndButton).exists()).toBe(true);

--- a/client/src/components/DatasetInformation/DatasetError.test.js
+++ b/client/src/components/DatasetInformation/DatasetError.test.js
@@ -61,4 +61,24 @@ describe("DatasetError", () => {
         expect(wrapper.findAll("#dataset-error-has-duplicate-inputs").length).toBe(0);
         expect(wrapper.findAll("#dataset-error-email").length).toBe(0);
     });
+
+    it("success message hides form fields and button", async () => {
+        const wrapper = buildWrapper();
+        const fieldsAndButton = "#fieldsAndButton";
+        expect(wrapper.find(fieldsAndButton).exists()).toBe(true);
+        await wrapper.setData({ resultMessages: [["message", "success"]] });
+        expect(wrapper.find(fieldsAndButton).exists()).toBe(false);
+    });
+
+    it("error message does not hide form fields and button", async () => {
+        const wrapper = buildWrapper();
+        const fieldsAndButton = "#fieldsAndButton";
+        expect(wrapper.find(fieldsAndButton).exists()).toBe(true);
+        const messages = [
+            ["message", "success"],
+            ["message", "danger"],
+        ]; // at least one has "danger"
+        await wrapper.setData({ resultMessages: messages });
+        expect(wrapper.find(fieldsAndButton).exists()).toBe(true);
+    });
 });

--- a/client/src/components/DatasetInformation/DatasetError.vue
+++ b/client/src/components/DatasetInformation/DatasetError.vue
@@ -58,23 +58,25 @@
                         show
                         >{{ resultMessage[0] }}</b-alert
                     >
-                    <FormElement
-                        v-if="!jobDetails.user_email"
-                        id="dataset-error-email"
-                        v-model="email"
-                        title="Please provide your email:" />
-                    <FormElement
-                        id="dataset-error-message"
-                        v-model="message"
-                        :area="true"
-                        title="Please provide detailed information on the activities leading to this issue:" />
-                    <b-button
-                        id="dataset-error-submit"
-                        variant="primary"
-                        @click="submit(dataset, jobDetails.user_email)"
-                        class="mt-3">
-                        <font-awesome-icon icon="bug" class="mr-1" />Report
-                    </b-button>
+                    <div v-if="showForm" id="fieldsAndButton">
+                        <FormElement
+                            v-if="!jobDetails.user_email"
+                            id="dataset-error-email"
+                            v-model="email"
+                            title="Please provide your email:" />
+                        <FormElement
+                            id="dataset-error-message"
+                            v-model="message"
+                            :area="true"
+                            title="Please provide detailed information on the activities leading to this issue:" />
+                        <b-button
+                            id="dataset-error-submit"
+                            variant="primary"
+                            @click="submit(dataset, jobDetails.user_email)"
+                            class="mt-3">
+                            <font-awesome-icon icon="bug" class="mr-1" />Report
+                        </b-button>
+                    </div>
                 </div>
             </JobDetailsProvider>
         </DatasetProvider>
@@ -131,6 +133,13 @@ export default {
                     this.errorMessage = errorMessage;
                 }
             );
+        },
+    },
+    computed: {
+        showForm() {
+            const noResult = !this.resultMessages.length;
+            const hasError = this.resultMessages.some((msg) => msg[1] === "danger");
+            return noResult || hasError;
         },
     },
 };


### PR DESCRIPTION
Ref #13144.

Upon clicking the "Report" button, if the report has been submitted without errors, the text input field(s) and the button will be hidden, leaving just the confirmation message. The fields and button will NOT be hidden if there is an error.

I considered moving the confirmation message to the top of the content area, as requested in the referenced issue. However, I think that's not optimal:
1. That would move the confirmation message out of its context, provided by the subheading. We are submitting an "Issue Report", not "Troubleshooting" - so the current placement is more logical.
2. In case of an error, the error message would be even more out of context (I think, it would be not immediately clear whether the error refers to the submitted report or the original job). And if we chose to let the error message be displayed in its current location and the success message - at the top of the page, that would be even more confusing due to the visual inconsistency.
3. At the same time, the text fields and the button are no longer relevant in case of a successful submission. Hiding them removes irrelevant stuff + gives the confirmation message focus.

Tests are included.

I'll make the URL configurable in a separate PR. 

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
See #13144 for steps to reproduce use case; observe improved UI.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
