### PR TITLE
[22.01] Limit required element validation to safe elements

### DIFF
--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -2537,7 +2537,9 @@ class RData(CompressedArchive):
     file_ext = 'rdata'
     check_required_metadata = True
 
-    MetadataElement(name="version", default=None, desc="serialisation version", param=MetadataParameter, readonly=True, visible=False, optional=False)
+    # Tools may in the past have output rdata files that are actually RDS files, and so parsing the version fails,
+    # that is why we have to keep optional="True".
+    MetadataElement(name="version", default=None, desc="serialisation version", param=MetadataParameter, readonly=True, visible=False, optional=True)
 
     def set_meta(self, dataset, overwrite=True, **kwd):
         super().set_meta(dataset, overwrite=overwrite, **kwd)

--- a/lib/galaxy/datatypes/binary.py
+++ b/lib/galaxy/datatypes/binary.py
@@ -2535,6 +2535,7 @@ class RData(CompressedArchive):
     VERSION_2_PREFIX = b'RDX2\nX\n'
     VERSION_3_PREFIX = b'RDX3\nX\n'
     file_ext = 'rdata'
+    check_required_metadata = True
 
     MetadataElement(name="version", default=None, desc="serialisation version", param=MetadataParameter, readonly=True, visible=False, optional=False)
 
@@ -2591,6 +2592,7 @@ class RDS(CompressedArchive):
     '3.5.0'
     """
     file_ext = 'rds'
+    check_required_metadata = True
 
     MetadataElement(name="version", default=None, desc="serialisation version", param=MetadataParameter, readonly=True, visible=False, optional=False)
     MetadataElement(name="rversion", default=None, desc="R version", param=MetadataParameter, readonly=True, visible=False, optional=False)

--- a/lib/galaxy/datatypes/data.py
+++ b/lib/galaxy/datatypes/data.py
@@ -243,7 +243,10 @@ class Data(metaclass=DataMeta):
                 continue
             if not check and len(skip) == 0 and dataset.metadata.spec[key].get("optional"):
                 continue  # we skip check for optional and nonrequested values here
-            if not dataset.metadata.element_is_set(key):
+            if not dataset.metadata.element_is_set(key) and (check or dataset.metadata.spec[key].check_required_metadata):
+                # FIXME: Optional metadata isn't always properly annotated,
+                # so skip check if check_required_metadata is false on the datatype that defined the metadata element.
+                # See https://github.com/galaxyproject/tools-iuc/issues/4367
                 return key
         return False
 

--- a/lib/galaxy/datatypes/interval.py
+++ b/lib/galaxy/datatypes/interval.py
@@ -379,6 +379,7 @@ class Bed(Interval):
     file_ext = "bed"
     data_sources = {"data": "tabix", "index": "bigwig", "feature_search": "fli"}
     track_type = Interval.track_type
+    check_required_metadata = True
 
     column_names = ['Chrom', 'Start', 'End', 'Name', 'Score', 'Strand', 'ThickStart', 'ThickEnd', 'ItemRGB', 'BlockCount', 'BlockSizes', 'BlockStarts']
 

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -166,13 +166,12 @@ class MetadataCollection(Mapping):
         :returns: True if the value differes from the no_value
                   False if its equal of if no metadata with the name is specified
         """
+        meta_val = self[name]
         try:
-            meta_val = self[name]
+            meta_spec = self.parent.metadata.spec[name]
         except KeyError:
-            log.debug(f"no metadata with name {name} found")
+            log.debug(f"No metadata element with name '{name}' found")
             return False
-
-        meta_spec = self.parent.metadata.spec[name]
         return meta_val != meta_spec.no_value
 
     def get_metadata_parameter(self, name, **kwd):

--- a/lib/galaxy/model/metadata.py
+++ b/lib/galaxy/model/metadata.py
@@ -373,6 +373,11 @@ class MetadataElementSpec:
         self.param = param(self)
         # add spec element to the spec
         datatype.metadata_spec.append(self)
+        # Should we validate that non-optional elements have been set ?
+        # (The answer is yes, but not all datatypes control optionality appropriately at this point.)
+        # This allows us to check that inherited MetadataElement instances from datatypes that set
+        # check_required_metadata have been reviewed and considered really required.
+        self.check_required_metadata = datatype.__dict__.get('check_required_metadata', False)
 
     def get(self, name, default=None):
         return self.__dict__.get(name, default)

--- a/test/unit/data/datatypes/test_check_required.py
+++ b/test/unit/data/datatypes/test_check_required.py
@@ -1,0 +1,42 @@
+from galaxy.datatypes.data import Data
+from galaxy.datatypes.metadata import MetadataElement
+from galaxy.model import HistoryDatasetAssociation
+from galaxy.model.unittest_utils import GalaxyDataTestApp
+
+
+class CheckRequiredFalse(Data):
+    ext = 'false'
+    MetadataElement(name="columns", desc="Number of columns")
+
+
+class CheckRequiredTrue(Data):
+    ext = 'true'
+    check_required_metadata = True
+    MetadataElement(name="columns", desc="Number of columns")
+
+
+class CheckRequiredInherited(CheckRequiredTrue):
+    ext = 'inherited'
+    MetadataElement(name="something")
+
+
+def test_check_required_metadata_false():
+    app = GalaxyDataTestApp()
+    app.datatypes_registry.datatypes_by_extension['false'] = CheckRequiredFalse
+    hda = HistoryDatasetAssociation(sa_session=app.model.session, extension='false')
+    assert not hda.metadata.spec['columns'].check_required_metadata
+
+
+def test_check_required_metadata_true():
+    app = GalaxyDataTestApp()
+    app.datatypes_registry.datatypes_by_extension['true'] = CheckRequiredTrue
+    hda = HistoryDatasetAssociation(sa_session=app.model.session, extension='true')
+    assert hda.metadata.spec['columns'].check_required_metadata
+
+
+def test_check_required_metadata_inherited():
+    app = GalaxyDataTestApp()
+    app.datatypes_registry.datatypes_by_extension['inherited'] = CheckRequiredInherited
+    hda = HistoryDatasetAssociation(sa_session=app.model.session, extension='inherited')
+    assert hda.metadata.spec['columns'].check_required_metadata
+    assert not hda.metadata.spec['something'].check_required_metadata


### PR DESCRIPTION
There used to be a long-standing bug in setting up the `MetadataValidator` if default values were used. We fixed this in
[`e194ef9` (#13139)](https://github.com/galaxyproject/galaxy/pull/13139/commits/e194ef97e49c4947711ad1d20873ddc0aa686a66), but that means we're now checking for all non-optional values before running a tool. We have a ton of non-optional `MetadatElement` items in datatypes that should maybe be optional (an indication might be if `default` and `no_value` are specified and set to the same value ... but I'm not sure that's a 100% thing). So I think that reviewing this requires domain knowledge of the datatypes and what elements are really required, and I'm not sure we can do this in a timely fashion, and not break something that used to work.

So my suggestion is that we add `check_required_metadata=True` on datatypes for which we have checked that non-optional metadata elements are really non-optional. For those metadata elements for which this is not the case we skip the validation as we would do prior to [`e194ef9` (#13139)](https://github.com/galaxyproject/galaxy/pull/13139/commits/e194ef97e49c4947711ad1d20873ddc0aa686a66).

As an example I have marked  RDS and RData with `check_required_metadata` and added a test for `check_required_metadata`.

## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
