### PR TITLE
[22.01] Ensure Notification API is available prior to trying to use it

### DIFF
--- a/client/src/components/User/UserPreferences.vue
+++ b/client/src/components/User/UserPreferences.vue
@@ -177,16 +177,20 @@ export default {
     },
     methods: {
         toggleNotifications() {
-            Notification.requestPermission().then(function (permission) {
-                //If the user accepts, let's create a notification
-                if (permission === "granted") {
-                    new Notification("Notifications enabled", {
-                        icon: "static/favicon.ico",
-                    });
-                } else {
-                    alert("Notifications disabled, please re-enable through browser settings.");
-                }
-            });
+            if (window.Notification) {
+                Notification.requestPermission().then(function (permission) {
+                    //If the user accepts, let's create a notification
+                    if (permission === "granted") {
+                        new Notification("Notifications enabled", {
+                            icon: "static/favicon.ico",
+                        });
+                    } else {
+                        alert("Notifications disabled, please re-enable through browser settings.");
+                    }
+                });
+            } else {
+                alert("Notifications are not supported by this browser.");
+            }
         },
         openManageCustomBuilds() {
             const Galaxy = getGalaxyInstance();

--- a/client/src/mvc/dataset/dataset-model.js
+++ b/client/src/mvc/dataset/dataset-model.js
@@ -103,19 +103,25 @@ var DatasetAssociation = Backbone.Model.extend(BASE_MVC.LoggableMixin).extend(
                         this.trigger("state:ready", currModel, newState, this.previous("state"));
                         if (newState != "discarded") {
                             if (newState === "ok") {
-                                new Notification(`Job complete: ${this.get("name")}`, {
-                                    icon: "static/favicon.ico",
-                                });
+                                // If Notifications are supported, send one.
+                                if (window.Notification) {
+                                    new Notification(`Job complete: ${this.get("name")}`, {
+                                        icon: "static/favicon.ico",
+                                    });
+                                }
                                 if (TAB_UPDATES.is_hidden()) {
                                     TAB_UPDATES.hidden_count(hiddenupdates);
                                     hiddenupdates++;
                                 }
                             } else if (newState == "error") {
-                                new Notification(`Job failure: ${this.get("name")}`, {
-                                    icon: "static/erricon.ico",
-                                });
-                                if (TAB_UPDATES.is_hidden() && Notification.permission == "granted") {
-                                    TAB_UPDATES.change_favicon("static/erricon.ico");
+                                // If Notifications are supported, send one.
+                                if (window.Notification) {
+                                    new Notification(`Job failure: ${this.get("name")}`, {
+                                        icon: "static/erricon.ico",
+                                    });
+                                    if (TAB_UPDATES.is_hidden() && Notification.permission == "granted") {
+                                        TAB_UPDATES.change_favicon("static/erricon.ico");
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This showed up in sentry.  There exist polyfills and we could maybe do something more here down the road but I decided not to overinvest because almost all browsers *do* support it (https://caniuse.com/notifications) and because it's an opt-in galaxy feature not critical to use of the application.

## How to test the changes?
(Select all options that apply)
- [x] This is a refactoring of components with existing test coverage.

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
