### PR TITLE
Add isort config to pyproject.toml

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+force_alphabetical_sort_within_sections=true
+multi_line_output=3
+force_grid_wrap=2
+include_trailing_comma=true
+src_paths=lib
+known_first_party=galaxy_test
+no_lines_before=LOCALFOLDER
+reverse_relative=true
+skip_gitignore=true
+line_length=200

--- a/lib/galaxy/util/__init__.py
+++ b/lib/galaxy/util/__init__.py
@@ -38,35 +38,33 @@ from urllib.parse import (
 )
 
 import requests
+from boltons.iterutils import (
+    default_enter,
+    remap,
+)
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 try:
     import grp
 except ImportError:
     # For Pulsar on Windows (which does not use the function that uses grp)
     grp = None  # type: ignore[assignment]
-from boltons.iterutils import (
-    default_enter,
-    remap,
-)
+try:
+    import uwsgi
+except ImportError:
+    uwsgi = None
 LXML_AVAILABLE = True
 try:
     from lxml import etree
 except ImportError:
     LXML_AVAILABLE = False
     import xml.etree.ElementTree as etree  # type: ignore[assignment,no-redef]
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
 try:
     import docutils.core as docutils_core
     import docutils.writers.html4css1 as docutils_html4css1
 except ImportError:
     docutils_core = None  # type: ignore[assignment]
     docutils_html4css1 = None  # type: ignore[assignment]
-
-try:
-    import uwsgi
-except ImportError:
-    uwsgi = None
 
 from .custom_logging import get_logger
 from .inflection import Inflector

--- a/lib/galaxy/util/path/__init__.py
+++ b/lib/galaxy/util/path/__init__.py
@@ -6,10 +6,6 @@ import imp
 import logging
 import shlex
 from functools import partial
-try:
-    from grp import getgrgid
-except ImportError:
-    getgrgid = None  # type: ignore[assignment]
 from itertools import starmap
 from operator import getitem
 from os import (
@@ -34,10 +30,14 @@ from os.path import (
 )
 from pathlib import Path
 try:
+    from grp import getgrgid
+except ImportError:
+    getgrgid = None  # type: ignore[assignment]
+
+try:
     from pwd import getpwuid
 except ImportError:
     getpwuid = None  # type: ignore[assignment]
-
 
 import galaxy.util
 

--- a/lib/galaxy/util/yaml_util.py
+++ b/lib/galaxy/util/yaml_util.py
@@ -3,11 +3,11 @@ import os
 from collections import OrderedDict
 
 import yaml
+from yaml.constructor import ConstructorError
 try:
     from yaml import CSafeLoader as SafeLoader
 except ImportError:
     from yaml import SafeLoader  # type: ignore[misc]
-from yaml.constructor import ConstructorError
 
 
 log = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,15 +118,3 @@ testfixtures = "*"
 tuspy = "*"
 twill = "*"
 watchdog = "*"
-
-[tool.isort]
-force_alphabetical_sort_within_sections = true
-multi_line_output = 3
-force_grid_wrap = 2
-include_trailing_comma = true
-src_paths = ['lib']
-known_first_party = ['galaxy_test']
-no_lines_before = ['LOCALFOLDER']
-reverse_relative = true
-skip_gitignore = true
-line_length = 200

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,14 @@ testfixtures = "*"
 tuspy = "*"
 twill = "*"
 watchdog = "*"
+
+[tool.isort]
+force_alphabetical_sort_within_sections = true
+multi_line_output = 3
+force_grid_wrap = 2
+include_trailing_comma = true
+src_paths = ['lib']
+known_first_party = ['galaxy_test']
+no_lines_before = ['LOCALFOLDER']
+reverse_relative = true
+skip_gitignore = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,3 +129,4 @@ known_first_party = ['galaxy_test']
 no_lines_before = ['LOCALFOLDER']
 reverse_relative = true
 skip_gitignore = true
+line_length = 200

--- a/test/unit/webapps/test_request_scoped_sqlalchemy_sessions.py
+++ b/test/unit/webapps/test_request_scoped_sqlalchemy_sessions.py
@@ -9,7 +9,6 @@ import pytest
 from fastapi import FastAPI
 from fastapi.param_functions import Depends
 from httpx import AsyncClient
-pytest.importorskip("starlette_context")
 from starlette_context import context as request_context
 
 from galaxy.app_unittest_utils.galaxy_mock import MockApp


### PR DESCRIPTION
Manually fixing the import order is quite the chore. With this config you can just run isort and our flake8 config will be happy.
The first 2 commits were necessary to prevent the isort result from being invalid with our flake8 config.
You can see the result of running this on the whole codebase here: https://github.com/mvdbeek/galaxy/commit/14a96ccab7282c4926326e6af24ed93e2e2ba4b0

I don't think we need to run this on the whole codebase now (though I wouldn't mind), instead we can put this in a pre-commit, have vscode do it, etc.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
