### PR TITLE
[21.09] Fix univa job runner setup without nativeSpecification

### DIFF
--- a/lib/galaxy/jobs/runners/univa.py
+++ b/lib/galaxy/jobs/runners/univa.py
@@ -80,7 +80,7 @@ class UnivaJobRunner(DRMAAJobRunner):
         if state in [self.drmaa.JobState.DONE, self.drmaa.JobState.FAILED]:
             # get configured job destination
             job_destination = ajs.job_wrapper.job_destination
-            native_spec = job_destination.params.get('nativeSpecification', None)
+            native_spec = job_destination.params.get('nativeSpecification', '')
             # determine time and memory that was granted for the job
             time_granted, mem_granted = _parse_native_specs(ajs.job_id, native_spec)
             time_wasted = extinfo["time_wasted"]


### PR DESCRIPTION
Fix for traceback:
```
Traceback (most recent call last):
  File "lib/galaxy/jobs/runners/__init__.py", line 707, in monitor
    self.check_watched_items()
  File "lib/galaxy/jobs/runners/drmaa.py", line 338, in check_watched_items
    if self._complete_terminal_job(ajs, drmaa_state=state) is not None:
  File "lib/galaxy/jobs/runners/univa.py", line 85, in _complete_terminal_job
    time_granted, mem_granted = _parse_native_specs(ajs.job_id, native_spec)
  File "lib/galaxy/jobs/runners/univa.py", line 572, in _parse_native_specs
    m = re.search(r"rt=([0-9:]+)[\s,]*", native_spec)
  File "/pool/spare/galaxy/galaxy/.venv/lib64/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```

See https://github.com/galaxyproject/galaxy/issues/13297 reported by @ajs6f fix from @mvdbeek


## How to test the changes?
- [ ] This is a refactoring of components with existing test coverage.


## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
