### PR TITLE
[22.01] Add missing collection types to xsd doc

### DIFF
--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1986,10 +1986,9 @@ This value is the same as the value of the ``name`` attribute of the
 ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="type" type="xs:string">
+    <xs:attribute name="type" type="CollectionType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Expected collection type (e.g. ``list``, ``paired``,
-or ``list:paired``).</xs:documentation>
+        <xs:documentation xml:lang="en">Expected collection type (e.g. ``list``, ``paired``, ``list:paired``, or ``list:list``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="count" type="xs:integer">
@@ -3405,11 +3404,11 @@ file (use the file extension). Used only when the ``type`` attribute value is
 ``data`` or ``data_collection``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="collection_type" type="xs:string">
+        <xs:attribute name="collection_type" type="CollectionType">
           <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
 Restrict the kind of collection that can be consumed by this parameter (e.g.
-``paired``, ``list:paired``, ``list``). Multiple such collection types can be
+``paired``, ``list:paired``, ``list``, ``list:list``). Multiple such collection types can be
 specified here as a comma-separated list. Used only when the ``type`` attribute
 value is ``data_collection``.
               ]]></xs:documentation>
@@ -5077,9 +5076,9 @@ Creating collections in tools is covered in-depth in
     </xs:sequence>
     <xs:attributeGroup ref="OutputCommon"/>
     <xs:attributeGroup ref="OutputCollectionAttributes"/>
-    <xs:attribute name="type" type="xs:string">
+    <xs:attribute name="type" type="CollectionType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Collection type for output (e.g. ``paired``, ``list``, or ``list:list``).</xs:documentation>
+        <xs:documentation xml:lang="en">Collection type for output (e.g. ``paired``, ``list``, ``list:paired`` or ``list:list``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="type_source" type="xs:string">
@@ -5115,7 +5114,7 @@ This tag describes an output to the tool.
     </xs:attribute>
     <xs:attribute name="collection_type" type="xs:string">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Collection type for output (e.g. ``paired``, ``list``, or ``list:list``).</xs:documentation>
+        <xs:documentation xml:lang="en">Collection type for output (e.g. ``paired``, ``list``, ``list:paired``, or ``list:list``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="collection_type_source" type="xs:string">
@@ -6901,5 +6900,15 @@ is the only supported options.</xs:documentation>
       <xs:enumeration value="aggressive"/>
     </xs:restriction>
   </xs:simpleType>
-
+  <xs:simpleType name="CollectionType">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Allowed collection types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="list"/>
+      <xs:enumeration value="paired"/>
+      <xs:enumeration value="list:list"/>
+      <xs:enumeration value="list:paired"/>
+    </xs:restriction>
+  </xs:simpleType>
 </xs:schema>

--- a/lib/galaxy/tool_util/xsd/galaxy.xsd
+++ b/lib/galaxy/tool_util/xsd/galaxy.xsd
@@ -1988,7 +1988,7 @@ This value is the same as the value of the ``name`` attribute of the
     </xs:attribute>
     <xs:attribute name="type" type="CollectionType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Expected collection type (e.g. ``list``, ``paired``, ``list:paired``, or ``list:list``).</xs:documentation>
+        <xs:documentation xml:lang="en">Expected collection type (``list`` or ``paired``), nested collections are specified as colon separated list (the most common types are ``list``, ``paired``, ``list:paired``, or ``list:list``).</xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="count" type="xs:integer">
@@ -3404,13 +3404,15 @@ file (use the file extension). Used only when the ``type`` attribute value is
 ``data`` or ``data_collection``.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="collection_type" type="CollectionType">
+        <xs:attribute name="collection_type" type="CollectionTypeList">
           <xs:annotation>
             <xs:documentation xml:lang="en"><![CDATA[
-Restrict the kind of collection that can be consumed by this parameter (e.g.
-``paired``, ``list:paired``, ``list``, ``list:list``). Multiple such collection types can be
-specified here as a comma-separated list. Used only when the ``type`` attribute
-value is ``data_collection``.
+Restrict the kind of collection that can be consumed by this parameter. Simple
+collections are either ``list`` or ``paired``), nested collections are specified
+as colon separated list of simple collection types (the most common types are
+``list``, ``paired``, ``list:paired``, or ``list:list``). Multiple such
+collection types can be specified here as a comma-separated list. Used only when
+the ``type`` attribute value is ``data_collection``.
               ]]></xs:documentation>
           </xs:annotation>
         </xs:attribute>
@@ -5078,7 +5080,12 @@ Creating collections in tools is covered in-depth in
     <xs:attributeGroup ref="OutputCollectionAttributes"/>
     <xs:attribute name="type" type="CollectionType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Collection type for output (e.g. ``paired``, ``list``, ``list:paired`` or ``list:list``).</xs:documentation>
+        <xs:documentation xml:lang="en"><![CDATA[
+Collection type for output. Simple collection types are either ``list`` or
+``paired``, nested collections are specified as colon separated list of simple
+collection types (the most common types are ``list``, ``paired``,
+``list:paired``, or ``list:list``).
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="type_source" type="xs:string">
@@ -5112,9 +5119,14 @@ This tag describes an output to the tool.
         <xs:documentation xml:lang="en">In expression tools, use this to specify a dictionary value to populate this output from. The semantics may change for other expression types in the future.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-    <xs:attribute name="collection_type" type="xs:string">
+    <xs:attribute name="collection_type" type="CollectionType">
       <xs:annotation>
-        <xs:documentation xml:lang="en">Collection type for output (e.g. ``paired``, ``list``, ``list:paired``, or ``list:list``).</xs:documentation>
+        <xs:documentation xml:lang="en"><![CDATA[
+Collection type for output. Simple collection types are either ``list`` or
+``paired``, nested collections are specified as colon separated list of simple
+collection types (the most common types are ``list``, ``paired``,
+``list:paired``, or ``list:list``).
+        ]]></xs:documentation>
       </xs:annotation>
     </xs:attribute>
     <xs:attribute name="collection_type_source" type="xs:string">
@@ -6905,10 +6917,15 @@ is the only supported options.</xs:documentation>
       <xs:documentation xml:lang="en">Allowed collection types</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:enumeration value="list"/>
-      <xs:enumeration value="paired"/>
-      <xs:enumeration value="list:list"/>
-      <xs:enumeration value="list:paired"/>
+      <xs:pattern value="(list|paired)([:](list|paired))*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CollectionTypeList">
+    <xs:annotation>
+      <xs:documentation xml:lang="en">Allowed collection types</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(list|paired)([:,](list|paired))*"/>
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
in `TestOutputCollection`, `InputType`, `OutputCollection`

and add new CollectionType

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
