### PR TITLE
Fix bugs on tags

### DIFF
--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -157,18 +157,20 @@ class TagHandler:
         return False
 
     def apply_item_tag(self, user, item, name, value=None, flush=True):
+        # Use lowercase name for searching/creating tag.
         if name is None:
             return
+        lc_name = name.lower()
         # Get or create item-tag association.
-        item_tag_assoc = self._get_item_tag_assoc(user, item, name)
+        item_tag_assoc = self._get_item_tag_assoc(user, item, lc_name)
         # If the association does not exist, or if it has a different value, add another.
         # We do allow multiple associations with different values.
         if not item_tag_assoc or (item_tag_assoc and item_tag_assoc.value != value):
             # Create item-tag association.
             # Create tag; if None, skip the tag (and log error).
-            tag = self._get_or_create_tag(name)
+            tag = self._get_or_create_tag(lc_name)
             if not tag:
-                log.warning(f"Failed to create tag with name {name}")
+                log.warning(f"Failed to create tag with name {lc_name}")
                 return
             # Create tag association based on item class.
             item_tag_assoc_class = self.get_tag_assoc_class(item.__class__)
@@ -214,7 +216,7 @@ class TagHandler:
     def get_tag_by_name(self, tag_name):
         """Get a Tag object from a tag name (string)."""
         if tag_name:
-            return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name).first()
+            return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name.lower()).first()
         return None
 
     def _create_tag(self, tag_str: str):

--- a/lib/galaxy/model/tags.py
+++ b/lib/galaxy/model/tags.py
@@ -157,20 +157,18 @@ class TagHandler:
         return False
 
     def apply_item_tag(self, user, item, name, value=None, flush=True):
-        # Use lowercase name for searching/creating tag.
         if name is None:
             return
-        lc_name = name.lower()
         # Get or create item-tag association.
-        item_tag_assoc = self._get_item_tag_assoc(user, item, lc_name)
+        item_tag_assoc = self._get_item_tag_assoc(user, item, name)
         # If the association does not exist, or if it has a different value, add another.
         # We do allow multiple associations with different values.
         if not item_tag_assoc or (item_tag_assoc and item_tag_assoc.value != value):
             # Create item-tag association.
             # Create tag; if None, skip the tag (and log error).
-            tag = self._get_or_create_tag(lc_name)
+            tag = self._get_or_create_tag(name)
             if not tag:
-                log.warning(f"Failed to create tag with name {lc_name}")
+                log.warning(f"Failed to create tag with name {name}")
                 return
             # Create tag association based on item class.
             item_tag_assoc_class = self.get_tag_assoc_class(item.__class__)
@@ -180,12 +178,9 @@ class TagHandler:
             item_tag_assoc.tag = tag
             item_tag_assoc.user = user
         # Apply attributes to item-tag association. Strip whitespace from user name and tag.
-        lc_value = None
-        if value:
-            lc_value = value.lower()
         item_tag_assoc.user_tname = name
         item_tag_assoc.user_value = value
-        item_tag_assoc.value = lc_value
+        item_tag_assoc.value = value
         if flush:
             self.sa_session.flush()
         return item_tag_assoc
@@ -219,7 +214,7 @@ class TagHandler:
     def get_tag_by_name(self, tag_name):
         """Get a Tag object from a tag name (string)."""
         if tag_name:
-            return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name.lower()).first()
+            return self.sa_session.query(galaxy.model.Tag).filter_by(name=tag_name).first()
         return None
 
     def _create_tag(self, tag_str: str):


### PR DESCRIPTION
Fix bug where multiple nametags that have different capitalization structures can cancel each other out. If, for example someone had tags for #EXAMPLE and #example, on reload, the dataset will lose #EXAMPLE, and only retain #example. Any datasets generated from that original will also only inherit #example.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
