### PR TITLE
Fix expect_test_failure for expect_num_outputs

### DIFF
--- a/lib/galaxy/tool_util/verify/interactor.py
+++ b/lib/galaxy/tool_util/verify/interactor.py
@@ -466,7 +466,6 @@ class GalaxyInteractorApi:
                 continue
             else:
                 break
-
         submit_response_object = ensure_tool_run_response_okay(submit_response, "execute tool", inputs_tree)
         try:
             return Bunch(
@@ -1172,13 +1171,6 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
     assert len(jobs) == 1, "Test framework logic error, somehow tool test resulted in more than one job."
     job = jobs[0]
 
-    maxseconds = testdef.maxseconds
-    if testdef.num_outputs is not None:
-        expected = testdef.num_outputs
-        actual = len(data_list) + len(data_collection_list)
-        if expected != actual:
-            message = f"Incorrect number of outputs - expected {expected}, found {actual}: datasets {data_list} collections {data_collection_list}"
-            raise Exception(message)
     found_exceptions = []
 
     def register_exception(e):
@@ -1193,6 +1185,7 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
         if testdef.outputs:
             raise Exception("Cannot specify outputs in a test expecting failure.")
 
+    maxseconds = testdef.maxseconds
     # Wait for the job to complete and register expections if the final
     # status was not what test was expecting.
     job_failed = False
@@ -1204,6 +1197,14 @@ def _verify_outputs(testdef, history, jobs, data_list, data_collection_list, gal
             found_exceptions.append(e)
 
     job_stdio = galaxy_interactor.get_job_stdio(job['id'])
+
+    if testdef.num_outputs is not None:
+        expected = testdef.num_outputs
+        actual = len(data_list) + len(data_collection_list)
+        if expected != actual:
+            message = f"Incorrect number of outputs - expected {expected}, found {actual}: datasets {data_list.keys()} collections {data_collection_list.keys()}"
+            error = AssertionError(message)
+            register_exception(error)
 
     if not job_failed and testdef.expect_failure:
         error = AssertionError("Expected job to fail but Galaxy indicated the job successfully completed.")


### PR DESCRIPTION
needs to be added to the list of exceptions `found_exceptions`
because otherwise it can't be controlled by `expect_test_failure`

therefore `expect_num_outputs` needs to be checked after the job run.
because the exceptions are added via `register_exception`
which needs job's stdio

follow up on https://github.com/galaxyproject/galaxy/pull/10304

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

Tests will be added in https://github.com/galaxyproject/galaxy/pull/7894 (where I will also cherry pick this commit).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
