### PR TITLE
[21.09] Make __link_file_check more robust

### DIFF
--- a/lib/galaxy/jobs/__init__.py
+++ b/lib/galaxy/jobs/__init__.py
@@ -2258,10 +2258,10 @@ class JobWrapper(HasResourceParameters):
         method should be removed ASAP and replaced with some properly generic
         and stateful way of determining link-only datasets. -nate
         """
-        if self.tool:
+        if self.tool and self.tool.id == 'upload1':
             job = self.get_job()
             param_dict = job.get_param_values(self.app)
-            return self.tool.id == 'upload1' and param_dict.get('link_data_only', None) == 'link_to_files'
+            return param_dict.get('link_data_only') == 'link_to_files'
         else:
             # The tool is unavailable, we try to move the outputs.
             return False


### PR DESCRIPTION
There's no need to load the job and job parameters if the tool isn't
upload1. This should fix https://github.com/galaxyproject/galaxy/issues/13311

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [ ] Instructions for manual testing are as follows:
  1. [add testing steps and prerequisites here if you didn't write automated tests covering all your changes]

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
