### PR TITLE
Add test that verifies invocation non-optional text parameter handling

### DIFF
--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2605,6 +2605,18 @@ text_input:
             jobs = self._history_jobs(history_id)
             assert len(jobs) == 1
 
+    def test_run_with_required_text_parameter_not_provided_fails(self):
+        with self.dataset_populator.test_history() as history_id:
+            try:
+                self._run_workflow("""
+class: GalaxyWorkflow
+inputs:
+  text_input: text
+steps: []
+""", assert_ok=True, history_id=history_id)
+            except AssertionError as e:
+                assert '(text_input) is not optional' in str(e)
+
     def test_run_with_int_parameter(self):
         with self.dataset_populator.test_history() as history_id:
             failed = False


### PR DESCRIPTION
We didn't test required text parameters, so this just fills the gap in testing. xref: https://github.com/galaxyproject/galaxy/issues/13220

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
