### PR TITLE
Add option for disabling tool shed datatypes...

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -592,6 +592,22 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``load_tool_shed_datatypes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    This option controls whether legacy datatypes are loaded from
+    installed tool shed repositories. We're are in the process of
+    disabling Tool Shed datatypes. This option with a default of true
+    will be added in 22.01, we will disable the datatypes on the big
+    public servers during that release. This option will be switched
+    to False by default in 22.05 and this broken functionality will be
+    removed all together during some future release.
+:Default: ``true``
+:Type: bool
+
+
 ~~~~~~~~~~~~~~~
 ``watch_tools``
 ~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -1353,7 +1353,7 @@ class ConfiguresGalaxyMixin:
         from galaxy.datatypes import registry
         # Create an empty datatypes registry.
         self.datatypes_registry = registry.Registry(self.config)
-        if installed_repository_manager:
+        if installed_repository_manager and self.config.load_tool_shed_datatypes:
             # Load proprietary datatypes defined in datatypes_conf.xml files in all installed tool shed repositories.  We
             # load proprietary datatypes before datatypes in the distribution because Galaxy's default sniffers include some
             # generic sniffers (eg text,xml) which catch anything, so it's impossible for proprietary sniffers to be used.

--- a/lib/galaxy/config/config_manage.py
+++ b/lib/galaxy/config/config_manage.py
@@ -769,6 +769,8 @@ def _parse_option_value(option_value):
         if option.get("type", "str") == "bool":
             value = str(value).lower() == "true"
         elif option.get("type", "str") == "int":
+            if value is None:
+                raise Exception(f"Failed to parse value for {option}, expected int got None")
             value = int(value)
     else:
         value = option_value

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -392,6 +392,15 @@ galaxy:
   # <config_dir>.
   #tool_sheds_config_file: tool_sheds_conf.xml
 
+  # This option controls whether legacy datatypes are loaded from
+  # installed tool shed repositories. We're are in the process of
+  # disabling Tool Shed datatypes. This option with a default of true
+  # will be added in 22.01, we will disable the datatypes on the big
+  # public servers during that release. This option will be switched to
+  # False by default in 22.05 and this broken functionality will be
+  # removed all together during some future release.
+  #load_tool_shed_datatypes: true
+
   # Monitor the tools and tool directories listed in any tool config
   # file specified in tool_config_file option.  If changes are found,
   # tools are automatically reloaded. Watchdog (

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -444,6 +444,17 @@ mapping:
           File containing the Galaxy Tool Sheds that should be made available to
           install from in the admin interface (.sample used if default does not exist).
 
+      load_tool_shed_datatypes:
+        type: bool
+        default: true
+        required: false
+        desc: |
+          This option controls whether legacy datatypes are loaded from installed tool shed repositories.
+          We're are in the process of disabling Tool Shed datatypes. This option with a default of true
+          will be added in 22.01, we will disable the datatypes on the big public servers during that
+          release. This option will be switched to False by default in 22.05 and this broken functionality
+          will be removed all together during some future release.
+
       watch_tools:
         type: str
         default: 'false'


### PR DESCRIPTION
...and start the process of disabling them. These have been broken since they were introduced. They have no clear upgrade path and loading Python code from the tool shed is fundamentally not something we should be doing.

Workaround for #11915

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  1. Let's try it on test maybe? Part of the point is to reduce untested paths through the code so I don't know if we need to add automated tests for temporary workarounds.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
