### PR TITLE
Maintain redirect if login is necessary

### DIFF
--- a/lib/galaxy/web/framework/decorators.py
+++ b/lib/galaxy/web/framework/decorators.py
@@ -82,9 +82,15 @@ def require_login(verb="perform this action", use_panels=False):
             if trans.get_user():
                 return func(self, trans, *args, **kwargs)
             else:
+                redirect_url = url_for(controller=trans.controller, action=trans.action)
+                query_string = trans.environ.get('QUERY_STRING', '')
+                if query_string:
+                    redirect_url = f"{redirect_url}?{query_string}"
+                href = url_for(controller='login', redirect=redirect_url)
                 return trans.show_error_message(
-                    'You must be <a target="galaxy_main" href="%s">logged in</a> to %s.'
-                    % (url_for(controller='login'), verb), use_panels=use_panels)
+                    f'You must be <a target="galaxy_main" href="{href}">logged in</a> to {verb}.',
+                    use_panels=use_panels
+                )
         return decorator
     return argcatcher
 

--- a/lib/galaxy/webapps/galaxy/api/users.py
+++ b/lib/galaxy/webapps/galaxy/api/users.py
@@ -276,6 +276,9 @@ class UserAPIController(BaseGalaxyAPIController, UsesTagsMixin, BaseUIController
     # TODO: move to more basal, common resource than this
     def anon_user_api_value(self, trans):
         """Return data for an anonymous user, truncated to only usage and quota_percent"""
+        if not trans.user and not trans.history:
+            # Can't return info about this user, may not have a history yet.
+            return {}
         usage = trans.app.quota_agent.get_usage(trans)
         percent = trans.app.quota_agent.get_percent(trans=trans, usage=usage)
         return {'total_disk_usage': int(usage),

--- a/lib/galaxy/webapps/galaxy/controllers/dataset.py
+++ b/lib/galaxy/webapps/galaxy/controllers/dataset.py
@@ -443,7 +443,7 @@ class DatasetInterface(BaseUIController, UsesAnnotations, UsesItemRatings, UsesE
         """ Import another user's dataset via a shared URL; dataset is added to user's current history. """
         # Set referer message.
         referer = trans.request.referer
-        if referer:
+        if referer and not referer.startswith(f"{trans.request.application_url}{url_for('/login')}"):
             referer_message = f"<a href='{escape(referer)}'>return to the previous page</a>"
         else:
             referer_message = f"<a href='{url_for('/')}'>go to Galaxy's start page</a>"

--- a/lib/galaxy/webapps/galaxy/controllers/visualization.py
+++ b/lib/galaxy/webapps/galaxy/controllers/visualization.py
@@ -383,7 +383,7 @@ class VisualizationController(BaseUIController, SharableMixin, UsesVisualization
         """ Import a visualization into user's workspace. """
         # Set referer message.
         referer = trans.request.referer
-        if referer:
+        if referer and not referer.startswith(f"{trans.request.application_url}{web.url_for('/login')}"):
             referer_message = f"<a href='{escape(referer)}'>return to the previous page</a>"
         else:
             referer_message = f"<a href='{web.url_for('/')}'>go to Galaxy's start page</a>"

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -394,7 +394,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         """Imports a workflow shared by other users."""
         # Set referer message.
         referer = trans.request.referer
-        if referer:
+        if referer and not referer.startswith(f"{trans.request.application_url}{url_for('/login')}"):
             referer_message = f"<a href='{escape(referer)}'>return to the previous page</a>"
         else:
             referer_message = f"<a href='{url_for('/')}'>go to Galaxy's start page</a>"

--- a/lib/galaxy_test/selenium/test_workflow_sharing.py
+++ b/lib/galaxy_test/selenium/test_workflow_sharing.py
@@ -1,0 +1,31 @@
+from galaxy_test.base.workflow_fixtures import WORKFLOW_SIMPLE_CAT_TWICE
+from .framework import (
+    selenium_test,
+    SeleniumTestCase,
+)
+
+
+class WorkflowSharingTestCase(SeleniumTestCase):
+
+    ensure_registered = True
+
+    @selenium_test
+    def test_share_workflow_with_login_redirect(self):
+        user_email = self.get_logged_in_user()["email"]
+        workflow_id = self.workflow_populator.upload_yaml_workflow(WORKFLOW_SIMPLE_CAT_TWICE)
+        self.logout()
+        sharing_url = f"workflow/sharing?id={workflow_id}"
+        self.get(sharing_url)
+        modal = self.components._.messages.error.wait_for_present()
+        assert modal.text == 'You must be logged in to Share or export Galaxy workflows.'
+        login_link = modal.find_element_by_tag_name('a')
+        assert login_link.text == 'logged in'
+        self.sleep_for(self.wait_types.UX_RENDER)
+        login_link.click()
+        form = self.wait_for_visible(self.navigation.login.selectors.form)
+        self.fill(form, {'login': user_email, 'password': self.default_password})
+        self.wait_for_and_click(self.navigation.login.selectors.submit)
+        self.wait_for_logged_in()
+        accessible_via_link_button = self.wait_for_selector('.make-accessible')
+        accessible_via_link_button.click()
+        self.wait_for_xpath('//strong[text()="accessible via link"]')

--- a/templates/webapps/galaxy/workflow/sharing.mako
+++ b/templates/webapps/galaxy/workflow/sharing.mako
@@ -177,11 +177,11 @@
             %else:
                 <p>This ${item_class_name_lc} is currently restricted so that only you and the users listed below can access it.</p>
                 <form action="${h.url_for(controller=controller_name, action='sharing', id=trans.security.encode_id(item.id) )}" method="POST">
-                    <input class="action-button" type="submit" name="make_accessible_via_link" value="Make ${item_class_name} Accessible via Link">
+                    <input class="action-button make-accessible" type="submit" name="make_accessible_via_link" value="Make ${item_class_name} Accessible via Link">
                     <div class="toolParamHelp">Generates a web link that you can share with other people so that they can view and import the ${item_class_name_lc}.</div>
 
                     <br />
-                    <input class="action-button" type="submit" name="make_accessible_and_publish" value="Make ${item_class_name} Accessible and Publish" method="POST">
+                    <input class="action-button make-publishable" type="submit" name="make_accessible_and_publish" value="Make ${item_class_name} Accessible and Publish" method="POST">
                     <div class="toolParamHelp">
                         Makes the ${item_class_name_lc} accessible via link (see above) and publishes the ${item_class_name_lc} to Galaxy's <a href='${h.url_for('/workflows/list_published')}' target='_top'>Published ${item_class_plural_name}</a> section, where it is publicly listed and searchable.
                     </div>


### PR DESCRIPTION
Which enables https://github.com/galaxyproject/galaxy/issues/12735.
Includes a new selenium test that exercises this functionality.
For the test I also had to fix a subtle bug when a user with a
Galaxy session but no history attempts to hit /api/users/current.
This seems to have been a problem previously as well
(https://github.com/galaxyproject/galaxy/blob/5210377c3f163220b48f1ee4f5ac8d8cd0c2b0e0/lib/galaxy/quota/__init__.py#L226)
and for this instance I don't see a problem returning an empty
dictionary, as the response is inconsisten between anon users
and logged in users anyway.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
