### PR TITLE
[21.09] Fix imported sub-workflows cannot be edited

### DIFF
--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -655,8 +655,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         """
         if not id:
             if workflow_id:
-                workflow = trans.sa_session.query(model.Workflow).get(trans.security.decode_id(workflow_id))
-                stored_workflow = workflow.stored_workflow
+                stored_workflow = self.app.workflow_manager.get_stored_workflow(trans, workflow_id, by_stored_id=False)
                 self.security_check(trans, stored_workflow, True, False)
                 stored_workflow_id = trans.security.encode_id(stored_workflow.id)
                 return trans.response.send_redirect(f'{url_for("/")}workflow/editor?id={stored_workflow_id}')


### PR DESCRIPTION
Fixes https://github.com/galaxyproject/galaxy/issues/13253

There may be no `StoredWorkflow` associated with the imported sub-workflow yet, so trying to edit the sub-workflow without it will fail.

xref https://github.com/galaxyproject/galaxy/pull/10160

## How to test the changes?
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
  - Create a workflow containing a sub-workflow
  - Share or publish the workflow
  - Login with a different user
  - Go to the shared workflow URL
  - Import the workflow
  - Go to Workflows and edit the imported workflow
  - Select the sub-workflow step and click the "Edit this Subworkflow" button
  - Check that the sub-workflow can now be edited

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
