### PR TITLE
Add documentation for MetadataElement

### DIFF
--- a/doc/source/dev/data_types.md
+++ b/doc/source/dev/data_types.md
@@ -255,7 +255,7 @@ from `dataset.metadata.number_of_sequences`.
 - `default` (default is `None`): the default value that is set if neither
   `set_meta` (see below) nor the user (if allowed, see `readonly`) has set a value
 - `no_value` (defaults to `None`): a value that indicates that the metadata has
-  not been set. In most cases `no_value` should be an invalid value, in particulat
+  not been set. In most cases `no_value` should be an invalid value, in particular
   one that can not be set by `set_meta`. In general `no_value` should be
   different from `default`. Having a `no_value` different from `None` can be of
   interest for user editable metadata (see `readonly`) - a good example is
@@ -263,8 +263,9 @@ from `dataset.metadata.number_of_sequences`.
   
   1. for the metadata validator that verifies that all mandatory metadata data is
      set (note that such a validator is added implicitly for all dataset
-     parameters), 
-  2. For metadata filters (applied to dynamic options), where unset
+     parameters),
+  2. `no_value` is used in the Cheetah code for metadata whose value is `None`
+  3. For metadata filters (applied to dynamic options), where unset
      metadata is ignored.  
 
 - `optional` (default `False`): determines if it is OK that metadata is unset, in
@@ -272,6 +273,9 @@ from `dataset.metadata.number_of_sequences`.
 - `visible` (default `True`): determines if the metadata element is visible to the user
 - `readonly` (default `False`): determines if the user can change the value. 
 - `set_in_upload` (default `False`)
+- `param` ??? e.g. `param=FileParameter`
+- `file_ext` ??? 
+
 
 There are a couple relevant functions you'll want to override here:
 

--- a/doc/source/dev/data_types.md
+++ b/doc/source/dev/data_types.md
@@ -246,14 +246,34 @@ entries inside your class like this:
 class GenBank(data.Text):
     file_ext = "genbank"
 
-    MetadataElement(name="number_of_sequences", default=0, desc="Number of sequences", readonly=True, visible=True, optional=True, no_value=0)
+    MetadataElement(name="number_of_sequences", default=0, desc="Number of sequences", readonly=True, visible=True, optional=True, no_value="?")
 ```
 
-Here we have a `MetadataElement`, accessible in
-methods with a dataset parameter from
-`dataset.metadata.number_of_sequences`. There are a
-couple relevant functions you'll want to override
-here:
+Here we have a `MetadataElement`, accessible in methods with a dataset parameter
+from `dataset.metadata.number_of_sequences`. 
+
+- `default` (default is `None`): the default value that is set if neither
+  `set_meta` (see below) nor the user (if allowed, see `readonly`) has set a value
+- `no_value` (defaults to `None`): a value that indicates that the metadata has
+  not been set. In most cases `no_value` should be an invalid value, in particulat
+  one that can not be set by `set_meta`. In general `no_value` should be
+  different from `default`. Having a `no_value` different from `None` can be of
+  interest for user editable metadata (see `readonly`) - a good example is
+  `dbkey` which has `no_value="?"`. `no_value` is relevant for instance:
+  
+  1. for the metadata validator that verifies that all mandatory metadata data is
+     set (note that such a validator is added implicitly for all dataset
+     parameters), 
+  2. For metadata filters (applied to dynamic options), where unset
+     metadata is ignored.  
+
+- `optional` (default `False`): determines if it is OK that metadata is unset, in
+  particular if the default metadata validator should ignore it.
+- `visible` (default `True`): determines if the metadata element is visible to the user
+- `readonly` (default `False`): determines if the user can change the value. 
+- `set_in_upload` (default `False`)
+
+There are a couple relevant functions you'll want to override here:
 
 *  ```python
    set_peek(self, dataset, is_multi_byte=False)

--- a/doc/source/dev/data_types.md
+++ b/doc/source/dev/data_types.md
@@ -273,7 +273,11 @@ from `dataset.metadata.number_of_sequences`.
 - `visible` (default `True`): determines if the metadata element is visible to the user
 - `readonly` (default `False`): determines if the user can change the value. 
 - `set_in_upload` (default `False`)
-- `param` ??? e.g. `param=FileParameter`
+- `param` ???
+   https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/model/metadata.py
+   SelectParameter, DBKeyParameter, RangeParameter, ColumnParameter,
+   ColumnParameter, ListParameter, DictParameter, PythonObjectParameter, FileParameter, 
+   e.g. `param=FileParameter`
 - `file_ext` ??? 
 
 


### PR DESCRIPTION
In https://github.com/galaxyproject/tools-iuc/issues/4367 we realised that documentation is missing for metadata elements of datasets. 

Places in the code corresponding to statements in the new docs:

`default`

- `default` is used if not set (by `set_meta` or the user): probably here:  https://github.com/galaxyproject/galaxy/blob/6df8d1ae5b54bbb0961576622066a3d2b95f6728/lib/galaxy/model/metadata.py#L73

`no_value`

-  in cheetah https://github.com/galaxyproject/galaxy/blob/6df8d1ae5b54bbb0961576622066a3d2b95f6728/lib/galaxy/tools/wrappers.py#L283
- metadata validator https://github.com/bernt-matthias/galaxy/blob/347e9fed2ea77576aebe5256151e8c493daacdd1/lib/galaxy/datatypes/data.py#L246 .. but this has been introduced recently https://github.com/galaxyproject/galaxy/pull/13139
- filter https://github.com/galaxyproject/galaxy/blob/6df8d1ae5b54bbb0961576622066a3d2b95f6728/lib/galaxy/tools/parameters/dynamic_options.py#L207

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
