### PR TITLE
[21.09] Fix stopping ITs on slurm

### DIFF
--- a/lib/galaxy/jobs/runners/slurm.py
+++ b/lib/galaxy/jobs/runners/slurm.py
@@ -131,6 +131,9 @@ class SlurmJobRunner(DRMAAJobRunner):
                         ajs.fail_message = check_memory_limit_msg
                         ajs.runner_state = ajs.runner_states.MEMORY_LIMIT_REACHED
                     else:
+                        if ajs.job_wrapper.get_state() == model.Job.states.STOPPED:
+                            # User requested to stop job, this isn't an error, just finish as normal
+                            return super()._complete_terminal_job(ajs, drmaa_state=drmaa_state)
                         log.info('(%s/%s) Job was cancelled via SLURM (e.g. with scancel(1))', ajs.job_wrapper.get_id_tag(), ajs.job_id)
                         ajs.fail_message = "This job failed because it was cancelled by an administrator."
                 elif slurm_state in ('PENDING', 'RUNNING'):


### PR DESCRIPTION
If slurm decided the job is in error. There are configurations of slurm
that error out when cancelling the container monitor script, and others that
don't do this.
Analogous to what we do in pulsar, and you can see we expect this in _complete_terminal_job already.
Should fix https://github.com/galaxyproject/galaxy/issues/13256.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
