### PR TITLE
[21.09] Fix dataset details and drag and drop

### DIFF
--- a/client/src/mvc/dataset/dataset-li-edit.js
+++ b/client/src/mvc/dataset/dataset-li-edit.js
@@ -59,7 +59,7 @@ var DatasetListItemEdit = _super.extend(
 
             var editBtnData = {
                 title: _l("Edit attributes"),
-                href: `${getAppRoot()}datasets/edit?dataset_id=${this.model.attributes.id}`,
+                href: `${getAppRoot()}datasets/edit?dataset_id=${this.model.get("element_id") || this.model.get("id")}`,
                 faIcon: "fa-pencil",
                 classes: "edit-btn",
                 onclick: function (ev) {
@@ -226,7 +226,9 @@ var DatasetListItemEdit = _super.extend(
             var self = this;
             return faIconButton({
                 title: _l("View or report this error"),
-                href: `${getAppRoot()}datasets/error?dataset_id=${this.model.attributes.id}`,
+                href: `${getAppRoot()}datasets/error?dataset_id=${
+                    self.model.get("element_id") || self.model.get("id")
+                }`,
                 classes: "report-error-btn",
                 faIcon: "fa-bug",
                 onclick: function (ev) {
@@ -234,7 +236,7 @@ var DatasetListItemEdit = _super.extend(
                     if (Galaxy.router) {
                         ev.preventDefault();
                         Galaxy.router.push("datasets/error", {
-                            dataset_id: self.model.attributes.id,
+                            dataset_id: self.model.get("element_id") || self.model.get("id"),
                         });
                     }
                 },
@@ -283,7 +285,7 @@ var DatasetListItemEdit = _super.extend(
                 return null;
             }
             if (visualizations.length >= 1) {
-                const dsid = this.model.get("id");
+                const dsid = this.model.get("element_id") || this.model.get("id");
                 const url = getAppRoot() + "visualizations?dataset_id=" + dsid;
                 return faIconButton({
                     title: _l("Visualize this data"),

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -279,8 +279,9 @@ export var DatasetListItemView = _super.extend(
                 target: this.linkTarget,
                 faIcon: "fa-info-circle",
                 onclick: (ev) => {
+                    console.log("model", this.model);
                     const Galaxy = getGalaxyInstance();
-                    const showDetailsUrl = `/datasets/${this.model.get("id")}/details`;
+                    const showDetailsUrl = `/datasets/${this.model.get("element_id") || this.model.get("id")}/details`;
                     if (Galaxy.frame && Galaxy.frame.active) {
                         ev.preventDefault();
                         Galaxy.frame.add({
@@ -290,7 +291,7 @@ export var DatasetListItemView = _super.extend(
                     } else if (Galaxy.router) {
                         ev.preventDefault();
                         Galaxy.router.push(showDetailsUrl);
-                        Galaxy.trigger("activate-hda", this.model.get("id"));
+                        Galaxy.trigger("activate-hda", this.model.get("element_id") || this.model.get("id"));
                     }
                 },
             });

--- a/client/src/mvc/dataset/dataset-li.js
+++ b/client/src/mvc/dataset/dataset-li.js
@@ -279,7 +279,6 @@ export var DatasetListItemView = _super.extend(
                 target: this.linkTarget,
                 faIcon: "fa-info-circle",
                 onclick: (ev) => {
-                    console.log("model", this.model);
                     const Galaxy = getGalaxyInstance();
                     const showDetailsUrl = `/datasets/${this.model.get("element_id") || this.model.get("id")}/details`;
                     if (Galaxy.frame && Galaxy.frame.active) {

--- a/client/src/mvc/ui/ui-select-content.js
+++ b/client/src/mvc/ui/ui-select-content.js
@@ -513,6 +513,9 @@ const View = Backbone.View.extend({
             if (values.length > 0) {
                 let data_changed = false;
                 _.each(values, (v) => {
+                    // element_id deals with override in old backbone code,
+                    // can remove when old history is deprecated
+                    v.id = v.element_id || v.id;
                     self._patchValue(v);
                     const new_id = v.id;
                     const new_src = (v.src = this._getSource(v));


### PR DESCRIPTION
Fixes #12911 and an issue that @Delphine-L reported where the "View details" button on currently running datasets in a collection point to the wrong dataset id. 

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:

Run a collection job that sleeps for a while and make sure the view details page makes sense.
Haven't included tests here since this is very specific to the backbone view and we're not going to do this magic in vue.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
