### PR TITLE
[22.01] Make tag filter input optional

### DIFF
--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -744,7 +744,7 @@ class InputDataModule(InputModule):
     def get_inputs(self):
         parameter_def = self._parse_state_into_dict()
         tag = parameter_def["tag"]
-        tag_source = dict(name="tag", label="Tag filter", type="text", value=tag, help="Tags to automatically filter inputs")
+        tag_source = dict(name="tag", label="Tag filter", type="text", optional="true", value=tag, help="Tags to automatically filter inputs")
         input_tag = TextToolParameter(None, tag_source)
         optional = parameter_def["optional"]
         inputs = {}


### PR DESCRIPTION
Minor followup to https://github.com/galaxyproject/galaxy/pull/12930, we probably don't want to have the input field highlight this as required.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
