### PR TITLE
[21.05] Restore Metadata size limit

### DIFF
--- a/lib/galaxy/model/mapping.py
+++ b/lib/galaxy/model/mapping.py
@@ -43,6 +43,7 @@ from galaxy import model
 from galaxy.model.base import SharedModelMapping
 from galaxy.model.custom_types import (
     JSONType,
+    MetadataType,
     MutableJSONType,
     TrimmedString,
     UUIDType,
@@ -248,7 +249,7 @@ model.HistoryDatasetAssociation.table = Table(
     Column("peek", TEXT, key="_peek"),
     Column("tool_version", TEXT),
     Column("extension", TrimmedString(64)),
-    Column("metadata", JSONType, key="_metadata"),
+    Column("metadata", MetadataType, key="_metadata"),
     Column("parent_id", Integer, ForeignKey("history_dataset_association.id"), nullable=True),
     Column("designation", TrimmedString(255)),
     Column("deleted", Boolean, index=True, default=False),
@@ -271,7 +272,7 @@ model.HistoryDatasetAssociationHistory.table = Table(
     Column("version", Integer),
     Column("name", TrimmedString(255)),
     Column("extension", TrimmedString(64)),
-    Column("metadata", JSONType, key="_metadata"),
+    Column("metadata", MetadataType, key="_metadata"),
     Column("extended_metadata_id", Integer, ForeignKey("extended_metadata.id"), index=True),
 )
 
@@ -527,7 +528,7 @@ model.LibraryDatasetDatasetAssociation.table = Table(
     Column("peek", TEXT, key="_peek"),
     Column("tool_version", TEXT),
     Column("extension", TrimmedString(64)),
-    Column("metadata", JSONType, key="_metadata"),
+    Column("metadata", MetadataType, key="_metadata"),
     Column("parent_id", Integer, ForeignKey("library_dataset_dataset_association.id"), nullable=True),
     Column("designation", TrimmedString(255)),
     Column("deleted", Boolean, index=True, default=False),

--- a/test/unit/data/test_metadata_limit.py
+++ b/test/unit/data/test_metadata_limit.py
@@ -1,0 +1,44 @@
+import pytest
+
+import galaxy.datatypes.registry as registry
+import galaxy.model.mapping as mapping
+from galaxy.model import (
+    custom_types,
+    HistoryDatasetAssociation,
+    set_datatypes_registry,
+)
+
+METADATA_LIMIT = 500
+
+
+@pytest.fixture(scope="module")
+def datatypes_registry():
+    r = registry.Registry()
+    r.load_datatypes()
+    set_datatypes_registry(r)
+
+
+@pytest.fixture
+def sa_session(datatypes_registry):
+    custom_types.MAX_METADATA_VALUE_SIZE = METADATA_LIMIT
+    return mapping.init("/tmp", "sqlite:///:memory:", create_tables=True).session
+
+
+def create_bed_data(sa_session, string_size):
+    hda = HistoryDatasetAssociation(extension="bed")
+    big_string = "0" * string_size
+    sa_session.add(hda)
+    hda.metadata.column_names = [big_string]
+    assert hda.metadata.column_names
+    sa_session.flush()
+    return hda
+
+
+def test_hda_below_limit(sa_session):
+    hda = create_bed_data(sa_session=sa_session, string_size=1)
+    assert len(hda.metadata.column_names[0]) == 1
+
+
+def test_hda_above_limit(sa_session):
+    hda = create_bed_data(sa_session=sa_session, string_size=1000)
+    assert not hda.metadata.column_names


### PR DESCRIPTION
Broke in https://github.com/galaxyproject/galaxy/pull/11902


## How to test the changes?
(Select all options that apply)
- [x] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
