### PR TITLE
Optimise simple file uploads

### DIFF
--- a/lib/galaxy/tools/actions/upload_common.py
+++ b/lib/galaxy/tools/actions/upload_common.py
@@ -397,6 +397,7 @@ def create_paramfile(trans, uploaded_datasets):
                           uuid=uuid_str,
                           to_posix_lines=getattr(uploaded_dataset, "to_posix_lines", True),
                           auto_decompress=getattr(uploaded_dataset, "auto_decompress", True),
+                          groom_content=getattr(uploaded_dataset, "groom_content", True),
                           purge_source=purge_source,
                           space_to_tab=uploaded_dataset.space_to_tab,
                           run_as_real_user=trans.app.config.external_chown_script is not None,

--- a/lib/galaxy/tools/data_fetch.py
+++ b/lib/galaxy/tools/data_fetch.py
@@ -233,7 +233,7 @@ def _fetch_target(upload_config, target):
             registry = upload_config.registry
             check_content = upload_config.check_content
 
-            stdout, ext, datatype, is_binary, converted_path, converted_newlines, converted_spaces = handle_upload(
+            stdout, ext, is_binary, converted_path, converted_newlines, converted_spaces = handle_upload(
                 registry=registry,
                 path=path,
                 requested_ext=requested_ext,
@@ -247,6 +247,7 @@ def _fetch_target(upload_config, target):
                 convert_to_posix_lines=to_posix_lines,
                 convert_spaces_to_tabs=space_to_tab,
             )
+            datatype = registry.get_datatype_by_extension(ext)
             transform = []
             if converted_newlines:
                 transform.append({"action": "to_posix_lines"})

--- a/lib/galaxy/tools/parameters/grouping.py
+++ b/lib/galaxy/tools/parameters/grouping.py
@@ -235,6 +235,7 @@ class Dataset(Bunch):
     primary_file: str
     to_posix_lines: bool
     auto_decompress: bool
+    groom_content: bool
     ext: str
     space_to_tab: bool
 
@@ -454,6 +455,9 @@ class UploadDataset(Group):
             auto_decompress = False
             if context.get('auto_decompress', None) not in ["None", None, False]:
                 auto_decompress = True
+            groom_content = False
+            if context.get('groom_content', None) not in ["None", None, False]:
+                groom_content = True
             space_to_tab = False
             if context.get('space_to_tab', None) not in ["None", None, False]:
                 space_to_tab = True
@@ -495,6 +499,7 @@ class UploadDataset(Group):
                         break
             file_bunch.to_posix_lines = to_posix_lines
             file_bunch.auto_decompress = auto_decompress
+            file_bunch.groom_content = groom_content
             file_bunch.space_to_tab = space_to_tab
             file_bunch.uuid = uuid
             if file_type is not None:
@@ -518,6 +523,9 @@ class UploadDataset(Group):
             auto_decompress = False
             if context.get('auto_decompress', None) not in ["None", None, False]:
                 auto_decompress = True
+            groom_content = False
+            if context.get('groom_content', None) not in ["None", None, False]:
+                groom_content = True
             space_to_tab = False
             if context.get('space_to_tab', None) not in ["None", None, False]:
                 space_to_tab = True
@@ -526,6 +534,7 @@ class UploadDataset(Group):
             if file_bunch.path:
                 file_bunch.to_posix_lines = to_posix_lines
                 file_bunch.auto_decompress = auto_decompress
+                file_bunch.groom_content = groom_content
                 file_bunch.space_to_tab = space_to_tab
                 if file_type is not None:
                     file_bunch.file_type = file_type
@@ -538,6 +547,7 @@ class UploadDataset(Group):
                     file_bunch.uuid = uuid
                     file_bunch.to_posix_lines = to_posix_lines
                     file_bunch.auto_decompress = auto_decompress
+                    file_bunch.groom_content = groom_content
                     file_bunch.space_to_tab = space_to_tab
                     if file_type is not None:
                         file_bunch.file_type = file_type
@@ -582,6 +592,7 @@ class UploadDataset(Group):
                 if file_bunch.path:
                     file_bunch.to_posix_lines = to_posix_lines
                     file_bunch.auto_decompress = auto_decompress
+                    file_bunch.groom_content = groom_content
                     file_bunch.space_to_tab = space_to_tab
                     if file_type is not None:
                         file_bunch.file_type = file_type
@@ -633,6 +644,7 @@ class UploadDataset(Group):
                 dataset.primary_file = temp_name
                 dataset.to_posix_lines = True
                 dataset.auto_decompress = True
+                dataset.groom_content = True
                 dataset.space_to_tab = False
             else:
                 file_bunch, warnings = get_one_filename(groups_incoming[0])
@@ -640,6 +652,7 @@ class UploadDataset(Group):
                 dataset.primary_file = file_bunch.path
                 dataset.to_posix_lines = file_bunch.to_posix_lines
                 dataset.auto_decompress = file_bunch.auto_decompress
+                dataset.groom_content = file_bunch.groom_content
                 dataset.space_to_tab = file_bunch.space_to_tab
                 if file_bunch.file_type:
                     dataset.file_type = file_type

--- a/lib/galaxy_test/api/test_tools_upload.py
+++ b/lib/galaxy_test/api/test_tools_upload.py
@@ -1,10 +1,12 @@
 import json
 import os
+import tempfile
 import urllib.parse
 
 import pytest
 from tusclient import client
 
+from galaxy.datatypes.binary import Bam
 from galaxy.tool_util.verify.test_data import TestDataResolver
 from galaxy_test.base.constants import (
     ONE_TO_SIX_ON_WINDOWS,
@@ -589,6 +591,14 @@ class ToolsUploadTestCase(ApiTestCase):
             details = self._upload_and_get_details(fh, file_type="auto")
         assert details["state"] == "ok"
         assert details["file_ext"] == "bam", details
+
+    def test_upload_skip_grooming(self):
+        bam_path = TestDataResolver().get_filename("2.shuffled.unsorted.bam")
+        with open(bam_path, "rb") as fh, tempfile.NamedTemporaryFile(prefix="skip_grooming") as ct:
+            content = self._upload_and_get_content(fh, file_type="auto", groom_content=None)
+            ct.write(content)
+            b = Bam()
+            assert b.dataset_content_needs_grooming(ct.name) is True
 
     def test_fetch_metadata(self):
         table = ONE_TO_SIX_WITH_SPACES

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -685,6 +685,8 @@ class BaseDatasetPopulator(BasePopulator):
             upload_params["files_0|space_to_tab"] = kwds["space_to_tab"]
         if "auto_decompress" in kwds:
             upload_params["files_0|auto_decompress"] = kwds["auto_decompress"]
+        if "groom_content" in kwds:
+            upload_params["files_0|groom_content"] = kwds["groom_content"]
         upload_params.update(kwds.get("extra_inputs", {}))
         return self.run_tool_payload(
             tool_id='upload1',

--- a/tools/data_source/upload.xml
+++ b/tools/data_source/upload.xml
@@ -43,6 +43,7 @@
       <param name="uuid" type="hidden" required="False" />
       <param name="to_posix_lines" type="hidden" value="Yes" />
       <param name="auto_decompress" type="hidden" value="Yes" />
+      <param name="groom_content" type="hidden" value="Yes" />
       <!-- allow per-file override of dbkey -->
       <param name="file_type" type="hidden" value="" />
       <param name="dbkey" type="hidden" value="" />


### PR DESCRIPTION
Datatype registry is lazy loaded by upload1 tool
groom_content hidden input added to disable file grooming
If Galaxy is configured with check_upload_content = false and an uncompressed file is uploaded with groom_content=false and auto_decompress=false, the datatype registry will not be loaded and a simpler execution path is followed.

My testing shows this shaves off about ~2 seconds on the run time of a small text file.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
