### PR TITLE
[22.01] Improve null value handling

### DIFF
--- a/client/src/components/Common/ButtonSpinner.vue
+++ b/client/src/components/Common/ButtonSpinner.vue
@@ -2,7 +2,13 @@
     <b-button v-if="wait" variant="info" disabled>
         <font-awesome-icon icon="spinner" class="mr-2" spin />Please wait...
     </b-button>
-    <b-button v-else variant="primary" v-b-tooltip.hover.bottom :title="tooltip" @click="$emit('onClick')">
+    <b-button
+        v-else
+        variant="primary"
+        v-b-tooltip.hover.bottom
+        :title="tooltip"
+        :disabled="disabled"
+        @click="$emit('onClick')">
         <font-awesome-icon icon="check" class="mr-2" />{{ title }}
     </b-button>
 </template>
@@ -30,6 +36,10 @@ export default {
         tooltip: {
             type: String,
             default: null,
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
         },
     },
 };

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -2,9 +2,15 @@
     <div>
         <div class="h4 clearfix mb-3">
             <b>Workflow: {{ model.name }}</b>
-            <ButtonSpinner class="float-right" title="Run Workflow" id="run-workflow" @onClick="onExecute" />
+            <ButtonSpinner
+                class="float-right"
+                title="Run Workflow"
+                id="run-workflow"
+                :disabled="runButtonDisabled"
+                :tooltip="errorMessage"
+                @onClick="onExecute" />
         </div>
-        <b-alert v-if="!!errorMessage" variant="info" show>
+        <b-alert v-if="!!errorMessage" variant="info" class="validation-error" show>
             {{ errorMessage }}
         </b-alert>
         <FormDisplay :inputs="formInputs" @onChange="onChange" @onValidation="onValidation" />
@@ -73,6 +79,9 @@ export default {
                 this.inputTypes[stepName] = step.step_type;
             });
             return inputs;
