### PR TITLE
[22.01] Prevent workflow submission if validation errors are present in simple workflow run form

### DIFF
--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -4,7 +4,10 @@
             <b>Workflow: {{ model.name }}</b>
             <ButtonSpinner class="float-right" title="Run Workflow" id="run-workflow" @onClick="onExecute" />
         </div>
-        <FormDisplay :inputs="formInputs" @onChange="onChange" />
+        <b-alert v-if="!!errorMessage" variant="info" show>
+            {{ errorMessage }}
+        </b-alert>
+        <FormDisplay :inputs="formInputs" @onChange="onChange" @onValidation="onValidation" />
         <!-- Options to default one way or the other, disable if admins want, etc.. -->
         <a href="#" @click="$emit('showAdvanced')">Expand to full workflow form.</a>
     </div>
@@ -38,6 +41,7 @@ export default {
     },
     data() {
         return {
+            errorMessage: null,
             formData: {},
             inputTypes: {},
         };
@@ -72,10 +76,18 @@ export default {
         },
     },
     methods: {
+        onValidation(validationError) {
+            this.errorMessage = validationError
+                ? "Please address the issues highlighted below before proceeding."
+                : null;
+        },
         onChange(data) {
             this.formData = data;
         },
         onExecute() {
+            if (this.errorMessage) {
+                return;
+            }
             const replacementParams = {};
             const inputs = {};
             for (const inputName in this.formData) {


### PR DESCRIPTION
Partially fixes #13232. This is the client part of this issue. In addition the invocations api needs to reject incomplete workflow submissions. Adds an error message to the simple workflow run form and prevents workflow submission while issues are present. Requires tests.

(Please replace this header with a description of your pull request. Please include *BOTH* what you did and why you made the changes. The "why" may simply be citing a relevant Galaxy issue.)
(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
