### PR TITLE
Add CONVERTER_ to all converter tool IDs

### DIFF
--- a/lib/galaxy/datatypes/converters/csv_to_tabular.xml
+++ b/lib/galaxy/datatypes/converters/csv_to_tabular.xml
@@ -1,4 +1,4 @@
-<tool id="csv_to_tabular" name="Convert CSV to tabular" version="1.0.0" profile="16.04">
+<tool id="CONVERTER_csv_to_tabular" name="Convert CSV to tabular" version="1.0.0" profile="16.04">
     <description></description>
     <requirements>
         <requirement type="package" version="3.7">python</requirement>

--- a/lib/galaxy/datatypes/converters/tabular_to_csv.xml
+++ b/lib/galaxy/datatypes/converters/tabular_to_csv.xml
@@ -1,4 +1,4 @@
-<tool id="tabular_to_csv" name="Convert tabular to CSV" version="1.0.0" profile="16.04">
+<tool id="CONVERTER_tabular_to_csv" name="Convert tabular to CSV" version="1.0.0" profile="16.04">
     <description></description>
     <requirements>
         <requirement type="package" version="3.7">python</requirement>

--- a/lib/galaxy/datatypes/converters/tabular_to_dbnsfp.xml
+++ b/lib/galaxy/datatypes/converters/tabular_to_dbnsfp.xml
@@ -1,4 +1,4 @@
-<tool id="tabular_to_dbnsfp" name="Convert tabular to dbnsfp" version="1.0.1" profile="16.04">
+<tool id="CONVERTER_tabular_to_dbnsfp" name="Convert tabular to dbnsfp" version="1.0.1" profile="16.04">
     <description></description>
     <requirements>
         <requirement type="package" version="0.15.4">pysam</requirement>


### PR DESCRIPTION
The missing `CONVERTER_` prefix is making these converters not be marked properly for Kubernetes/Helm Galaxy instances: https://github.com/galaxyproject/galaxy-helm/blob/master/galaxy/files/rules/k8s_container_mapper.py#L92.

If changing the tool ID here is problematic/undesirable, I can alternatively special case these tool IDs in the above line.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