+        },
+        runButtonDisabled() {
+            return this.errorMessage !== null;
         },
     },
     methods: {

--- a/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
+++ b/client/src/components/Workflow/Run/WorkflowRunFormSimple.vue
@@ -4,7 +4,10 @@
             <b>Workflow: {{ model.name }}</b>
             <ButtonSpinner class="float-right" title="Run Workflow" id="run-workflow" @onClick="onExecute" />
         </div>
-        <FormDisplay :inputs="formInputs" @onChange="onChange" />
+        <b-alert v-if="!!errorMessage" variant="info" show>
+            {{ errorMessage }}
+        </b-alert>
+        <FormDisplay :inputs="formInputs" @onChange="onChange" @onValidation="onValidation" />
         <!-- Options to default one way or the other, disable if admins want, etc.. -->
         <a href="#" @click="$emit('showAdvanced')">Expand to full workflow form.</a>
     </div>
@@ -38,6 +41,7 @@ export default {
     },
     data() {
         return {
+            errorMessage: null,
             formData: {},
             inputTypes: {},
         };
@@ -72,10 +76,18 @@ export default {
         },
     },
     methods: {
+        onValidation(validationError) {
+            this.errorMessage = validationError
+                ? "Please address the issues highlighted below before proceeding."
+                : null;
+        },
         onChange(data) {
             this.formData = data;
         },
         onExecute() {
+            if (this.errorMessage) {
+                return;
+            }
             const replacementParams = {};
             const inputs = {};
             for (const inputName in this.formData) {

--- a/client/src/mvc/ui/ui-misc.js
+++ b/client/src/mvc/ui/ui-misc.js
@@ -86,7 +86,8 @@ export var Input = Backbone.View.extend({
         input: "_onchange",
     },
     value: function (new_val) {
-        new_val !== undefined && this.model.set("value", typeof new_val === "string" ? new_val : "");
+        new_val !== undefined &&
+            this.model.set("value", new_val === null || typeof new_val === "string" ? new_val : "");
         return this.model.get("value");
     },
     render: function () {

--- a/lib/galaxy/selenium/navigates_galaxy.py
+++ b/lib/galaxy/selenium/navigates_galaxy.py
@@ -1217,7 +1217,7 @@ class NavigatesGalaxy(HasDriver):
             self.send_enter(tag_area)
 
     def workflow_run_submit(self):
-        self.wait_for_and_click_selector("button.btn-primary")
+        self.wait_for_and_click_selector("#run-workflow")
 
     def workflow_create_new(self, annotation=None, clear_placeholder=False):
         self.workflow_index_open()

--- a/lib/galaxy/selenium/navigation.yml
+++ b/lib/galaxy/selenium/navigation.yml
@@ -524,6 +524,8 @@ workflow_run:
     input_data_div: "[step-label='${label}'] .select2-container"
     # TODO: put step labels in the DOM ideally
     subworkflow_step_icon: ".portlet-title-icon.fa-sitemap"
+    run_workflow: "#run-workflow"
+    validation_error: ".validation-error"
 
 workflow_editor:
 

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -326,11 +326,7 @@ class SimpleTextToolParameter(ToolParameter):
 
     def to_json(self, value, app, use_security):
         """Convert a value to a string representation suitable for persisting"""
-        if value is None:
-            rval = '' if not self.optional else None
-        else:
-            rval = unicodify(value)
-        return rval
+        return unicodify(value)
 
     def get_initial_value(self, trans, other_values):
         return self.value

--- a/lib/galaxy/tools/parameters/validation.py
+++ b/lib/galaxy/tools/parameters/validation.py
@@ -737,7 +737,9 @@ class EmptyTextfieldValidator(Validator):
         return cls(message, negate)
 
     def validate(self, value, trans=None):
-        super().validate(value != '')
+        # Ideally the empty string validator should only check against an actual empty string,
+        # but the fill_defaults logic will store the result of `get_initial_value``, which is None.
+        super().validate(value not in ('', None))
 
 
 class MetadataInFileColumnValidator(Validator):

--- a/lib/galaxy/webapps/galaxy/controllers/workflow.py
+++ b/lib/galaxy/webapps/galaxy/controllers/workflow.py
@@ -429,7 +429,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
         stored = self.get_stored_workflow(trans, id)
         if new_annotation:
             # Sanitize annotation before adding it.
-            new_annotation = sanitize_html(new_annotation)
+            new_annotation = sanitize_html(new_annotation or '')
             self.add_item_annotation(trans.sa_session, trans.get_user(), stored, new_annotation)
             trans.sa_session.flush()
             return new_annotation
@@ -572,7 +572,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             workflow.stored_workflow = stored_workflow
             stored_workflow.latest_workflow = workflow
             # Add annotation.
-            workflow_annotation = sanitize_html(workflow_annotation)
+            workflow_annotation = sanitize_html(workflow_annotation or '')
             self.add_item_annotation(trans.sa_session, trans.get_user(), stored_workflow, workflow_annotation)
             # Persist
             session = trans.sa_session
@@ -598,7 +598,7 @@ class WorkflowController(BaseUIController, SharableMixin, UsesStoredWorkflowMixi
             workflow.stored_workflow = stored_workflow
             stored_workflow.latest_workflow = workflow
             # Add annotation.
-            workflow_annotation = sanitize_html(workflow_annotation)
+            workflow_annotation = sanitize_html(workflow_annotation or '')
             self.add_item_annotation(trans.sa_session, trans.get_user(), stored_workflow, workflow_annotation)
 
             # Persist

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -865,9 +865,9 @@ class InputParameterModule(WorkflowModule):
             )
             if param_type == "text":
                 if parameter_type == "text":
-                    text_default = parameter_def.get("default") or ""
+                    text_default = parameter_def.get("default")
                 else:
-                    text_default = ""
+                    text_default = None
                 default_source["value"] = text_default
                 input_default_value: Union[
                     TextToolParameter,

--- a/lib/galaxy/workflow/run_request.py
+++ b/lib/galaxy/workflow/run_request.py
@@ -89,10 +89,17 @@ def _normalize_inputs(steps, inputs, inputs_by):
         # start to ensure tool state is being preserved and loaded in a type safe way.
         assert isinstance(optional, bool)
         if not inputs_key and default_value is None and not optional:
-            message = f"Workflow cannot be run because an expected input step '{step.id}' ({step.label}) is not optional and no input."
+            message = f"Workflow cannot be run because an expected input step '{step.order_index}' ({step.label}) is not optional and no input."
             raise exceptions.MessageException(message)
         if inputs_key:
-            normalized_inputs[step.id] = inputs[inputs_key]
+            input_value = inputs[inputs_key]
+            if input_value is None and default_value is None and not optional:
+                # We've got a null value in a required parameter.
+                # I can't think of a situation where this should be valid,
+                # so let's fail early here
+                message = f"Workflow cannot be run because an expected input step '{step.order_index}' ({step.label}) is not optional and input is null."
+                raise exceptions.MessageException(message)
+            normalized_inputs[step.id] = input_value
     return normalized_inputs
 
 

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2617,6 +2617,22 @@ steps: []
             except AssertionError as e:
                 assert '(text_input) is not optional' in str(e)
 
+    def test_run_with_required_text_parameter_null_fails(self):
+        with self.dataset_populator.test_history() as history_id:
+            try:
+                self._run_workflow("""
+class: GalaxyWorkflow
+inputs:
+  text_input: text
+steps: []
+""", test_data="""
+text_input:
+  value: null
+  type: raw
+""", assert_ok=True, history_id=history_id)
+            except AssertionError as e:
+                assert '(text_input) is not optional' in str(e)
+
     def test_run_with_int_parameter(self):
         with self.dataset_populator.test_history() as history_id:
             failed = False

--- a/lib/galaxy_test/api/test_workflows.py
+++ b/lib/galaxy_test/api/test_workflows.py
@@ -2605,6 +2605,18 @@ text_input:
             jobs = self._history_jobs(history_id)
             assert len(jobs) == 1
 
+    def test_run_with_required_text_parameter_not_provided_fails(self):
+        with self.dataset_populator.test_history() as history_id:
+            try:
+                self._run_workflow("""
+class: GalaxyWorkflow
+inputs:
+  text_input: text
+steps: []
+""", assert_ok=True, history_id=history_id)
+            except AssertionError as e:
+                assert '(text_input) is not optional' in str(e)
+
     def test_run_with_int_parameter(self):
         with self.dataset_populator.test_history() as history_id:
             failed = False

--- a/lib/galaxy_test/selenium/test_workflow_run.py
+++ b/lib/galaxy_test/selenium/test_workflow_run.py
@@ -228,6 +228,19 @@ steps:
         history_id = self.current_history_id()
         self.workflow_populator.wait_for_history_workflows(history_id, expected_invocation_count=1)
 
+    @selenium_test
+    def test_simple_workflow_run_form_validation_required_text_param(self):
+        workflow_id = self.workflow_populator.upload_yaml_workflow("""
+class: GalaxyWorkflow
+inputs:
+  text_input: text
+steps: []
+""")
+        self.simplified_workflow_run_by_id(workflow_id)
+        run_button = self.components.workflow_run.run_workflow.wait_for_visible()
+        assert run_button.get_attribute('disabled') == 'true'
+        self.components.workflow_run.validation_error.wait_for_visible()
+
     def open_in_workflow_run(self, yaml_content):
         name = self.workflow_upload_yaml_with_random_name(yaml_content)
         self.workflow_run_with_name(name)
@@ -253,6 +266,9 @@ steps:
         self.workflow_index_open()
         self.workflow_index_search_for(name)
         self.workflow_click_option(".workflow-run")
+
+    def simplified_workflow_run_by_id(self, workflow_id):
+        self.get(f"workflows/run?id={workflow_id}&simplified_workflow_run_ui=prefer")
 
     def _assert_has_3_lines_after_run(self, hid):
         if self.is_beta_history():


### PR DESCRIPTION
With these changes, required text parameters without a value are properly highlighted in the workflow run form, a warning is shown in the form and the run workflow button is disabled. Of course we still don't properly discriminate null from text, so once you click into the text field the run form will send `""` as the value ... but at least you've been warned.

<img width="622" alt="Screenshot 2022-02-01 at 15 33 02" src="https://user-images.githubusercontent.com/6804901/151987778-dbf9e370-21f3-48e0-8406-5cf53d693c57.png">

(That's an old screenshot showing the backend response, you can't submit this anymore after 3f3de358cd931c01501fa18683cd817ad521bde7)

I think this largely fixes https://github.com/galaxyproject/galaxy/issues/13220, with the caveat mentioned above.
Maybe we should just not allow submitting required parameters with `""` as the value ... ?

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
