### PR TITLE
[22.01] Add config variable for setting tus upload directory

### DIFF
--- a/doc/source/admin/galaxy_options.rst
+++ b/doc/source/admin/galaxy_options.rst
@@ -2342,6 +2342,18 @@
 :Type: str
 
 
+~~~~~~~~~~~~~~~~~~~~
+``tus_upload_store``
+~~~~~~~~~~~~~~~~~~~~
+
+:Description:
+    The upload store is a temporary directory in which files uploaded
+    by the tus middleware or server will be placed. Defaults to
+    new_file_path if not set.
+:Default: ``None``
+:Type: str
+
+
 ~~~~~~~~~~~~~~~~~~~~~
 ``chunk_upload_size``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/lib/galaxy/config/__init__.py
+++ b/lib/galaxy/config/__init__.py
@@ -622,6 +622,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
     involucro_path: str
     mulled_channels: List[str]
     nginx_upload_store: str
+    tus_upload_store: str
     pretty_datetime_format: str
     visualization_plugins_directory: str
     galaxy_infrastructure_url: str
@@ -866,6 +867,9 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
         if self.nginx_upload_store:
             self.nginx_upload_store = os.path.abspath(self.nginx_upload_store)
 
+        if self.tus_upload_store:
+            self.tus_upload_store = os.path.abspath(self.tus_upload_store)
+
         self.object_store = kwargs.get('object_store', 'disk')
         self.object_store_check_old_style = string_as_bool(kwargs.get('object_store_check_old_style', False))
         self.object_store_cache_path = self._in_root_dir(kwargs.get("object_store_cache_path", self._in_data_dir("object_store_cache")))
@@ -1095,6 +1099,7 @@ class GalaxyAppConfiguration(BaseAppConfiguration, CommonConfigurationMixin):
             self.managed_config_dir,
             self.new_file_path,
             self.nginx_upload_store,
+            self.tus_upload_store,
             self.object_store_cache_path,
             self.template_cache_path,
             self.tool_data_path,

--- a/lib/galaxy/config/sample/galaxy.yml.sample
+++ b/lib/galaxy/config/sample/galaxy.yml.sample
@@ -1189,6 +1189,11 @@ galaxy:
   # documentation for the corresponding nginx configuration.
   #nginx_upload_job_files_path: null
 
+  # The upload store is a temporary directory in which files uploaded by
+  # the tus middleware or server will be placed. Defaults to
+  # new_file_path if not set.
+  #tus_upload_store: null
+
   # Galaxy can upload user files in chunks without using nginx. Enable
   # the chunk uploader by specifying a chunk size larger than 0. The
   # chunk size is specified in bytes (default: 10MB).

--- a/lib/galaxy/config/schemas/config_schema.yml
+++ b/lib/galaxy/config/schemas/config_schema.yml
@@ -1709,6 +1709,14 @@ mapping:
           operations on the remote end.  See the Galaxy nginx documentation for the
           corresponding nginx configuration.
 
+      tus_upload_store:
+        type: str
+        required: False
+        desc: |
+          The upload store is a temporary directory in which files uploaded by the
+          tus middleware or server will be placed.
+          Defaults to new_file_path if not set.
+
       chunk_upload_size:
         type: int
         default: 10485760

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -600,7 +600,7 @@ class FileToolParameter(ToolParameter):
             if 'session_id' in value:
                 # handle api upload
                 session_id = value["session_id"]
-                upload_store = trans.app.config.new_file_path
+                upload_store = trans.app.config.tus_upload_store or trans.app.config.new_file_path
                 if re.match(r'^[\w-]+$', session_id) is None:
                     raise ValueError("Invalid session id format.")
                 local_filename = os.path.abspath(os.path.join(upload_store, session_id))

--- a/lib/galaxy/tools/parameters/basic.py
+++ b/lib/galaxy/tools/parameters/basic.py
@@ -604,6 +604,9 @@ class FileToolParameter(ToolParameter):
                 if re.match(r'^[\w-]+$', session_id) is None:
                     raise ValueError("Invalid session id format.")
                 local_filename = os.path.abspath(os.path.join(upload_store, session_id))
+                if upload_store != trans.app.config.new_file_path and not os.path.exists(local_filename):
+                    # Fallback for old chunked API, remove in 22.05
+                    local_filename = os.path.abspath(os.path.join(trans.app.config.new_file_path, session_id))
             else:
                 # handle nginx upload
                 upload_store = trans.app.config.nginx_upload_store

--- a/lib/galaxy/webapps/galaxy/buildapp.py
+++ b/lib/galaxy/webapps/galaxy/buildapp.py
@@ -1391,7 +1391,7 @@ def wrap_in_middleware(app, global_conf, application_stack, **local_conf):
     # TUS upload middleware
     app = wrap_if_allowed(app, stack, TusMiddleware, kwargs={
         'upload_path': urljoin(f"{application_stack.config.galaxy_url_prefix}/", 'api/upload/resumable_upload'),
-        'tmp_dir': application_stack.config.new_file_path,
+        'tmp_dir': application_stack.config.tus_upload_store or application_stack.config.new_file_path,
         'max_size': application_stack.config.maximum_upload_file_size
     })
     # api batch call processing middleware


### PR DESCRIPTION
Main's new_file_dir has so many entries that listing it takes very long, and that seems to delay uploads.
So here I'm adding a separate upload dir, just like we have one for nginx.

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [x] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
